### PR TITLE
Provide length when getting serialization buffer writer

### DIFF
--- a/src/csharp/Grpc.Core.Api/SerializationContext.cs
+++ b/src/csharp/Grpc.Core.Api/SerializationContext.cs
@@ -41,7 +41,8 @@ namespace Grpc.Core
         /// Gets buffer writer that can be used to write the serialized data. Once serialization is finished,
         /// <c>Complete()</c> needs to be called.
         /// </summary>
-        public virtual IBufferWriter<byte> GetBufferWriter()
+        /// <param name="payloadLength">The total length of the payload in bytes.</param>
+        public virtual IBufferWriter<byte> GetBufferWriter(int payloadLength)
         {
             throw new NotImplementedException();
         }
@@ -52,7 +53,6 @@ namespace Grpc.Core
         public virtual void Complete()
         {
             throw new NotImplementedException();
-
         }
     }
 }

--- a/src/csharp/Grpc.Core.Api/SerializationContext.cs
+++ b/src/csharp/Grpc.Core.Api/SerializationContext.cs
@@ -39,12 +39,22 @@ namespace Grpc.Core
 
         /// <summary>
         /// Gets buffer writer that can be used to write the serialized data. Once serialization is finished,
-        /// <c>Complete()</c> needs to be called.
+        /// <c>Complete()</c> needs to be called. A <c>null</c> value will be returned if serialization
+        /// with a buffer writer is not supported.
+        /// </summary>
+        public virtual IBufferWriter<byte> GetBufferWriter()
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Sets the payload length when writing serialized data a buffer writer. This method should be called before <c>GetBufferWriter</c>.
+        /// Calling this method is optional. If the payload length is not set then the length is calculated using the data written to the
+        /// buffer writer when <c>Complete()</c> is called.
         /// </summary>
         /// <param name="payloadLength">The total length of the payload in bytes.</param>
