### PR TITLE
Put a 2-second deadline on ALTS handshake RPCs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,6 +514,9 @@ add_dependencies(buildtests_c uri_fuzzer_test_one_entry)
 
 add_custom_target(buildtests_cxx)
 add_dependencies(buildtests_cxx alarm_test)
+if(_gRPC_PLATFORM_LINUX)
+add_dependencies(buildtests_cxx alts_concurrent_connectivity_test)
+endif()
 add_dependencies(buildtests_cxx alts_counter_test)
 add_dependencies(buildtests_cxx alts_crypt_test)
 add_dependencies(buildtests_cxx alts_crypter_test)
@@ -10026,6 +10029,66 @@ target_link_libraries(alarm_test
 )
 
 
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX)
+
+add_executable(alts_concurrent_connectivity_test
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/handshaker.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/handshaker.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/handshaker.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/handshaker.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/transport_security_common.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/transport_security_common.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/transport_security_common.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/transport_security_common.grpc.pb.h
+  test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
+  test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+protobuf_generate_grpc_cpp(
+  test/core/tsi/alts/fake_handshaker/handshaker.proto
+)
+protobuf_generate_grpc_cpp(
+  test/core/tsi/alts/fake_handshaker/transport_security_common.proto
+)
+
+target_include_directories(alts_concurrent_connectivity_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_UPB_GENERATED_DIR}
+  PRIVATE ${_gRPC_UPB_GRPC_GENERATED_DIR}
+  PRIVATE ${_gRPC_UPB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE third_party/googletest/googletest/include
+  PRIVATE third_party/googletest/googletest
+  PRIVATE third_party/googletest/googlemock/include
+  PRIVATE third_party/googletest/googlemock
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(alts_concurrent_connectivity_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++_test_util
+  grpc_test_util
+  grpc++
+  grpc
+  gpr
+  grpc++_test_config
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+
+endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 

--- a/build.yaml
+++ b/build.yaml
@@ -3926,6 +3926,25 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - gpr
+- name: alts_concurrent_connectivity_test
+  build: test
+  language: c++
+  headers:
+  - test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
+  src:
+  - test/core/tsi/alts/fake_handshaker/handshaker.proto
+  - test/core/tsi/alts/fake_handshaker/transport_security_common.proto
+  - test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
+  - test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+  deps:
+  - grpc++_test_util
+  - grpc_test_util
+  - grpc++
+  - grpc
+  - gpr
+  - grpc++_test_config
+  platforms:
+  - linux
 - name: alts_counter_test
   build: test
   language: c++

--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -398,6 +398,8 @@ typedef struct {
 #define GRPC_ARG_CHANNEL_POOL_DOMAIN "grpc.channel_pooling_domain"
 /** gRPC Objective-C channel pooling id. */
 #define GRPC_ARG_CHANNEL_ID "grpc.channel_id"
+#define GRPC_ARG_ALTS_HANDSHAKE_RPC_DEADLINE_MS \
+  "grpc.alts_handshake_rpc_deadline_ms"
 /** \} */
 
 /** Result of a grpc call. If the caller satisfies the prerequisites of a

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.h
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.h
@@ -25,6 +25,7 @@
 #include "src/core/lib/security/credentials/alts/grpc_alts_credentials_options.h"
 
 #define GRPC_ALTS_TRANSPORT_SECURITY_TYPE "alts"
+#define GRPC_ALTS_DEFAULT_HANDSHAKE_RPC_DEADLINE_MS 2000
 
 /**
  * This method creates an ALTS channel security connector.

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -23,6 +23,7 @@
 #include <grpc/byte_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
+#include <grpc/support/string_util.h>
 
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/call.h"
@@ -83,7 +84,7 @@ typedef struct alts_grpc_handshaker_client {
   size_t buffer_size;
 } alts_grpc_handshaker_client;
 
-static void handshaker_client_send_buffer_destroy(
+static void handshaker_client_send_buffer_destroy_locked(
     alts_grpc_handshaker_client* client) {
   GPR_ASSERT(client != nullptr);
   grpc_byte_buffer_destroy(client->send_buffer);
@@ -98,45 +99,86 @@ static bool is_handshake_finished_properly(grpc_gcp_HandshakerResp* resp) {
   return false;
 }
 
-void alts_handshaker_client_handle_response(alts_handshaker_client* c,
-                                            bool is_ok) {
+struct invoke_tsi_next_cb_args {
+  tsi_handshaker_on_next_done_cb cb;
+  tsi_result status;
+  void* user_data;
+  const unsigned char* bytes_to_send;
+  size_t bytes_to_send_size;
+  tsi_handshaker_result* result;
+};
+
+// Invoke the TSI API callback without holding the alts_tsi_handshaker's lock
+void invoke_tsi_next_cb(void* arg, grpc_error* error_unused) {
+  invoke_tsi_next_cb_args* t = static_cast<invoke_tsi_next_cb_args*>(arg);
+  t->cb(t->status, t->user_data, t->bytes_to_send, t->bytes_to_send_size,
+        t->result);
+  gpr_free(t);
+}
+
+static void handle_response_done_locked(alts_grpc_handshaker_client* c,
+                                        tsi_result status,
+                                        const unsigned char* bytes_to_send,
+                                        size_t bytes_to_send_size,
+                                        tsi_handshaker_result* result) {
+  gpr_log(GPR_DEBUG,
+          "handle_response_done_locked client:%p status:%d user_data:%p "
+          "bytes_to_send_size:%ld result:%p",
+          c, status, c->user_data, bytes_to_send_size, result);
+  invoke_tsi_next_cb_args* t = static_cast<invoke_tsi_next_cb_args*>(
+      gpr_zalloc(sizeof(invoke_tsi_next_cb_args)));
+  t->cb = c->cb;
+  t->status = status;
+  t->user_data = c->user_data;
+  t->bytes_to_send = bytes_to_send;
+  t->bytes_to_send_size = bytes_to_send_size;
+  t->result = result;
+  GRPC_CLOSURE_SCHED(
+      GRPC_CLOSURE_CREATE(invoke_tsi_next_cb, t, grpc_schedule_on_exec_ctx),
+      GRPC_ERROR_NONE);
+}
+
+void alts_handshaker_client_handle_response_locked(alts_handshaker_client* c,
+                                                   bool is_ok) {
   GPR_ASSERT(c != nullptr);
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
   grpc_byte_buffer* recv_buffer = client->recv_buffer;
   grpc_status_code status = client->status;
-  tsi_handshaker_on_next_done_cb cb = client->cb;
-  void* user_data = client->user_data;
   alts_tsi_handshaker* handshaker = client->handshaker;
 
   /* Invalid input check. */
-  if (cb == nullptr) {
+  if (client->cb == nullptr) {
     gpr_log(GPR_ERROR,
-            "cb is nullptr in alts_tsi_handshaker_handle_response()");
+            "client->cb is nullptr in alts_tsi_handshaker_handle_response()");
     return;
   }
   if (handshaker == nullptr) {
     gpr_log(GPR_ERROR,
             "handshaker is nullptr in alts_tsi_handshaker_handle_response()");
-    cb(TSI_INTERNAL_ERROR, user_data, nullptr, 0, nullptr);
+    handle_response_done_locked(client, TSI_INTERNAL_ERROR, nullptr, 0,
+                                nullptr);
     return;
   }
   /* TSI handshake has been shutdown. */
-  if (alts_tsi_handshaker_has_shutdown(handshaker)) {
+  if (alts_tsi_handshaker_has_shutdown_locked(handshaker)) {
     gpr_log(GPR_ERROR, "TSI handshake shutdown");
-    cb(TSI_HANDSHAKE_SHUTDOWN, user_data, nullptr, 0, nullptr);
+    handle_response_done_locked(client, TSI_HANDSHAKE_SHUTDOWN, nullptr, 0,
+                                nullptr);
     return;
   }
   /* Failed grpc call check. */
   if (!is_ok || status != GRPC_STATUS_OK) {
     gpr_log(GPR_ERROR, "grpc call made to handshaker service failed");
-    cb(TSI_INTERNAL_ERROR, user_data, nullptr, 0, nullptr);
+    handle_response_done_locked(client, TSI_INTERNAL_ERROR, nullptr, 0,
+                                nullptr);
     return;
   }
   if (recv_buffer == nullptr) {
     gpr_log(GPR_ERROR,
             "recv_buffer is nullptr in alts_tsi_handshaker_handle_response()");
-    cb(TSI_INTERNAL_ERROR, user_data, nullptr, 0, nullptr);
+    handle_response_done_locked(client, TSI_INTERNAL_ERROR, nullptr, 0,
+                                nullptr);
     return;
   }
   upb::Arena arena;
@@ -147,14 +189,16 @@ void alts_handshaker_client_handle_response(alts_handshaker_client* c,
   /* Invalid handshaker response check. */
   if (resp == nullptr) {
     gpr_log(GPR_ERROR, "alts_tsi_utils_deserialize_response() failed");
-    cb(TSI_DATA_CORRUPTED, user_data, nullptr, 0, nullptr);
+    handle_response_done_locked(client, TSI_DATA_CORRUPTED, nullptr, 0,
+                                nullptr);
     return;
   }
   const grpc_gcp_HandshakerStatus* resp_status =
       grpc_gcp_HandshakerResp_status(resp);
   if (resp_status == nullptr) {
     gpr_log(GPR_ERROR, "No status in HandshakerResp");
-    cb(TSI_DATA_CORRUPTED, user_data, nullptr, 0, nullptr);
+    handle_response_done_locked(client, TSI_DATA_CORRUPTED, nullptr, 0,
+                                nullptr);
     return;
   }
   upb_strview out_frames = grpc_gcp_HandshakerResp_out_frames(resp);
@@ -188,22 +232,22 @@ void alts_handshaker_client_handle_response(alts_handshaker_client* c,
       gpr_free(error_details);
     }
   }
-  cb(alts_tsi_utils_convert_to_tsi_result(code), user_data, bytes_to_send,
-     bytes_to_send_size, result);
+  handle_response_done_locked(client,
+                              alts_tsi_utils_convert_to_tsi_result(code),
+                              bytes_to_send, bytes_to_send_size, result);
 }
 
-/**
- * Populate grpc operation data with the fields of ALTS handshaker client and
- * make a grpc call.
- */
-static tsi_result make_grpc_call(alts_handshaker_client* c, bool is_start) {
-  GPR_ASSERT(c != nullptr);
+void alts_handshaker_client_continue_make_grpc_call_locked(
+    alts_handshaker_client* c, grpc_call* call) {
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
+  bool is_start = call != nullptr ? true : false;
   grpc_op ops[kHandshakerClientOpNum];
   memset(ops, 0, sizeof(ops));
   grpc_op* op = ops;
   if (is_start) {
+    GPR_ASSERT(client->call == nullptr);
+    client->call = call;
     op->op = GRPC_OP_SEND_INITIAL_METADATA;
     op->data.send_initial_metadata.count = 0;
     op++;
@@ -223,12 +267,33 @@ static tsi_result make_grpc_call(alts_handshaker_client* c, bool is_start) {
   op++;
   GPR_ASSERT(op - ops <= kHandshakerClientOpNum);
   GPR_ASSERT(client->grpc_caller != nullptr);
-  if (client->grpc_caller(client->call, ops, static_cast<size_t>(op - ops),
-                          &client->on_handshaker_service_resp_recv) !=
-      GRPC_CALL_OK) {
-    gpr_log(GPR_ERROR, "Start batch operation failed");
-    return TSI_INTERNAL_ERROR;
-  }
+  grpc_call_error call_error =
+      client->grpc_caller(client->call, ops, static_cast<size_t>(op - ops),
+                          &client->on_handshaker_service_resp_recv);
+  GPR_ASSERT(call_error == GRPC_CALL_OK);
+}
+
+/**
+ * Populate grpc operation data with the fields of ALTS handshaker client and
+ * make a grpc call. First bounce into the alts_tsi_handshaker in order to
+ * safely create channnel, if needed.
+ */
+static tsi_result make_grpc_call_locked(alts_handshaker_client* c,
+                                        bool is_start) {
+  GPR_ASSERT(c != nullptr);
+  alts_grpc_handshaker_client* client =
+      reinterpret_cast<alts_grpc_handshaker_client*>(c);
+  alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call_args* args =
+      static_cast<
+          alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call_args*>(
+          gpr_zalloc(sizeof(*args)));
+  args->is_start = is_start;
+  args->handshaker = client->handshaker;
+  GRPC_CLOSURE_SCHED(
+      GRPC_CLOSURE_CREATE(
+          alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call, args,
+          grpc_schedule_on_exec_ctx),
+      GRPC_ERROR_NONE);
   return TSI_OK;
 }
 
@@ -248,7 +313,7 @@ static grpc_byte_buffer* get_serialized_handshaker_req(
 }
 
 /* Create and populate a client_start handshaker request, then serialize it. */
-static grpc_byte_buffer* get_serialized_start_client(
+static grpc_byte_buffer* get_serialized_start_client_locked(
     alts_handshaker_client* c) {
   GPR_ASSERT(c != nullptr);
   alts_grpc_handshaker_client* client =
@@ -287,29 +352,27 @@ static grpc_byte_buffer* get_serialized_start_client(
   return get_serialized_handshaker_req(req, arena.ptr());
 }
 
-static tsi_result handshaker_client_start_client(alts_handshaker_client* c) {
+static tsi_result handshaker_client_start_client_locked(
+    alts_handshaker_client* c) {
   if (c == nullptr) {
     gpr_log(GPR_ERROR, "client is nullptr in handshaker_client_start_client()");
     return TSI_INVALID_ARGUMENT;
   }
-  grpc_byte_buffer* buffer = get_serialized_start_client(c);
+  grpc_byte_buffer* buffer = get_serialized_start_client_locked(c);
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
   if (buffer == nullptr) {
     gpr_log(GPR_ERROR, "get_serialized_start_client() failed");
     return TSI_INTERNAL_ERROR;
   }
-  handshaker_client_send_buffer_destroy(client);
+  handshaker_client_send_buffer_destroy_locked(client);
   client->send_buffer = buffer;
-  tsi_result result = make_grpc_call(&client->base, true /* is_start */);
-  if (result != TSI_OK) {
-    gpr_log(GPR_ERROR, "make_grpc_call() failed");
-  }
-  return result;
+  make_grpc_call_locked(&client->base, true /* is_start */);
+  return TSI_OK;
 }
 
 /* Create and populate a start_server handshaker request, then serialize it. */
-static grpc_byte_buffer* get_serialized_start_server(
+static grpc_byte_buffer* get_serialized_start_server_locked(
     alts_handshaker_client* c, grpc_slice* bytes_received) {
   GPR_ASSERT(c != nullptr);
   GPR_ASSERT(bytes_received != nullptr);
@@ -346,26 +409,24 @@ static grpc_byte_buffer* get_serialized_start_server(
   return get_serialized_handshaker_req(req, arena.ptr());
 }
 
-static tsi_result handshaker_client_start_server(alts_handshaker_client* c,
-                                                 grpc_slice* bytes_received) {
+static tsi_result handshaker_client_start_server_locked(
+    alts_handshaker_client* c, grpc_slice* bytes_received) {
   if (c == nullptr || bytes_received == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to handshaker_client_start_server()");
     return TSI_INVALID_ARGUMENT;
   }
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
-  grpc_byte_buffer* buffer = get_serialized_start_server(c, bytes_received);
+  grpc_byte_buffer* buffer =
+      get_serialized_start_server_locked(c, bytes_received);
   if (buffer == nullptr) {
     gpr_log(GPR_ERROR, "get_serialized_start_server() failed");
     return TSI_INTERNAL_ERROR;
   }
-  handshaker_client_send_buffer_destroy(client);
+  handshaker_client_send_buffer_destroy_locked(client);
   client->send_buffer = buffer;
-  tsi_result result = make_grpc_call(&client->base, true /* is_start */);
-  if (result != TSI_OK) {
-    gpr_log(GPR_ERROR, "make_grpc_call() failed");
-  }
-  return result;
+  make_grpc_call_locked(&client->base, true /* is_start */);
+  return TSI_OK;
 }
 
 /* Create and populate a next handshaker request, then serialize it. */
@@ -382,8 +443,8 @@ static grpc_byte_buffer* get_serialized_next(grpc_slice* bytes_received) {
   return get_serialized_handshaker_req(req, arena.ptr());
 }
 
-static tsi_result handshaker_client_next(alts_handshaker_client* c,
-                                         grpc_slice* bytes_received) {
+static tsi_result handshaker_client_next_locked(alts_handshaker_client* c,
+                                                grpc_slice* bytes_received) {
   if (c == nullptr || bytes_received == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to handshaker_client_next()");
     return TSI_INVALID_ARGUMENT;
@@ -397,16 +458,13 @@ static tsi_result handshaker_client_next(alts_handshaker_client* c,
     gpr_log(GPR_ERROR, "get_serialized_next() failed");
     return TSI_INTERNAL_ERROR;
   }
-  handshaker_client_send_buffer_destroy(client);
+  handshaker_client_send_buffer_destroy_locked(client);
   client->send_buffer = buffer;
-  tsi_result result = make_grpc_call(&client->base, false /* is_start */);
-  if (result != TSI_OK) {
-    gpr_log(GPR_ERROR, "make_grpc_call() failed");
-  }
-  return result;
+  make_grpc_call_locked(&client->base, false /* is_start */);
+  return TSI_OK;
 }
 
-static void handshaker_client_shutdown(alts_handshaker_client* c) {
+static void handshaker_client_shutdown_locked(alts_handshaker_client* c) {
   GPR_ASSERT(c != nullptr);
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
@@ -415,7 +473,7 @@ static void handshaker_client_shutdown(alts_handshaker_client* c) {
   }
 }
 
-static void handshaker_client_destruct(alts_handshaker_client* c) {
+static void handshaker_client_destruct_locked(alts_handshaker_client* c) {
   if (c == nullptr) {
     return;
   }
@@ -427,21 +485,15 @@ static void handshaker_client_destruct(alts_handshaker_client* c) {
 }
 
 static const alts_handshaker_client_vtable vtable = {
-    handshaker_client_start_client, handshaker_client_start_server,
-    handshaker_client_next, handshaker_client_shutdown,
-    handshaker_client_destruct};
+    handshaker_client_start_client_locked,
+    handshaker_client_start_server_locked, handshaker_client_next_locked,
+    handshaker_client_shutdown_locked, handshaker_client_destruct_locked};
 
-alts_handshaker_client* alts_grpc_handshaker_client_create(
-    alts_tsi_handshaker* handshaker, grpc_channel* channel,
-    const char* handshaker_service_url, grpc_pollset_set* interested_parties,
-    grpc_alts_credentials_options* options, const grpc_slice& target_name,
-    grpc_iomgr_cb_func grpc_cb, tsi_handshaker_on_next_done_cb cb,
-    void* user_data, alts_handshaker_client_vtable* vtable_for_testing,
-    bool is_client) {
-  if (channel == nullptr || handshaker_service_url == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid arguments to alts_handshaker_client_create()");
-    return nullptr;
-  }
+alts_handshaker_client* alts_grpc_handshaker_client_create_locked(
+    alts_tsi_handshaker* handshaker, grpc_alts_credentials_options* options,
+    const grpc_slice& target_name, grpc_iomgr_cb_func grpc_cb,
+    tsi_handshaker_on_next_done_cb cb, void* user_data,
+    alts_handshaker_client_vtable* vtable_for_testing, bool is_client) {
   alts_grpc_handshaker_client* client =
       static_cast<alts_grpc_handshaker_client*>(gpr_zalloc(sizeof(*client)));
   client->grpc_caller = grpc_call_start_batch_and_execute;
@@ -458,20 +510,11 @@ alts_handshaker_client* alts_grpc_handshaker_client_create(
   client->is_client = is_client;
   client->buffer_size = TSI_ALTS_INITIAL_BUFFER_SIZE;
   client->buffer = static_cast<unsigned char*>(gpr_zalloc(client->buffer_size));
-  grpc_slice slice = grpc_slice_from_copied_string(handshaker_service_url);
-  client->call =
-      strcmp(handshaker_service_url, ALTS_HANDSHAKER_SERVICE_URL_FOR_TESTING) ==
-              0
-          ? nullptr
-          : grpc_channel_create_pollset_set_call(
-                channel, nullptr, GRPC_PROPAGATE_DEFAULTS, interested_parties,
-                grpc_slice_from_static_string(ALTS_SERVICE_METHOD), &slice,
-                GRPC_MILLIS_INF_FUTURE, nullptr);
+  client->call = nullptr;
   client->base.vtable =
       vtable_for_testing == nullptr ? &vtable : vtable_for_testing;
   GRPC_CLOSURE_INIT(&client->on_handshaker_service_resp_recv, client->grpc_cb,
-                    client, grpc_schedule_on_exec_ctx);
-  grpc_slice_unref_internal(slice);
+                    client->handshaker, grpc_schedule_on_exec_ctx);
   return &client->base;
 }
 
@@ -583,49 +626,50 @@ grpc_closure* alts_handshaker_client_get_closure_for_testing(
 }  // namespace internal
 }  // namespace grpc_core
 
-tsi_result alts_handshaker_client_start_client(alts_handshaker_client* client) {
+tsi_result alts_handshaker_client_start_client_locked(
+    alts_handshaker_client* client) {
   if (client != nullptr && client->vtable != nullptr &&
-      client->vtable->client_start != nullptr) {
-    return client->vtable->client_start(client);
+      client->vtable->client_start_locked != nullptr) {
+    return client->vtable->client_start_locked(client);
   }
   gpr_log(GPR_ERROR,
           "client or client->vtable has not been initialized properly");
   return TSI_INVALID_ARGUMENT;
 }
 
-tsi_result alts_handshaker_client_start_server(alts_handshaker_client* client,
-                                               grpc_slice* bytes_received) {
+tsi_result alts_handshaker_client_start_server_locked(
+    alts_handshaker_client* client, grpc_slice* bytes_received) {
   if (client != nullptr && client->vtable != nullptr &&
-      client->vtable->server_start != nullptr) {
-    return client->vtable->server_start(client, bytes_received);
+      client->vtable->server_start_locked != nullptr) {
+    return client->vtable->server_start_locked(client, bytes_received);
   }
   gpr_log(GPR_ERROR,
           "client or client->vtable has not been initialized properly");
   return TSI_INVALID_ARGUMENT;
 }
 
-tsi_result alts_handshaker_client_next(alts_handshaker_client* client,
-                                       grpc_slice* bytes_received) {
+tsi_result alts_handshaker_client_next_locked(alts_handshaker_client* client,
+                                              grpc_slice* bytes_received) {
   if (client != nullptr && client->vtable != nullptr &&
-      client->vtable->next != nullptr) {
-    return client->vtable->next(client, bytes_received);
+      client->vtable->next_locked != nullptr) {
+    return client->vtable->next_locked(client, bytes_received);
   }
   gpr_log(GPR_ERROR,
           "client or client->vtable has not been initialized properly");
   return TSI_INVALID_ARGUMENT;
 }
 
-void alts_handshaker_client_shutdown(alts_handshaker_client* client) {
+void alts_handshaker_client_shutdown_locked(alts_handshaker_client* client) {
   if (client != nullptr && client->vtable != nullptr &&
-      client->vtable->shutdown != nullptr) {
-    client->vtable->shutdown(client);
+      client->vtable->shutdown_locked != nullptr) {
+    client->vtable->shutdown_locked(client);
   }
 }
 
-void alts_handshaker_client_destroy(alts_handshaker_client* c) {
+void alts_handshaker_client_destroy_locked(alts_handshaker_client* c) {
   if (c != nullptr) {
-    if (c->vtable != nullptr && c->vtable->destruct != nullptr) {
-      c->vtable->destruct(c);
+    if (c->vtable != nullptr && c->vtable->destruct_locked != nullptr) {
+      c->vtable->destruct_locked(c);
     }
     alts_grpc_handshaker_client* client =
         reinterpret_cast<alts_grpc_handshaker_client*>(c);

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -138,6 +138,14 @@ static void handle_response_done_locked(alts_grpc_handshaker_client* c,
       GRPC_ERROR_NONE);
 }
 
+void alts_handshaker_client_cancel_call_locked(alts_handshaker_client* c) {
+  alts_grpc_handshaker_client* client =
+      reinterpret_cast<alts_grpc_handshaker_client*>(c);
+  if (client->call != nullptr) {
+    grpc_call_cancel_internal(client->call);
+  }
+}
+
 void alts_handshaker_client_handle_response_locked(alts_handshaker_client* c,
                                                    bool is_ok) {
   GPR_ASSERT(c != nullptr);

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.h
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.h
@@ -53,13 +53,13 @@ typedef grpc_call_error (*alts_grpc_caller)(grpc_call* call, const grpc_op* ops,
 
 /* V-table for ALTS handshaker client operations. */
 typedef struct alts_handshaker_client_vtable {
-  tsi_result (*client_start)(alts_handshaker_client* client);
-  tsi_result (*server_start)(alts_handshaker_client* client,
-                             grpc_slice* bytes_received);
-  tsi_result (*next)(alts_handshaker_client* client,
-                     grpc_slice* bytes_received);
-  void (*shutdown)(alts_handshaker_client* client);
-  void (*destruct)(alts_handshaker_client* client);
+  tsi_result (*client_start_locked)(alts_handshaker_client* client);
+  tsi_result (*server_start_locked)(alts_handshaker_client* client,
+                                    grpc_slice* bytes_received);
+  tsi_result (*next_locked)(alts_handshaker_client* client,
+                            grpc_slice* bytes_received);
+  void (*shutdown_locked)(alts_handshaker_client* client);
+  void (*destruct_locked)(alts_handshaker_client* client);
 } alts_handshaker_client_vtable;
 
 /**
@@ -70,7 +70,8 @@ typedef struct alts_handshaker_client_vtable {
  *
  * It returns TSI_OK on success and an error status code on failure.
  */
-tsi_result alts_handshaker_client_start_client(alts_handshaker_client* client);
+tsi_result alts_handshaker_client_start_client_locked(
+    alts_handshaker_client* client);
 
 /**
  * This method schedules a server_start handshaker request to ALTS handshaker
@@ -82,8 +83,8 @@ tsi_result alts_handshaker_client_start_client(alts_handshaker_client* client);
  *
  * It returns TSI_OK on success and an error status code on failure.
  */
-tsi_result alts_handshaker_client_start_server(alts_handshaker_client* client,
-                                               grpc_slice* bytes_received);
+tsi_result alts_handshaker_client_start_server_locked(
+    alts_handshaker_client* client, grpc_slice* bytes_received);
 
 /**
  * This method schedules a next handshaker request to ALTS handshaker service.
@@ -94,8 +95,8 @@ tsi_result alts_handshaker_client_start_server(alts_handshaker_client* client,
  *
  * It returns TSI_OK on success and an error status code on failure.
  */
-tsi_result alts_handshaker_client_next(alts_handshaker_client* client,
-                                       grpc_slice* bytes_received);
+tsi_result alts_handshaker_client_next_locked(alts_handshaker_client* client,
+                                              grpc_slice* bytes_received);
 
 /**
  * This method cancels previously scheduled, but yet executed handshaker
@@ -104,14 +105,14 @@ tsi_result alts_handshaker_client_next(alts_handshaker_client* client,
  *
  * - client: ALTS handshaker client instance.
  */
-void alts_handshaker_client_shutdown(alts_handshaker_client* client);
+void alts_handshaker_client_shutdown_locked(alts_handshaker_client* client);
 
 /**
  * This method destroys an ALTS handshaker client.
  *
  * - client: an ALTS handshaker client instance.
  */
-void alts_handshaker_client_destroy(alts_handshaker_client* client);
+void alts_handshaker_client_destroy_locked(alts_handshaker_client* client);
 
 /**
  * This method creates an ALTS handshaker client.
@@ -135,23 +136,24 @@ void alts_handshaker_client_destroy(alts_handshaker_client* client);
  * used at the client (is_client = true) or server (is_client = false) side. It
  * returns the created ALTS handshaker client on success, and NULL on failure.
  */
-alts_handshaker_client* alts_grpc_handshaker_client_create(
-    alts_tsi_handshaker* handshaker, grpc_channel* channel,
-    const char* handshaker_service_url, grpc_pollset_set* interested_parties,
-    grpc_alts_credentials_options* options, const grpc_slice& target_name,
-    grpc_iomgr_cb_func grpc_cb, tsi_handshaker_on_next_done_cb cb,
-    void* user_data, alts_handshaker_client_vtable* vtable_for_testing,
-    bool is_client);
+alts_handshaker_client* alts_grpc_handshaker_client_create_locked(
+    alts_tsi_handshaker* handshaker, grpc_alts_credentials_options* options,
+    const grpc_slice& target_name, grpc_iomgr_cb_func grpc_cb,
+    tsi_handshaker_on_next_done_cb cb, void* user_data,
+    alts_handshaker_client_vtable* vtable_for_testing, bool is_client);
 
 /**
  * This method handles handshaker response returned from ALTS handshaker
- * service. Note that the only reason the API is exposed is that it is used in
- * alts_shared_resources.cc.
- *
- * - client: an ALTS handshaker client instance.
- * - is_ok: a boolean value indicating if the handshaker response is ok to read.
- */
-void alts_handshaker_client_handle_response(alts_handshaker_client* client,
-                                            bool is_ok);
+ * service. */
+void alts_handshaker_client_handle_response_locked(
+    alts_handshaker_client* client, bool is_ok);
+
+/* This is used to continue making a gRPC call after the ALTS TSI handshaker
+ * first creates a channel and call (if necessary). Note that this is exposed
+ * only because some back-and-forth between an alts_handshaker_client object
+ * and its owning alts_tsi_handshaker object is currently necessary in order
+ * to drop the alts_tsi_handshaker's lock and then grab it again. */
+void alts_handshaker_client_continue_make_grpc_call_locked(
+    alts_handshaker_client* client, grpc_call* call);
 
 #endif /* GRPC_CORE_TSI_ALTS_HANDSHAKER_ALTS_HANDSHAKER_CLIENT_H */

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.h
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.h
@@ -159,4 +159,9 @@ void alts_handshaker_client_continue_make_grpc_call_locked(
 /** Cancels any active handshake call. */
 void alts_handshaker_client_cancel_call_locked(alts_handshaker_client* client);
 
+/** Invoked under the alts_tsi_handshaker's lock when the handshake gRPC status
+ * has been received. */
+void alts_handshaker_client_on_status_received_locked(
+    alts_handshaker_client* client, grpc_error* error);
+
 #endif /* GRPC_CORE_TSI_ALTS_HANDSHAKER_ALTS_HANDSHAKER_CLIENT_H */

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.h
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.h
@@ -156,4 +156,7 @@ void alts_handshaker_client_handle_response_locked(
 void alts_handshaker_client_continue_make_grpc_call_locked(
     alts_handshaker_client* client, grpc_call* call);
 
+/** Cancels any active handshake call. */
+void alts_handshaker_client_cancel_call_locked(alts_handshaker_client* client);
+
 #endif /* GRPC_CORE_TSI_ALTS_HANDSHAKER_ALTS_HANDSHAKER_CLIENT_H */

--- a/src/core/tsi/alts/handshaker/alts_shared_resource.cc
+++ b/src/core/tsi/alts/handshaker/alts_shared_resource.cc
@@ -40,9 +40,8 @@ static void thread_worker(void* arg) {
       break;
     }
     GPR_ASSERT(event.type == GRPC_OP_COMPLETE);
-    alts_handshaker_client* client =
-        static_cast<alts_handshaker_client*>(event.tag);
-    alts_handshaker_client_handle_response(client, event.success);
+    alts_tsi_handshaker* client = static_cast<alts_tsi_handshaker*>(event.tag);
+    alts_tsi_handshaker_handle_response_dedicated(client, event.success);
   }
 }
 

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -581,7 +581,7 @@ bool alts_tsi_handshaker_get_is_client_for_testing(
   return handshaker->is_client;
 }
 
-bool alts_tsi_handshaker_set_receive_status_pending_for_testing(
+void alts_tsi_handshaker_set_receive_status_pending_for_testing(
     alts_tsi_handshaker* handshaker, bool receive_status_pending) {
   GPR_ASSERT(handshaker != nullptr);
   return handshaker->receive_status_pending = receive_status_pending;

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -407,10 +407,10 @@ static void alts_tsi_handshaker_destroy_locked(alts_tsi_handshaker* self) {
   gpr_free(self);
 }
 
-// To be called when we've received a status for a call and processed
-// it, or if we're done with a handshake before starting a call.
-// Note that this unlocks handshaker->mu before returning.
-static void on_call_finished_locked(alts_tsi_handshaker* handshaker) {
+void alts_tsi_handshaker_on_status_received(void* arg, grpc_error* error) {
+  alts_tsi_handshaker* handshaker = static_cast<alts_tsi_handshaker*>(arg);
+  gpr_mu_lock(&handshaker->mu);
+  alts_handshaker_client_on_status_received_locked(handshaker->client, error);
   GPR_ASSERT(handshaker->receive_status_pending);
   handshaker->receive_status_pending = false;
   if (handshaker->tsi_destroy_called) {
@@ -418,13 +418,6 @@ static void on_call_finished_locked(alts_tsi_handshaker* handshaker) {
   } else {
     gpr_mu_unlock(&handshaker->mu);
   }
-}
-
-void alts_tsi_handshaker_on_status_received(void* arg, grpc_error* error) {
-  alts_tsi_handshaker* handshaker = static_cast<alts_tsi_handshaker*>(arg);
-  gpr_mu_lock(&handshaker->mu);
-  alts_handshaker_client_on_status_received_locked(handshaker->client, error);
-  on_call_finished_locked(handshaker);
 }
 
 static void handshaker_orphan(tsi_handshaker* self) {

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -392,9 +392,9 @@ static void handshaker_channel_destroy(void* arg, grpc_error* /* error */) {
 }
 
 static void alts_tsi_handshaker_destroy_locked(alts_tsi_handshaker* self) {
-  if (handshaker->channel != nullptr) {
+  if (self->channel != nullptr) {
     GRPC_CLOSURE_SCHED(
-        GRPC_CLOSURE_CREATE(handshaker_channel_destroy, handshaker->channel,
+        GRPC_CLOSURE_CREATE(handshaker_channel_destroy, self->channel,
                             grpc_schedule_on_exec_ctx),
         GRPC_ERROR_NONE);
   }

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -474,6 +474,12 @@ void alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call(
   alts_tsi_handshaker* handshaker = args->handshaker;
   bool is_start = args->is_start;
   gpr_free(args);
+  {
+    grpc_core::MutexLock(&handshaker->mu);
+    if (handshaker->shutdown) {
+      return;
+    }
+  }
   if (is_start) {
     grpc_core::UniquePtr<char> handshaker_service_url;
     bool use_dedicated_cq;

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -584,7 +584,7 @@ bool alts_tsi_handshaker_get_is_client_for_testing(
 void alts_tsi_handshaker_set_receive_status_pending_for_testing(
     alts_tsi_handshaker* handshaker, bool receive_status_pending) {
   GPR_ASSERT(handshaker != nullptr);
-  return handshaker->receive_status_pending = receive_status_pending;
+  handshaker->receive_status_pending = receive_status_pending;
 }
 
 alts_handshaker_client* alts_tsi_handshaker_get_client_for_testing(

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -89,6 +89,27 @@ void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* result,
  * This method returns a boolean value indicating if an ALTS TSI handshaker
  * has been shutdown or not.
  */
-bool alts_tsi_handshaker_has_shutdown(alts_tsi_handshaker* handshaker);
+bool alts_tsi_handshaker_has_shutdown_locked(alts_tsi_handshaker* handshaker);
+
+/* Invoked by the dedicated handshaker completion-queue-polling thread
+ * to handle a response.
+ *
+ * - client: an ALTS handshaker client instance.
+ * - is_ok: a boolean value indicating if the handshaker response is ok to read.
+ */
+void alts_tsi_handshaker_handle_response_dedicated(
+    alts_tsi_handshaker* handshaker, bool success);
+
+struct alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call_args {
+  alts_tsi_handshaker* handshaker;
+  bool is_start;
+};
+
+/* This is used by alts_handshaker_client objects to create a channel without
+ * holding any locks (in order to avoid potential cycles with g_init_mu), and
+ * then get back into the lock of the alts_tsi_handshaker to continue perfoming
+ * a call. */
+void alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call(
+    void* arg, grpc_error* unused_error);
 
 #endif /* GRPC_CORE_TSI_ALTS_HANDSHAKER_ALTS_TSI_HANDSHAKER_H */

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -60,7 +60,8 @@ typedef struct alts_tsi_handshaker alts_tsi_handshaker;
 tsi_result alts_tsi_handshaker_create(
     const grpc_alts_credentials_options* options, const char* target_name,
     const char* handshaker_service_url, bool is_client,
-    grpc_pollset_set* interested_parties, tsi_handshaker** self);
+    grpc_pollset_set* interested_parties, grpc_millis handshake_rpc_deadline_ms,
+    tsi_handshaker** self);
 
 /**
  * This method creates an ALTS TSI handshaker result instance.
@@ -111,5 +112,8 @@ struct alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call_args {
  * a call. */
 void alts_tsi_handshaker_re_enter_lock_then_continue_make_grpc_call(
     void* arg, grpc_error* unused_error);
+
+/* gRPC status received callback for handshake RPCs. */
+void alts_tsi_handshaker_on_status_received(void* arg, grpc_error* error);
 
 #endif /* GRPC_CORE_TSI_ALTS_HANDSHAKER_ALTS_TSI_HANDSHAKER_H */

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
@@ -32,6 +32,9 @@ namespace internal {
 alts_handshaker_client* alts_tsi_handshaker_get_client_for_testing(
     alts_tsi_handshaker* handshaker);
 
+void alts_tsi_handshaker_set_client_for_testing(alts_tsi_handshaker* handshaker,
+                                                alts_handshaker_client* client);
+
 bool alts_tsi_handshaker_get_has_sent_start_message_for_testing(
     alts_tsi_handshaker* handshaker);
 

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
@@ -80,6 +80,9 @@ void alts_handshaker_client_set_cb_for_testing(
 grpc_closure* alts_handshaker_client_get_closure_for_testing(
     alts_handshaker_client* client);
 
+void alts_tsi_handshaker_set_receive_status_pending_for_testing(
+    alts_tsi_handshaker* handshaker, bool receive_status_pending);
+
 }  // namespace internal
 }  // namespace grpc_core
 

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
@@ -15,6 +15,10 @@
  * limitations under the License.
  *
  */
+
+#ifndef TEST_CORE_TSI_ALTS_FAKE_HANDSHAKER_FAKE_HANDSHAKER_SERVER_H
+#define TEST_CORE_TSI_ALTS_FAKE_HANDSHAKER_FAKE_HANDSHAKER_SERVER_H
+
 #include <memory>
 #include <string>
 
@@ -27,3 +31,5 @@ std::unique_ptr<grpc::Service> CreateFakeHandshakerService();
 
 }  // namespace gcp
 }  // namespace grpc
+
+#endif  // TEST_CORE_TSI_ALTS_FAKE_HANDSHAKER_FAKE_HANDSHAKER_SERVER_H

--- a/test/core/tsi/alts/handshaker/BUILD
+++ b/test/core/tsi/alts/handshaker/BUILD
@@ -77,3 +77,21 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
     ],
 )
+
+grpc_cc_test(
+    name = "alts_concurrent_connectivity_test",
+    srcs = [
+        "alts_concurrent_connectivity_test.cc",
+    ],
+    language = "C++",
+    deps = [
+        "//:alts_util",
+        "//:grpc",
+        "//test/core/util:grpc_test_util",
+        "//test/core/tsi/alts/fake_handshaker:fake_handshaker_lib",
+        "//test/core/end2end:cq_verifier",
+    ],
+    # TODO(apolcyn): make the fake TCP server used in this
+    # test portable to Windows.
+    tags = ["no_windows"],
+)

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -1,0 +1,534 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/port_platform.h>
+
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <functional>
+#include <set>
+
+#include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
+#include <grpc/slice.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+#include <grpc/support/string_util.h>
+#include <grpc/support/time.h>
+
+#include <grpcpp/impl/codegen/service_type.h>
+#include <grpcpp/server_builder.h>
+
+#include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/gprpp/thd.h"
+#include "src/core/lib/iomgr/error.h"
+#include "src/core/lib/security/credentials/alts/alts_credentials.h"
+#include "src/core/lib/security/credentials/credentials.h"
+#include "src/core/lib/security/security_connector/alts/alts_security_connector.h"
+#include "src/core/lib/slice/slice_string_helpers.h"
+
+#include "test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h"
+#include "test/core/util/memory_counters.h"
+#include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
+
+#include "test/core/end2end/cq_verifier.h"
+
+namespace {
+
+void drain_cq(grpc_completion_queue* cq) {
+  grpc_event ev;
+  do {
+    ev = grpc_completion_queue_next(
+        cq, grpc_timeout_milliseconds_to_deadline(5000), nullptr);
+  } while (ev.type != GRPC_QUEUE_SHUTDOWN);
+}
+
+grpc_channel* create_secure_channel_for_test(
+    const char* server_addr, const char* fake_handshake_server_addr,
+    const void* debug_id) {
+  grpc_alts_credentials_options* alts_options =
+      grpc_alts_credentials_client_options_create();
+  grpc_channel_credentials* channel_creds =
+      grpc_alts_credentials_create_customized(alts_options,
+                                              fake_handshake_server_addr,
+                                              true /* enable_untrusted_alts */);
+  grpc_alts_credentials_options_destroy(alts_options);
+  // The main goal of these tests are to stress concurrent ALTS handshakes,
+  // so we prevent subchnannel sharing.
+  char* log_trace_id;
+  GPR_ASSERT(gpr_asprintf(&log_trace_id, "%p", debug_id));
+  grpc_arg extra_arg;
+  extra_arg.type = GRPC_ARG_STRING;
+  extra_arg.key = const_cast<char*>("ensure_subchannel_sharing_disabled");
+  extra_arg.value.string = log_trace_id;
+  grpc_channel_args* channel_args =
+      grpc_channel_args_copy_and_add(nullptr, &extra_arg, 1);
+  gpr_free(log_trace_id);
+  grpc_channel* channel = grpc_secure_channel_create(channel_creds, server_addr,
+                                                     channel_args, nullptr);
+  grpc_channel_args_destroy(channel_args);
+  grpc_channel_credentials_release(channel_creds);
+  return channel;
+}
+
+class FakeHandshakeServer {
+ public:
+  FakeHandshakeServer() {
+    int port = grpc_pick_unused_port_or_die();
+    grpc_core::JoinHostPort(&address_, "localhost", port);
+    service_ = grpc::gcp::CreateFakeHandshakerService();
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(address_.get(), grpc::InsecureServerCredentials());
+    builder.RegisterService(service_.get());
+    server_ = builder.BuildAndStart();
+    gpr_log(GPR_INFO, "Fake handshaker server listening on %s", address_.get());
+  }
+
+  ~FakeHandshakeServer() {
+    server_->Shutdown(grpc_timeout_milliseconds_to_deadline(0));
+  }
+
+  grpc_core::UniquePtr<char> Address() {
+    return grpc_core::UniquePtr<char>(gpr_strdup(address_.get()));
+  }
+
+ private:
+  grpc_core::UniquePtr<char> address_;
+  std::unique_ptr<grpc::Service> service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+class TestServer {
+ public:
+  TestServer(grpc_core::UniquePtr<char> fake_handshake_server_address) {
+    grpc_alts_credentials_options* alts_options =
+        grpc_alts_credentials_server_options_create();
+    grpc_server_credentials* server_creds =
+        grpc_alts_server_credentials_create_customized(
+            alts_options, fake_handshake_server_address.get(),
+            true /* enable_untrusted_alts */);
+    grpc_alts_credentials_options_destroy(alts_options);
+    server_ = grpc_server_create(nullptr, nullptr);
+    server_cq_ = grpc_completion_queue_create_for_next(nullptr);
+    grpc_server_register_completion_queue(server_, server_cq_, nullptr);
+    int port = grpc_pick_unused_port_or_die();
+    GPR_ASSERT(grpc_core::JoinHostPort(&server_addr_, "localhost", port));
+    GPR_ASSERT(grpc_server_add_secure_http2_port(server_, server_addr_.get(),
+                                                 server_creds));
+    grpc_server_credentials_release(server_creds);
+    grpc_server_start(server_);
+    gpr_log(GPR_DEBUG, "Start TestServer %p. listen on %s", this,
+            server_addr_.get());
+    server_thd_ = grpc_core::MakeUnique<grpc_core::Thread>(
+        "server thread", PollUntilShutdown, this);
+    server_thd_->Start();
+  }
+
+  ~TestServer() {
+    gpr_log(GPR_DEBUG, "Begin dtor of TestServer %p", this);
+    grpc_server_shutdown_and_notify(server_, server_cq_, this);
+    server_thd_->Join();
+    grpc_server_destroy(server_);
+    grpc_completion_queue_shutdown(server_cq_);
+    drain_cq(server_cq_);
+    grpc_completion_queue_destroy(server_cq_);
+  }
+
+  grpc_core::UniquePtr<char> Address() {
+    return grpc_core::UniquePtr<char>(gpr_strdup(server_addr_.get()));
+  }
+
+  static void PollUntilShutdown(void* arg) {
+    TestServer* self = static_cast<TestServer*>(arg);
+    grpc_event ev = grpc_completion_queue_next(
+        self->server_cq_, gpr_inf_future(GPR_CLOCK_REALTIME), nullptr);
+    GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+    GPR_ASSERT(ev.tag == self);
+    gpr_log(GPR_DEBUG, "TestServer %p stop polling", self);
+  }
+
+ private:
+  grpc_server* server_;
+  grpc_completion_queue* server_cq_;
+  grpc_core::UniquePtr<grpc_core::Thread> server_thd_;
+  grpc_core::UniquePtr<char> server_addr_;
+};
+
+struct connect_args {
+  grpc_core::UniquePtr<char> server_address;
+  grpc_core::UniquePtr<char> fake_handshaker_server_addr;
+  const void* debug_id;
+  int per_connect_deadline_seconds;
+  int loops;
+};
+
+void connect_loop(void* arg) {
+  connect_args* args = static_cast<connect_args*>(arg);
+  void* debug_id = &args;
+  for (size_t i = 0; i < args->loops; i++) {
+    gpr_log(GPR_DEBUG, "debug_id:%p connect_loop begin loop %ld", debug_id, i);
+    grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
+    grpc_channel* channel = create_secure_channel_for_test(
+        args->server_address.get(), args->fake_handshaker_server_addr.get(),
+        debug_id);
+    // Connect, forcing an ALTS handshake
+    gpr_timespec connect_deadline =
+        grpc_timeout_seconds_to_deadline(args->per_connect_deadline_seconds);
+    grpc_connectivity_state state =
+        grpc_channel_check_connectivity_state(channel, 1);
+    GPR_ASSERT(state == GRPC_CHANNEL_IDLE);
+    while (state != GRPC_CHANNEL_READY) {
+      grpc_channel_watch_connectivity_state(
+          channel, state, gpr_inf_future(GPR_CLOCK_REALTIME), cq, nullptr);
+      grpc_event ev = grpc_completion_queue_next(cq, connect_deadline, nullptr);
+      if (ev.type != GRPC_OP_COMPLETE) {
+        gpr_log(GPR_ERROR, "connect_loop debug_id:%p got ev.type:%d i:%ld",
+                debug_id, ev.type, i);
+        abort();
+      }
+      GPR_ASSERT(ev.success);
+      state = grpc_channel_check_connectivity_state(channel, 1);
+    }
+    grpc_channel_destroy(channel);
+    grpc_completion_queue_shutdown(cq);
+    drain_cq(cq);
+    grpc_completion_queue_destroy(cq);
+    gpr_log(GPR_DEBUG, "debug_id:%p connect_loop finished loop %ld", debug_id,
+            i);
+  }
+}
+
+// Perform a few ALTS handshakes sequentially (using the fake, in-process ALTS
+// handshake server).
+void test_basic_client_server_handshake() {
+  gpr_log(GPR_DEBUG, "Running test: test_basic_client_server_handshake");
+  FakeHandshakeServer fake_handshake_server;
+  TestServer test_server(fake_handshake_server.Address());
+  {
+    connect_args args;
+    args.fake_handshaker_server_addr = fake_handshake_server.Address();
+    args.server_address = test_server.Address();
+    args.per_connect_deadline_seconds = 5;
+    args.loops = 10;
+    connect_loop(&args);
+  }
+}
+
+/* Run a bunch of concurrent ALTS handshakes on concurrent channels
+ * (using the fake, in-process handshake server). */
+void test_concurrent_client_server_handshakes() {
+  gpr_log(GPR_DEBUG, "Running test: test_concurrent_client_server_handshakes");
+  FakeHandshakeServer fake_handshake_server;
+  // Test
+  {
+    TestServer test_server(fake_handshake_server.Address());
+    gpr_timespec test_deadline = grpc_timeout_seconds_to_deadline(20);
+    int num_concurrent_connects = 50;
+    std::vector<grpc_core::UniquePtr<grpc_core::Thread>> thds;
+    thds.reserve(num_concurrent_connects);
+    connect_args c_args;
+    c_args.fake_handshaker_server_addr = fake_handshake_server.Address();
+    c_args.server_address = test_server.Address();
+    c_args.per_connect_deadline_seconds = 15;
+    c_args.loops = 5;
+    gpr_log(GPR_DEBUG,
+            "start performing concurrent expected-to-succeed connects");
+    for (size_t i = 0; i < num_concurrent_connects; i++) {
+      auto new_thd = grpc_core::MakeUnique<grpc_core::Thread>(
+          "test_concurrent_client_server_handshakes thd", connect_loop,
+          &c_args);
+      new_thd->Start();
+      thds.push_back(std::move(new_thd));
+    }
+    for (size_t i = 0; i < num_concurrent_connects; i++) {
+      thds[i]->Join();
+    }
+    gpr_log(GPR_DEBUG,
+            "done performing concurrent expected-to-succeed connects");
+    if (gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), test_deadline) > 0) {
+      gpr_log(GPR_DEBUG, "Test took longer than expected.");
+      abort();
+    }
+  }
+}
+
+class FakeTcpServer {
+ public:
+  enum ProcessReadResult {
+    CONTINUE_READING,
+    CLOSE_SOCKET,
+  };
+
+  FakeTcpServer(
+      const std::function<ProcessReadResult(int, int, int)>& process_read_cb)
+      : process_read_cb_(process_read_cb) {
+    port_ = grpc_pick_unused_port_or_die();
+    accept_socket_ = socket(AF_INET6, SOCK_STREAM, 0);
+    GPR_ASSERT(accept_socket_ != -1);
+    if (accept_socket_ == -1) {
+      gpr_log(GPR_ERROR, "Failed to create socket: %d", errno);
+      abort();
+    }
+    int val = 1;
+    if (setsockopt(accept_socket_, SOL_SOCKET, SO_REUSEADDR, &val,
+                   sizeof(val)) != 0) {
+      gpr_log(GPR_ERROR,
+              "Failed to set SO_REUSEADDR on socket bound to [::1]:%d : %d",
+              port_, errno);
+      abort();
+    }
+    if (fcntl(accept_socket_, F_SETFL, O_NONBLOCK) != 0) {
+      gpr_log(GPR_ERROR, "Failed to set O_NONBLOCK on socket: %d", errno);
+      abort();
+    }
+    sockaddr_in6 addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(port_);
+    ((char*)&addr.sin6_addr)[15] = 1;
+    if (bind(accept_socket_, (const sockaddr*)&addr, sizeof(addr)) != 0) {
+      gpr_log(GPR_ERROR, "Failed to bind socket to [::1]:%d : %d", port_,
+              errno);
+      abort();
+    }
+    if (listen(accept_socket_, 100)) {
+      gpr_log(GPR_ERROR, "Failed to listen on socket bound to [::1]:%d : %d",
+              port_, errno);
+      abort();
+    }
+    gpr_event_init(&stop_ev_);
+    run_server_loop_thd_ = grpc_core::MakeUnique<grpc_core::Thread>(
+        "fake tcp server that closes connections upon receiving bytes",
+        RunServerLoop, this);
+    run_server_loop_thd_->Start();
+  }
+
+  ~FakeTcpServer() {
+    gpr_log(GPR_DEBUG,
+            "FakeTcpServer stop and "
+            "join server thread");
+    gpr_event_set(&stop_ev_, (void*)1);
+    run_server_loop_thd_->Join();
+    gpr_log(GPR_DEBUG,
+            "FakeTcpServer join server "
+            "thread complete");
+  }
+
+  grpc_core::UniquePtr<char> Address() {
+    char* addr;
+    GPR_ASSERT(gpr_asprintf(&addr, "[::]:%d", port_));
+    return grpc_core::UniquePtr<char>(addr);
+  }
+
+  static ProcessReadResult CloseSocketUponReceivingBytesFromPeer(
+      int bytes_received_size, int read_error, int s) {
+    if (bytes_received_size < 0 && read_error != EAGAIN &&
+        read_error != EWOULDBLOCK) {
+      gpr_log(GPR_ERROR, "Failed to receive from peer socket: %d. errno: %d", s,
+              errno);
+      abort();
+    }
+    if (bytes_received_size >= 0) {
+      gpr_log(GPR_DEBUG,
+              "Fake TCP server received %d bytes from peer socket: %d. Close "
+              "the "
+              "connection.",
+              bytes_received_size, s);
+      return CLOSE_SOCKET;
+    }
+    return CONTINUE_READING;
+  }
+
+  static ProcessReadResult CloseSocketUponCloseFromPeer(int bytes_received_size,
+                                                        int read_error, int s) {
+    if (bytes_received_size < 0 && read_error != EAGAIN &&
+        read_error != EWOULDBLOCK) {
+      gpr_log(GPR_ERROR, "Failed to receive from peer socket: %d. errno: %d", s,
+              errno);
+      abort();
+    }
+    if (bytes_received_size == 0) {
+      // The peer has shut down the connection.
+      gpr_log(GPR_DEBUG,
+              "Fake TCP server received 0 bytes from peer socket: %d. Close "
+              "the "
+              "connection.",
+              s);
+      return CLOSE_SOCKET;
+    }
+    return CONTINUE_READING;
+  }
+
+  // Run a loop that periodically, every 10 ms:
+  //   1) Checks if there are any new TCP connections to accept.
+  //   2) Checks if any data has arrived yet on established connections,
+  //      and closes them if so.
+  static void RunServerLoop(void* arg) {
+    FakeTcpServer* self = static_cast<FakeTcpServer*>(arg);
+    std::set<int> peers;
+    while (!gpr_event_get(&self->stop_ev_)) {
+      int p = accept(self->accept_socket_, nullptr, nullptr);
+      if (p == -1 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        gpr_log(GPR_ERROR, "Failed to accept connection: %d", errno);
+        abort();
+      }
+      if (p != -1) {
+        gpr_log(GPR_DEBUG, "accepted peer socket: %d", p);
+        if (fcntl(p, F_SETFL, O_NONBLOCK) != 0) {
+          gpr_log(GPR_ERROR, "Failed to set O_NONBLOCK on peer socket: %d", p,
+                  errno);
+          abort();
+        }
+        peers.insert(p);
+      }
+      auto it = peers.begin();
+      while (it != peers.end()) {
+        int p = *it;
+        char buf[100];
+        int bytes_received_size = recv(p, buf, 100, 0);
+        ProcessReadResult r =
+            self->process_read_cb_(bytes_received_size, errno, p);
+        if (r == CLOSE_SOCKET) {
+          close(p);
+          it = peers.erase(it);
+        } else {
+          GPR_ASSERT(r == CONTINUE_READING);
+          it++;
+        }
+      }
+      gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+                                   gpr_time_from_millis(10, GPR_TIMESPAN)));
+    }
+    for (auto it = peers.begin(); it != peers.end(); it++) {
+      close(*it);
+    }
+    close(self->accept_socket_);
+  }
+
+ private:
+  int accept_socket_;
+  int port_;
+  gpr_event stop_ev_;
+  grpc_core::UniquePtr<grpc_core::Thread> run_server_loop_thd_;
+  std::function<ProcessReadResult(int, int, int)> process_read_cb_;
+};
+
+void expect_connect_fails_loop(void* arg) {
+  connect_args* args = static_cast<connect_args*>(arg);
+  void* debug_id = &args;
+  for (size_t i = 0; i < args->loops; i++) {
+    gpr_log(GPR_DEBUG, "debug_id:%p expect_connect_fails_loop begin loop %ld",
+            debug_id, i);
+    grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
+    grpc_channel* channel = create_secure_channel_for_test(
+        args->server_address.get(), args->fake_handshaker_server_addr.get(),
+        debug_id);
+    // Connect, forcing an ALTS handshake attempt
+    gpr_timespec connect_failure_deadline =
+        grpc_timeout_seconds_to_deadline(args->per_connect_deadline_seconds);
+    grpc_connectivity_state state =
+        grpc_channel_check_connectivity_state(channel, 1);
+    GPR_ASSERT(state == GRPC_CHANNEL_IDLE);
+    while (state != GRPC_CHANNEL_TRANSIENT_FAILURE) {
+      GPR_ASSERT(state != GRPC_CHANNEL_READY);  // sanity check
+      grpc_channel_watch_connectivity_state(
+          channel, state, gpr_inf_future(GPR_CLOCK_REALTIME), cq, nullptr);
+      grpc_event ev =
+          grpc_completion_queue_next(cq, connect_failure_deadline, nullptr);
+      if (ev.type != GRPC_OP_COMPLETE) {
+        gpr_log(GPR_ERROR,
+                "expect_connect_fails_loop debug_id:%p got ev.type:%d i:%ld",
+                debug_id, ev.type, i);
+        abort();
+      }
+      state = grpc_channel_check_connectivity_state(channel, 1);
+    }
+    grpc_channel_destroy(channel);
+    grpc_completion_queue_shutdown(cq);
+    drain_cq(cq);
+    grpc_completion_queue_destroy(cq);
+    gpr_log(GPR_DEBUG,
+            "debug_id:%p expect_connect_fails_loop finished loop %ld", debug_id,
+            i);
+  }
+}
+
+/* This test is intended to make sure that ALTS handshakes we correctly
+ * fail fast when the security handshaker gets an error while reading
+ * from the remote peer, after having earlier sent the first bytes of the
+ * ALTS handshake to the peer, i.e. after getting into the middle of a
+ * handshake. */
+void test_handshake_fails_fast_when_peer_endpoint_closes_connection_after_accepting() {
+  gpr_log(GPR_DEBUG,
+          "Running test: "
+          "test_handshake_fails_fast_when_peer_endpoint_closes_connection_"
+          "after_accepting");
+  FakeHandshakeServer fake_handshake_server;
+  FakeTcpServer fake_tcp_server(
+      FakeTcpServer::CloseSocketUponReceivingBytesFromPeer);
+  {
+    gpr_timespec test_deadline = grpc_timeout_seconds_to_deadline(20);
+    std::vector<grpc_core::UniquePtr<grpc_core::Thread>> connect_thds;
+    int num_concurrent_connects = 100;
+    connect_thds.reserve(num_concurrent_connects);
+    connect_args c_args;
+    c_args.server_address = fake_tcp_server.Address();
+    c_args.fake_handshaker_server_addr = fake_handshake_server.Address();
+    c_args.per_connect_deadline_seconds = 10;
+    c_args.loops = 5;
+    gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
+    for (size_t i = 0; i < num_concurrent_connects; i++) {
+      auto new_thd = grpc_core::MakeUnique<grpc_core::Thread>(
+          "connect fails fast", expect_connect_fails_loop, &c_args);
+      new_thd->Start();
+      connect_thds.push_back(std::move(new_thd));
+    }
+    for (size_t i = 0; i < num_concurrent_connects; i++) {
+      connect_thds[i]->Join();
+    }
+    gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");
+    if (gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), test_deadline) > 0) {
+      gpr_log(GPR_ERROR,
+              "Exceeded test deadline. ALTS handshakes might not be failing "
+              "fast when the peer endpoint closes the connection abruptly");
+      abort();
+    }
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  grpc_init();
+  {
+    test_basic_client_server_handshake();
+    test_concurrent_client_server_handshakes();
+    test_handshake_fails_fast_when_peer_endpoint_closes_connection_after_accepting();
+  }
+  grpc_shutdown();
+  return 0;
+}

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -499,7 +499,7 @@ void test_handshake_fails_fast_when_peer_endpoint_closes_connection_after_accept
     c_args.server_address = fake_tcp_server.Address();
     c_args.fake_handshaker_server_addr = fake_handshake_server.Address();
     c_args.per_connect_deadline_seconds = 10;
-    c_args.loops = 5;
+    c_args.loops = 2;
     gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
     for (size_t i = 0; i < num_concurrent_connects; i++) {
       auto new_thd = grpc_core::MakeUnique<grpc_core::Thread>(

--- a/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
@@ -18,6 +18,7 @@
 
 #include <grpc/grpc.h>
 
+#include "src/core/lib/iomgr/pollset_set.h"
 #include "src/core/tsi/alts/handshaker/alts_handshaker_client.h"
 #include "src/core/tsi/alts/handshaker/alts_shared_resource.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
@@ -44,13 +45,17 @@ using grpc_core::internal::
     alts_handshaker_client_get_recv_buffer_addr_for_testing;
 using grpc_core::internal::alts_handshaker_client_get_send_buffer_for_testing;
 using grpc_core::internal::alts_handshaker_client_set_grpc_caller_for_testing;
+using grpc_core::internal::alts_tsi_handshaker_get_client_for_testing;
+using grpc_core::internal::alts_tsi_handshaker_set_client_for_testing;
 
 typedef struct alts_handshaker_client_test_config {
-  grpc_channel* channel;
-  grpc_completion_queue* cq;
   alts_handshaker_client* client;
   alts_handshaker_client* server;
   grpc_slice out_frame;
+  // dummy_pss is a placeholder but isn't actually used in these tests.
+  grpc_pollset_set* dummy_pss;
+  alts_tsi_handshaker* client_tsi_handshaker;
+  alts_tsi_handshaker* server_tsi_handshaker;
 } alts_handshaker_client_test_config;
 
 static void validate_rpc_protocol_versions(
@@ -152,8 +157,8 @@ static grpc_call_error check_client_start_success(grpc_call* /*call*/,
                                                   size_t nops,
                                                   grpc_closure* closure) {
   upb::Arena arena;
-  alts_handshaker_client* client =
-      static_cast<alts_handshaker_client*>(closure->cb_arg);
+  alts_handshaker_client* client = alts_tsi_handshaker_get_client_for_testing(
+      static_cast<alts_tsi_handshaker*>(closure->cb_arg));
   GPR_ASSERT(alts_handshaker_client_get_closure_for_testing(client) == closure);
   grpc_gcp_HandshakerReq* req = deserialize_handshaker_req(
       alts_handshaker_client_get_send_buffer_for_testing(client), arena.ptr());
@@ -197,8 +202,8 @@ static grpc_call_error check_server_start_success(grpc_call* /*call*/,
                                                   size_t nops,
                                                   grpc_closure* closure) {
   upb::Arena arena;
-  alts_handshaker_client* client =
-      static_cast<alts_handshaker_client*>(closure->cb_arg);
+  alts_handshaker_client* client = alts_tsi_handshaker_get_client_for_testing(
+      static_cast<alts_tsi_handshaker*>(closure->cb_arg));
   GPR_ASSERT(alts_handshaker_client_get_closure_for_testing(client) == closure);
   grpc_gcp_HandshakerReq* req = deserialize_handshaker_req(
       alts_handshaker_client_get_send_buffer_for_testing(client), arena.ptr());
@@ -239,8 +244,8 @@ static grpc_call_error check_next_success(grpc_call* /*call*/,
                                           const grpc_op* op, size_t nops,
                                           grpc_closure* closure) {
   upb::Arena arena;
-  alts_handshaker_client* client =
-      static_cast<alts_handshaker_client*>(closure->cb_arg);
+  alts_handshaker_client* client = alts_tsi_handshaker_get_client_for_testing(
+      static_cast<alts_tsi_handshaker*>(closure->cb_arg));
   GPR_ASSERT(alts_handshaker_client_get_closure_for_testing(client) == closure);
   grpc_gcp_HandshakerReq* req = deserialize_handshaker_req(
       alts_handshaker_client_get_send_buffer_for_testing(client), arena.ptr());
@@ -251,18 +256,6 @@ static grpc_call_error check_next_success(grpc_call* /*call*/,
       upb_strview_makez(ALTS_HANDSHAKER_CLIENT_TEST_OUT_FRAME)));
   GPR_ASSERT(validate_op(client, op, nops, false /* is_start */));
   return GRPC_CALL_OK;
-}
-
-/**
- * A mock grpc_caller used to check if client_start, server_start, and next
- * operations correctly handle the situation when the grpc call made to the
- * handshaker service fails.
- */
-static grpc_call_error check_grpc_call_failure(grpc_call* /*call*/,
-                                               const grpc_op* /*op*/,
-                                               size_t /*nops*/,
-                                               grpc_closure* /*tag*/) {
-  return GRPC_CALL_ERROR;
 }
 
 static grpc_alts_credentials_options* create_credentials_options(
@@ -288,23 +281,38 @@ static alts_handshaker_client_test_config* create_config() {
   alts_handshaker_client_test_config* config =
       static_cast<alts_handshaker_client_test_config*>(
           gpr_zalloc(sizeof(*config)));
-  config->channel = grpc_insecure_channel_create(
-      ALTS_HANDSHAKER_SERVICE_URL_FOR_TESTING, nullptr, nullptr);
-  config->cq = grpc_completion_queue_create_for_next(nullptr);
   grpc_alts_credentials_options* client_options =
       create_credentials_options(true /* is_client */);
   grpc_alts_credentials_options* server_options =
       create_credentials_options(false /*  is_client */);
-  config->server = alts_grpc_handshaker_client_create(
-      nullptr, config->channel, ALTS_HANDSHAKER_SERVICE_URL_FOR_TESTING,
-      nullptr, server_options,
-      grpc_slice_from_static_string(ALTS_HANDSHAKER_CLIENT_TEST_TARGET_NAME),
-      nullptr, nullptr, nullptr, nullptr, false);
-  config->client = alts_grpc_handshaker_client_create(
-      nullptr, config->channel, ALTS_HANDSHAKER_SERVICE_URL_FOR_TESTING,
-      nullptr, client_options,
+  // Create "TSI handshaker" objects
+  config->dummy_pss = grpc_pollset_set_create();
+  GPR_ASSERT(config->client_tsi_handshaker == nullptr);
+  alts_tsi_handshaker_create(
+      client_options, ALTS_HANDSHAKER_SERVICE_URL_FOR_TESTING,
+      ALTS_HANDSHAKER_CLIENT_TEST_TARGET_NAME, true /* is client */,
+      config->dummy_pss,
+      reinterpret_cast<tsi_handshaker**>(&config->client_tsi_handshaker));
+  GPR_ASSERT(config->server_tsi_handshaker == nullptr);
+  alts_tsi_handshaker_create(
+      server_options, ALTS_HANDSHAKER_SERVICE_URL_FOR_TESTING,
+      ALTS_HANDSHAKER_CLIENT_TEST_TARGET_NAME, false /* is client */,
+      config->dummy_pss,
+      reinterpret_cast<tsi_handshaker**>(&config->server_tsi_handshaker));
+  // Create "handshaker client" objects
+  config->client = alts_grpc_handshaker_client_create_locked(
+      config->client_tsi_handshaker, client_options,
       grpc_slice_from_static_string(ALTS_HANDSHAKER_CLIENT_TEST_TARGET_NAME),
       nullptr, nullptr, nullptr, nullptr, true);
+  config->server = alts_grpc_handshaker_client_create_locked(
+      config->server_tsi_handshaker, server_options,
+      grpc_slice_from_static_string(ALTS_HANDSHAKER_CLIENT_TEST_TARGET_NAME),
+      nullptr, nullptr, nullptr, nullptr, false);
+  // Artificially attach the "handshake client" and "TSI handshaker" objects.
+  grpc_core::internal::alts_tsi_handshaker_set_client_for_testing(
+      config->client_tsi_handshaker, config->client);
+  grpc_core::internal::alts_tsi_handshaker_set_client_for_testing(
+      config->server_tsi_handshaker, config->server);
   GPR_ASSERT(config->client != nullptr);
   GPR_ASSERT(config->server != nullptr);
   grpc_alts_credentials_options_destroy(client_options);
@@ -318,11 +326,11 @@ static void destroy_config(alts_handshaker_client_test_config* config) {
   if (config == nullptr) {
     return;
   }
-  grpc_completion_queue_destroy(config->cq);
-  grpc_channel_destroy(config->channel);
-  alts_handshaker_client_destroy(config->client);
-  alts_handshaker_client_destroy(config->server);
-  grpc_slice_unref(config->out_frame);
+  tsi_handshaker_destroy(
+      reinterpret_cast<tsi_handshaker*>(config->client_tsi_handshaker));
+  tsi_handshaker_destroy(
+      reinterpret_cast<tsi_handshaker*>(config->server_tsi_handshaker));
+  grpc_pollset_set_destroy(config->dummy_pss);
   gpr_free(config);
 }
 
@@ -333,20 +341,20 @@ static void schedule_request_invalid_arg_test() {
   alts_handshaker_client_set_grpc_caller_for_testing(config->client,
                                                      check_must_not_be_called);
   /* Check client_start. */
-  GPR_ASSERT(alts_handshaker_client_start_client(nullptr) ==
+  GPR_ASSERT(alts_handshaker_client_start_client_locked(nullptr) ==
              TSI_INVALID_ARGUMENT);
   /* Check server_start. */
-  GPR_ASSERT(alts_handshaker_client_start_server(config->server, nullptr) ==
-             TSI_INVALID_ARGUMENT);
-  GPR_ASSERT(alts_handshaker_client_start_server(nullptr, &config->out_frame) ==
-             TSI_INVALID_ARGUMENT);
+  GPR_ASSERT(alts_handshaker_client_start_server_locked(
+                 config->server, nullptr) == TSI_INVALID_ARGUMENT);
+  GPR_ASSERT(alts_handshaker_client_start_server_locked(
+                 nullptr, &config->out_frame) == TSI_INVALID_ARGUMENT);
   /* Check next. */
-  GPR_ASSERT(alts_handshaker_client_next(config->client, nullptr) ==
+  GPR_ASSERT(alts_handshaker_client_next_locked(config->client, nullptr) ==
              TSI_INVALID_ARGUMENT);
-  GPR_ASSERT(alts_handshaker_client_next(nullptr, &config->out_frame) ==
+  GPR_ASSERT(alts_handshaker_client_next_locked(nullptr, &config->out_frame) ==
              TSI_INVALID_ARGUMENT);
   /* Check shutdown. */
-  alts_handshaker_client_shutdown(nullptr);
+  alts_handshaker_client_shutdown_locked(nullptr);
   /* Cleanup. */
   destroy_config(config);
 }
@@ -354,48 +362,38 @@ static void schedule_request_invalid_arg_test() {
 static void schedule_request_success_test() {
   /* Initialization. */
   alts_handshaker_client_test_config* config = create_config();
-  /* Check client_start success. */
-  alts_handshaker_client_set_grpc_caller_for_testing(
-      config->client, check_client_start_success);
-  GPR_ASSERT(alts_handshaker_client_start_client(config->client) == TSI_OK);
-  /* Check server_start success. */
-  alts_handshaker_client_set_grpc_caller_for_testing(
-      config->server, check_server_start_success);
-  GPR_ASSERT(alts_handshaker_client_start_server(config->server,
-                                                 &config->out_frame) == TSI_OK);
-  /* Check client next success. */
-  alts_handshaker_client_set_grpc_caller_for_testing(config->client,
-                                                     check_next_success);
-  GPR_ASSERT(alts_handshaker_client_next(config->client, &config->out_frame) ==
-             TSI_OK);
-  /* Check server next success. */
-  alts_handshaker_client_set_grpc_caller_for_testing(config->server,
-                                                     check_next_success);
-  GPR_ASSERT(alts_handshaker_client_next(config->server, &config->out_frame) ==
-             TSI_OK);
-  /* Cleanup. */
-  destroy_config(config);
-}
-
-static void schedule_request_grpc_call_failure_test() {
-  /* Initialization. */
-  alts_handshaker_client_test_config* config = create_config();
-  /* Check client_start failure. */
-  alts_handshaker_client_set_grpc_caller_for_testing(config->client,
-                                                     check_grpc_call_failure);
-  GPR_ASSERT(alts_handshaker_client_start_client(config->client) ==
-             TSI_INTERNAL_ERROR);
-  /* Check server_start failure. */
-  alts_handshaker_client_set_grpc_caller_for_testing(config->server,
-                                                     check_grpc_call_failure);
-  GPR_ASSERT(alts_handshaker_client_start_server(
-                 config->server, &config->out_frame) == TSI_INTERNAL_ERROR);
-  /* Check client next failure. */
-  GPR_ASSERT(alts_handshaker_client_next(config->client, &config->out_frame) ==
-             TSI_INTERNAL_ERROR);
-  /* Check server next failure. */
-  GPR_ASSERT(alts_handshaker_client_next(config->server, &config->out_frame) ==
-             TSI_INTERNAL_ERROR);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    /* Check client_start success. */
+    alts_handshaker_client_set_grpc_caller_for_testing(
+        config->client, check_client_start_success);
+    GPR_ASSERT(alts_handshaker_client_start_client_locked(config->client) ==
+               TSI_OK);
+  }
+  {
+    grpc_core::ExecCtx exec_ctx;
+    /* Check server_start success. */
+    alts_handshaker_client_set_grpc_caller_for_testing(
+        config->server, check_server_start_success);
+    GPR_ASSERT(alts_handshaker_client_start_server_locked(
+                   config->server, &config->out_frame) == TSI_OK);
+  }
+  {
+    grpc_core::ExecCtx exec_ctx;
+    /* Check client next success. */
+    alts_handshaker_client_set_grpc_caller_for_testing(config->client,
+                                                       check_next_success);
+    GPR_ASSERT(alts_handshaker_client_next_locked(
+                   config->client, &config->out_frame) == TSI_OK);
+  }
+  {
+    grpc_core::ExecCtx exec_ctx;
+    /* Check server next success. */
+    alts_handshaker_client_set_grpc_caller_for_testing(config->server,
+                                                       check_next_success);
+    GPR_ASSERT(alts_handshaker_client_next_locked(
+                   config->server, &config->out_frame) == TSI_OK);
+  }
   /* Cleanup. */
   destroy_config(config);
 }
@@ -407,7 +405,6 @@ int main(int /*argc*/, char** /*argv*/) {
   /* Tests. */
   schedule_request_invalid_arg_test();
   schedule_request_success_test();
-  schedule_request_grpc_call_failure_test();
   /* Cleanup. */
   grpc_alts_shared_resource_dedicated_shutdown();
   grpc_shutdown();

--- a/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
@@ -323,6 +323,7 @@ static alts_handshaker_client_test_config* create_config() {
 }
 
 static void destroy_config(alts_handshaker_client_test_config* config) {
+  grpc_core::ExecCtx exec_ctx;
   if (config == nullptr) {
     return;
   }

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3039,6 +3039,24 @@
     "args": [], 
     "benchmark": false, 
     "ci_platforms": [
+      "linux"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
+    "name": "alts_concurrent_connectivity_test", 
+    "platforms": [
+      "linux"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
       "linux", 
       "mac", 
       "posix", 


### PR DESCRIPTION
Based on https://github.com/grpc/grpc/pull/20596

ALTS handshakes can get stuck e.g. until subchannel connect deadlines expire, for different reasons (e.g. a slow or non-responsive peer). When that happens, these handshakes are susceptible to holding up resources and preventing other, otherwise-independent ALTS handshakes from making progress.
The new `test_handshake_fails_within_short_deadline_when_peer_endpoint_is_non_responsive_after_accepting` test here is meant to try to illustrate this.

Note follow-up PR on top of this one: https://github.com/grpc/grpc/pull/20722