-        public virtual IBufferWriter<byte> GetBufferWriter(int payloadLength)
+        public virtual void SetPayloadLength(int payloadLength)
         {
-            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core.Api/SerializationContext.cs
+++ b/src/csharp/Grpc.Core.Api/SerializationContext.cs
@@ -39,18 +39,19 @@ namespace Grpc.Core
 
         /// <summary>
         /// Gets buffer writer that can be used to write the serialized data. Once serialization is finished,
-        /// <c>Complete()</c> needs to be called. A <c>null</c> value will be returned if serialization
-        /// with a buffer writer is not supported.
+        /// <c>Complete()</c> needs to be called.
         /// </summary>
         public virtual IBufferWriter<byte> GetBufferWriter()
         {
-            return null;
+            throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Sets the payload length when writing serialized data a buffer writer. This method should be called before <c>GetBufferWriter</c>.
-        /// Calling this method is optional. If the payload length is not set then the length is calculated using the data written to the
-        /// buffer writer when <c>Complete()</c> is called.
+        /// Sets the payload length when writing serialized data into a buffer writer. If the serializer knows the full payload
+        /// length in advance, providing that information before obtaining the buffer writer using <c>GetBufferWriter()</c> can improve
+        /// serialization efficiency by avoiding copies. The provided payload length must be the same as the data written to the writer.
+        /// Calling this method is optional. If the payload length is not set then the length is calculated using the data written to
+        /// the buffer writer when <c>Complete()</c> is called.
         /// </summary>
         /// <param name="payloadLength">The total length of the payload in bytes.</param>
         public virtual void SetPayloadLength(int payloadLength)

--- a/src/csharp/Grpc.Core.Tests/Internal/DefaultSerializationContextTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/DefaultSerializationContextTest.cs
@@ -84,7 +84,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 var origPayload = GetTestBuffer(payloadSize);
 
-                var bufferWriter = context.GetBufferWriter(payloadSize);
+                var bufferWriter = context.GetBufferWriter();
                 origPayload.AsSpan().CopyTo(bufferWriter.GetSpan(payloadSize));
                 bufferWriter.Advance(payloadSize);
                 context.Complete();
@@ -106,7 +106,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 var origPayload = GetTestBuffer(payloadSize);
 
-                var bufferWriter = context.GetBufferWriter(payloadSize);
+                var bufferWriter = context.GetBufferWriter();
                 origPayload.AsSpan().CopyTo(bufferWriter.GetMemory(payloadSize).Span);
                 bufferWriter.Advance(payloadSize);
                 context.Complete();
@@ -131,7 +131,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 var origPayload = GetTestBuffer(payloadSize);
 
-                var bufferWriter = context.GetBufferWriter(payloadSize);
+                var bufferWriter = context.GetBufferWriter();
                 for (int offset = 0; offset < payloadSize; offset += maxSliceSize)
                 {
                     var sliceSize = Math.Min(maxSliceSize, payloadSize - offset);
@@ -165,7 +165,7 @@ namespace Grpc.Core.Internal.Tests
 
                 var origPayload2 = GetTestBuffer(20);
     
-                var bufferWriter = context.GetBufferWriter(20);
+                var bufferWriter = context.GetBufferWriter();
                 origPayload2.AsSpan().CopyTo(bufferWriter.GetMemory(origPayload2.Length).Span);
                 bufferWriter.Advance(origPayload2.Length);
                 context.Complete();
@@ -185,7 +185,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 context.Complete(GetTestBuffer(10));
 
-                Assert.Throws(typeof(InvalidOperationException), () => context.GetBufferWriter(10));
+                Assert.Throws(typeof(InvalidOperationException), () => context.GetBufferWriter());
             }
         }
 

--- a/src/csharp/Grpc.Core.Tests/Internal/DefaultSerializationContextTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/DefaultSerializationContextTest.cs
@@ -84,7 +84,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 var origPayload = GetTestBuffer(payloadSize);
 
-                var bufferWriter = context.GetBufferWriter();
+                var bufferWriter = context.GetBufferWriter(payloadSize);
                 origPayload.AsSpan().CopyTo(bufferWriter.GetSpan(payloadSize));
                 bufferWriter.Advance(payloadSize);
                 context.Complete();
@@ -106,7 +106,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 var origPayload = GetTestBuffer(payloadSize);
 
-                var bufferWriter = context.GetBufferWriter();
+                var bufferWriter = context.GetBufferWriter(payloadSize);
                 origPayload.AsSpan().CopyTo(bufferWriter.GetMemory(payloadSize).Span);
                 bufferWriter.Advance(payloadSize);
                 context.Complete();
@@ -131,7 +131,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 var origPayload = GetTestBuffer(payloadSize);
 
-                var bufferWriter = context.GetBufferWriter();
+                var bufferWriter = context.GetBufferWriter(payloadSize);
                 for (int offset = 0; offset < payloadSize; offset += maxSliceSize)
                 {
                     var sliceSize = Math.Min(maxSliceSize, payloadSize - offset);
@@ -165,7 +165,7 @@ namespace Grpc.Core.Internal.Tests
 
                 var origPayload2 = GetTestBuffer(20);
     
-                var bufferWriter = context.GetBufferWriter();
+                var bufferWriter = context.GetBufferWriter(20);
                 origPayload2.AsSpan().CopyTo(bufferWriter.GetMemory(origPayload2.Length).Span);
                 bufferWriter.Advance(origPayload2.Length);
                 context.Complete();
@@ -185,7 +185,7 @@ namespace Grpc.Core.Internal.Tests
                 var context = scope.Context;
                 context.Complete(GetTestBuffer(10));
 
-                Assert.Throws(typeof(InvalidOperationException), () => context.GetBufferWriter());
+                Assert.Throws(typeof(InvalidOperationException), () => context.GetBufferWriter(10));
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/DefaultSerializationContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultSerializationContext.cs
@@ -50,10 +50,15 @@ namespace Grpc.Core.Internal
         /// <summary>
         /// Expose serializer as buffer writer
         /// </summary>
-        public override IBufferWriter<byte> GetBufferWriter(int payloadLength)
+        public override IBufferWriter<byte> GetBufferWriter()
         {
             GrpcPreconditions.CheckState(!isComplete);
             return sliceBuffer;
+        }
+
+        public override void SetPayloadLength(int payloadLength)
+        {
+            // Length is calculated using the buffer writer
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/DefaultSerializationContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultSerializationContext.cs
@@ -50,7 +50,7 @@ namespace Grpc.Core.Internal
         /// <summary>
         /// Expose serializer as buffer writer
         /// </summary>
-        public override IBufferWriter<byte> GetBufferWriter()
+        public override IBufferWriter<byte> GetBufferWriter(int payloadLength)
         {
             GrpcPreconditions.CheckState(!isComplete);
             return sliceBuffer;


### PR DESCRIPTION
One of the goals of using `IBufferWriter<byte>` in Grpc.AspNetCore was to write messages directly to the `Response.BodyWriter`. Unfortunately that is not possible at the moment because serialization logic will get the writer and start serialization before a length is known, and the length must prefix the message in the response. With the current API content still has to be written somewhere, the length calculated, then the length and content written to `Response.BodyWriter`.

More detail: https://github.com/grpc/grpc-dotnet/pull/611

Adding the argument to `GetBufferWriter` is an API change but it is to the contextual serialization experimental type.

If the API change is not wanted then an alternative would be to add a new method to `SerializationContent` to set the payload length:

```cs
public virtual void SetPayloadLength(int payloadLength)
{
    throw new NotImplementedException();
}
```

**Edit:** `SetPayloadLength` might be the better solution - https://github.com/grpc/grpc-dotnet/pull/611#issuecomment-544434340

@jtattermusch @mgravell