### PR TITLE
Remove unused-parameter warnings, round 2

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -584,7 +584,7 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
 
 void PrintHeaderClientMethodCallbackInterfacesStart(
     grpc_generator::Printer* printer,
-    std::map<grpc::string, grpc::string>* vars) {
+    std::map<grpc::string, grpc::string>* /*vars*/) {
   // This declares the interface for the callback-based API. The components
   // are pure; even though this is new (post-1.0) API, it can be pure because
   // it is an entirely new interface that happens to be scoped within
@@ -599,10 +599,7 @@ void PrintHeaderClientMethodCallbackInterfacesStart(
 
 void PrintHeaderClientMethodCallbackInterfaces(
     grpc_generator::Printer* printer, const grpc_generator::Method* method,
-    std::map<grpc::string, grpc::string>* vars, bool is_public) {
-  // Reserve is_public for future expansion
-  assert(is_public);
-
+    std::map<grpc::string, grpc::string>* vars) {
   (*vars)["Method"] = method->name();
   (*vars)["Request"] = method->input_type_name();
   (*vars)["Response"] = method->output_type_name();
@@ -646,7 +643,7 @@ void PrintHeaderClientMethodCallbackInterfaces(
 
 void PrintHeaderClientMethodCallbackInterfacesEnd(
     grpc_generator::Printer* printer,
-    std::map<grpc::string, grpc::string>* vars) {
+    std::map<grpc::string, grpc::string>* /*vars*/) {
   printer->Outdent();
   printer->Print("};\n");
 
@@ -662,7 +659,7 @@ void PrintHeaderClientMethodCallbackInterfacesEnd(
 
 void PrintHeaderClientMethodCallbackStart(
     grpc_generator::Printer* printer,
-    std::map<grpc::string, grpc::string>* vars) {
+    std::map<grpc::string, grpc::string>* /*vars*/) {
   // This declares the stub entry for the callback-based API.
   printer->Print("class experimental_async final :\n");
   printer->Print("  public StubInterface::experimental_async_interface {\n");
@@ -670,13 +667,9 @@ void PrintHeaderClientMethodCallbackStart(
   printer->Indent();
 }
 
-void PrintHeaderClientMethodCallback(grpc_generator::Printer* printer,
-                                     const grpc_generator::Method* method,
-                                     std::map<grpc::string, grpc::string>* vars,
-                                     bool is_public) {
-  // Reserve is_public for future expansion
-  assert(is_public);
-
+void PrintHeaderClientMethodCallback(
+    grpc_generator::Printer* printer, const grpc_generator::Method* method,
+    std::map<grpc::string, grpc::string>* vars) {
   (*vars)["Method"] = method->name();
   (*vars)["Request"] = method->input_type_name();
   (*vars)["Response"] = method->output_type_name();
@@ -723,7 +716,7 @@ void PrintHeaderClientMethodCallback(grpc_generator::Printer* printer,
 
 void PrintHeaderClientMethodCallbackEnd(
     grpc_generator::Printer* printer,
-    std::map<grpc::string, grpc::string>* vars) {
+    std::map<grpc::string, grpc::string>* /*vars*/) {
   printer->Outdent();
   printer->Print(" private:\n");
   printer->Indent();
@@ -1372,7 +1365,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
   for (int i = 0; i < service->method_count(); ++i) {
     printer->Print(service->method(i)->GetLeadingComments("//").c_str());
     PrintHeaderClientMethodCallbackInterfaces(printer, service->method(i).get(),
-                                              vars, true);
+                                              vars);
     printer->Print(service->method(i)->GetTrailingComments("//").c_str());
   }
   PrintHeaderClientMethodCallbackInterfacesEnd(printer, vars);
@@ -1397,8 +1390,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
   }
   PrintHeaderClientMethodCallbackStart(printer, vars);
   for (int i = 0; i < service->method_count(); ++i) {
-    PrintHeaderClientMethodCallback(printer, service->method(i).get(), vars,
-                                    true);
+    PrintHeaderClientMethodCallback(printer, service->method(i).get(), vars);
   }
   PrintHeaderClientMethodCallbackEnd(printer, vars);
   printer->Outdent();

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -166,7 +166,7 @@ inline MethodType GetMethodType(
   }
 }
 
-inline void Split(const grpc::string& s, char delim,
+inline void Split(const grpc::string& s, char /*delim*/,
                   std::vector<grpc::string>* append_to) {
   std::istringstream iss(s);
   grpc::string piece;

--- a/src/compiler/ruby_plugin.cc
+++ b/src/compiler/ruby_plugin.cc
@@ -30,9 +30,9 @@ class RubyGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
   ~RubyGrpcGenerator() {}
 
   bool Generate(const grpc::protobuf::FileDescriptor* file,
-                const grpc::string& parameter,
+                const grpc::string& /*parameter*/,
                 grpc::protobuf::compiler::GeneratorContext* context,
-                grpc::string* error) const {
+                grpc::string* /*error*/) const {
     grpc::string code = grpc_ruby_generator::GetServices(file);
     if (code.size() == 0) {
       return true;  // don't generate a file if there are no services

--- a/src/core/ext/filters/client_channel/backup_poller.cc
+++ b/src/core/ext/filters/client_channel/backup_poller.cc
@@ -89,7 +89,7 @@ static void backup_poller_shutdown_unref(backup_poller* p) {
   }
 }
 
-static void done_poller(void* arg, grpc_error* error) {
+static void done_poller(void* arg, grpc_error* /*error*/) {
   backup_poller_shutdown_unref(static_cast<backup_poller*>(arg));
 }
 

--- a/src/core/ext/filters/client_channel/channel_connectivity.cc
+++ b/src/core/ext/filters/client_channel/channel_connectivity.cc
@@ -90,7 +90,7 @@ static void delete_state_watcher(state_watcher* w) {
   gpr_free(w);
 }
 
-static void finished_completion(void* pw, grpc_cq_completion* ignored) {
+static void finished_completion(void* pw, grpc_cq_completion* /*ignored*/) {
   bool should_delete = false;
   state_watcher* w = static_cast<state_watcher*>(pw);
   gpr_mu_lock(&w->mu);
@@ -198,7 +198,7 @@ typedef struct watcher_timer_init_arg {
   gpr_timespec deadline;
 } watcher_timer_init_arg;
 
-static void watcher_timer_init(void* arg, grpc_error* error_ignored) {
+static void watcher_timer_init(void* arg, grpc_error* /*error_ignored*/) {
   watcher_timer_init_arg* wa = static_cast<watcher_timer_init_arg*>(arg);
 
   grpc_timer_init(&wa->w->alarm, grpc_timespec_to_millis_round_up(wa->deadline),

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -584,10 +584,10 @@ class CallData {
   // A predicate type and some useful implementations for PendingBatchesFail().
   typedef bool (*YieldCallCombinerPredicate)(
       const CallCombinerClosureList& closures);
-  static bool YieldCallCombiner(const CallCombinerClosureList& closures) {
+  static bool YieldCallCombiner(const CallCombinerClosureList& /*closures*/) {
     return true;
   }
-  static bool NoYieldCallCombiner(const CallCombinerClosureList& closures) {
+  static bool NoYieldCallCombiner(const CallCombinerClosureList& /*closures*/) {
     return false;
   }
   static bool YieldCallCombinerIfPendingBatchesFound(
@@ -1052,7 +1052,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
 
      private:
       static void ApplyUpdateInControlPlaneCombiner(void* arg,
-                                                    grpc_error* error) {
+                                                    grpc_error* /*error*/) {
         Updater* self = static_cast<Updater*>(arg);
         if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
           gpr_log(GPR_INFO,
@@ -1188,7 +1188,7 @@ void ChannelData::ExternalConnectivityWatcher::Cancel() {
 }
 
 void ChannelData::ExternalConnectivityWatcher::AddWatcherLocked(
-    void* arg, grpc_error* ignored) {
+    void* arg, grpc_error* /*ignored*/) {
   ExternalConnectivityWatcher* self =
       static_cast<ExternalConnectivityWatcher*>(arg);
   // This assumes that the closure is scheduled on the ExecCtx scheduler
@@ -1201,7 +1201,7 @@ void ChannelData::ExternalConnectivityWatcher::AddWatcherLocked(
 }
 
 void ChannelData::ExternalConnectivityWatcher::RemoveWatcherLocked(
-    void* arg, grpc_error* ignored) {
+    void* arg, grpc_error* /*ignored*/) {
   ExternalConnectivityWatcher* self =
       static_cast<ExternalConnectivityWatcher*>(arg);
   self->chand_->state_tracker_.RemoveWatcher(self);
@@ -1228,7 +1228,7 @@ class ChannelData::ConnectivityWatcherAdder {
   }
 
  private:
-  static void AddWatcherLocked(void* arg, grpc_error* error) {
+  static void AddWatcherLocked(void* arg, grpc_error* /*error*/) {
     ConnectivityWatcherAdder* self =
         static_cast<ConnectivityWatcherAdder*>(arg);
     self->chand_->state_tracker_.AddWatcher(self->initial_state_,
@@ -1262,7 +1262,7 @@ class ChannelData::ConnectivityWatcherRemover {
   }
 
  private:
-  static void RemoveWatcherLocked(void* arg, grpc_error* error) {
+  static void RemoveWatcherLocked(void* arg, grpc_error* /*error*/) {
     ConnectivityWatcherRemover* self =
         static_cast<ConnectivityWatcherRemover*>(arg);
     self->chand_->state_tracker_.RemoveWatcher(self->watcher_);
@@ -1809,7 +1809,7 @@ grpc_error* ChannelData::DoPingLocked(grpc_transport_op* op) {
   return result.error;
 }
 
-void ChannelData::StartTransportOpLocked(void* arg, grpc_error* ignored) {
+void ChannelData::StartTransportOpLocked(void* arg, grpc_error* /*ignored*/) {
   grpc_transport_op* op = static_cast<grpc_transport_op*>(arg);
   grpc_channel_element* elem =
       static_cast<grpc_channel_element*>(op->handler_private.extra_arg);
@@ -1937,7 +1937,7 @@ ChannelData::GetConnectedSubchannelInDataPlane(
   return connected_subchannel->Ref();
 }
 
-void ChannelData::TryToConnectLocked(void* arg, grpc_error* error_ignored) {
+void ChannelData::TryToConnectLocked(void* arg, grpc_error* /*error_ignored*/) {
   auto* chand = static_cast<ChannelData*>(arg);
   if (chand->resolving_lb_policy_ != nullptr) {
     chand->resolving_lb_policy_->ExitIdleLocked();
@@ -2050,7 +2050,7 @@ grpc_error* CallData::Init(grpc_call_element* elem,
 }
 
 void CallData::Destroy(grpc_call_element* elem,
-                       const grpc_call_final_info* final_info,
+                       const grpc_call_final_info* /*final_info*/,
                        grpc_closure* then_schedule_closure) {
   CallData* calld = static_cast<CallData*>(elem->call_data);
   if (GPR_LIKELY(calld->subchannel_call_ != nullptr)) {
@@ -2445,7 +2445,7 @@ void CallData::PendingBatchesFail(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void CallData::ResumePendingBatchInCallCombiner(void* arg,
-                                                grpc_error* ignored) {
+                                                grpc_error* /*ignored*/) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   SubchannelCall* subchannel_call =
@@ -2908,7 +2908,7 @@ void CallData::RecvMessageReady(void* arg, grpc_error* error) {
 // recv_trailing_metadata handling
 //
 
-void CallData::GetCallStatus(grpc_call_element* elem,
+void CallData::GetCallStatus(grpc_call_element* /*elem*/,
                              grpc_metadata_batch* md_batch, grpc_error* error,
                              grpc_status_code* status,
                              grpc_mdelem** server_pushback_md) {
@@ -3111,7 +3111,7 @@ void CallData::RecvTrailingMetadataReady(void* arg, grpc_error* error) {
 
 void CallData::AddClosuresForCompletedPendingBatch(
     grpc_call_element* elem, SubchannelCallBatchData* batch_data,
-    SubchannelCallRetryState* retry_state, grpc_error* error,
+    SubchannelCallRetryState* /*retry_state*/, grpc_error* error,
     CallCombinerClosureList* closures) {
   PendingBatch* pending = PendingBatchFind(
       elem, "completed", [batch_data](grpc_transport_stream_op_batch* batch) {
@@ -3238,7 +3238,7 @@ void CallData::OnComplete(void* arg, grpc_error* error) {
 // subchannel batch construction
 //
 
-void CallData::StartBatchInCallCombiner(void* arg, grpc_error* ignored) {
+void CallData::StartBatchInCallCombiner(void* arg, grpc_error* /*ignored*/) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   SubchannelCall* subchannel_call =
@@ -3608,7 +3608,8 @@ void CallData::AddSubchannelBatchesForPendingBatches(
   }
 }
 
-void CallData::StartRetriableSubchannelBatches(void* arg, grpc_error* ignored) {
+void CallData::StartRetriableSubchannelBatches(void* arg,
+                                               grpc_error* /*ignored*/) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(arg);
   ChannelData* chand = static_cast<ChannelData*>(elem->channel_data);
   CallData* calld = static_cast<CallData*>(elem->call_data);

--- a/src/core/ext/filters/client_channel/client_channel_factory.cc
+++ b/src/core/ext/filters/client_channel/client_channel_factory.cc
@@ -29,7 +29,7 @@ namespace grpc_core {
 namespace {
 
 void* factory_arg_copy(void* f) { return f; }
-void factory_arg_destroy(void* f) {}
+void factory_arg_destroy(void* /*f*/) {}
 int factory_arg_cmp(void* factory1, void* factory2) {
   return GPR_ICMP(factory1, factory2);
 }

--- a/src/core/ext/filters/client_channel/global_subchannel_pool.cc
+++ b/src/core/ext/filters/client_channel/global_subchannel_pool.cc
@@ -140,28 +140,28 @@ RefCountedPtr<GlobalSubchannelPool>* GlobalSubchannelPool::instance_ = nullptr;
 
 namespace {
 
-void sck_avl_destroy(void* p, void* user_data) {
+void sck_avl_destroy(void* p, void* /*user_data*/) {
   SubchannelKey* key = static_cast<SubchannelKey*>(p);
   Delete(key);
 }
 
-void* sck_avl_copy(void* p, void* unused) {
+void* sck_avl_copy(void* p, void* /*unused*/) {
   const SubchannelKey* key = static_cast<const SubchannelKey*>(p);
   auto* new_key = New<SubchannelKey>(*key);
   return static_cast<void*>(new_key);
 }
 
-long sck_avl_compare(void* a, void* b, void* unused) {
+long sck_avl_compare(void* a, void* b, void* /*unused*/) {
   const SubchannelKey* key_a = static_cast<const SubchannelKey*>(a);
   const SubchannelKey* key_b = static_cast<const SubchannelKey*>(b);
   return key_a->Cmp(*key_b);
 }
 
-void scv_avl_destroy(void* p, void* user_data) {
+void scv_avl_destroy(void* p, void* /*user_data*/) {
   GRPC_SUBCHANNEL_WEAK_UNREF((Subchannel*)p, "global_subchannel_pool");
 }
 
-void* scv_avl_copy(void* p, void* unused) {
+void* scv_avl_copy(void* p, void* /*unused*/) {
   GRPC_SUBCHANNEL_WEAK_REF((Subchannel*)p, "global_subchannel_pool");
   return p;
 }

--- a/src/core/ext/filters/client_channel/health/health_check_client.cc
+++ b/src/core/ext/filters/client_channel/health/health_check_client.cc
@@ -377,8 +377,8 @@ void HealthCheckClient::CallState::StartCall() {
   StartBatch(&recv_trailing_metadata_batch_);
 }
 
-void HealthCheckClient::CallState::StartBatchInCallCombiner(void* arg,
-                                                            grpc_error* error) {
+void HealthCheckClient::CallState::StartBatchInCallCombiner(
+    void* arg, grpc_error* /*error*/) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   SubchannelCall* call =
@@ -396,21 +396,22 @@ void HealthCheckClient::CallState::StartBatch(
 }
 
 void HealthCheckClient::CallState::AfterCallStackDestruction(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   Delete(self);
 }
 
 void HealthCheckClient::CallState::OnCancelComplete(void* arg,
-                                                    grpc_error* error) {
+                                                    grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   GRPC_CALL_COMBINER_STOP(&self->call_combiner_, "health_cancel");
   self->call_->Unref(DEBUG_LOCATION, "cancel");
 }
 
-void HealthCheckClient::CallState::StartCancel(void* arg, grpc_error* error) {
+void HealthCheckClient::CallState::StartCancel(void* arg,
+                                               grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   auto* batch = grpc_make_transport_stream_op(
@@ -432,7 +433,8 @@ void HealthCheckClient::CallState::Cancel() {
   }
 }
 
-void HealthCheckClient::CallState::OnComplete(void* arg, grpc_error* error) {
+void HealthCheckClient::CallState::OnComplete(void* arg,
+                                              grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   GRPC_CALL_COMBINER_STOP(&self->call_combiner_, "on_complete");
@@ -441,8 +443,8 @@ void HealthCheckClient::CallState::OnComplete(void* arg, grpc_error* error) {
   self->call_->Unref(DEBUG_LOCATION, "on_complete");
 }
 
-void HealthCheckClient::CallState::RecvInitialMetadataReady(void* arg,
-                                                            grpc_error* error) {
+void HealthCheckClient::CallState::RecvInitialMetadataReady(
+    void* arg, grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   GRPC_CALL_COMBINER_STOP(&self->call_combiner_, "recv_initial_metadata_ready");
@@ -524,7 +526,7 @@ void HealthCheckClient::CallState::OnByteStreamNext(void* arg,
 }
 
 void HealthCheckClient::CallState::RecvMessageReady(void* arg,
-                                                    grpc_error* error) {
+                                                    grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   GRPC_CALL_COMBINER_STOP(&self->call_combiner_, "recv_message_ready");
@@ -583,7 +585,7 @@ void HealthCheckClient::CallState::RecvTrailingMetadataReady(
 }
 
 void HealthCheckClient::CallState::CallEndedRetry(void* arg,
-                                                  grpc_error* error) {
+                                                  grpc_error* /*error*/) {
   HealthCheckClient::CallState* self =
       static_cast<HealthCheckClient::CallState*>(arg);
   self->CallEnded(true /* retry */);

--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -246,7 +246,7 @@ void HttpConnectHandshaker::Shutdown(grpc_error* why) {
   GRPC_ERROR_UNREF(why);
 }
 
-void HttpConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* acceptor,
+void HttpConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                                         grpc_closure* on_handshake_done,
                                         HandshakerArgs* args) {
   // Check for HTTP CONNECT channel arg.
@@ -340,8 +340,8 @@ HttpConnectHandshaker::HttpConnectHandshaker() {
 
 class HttpConnectHandshakerFactory : public HandshakerFactory {
  public:
-  void AddHandshakers(const grpc_channel_args* args,
-                      grpc_pollset_set* interested_parties,
+  void AddHandshakers(const grpc_channel_args* /*args*/,
+                      grpc_pollset_set* /*interested_parties*/,
                       HandshakeManager* handshake_mgr) override {
     handshake_mgr->Add(MakeRefCounted<HttpConnectHandshaker>());
   }

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -99,7 +99,7 @@ bool http_proxy_enabled(const grpc_channel_args* args) {
   return grpc_channel_arg_get_bool(arg, true);
 }
 
-static bool proxy_mapper_map_name(grpc_proxy_mapper* mapper,
+static bool proxy_mapper_map_name(grpc_proxy_mapper* /*mapper*/,
                                   const char* server_uri,
                                   const grpc_channel_args* args,
                                   char** name_to_resolve,
@@ -195,15 +195,15 @@ no_use_proxy:
   return false;
 }
 
-static bool proxy_mapper_map_address(grpc_proxy_mapper* mapper,
-                                     const grpc_resolved_address* address,
-                                     const grpc_channel_args* args,
-                                     grpc_resolved_address** new_address,
-                                     grpc_channel_args** new_args) {
+static bool proxy_mapper_map_address(grpc_proxy_mapper* /*mapper*/,
+                                     const grpc_resolved_address* /*address*/,
+                                     const grpc_channel_args* /*args*/,
+                                     grpc_resolved_address** /*new_address*/,
+                                     grpc_channel_args** /*new_args*/) {
   return false;
 }
 
-static void proxy_mapper_destroy(grpc_proxy_mapper* mapper) {}
+static void proxy_mapper_destroy(grpc_proxy_mapper* /*mapper*/) {}
 
 static const grpc_proxy_mapper_vtable proxy_mapper_vtable = {
     proxy_mapper_map_name, proxy_mapper_map_address, proxy_mapper_destroy};

--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -90,7 +90,7 @@ LoadBalancingPolicy::UpdateArgs& LoadBalancingPolicy::UpdateArgs::operator=(
 //
 
 LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
-    PickArgs args) {
+    PickArgs /*args*/) {
   // We invoke the parent's ExitIdleLocked() via a closure instead
   // of doing it directly here, for two reasons:
   // 1. ExitIdleLocked() may cause the policy's state to change and
@@ -115,7 +115,7 @@ LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
 }
 
 void LoadBalancingPolicy::QueuePicker::CallExitIdle(void* arg,
-                                                    grpc_error* error) {
+                                                    grpc_error* /*error*/) {
   LoadBalancingPolicy* parent = static_cast<LoadBalancingPolicy*>(arg);
   parent->ExitIdleLocked();
   parent->Unref();
@@ -126,7 +126,7 @@ void LoadBalancingPolicy::QueuePicker::CallExitIdle(void* arg,
 //
 
 LoadBalancingPolicy::PickResult
-LoadBalancingPolicy::TransientFailurePicker::Pick(PickArgs args) {
+LoadBalancingPolicy::TransientFailurePicker::Pick(PickArgs /*args*/) {
   PickResult result;
   result.type = PickResult::PICK_FAILED;
   result.error = GRPC_ERROR_REF(error_);

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
@@ -30,12 +30,12 @@
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/profiling/timers.h"
 
-static grpc_error* clr_init_channel_elem(grpc_channel_element* elem,
-                                         grpc_channel_element_args* args) {
+static grpc_error* clr_init_channel_elem(grpc_channel_element* /*elem*/,
+                                         grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
-static void clr_destroy_channel_elem(grpc_channel_element* elem) {}
+static void clr_destroy_channel_elem(grpc_channel_element* /*elem*/) {}
 
 namespace {
 
@@ -79,8 +79,8 @@ static grpc_error* clr_init_call_elem(grpc_call_element* elem,
 }
 
 static void clr_destroy_call_elem(grpc_call_element* elem,
-                                  const grpc_call_final_info* final_info,
-                                  grpc_closure* ignored) {
+                                  const grpc_call_final_info* /*final_info*/,
+                                  grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   if (calld->client_stats != nullptr) {
     // Record call finished, optionally setting client_failed_to_send and

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -468,7 +468,7 @@ void client_stats_destroy(void* p) {
   GrpcLbClientStats* client_stats = static_cast<GrpcLbClientStats*>(p);
   client_stats->Unref();
 }
-int equal_cmp(void* p1, void* p2) {
+int equal_cmp(void* /*p1*/, void* /*p2*/) {
   // Always indicate a match, since we don't want this channel arg to
   // affect the subchannel's key in the index.
   // TODO(roth): Is this right?  This does prevent us from needlessly
@@ -1025,8 +1025,8 @@ void GrpcLb::BalancerCallState::OnInitialRequestSent(void* arg,
       GRPC_ERROR_REF(error));
 }
 
-void GrpcLb::BalancerCallState::OnInitialRequestSentLocked(void* arg,
-                                                           grpc_error* error) {
+void GrpcLb::BalancerCallState::OnInitialRequestSentLocked(
+    void* arg, grpc_error* /*error*/) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   grpc_byte_buffer_destroy(lb_calld->send_message_payload_);
   lb_calld->send_message_payload_ = nullptr;
@@ -1050,7 +1050,7 @@ void GrpcLb::BalancerCallState::OnBalancerMessageReceived(void* arg,
 }
 
 void GrpcLb::BalancerCallState::OnBalancerMessageReceivedLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   GrpcLb* grpclb_policy = lb_calld->grpclb_policy();
   // Null payload means the LB call was cancelled.
@@ -1547,7 +1547,7 @@ void GrpcLb::OnBalancerChannelConnectivityChanged(void* arg,
 }
 
 void GrpcLb::OnBalancerChannelConnectivityChangedLocked(void* arg,
-                                                        grpc_error* error) {
+                                                        grpc_error* /*error*/) {
   GrpcLb* self = static_cast<GrpcLb*>(arg);
   if (!self->shutting_down_ && self->fallback_at_startup_checks_pending_) {
     if (self->lb_channel_connectivity_ != GRPC_CHANNEL_TRANSIENT_FAILURE) {

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
@@ -25,7 +25,7 @@
 namespace grpc_core {
 
 grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
-    const ServerAddressList& addresses, grpc_channel_args* args) {
+    const ServerAddressList& /*addresses*/, grpc_channel_args* args) {
   return args;
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -112,7 +112,7 @@ class PickFirst : public LoadBalancingPolicy {
     explicit Picker(RefCountedPtr<SubchannelInterface> subchannel)
         : subchannel_(std::move(subchannel)) {}
 
-    PickResult Pick(PickArgs args) override {
+    PickResult Pick(PickArgs /*args*/) override {
       PickResult result;
       result.type = PickResult::PICK_COMPLETE;
       result.subchannel = subchannel_;
@@ -490,7 +490,7 @@ class PickFirstFactory : public LoadBalancingPolicyFactory {
   const char* name() const override { return kPickFirst; }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const grpc_json* json, grpc_error** error) const override {
+      const grpc_json* json, grpc_error** /*error*/) const override {
     if (json != nullptr) {
       GPR_DEBUG_ASSERT(strcmp(json->key, name()) == 0);
     }

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -204,7 +204,7 @@ RoundRobin::Picker::Picker(RoundRobin* parent,
   }
 }
 
-RoundRobin::PickResult RoundRobin::Picker::Pick(PickArgs args) {
+RoundRobin::PickResult RoundRobin::Picker::Pick(PickArgs /*args*/) {
   last_picked_index_ = (last_picked_index_ + 1) % subchannels_.size();
   if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_round_robin_trace)) {
     gpr_log(GPR_INFO,
@@ -486,7 +486,7 @@ class RoundRobinFactory : public LoadBalancingPolicyFactory {
   const char* name() const override { return kRoundRobin; }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const grpc_json* json, grpc_error** error) const override {
+      const grpc_json* json, grpc_error** /*error*/) const override {
     if (json != nullptr) {
       GPR_DEBUG_ASSERT(strcmp(json->key, name()) == 0);
     }

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -267,7 +267,8 @@ void SubchannelData<SubchannelListType, SubchannelDataType>::Watcher::
 template <typename SubchannelListType, typename SubchannelDataType>
 SubchannelData<SubchannelListType, SubchannelDataType>::SubchannelData(
     SubchannelList<SubchannelListType, SubchannelDataType>* subchannel_list,
-    const ServerAddress& address, RefCountedPtr<SubchannelInterface> subchannel)
+    const ServerAddress& /*address*/,
+    RefCountedPtr<SubchannelInterface> subchannel)
     : subchannel_list_(subchannel_list),
       subchannel_(std::move(subchannel)),
       // We assume that the current state is IDLE.  If not, we'll get a
@@ -281,7 +282,7 @@ SubchannelData<SubchannelListType, SubchannelDataType>::~SubchannelData() {
 
 template <typename SubchannelListType, typename SubchannelDataType>
 void SubchannelData<SubchannelListType, SubchannelDataType>::
-    UnrefSubchannelLocked(const char* reason) {
+    UnrefSubchannelLocked(const char* /*reason*/) {
   if (subchannel_ != nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(*subchannel_list_->tracer())) {
       gpr_log(GPR_INFO,

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -479,8 +479,8 @@ LoadBalancingPolicy::PickResult XdsLb::EndpointPickerWrapper::Pick(
   result.recv_trailing_metadata_ready =
       // Note: This callback does not run in either the control plane
       // combiner or in the data plane mutex.
-      [locality_stats](grpc_error* error, MetadataInterface* metadata,
-                       CallState* call_state) {
+      [locality_stats](grpc_error* error, MetadataInterface* /*metadata*/,
+                       CallState* /*call_state*/) {
         const bool call_failed = error != GRPC_ERROR_NONE;
         locality_stats->AddCallFinished(call_failed);
         locality_stats->Unref(DEBUG_LOCATION, "LocalityStats+call");

--- a/src/core/ext/filters/client_channel/local_subchannel_pool.cc
+++ b/src/core/ext/filters/client_channel/local_subchannel_pool.cc
@@ -62,26 +62,26 @@ Subchannel* LocalSubchannelPool::FindSubchannel(SubchannelKey* key) {
 
 namespace {
 
-void sck_avl_destroy(void* p, void* user_data) {
+void sck_avl_destroy(void* p, void* /*user_data*/) {
   SubchannelKey* key = static_cast<SubchannelKey*>(p);
   Delete(key);
 }
 
-void* sck_avl_copy(void* p, void* unused) {
+void* sck_avl_copy(void* p, void* /*unused*/) {
   const SubchannelKey* key = static_cast<const SubchannelKey*>(p);
   auto new_key = New<SubchannelKey>(*key);
   return static_cast<void*>(new_key);
 }
 
-long sck_avl_compare(void* a, void* b, void* unused) {
+long sck_avl_compare(void* a, void* b, void* /*unused*/) {
   const SubchannelKey* key_a = static_cast<const SubchannelKey*>(a);
   const SubchannelKey* key_b = static_cast<const SubchannelKey*>(b);
   return key_a->Cmp(*key_b);
 }
 
-void scv_avl_destroy(void* p, void* user_data) {}
+void scv_avl_destroy(void* /*p*/, void* /*user_data*/) {}
 
-void* scv_avl_copy(void* p, void* unused) { return p; }
+void* scv_avl_copy(void* p, void* /*unused*/) { return p; }
 
 }  // namespace
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -451,7 +451,7 @@ void AresDnsResolver::StartResolvingLocked() {
 
 class AresDnsResolverFactory : public ResolverFactory {
  public:
-  bool IsValidUri(const grpc_uri* uri) const override { return true; }
+  bool IsValidUri(const grpc_uri* /*uri*/) const override { return true; }
 
   OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
     return MakeOrphanable<AresDnsResolver>(std::move(args));

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
@@ -138,7 +138,7 @@ static void on_timeout_locked(void* arg, grpc_error* error);
 static void on_ares_backup_poll_alarm(void* arg, grpc_error* error);
 static void on_ares_backup_poll_alarm_locked(void* arg, grpc_error* error);
 
-static void noop_inject_channel_config(ares_channel channel) {}
+static void noop_inject_channel_config(ares_channel /*channel*/) {}
 
 void (*grpc_ares_test_only_inject_config)(ares_channel channel) =
     noop_inject_channel_config;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -90,14 +90,14 @@ class GrpcPolledFdFactoryPosix : public GrpcPolledFdFactory {
  public:
   GrpcPolledFd* NewGrpcPolledFdLocked(ares_socket_t as,
                                       grpc_pollset_set* driver_pollset_set,
-                                      Combiner* combiner) override {
+                                      Combiner* /*combiner*/) override {
     return New<GrpcPolledFdPosix>(as, driver_pollset_set);
   }
 
-  void ConfigureAresChannelLocked(ares_channel channel) override {}
+  void ConfigureAresChannelLocked(ares_channel /*channel*/) override {}
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner) {
+UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* /*combiner*/) {
   return MakeUnique<GrpcPolledFdFactoryPosix>();
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -175,7 +175,7 @@ static void destroy_hostbyname_request_locked(
   gpr_free(hr);
 }
 
-static void on_hostbyname_done_locked(void* arg, int status, int timeouts,
+static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
                                       struct hostent* hostent) {
   grpc_ares_hostbyname_request* hr =
       static_cast<grpc_ares_hostbyname_request*>(arg);
@@ -248,7 +248,7 @@ static void on_hostbyname_done_locked(void* arg, int status, int timeouts,
   destroy_hostbyname_request_locked(hr);
 }
 
-static void on_srv_query_done_locked(void* arg, int status, int timeouts,
+static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
                                      unsigned char* abuf, int alen) {
   grpc_ares_request* r = static_cast<grpc_ares_request*>(arg);
   if (status == ARES_SUCCESS) {
@@ -293,7 +293,7 @@ static void on_srv_query_done_locked(void* arg, int status, int timeouts,
 
 static const char g_service_config_attribute_prefix[] = "grpc_config=";
 
-static void on_txt_done_locked(void* arg, int status, int timeouts,
+static void on_txt_done_locked(void* arg, int status, int /*timeouts*/,
                                unsigned char* buf, int len) {
   char* error_msg;
   grpc_ares_request* r = static_cast<grpc_ares_request*>(arg);
@@ -579,8 +579,8 @@ static bool grpc_ares_maybe_resolve_localhost_manually_locked(
 }
 #else  /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
-    const char* name, const char* default_port,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs) {
+    const char* /*name*/, const char* /*default_port*/,
+    grpc_core::UniquePtr<grpc_core::ServerAddressList>* /*addrs*/) {
   return false;
 }
 #endif /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
@@ -728,7 +728,7 @@ static void on_dns_lookup_done(void* arg, grpc_error* error) {
 }
 
 static void grpc_resolve_address_invoke_dns_lookup_ares_locked(
-    void* arg, grpc_error* unused_error) {
+    void* arg, grpc_error* /*unused_error*/) {
   grpc_resolve_address_ares_request* r =
       static_cast<grpc_resolve_address_ares_request*>(arg);
   GRPC_CLOSURE_INIT(&r->on_dns_lookup_done_locked, on_dns_lookup_done, r,

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -159,7 +159,7 @@ void FakeResolver::MaybeSendResultLocked() {
   }
 }
 
-void FakeResolver::ReturnReresolutionResult(void* arg, grpc_error* error) {
+void FakeResolver::ReturnReresolutionResult(void* arg, grpc_error* /*error*/) {
   FakeResolver* self = static_cast<FakeResolver*>(arg);
   self->reresolution_closure_pending_ = false;
   self->MaybeSendResultLocked();
@@ -183,7 +183,7 @@ struct SetResponseClosureArg {
 };
 
 void FakeResolverResponseGenerator::SetResponseLocked(void* arg,
-                                                      grpc_error* error) {
+                                                      grpc_error* /*error*/) {
   SetResponseClosureArg* closure_arg = static_cast<SetResponseClosureArg*>(arg);
   auto& resolver = closure_arg->resolver;
   if (!resolver->shutdown_) {
@@ -215,7 +215,7 @@ void FakeResolverResponseGenerator::SetResponse(Resolver::Result result) {
 }
 
 void FakeResolverResponseGenerator::SetReresolutionResponseLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   SetResponseClosureArg* closure_arg = static_cast<SetResponseClosureArg*>(arg);
   auto& resolver = closure_arg->resolver;
   if (!resolver->shutdown_) {
@@ -259,7 +259,7 @@ void FakeResolverResponseGenerator::UnsetReresolutionResponse() {
 }
 
 void FakeResolverResponseGenerator::SetFailureLocked(void* arg,
-                                                     grpc_error* error) {
+                                                     grpc_error* /*error*/) {
   SetResponseClosureArg* closure_arg = static_cast<SetResponseClosureArg*>(arg);
   auto& resolver = closure_arg->resolver;
   if (!resolver->shutdown_) {
@@ -371,7 +371,7 @@ namespace {
 
 class FakeResolverFactory : public ResolverFactory {
  public:
-  bool IsValidUri(const grpc_uri* uri) const override { return true; }
+  bool IsValidUri(const grpc_uri* /*uri*/) const override { return true; }
 
   OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
     return MakeOrphanable<FakeResolver>(std::move(args));

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -78,7 +78,7 @@ void SockaddrResolver::StartLocked() {
 // Factory
 //
 
-void DoNothing(void* ignored) {}
+void DoNothing(void* /*ignored*/) {}
 
 bool ParseUri(const grpc_uri* uri,
               bool parse(const grpc_uri* uri, grpc_resolved_address* dst),
@@ -160,7 +160,7 @@ class UnixResolverFactory : public ResolverFactory {
     return CreateSockaddrResolver(std::move(args), grpc_parse_unix);
   }
 
-  UniquePtr<char> GetDefaultAuthority(grpc_uri* uri) const override {
+  UniquePtr<char> GetDefaultAuthority(grpc_uri* /*uri*/) const override {
     return UniquePtr<char>(gpr_strdup("localhost"));
   }
 

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -152,7 +152,8 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
     }
   }
 
-  void AddTraceEvent(TraceSeverity severity, StringView message) override {}
+  void AddTraceEvent(TraceSeverity /*severity*/,
+                     StringView /*message*/) override {}
 
   void set_child(LoadBalancingPolicy* child) { child_ = child; }
 

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -74,7 +74,7 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
   // No-op -- should never get updates from the channel.
   // TODO(roth): Need to support updating child LB policy's config for xds
   // use case.
-  void UpdateLocked(UpdateArgs args) override {}
+  void UpdateLocked(UpdateArgs /*args*/) override {}
 
   void ExitIdleLocked() override;
 

--- a/src/core/ext/filters/client_channel/retry_throttle.cc
+++ b/src/core/ext/filters/client_channel/retry_throttle.cc
@@ -118,27 +118,27 @@ void ServerRetryThrottleData::RecordSuccess() {
 
 namespace {
 
-void* copy_server_name(void* key, void* unused) {
+void* copy_server_name(void* key, void* /*unused*/) {
   return gpr_strdup(static_cast<const char*>(key));
 }
 
-long compare_server_name(void* key1, void* key2, void* unused) {
+long compare_server_name(void* key1, void* key2, void* /*unused*/) {
   return strcmp(static_cast<const char*>(key1), static_cast<const char*>(key2));
 }
 
-void destroy_server_retry_throttle_data(void* value, void* unused) {
+void destroy_server_retry_throttle_data(void* value, void* /*unused*/) {
   ServerRetryThrottleData* throttle_data =
       static_cast<ServerRetryThrottleData*>(value);
   throttle_data->Unref();
 }
 
-void* copy_server_retry_throttle_data(void* value, void* unused) {
+void* copy_server_retry_throttle_data(void* value, void* /*unused*/) {
   ServerRetryThrottleData* throttle_data =
       static_cast<ServerRetryThrottleData*>(value);
   return throttle_data->Ref().release();
 }
 
-void destroy_server_name(void* key, void* unused) { gpr_free(key); }
+void destroy_server_name(void* key, void* /*unused*/) { gpr_free(key); }
 
 const grpc_avl_vtable avl_vtable = {
     destroy_server_name, copy_server_name, compare_server_name,

--- a/src/core/ext/filters/client_channel/service_config.h
+++ b/src/core/ext/filters/client_channel/service_config.h
@@ -71,12 +71,16 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
 
     virtual UniquePtr<ParsedConfig> ParseGlobalParams(
         const grpc_json* /* json */, grpc_error** error) {
+      // Avoid unused parameter warning on debug-only parameter
+      (void)error;
       GPR_DEBUG_ASSERT(error != nullptr);
       return nullptr;
     }
 
     virtual UniquePtr<ParsedConfig> ParsePerMethodParams(
         const grpc_json* /* json */, grpc_error** error) {
+      // Avoid unused parameter warning on debug-only parameter
+      (void)error;
       GPR_DEBUG_ASSERT(error != nullptr);
       return nullptr;
     }

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -213,11 +213,12 @@ void SubchannelCall::Unref() {
   GRPC_CALL_STACK_UNREF(SUBCHANNEL_CALL_TO_CALL_STACK(this), "");
 }
 
-void SubchannelCall::Unref(const DebugLocation& location, const char* reason) {
+void SubchannelCall::Unref(const DebugLocation& /*location*/,
+                           const char* reason) {
   GRPC_CALL_STACK_UNREF(SUBCHANNEL_CALL_TO_CALL_STACK(this), reason);
 }
 
-void SubchannelCall::Destroy(void* arg, grpc_error* error) {
+void SubchannelCall::Destroy(void* arg, grpc_error* /*error*/) {
   GPR_TIMER_SCOPE("subchannel_call_destroy", 0);
   SubchannelCall* self = static_cast<SubchannelCall*>(arg);
   // Keep some members before destroying the subchannel call.
@@ -300,8 +301,8 @@ void SubchannelCall::IncrementRefCount() {
   GRPC_CALL_STACK_REF(SUBCHANNEL_CALL_TO_CALL_STACK(this), "");
 }
 
-void SubchannelCall::IncrementRefCount(const grpc_core::DebugLocation& location,
-                                       const char* reason) {
+void SubchannelCall::IncrementRefCount(
+    const grpc_core::DebugLocation& /*location*/, const char* reason) {
   GRPC_CALL_STACK_REF(SUBCHANNEL_CALL_TO_CALL_STACK(this), reason);
 }
 
@@ -721,7 +722,7 @@ Subchannel* Subchannel::WeakRef(GRPC_SUBCHANNEL_REF_EXTRA_ARGS) {
 
 namespace {
 
-void subchannel_destroy(void* arg, grpc_error* error) {
+void subchannel_destroy(void* arg, grpc_error* /*error*/) {
   Subchannel* self = static_cast<Subchannel*>(arg);
   Delete(self);
 }
@@ -739,7 +740,7 @@ void Subchannel::WeakUnref(GRPC_SUBCHANNEL_REF_EXTRA_ARGS) {
   }
 }
 
-Subchannel* Subchannel::RefFromWeakRef(GRPC_SUBCHANNEL_REF_EXTRA_ARGS) {
+Subchannel* Subchannel::RefFromWeakRef() {
   for (;;) {
     gpr_atm old_refs = gpr_atm_acq_load(&ref_pair_);
     if (old_refs >= (1 << INTERNAL_REF_BITS)) {
@@ -1008,7 +1009,7 @@ void Subchannel::OnConnectingFinished(void* arg, grpc_error* error) {
 
 namespace {
 
-void ConnectionDestroy(void* arg, grpc_error* error) {
+void ConnectionDestroy(void* arg, grpc_error* /*error*/) {
   grpc_channel_stack* stk = static_cast<grpc_channel_stack*>(arg);
   grpc_channel_stack_destroy(stk);
   gpr_free(stk);

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -43,8 +43,7 @@
 // For debugging refcounting.
 #ifndef NDEBUG
 #define GRPC_SUBCHANNEL_REF(p, r) (p)->Ref(__FILE__, __LINE__, (r))
-#define GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(p, r) \
-  (p)->RefFromWeakRef(__FILE__, __LINE__, (r))
+#define GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(p, r) (p)->RefFromWeakRef()
 #define GRPC_SUBCHANNEL_UNREF(p, r) (p)->Unref(__FILE__, __LINE__, (r))
 #define GRPC_SUBCHANNEL_WEAK_REF(p, r) (p)->WeakRef(__FILE__, __LINE__, (r))
 #define GRPC_SUBCHANNEL_WEAK_UNREF(p, r) (p)->WeakUnref(__FILE__, __LINE__, (r))
@@ -214,7 +213,7 @@ class Subchannel {
   // Attempts to return a strong ref when only the weak refcount is guaranteed
   // non-zero. If the strong refcount is zero, does not alter the refcount and
   // returns null.
-  Subchannel* RefFromWeakRef(GRPC_SUBCHANNEL_REF_EXTRA_ARGS);
+  Subchannel* RefFromWeakRef();
 
   // Gets the string representing the subchannel address.
   // Caller doesn't take ownership.

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -639,7 +639,7 @@ void XdsClient::ChannelState::AdsCallState::OnResponseReceived(
 }
 
 void XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   AdsCallState* ads_calld = static_cast<AdsCallState*>(arg);
   XdsClient* xds_client = ads_calld->xds_client();
   // Empty payload means the call was cancelled.
@@ -1086,7 +1086,7 @@ void XdsClient::ChannelState::LrsCallState::OnInitialRequestSent(
 }
 
 void XdsClient::ChannelState::LrsCallState::OnInitialRequestSentLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   LrsCallState* lrs_calld = static_cast<LrsCallState*>(arg);
   // Clear the send_message_payload_.
   grpc_byte_buffer_destroy(lrs_calld->send_message_payload_);
@@ -1105,7 +1105,7 @@ void XdsClient::ChannelState::LrsCallState::OnResponseReceived(
 }
 
 void XdsClient::ChannelState::LrsCallState::OnResponseReceivedLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   LrsCallState* lrs_calld = static_cast<LrsCallState*>(arg);
   XdsClient* xds_client = lrs_calld->xds_client();
   // Empty payload means the call was cancelled.
@@ -1289,17 +1289,17 @@ void XdsClient::Orphan() {
   Unref(DEBUG_LOCATION, "XdsClient::Orphan()");
 }
 
-void XdsClient::WatchClusterData(StringView cluster,
-                                 UniquePtr<ClusterWatcherInterface> watcher) {
+void XdsClient::WatchClusterData(
+    StringView /*cluster*/, UniquePtr<ClusterWatcherInterface> /*watcher*/) {
   // TODO(juanlishen): Implement.
 }
 
-void XdsClient::CancelClusterDataWatch(StringView cluster,
-                                       ClusterWatcherInterface* watcher) {
+void XdsClient::CancelClusterDataWatch(StringView /*cluster*/,
+                                       ClusterWatcherInterface* /*watcher*/) {
   // TODO(juanlishen): Implement.
 }
 
-void XdsClient::WatchEndpointData(StringView cluster,
+void XdsClient::WatchEndpointData(StringView /*cluster*/,
                                   UniquePtr<EndpointWatcherInterface> watcher) {
   EndpointWatcherInterface* w = watcher.get();
   cluster_state_.endpoint_watchers[w] = std::move(watcher);
@@ -1311,7 +1311,7 @@ void XdsClient::WatchEndpointData(StringView cluster,
   chand_->MaybeStartAdsCall();
 }
 
-void XdsClient::CancelEndpointDataWatch(StringView cluster,
+void XdsClient::CancelEndpointDataWatch(StringView /*cluster*/,
                                         EndpointWatcherInterface* watcher) {
   auto it = cluster_state_.endpoint_watchers.find(watcher);
   if (it != cluster_state_.endpoint_watchers.end()) {
@@ -1322,7 +1322,8 @@ void XdsClient::CancelEndpointDataWatch(StringView cluster,
   }
 }
 
-void XdsClient::AddClientStats(StringView lrs_server, StringView cluster,
+void XdsClient::AddClientStats(StringView /*lrs_server*/,
+                               StringView /*cluster*/,
                                XdsClientStats* client_stats) {
   // TODO(roth): When we add support for direct federation, use the
   // server name specified in lrs_server.
@@ -1330,7 +1331,8 @@ void XdsClient::AddClientStats(StringView lrs_server, StringView cluster,
   chand_->MaybeStartLrsCall();
 }
 
-void XdsClient::RemoveClientStats(StringView lrs_server, StringView cluster,
+void XdsClient::RemoveClientStats(StringView /*lrs_server*/,
+                                  StringView /*cluster*/,
                                   XdsClientStats* client_stats) {
   // TODO(roth): When we add support for direct federation, use the
   // server name specified in lrs_server.

--- a/src/core/ext/filters/client_idle/client_idle_filter.cc
+++ b/src/core/ext/filters/client_idle/client_idle_filter.cc
@@ -283,7 +283,8 @@ void ChannelData::DecreaseCallCount() {
 }
 
 ChannelData::ChannelData(grpc_channel_element* elem,
-                         grpc_channel_element_args* args, grpc_error** error)
+                         grpc_channel_element_args* args,
+                         grpc_error** /*error*/)
     : elem_(elem),
       channel_stack_(args->channel_stack),
       client_idle_timeout_(GetClientIdleTimeout(args->channel_args)) {
@@ -352,7 +353,7 @@ void ChannelData::IdleTimerCallback(void* arg, grpc_error* error) {
 }
 
 void ChannelData::IdleTransportOpCompleteCallback(void* arg,
-                                                  grpc_error* error) {
+                                                  grpc_error* /*error*/) {
   ChannelData* chand = static_cast<ChannelData*>(arg);
   GRPC_CHANNEL_STACK_UNREF(chand->channel_stack_, "idle transport op");
 }
@@ -389,15 +390,15 @@ class CallData {
 };
 
 grpc_error* CallData::Init(grpc_call_element* elem,
-                           const grpc_call_element_args* args) {
+                           const grpc_call_element_args* /*args*/) {
   ChannelData* chand = static_cast<ChannelData*>(elem->channel_data);
   chand->IncreaseCallCount();
   return GRPC_ERROR_NONE;
 }
 
 void CallData::Destroy(grpc_call_element* elem,
-                       const grpc_call_final_info* final_info,
-                       grpc_closure* ignored) {
+                       const grpc_call_final_info* /*final_info*/,
+                       grpc_closure* /*ignored*/) {
   ChannelData* chand = static_cast<ChannelData*>(elem->channel_data);
   chand->DecreaseCallCount();
 }
@@ -416,7 +417,7 @@ const grpc_channel_filter grpc_client_idle_filter = {
     "client_idle"};
 
 static bool MaybeAddClientIdleFilter(grpc_channel_stack_builder* builder,
-                                     void* arg) {
+                                     void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   if (!grpc_channel_args_want_minimal_stack(channel_args) &&

--- a/src/core/ext/filters/deadline/deadline_filter.cc
+++ b/src/core/ext/filters/deadline/deadline_filter.cc
@@ -38,7 +38,7 @@
 
 // The on_complete callback used when sending a cancel_error batch down the
 // filter stack.  Yields the call combiner when the batch returns.
-static void yield_call_combiner(void* arg, grpc_error* ignored) {
+static void yield_call_combiner(void* arg, grpc_error* /*ignored*/) {
   grpc_deadline_state* deadline_state = static_cast<grpc_deadline_state*>(arg);
   GRPC_CALL_COMBINER_STOP(deadline_state->call_combiner,
                           "got on_complete from cancel_stream batch");
@@ -233,14 +233,14 @@ void grpc_deadline_state_client_start_transport_stream_op_batch(
 //
 
 // Constructor for channel_data.  Used for both client and server filters.
-static grpc_error* deadline_init_channel_elem(grpc_channel_element* elem,
+static grpc_error* deadline_init_channel_elem(grpc_channel_element* /*elem*/,
                                               grpc_channel_element_args* args) {
   GPR_ASSERT(!args->is_last);
   return GRPC_ERROR_NONE;
 }
 
 // Destructor for channel_data.  Used for both client and server filters.
-static void deadline_destroy_channel_elem(grpc_channel_element* elem) {}
+static void deadline_destroy_channel_elem(grpc_channel_element* /*elem*/) {}
 
 // Call data used for both client and server filter.
 typedef struct base_call_data {
@@ -268,9 +268,9 @@ static grpc_error* deadline_init_call_elem(grpc_call_element* elem,
 }
 
 // Destructor for call_data.  Used for both client and server filters.
-static void deadline_destroy_call_elem(grpc_call_element* elem,
-                                       const grpc_call_final_info* final_info,
-                                       grpc_closure* ignored) {
+static void deadline_destroy_call_elem(
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   grpc_deadline_state* deadline_state =
       static_cast<grpc_deadline_state*>(elem->call_data);
   deadline_state->~grpc_deadline_state();

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -99,7 +99,7 @@ struct channel_data {
 };
 }  // namespace
 
-static grpc_error* client_filter_incoming_metadata(grpc_call_element* elem,
+static grpc_error* client_filter_incoming_metadata(grpc_call_element* /*elem*/,
                                                    grpc_metadata_batch* b) {
   if (b->idx.named.status != nullptr) {
     /* If both gRPC status and HTTP status are provided in the response, we
@@ -473,8 +473,8 @@ static grpc_error* http_client_init_call_elem(
 
 /* Destructor for call_data */
 static void http_client_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->~call_data();
 }

--- a/src/core/ext/filters/http/client_authority_filter.cc
+++ b/src/core/ext/filters/http/client_authority_filter.cc
@@ -80,9 +80,9 @@ grpc_error* client_authority_init_call_elem(
 }
 
 /* Destructor for call_data */
-void client_authority_destroy_call_elem(grpc_call_element* elem,
-                                        const grpc_call_final_info* final_info,
-                                        grpc_closure* ignored) {}
+void client_authority_destroy_call_elem(
+    grpc_call_element* /*elem*/, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {}
 
 /* Constructor for channel_data */
 grpc_error* client_authority_init_channel_elem(

--- a/src/core/ext/filters/http/message_compress/message_compress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.cc
@@ -361,7 +361,7 @@ static void on_send_message_next_done(void* arg, grpc_error* error) {
   }
 }
 
-static void start_send_message_batch(void* arg, grpc_error* unused) {
+static void start_send_message_batch(void* arg, grpc_error* /*unused*/) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(arg);
   if (skip_message_compression(elem)) {
     send_message_batch_continue(elem);
@@ -448,9 +448,9 @@ static grpc_error* compress_init_call_elem(grpc_call_element* elem,
 }
 
 /* Destructor for call_data */
-static void compress_destroy_call_elem(grpc_call_element* elem,
-                                       const grpc_call_final_info* final_info,
-                                       grpc_closure* ignored) {
+static void compress_destroy_call_elem(
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->~call_data();
 }
@@ -487,7 +487,7 @@ static grpc_error* compress_init_channel_elem(grpc_channel_element* elem,
 }
 
 /* Destructor for channel data */
-static void compress_destroy_channel_elem(grpc_channel_element* elem) {}
+static void compress_destroy_channel_elem(grpc_channel_element* /*elem*/) {}
 
 const grpc_channel_filter grpc_message_compress_filter = {
     compress_start_transport_stream_op_batch,

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -99,7 +99,7 @@ struct channel_data {
 
 }  // namespace
 
-static grpc_error* hs_filter_outgoing_metadata(grpc_call_element* elem,
+static grpc_error* hs_filter_outgoing_metadata(grpc_call_element* /*elem*/,
                                                grpc_metadata_batch* b) {
   if (b->idx.named.grpc_message != nullptr) {
     grpc_slice pct_encoded_msg = grpc_percent_encode_slice(
@@ -492,8 +492,8 @@ static grpc_error* hs_init_call_elem(grpc_call_element* elem,
 
 /* Destructor for call_data */
 static void hs_destroy_call_elem(grpc_call_element* elem,
-                                 const grpc_call_final_info* final_info,
-                                 grpc_closure* ignored) {
+                                 const grpc_call_final_info* /*final_info*/,
+                                 grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->~call_data();
 }
@@ -511,7 +511,7 @@ static grpc_error* hs_init_channel_elem(grpc_channel_element* elem,
 }
 
 /* Destructor for channel data */
-static void hs_destroy_channel_elem(grpc_channel_element* elem) {}
+static void hs_destroy_channel_elem(grpc_channel_element* /*elem*/) {}
 
 const grpc_channel_filter grpc_http_server_filter = {
     hs_start_transport_stream_op_batch,

--- a/src/core/ext/filters/max_age/max_age_filter.cc
+++ b/src/core/ext/filters/max_age/max_age_filter.cc
@@ -206,7 +206,7 @@ static void decrease_call_count(channel_data* chand) {
   }
 }
 
-static void start_max_idle_timer_after_init(void* arg, grpc_error* error) {
+static void start_max_idle_timer_after_init(void* arg, grpc_error* /*error*/) {
   channel_data* chand = static_cast<channel_data*>(arg);
   /* Decrease call_count. If there are no active calls at this time,
      max_idle_timer will start here. If the number of active calls is not 0,
@@ -257,7 +257,7 @@ class ConnectivityWatcher : public AsyncConnectivityStateWatcherInterface {
 
 }  // namespace grpc_core
 
-static void start_max_age_timer_after_init(void* arg, grpc_error* error) {
+static void start_max_age_timer_after_init(void* arg, grpc_error* /*error*/) {
   channel_data* chand = static_cast<channel_data*>(arg);
   gpr_mu_lock(&chand->max_age_timer_mu);
   chand->max_age_timer_pending = true;
@@ -276,7 +276,7 @@ static void start_max_age_timer_after_init(void* arg, grpc_error* error) {
 }
 
 static void start_max_age_grace_timer_after_goaway_op(void* arg,
-                                                      grpc_error* error) {
+                                                      grpc_error* /*error*/) {
   channel_data* chand = static_cast<channel_data*>(arg);
   gpr_mu_lock(&chand->max_age_timer_mu);
   chand->max_age_grace_timer_pending = true;
@@ -407,17 +407,17 @@ add_random_max_connection_age_jitter_and_convert_to_grpc_millis(int value) {
 }
 
 /* Constructor for call_data. */
-static grpc_error* max_age_init_call_elem(grpc_call_element* elem,
-                                          const grpc_call_element_args* args) {
+static grpc_error* max_age_init_call_elem(
+    grpc_call_element* elem, const grpc_call_element_args* /*args*/) {
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   increase_call_count(chand);
   return GRPC_ERROR_NONE;
 }
 
 /* Destructor for call_data. */
-static void max_age_destroy_call_elem(grpc_call_element* elem,
-                                      const grpc_call_final_info* final_info,
-                                      grpc_closure* ignored) {
+static void max_age_destroy_call_elem(
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   decrease_call_count(chand);
 }
@@ -527,7 +527,7 @@ const grpc_channel_filter grpc_max_age_filter = {
     "max_age"};
 
 static bool maybe_add_max_age_filter(grpc_channel_stack_builder* builder,
-                                     void* arg) {
+                                     void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   bool enable =

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -286,8 +286,8 @@ static grpc_error* message_size_init_call_elem(
 
 // Destructor for call_data.
 static void message_size_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   call_data* calld = (call_data*)elem->call_data;
   calld->~call_data();
 }
@@ -375,7 +375,7 @@ const grpc_channel_filter grpc_message_size_filter = {
 
 // Used for GRPC_CLIENT_SUBCHANNEL
 static bool maybe_add_message_size_filter_subchannel(
-    grpc_channel_stack_builder* builder, void* arg) {
+    grpc_channel_stack_builder* builder, void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   if (grpc_channel_args_want_minimal_stack(channel_args)) {
@@ -388,7 +388,7 @@ static bool maybe_add_message_size_filter_subchannel(
 // Used for GRPC_CLIENT_DIRECT_CHANNEL and GRPC_SERVER_CHANNEL. Adds the filter
 // only if message size limits or service config is specified.
 static bool maybe_add_message_size_filter(grpc_channel_stack_builder* builder,
-                                          void* arg) {
+                                          void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   bool enable = false;

--- a/src/core/ext/filters/workarounds/workaround_cronet_compression_filter.cc
+++ b/src/core/ext/filters/workarounds/workaround_cronet_compression_filter.cc
@@ -105,7 +105,7 @@ static void cronet_compression_start_transport_stream_op_batch(
 
 // Constructor for call_data.
 static grpc_error* cronet_compression_init_call_elem(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+    grpc_call_element* elem, const grpc_call_element_args* /*args*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->next_recv_initial_metadata_ready = nullptr;
   calld->workaround_active = false;
@@ -117,18 +117,18 @@ static grpc_error* cronet_compression_init_call_elem(
 
 // Destructor for call_data.
 static void cronet_compression_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {}
+    grpc_call_element* /*elem*/, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {}
 
 // Constructor for channel_data.
 static grpc_error* cronet_compression_init_channel_elem(
-    grpc_channel_element* elem, grpc_channel_element_args* args) {
+    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
 // Destructor for channel_data.
 static void cronet_compression_destroy_channel_elem(
-    grpc_channel_element* elem) {}
+    grpc_channel_element* /*elem*/) {}
 
 // Parse the user agent
 static bool parse_user_agent(grpc_mdelem md) {
@@ -183,7 +183,7 @@ const grpc_channel_filter grpc_workaround_cronet_compression_filter = {
     "workaround_cronet_compression"};
 
 static bool register_workaround_cronet_compression(
-    grpc_channel_stack_builder* builder, void* arg) {
+    grpc_channel_stack_builder* builder, void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   const grpc_arg* a = grpc_channel_args_find(

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -240,7 +240,7 @@ static void on_accept(void* arg, grpc_endpoint* tcp,
 }
 
 /* Server callback: start listening on our ports */
-static void server_start_listener(grpc_server* server, void* arg,
+static void server_start_listener(grpc_server* /*server*/, void* arg,
                                   grpc_pollset** pollsets,
                                   size_t pollset_count) {
   server_state* state = static_cast<server_state*>(arg);
@@ -276,7 +276,7 @@ static void tcp_server_shutdown_complete(void* arg, grpc_error* error) {
 
 /* Server callback: destroy the tcp listener (so we don't generate further
    callbacks) */
-static void server_destroy_listener(grpc_server* server, void* arg,
+static void server_destroy_listener(grpc_server* /*server*/, void* arg,
                                     grpc_closure* destroy_done) {
   server_state* state = static_cast<server_state*>(arg);
   gpr_mu_lock(&state->mu);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -525,7 +525,7 @@ grpc_chttp2_transport::grpc_chttp2_transport(
   post_benign_reclaimer(this);
 }
 
-static void destroy_transport_locked(void* tp, grpc_error* error) {
+static void destroy_transport_locked(void* tp, grpc_error* /*error*/) {
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(tp);
   t->destroying = 1;
   close_transport_locked(
@@ -718,7 +718,7 @@ static int init_stream(grpc_transport* gt, grpc_stream* gs,
   return 0;
 }
 
-static void destroy_stream_locked(void* sp, grpc_error* error) {
+static void destroy_stream_locked(void* sp, grpc_error* /*error*/) {
   GPR_TIMER_SCOPE("destroy_stream", 0);
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(sp);
   s->~grpc_chttp2_stream();
@@ -935,7 +935,7 @@ static const char* begin_writing_desc(bool partial) {
   }
 }
 
-static void write_action_begin_locked(void* gt, grpc_error* error_ignored) {
+static void write_action_begin_locked(void* gt, grpc_error* /*error_ignored*/) {
   GPR_TIMER_SCOPE("write_action_begin_locked", 0);
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(gt);
   GPR_ASSERT(t->write_state != GRPC_CHTTP2_WRITE_STATE_IDLE);
@@ -974,7 +974,7 @@ static void write_action_begin_locked(void* gt, grpc_error* error_ignored) {
   }
 }
 
-static void write_action(void* gt, grpc_error* error) {
+static void write_action(void* gt, grpc_error* /*error*/) {
   GPR_TIMER_SCOPE("write_action", 0);
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(gt);
   void* cl = t->cl;
@@ -1181,7 +1181,7 @@ static void null_then_sched_closure(grpc_closure** closure) {
 }
 
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
-                                       grpc_chttp2_stream* s,
+                                       grpc_chttp2_stream* /*s*/,
                                        grpc_closure** pclosure,
                                        grpc_error* error, const char* desc) {
   grpc_closure* closure = *pclosure;
@@ -1338,7 +1338,7 @@ static void log_metadata(const grpc_metadata_batch* md_batch, uint32_t id,
 }
 
 static void perform_stream_op_locked(void* stream_op,
-                                     grpc_error* error_ignored) {
+                                     grpc_error* /*error_ignored*/) {
   GPR_TIMER_SCOPE("perform_stream_op_locked", 0);
 
   grpc_transport_stream_op_batch* op =
@@ -1792,7 +1792,7 @@ void grpc_chttp2_add_ping_strike(grpc_chttp2_transport* t) {
 }
 
 static void perform_transport_op_locked(void* stream_op,
-                                        grpc_error* error_ignored) {
+                                        grpc_error* /*error_ignored*/) {
   grpc_transport_op* op = static_cast<grpc_transport_op*>(stream_op);
   grpc_chttp2_transport* t =
       static_cast<grpc_chttp2_transport*>(op->handler_private.extra_arg);
@@ -1854,8 +1854,8 @@ static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
  * INPUT PROCESSING - GENERAL
  */
 
-void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
-                                                      grpc_chttp2_stream* s) {
+void grpc_chttp2_maybe_complete_recv_initial_metadata(
+    grpc_chttp2_transport* /*t*/, grpc_chttp2_stream* s) {
   if (s->recv_initial_metadata_ready != nullptr &&
       s->published_metadata[0] != GRPC_METADATA_NOT_PUBLISHED) {
     if (s->seen_error) {
@@ -1871,7 +1871,7 @@ void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
   }
 }
 
-void grpc_chttp2_maybe_complete_recv_message(grpc_chttp2_transport* t,
+void grpc_chttp2_maybe_complete_recv_message(grpc_chttp2_transport* /*t*/,
                                              grpc_chttp2_stream* s) {
   grpc_error* error = GRPC_ERROR_NONE;
   if (s->recv_message_ready != nullptr) {
@@ -2400,7 +2400,7 @@ typedef struct {
   grpc_chttp2_transport* t;
 } cancel_stream_cb_args;
 
-static void cancel_stream_cb(void* user_data, uint32_t key, void* stream) {
+static void cancel_stream_cb(void* user_data, uint32_t /*key*/, void* stream) {
   cancel_stream_cb_args* args = static_cast<cancel_stream_cb_args*>(user_data);
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(stream);
   grpc_chttp2_cancel_stream(args->t, s, GRPC_ERROR_REF(args->error));
@@ -2909,13 +2909,13 @@ static void connectivity_state_set(grpc_chttp2_transport* t,
  * POLLSET STUFF
  */
 
-static void set_pollset(grpc_transport* gt, grpc_stream* gs,
+static void set_pollset(grpc_transport* gt, grpc_stream* /*gs*/,
                         grpc_pollset* pollset) {
   grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
   grpc_endpoint_add_to_pollset(t->ep, pollset);
 }
 
-static void set_pollset_set(grpc_transport* gt, grpc_stream* gs,
+static void set_pollset_set(grpc_transport* gt, grpc_stream* /*gs*/,
                             grpc_pollset_set* pollset_set) {
   grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
   grpc_endpoint_add_to_pollset_set(t->ep, pollset_set);
@@ -2957,7 +2957,7 @@ Chttp2IncomingByteStream::Chttp2IncomingByteStream(
 }
 
 void Chttp2IncomingByteStream::OrphanLocked(void* arg,
-                                            grpc_error* error_ignored) {
+                                            grpc_error* /*error_ignored*/) {
   Chttp2IncomingByteStream* bs = static_cast<Chttp2IncomingByteStream*>(arg);
   grpc_chttp2_stream* s = bs->stream_;
   grpc_chttp2_transport* t = s->t;
@@ -2976,7 +2976,7 @@ void Chttp2IncomingByteStream::Orphan() {
 }
 
 void Chttp2IncomingByteStream::NextLocked(void* arg,
-                                          grpc_error* error_ignored) {
+                                          grpc_error* /*error_ignored*/) {
   Chttp2IncomingByteStream* bs = static_cast<Chttp2IncomingByteStream*>(arg);
   grpc_chttp2_transport* t = bs->transport_;
   grpc_chttp2_stream* s = bs->stream_;

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -40,10 +40,9 @@ grpc_chttp2_data_parser::~grpc_chttp2_data_parser() {
   GRPC_ERROR_UNREF(error);
 }
 
-grpc_error* grpc_chttp2_data_parser_begin_frame(grpc_chttp2_data_parser* parser,
-                                                uint8_t flags,
-                                                uint32_t stream_id,
-                                                grpc_chttp2_stream* s) {
+grpc_error* grpc_chttp2_data_parser_begin_frame(
+    grpc_chttp2_data_parser* /*parser*/, uint8_t flags, uint32_t stream_id,
+    grpc_chttp2_stream* s) {
   if (flags & ~GRPC_CHTTP2_DATA_FLAG_END_STREAM) {
     char* msg;
     gpr_asprintf(&msg, "unsupported data flags: 0x%02x", flags);
@@ -279,7 +278,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error* grpc_chttp2_data_parser_parse(void* parser,
+grpc_error* grpc_chttp2_data_parser_parse(void* /*parser*/,
                                           grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s,
                                           const grpc_slice& slice,

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -37,7 +37,7 @@ void grpc_chttp2_goaway_parser_destroy(grpc_chttp2_goaway_parser* p) {
 
 grpc_error* grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
                                                   uint32_t length,
-                                                  uint8_t flags) {
+                                                  uint8_t /*flags*/) {
   if (length < 8) {
     char* msg;
     gpr_asprintf(&msg, "goaway frame too short (%d bytes)", length);
@@ -56,7 +56,7 @@ grpc_error* grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
 
 grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
                                             grpc_chttp2_transport* t,
-                                            grpc_chttp2_stream* s,
+                                            grpc_chttp2_stream* /*s*/,
                                             const grpc_slice& slice,
                                             int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -72,7 +72,7 @@ grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,
 
 grpc_error* grpc_chttp2_ping_parser_parse(void* parser,
                                           grpc_chttp2_transport* t,
-                                          grpc_chttp2_stream* s,
+                                          grpc_chttp2_stream* /*s*/,
                                           const grpc_slice& slice,
                                           int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -110,7 +110,7 @@ grpc_error* grpc_chttp2_settings_parser_begin_frame(
 }
 
 grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
-                                              grpc_chttp2_stream* s,
+                                              grpc_chttp2_stream* /*s*/,
                                               const grpc_slice& slice,
                                               int is_last) {
   grpc_chttp2_settings_parser* parser =

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -224,7 +224,7 @@ static void UpdateAddOrEvict(Hashtable hashtable, const ValueType& value,
 }
 
 /* halve all counts because an element reached max */
-static void HalveFilter(uint8_t idx, uint32_t* sum, uint8_t* elems) {
+static void HalveFilter(uint8_t /*idx*/, uint32_t* sum, uint8_t* elems) {
   *sum = 0;
   for (int i = 0; i < GRPC_CHTTP2_HPACKC_NUM_VALUES; i++) {
     elems[i] /= 2;
@@ -452,8 +452,8 @@ static void add_key(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
   }
 }
 
-static void emit_indexed(grpc_chttp2_hpack_compressor* c, uint32_t elem_index,
-                         framer_state* st) {
+static void emit_indexed(grpc_chttp2_hpack_compressor* /*c*/,
+                         uint32_t elem_index, framer_state* st) {
   GRPC_STATS_INC_HPACK_SEND_INDEXED();
   uint32_t len = GRPC_CHTTP2_VARINT_LENGTH(elem_index, 1);
   GRPC_CHTTP2_WRITE_VARINT(elem_index, 1, 0x80, add_tiny_header_data(st, len),
@@ -511,7 +511,7 @@ enum class EmitLitHdrVType { INC_IDX_V, NO_IDX_V };
 }  // namespace
 
 template <EmitLitHdrType type>
-static void emit_lithdr(grpc_chttp2_hpack_compressor* c, uint32_t key_index,
+static void emit_lithdr(grpc_chttp2_hpack_compressor* /*c*/, uint32_t key_index,
                         grpc_mdelem elem, framer_state* st) {
   switch (type) {
     case EmitLitHdrType::INC_IDX:
@@ -549,7 +549,7 @@ static void emit_lithdr(grpc_chttp2_hpack_compressor* c, uint32_t key_index,
 }
 
 template <EmitLitHdrVType type>
-static void emit_lithdr_v(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
+static void emit_lithdr_v(grpc_chttp2_hpack_compressor* /*c*/, grpc_mdelem elem,
                           framer_state* st) {
   switch (type) {
     case EmitLitHdrVType::INC_IDX_V:

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -659,7 +659,7 @@ static grpc_error* on_hdr(grpc_chttp2_hpack_parser* p, grpc_mdelem md) {
 }
 
 static grpc_core::UnmanagedMemorySlice take_string_extern(
-    grpc_chttp2_hpack_parser* p, grpc_chttp2_hpack_parser_string* str) {
+    grpc_chttp2_hpack_parser* /*p*/, grpc_chttp2_hpack_parser_string* str) {
   grpc_core::UnmanagedMemorySlice s;
   if (!str->copied) {
     GPR_DEBUG_ASSERT(!grpc_slice_is_interned(str->data.referenced));
@@ -675,7 +675,7 @@ static grpc_core::UnmanagedMemorySlice take_string_extern(
 }
 
 static grpc_core::ManagedMemorySlice take_string_intern(
-    grpc_chttp2_hpack_parser* p, grpc_chttp2_hpack_parser_string* str) {
+    grpc_chttp2_hpack_parser* /*p*/, grpc_chttp2_hpack_parser_string* str) {
   grpc_core::ManagedMemorySlice s;
   if (!str->copied) {
     s = grpc_core::ManagedMemorySlice(&str->data.referenced);
@@ -811,11 +811,11 @@ static grpc_error* parse_indexed_field_x(grpc_chttp2_hpack_parser* p,
    cached metadata corresponds with the index we are examining. */
 static grpc_mdelem get_precomputed_md_for_idx(grpc_chttp2_hpack_parser* p) {
   GPR_DEBUG_ASSERT(p->md_for_index.payload != 0);
-  GPR_DEBUG_ASSERT(static_cast<int64_t>(p->index) == p->precomputed_md_index);
   grpc_mdelem md = p->md_for_index;
   GPR_DEBUG_ASSERT(!GRPC_MDISNULL(md)); /* handled in string parsing */
   p->md_for_index.payload = 0; /* Invalidate cached md when index changes. */
 #ifndef NDEBUG
+  GPR_DEBUG_ASSERT(static_cast<int64_t>(p->index) == p->precomputed_md_index);
   p->precomputed_md_index = -1;
 #endif
   return md;
@@ -1067,8 +1067,9 @@ static grpc_error* parse_max_tbl_size_x(grpc_chttp2_hpack_parser* p,
 }
 
 /* a parse error: jam the parse state into parse_error, and return error */
-static grpc_error* parse_error(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
-                               const uint8_t* end, grpc_error* err) {
+static grpc_error* parse_error(grpc_chttp2_hpack_parser* p,
+                               const uint8_t* /*cur*/, const uint8_t* /*end*/,
+                               grpc_error* err) {
   GPR_ASSERT(err != GRPC_ERROR_NONE);
   if (p->last_error == GRPC_ERROR_NONE) {
     p->last_error = GRPC_ERROR_REF(err);
@@ -1078,7 +1079,8 @@ static grpc_error* parse_error(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
 }
 
 static grpc_error* still_parse_error(grpc_chttp2_hpack_parser* p,
-                                     const uint8_t* cur, const uint8_t* end) {
+                                     const uint8_t* /*cur*/,
+                                     const uint8_t* /*end*/) {
   return GRPC_ERROR_REF(p->last_error);
 }
 
@@ -1541,9 +1543,9 @@ static bool is_binary_literal_header(grpc_chttp2_hpack_parser* p) {
 static void set_precomputed_md_idx(grpc_chttp2_hpack_parser* p,
                                    grpc_mdelem md) {
   GPR_DEBUG_ASSERT(p->md_for_index.payload == 0);
-  GPR_DEBUG_ASSERT(p->precomputed_md_index == -1);
   p->md_for_index = md;
 #ifndef NDEBUG
+  GPR_DEBUG_ASSERT(p->precomputed_md_index == -1);
   p->precomputed_md_index = p->index;
 #endif
 }
@@ -1593,7 +1595,8 @@ static grpc_error* parse_value_string_with_literal_key(
 }
 
 /* "Uninitialized" header parser to save us a branch in on_hdr().  */
-static grpc_error* on_header_uninitialized(void* user_data, grpc_mdelem md) {
+static grpc_error* on_header_uninitialized(void* /*user_data*/,
+                                           grpc_mdelem md) {
   GRPC_MDELEM_UNREF(md);
   return GRPC_ERROR_CREATE_FROM_STATIC_STRING("on_header callback not set");
 }
@@ -1666,7 +1669,7 @@ static const maybe_complete_func_type maybe_complete_funcs[] = {
     grpc_chttp2_maybe_complete_recv_initial_metadata,
     grpc_chttp2_maybe_complete_recv_trailing_metadata};
 
-static void force_client_rst_stream(void* sp, grpc_error* error) {
+static void force_client_rst_stream(void* sp, grpc_error* /*error*/) {
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(sp);
   grpc_chttp2_transport* t = s->t;
   if (!s->write_closed) {
@@ -1678,7 +1681,7 @@ static void force_client_rst_stream(void* sp, grpc_error* error) {
   GRPC_CHTTP2_STREAM_UNREF(s, "final_rst");
 }
 
-static void parse_stream_compression_md(grpc_chttp2_transport* t,
+static void parse_stream_compression_md(grpc_chttp2_transport* /*t*/,
                                         grpc_chttp2_stream* s,
                                         grpc_metadata_batch* initial_metadata) {
   if (initial_metadata->idx.named.content_encoding == nullptr ||

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -312,13 +312,13 @@ static grpc_error* init_frame_parser(grpc_chttp2_transport* t) {
   }
 }
 
-static grpc_error* skip_parser(void* parser, grpc_chttp2_transport* t,
-                               grpc_chttp2_stream* s, const grpc_slice& slice,
-                               int is_last) {
+static grpc_error* skip_parser(void* /*parser*/, grpc_chttp2_transport* /*t*/,
+                               grpc_chttp2_stream* /*s*/,
+                               const grpc_slice& /*slice*/, int /*is_last*/) {
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error* skip_header(void* tp, grpc_mdelem md) {
+static grpc_error* skip_header(void* /*tp*/, grpc_mdelem md) {
   GRPC_MDELEM_UNREF(md);
   return GRPC_ERROR_NONE;
 }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -176,7 +176,7 @@ static void report_stall(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 }
 
 /* How many bytes would we like to put on the wire during a single syscall */
-static uint32_t target_write_size(grpc_chttp2_transport* t) {
+static uint32_t target_write_size(grpc_chttp2_transport* /*t*/) {
   return 1024 * 1024;
 }
 

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -900,7 +900,7 @@ bool cancel_stream_locked(inproc_stream* s, grpc_error* error) {
   return ret;
 }
 
-void do_nothing(void* arg, grpc_error* error) {}
+void do_nothing(void* /*arg*/, grpc_error* /*error*/) {}
 
 void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
                        grpc_transport_stream_op_batch* op) {
@@ -1140,7 +1140,7 @@ void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   gpr_mu_unlock(&t->mu->mu);
 }
 
-void destroy_stream(grpc_transport* gt, grpc_stream* gs,
+void destroy_stream(grpc_transport* /*gt*/, grpc_stream* gs,
                     grpc_closure* then_schedule_closure) {
   INPROC_LOG(GPR_INFO, "destroy_stream %p %p", gs, then_schedule_closure);
   inproc_stream* s = reinterpret_cast<inproc_stream*>(gs);
@@ -1162,16 +1162,17 @@ void destroy_transport(grpc_transport* gt) {
  * INTEGRATION GLUE
  */
 
-void set_pollset(grpc_transport* gt, grpc_stream* gs, grpc_pollset* pollset) {
+void set_pollset(grpc_transport* /*gt*/, grpc_stream* /*gs*/,
+                 grpc_pollset* /*pollset*/) {
   // Nothing to do here
 }
 
-void set_pollset_set(grpc_transport* gt, grpc_stream* gs,
-                     grpc_pollset_set* pollset_set) {
+void set_pollset_set(grpc_transport* /*gt*/, grpc_stream* /*gs*/,
+                     grpc_pollset_set* /*pollset_set*/) {
   // Nothing to do here
 }
 
-grpc_endpoint* get_endpoint(grpc_transport* t) { return nullptr; }
+grpc_endpoint* get_endpoint(grpc_transport* /*t*/) { return nullptr; }
 
 const grpc_transport_vtable inproc_vtable = {
     sizeof(inproc_stream), "inproc",        init_stream,
@@ -1183,9 +1184,9 @@ const grpc_transport_vtable inproc_vtable = {
  * Main inproc transport functions
  */
 void inproc_transports_create(grpc_transport** server_transport,
-                              const grpc_channel_args* server_args,
+                              const grpc_channel_args* /*server_args*/,
                               grpc_transport** client_transport,
-                              const grpc_channel_args* client_args) {
+                              const grpc_channel_args* /*client_args*/) {
   INPROC_LOG(GPR_INFO, "inproc_transports_create");
   shared_mu* mu = new (gpr_malloc(sizeof(*mu))) shared_mu();
   inproc_transport* st = new (gpr_malloc(sizeof(*st)))
@@ -1221,7 +1222,7 @@ void grpc_inproc_transport_init(void) {
 
 grpc_channel* grpc_inproc_channel_create(grpc_server* server,
                                          grpc_channel_args* args,
-                                         void* reserved) {
+                                         void* /*reserved*/) {
   GRPC_API_TRACE("grpc_inproc_channel_create(server=%p, args=%p)", 2,
                  (server, args));
 

--- a/src/core/lib/avl/avl.cc
+++ b/src/core/lib/avl/avl.cc
@@ -294,7 +294,7 @@ grpc_avl grpc_avl_remove(grpc_avl avl, void* key, void* user_data) {
   return avl;
 }
 
-grpc_avl grpc_avl_ref(grpc_avl avl, void* user_data) {
+grpc_avl grpc_avl_ref(grpc_avl avl, void* /*user_data*/) {
   ref_node(avl.root);
   return avl;
 }

--- a/src/core/lib/channel/channel_stack.cc
+++ b/src/core/lib/channel/channel_stack.cc
@@ -203,7 +203,7 @@ void grpc_call_stack_set_pollset_or_pollset_set(grpc_call_stack* call_stack,
 }
 
 void grpc_call_stack_ignore_set_pollset_or_pollset_set(
-    grpc_call_element* elem, grpc_polling_entity* pollent) {}
+    grpc_call_element* /*elem*/, grpc_polling_entity* /*pollent*/) {}
 
 void grpc_call_stack_destroy(grpc_call_stack* stack,
                              const grpc_call_final_info* final_info,

--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -235,13 +235,25 @@ void grpc_call_stack_set_pollset_or_pollset_set(grpc_call_stack* call_stack,
   grpc_stream_unref(&(channel_stack)->refcount, reason)
 #else
 #define GRPC_CALL_STACK_REF(call_stack, reason) \
-  grpc_stream_ref(&(call_stack)->refcount)
+  do {                                          \
+    grpc_stream_ref(&(call_stack)->refcount);   \
+    (void)(reason);                             \
+  } while (0);
 #define GRPC_CALL_STACK_UNREF(call_stack, reason) \
-  grpc_stream_unref(&(call_stack)->refcount)
+  do {                                            \
+    grpc_stream_unref(&(call_stack)->refcount);   \
+    (void)(reason);                               \
+  } while (0);
 #define GRPC_CHANNEL_STACK_REF(channel_stack, reason) \
-  grpc_stream_ref(&(channel_stack)->refcount)
+  do {                                                \
+    grpc_stream_ref(&(channel_stack)->refcount);      \
+    (void)(reason);                                   \
+  } while (0);
 #define GRPC_CHANNEL_STACK_UNREF(channel_stack, reason) \
-  grpc_stream_unref(&(channel_stack)->refcount)
+  do {                                                  \
+    grpc_stream_unref(&(channel_stack)->refcount);      \
+    (void)(reason);                                     \
+  } while (0);
 #endif
 
 /* Destroy a call stack */

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -54,7 +54,7 @@ namespace channelz {
 namespace {
 
 void* parent_uuid_copy(void* p) { return p; }
-void parent_uuid_destroy(void* p) {}
+void parent_uuid_destroy(void* /*p*/) {}
 int parent_uuid_cmp(void* p1, void* p2) { return GPR_ICMP(p1, p2); }
 const grpc_arg_pointer_vtable parent_uuid_vtable = {
     parent_uuid_copy, parent_uuid_destroy, parent_uuid_cmp};
@@ -315,7 +315,7 @@ void ChannelNode::RemoveChildSubchannel(intptr_t child_uuid) {
 // ServerNode
 //
 
-ServerNode::ServerNode(grpc_server* server, size_t channel_tracer_max_nodes)
+ServerNode::ServerNode(grpc_server* /*server*/, size_t channel_tracer_max_nodes)
     : BaseNode(EntityType::kServer, /* name */ nullptr),
       trace_(channel_tracer_max_nodes) {}
 

--- a/src/core/lib/channel/connected_channel.cc
+++ b/src/core/lib/channel/connected_channel.cc
@@ -167,7 +167,7 @@ static void set_pollset_or_pollset_set(grpc_call_element* elem,
 
 /* Destructor for call_data */
 static void connected_channel_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
     grpc_closure* then_schedule_closure) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
@@ -195,7 +195,8 @@ static void connected_channel_destroy_channel_elem(grpc_channel_element* elem) {
 
 /* No-op. */
 static void connected_channel_get_channel_info(
-    grpc_channel_element* elem, const grpc_channel_info* channel_info) {}
+    grpc_channel_element* /*elem*/, const grpc_channel_info* /*channel_info*/) {
+}
 
 const grpc_channel_filter grpc_connected_filter = {
     connected_channel_start_transport_stream_op_batch,

--- a/src/core/lib/compression/message_compress.cc
+++ b/src/core/lib/compression/message_compress.cc
@@ -80,11 +80,12 @@ error:
   return 0;
 }
 
-static void* zalloc_gpr(void* opaque, unsigned int items, unsigned int size) {
+static void* zalloc_gpr(void* /*opaque*/, unsigned int items,
+                        unsigned int size) {
   return gpr_malloc(items * size);
 }
 
-static void zfree_gpr(void* opaque, void* address) { gpr_free(address); }
+static void zfree_gpr(void* /*opaque*/, void* address) { gpr_free(address); }
 
 static int zlib_compress(grpc_slice_buffer* input, grpc_slice_buffer* output,
                          int gzip) {

--- a/src/core/lib/compression/stream_compression_identity.cc
+++ b/src/core/lib/compression/stream_compression_identity.cc
@@ -47,12 +47,10 @@ static void grpc_stream_compression_pass_through(grpc_slice_buffer* in,
   }
 }
 
-static bool grpc_stream_compress_identity(grpc_stream_compression_context* ctx,
-                                          grpc_slice_buffer* in,
-                                          grpc_slice_buffer* out,
-                                          size_t* output_size,
-                                          size_t max_output_size,
-                                          grpc_stream_compression_flush flush) {
+static bool grpc_stream_compress_identity(
+    grpc_stream_compression_context* ctx, grpc_slice_buffer* in,
+    grpc_slice_buffer* out, size_t* output_size, size_t max_output_size,
+    grpc_stream_compression_flush /*flush*/) {
   if (ctx == nullptr) {
     return false;
   }
@@ -84,7 +82,7 @@ grpc_stream_compression_context_create_identity(
 }
 
 static void grpc_stream_compression_context_destroy_identity(
-    grpc_stream_compression_context* ctx) {
+    grpc_stream_compression_context* /*ctx*/) {
   return;
 }
 

--- a/src/core/lib/debug/trace.h
+++ b/src/core/lib/debug/trace.h
@@ -116,12 +116,13 @@ typedef TraceFlag DebugOnlyTraceFlag;
 #else
 class DebugOnlyTraceFlag {
  public:
-  constexpr DebugOnlyTraceFlag(bool default_enabled, const char* name) {}
+  constexpr DebugOnlyTraceFlag(bool /*default_enabled*/, const char* /*name*/) {
+  }
   constexpr bool enabled() const { return false; }
   constexpr const char* name() const { return "DebugOnlyTraceFlag"; }
 
  private:
-  void set_enabled(bool enabled) {}
+  void set_enabled(bool /*enabled*/) {}
 };
 #endif
 

--- a/src/core/lib/gprpp/memory.h
+++ b/src/core/lib/gprpp/memory.h
@@ -107,7 +107,7 @@ class Allocator {
   pointer address(reference x) const { return &x; }
   const_pointer address(const_reference x) const { return &x; }
   pointer allocate(std::size_t n,
-                   std::allocator<void>::const_pointer hint = nullptr) {
+                   std::allocator<void>::const_pointer /*hint*/ = nullptr) {
     return static_cast<pointer>(gpr_malloc(n * sizeof(T)));
   }
   void deallocate(T* p, std::size_t /* n */) { gpr_free(p); }
@@ -132,7 +132,7 @@ bool operator==(Allocator<T> const&, Allocator<U> const&) noexcept {
 }
 
 template <class T, class U>
-bool operator!=(Allocator<T> const& x, Allocator<U> const& y) noexcept {
+bool operator!=(Allocator<T> const& /*x*/, Allocator<U> const& /*y*/) noexcept {
   return false;
 }
 

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -69,7 +69,14 @@ class RefCount {
   // Note: RefCount tracing is only enabled on debug builds, even when a
   //       TraceFlag is used.
   template <typename TraceFlagT = TraceFlag>
-  constexpr explicit RefCount(Value init = 1, TraceFlagT* trace_flag = nullptr)
+  constexpr explicit RefCount(
+      Value init = 1,
+      TraceFlagT*
+#ifndef NDEBUG
+          // Leave unnamed if NDEBUG to avoid unused parameter warning
+          trace_flag
+#endif
+      = nullptr)
       :
 #ifndef NDEBUG
         trace_flag_(trace_flag),
@@ -98,6 +105,10 @@ class RefCount {
               prior, prior + n, reason);
     }
 #else
+    // Use conditionally-important parameters
+    (void)location;
+    (void)reason;
+
     value_.FetchAdd(n, MemoryOrder::RELAXED);
 #endif
   }
@@ -125,6 +136,9 @@ class RefCount {
     }
     assert(prior > 0);
 #else
+    // Avoid unused-parameter warnings for debug-only parameters
+    (void)location;
+    (void)reason;
     RefNonZero();
 #endif
   }
@@ -150,6 +164,9 @@ class RefCount {
               prior, prior + 1, reason);
     }
 #endif
+    // Avoid unused-parameter warnings for debug-only parameters
+    (void)location;
+    (void)reason;
     return value_.IncrementIfNonzero();
   }
 
@@ -184,6 +201,10 @@ class RefCount {
               prior - 1, reason);
     }
     GPR_DEBUG_ASSERT(prior > 0);
+#else
+    // Avoid unused-parameter warnings for debug-only parameters
+    (void)location;
+    (void)reason;
 #endif
     return prior == 1;
   }

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -66,7 +66,7 @@ static grpc_httpcli_get_override g_get_override = nullptr;
 static grpc_httpcli_post_override g_post_override = nullptr;
 
 static void plaintext_handshake(void* arg, grpc_endpoint* endpoint,
-                                const char* host, grpc_millis deadline,
+                                const char* /*host*/, grpc_millis /*deadline*/,
                                 void (*on_done)(void* arg,
                                                 grpc_endpoint* endpoint)) {
   on_done(arg, endpoint);

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -67,7 +67,7 @@ class grpc_httpcli_ssl_channel_security_connector final
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     tsi_handshaker* handshaker = nullptr;
     if (handshaker_factory_ != nullptr) {
@@ -86,7 +86,7 @@ class grpc_httpcli_ssl_channel_security_connector final
     return handshaker_factory_;
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* /*auth_context*/,
                   grpc_closure* on_peer_checked) override {
     grpc_error* error = GRPC_ERROR_NONE;
@@ -111,15 +111,15 @@ class grpc_httpcli_ssl_channel_security_connector final
     return strcmp(secure_peer_name_, other->secure_peer_name_);
   }
 
-  bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+  bool check_call_host(grpc_core::StringView /*host*/,
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     *error = GRPC_ERROR_NONE;
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -134,7 +134,7 @@ class grpc_httpcli_ssl_channel_security_connector final
 static grpc_core::RefCountedPtr<grpc_channel_security_connector>
 httpcli_ssl_channel_security_connector_create(
     const char* pem_root_certs, const tsi_ssl_root_certs_store* root_store,
-    const char* secure_peer_name, grpc_channel_args* channel_args) {
+    const char* secure_peer_name, grpc_channel_args* /*channel_args*/) {
   if (secure_peer_name != nullptr && pem_root_certs == nullptr) {
     gpr_log(GPR_ERROR,
             "Cannot assert a secure peer name without a trust root.");

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -327,7 +327,7 @@ void grpc_http_parser_init(grpc_http_parser* parser, grpc_http_type type,
   parser->cur_line_end_length = 2;
 }
 
-void grpc_http_parser_destroy(grpc_http_parser* parser) {}
+void grpc_http_parser_destroy(grpc_http_parser* /*parser*/) {}
 
 void grpc_http_request_destroy(grpc_http_request* request) {
   size_t i;

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -39,8 +39,8 @@ void fill_gpr_from_timestamp(gpr_timespec* gts, const struct timespec* ts) {
   gts->clock_type = GPR_CLOCK_REALTIME;
 }
 
-void default_timestamps_callback(void* arg, grpc_core::Timestamps* ts,
-                                 grpc_error* shudown_err) {
+void default_timestamps_callback(void* /*arg*/, grpc_core::Timestamps* /*ts*/,
+                                 grpc_error* /*shudown_err*/) {
   gpr_log(GPR_DEBUG, "Timestamps callback has not been registered");
 }
 
@@ -293,9 +293,8 @@ void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
 #else /* GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_core {
-void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
-                                                       grpc_core::Timestamps*,
-                                                       grpc_error* error)) {
+void grpc_tcp_set_write_timestamps_callback(
+    void (*/*fn*/)(void*, grpc_core::Timestamps*, grpc_error* error)) {
   gpr_log(GPR_DEBUG, "Timestamps callback is not enabled for this platform");
 }
 } /* namespace grpc_core */

--- a/src/core/lib/iomgr/buffer_list.h
+++ b/src/core/lib/iomgr/buffer_list.h
@@ -146,7 +146,7 @@ class TracedBuffer {
 class TracedBuffer {
  public:
   /* Dummy shutdown function */
-  static void Shutdown(grpc_core::TracedBuffer** head, void* remaining,
+  static void Shutdown(grpc_core::TracedBuffer** /*head*/, void* /*remaining*/,
                        grpc_error* shutdown_err) {
     GRPC_ERROR_UNREF(shutdown_err);
   }

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -168,7 +168,7 @@ static void move_next() {
   }
 }
 
-static void offload(void* arg, grpc_error* error) {
+static void offload(void* arg, grpc_error* /*error*/) {
   grpc_core::Combiner* lock = static_cast<grpc_core::Combiner*>(arg);
   push_last_on_exec_ctx(lock);
 }

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -658,7 +658,7 @@ static int poll_deadline_to_millis_timeout(grpc_millis millis) {
    NOTE ON SYNCRHONIZATION: Similar to do_epoll_wait(), this function is only
    called by g_active_poller thread. So there is no need for synchronization
    when accessing fields in g_epoll_set */
-static grpc_error* process_epoll_events(grpc_pollset* pollset) {
+static grpc_error* process_epoll_events(grpc_pollset* /*pollset*/) {
   GPR_TIMER_SCOPE("process_epoll_events", 0);
 
   static const char* err_desc = "process_events";
@@ -1219,7 +1219,7 @@ done:
   return ret_err;
 }
 
-static void pollset_add_fd(grpc_pollset* pollset, grpc_fd* fd) {}
+static void pollset_add_fd(grpc_pollset* /*pollset*/, grpc_fd* /*fd*/) {}
 
 /*******************************************************************************
  * Pollset-set Definitions
@@ -1229,21 +1229,23 @@ static grpc_pollset_set* pollset_set_create(void) {
   return (grpc_pollset_set*)(static_cast<intptr_t>(0xdeafbeef));
 }
 
-static void pollset_set_destroy(grpc_pollset_set* pss) {}
+static void pollset_set_destroy(grpc_pollset_set* /*pss*/) {}
 
-static void pollset_set_add_fd(grpc_pollset_set* pss, grpc_fd* fd) {}
+static void pollset_set_add_fd(grpc_pollset_set* /*pss*/, grpc_fd* /*fd*/) {}
 
-static void pollset_set_del_fd(grpc_pollset_set* pss, grpc_fd* fd) {}
+static void pollset_set_del_fd(grpc_pollset_set* /*pss*/, grpc_fd* /*fd*/) {}
 
-static void pollset_set_add_pollset(grpc_pollset_set* pss, grpc_pollset* ps) {}
+static void pollset_set_add_pollset(grpc_pollset_set* /*pss*/,
+                                    grpc_pollset* /*ps*/) {}
 
-static void pollset_set_del_pollset(grpc_pollset_set* pss, grpc_pollset* ps) {}
+static void pollset_set_del_pollset(grpc_pollset_set* /*pss*/,
+                                    grpc_pollset* /*ps*/) {}
 
-static void pollset_set_add_pollset_set(grpc_pollset_set* bag,
-                                        grpc_pollset_set* item) {}
+static void pollset_set_add_pollset_set(grpc_pollset_set* /*bag*/,
+                                        grpc_pollset_set* /*item*/) {}
 
-static void pollset_set_del_pollset_set(grpc_pollset_set* bag,
-                                        grpc_pollset_set* item) {}
+static void pollset_set_del_pollset_set(grpc_pollset_set* /*bag*/,
+                                        grpc_pollset_set* /*item*/) {}
 
 /*******************************************************************************
  * Event engine binding
@@ -1253,8 +1255,8 @@ static bool is_any_background_poller_thread(void) { return false; }
 
 static void shutdown_background_closure(void) {}
 
-static bool add_closure_to_background_poller(grpc_closure* closure,
-                                             grpc_error* error) {
+static bool add_closure_to_background_poller(grpc_closure* /*closure*/,
+                                             grpc_error* /*error*/) {
   return false;
 }
 
@@ -1325,7 +1327,8 @@ static void reset_event_manager_on_fork() {
 /* It is possible that GLIBC has epoll but the underlying kernel doesn't.
  * Create epoll_fd (epoll_set_init() takes care of that) to make sure epoll
  * support is available */
-const grpc_event_engine_vtable* grpc_init_epoll1_linux(bool explicit_request) {
+const grpc_event_engine_vtable* grpc_init_epoll1_linux(
+    bool /*explicit_request*/) {
   if (!grpc_has_wakeup_fd()) {
     gpr_log(GPR_ERROR, "Skipping epoll1 because of no wakeup fd.");
     return nullptr;
@@ -1356,7 +1359,8 @@ const grpc_event_engine_vtable* grpc_init_epoll1_linux(bool explicit_request) {
 #include "src/core/lib/iomgr/ev_epoll1_linux.h"
 /* If GRPC_LINUX_EPOLL is not defined, it means epoll is not available. Return
  * NULL */
-const grpc_event_engine_vtable* grpc_init_epoll1_linux(bool explicit_request) {
+const grpc_event_engine_vtable* grpc_init_epoll1_linux(
+    bool /*explicit_request*/) {
   return nullptr;
 }
 #endif /* defined(GRPC_POSIX_SOCKET_EV_EPOLL1) */

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -323,8 +323,16 @@ static void ref_by(grpc_fd* fd, int n, const char* reason, const char* file,
             gpr_atm_no_barrier_load(&fd->refst) + n, reason, file, line);
   }
 #else
-#define REF_BY(fd, n, reason) ref_by(fd, n)
-#define UNREF_BY(fd, n, reason) unref_by(fd, n)
+#define REF_BY(fd, n, reason) \
+  do {                        \
+    ref_by(fd, n);            \
+    (void)(reason);           \
+  } while (0)
+#define UNREF_BY(fd, n, reason) \
+  do {                          \
+    unref_by(fd, n);            \
+    (void)(reason);             \
+  } while (0)
 static void ref_by(grpc_fd* fd, int n) {
 #endif
   GPR_ASSERT(gpr_atm_no_barrier_fetch_add(&fd->refst, n) > 0);
@@ -355,6 +363,8 @@ static void unref_by(grpc_fd* fd, int n) {
 }
 
 static grpc_fd* fd_create(int fd, const char* name, bool track_err) {
+  // Avoid unused-parameter warning for debug-only parameter
+  (void)track_err;
   GPR_DEBUG_ASSERT(track_err == false);
   grpc_fd* r = static_cast<grpc_fd*>(gpr_malloc(sizeof(*r)));
   gpr_mu_init(&r->mu);
@@ -560,7 +570,7 @@ static void fd_notify_on_write(grpc_fd* fd, grpc_closure* closure) {
   gpr_mu_unlock(&fd->mu);
 }
 
-static void fd_notify_on_error(grpc_fd* fd, grpc_closure* closure) {
+static void fd_notify_on_error(grpc_fd* /*fd*/, grpc_closure* closure) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     gpr_log(GPR_ERROR, "Polling engine does not support tracking errors.");
   }
@@ -579,7 +589,7 @@ static void fd_set_writable(grpc_fd* fd) {
   gpr_mu_unlock(&fd->mu);
 }
 
-static void fd_set_error(grpc_fd* fd) {
+static void fd_set_error(grpc_fd* /*fd*/) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     gpr_log(GPR_ERROR, "Polling engine does not support tracking errors.");
   }
@@ -696,7 +706,7 @@ static void fd_end_poll(grpc_fd_watcher* watcher, int got_read, int got_write) {
 GPR_TLS_DECL(g_current_thread_poller);
 GPR_TLS_DECL(g_current_thread_worker);
 
-static void remove_worker(grpc_pollset* p, grpc_pollset_worker* worker) {
+static void remove_worker(grpc_pollset* /*p*/, grpc_pollset_worker* worker) {
   worker->prev->next = worker->next;
   worker->next->prev = worker->prev;
 }
@@ -1320,8 +1330,8 @@ static bool is_any_background_poller_thread(void) { return false; }
 
 static void shutdown_background_closure(void) {}
 
-static bool add_closure_to_background_poller(grpc_closure* closure,
-                                             grpc_error* error) {
+static bool add_closure_to_background_poller(grpc_closure* /*closure*/,
+                                             grpc_error* /*error*/) {
   return false;
 }
 
@@ -1392,7 +1402,8 @@ static void reset_event_manager_on_fork() {
   gpr_mu_unlock(&fork_fd_list_mu);
 }
 
-const grpc_event_engine_vtable* grpc_init_poll_posix(bool explicit_request) {
+const grpc_event_engine_vtable* grpc_init_poll_posix(
+    bool /*explicit_request*/) {
   if (!grpc_has_wakeup_fd()) {
     gpr_log(GPR_ERROR, "Skipping poll because of no wakeup fd.");
     return nullptr;

--- a/src/core/lib/iomgr/iomgr_custom.cc
+++ b/src/core/lib/iomgr/iomgr_custom.cc
@@ -45,7 +45,7 @@ static bool iomgr_platform_is_any_background_poller_thread(void) {
   return false;
 }
 static bool iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error* error) {
+    grpc_closure* /*closure*/, grpc_error* /*error*/) {
   return false;
 }
 

--- a/src/core/lib/iomgr/pollset_custom.cc
+++ b/src/core/lib/iomgr/pollset_custom.cc
@@ -53,7 +53,7 @@ static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
   *mu = &pollset->mu;
 }
 
-static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
+static void pollset_shutdown(grpc_pollset* /*pollset*/, grpc_closure* closure) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   GRPC_CLOSURE_SCHED(closure, GRPC_ERROR_NONE);
 }
@@ -64,7 +64,7 @@ static void pollset_destroy(grpc_pollset* pollset) {
 }
 
 static grpc_error* pollset_work(grpc_pollset* pollset,
-                                grpc_pollset_worker** worker_hdl,
+                                grpc_pollset_worker** /*worker_hdl*/,
                                 grpc_millis deadline) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   gpr_mu_unlock(&pollset->mu);
@@ -87,8 +87,8 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error* pollset_kick(grpc_pollset* pollset,
-                                grpc_pollset_worker* specific_worker) {
+static grpc_error* pollset_kick(grpc_pollset* /*pollset*/,
+                                grpc_pollset_worker* /*specific_worker*/) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   poller_vtable->kick();
   return GRPC_ERROR_NONE;

--- a/src/core/lib/iomgr/pollset_set_custom.cc
+++ b/src/core/lib/iomgr/pollset_set_custom.cc
@@ -26,19 +26,19 @@ grpc_pollset_set* pollset_set_create(void) {
   return (grpc_pollset_set*)((intptr_t)0xdeafbeef);
 }
 
-void pollset_set_destroy(grpc_pollset_set* pollset_set) {}
+void pollset_set_destroy(grpc_pollset_set* /*pollset_set*/) {}
 
-void pollset_set_add_pollset(grpc_pollset_set* pollset_set,
-                             grpc_pollset* pollset) {}
+void pollset_set_add_pollset(grpc_pollset_set* /*pollset_set*/,
+                             grpc_pollset* /*pollset*/) {}
 
-void pollset_set_del_pollset(grpc_pollset_set* pollset_set,
-                             grpc_pollset* pollset) {}
+void pollset_set_del_pollset(grpc_pollset_set* /*pollset_set*/,
+                             grpc_pollset* /*pollset*/) {}
 
-void pollset_set_add_pollset_set(grpc_pollset_set* bag,
-                                 grpc_pollset_set* item) {}
+void pollset_set_add_pollset_set(grpc_pollset_set* /*bag*/,
+                                 grpc_pollset_set* /*item*/) {}
 
-void pollset_set_del_pollset_set(grpc_pollset_set* bag,
-                                 grpc_pollset_set* item) {}
+void pollset_set_del_pollset_set(grpc_pollset_set* /*bag*/,
+                                 grpc_pollset_set* /*item*/) {}
 
 static grpc_pollset_set_vtable vtable = {
     pollset_set_create,          pollset_set_destroy,

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -151,7 +151,7 @@ static grpc_error* blocking_resolve_address_impl(
 }
 
 static void resolve_address_impl(const char* name, const char* default_port,
-                                 grpc_pollset_set* interested_parties,
+                                 grpc_pollset_set* /*interested_parties*/,
                                  grpc_closure* on_done,
                                  grpc_resolved_addresses** addrs) {
   grpc_custom_resolver* r = nullptr;

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -150,7 +150,7 @@ typedef struct {
 
 /* Callback to be passed to grpc Executor to asynch-ify
  * grpc_blocking_resolve_address */
-static void do_request_thread(void* rp, grpc_error* error) {
+static void do_request_thread(void* rp, grpc_error* /*error*/) {
   request* r = static_cast<request*>(rp);
   GRPC_CLOSURE_SCHED(r->on_done, grpc_blocking_resolve_address(
                                      r->name, r->default_port, r->addrs_out));
@@ -160,7 +160,7 @@ static void do_request_thread(void* rp, grpc_error* error) {
 }
 
 static void posix_resolve_address(const char* name, const char* default_port,
-                                  grpc_pollset_set* interested_parties,
+                                  grpc_pollset_set* /*interested_parties*/,
                                   grpc_closure* on_done,
                                   grpc_resolved_addresses** addrs) {
   request* r = static_cast<request*>(gpr_malloc(sizeof(request)));

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -274,7 +274,7 @@ static bool rq_reclaim_from_per_user_free_pool(
     grpc_resource_quota* resource_quota);
 static bool rq_reclaim(grpc_resource_quota* resource_quota, bool destructive);
 
-static void rq_step(void* rq, grpc_error* error) {
+static void rq_step(void* rq, grpc_error* /*error*/) {
   grpc_resource_quota* resource_quota = static_cast<grpc_resource_quota*>(rq);
   resource_quota->step_scheduled = false;
   do {
@@ -479,7 +479,7 @@ static grpc_slice ru_slice_create(grpc_resource_user* resource_user,
  * the combiner
  */
 
-static void ru_allocate(void* ru, grpc_error* error) {
+static void ru_allocate(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (rulist_empty(resource_user->resource_quota,
                    GRPC_RULIST_AWAITING_ALLOCATION)) {
@@ -488,7 +488,7 @@ static void ru_allocate(void* ru, grpc_error* error) {
   rulist_add_tail(resource_user, GRPC_RULIST_AWAITING_ALLOCATION);
 }
 
-static void ru_add_to_free_pool(void* ru, grpc_error* error) {
+static void ru_add_to_free_pool(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (!rulist_empty(resource_user->resource_quota,
                     GRPC_RULIST_AWAITING_ALLOCATION) &&
@@ -513,7 +513,7 @@ static bool ru_post_reclaimer(grpc_resource_user* resource_user,
   return true;
 }
 
-static void ru_post_benign_reclaimer(void* ru, grpc_error* error) {
+static void ru_post_benign_reclaimer(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (!ru_post_reclaimer(resource_user, false)) return;
   if (!rulist_empty(resource_user->resource_quota,
@@ -527,7 +527,7 @@ static void ru_post_benign_reclaimer(void* ru, grpc_error* error) {
   rulist_add_tail(resource_user, GRPC_RULIST_RECLAIMER_BENIGN);
 }
 
-static void ru_post_destructive_reclaimer(void* ru, grpc_error* error) {
+static void ru_post_destructive_reclaimer(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (!ru_post_reclaimer(resource_user, true)) return;
   if (!rulist_empty(resource_user->resource_quota,
@@ -543,7 +543,7 @@ static void ru_post_destructive_reclaimer(void* ru, grpc_error* error) {
   rulist_add_tail(resource_user, GRPC_RULIST_RECLAIMER_DESTRUCTIVE);
 }
 
-static void ru_shutdown(void* ru, grpc_error* error) {
+static void ru_shutdown(void* ru, grpc_error* /*error*/) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
     gpr_log(GPR_INFO, "RU shutdown %p", ru);
   }
@@ -561,7 +561,7 @@ static void ru_shutdown(void* ru, grpc_error* error) {
   gpr_mu_unlock(&resource_user->mu);
 }
 
-static void ru_destroy(void* ru, grpc_error* error) {
+static void ru_destroy(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   GPR_ASSERT(gpr_atm_no_barrier_load(&resource_user->refs) == 0);
   // Free all the remaining thread quota
@@ -611,7 +611,7 @@ typedef struct {
   grpc_closure closure;
 } rq_resize_args;
 
-static void rq_resize(void* args, grpc_error* error) {
+static void rq_resize(void* args, grpc_error* /*error*/) {
   rq_resize_args* a = static_cast<rq_resize_args*>(args);
   int64_t delta = a->size - a->resource_quota->size;
   a->resource_quota->size += delta;
@@ -622,7 +622,7 @@ static void rq_resize(void* args, grpc_error* error) {
   gpr_free(a);
 }
 
-static void rq_reclamation_done(void* rq, grpc_error* error) {
+static void rq_reclamation_done(void* rq, grpc_error* /*error*/) {
   grpc_resource_quota* resource_quota = static_cast<grpc_resource_quota*>(rq);
   resource_quota->reclaiming = false;
   rq_step_sched(resource_quota);

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -84,11 +84,16 @@ grpc_error* grpc_set_socket_no_sigpipe_if_possible(int fd) {
   if ((newval != 0) != (val != 0)) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_NOSIGPIPE");
   }
+#else
+  // Avoid unused parameter warning for conditional parameter
+  (void)fd;
 #endif
   return GRPC_ERROR_NONE;
 }
 
 grpc_error* grpc_set_socket_ip_pktinfo_if_possible(int fd) {
+  // Use conditionally-important parameter to avoid warning
+  (void)fd;
 #ifdef GRPC_HAVE_IP_PKTINFO
   int get_local_ip = 1;
   if (0 != setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &get_local_ip,
@@ -100,6 +105,8 @@ grpc_error* grpc_set_socket_ip_pktinfo_if_possible(int fd) {
 }
 
 grpc_error* grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
+  // Use conditionally-important parameter to avoid warning
+  (void)fd;
 #ifdef GRPC_HAVE_IPV6_RECVPKTINFO
   int get_local_ip = 1;
   if (0 != setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &get_local_ip,
@@ -256,6 +263,10 @@ void config_default_tcp_user_timeout(bool enable, int timeout, bool is_client) {
 /* Set TCP_USER_TIMEOUT */
 grpc_error* grpc_set_socket_tcp_user_timeout(
     int fd, const grpc_channel_args* channel_args, bool is_client) {
+  // Use conditionally-important parameter to avoid warning
+  (void)fd;
+  (void)channel_args;
+  (void)is_client;
 #ifdef GRPC_HAVE_TCP_USER_TIMEOUT
   bool enable;
   int timeout;

--- a/src/core/lib/iomgr/tcp_client_custom.cc
+++ b/src/core/lib/iomgr/tcp_client_custom.cc
@@ -58,7 +58,7 @@ static void custom_tcp_connect_cleanup(grpc_custom_tcp_connect* connect) {
   }
 }
 
-static void custom_close_callback(grpc_custom_socket* socket) {}
+static void custom_close_callback(grpc_custom_socket* /*socket*/) {}
 
 static void on_alarm(void* acp, grpc_error* error) {
   int done;

--- a/src/core/lib/iomgr/tcp_custom.cc
+++ b/src/core/lib/iomgr/tcp_custom.cc
@@ -193,7 +193,7 @@ static void tcp_read_allocation_done(void* tcpp, grpc_error* error) {
 }
 
 static void endpoint_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
-                          grpc_closure* cb, bool urgent) {
+                          grpc_closure* cb, bool /*urgent*/) {
   custom_tcp_endpoint* tcp = (custom_tcp_endpoint*)ep;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   GPR_ASSERT(tcp->read_cb == nullptr);
@@ -224,7 +224,7 @@ static void custom_write_callback(grpc_custom_socket* socket,
 }
 
 static void endpoint_write(grpc_endpoint* ep, grpc_slice_buffer* write_slices,
-                           grpc_closure* cb, void* arg) {
+                           grpc_closure* cb, void* /*arg*/) {
   custom_tcp_endpoint* tcp = (custom_tcp_endpoint*)ep;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
 
@@ -327,9 +327,9 @@ static grpc_resource_user* endpoint_get_resource_user(grpc_endpoint* ep) {
   return tcp->resource_user;
 }
 
-static int endpoint_get_fd(grpc_endpoint* ep) { return -1; }
+static int endpoint_get_fd(grpc_endpoint* /*ep*/) { return -1; }
 
-static bool endpoint_can_track_err(grpc_endpoint* ep) { return false; }
+static bool endpoint_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
 static grpc_endpoint_vtable vtable = {endpoint_read,
                                       endpoint_write,

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -161,7 +161,7 @@ static void tcp_handle_write(void* arg /* grpc_tcp */, grpc_error* error);
 static void tcp_drop_uncovered_then_handle_write(void* arg /* grpc_tcp */,
                                                  grpc_error* error);
 
-static void done_poller(void* bp, grpc_error* error_ignored) {
+static void done_poller(void* bp, grpc_error* /*error_ignored*/) {
   backup_poller* p = static_cast<backup_poller*>(bp);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_INFO, "BACKUP_POLLER:%p destroy", p);
@@ -170,7 +170,7 @@ static void done_poller(void* bp, grpc_error* error_ignored) {
   gpr_free(p);
 }
 
-static void run_poller(void* bp, grpc_error* error_ignored) {
+static void run_poller(void* bp, grpc_error* /*error_ignored*/) {
   backup_poller* p = static_cast<backup_poller*>(bp);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_INFO, "BACKUP_POLLER:%p run", p);
@@ -206,7 +206,7 @@ static void run_poller(void* bp, grpc_error* error_ignored) {
   }
 }
 
-static void drop_uncovered(grpc_tcp* tcp) {
+static void drop_uncovered(grpc_tcp* /*tcp*/) {
   backup_poller* p = (backup_poller*)gpr_atm_acq_load(&g_backup_poller);
   gpr_atm old_count =
       gpr_atm_full_fetch_add(&g_uncovered_notifications_pending, -1);
@@ -876,15 +876,16 @@ static void tcp_handle_error(void* arg /* grpc_tcp */, grpc_error* error) {
 }
 
 #else  /* GRPC_LINUX_ERRQUEUE */
-static bool tcp_write_with_timestamps(grpc_tcp* tcp, struct msghdr* msg,
-                                      size_t sending_length,
-                                      ssize_t* sent_length) {
+static bool tcp_write_with_timestamps(grpc_tcp* /*tcp*/, struct msghdr* /*msg*/,
+                                      size_t /*sending_length*/,
+                                      ssize_t* /*sent_length*/) {
   gpr_log(GPR_ERROR, "Write with timestamps not supported for this platform");
   GPR_ASSERT(0);
   return false;
 }
 
-static void tcp_handle_error(void* arg /* grpc_tcp */, grpc_error* error) {
+static void tcp_handle_error(void* /*arg*/ /* grpc_tcp */,
+                             grpc_error* /*error*/) {
   gpr_log(GPR_ERROR, "Error handling is not supported for this platform");
   GPR_ASSERT(0);
 }

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -439,13 +439,13 @@ static void tcp_server_start(grpc_tcp_server* server, grpc_pollset** pollsets,
   }
 }
 
-static unsigned tcp_server_port_fd_count(grpc_tcp_server* s,
-                                         unsigned port_index) {
+static unsigned tcp_server_port_fd_count(grpc_tcp_server* /*s*/,
+                                         unsigned /*port_index*/) {
   return 0;
 }
 
-static int tcp_server_port_fd(grpc_tcp_server* s, unsigned port_index,
-                              unsigned fd_index) {
+static int tcp_server_port_fd(grpc_tcp_server* /*s*/, unsigned /*port_index*/,
+                              unsigned /*fd_index*/) {
   return -1;
 }
 
@@ -459,7 +459,7 @@ static void tcp_server_shutdown_listeners(grpc_tcp_server* s) {
 }
 
 static grpc_core::TcpServerFdHandler* tcp_server_create_fd_handler(
-    grpc_tcp_server* s) {
+    grpc_tcp_server* /*s*/) {
   return nullptr;
 }
 

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -124,7 +124,7 @@ static void finish_shutdown(grpc_tcp_server* s) {
   gpr_free(s);
 }
 
-static void destroyed_port(void* server, grpc_error* error) {
+static void destroyed_port(void* server, grpc_error* /*error*/) {
   grpc_tcp_server* s = static_cast<grpc_tcp_server*>(server);
   gpr_mu_lock(&s->mu);
   s->destroyed_ports++;

--- a/src/core/lib/iomgr/timer_custom.cc
+++ b/src/core/lib/iomgr/timer_custom.cc
@@ -30,7 +30,7 @@
 
 static grpc_custom_timer_vtable* custom_timer_impl;
 
-void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error) {
+void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* /*error*/) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
@@ -75,7 +75,7 @@ static void timer_cancel(grpc_timer* timer) {
   }
 }
 
-static grpc_timer_check_result timer_check(grpc_millis* next) {
+static grpc_timer_check_result timer_check(grpc_millis* /*next*/) {
   return GRPC_TIMERS_NOT_CHECKED;
 }
 

--- a/src/core/lib/iomgr/udp_server.cc
+++ b/src/core/lib/iomgr/udp_server.cc
@@ -260,7 +260,7 @@ static void finish_shutdown(grpc_udp_server* s) {
   grpc_core::Delete(s);
 }
 
-static void destroyed_port(void* server, grpc_error* error) {
+static void destroyed_port(void* server, grpc_error* /*error*/) {
   grpc_udp_server* s = static_cast<grpc_udp_server*>(server);
   gpr_mu_lock(&s->mu);
   s->destroyed_ports++;
@@ -495,7 +495,8 @@ void GrpcUdpListener::OnRead(grpc_error* error, void* do_read_arg) {
 
 // static
 // Wrapper of grpc_fd_notify_on_write() with a grpc_closure callback interface.
-void GrpcUdpListener::fd_notify_on_write_wrapper(void* arg, grpc_error* error) {
+void GrpcUdpListener::fd_notify_on_write_wrapper(void* arg,
+                                                 grpc_error* /*error*/) {
   GrpcUdpListener* sp = static_cast<GrpcUdpListener*>(arg);
   gpr_mu_lock(sp->mutex());
   if (!sp->notify_on_write_armed_) {

--- a/src/core/lib/profiling/basic_timers.cc
+++ b/src/core/lib/profiling/basic_timers.cc
@@ -287,7 +287,7 @@ void gpr_timers_global_init(void) {}
 
 void gpr_timers_global_destroy(void) {}
 
-void gpr_timers_set_log_filename(const char* filename) {}
+void gpr_timers_set_log_filename(const char* /*filename*/) {}
 
-void gpr_timer_set_enabled(int enabled) {}
+void gpr_timer_set_enabled(int /*enabled*/) {}
 #endif /* GRPC_BASIC_PROFILER */

--- a/src/core/lib/security/credentials/alts/alts_credentials.cc
+++ b/src/core/lib/security/credentials/alts/alts_credentials.cc
@@ -50,8 +50,8 @@ grpc_alts_credentials::~grpc_alts_credentials() {
 grpc_core::RefCountedPtr<grpc_channel_security_connector>
 grpc_alts_credentials::create_security_connector(
     grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
-    const char* target_name, const grpc_channel_args* args,
-    grpc_channel_args** new_args) {
+    const char* target_name, const grpc_channel_args* /*args*/,
+    grpc_channel_args** /*new_args*/) {
   return grpc_alts_channel_security_connector_create(
       this->Ref(), std::move(call_creds), target_name);
 }

--- a/src/core/lib/security/credentials/alts/grpc_alts_credentials_server_options.cc
+++ b/src/core/lib/security/credentials/alts/grpc_alts_credentials_server_options.cc
@@ -31,7 +31,7 @@ static grpc_alts_credentials_options* alts_server_options_copy(
     const grpc_alts_credentials_options* options);
 
 static void alts_server_options_destroy(
-    grpc_alts_credentials_options* options) {}
+    grpc_alts_credentials_options* /*options*/) {}
 
 static const grpc_alts_credentials_options_vtable vtable = {
     alts_server_options_copy, alts_server_options_destroy};

--- a/src/core/lib/security/credentials/fake/fake_credentials.cc
+++ b/src/core/lib/security/credentials/fake/fake_credentials.cc
@@ -45,7 +45,7 @@ class grpc_fake_channel_credentials final : public grpc_channel_credentials {
   create_security_connector(
       grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
       const char* target, const grpc_channel_args* args,
-      grpc_channel_args** new_args) override {
+      grpc_channel_args** /*new_args*/) override {
     return grpc_fake_channel_security_connector_create(
         this->Ref(), std::move(call_creds), target, args);
   }
@@ -89,9 +89,9 @@ const char* grpc_fake_transport_get_expected_targets(
 /* -- Metadata-only test credentials. -- */
 
 bool grpc_md_only_test_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context /*context*/,
     grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_error** /*error*/) {
   grpc_credentials_mdelem_array_add(md_array, md_);
   if (is_async_) {
     GRPC_CLOSURE_SCHED(on_request_metadata, GRPC_ERROR_NONE);
@@ -101,7 +101,7 @@ bool grpc_md_only_test_credentials::get_request_metadata(
 }
 
 void grpc_md_only_test_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -154,7 +154,7 @@ static void on_metadata_server_detection_http_response(void* user_data,
   gpr_mu_unlock(g_polling_mu);
 }
 
-static void destroy_pollset(void* p, grpc_error* e) {
+static void destroy_pollset(void* p, grpc_error* /*e*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/src/core/lib/security/credentials/iam/iam_credentials.cc
+++ b/src/core/lib/security/credentials/iam/iam_credentials.cc
@@ -35,15 +35,15 @@ grpc_google_iam_credentials::~grpc_google_iam_credentials() {
 }
 
 bool grpc_google_iam_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
-    grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context /*context*/,
+    grpc_credentials_mdelem_array* md_array,
+    grpc_closure* /*on_request_metadata*/, grpc_error** /*error*/) {
   grpc_credentials_mdelem_array_append(md_array, &md_array_);
   return true;
 }
 
 void grpc_google_iam_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/jwt/jwt_credentials.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_credentials.cc
@@ -50,9 +50,9 @@ grpc_service_account_jwt_access_credentials::
 }
 
 bool grpc_service_account_jwt_access_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
-    grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context context,
+    grpc_credentials_mdelem_array* md_array,
+    grpc_closure* /*on_request_metadata*/, grpc_error** error) {
   gpr_timespec refresh_threshold = gpr_time_from_seconds(
       GRPC_SECURE_TOKEN_REFRESH_THRESHOLD_SECS, GPR_TIMESPAN);
 
@@ -104,7 +104,7 @@ bool grpc_service_account_jwt_access_credentials::get_request_metadata(
 }
 
 void grpc_service_account_jwt_access_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -636,7 +636,7 @@ end:
   return result;
 }
 
-static void on_keys_retrieved(void* user_data, grpc_error* error) {
+static void on_keys_retrieved(void* user_data, grpc_error* /*error*/) {
   verifier_cb_ctx* ctx = static_cast<verifier_cb_ctx*>(user_data);
   grpc_json* json = json_from_http(&ctx->responses[HTTP_RESPONSE_KEYS]);
   EVP_PKEY* verification_key = nullptr;
@@ -676,7 +676,7 @@ end:
   verifier_cb_ctx_destroy(ctx);
 }
 
-static void on_openid_config_retrieved(void* user_data, grpc_error* error) {
+static void on_openid_config_retrieved(void* user_data, grpc_error* /*error*/) {
   const grpc_json* cur;
   verifier_cb_ctx* ctx = static_cast<verifier_cb_ctx*>(user_data);
   const grpc_http_response* response = &ctx->responses[HTTP_RESPONSE_OPENID];

--- a/src/core/lib/security/credentials/local/local_credentials.cc
+++ b/src/core/lib/security/credentials/local/local_credentials.cc
@@ -33,7 +33,7 @@ grpc_core::RefCountedPtr<grpc_channel_security_connector>
 grpc_local_credentials::create_security_connector(
     grpc_core::RefCountedPtr<grpc_call_credentials> request_metadata_creds,
     const char* target_name, const grpc_channel_args* args,
-    grpc_channel_args** new_args) {
+    grpc_channel_args** /*new_args*/) {
   return grpc_local_channel_security_connector_create(
       this->Ref(), std::move(request_metadata_creds), args, target_name);
 }

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -269,9 +269,9 @@ void grpc_oauth2_token_fetcher_credentials::on_http_response(
 }
 
 bool grpc_oauth2_token_fetcher_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
+    grpc_polling_entity* pollent, grpc_auth_metadata_context /*context*/,
     grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_error** /*error*/) {
   // Check if we can use the cached token.
   grpc_millis refresh_threshold =
       GRPC_SECURE_TOKEN_REFRESH_THRESHOLD_SECS * GPR_MS_PER_SEC;
@@ -702,15 +702,15 @@ grpc_access_token_credentials::~grpc_access_token_credentials() {
 }
 
 bool grpc_access_token_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
-    grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context /*context*/,
+    grpc_credentials_mdelem_array* md_array,
+    grpc_closure* /*on_request_metadata*/, grpc_error** /*error*/) {
   grpc_credentials_mdelem_array_add(md_array, access_token_md_);
   return true;
 }
 
 void grpc_access_token_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/plugin/plugin_credentials.cc
+++ b/src/core/lib/security/credentials/plugin/plugin_credentials.cc
@@ -142,7 +142,7 @@ static void plugin_md_request_metadata_ready(void* request,
 }
 
 bool grpc_plugin_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context context,
     grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
     grpc_error** error) {
   bool retval = true;  // Synchronous return.

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -94,7 +94,7 @@ class grpc_alts_channel_security_connector final
         grpc_core::SecurityHandshakerCreate(handshaker, this, args));
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     alts_check_peer(peer, auth_context, on_peer_checked);
@@ -109,8 +109,8 @@ class grpc_alts_channel_security_connector final
   }
 
   bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     if (host.empty() || host != target_name_) {
       *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -119,7 +119,7 @@ class grpc_alts_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -154,7 +154,7 @@ class grpc_alts_server_security_connector final
         grpc_core::SecurityHandshakerCreate(handshaker, this, args));
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     alts_check_peer(peer, auth_context, on_peer_checked);

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -97,16 +97,16 @@ class grpc_fake_channel_security_connector final
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     handshake_mgr->Add(grpc_core::SecurityHandshakerCreate(
         tsi_create_fake_handshaker(/*is_client=*/true), this, args));
   }
 
   bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
-                       grpc_error** error) override {
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
+                       grpc_error** /*error*/) override {
     grpc_core::StringView authority_hostname;
     grpc_core::StringView authority_ignored_port;
     grpc_core::StringView target_hostname;
@@ -135,7 +135,7 @@ class grpc_fake_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -213,7 +213,7 @@ class grpc_fake_channel_security_connector final
 };
 
 static void fake_check_peer(
-    grpc_security_connector* sc, tsi_peer peer,
+    grpc_security_connector* /*sc*/, tsi_peer peer,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   const char* prop_name;
@@ -250,7 +250,7 @@ end:
 }
 
 void grpc_fake_channel_security_connector::check_peer(
-    tsi_peer peer, grpc_endpoint* ep,
+    tsi_peer peer, grpc_endpoint* /*ep*/,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   fake_check_peer(this, peer, auth_context, on_peer_checked);
@@ -266,14 +266,14 @@ class grpc_fake_server_security_connector
                                        std::move(server_creds)) {}
   ~grpc_fake_server_security_connector() override = default;
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     fake_check_peer(this, peer, auth_context, on_peer_checked);
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     handshake_mgr->Add(grpc_core::SecurityHandshakerCreate(
         tsi_create_fake_handshaker(/*=is_client*/ false), this, args));

--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -58,7 +58,7 @@ grpc_core::RefCountedPtr<grpc_auth_context> local_auth_context_create() {
   return ctx;
 }
 
-void local_check_peer(grpc_security_connector* sc, tsi_peer peer,
+void local_check_peer(grpc_security_connector* /*sc*/, tsi_peer /*peer*/,
                       grpc_endpoint* ep,
                       grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                       grpc_closure* on_peer_checked,
@@ -129,7 +129,7 @@ class grpc_local_channel_security_connector final
   ~grpc_local_channel_security_connector() override { gpr_free(target_name_); }
 
   void add_handshakers(
-      const grpc_channel_args* args, grpc_pollset_set* interested_parties,
+      const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
       grpc_core::HandshakeManager* handshake_manager) override {
     tsi_handshaker* handshaker = nullptr;
     GPR_ASSERT(local_tsi_handshaker_create(true /* is_client */, &handshaker) ==
@@ -157,8 +157,8 @@ class grpc_local_channel_security_connector final
   }
 
   bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     if (host.empty() || host != target_name_) {
       *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -167,7 +167,7 @@ class grpc_local_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -187,7 +187,7 @@ class grpc_local_server_security_connector final
   ~grpc_local_server_security_connector() override = default;
 
   void add_handshakers(
-      const grpc_channel_args* args, grpc_pollset_set* interested_parties,
+      const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
       grpc_core::HandshakeManager* handshake_manager) override {
     tsi_handshaker* handshaker = nullptr;
     GPR_ASSERT(local_tsi_handshaker_create(false /* is_client */,

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -118,7 +118,7 @@ class grpc_ssl_channel_security_connector final
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     // Instantiate TSI handshaker.
     tsi_handshaker* tsi_hs = nullptr;
@@ -136,7 +136,7 @@ class grpc_ssl_channel_security_connector final
     handshake_mgr->Add(grpc_core::SecurityHandshakerCreate(tsi_hs, this, args));
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     const char* target_name = overridden_target_name_ != nullptr
@@ -188,7 +188,7 @@ class grpc_ssl_channel_security_connector final
 
   bool check_call_host(grpc_core::StringView host,
                        grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     grpc_security_status status = GRPC_SECURITY_ERROR;
     tsi_peer peer = grpc_shallow_peer_from_ssl_auth_context(auth_context);
@@ -207,7 +207,7 @@ class grpc_ssl_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -281,7 +281,7 @@ class grpc_ssl_server_security_connector
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     // Instantiate TSI handshaker.
     try_fetch_ssl_server_credentials();
@@ -297,7 +297,7 @@ class grpc_ssl_server_security_connector
     handshake_mgr->Add(grpc_core::SecurityHandshakerCreate(tsi_hs, this, args));
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     grpc_error* error = ssl_check_peer(nullptr, &peer, auth_context);

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -143,7 +143,7 @@ bool grpc_ssl_check_call_host(grpc_core::StringView host,
                               grpc_core::StringView target_name,
                               grpc_core::StringView overridden_target_name,
                               grpc_auth_context* auth_context,
-                              grpc_closure* on_call_host_checked,
+                              grpc_closure* /*on_call_host_checked*/,
                               grpc_error** error) {
   grpc_security_status status = GRPC_SECURITY_ERROR;
   tsi_peer peer = grpc_shallow_peer_from_ssl_auth_context(auth_context);

--- a/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
@@ -141,7 +141,7 @@ SpiffeChannelSecurityConnector::~SpiffeChannelSecurityConnector() {
 }
 
 void SpiffeChannelSecurityConnector::add_handshakers(
-    const grpc_channel_args* args, grpc_pollset_set* interested_parties,
+    const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
     grpc_core::HandshakeManager* handshake_mgr) {
   if (RefreshHandshakerFactory() != GRPC_SECURITY_OK) {
     gpr_log(GPR_ERROR, "Handshaker factory refresh failed.");
@@ -164,7 +164,7 @@ void SpiffeChannelSecurityConnector::add_handshakers(
 }
 
 void SpiffeChannelSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* ep,
+    tsi_peer peer, grpc_endpoint* /*ep*/,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   const char* target_name = overridden_target_name_ != nullptr
@@ -239,7 +239,7 @@ bool SpiffeChannelSecurityConnector::check_call_host(
 }
 
 void SpiffeChannelSecurityConnector::cancel_check_call_host(
-    grpc_closure* on_call_host_checked, grpc_error* error) {
+    grpc_closure* /*on_call_host_checked*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 
@@ -419,7 +419,7 @@ SpiffeServerSecurityConnector::~SpiffeServerSecurityConnector() {
 }
 
 void SpiffeServerSecurityConnector::add_handshakers(
-    const grpc_channel_args* args, grpc_pollset_set* interested_parties,
+    const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
     grpc_core::HandshakeManager* handshake_mgr) {
   /* Refresh handshaker factory if needed. */
   if (RefreshHandshakerFactory() != GRPC_SECURITY_OK) {
@@ -439,7 +439,7 @@ void SpiffeServerSecurityConnector::add_handshakers(
 }
 
 void SpiffeServerSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* ep,
+    tsi_peer peer, grpc_endpoint* /*ep*/,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   grpc_error* error = grpc_ssl_check_alpn(&peer);

--- a/src/core/lib/security/transport/client_auth_filter.cc
+++ b/src/core/lib/security/transport/client_auth_filter.cc
@@ -383,8 +383,8 @@ static void client_auth_set_pollset_or_pollset_set(
 
 /* Destructor for call_data */
 static void client_auth_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->destroy();
 }

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -421,7 +421,7 @@ void SecurityHandshaker::Shutdown(grpc_error* why) {
   GRPC_ERROR_UNREF(why);
 }
 
-void SecurityHandshaker::DoHandshake(grpc_tcp_server_acceptor* acceptor,
+void SecurityHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                                      grpc_closure* on_handshake_done,
                                      HandshakerArgs* args) {
   auto ref = Ref();
@@ -446,9 +446,9 @@ class FailHandshaker : public Handshaker {
  public:
   const char* name() const override { return "security_fail"; }
   void Shutdown(grpc_error* why) override { GRPC_ERROR_UNREF(why); }
-  void DoHandshake(grpc_tcp_server_acceptor* acceptor,
+  void DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                    grpc_closure* on_handshake_done,
-                   HandshakerArgs* args) override {
+                   HandshakerArgs* /*args*/) override {
     GRPC_CLOSURE_SCHED(on_handshake_done,
                        GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                            "Failed to create security handshaker"));

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -286,8 +286,8 @@ static grpc_error* server_auth_init_call_elem(
 
 /* Destructor for call_data */
 static void server_auth_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->~call_data();
 }

--- a/src/core/lib/slice/b64.cc
+++ b/src/core/lib/slice/b64.cc
@@ -65,7 +65,7 @@ char* grpc_base64_encode(const void* vdata, size_t data_size, int url_safe,
   return result;
 }
 
-size_t grpc_base64_estimate_encoded_size(size_t data_size, int url_safe,
+size_t grpc_base64_estimate_encoded_size(size_t data_size, int /*url_safe*/,
                                          int multiline) {
   size_t result_projected_size =
       4 * ((data_size + 3) / 3) +

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -511,7 +511,7 @@ void grpc_call_internal_unref(grpc_call* c REF_ARG) {
   GRPC_CALL_STACK_UNREF(CALL_STACK_FROM_CALL(c), REF_REASON);
 }
 
-static void release_call(void* call, grpc_error* error) {
+static void release_call(void* call, grpc_error* /*error*/) {
   grpc_call* c = static_cast<grpc_call*>(call);
   grpc_channel* channel = c->channel;
   grpc_core::Arena* arena = c->arena;
@@ -520,7 +520,7 @@ static void release_call(void* call, grpc_error* error) {
   GRPC_CHANNEL_INTERNAL_UNREF(channel, "call");
 }
 
-static void destroy_call(void* call, grpc_error* error) {
+static void destroy_call(void* call, grpc_error* /*error*/) {
   GPR_TIMER_SCOPE("destroy_call", 0);
   size_t i;
   int ii;
@@ -617,7 +617,7 @@ grpc_call_error grpc_call_cancel(grpc_call* call, void* reserved) {
 
 // This is called via the call combiner to start sending a batch down
 // the filter stack.
-static void execute_batch_in_call_combiner(void* arg, grpc_error* ignored) {
+static void execute_batch_in_call_combiner(void* arg, grpc_error* /*ignored*/) {
   GPR_TIMER_SCOPE("execute_batch_in_call_combiner", 0);
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
@@ -678,7 +678,7 @@ typedef struct {
 
 // The on_complete callback used when sending a cancel_stream batch down
 // the filter stack.  Yields the call combiner when the batch is done.
-static void done_termination(void* arg, grpc_error* error) {
+static void done_termination(void* arg, grpc_error* /*error*/) {
   cancel_state* state = static_cast<cancel_state*>(arg);
   GRPC_CALL_COMBINER_STOP(&state->call->call_combiner,
                           "on_complete for cancel_stream op");
@@ -805,9 +805,10 @@ uint32_t grpc_call_test_only_get_message_flags(grpc_call* call) {
   return flags;
 }
 
-static void destroy_encodings_accepted_by_peer(void* p) { return; }
+static void destroy_encodings_accepted_by_peer(void* /*p*/) { return; }
 
-static void set_encodings_accepted_by_peer(grpc_call* call, grpc_mdelem mdel,
+static void set_encodings_accepted_by_peer(grpc_call* /*call*/,
+                                           grpc_mdelem mdel,
                                            uint32_t* encodings_accepted_by_peer,
                                            bool stream_encoding) {
   size_t i;
@@ -1152,7 +1153,7 @@ static batch_control* reuse_or_allocate_batch_control(grpc_call* call,
 }
 
 static void finish_batch_completion(void* user_data,
-                                    grpc_cq_completion* storage) {
+                                    grpc_cq_completion* /*storage*/) {
   batch_control* bctl = static_cast<batch_control*>(user_data);
   grpc_call* call = bctl->call;
   bctl->call = nullptr;
@@ -1545,7 +1546,7 @@ static void finish_batch(void* bctlp, grpc_error* error) {
   finish_batch_step(bctl);
 }
 
-static void free_no_op_completion(void* p, grpc_cq_completion* completion) {
+static void free_no_op_completion(void* /*p*/, grpc_cq_completion* completion) {
   gpr_free(completion);
 }
 

--- a/src/core/lib/surface/call_log_batch.cc
+++ b/src/core/lib/surface/call_log_batch.cc
@@ -108,8 +108,8 @@ char* grpc_op_string(const grpc_op* op) {
 }
 
 void grpc_call_log_batch(const char* file, int line, gpr_log_severity severity,
-                         grpc_call* call, const grpc_op* ops, size_t nops,
-                         void* tag) {
+                         grpc_call* /*call*/, const grpc_op* ops, size_t nops,
+                         void* /*tag*/) {
   char* tmp;
   size_t i;
   for (i = 0; i < nops; i++) {

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -463,7 +463,7 @@ grpc_call* grpc_channel_create_registered_call(
   return call;
 }
 
-static void destroy_channel(void* arg, grpc_error* error) {
+static void destroy_channel(void* arg, grpc_error* /*error*/) {
   grpc_channel* channel = static_cast<grpc_channel*>(arg);
   if (channel->channelz_node != nullptr) {
     if (channel->channelz_node->parent_uuid() > 0) {
@@ -513,8 +513,8 @@ void grpc_channel_destroy(grpc_channel* channel) {
   GRPC_CHANNEL_INTERNAL_UNREF(channel, "channel");
 }
 
-grpc_mdelem grpc_channel_get_reffed_status_elem_slowpath(grpc_channel* channel,
-                                                         int i) {
+grpc_mdelem grpc_channel_get_reffed_status_elem_slowpath(
+    grpc_channel* /*channel*/, int i) {
   char tmp[GPR_LTOA_MIN_BUFSIZE];
   gpr_ltoa(i, tmp);
   return grpc_mdelem_from_slices(GRPC_MDSTR_GRPC_STATUS,

--- a/src/core/lib/surface/channel_ping.cc
+++ b/src/core/lib/surface/channel_ping.cc
@@ -35,7 +35,7 @@ typedef struct {
   grpc_cq_completion completion_storage;
 } ping_result;
 
-static void ping_destroy(void* arg, grpc_cq_completion* storage) {
+static void ping_destroy(void* arg, grpc_cq_completion* /*storage*/) {
   gpr_free(arg);
 }
 

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -529,7 +529,8 @@ grpc_completion_queue* grpc_completion_queue_create_internal(
 }
 
 static void cq_init_next(
-    void* data, grpc_experimental_completion_queue_functor* shutdown_callback) {
+    void* data,
+    grpc_experimental_completion_queue_functor* /*shutdown_callback*/) {
   new (data) cq_next_data();
 }
 
@@ -539,7 +540,8 @@ static void cq_destroy_next(void* data) {
 }
 
 static void cq_init_pluck(
-    void* data, grpc_experimental_completion_queue_functor* shutdown_callback) {
+    void* data,
+    grpc_experimental_completion_queue_functor* /*shutdown_callback*/) {
   new (data) cq_pluck_data();
 }
 
@@ -582,7 +584,7 @@ void grpc_cq_internal_ref(grpc_completion_queue* cq) {
   cq->owning_refs.Ref(debug_location, reason);
 }
 
-static void on_pollset_shutdown_done(void* arg, grpc_error* error) {
+static void on_pollset_shutdown_done(void* arg, grpc_error* /*error*/) {
   grpc_completion_queue* cq = static_cast<grpc_completion_queue*>(arg);
   GRPC_CQ_INTERNAL_UNREF(cq, "pollset_destroy");
 }
@@ -630,20 +632,21 @@ static void cq_check_tag(grpc_completion_queue* cq, void* tag, bool lock_cq) {
   GPR_ASSERT(found);
 }
 #else
-static void cq_check_tag(grpc_completion_queue* cq, void* tag, bool lock_cq) {}
+static void cq_check_tag(grpc_completion_queue* /*cq*/, void* /*tag*/,
+                         bool /*lock_cq*/) {}
 #endif
 
-static bool cq_begin_op_for_next(grpc_completion_queue* cq, void* tag) {
+static bool cq_begin_op_for_next(grpc_completion_queue* cq, void* /*tag*/) {
   cq_next_data* cqd = static_cast<cq_next_data*> DATA_FROM_CQ(cq);
   return cqd->pending_events.IncrementIfNonzero();
 }
 
-static bool cq_begin_op_for_pluck(grpc_completion_queue* cq, void* tag) {
+static bool cq_begin_op_for_pluck(grpc_completion_queue* cq, void* /*tag*/) {
   cq_pluck_data* cqd = static_cast<cq_pluck_data*> DATA_FROM_CQ(cq);
   return cqd->pending_events.IncrementIfNonzero();
 }
 
-static bool cq_begin_op_for_callback(grpc_completion_queue* cq, void* tag) {
+static bool cq_begin_op_for_callback(grpc_completion_queue* cq, void* /*tag*/) {
   cq_callback_data* cqd = static_cast<cq_callback_data*> DATA_FROM_CQ(cq);
   return cqd->pending_events.IncrementIfNonzero();
 }
@@ -669,7 +672,7 @@ bool grpc_cq_begin_op(grpc_completion_queue* cq, void* tag) {
 static void cq_end_op_for_next(
     grpc_completion_queue* cq, void* tag, grpc_error* error,
     void (*done)(void* done_arg, grpc_cq_completion* storage), void* done_arg,
-    grpc_cq_completion* storage, bool internal) {
+    grpc_cq_completion* storage, bool /*internal*/) {
   GPR_TIMER_SCOPE("cq_end_op_for_next", 0);
 
   if (GRPC_TRACE_FLAG_ENABLED(grpc_api_trace) ||
@@ -748,7 +751,7 @@ static void cq_end_op_for_next(
 static void cq_end_op_for_pluck(
     grpc_completion_queue* cq, void* tag, grpc_error* error,
     void (*done)(void* done_arg, grpc_cq_completion* storage), void* done_arg,
-    grpc_cq_completion* storage, bool internal) {
+    grpc_cq_completion* storage, bool /*internal*/) {
   GPR_TIMER_SCOPE("cq_end_op_for_pluck", 0);
 
   cq_pluck_data* cqd = static_cast<cq_pluck_data*> DATA_FROM_CQ(cq);
@@ -939,7 +942,7 @@ static void dump_pending_tags(grpc_completion_queue* cq) {
   gpr_free(out);
 }
 #else
-static void dump_pending_tags(grpc_completion_queue* cq) {}
+static void dump_pending_tags(grpc_completion_queue* /*cq*/) {}
 #endif
 
 static grpc_event cq_next(grpc_completion_queue* cq, gpr_timespec deadline,

--- a/src/core/lib/surface/completion_queue_factory.cc
+++ b/src/core/lib/surface/completion_queue_factory.cc
@@ -28,7 +28,7 @@
  */
 
 static grpc_completion_queue* default_create(
-    const grpc_completion_queue_factory* factory,
+    const grpc_completion_queue_factory* /*factory*/,
     const grpc_completion_queue_attributes* attr) {
   return grpc_completion_queue_create_internal(
       attr->cq_completion_type, attr->cq_polling_type, attr->cq_shutdown_cb);

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -197,7 +197,7 @@ void grpc_shutdown_internal_locked(void) {
   grpc_destroy_static_metadata_ctx();
 }
 
-void grpc_shutdown_internal(void* ignored) {
+void grpc_shutdown_internal(void* /*ignored*/) {
   GRPC_API_TRACE("grpc_shutdown_internal", 0, ());
   grpc_core::MutexLock lock(&g_init_mu);
   // We have released lock from the shutdown thread and it is possible that

--- a/src/core/lib/surface/init_secure.cc
+++ b/src/core/lib/surface/init_secure.cc
@@ -37,7 +37,7 @@
 void grpc_security_pre_init(void) {}
 
 static bool maybe_prepend_client_auth_filter(
-    grpc_channel_stack_builder* builder, void* arg) {
+    grpc_channel_stack_builder* builder, void* /*arg*/) {
   const grpc_channel_args* args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   if (args) {
@@ -52,7 +52,7 @@ static bool maybe_prepend_client_auth_filter(
 }
 
 static bool maybe_prepend_server_auth_filter(
-    grpc_channel_stack_builder* builder, void* arg) {
+    grpc_channel_stack_builder* builder, void* /*arg*/) {
   const grpc_channel_args* args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   if (args) {

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -94,8 +94,8 @@ static void lame_start_transport_stream_op_batch(
       calld->call_combiner);
 }
 
-static void lame_get_channel_info(grpc_channel_element* elem,
-                                  const grpc_channel_info* channel_info) {}
+static void lame_get_channel_info(grpc_channel_element* /*elem*/,
+                                  const grpc_channel_info* /*channel_info*/) {}
 
 static void lame_start_transport_op(grpc_channel_element* elem,
                                     grpc_transport_op* op) {
@@ -133,8 +133,8 @@ static grpc_error* lame_init_call_elem(grpc_call_element* elem,
   return GRPC_ERROR_NONE;
 }
 
-static void lame_destroy_call_elem(grpc_call_element* elem,
-                                   const grpc_call_final_info* final_info,
+static void lame_destroy_call_elem(grpc_call_element* /*elem*/,
+                                   const grpc_call_final_info* /*final_info*/,
                                    grpc_closure* then_schedule_closure) {
   GRPC_CLOSURE_SCHED(then_schedule_closure, GRPC_ERROR_NONE);
 }

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -302,7 +302,7 @@ struct shutdown_cleanup_args {
   grpc_slice slice;
 };
 
-static void shutdown_cleanup(void* arg, grpc_error* error) {
+static void shutdown_cleanup(void* arg, grpc_error* /*error*/) {
   struct shutdown_cleanup_args* a =
       static_cast<struct shutdown_cleanup_args*>(arg);
   grpc_slice_unref_internal(a->slice);
@@ -367,7 +367,7 @@ static void request_matcher_destroy(request_matcher* rm) {
   gpr_free(rm->requests_per_cq);
 }
 
-static void kill_zombie(void* elem, grpc_error* error) {
+static void kill_zombie(void* elem, grpc_error* /*error*/) {
   grpc_call_unref(
       grpc_call_from_top_element(static_cast<grpc_call_element*>(elem)));
 }
@@ -449,7 +449,7 @@ static void orphan_channel(channel_data* chand) {
   chand->next = chand->prev = chand;
 }
 
-static void finish_destroy_channel(void* cd, grpc_error* error) {
+static void finish_destroy_channel(void* cd, grpc_error* /*error*/) {
   channel_data* chand = static_cast<channel_data*>(cd);
   grpc_server* server = chand->server;
   GRPC_CHANNEL_INTERNAL_UNREF(chand->channel, "server");
@@ -477,7 +477,7 @@ static void destroy_channel(channel_data* chand) {
                        op);
 }
 
-static void done_request_event(void* req, grpc_cq_completion* c) {
+static void done_request_event(void* req, grpc_cq_completion* /*c*/) {
   gpr_free(req);
 }
 
@@ -672,7 +672,8 @@ static int num_listeners(grpc_server* server) {
   return n;
 }
 
-static void done_shutdown_event(void* server, grpc_cq_completion* completion) {
+static void done_shutdown_event(void* server,
+                                grpc_cq_completion* /*completion*/) {
   server_unref(static_cast<grpc_server*>(server));
 }
 
@@ -850,7 +851,7 @@ static void got_initial_metadata(void* ptr, grpc_error* error) {
   }
 }
 
-static void accept_stream(void* cd, grpc_transport* transport,
+static void accept_stream(void* cd, grpc_transport* /*transport*/,
                           const void* transport_server_data) {
   channel_data* chand = static_cast<channel_data*>(cd);
   /* create a call */
@@ -895,8 +896,8 @@ static grpc_error* server_init_call_elem(grpc_call_element* elem,
 }
 
 static void server_destroy_call_elem(grpc_call_element* elem,
-                                     const grpc_call_final_info* final_info,
-                                     grpc_closure* ignored) {
+                                     const grpc_call_final_info* /*final_info*/,
+                                     grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->~call_data();
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
@@ -1258,7 +1259,7 @@ void done_published_shutdown(void* done_arg, grpc_cq_completion* storage) {
   gpr_free(storage);
 }
 
-static void listener_destroy_done(void* s, grpc_error* error) {
+static void listener_destroy_done(void* s, grpc_error* /*error*/) {
   grpc_server* server = static_cast<grpc_server*>(s);
   gpr_mu_lock(&server->mu_global);
   server->listeners_destroyed++;

--- a/src/core/lib/transport/byte_stream.cc
+++ b/src/core/lib/transport/byte_stream.cc
@@ -53,8 +53,8 @@ void SliceBufferByteStream::Orphan() {
   // filter stack.
 }
 
-bool SliceBufferByteStream::Next(size_t max_size_hint,
-                                 grpc_closure* on_complete) {
+bool SliceBufferByteStream::Next(size_t /*max_size_hint*/,
+                                 grpc_closure* /*on_complete*/) {
   GPR_DEBUG_ASSERT(backing_buffer_.count > 0);
   return true;
 }

--- a/src/core/lib/transport/connectivity_state.cc
+++ b/src/core/lib/transport/connectivity_state.cc
@@ -72,7 +72,7 @@ class AsyncConnectivityStateWatcherInterface::Notifier {
   }
 
  private:
-  static void SendNotification(void* arg, grpc_error* ignored) {
+  static void SendNotification(void* arg, grpc_error* /*ignored*/) {
     Notifier* self = static_cast<Notifier*>(arg);
     if (GRPC_TRACE_FLAG_ENABLED(grpc_connectivity_state_trace)) {
       gpr_log(GPR_INFO, "watcher %p: delivering async notification for %s",

--- a/src/core/lib/transport/metadata_batch.cc
+++ b/src/core/lib/transport/metadata_batch.cc
@@ -50,6 +50,9 @@ static void assert_valid_list(grpc_mdelem_list* list) {
     verified_count++;
   }
   GPR_ASSERT(list->count == verified_count);
+#else
+  // Avoid unused-parameter warning for debug-only parameter
+  (void)list;
 #endif /* NDEBUG */
 }
 
@@ -64,6 +67,9 @@ static void assert_valid_callouts(grpc_metadata_batch* batch) {
     }
     grpc_slice_unref_internal(key_interned);
   }
+#else
+  // Avoid unused-parameter warning for debug-only parameter
+  (void)batch;
 #endif
 }
 

--- a/src/core/lib/transport/status_conversion.cc
+++ b/src/core/lib/transport/status_conversion.cc
@@ -97,4 +97,4 @@ grpc_status_code grpc_http2_status_to_grpc_status(int status) {
   }
 }
 
-int grpc_status_to_http2_status(grpc_status_code status) { return 200; }
+int grpc_status_to_http2_status(grpc_status_code /*status*/) { return 200; }

--- a/src/core/lib/transport/status_metadata.cc
+++ b/src/core/lib/transport/status_metadata.cc
@@ -28,7 +28,7 @@
    */
 #define STATUS_OFFSET 1
 
-static void destroy_status(void* ignored) {}
+static void destroy_status(void* /*ignored*/) {}
 
 grpc_status_code grpc_get_status_code_from_metadata(grpc_mdelem md) {
   if (grpc_mdelem_static_value_eq(md, GRPC_MDELEM_GRPC_STATUS_0)) {

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -80,12 +80,12 @@ grpc_slice grpc_slice_from_stream_owned_buffer(grpc_stream_refcount* refcount,
 }
 
 #ifndef NDEBUG
-void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
+void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
                           grpc_iomgr_cb_func cb, void* cb_arg,
                           const char* object_type) {
   refcount->object_type = object_type;
 #else
-void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
+void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
                           grpc_iomgr_cb_func cb, void* cb_arg) {
 #endif
   GRPC_CLOSURE_INIT(&refcount->destroy, cb, cb_arg, grpc_schedule_on_exec_ctx);

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -72,7 +72,10 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
 void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
                           grpc_iomgr_cb_func cb, void* cb_arg);
 #define GRPC_STREAM_REF_INIT(rc, ir, cb, cb_arg, objtype) \
-  grpc_stream_ref_init(rc, ir, cb, cb_arg)
+  do {                                                    \
+    grpc_stream_ref_init(rc, ir, cb, cb_arg);             \
+    (void)(objtype);                                      \
+  } while (0)
 #endif
 
 #ifndef NDEBUG

--- a/src/core/tsi/alts/frame_protector/alts_unseal_privacy_integrity_crypter.cc
+++ b/src/core/tsi/alts/frame_protector/alts_unseal_privacy_integrity_crypter.cc
@@ -33,7 +33,7 @@ static void maybe_copy_error_msg(const char* src, char** dst) {
 
 /* Perform input santity check. */
 static grpc_status_code unseal_check(alts_crypter* c, const unsigned char* data,
-                                     size_t data_allocated_size,
+                                     size_t /*data_allocated_size*/,
                                      size_t data_size, size_t* output_size,
                                      char** error_details) {
   /* Do common input sanity check. */

--- a/src/core/tsi/alts/handshaker/alts_shared_resource.cc
+++ b/src/core/tsi/alts/handshaker/alts_shared_resource.cc
@@ -30,7 +30,7 @@ alts_shared_resource_dedicated* grpc_alts_get_shared_resource_dedicated(void) {
   return &g_alts_resource_dedicated;
 }
 
-static void thread_worker(void* arg) {
+static void thread_worker(void* /*arg*/) {
   while (true) {
     grpc_event event =
         grpc_completion_queue_next(g_alts_resource_dedicated.cq,

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -264,18 +264,18 @@ static void on_handshaker_service_resp_recv(void* arg, grpc_error* error) {
 /* gRPC provided callback used when dedicatd CQ and thread are used.
  * It serves to safely bring the control back to application. */
 static void on_handshaker_service_resp_recv_dedicated(void* arg,
-                                                      grpc_error* error) {
+                                                      grpc_error* /*error*/) {
   alts_shared_resource_dedicated* resource =
       grpc_alts_get_shared_resource_dedicated();
   grpc_cq_end_op(resource->cq, arg, GRPC_ERROR_NONE,
-                 [](void* done_arg, grpc_cq_completion* storage) {}, nullptr,
-                 &resource->storage);
+                 [](void* /*done_arg*/, grpc_cq_completion* /*storage*/) {},
+                 nullptr, &resource->storage);
 }
 
 static tsi_result handshaker_next(
     tsi_handshaker* self, const unsigned char* received_bytes,
-    size_t received_bytes_size, const unsigned char** bytes_to_send,
-    size_t* bytes_to_send_size, tsi_handshaker_result** result,
+    size_t received_bytes_size, const unsigned char** /*bytes_to_send*/,
+    size_t* /*bytes_to_send_size*/, tsi_handshaker_result** /*result*/,
     tsi_handshaker_on_next_done_cb cb, void* user_data) {
   if (self == nullptr || cb == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to handshaker_next()");

--- a/src/core/tsi/fake_transport_security.cc
+++ b/src/core/tsi/fake_transport_security.cc
@@ -495,7 +495,7 @@ typedef struct {
 } fake_handshaker_result;
 
 static tsi_result fake_handshaker_result_extract_peer(
-    const tsi_handshaker_result* self, tsi_peer* peer) {
+    const tsi_handshaker_result* /*self*/, tsi_peer* peer) {
   /* Construct a tsi_peer with 1 property: certificate type. */
   tsi_result result = tsi_construct_peer(1, peer);
   if (result != TSI_OK) return result;
@@ -507,7 +507,8 @@ static tsi_result fake_handshaker_result_extract_peer(
 }
 
 static tsi_result fake_handshaker_result_create_zero_copy_grpc_protector(
-    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
+    const tsi_handshaker_result* /*self*/,
+    size_t* max_output_protected_frame_size,
     tsi_zero_copy_grpc_protector** protector) {
   *protector =
       tsi_create_fake_zero_copy_grpc_protector(max_output_protected_frame_size);
@@ -515,8 +516,8 @@ static tsi_result fake_handshaker_result_create_zero_copy_grpc_protector(
 }
 
 static tsi_result fake_handshaker_result_create_frame_protector(
-    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
-    tsi_frame_protector** protector) {
+    const tsi_handshaker_result* /*self*/,
+    size_t* max_output_protected_frame_size, tsi_frame_protector** protector) {
   *protector = tsi_create_fake_frame_protector(max_output_protected_frame_size);
   return TSI_OK;
 }
@@ -670,7 +671,7 @@ static tsi_result fake_handshaker_next(
     tsi_handshaker* self, const unsigned char* received_bytes,
     size_t received_bytes_size, const unsigned char** bytes_to_send,
     size_t* bytes_to_send_size, tsi_handshaker_result** handshaker_result,
-    tsi_handshaker_on_next_done_cb cb, void* user_data) {
+    tsi_handshaker_on_next_done_cb /*cb*/, void* /*user_data*/) {
   /* Sanity check the arguments. */
   if ((received_bytes_size > 0 && received_bytes == nullptr) ||
       bytes_to_send == nullptr || bytes_to_send_size == nullptr ||

--- a/src/core/tsi/local_transport_security.cc
+++ b/src/core/tsi/local_transport_security.cc
@@ -105,12 +105,13 @@ tsi_result local_zero_copy_grpc_protector_create(
 /* --- tsi_handshaker_result methods implementation. --- */
 
 static tsi_result handshaker_result_extract_peer(
-    const tsi_handshaker_result* self, tsi_peer* peer) {
+    const tsi_handshaker_result* /*self*/, tsi_peer* /*peer*/) {
   return TSI_OK;
 }
 
 static tsi_result handshaker_result_create_zero_copy_grpc_protector(
-    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
+    const tsi_handshaker_result* self,
+    size_t* /*max_output_protected_frame_size*/,
     tsi_zero_copy_grpc_protector** protector) {
   if (self == nullptr || protector == nullptr) {
     gpr_log(GPR_ERROR,
@@ -158,10 +159,10 @@ static tsi_result create_handshaker_result(bool is_client,
 /* --- tsi_handshaker methods implementation. --- */
 
 static tsi_result handshaker_next(
-    tsi_handshaker* self, const unsigned char* received_bytes,
-    size_t received_bytes_size, const unsigned char** bytes_to_send,
+    tsi_handshaker* self, const unsigned char* /*received_bytes*/,
+    size_t /*received_bytes_size*/, const unsigned char** /*bytes_to_send*/,
     size_t* bytes_to_send_size, tsi_handshaker_result** result,
-    tsi_handshaker_on_next_done_cb cb, void* user_data) {
+    tsi_handshaker_on_next_done_cb /*cb*/, void* /*user_data*/) {
   if (self == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to handshaker_next()");
     return TSI_INVALID_ARGUMENT;

--- a/src/core/tsi/ssl/session_cache/ssl_session_cache.cc
+++ b/src/core/tsi/ssl/session_cache/ssl_session_cache.cc
@@ -28,18 +28,20 @@
 
 namespace tsi {
 
-static void cache_key_avl_destroy(void* key, void* unused) {}
+static void cache_key_avl_destroy(void* /*key*/, void* /*unused*/) {}
 
-static void* cache_key_avl_copy(void* key, void* unused) { return key; }
+static void* cache_key_avl_copy(void* key, void* /*unused*/) { return key; }
 
-static long cache_key_avl_compare(void* key1, void* key2, void* unused) {
+static long cache_key_avl_compare(void* key1, void* key2, void* /*unused*/) {
   return grpc_slice_cmp(*static_cast<grpc_slice*>(key1),
                         *static_cast<grpc_slice*>(key2));
 }
 
-static void cache_value_avl_destroy(void* value, void* unused) {}
+static void cache_value_avl_destroy(void* /*value*/, void* /*unused*/) {}
 
-static void* cache_value_avl_copy(void* value, void* unused) { return value; }
+static void* cache_value_avl_copy(void* value, void* /*unused*/) {
+  return value;
+}
 
 // AVL only stores pointers, ownership belonges to the linked list.
 static const grpc_avl_vtable cache_avl_vtable = {

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -774,7 +774,7 @@ static tsi_result build_alpn_protocol_name_list(
 // the server's certificate, but we need to pull it anyway, in case a higher
 // layer wants to look at it. In this case the verification may fail, but
 // we don't really care.
-static int NullVerifyCallback(int preverify_ok, X509_STORE_CTX* ctx) {
+static int NullVerifyCallback(int /*preverify_ok*/, X509_STORE_CTX* /*ctx*/) {
   return 1;
 }
 
@@ -1265,7 +1265,7 @@ static tsi_result ssl_handshaker_next(
     tsi_handshaker* self, const unsigned char* received_bytes,
     size_t received_bytes_size, const unsigned char** bytes_to_send,
     size_t* bytes_to_send_size, tsi_handshaker_result** handshaker_result,
-    tsi_handshaker_on_next_done_cb cb, void* user_data) {
+    tsi_handshaker_on_next_done_cb /*cb*/, void* /*user_data*/) {
   /* Input sanity check.  */
   if ((received_bytes_size > 0 && received_bytes == nullptr) ||
       bytes_to_send == nullptr || bytes_to_send_size == nullptr ||
@@ -1465,11 +1465,9 @@ static void tsi_ssl_client_handshaker_factory_destroy(
   gpr_free(self);
 }
 
-static int client_handshaker_factory_npn_callback(SSL* ssl, unsigned char** out,
-                                                  unsigned char* outlen,
-                                                  const unsigned char* in,
-                                                  unsigned int inlen,
-                                                  void* arg) {
+static int client_handshaker_factory_npn_callback(
+    SSL* /*ssl*/, unsigned char** out, unsigned char* outlen,
+    const unsigned char* in, unsigned int inlen, void* arg) {
   tsi_ssl_client_handshaker_factory* factory =
       static_cast<tsi_ssl_client_handshaker_factory*>(arg);
   return select_protocol_list((const unsigned char**)out, outlen,
@@ -1556,7 +1554,8 @@ static int does_entry_match_name(grpc_core::StringView entry,
   return !entry.empty() && name_subdomain == entry;
 }
 
-static int ssl_server_handshaker_factory_servername_callback(SSL* ssl, int* ap,
+static int ssl_server_handshaker_factory_servername_callback(SSL* ssl,
+                                                             int* /*ap*/,
                                                              void* arg) {
   tsi_ssl_server_handshaker_factory* impl =
       static_cast<tsi_ssl_server_handshaker_factory*>(arg);
@@ -1579,7 +1578,7 @@ static int ssl_server_handshaker_factory_servername_callback(SSL* ssl, int* ap,
 
 #if TSI_OPENSSL_ALPN_SUPPORT
 static int server_handshaker_factory_alpn_callback(
-    SSL* ssl, const unsigned char** out, unsigned char* outlen,
+    SSL* /*ssl*/, const unsigned char** out, unsigned char* outlen,
     const unsigned char* in, unsigned int inlen, void* arg) {
   tsi_ssl_server_handshaker_factory* factory =
       static_cast<tsi_ssl_server_handshaker_factory*>(arg);
@@ -1590,7 +1589,7 @@ static int server_handshaker_factory_alpn_callback(
 #endif /* TSI_OPENSSL_ALPN_SUPPORT */
 
 static int server_handshaker_factory_npn_advertised_callback(
-    SSL* ssl, const unsigned char** out, unsigned int* outlen, void* arg) {
+    SSL* /*ssl*/, const unsigned char** out, unsigned int* outlen, void* arg) {
   tsi_ssl_server_handshaker_factory* factory =
       static_cast<tsi_ssl_server_handshaker_factory*>(arg);
   *out = factory->alpn_protocol_list;

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -180,7 +180,7 @@ class TagSaver final : public ::grpc::internal::CompletionQueueTag {
  public:
   explicit TagSaver(void* tag) : tag_(tag) {}
   ~TagSaver() override {}
-  bool FinalizeResult(void** tag, bool* status) override {
+  bool FinalizeResult(void** tag, bool* /*status*/) override {
     *tag = tag_;
     delete this;
     return true;

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -39,8 +39,8 @@ class DefaultGlobalClientCallbacks final
     : public ClientContext::GlobalCallbacks {
  public:
   ~DefaultGlobalClientCallbacks() override {}
-  void DefaultConstructor(ClientContext* context) override {}
-  void Destructor(ClientContext* context) override {}
+  void DefaultConstructor(ClientContext* /*context*/) override {}
+  void Destructor(ClientContext* /*context*/) override {}
 };
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;

--- a/src/cpp/common/alarm.cc
+++ b/src/cpp/common/alarm.cc
@@ -41,7 +41,7 @@ class AlarmImpl : public ::grpc::internal::CompletionQueueTag {
     grpc_timer_init_unset(&timer_);
   }
   ~AlarmImpl() {}
-  bool FinalizeResult(void** tag, bool* status) override {
+  bool FinalizeResult(void** tag, bool* /*status*/) override {
     *tag = tag_;
     Unref();
     return true;
@@ -53,22 +53,23 @@ class AlarmImpl : public ::grpc::internal::CompletionQueueTag {
     cq_ = cq->cq();
     tag_ = tag;
     GPR_ASSERT(grpc_cq_begin_op(cq_, this));
-    GRPC_CLOSURE_INIT(&on_alarm_,
-                      [](void* arg, grpc_error* error) {
-                        // queue the op on the completion queue
-                        AlarmImpl* alarm = static_cast<AlarmImpl*>(arg);
-                        alarm->Ref();
-                        // Preserve the cq and reset the cq_ so that the alarm
-                        // can be reset when the alarm tag is delivered.
-                        grpc_completion_queue* cq = alarm->cq_;
-                        alarm->cq_ = nullptr;
-                        grpc_cq_end_op(
-                            cq, alarm, error,
-                            [](void* arg, grpc_cq_completion* completion) {},
-                            arg, &alarm->completion_);
-                        GRPC_CQ_INTERNAL_UNREF(cq, "alarm");
-                      },
-                      this, grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(
+        &on_alarm_,
+        [](void* arg, grpc_error* error) {
+          // queue the op on the completion queue
+          AlarmImpl* alarm = static_cast<AlarmImpl*>(arg);
+          alarm->Ref();
+          // Preserve the cq and reset the cq_ so that the alarm
+          // can be reset when the alarm tag is delivered.
+          grpc_completion_queue* cq = alarm->cq_;
+          alarm->cq_ = nullptr;
+          grpc_cq_end_op(
+              cq, alarm, error,
+              [](void* /*arg*/, grpc_cq_completion* /*completion*/) {}, arg,
+              &alarm->completion_);
+          GRPC_CQ_INTERNAL_UNREF(cq, "alarm");
+        },
+        this, grpc_schedule_on_exec_ctx);
     grpc_timer_init(&timer_, grpc_timespec_to_millis_round_up(deadline),
                     &on_alarm_);
   }

--- a/src/cpp/server/channel_argument_option.cc
+++ b/src/cpp/server/channel_argument_option.cc
@@ -31,7 +31,8 @@ std::unique_ptr<ServerBuilderOption> MakeChannelArgumentOption(
       args->SetString(name_, value_);
     }
     virtual void UpdatePlugins(
-        std::vector<std::unique_ptr<ServerBuilderPlugin>>* plugins) override {}
+        std::vector<std::unique_ptr<ServerBuilderPlugin>>* /*plugins*/)
+        override {}
 
    private:
     const grpc::string name_;
@@ -51,7 +52,8 @@ std::unique_ptr<ServerBuilderOption> MakeChannelArgumentOption(
       args->SetInt(name_, value_);
     }
     virtual void UpdatePlugins(
-        std::vector<std::unique_ptr<ServerBuilderPlugin>>* plugins) override {}
+        std::vector<std::unique_ptr<ServerBuilderPlugin>>* /*plugins*/)
+        override {}
 
    private:
     const grpc::string name_;

--- a/src/cpp/server/health/health_check_service_server_builder_option.cc
+++ b/src/cpp/server/health/health_check_service_server_builder_option.cc
@@ -30,6 +30,6 @@ void HealthCheckServiceServerBuilderOption::UpdateArguments(
 }
 
 void HealthCheckServiceServerBuilderOption::UpdatePlugins(
-    std::vector<std::unique_ptr<ServerBuilderPlugin>>* plugins) {}
+    std::vector<std::unique_ptr<ServerBuilderPlugin>>* /*plugins*/) {}
 
 }  // namespace grpc

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -74,6 +74,9 @@ class ServerContext::CompletionOp final
   // But this class is not trivially destructible, so must actually call delete
   // before allowing the arena to be freed
   static void operator delete(void* /*ptr*/, std::size_t size) {
+    // Use size to avoid unused-parameter warning since assert seems to be
+    // compiled out and treated as unused in some gcc optimized versions.
+    (void)size;
     assert(size == sizeof(CompletionOp));
   }
 

--- a/templates/test/core/surface/public_headers_must_be_c89.c.template
+++ b/templates/test/core/surface/public_headers_must_be_c89.c.template
@@ -50,6 +50,11 @@
   #include <stdio.h>
 
   int main(int argc, char **argv) {
+    /* Use the parameters to avoid unused-parameter warning.
+       (C89 parameters must be named.) */
+    (void)argc;
+    (void)argv;
+
     % for fn in fns:
     printf("%lx", (unsigned long) ${fn});
     % endfor

--- a/test/core/avl/avl_test.cc
+++ b/test/core/avl/avl_test.cc
@@ -33,14 +33,14 @@ static int* box(int x) {
   return b;
 }
 
-static long int_compare(void* int1, void* int2, void* unused) {
+static long int_compare(void* int1, void* int2, void* /*unused*/) {
   return (*static_cast<int*>(int1)) - (*static_cast<int*>(int2));
 }
-static void* int_copy(void* p, void* unused) {
+static void* int_copy(void* p, void* /*unused*/) {
   return box(*static_cast<int*>(p));
 }
 
-static void destroy(void* p, void* unused) { gpr_free(p); }
+static void destroy(void* p, void* /*unused*/) { gpr_free(p); }
 
 static const grpc_avl_vtable int_int_vtable = {destroy, int_copy, int_compare,
                                                destroy, int_copy};

--- a/test/core/bad_ssl/server_common.cc
+++ b/test/core/bad_ssl/server_common.cc
@@ -30,7 +30,7 @@
 
 static int got_sigint = 0;
 
-static void sigint_handler(int x) { got_sigint = 1; }
+static void sigint_handler(int /*x*/) { got_sigint = 1; }
 
 const char* bad_ssl_addr(int argc, char** argv) {
   gpr_cmdline* cl;

--- a/test/core/debug/stats_test.cc
+++ b/test/core/debug/stats_test.cc
@@ -151,5 +151,9 @@ int main(int argc, char** argv) {
   int ret = RUN_ALL_TESTS();
   grpc_shutdown();
   return ret;
+#else
+  // Avoid unused parameter warning for conditional parameters.
+  (void)argc;
+  (void)argv;
 #endif
 }

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -119,12 +119,14 @@ typedef struct proxy_connection {
   grpc_http_request http_request;
 } proxy_connection;
 
-static void proxy_connection_ref(proxy_connection* conn, const char* reason) {
+static void proxy_connection_ref(proxy_connection* conn,
+                                 const char* /*reason*/) {
   gpr_ref(&conn->refcount);
 }
 
 // Helper function to destroy the proxy connection.
-static void proxy_connection_unref(proxy_connection* conn, const char* reason) {
+static void proxy_connection_unref(proxy_connection* conn,
+                                   const char* /*reason*/) {
   if (gpr_unref(&conn->refcount)) {
     gpr_log(GPR_DEBUG, "endpoints: %p %p", conn->client_endpoint,
             conn->server_endpoint);
@@ -554,7 +556,7 @@ static void on_read_request_done(void* arg, grpc_error* error) {
 }
 
 static void on_accept(void* arg, grpc_endpoint* endpoint,
-                      grpc_pollset* accepting_pollset,
+                      grpc_pollset* /*accepting_pollset*/,
                       grpc_tcp_server_acceptor* acceptor) {
   gpr_free(acceptor);
   grpc_end2end_http_proxy* proxy = static_cast<grpc_end2end_http_proxy*>(arg);
@@ -639,7 +641,7 @@ grpc_end2end_http_proxy* grpc_end2end_http_proxy_create(
   return proxy;
 }
 
-static void destroy_pollset(void* arg, grpc_error* error) {
+static void destroy_pollset(void* arg, grpc_error* /*error*/) {
   grpc_pollset* pollset = static_cast<grpc_pollset*>(arg);
   grpc_pollset_destroy(pollset);
   gpr_free(pollset);

--- a/test/core/end2end/fixtures/local_util.cc
+++ b/test/core/end2end/fixtures/local_util.cc
@@ -73,8 +73,9 @@ static bool fail_server_auth_check(grpc_channel_args* server_args) {
   return false;
 }
 
-static void process_auth_failure(void* state, grpc_auth_context* ctx,
-                                 const grpc_metadata* md, size_t md_count,
+static void process_auth_failure(void* state, grpc_auth_context* /*ctx*/,
+                                 const grpc_metadata* /*md*/,
+                                 size_t /*md_count*/,
                                  grpc_process_auth_metadata_done_cb cb,
                                  void* user_data) {
   GPR_ASSERT(state == nullptr);

--- a/test/core/end2end/fixtures/proxy.cc
+++ b/test/core/end2end/fixtures/proxy.cc
@@ -120,7 +120,7 @@ static closure* new_closure(void (*func)(void* arg, int success), void* arg) {
   return cl;
 }
 
-static void shutdown_complete(void* arg, int success) {
+static void shutdown_complete(void* arg, int /*success*/) {
   grpc_end2end_proxy* proxy = static_cast<grpc_end2end_proxy*>(arg);
   proxy->shutdown = 1;
   grpc_completion_queue_shutdown(proxy->cq);
@@ -137,7 +137,7 @@ void grpc_end2end_proxy_destroy(grpc_end2end_proxy* proxy) {
   grpc_core::Delete(proxy);
 }
 
-static void unrefpc(proxy_call* pc, const char* reason) {
+static void unrefpc(proxy_call* pc, const char* /*reason*/) {
   if (gpr_unref(&pc->refs)) {
     grpc_call_unref(pc->c2p);
     grpc_call_unref(pc->p2s);
@@ -149,14 +149,16 @@ static void unrefpc(proxy_call* pc, const char* reason) {
   }
 }
 
-static void refpc(proxy_call* pc, const char* reason) { gpr_ref(&pc->refs); }
+static void refpc(proxy_call* pc, const char* /*reason*/) {
+  gpr_ref(&pc->refs);
+}
 
-static void on_c2p_sent_initial_metadata(void* arg, int success) {
+static void on_c2p_sent_initial_metadata(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_c2p_sent_initial_metadata");
 }
 
-static void on_p2s_recv_initial_metadata(void* arg, int success) {
+static void on_p2s_recv_initial_metadata(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   grpc_op op;
   grpc_call_error err;
@@ -178,7 +180,7 @@ static void on_p2s_recv_initial_metadata(void* arg, int success) {
   unrefpc(pc, "on_p2s_recv_initial_metadata");
 }
 
-static void on_p2s_sent_initial_metadata(void* arg, int success) {
+static void on_p2s_sent_initial_metadata(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_p2s_sent_initial_metadata");
 }
@@ -205,7 +207,7 @@ static void on_p2s_sent_message(void* arg, int success) {
   unrefpc(pc, "on_p2s_sent_message");
 }
 
-static void on_p2s_sent_close(void* arg, int success) {
+static void on_p2s_sent_close(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_p2s_sent_close");
 }
@@ -285,7 +287,7 @@ static void on_p2s_recv_msg(void* arg, int success) {
   unrefpc(pc, "on_p2s_recv_msg");
 }
 
-static void on_c2p_sent_status(void* arg, int success) {
+static void on_c2p_sent_status(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_c2p_sent_status");
 }
@@ -315,7 +317,7 @@ static void on_p2s_status(void* arg, int success) {
   unrefpc(pc, "on_p2s_status");
 }
 
-static void on_c2p_closed(void* arg, int success) {
+static void on_c2p_closed(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_c2p_closed");
 }

--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -89,7 +89,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f, size_t num_ops) {
   grpc_call* c;
   cq_verifier* cqv = cq_verifier_create(f.cq);

--- a/test/core/end2end/tests/disappearing_server.cc
+++ b/test/core/end2end/tests/disappearing_server.cc
@@ -68,7 +68,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void do_request_and_shutdown_server(grpc_end2end_test_config config,
+static void do_request_and_shutdown_server(grpc_end2end_test_config /*config*/,
                                            grpc_end2end_test_fixture* f,
                                            cq_verifier* cqv) {
   grpc_call* c;

--- a/test/core/end2end/tests/empty_batch.cc
+++ b/test/core/end2end/tests/empty_batch.cc
@@ -85,7 +85,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void empty_batch_body(grpc_end2end_test_config config,
+static void empty_batch_body(grpc_end2end_test_config /*config*/,
                              grpc_end2end_test_fixture f) {
   grpc_call* c;
   cq_verifier* cqv = cq_verifier_create(f.cq);

--- a/test/core/end2end/tests/high_initial_seqno.cc
+++ b/test/core/end2end/tests/high_initial_seqno.cc
@@ -87,7 +87,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/hpack_size.cc
+++ b/test/core/end2end/tests/hpack_size.cc
@@ -228,7 +228,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f, size_t index) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/idempotent_request.cc
+++ b/test/core/end2end/tests/idempotent_request.cc
@@ -86,7 +86,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/max_concurrent_streams.cc
+++ b/test/core/end2end/tests/max_concurrent_streams.cc
@@ -83,7 +83,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -42,7 +42,7 @@ static void drain_cq(grpc_completion_queue* cq) {
   } while (ev.type != GRPC_QUEUE_SHUTDOWN);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture* f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/negative_deadline.cc
+++ b/test/core/end2end/tests/negative_deadline.cc
@@ -86,7 +86,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f, size_t num_ops) {
   grpc_call* c;
   cq_verifier* cqv = cq_verifier_create(f.cq);

--- a/test/core/end2end/tests/payload.cc
+++ b/test/core/end2end/tests/payload.cc
@@ -100,7 +100,7 @@ static grpc_slice generate_random_slice() {
   return out;
 }
 
-static void request_response_with_payload(grpc_end2end_test_config config,
+static void request_response_with_payload(grpc_end2end_test_config /*config*/,
                                           grpc_end2end_test_fixture f) {
   /* Create large request and response bodies. These are big enough to require
    * multiple round trips to deliver to the peer, and their exact contents of

--- a/test/core/end2end/tests/proxy_auth.cc
+++ b/test/core/end2end/tests/proxy_auth.cc
@@ -90,7 +90,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/registered_call.cc
+++ b/test/core/end2end/tests/registered_call.cc
@@ -86,7 +86,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f, void* rc) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/server_finishes_request.cc
+++ b/test/core/end2end/tests/server_finishes_request.cc
@@ -85,7 +85,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/simple_delayed_request.cc
+++ b/test/core/end2end/tests/simple_delayed_request.cc
@@ -75,7 +75,7 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
                                         grpc_end2end_test_fixture* f,
                                         grpc_channel_args* client_args,
                                         grpc_channel_args* server_args,
-                                        long delay_us) {
+                                        long /*delay_us*/) {
   grpc_call* c;
   grpc_call* s;
   cq_verifier* cqv = cq_verifier_create(f->cq);

--- a/test/core/gpr/alloc_test.cc
+++ b/test/core/gpr/alloc_test.cc
@@ -25,7 +25,7 @@
 
 static void* fake_malloc(size_t size) { return (void*)size; }
 
-static void* fake_realloc(void* addr, size_t size) { return (void*)size; }
+static void* fake_realloc(void* /*addr*/, size_t size) { return (void*)size; }
 
 static void fake_free(void* addr) {
   *(static_cast<intptr_t*>(addr)) = static_cast<intptr_t>(0xdeadd00d);

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -131,6 +131,6 @@ int main(int argc, char** argv) {
 
 #else /* GRPC_LINUX_ERRQUEUE */
 
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 
 #endif /* GRPC_LINUX_ERRQUEUE */

--- a/test/core/iomgr/ev_epollex_linux_test.cc
+++ b/test/core/iomgr/ev_epollex_linux_test.cc
@@ -111,5 +111,5 @@ int main(int argc, char** argv) {
   return 0;
 }
 #else /* defined(GRPC_LINUX_EPOLL_CREATE1) && defined(GRPC_LINUX_EVENTFD) */
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 #endif

--- a/test/core/iomgr/tcp_client_uv_test.cc
+++ b/test/core/iomgr/tcp_client_uv_test.cc
@@ -209,6 +209,6 @@ int main(int argc, char** argv) {
 
 #else /* GRPC_UV */
 
-int main(int argc, char** argv) { return 1; }
+int main(int /*argc*/, char** /*argv*/) { return 1; }
 
 #endif /* GRPC_UV */

--- a/test/core/iomgr/tcp_server_uv_test.cc
+++ b/test/core/iomgr/tcp_server_uv_test.cc
@@ -314,6 +314,6 @@ int main(int argc, char** argv) {
 
 #else /* GRPC_UV */
 
-int main(int argc, char** argv) { return 1; }
+int main(int /*argc*/, char** /*argv*/) { return 1; }
 
 #endif /* GRPC_UV */

--- a/test/core/json/json_stream_error_test.cc
+++ b/test/core/json/json_stream_error_test.cc
@@ -28,12 +28,14 @@
 
 static int g_string_clear_once = 0;
 
-static void string_clear(void* userdata) {
+static void string_clear(void* /*userdata*/) {
   GPR_ASSERT(!g_string_clear_once);
   g_string_clear_once = 1;
 }
 
-static uint32_t read_char(void* userdata) { return GRPC_JSON_READ_CHAR_ERROR; }
+static uint32_t read_char(void* /*userdata*/) {
+  return GRPC_JSON_READ_CHAR_ERROR;
+}
 
 static grpc_json_reader_vtable reader_vtable = {
     string_clear, nullptr, nullptr, read_char, nullptr, nullptr,

--- a/test/core/security/check_gcp_environment_linux_test.cc
+++ b/test/core/security/check_gcp_environment_linux_test.cc
@@ -72,7 +72,7 @@ static void test_gcp_environment_check_failure() {
   GPR_ASSERT(!check_bios_data_linux_test("\n"));
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   /* Tests. */
   test_gcp_environment_check_success();
   test_gcp_environment_check_failure();
@@ -81,6 +81,6 @@ int main(int argc, char** argv) {
 
 #else  // GPR_LINUX
 
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 
 #endif  // GPR_LINUX

--- a/test/core/security/check_gcp_environment_windows_test.cc
+++ b/test/core/security/check_gcp_environment_windows_test.cc
@@ -68,6 +68,6 @@ int main(int argc, char** argv) {
 }
 #else  // GPR_WINDOWS
 
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 
 #endif  // GPR_WINDOWS

--- a/test/core/security/grpc_alts_credentials_options_test.cc
+++ b/test/core/security/grpc_alts_credentials_options_test.cc
@@ -87,7 +87,7 @@ static void test_client_options_api_success() {
   grpc_alts_credentials_options_destroy(new_options);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   /* Test. */
   test_copy_client_options_failure();
   test_client_options_api_success();

--- a/test/core/security/oauth2_utils.cc
+++ b/test/core/security/oauth2_utils.cc
@@ -63,7 +63,7 @@ static void on_oauth2_response(void* arg, grpc_error* error) {
   gpr_mu_unlock(request->mu);
 }
 
-static void destroy_after_shutdown(void* pollset, grpc_error* error) {
+static void destroy_after_shutdown(void* pollset, grpc_error* /*error*/) {
   grpc_pollset_destroy(reinterpret_cast<grpc_pollset*>(pollset));
   gpr_free(pollset);
 }

--- a/test/core/surface/public_headers_must_be_c89.c
+++ b/test/core/surface/public_headers_must_be_c89.c
@@ -61,6 +61,11 @@
 #include <stdio.h>
 
 int main(int argc, char **argv) {
+  /* Use the parameters to avoid unused-parameter warning.
+     (C89 parameters must be named.) */
+  (void)argc;
+  (void)argv;
+
   printf("%lx", (unsigned long) grpc_compression_algorithm_is_message);
   printf("%lx", (unsigned long) grpc_compression_algorithm_is_stream);
   printf("%lx", (unsigned long) grpc_compression_algorithm_parse);

--- a/test/core/transport/chttp2/bin_encoder_test.cc
+++ b/test/core/transport/chttp2/bin_encoder_test.cc
@@ -98,7 +98,7 @@ static void expect_binary_header(const char* hdr, int binary) {
   }
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   grpc_init();
 
   /* Base64 test vectors from RFC 4648, with padding removed */

--- a/test/core/tsi/alts/crypt/aes_gcm_test.cc
+++ b/test/core/tsi/alts/crypt/aes_gcm_test.cc
@@ -2093,7 +2093,7 @@ static void gsec_test_do_vector_tests_ieee() {
   gsec_aead_free_test_vector(test_vector_20);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   grpc_init();
   gsec_test_do_generic_crypter_tests();
   gsec_test_do_vector_tests_nist();

--- a/test/core/tsi/alts/frame_protector/alts_counter_test.cc
+++ b/test/core/tsi/alts/frame_protector/alts_counter_test.cc
@@ -27,8 +27,8 @@ const size_t kSmallOverflowSize = 1;
 const size_t kGcmCounterSize = 12;
 const size_t kGcmOverflowSize = 5;
 
-static bool do_bytes_represent_client(alts_counter* ctr, unsigned char* counter,
-                                      size_t size) {
+static bool do_bytes_represent_client(alts_counter* ctr,
+                                      unsigned char* /*counter*/, size_t size) {
   return (ctr->counter[size - 1] & 0x80) == 0x80;
 }
 
@@ -165,7 +165,7 @@ static void alts_counter_test_overflow_single_increment(bool is_client,
   alts_counter_destroy(ctr);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   alts_counter_test_input_sanity_check(kGcmCounterSize, kGcmOverflowSize);
   alts_counter_test_overflow_full_range(true, kSmallCounterSize,
                                         kSmallOverflowSize);

--- a/test/core/tsi/alts/frame_protector/alts_crypter_test.cc
+++ b/test/core/tsi/alts/frame_protector/alts_crypter_test.cc
@@ -128,10 +128,9 @@ static void alts_crypter_test_multiple_random_seal_unseal(
   gpr_free(duplicate_buffer2);
 }
 
-static void alts_crypter_test_corrupted_unseal(alts_crypter* server_seal,
-                                               alts_crypter* server_unseal,
-                                               alts_crypter* client_seal,
-                                               alts_crypter* client_unseal) {
+static void alts_crypter_test_corrupted_unseal(
+    alts_crypter* server_seal, alts_crypter* server_unseal,
+    alts_crypter* client_seal, alts_crypter* /*client_unseal*/) {
   size_t data_size = gsec_test_bias_random_uint32(1024) + 1;
   size_t num_overhead_bytes = alts_crypter_num_overhead_bytes(server_seal);
   size_t protected_data_size = data_size + num_overhead_bytes;
@@ -487,7 +486,7 @@ static void alts_crypter_do_generic_tests() {
                                    client_unseal);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   alts_crypter_do_generic_tests();
   return 0;
 }

--- a/test/core/tsi/alts/frame_protector/frame_handler_test.cc
+++ b/test/core/tsi/alts/frame_protector/frame_handler_test.cc
@@ -228,7 +228,7 @@ static void frame_handler_test_null_reader_bytes() {
   destroy_frame_handler(handler);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   frame_handler_test_frame_deframe();
   frame_handler_test_small_buffer();
   frame_handler_test_null_input_stream();

--- a/test/core/tsi/alts/handshaker/transport_security_common_api_test.cc
+++ b/test/core/tsi/alts/handshaker/transport_security_common_api_test.cc
@@ -155,7 +155,7 @@ static void test_check_failure() {
                  &highest_common_version) == 0);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   /* Run tests. */
   test_success();
   test_failure();

--- a/test/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol_test.cc
+++ b/test/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol_test.cc
@@ -917,7 +917,7 @@ static void alts_iovec_record_protocol_mix_operations_tests() {
   alts_iovec_record_protocol_test_fixture_destroy(fixture_2);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   alts_iovec_record_protocol_random_seal_unseal_tests();
   alts_iovec_record_protocol_empty_seal_unseal_tests();
   alts_iovec_record_protocol_unsync_seal_unseal_tests();

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -41,7 +41,7 @@ typedef struct mock_endpoint {
 } mock_endpoint;
 
 static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                    grpc_closure* cb, bool urgent) {
+                    grpc_closure* cb, bool /*urgent*/) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   gpr_mu_lock(&m->mu);
   if (m->read_buffer.count > 0) {
@@ -55,7 +55,7 @@ static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
 }
 
 static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                     grpc_closure* cb, void* arg) {
+                     grpc_closure* cb, void* /*arg*/) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   for (size_t i = 0; i < slices->count; i++) {
     m->on_write(slices->slices[i]);
@@ -63,13 +63,14 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   GRPC_CLOSURE_SCHED(cb, GRPC_ERROR_NONE);
 }
 
-static void me_add_to_pollset(grpc_endpoint* ep, grpc_pollset* pollset) {}
+static void me_add_to_pollset(grpc_endpoint* /*ep*/,
+                              grpc_pollset* /*pollset*/) {}
 
-static void me_add_to_pollset_set(grpc_endpoint* ep,
-                                  grpc_pollset_set* pollset) {}
+static void me_add_to_pollset_set(grpc_endpoint* /*ep*/,
+                                  grpc_pollset_set* /*pollset*/) {}
 
-static void me_delete_from_pollset_set(grpc_endpoint* ep,
-                                       grpc_pollset_set* pollset) {}
+static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
+                                       grpc_pollset_set* /*pollset*/) {}
 
 static void me_shutdown(grpc_endpoint* ep, grpc_error* why) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
@@ -93,7 +94,7 @@ static void me_destroy(grpc_endpoint* ep) {
   gpr_free(m);
 }
 
-static char* me_get_peer(grpc_endpoint* ep) {
+static char* me_get_peer(grpc_endpoint* /*ep*/) {
   return gpr_strdup("fake:mock_endpoint");
 }
 
@@ -102,9 +103,9 @@ static grpc_resource_user* me_get_resource_user(grpc_endpoint* ep) {
   return m->resource_user;
 }
 
-static int me_get_fd(grpc_endpoint* ep) { return -1; }
+static int me_get_fd(grpc_endpoint* /*ep*/) { return -1; }
 
-static bool me_can_track_err(grpc_endpoint* ep) { return false; }
+static bool me_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
 static const grpc_endpoint_vtable vtable = {me_read,
                                             me_write,

--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -54,7 +54,7 @@ struct passthru_endpoint {
 };
 
 static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                    grpc_closure* cb, bool urgent) {
+                    grpc_closure* cb, bool /*urgent*/) {
   half* m = reinterpret_cast<half*>(ep);
   gpr_mu_lock(&m->parent->mu);
   if (m->parent->shutdown) {
@@ -76,7 +76,7 @@ static half* other_half(half* h) {
 }
 
 static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                     grpc_closure* cb, void* arg) {
+                     grpc_closure* cb, void* /*arg*/) {
   half* m = other_half(reinterpret_cast<half*>(ep));
   gpr_mu_lock(&m->parent->mu);
   grpc_error* error = GRPC_ERROR_NONE;
@@ -99,13 +99,14 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   GRPC_CLOSURE_SCHED(cb, error);
 }
 
-static void me_add_to_pollset(grpc_endpoint* ep, grpc_pollset* pollset) {}
+static void me_add_to_pollset(grpc_endpoint* /*ep*/,
+                              grpc_pollset* /*pollset*/) {}
 
-static void me_add_to_pollset_set(grpc_endpoint* ep,
-                                  grpc_pollset_set* pollset) {}
+static void me_add_to_pollset_set(grpc_endpoint* /*ep*/,
+                                  grpc_pollset_set* /*pollset*/) {}
 
-static void me_delete_from_pollset_set(grpc_endpoint* ep,
-                                       grpc_pollset_set* pollset) {}
+static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
+                                       grpc_pollset_set* /*pollset*/) {}
 
 static void me_shutdown(grpc_endpoint* ep, grpc_error* why) {
   half* m = reinterpret_cast<half*>(ep);
@@ -153,9 +154,9 @@ static char* me_get_peer(grpc_endpoint* ep) {
              : gpr_strdup("fake:mock_server_endpoint");
 }
 
-static int me_get_fd(grpc_endpoint* ep) { return -1; }
+static int me_get_fd(grpc_endpoint* /*ep*/) { return -1; }
 
-static bool me_can_track_err(grpc_endpoint* ep) { return false; }
+static bool me_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
 static grpc_resource_user* me_get_resource_user(grpc_endpoint* ep) {
   half* m = reinterpret_cast<half*>(ep);

--- a/test/core/util/port_server_client.cc
+++ b/test/core/util/port_server_client.cc
@@ -40,14 +40,14 @@ typedef struct freereq {
   int done = 0;
 } freereq;
 
-static void destroy_pops_and_shutdown(void* p, grpc_error* error) {
+static void destroy_pops_and_shutdown(void* p, grpc_error* /*error*/) {
   grpc_pollset* pollset =
       grpc_polling_entity_pollset(static_cast<grpc_polling_entity*>(p));
   grpc_pollset_destroy(pollset);
   gpr_free(pollset);
 }
 
-static void freed_port_from_server(void* arg, grpc_error* error) {
+static void freed_port_from_server(void* arg, grpc_error* /*error*/) {
   freereq* pr = static_cast<freereq*>(arg);
   gpr_mu_lock(pr->mu);
   pr->done = 1;

--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -231,7 +231,7 @@ static void output_num(long num) {
   output_string(buf);
 }
 
-static void crash_handler(int signum, siginfo_t* info, void* data) {
+static void crash_handler(int signum, siginfo_t* /*info*/, void* /*data*/) {
   void* addrlist[MAX_FRAMES + 1];
   int addrlen;
 
@@ -379,7 +379,7 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms) {
           GPR_TIMESPAN));
 }
 
-void grpc_test_init(int argc, char** argv) {
+void grpc_test_init(int /*argc*/, char** /*argv*/) {
   install_crash_handler();
   gpr_log(GPR_DEBUG,
           "test slowdown factor: sanitizer=%" PRId64 ", fixture=%" PRId64

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -185,7 +185,7 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
     }
 
    private:
-    void RecordRecvTrailingMetadata(grpc_error* error,
+    void RecordRecvTrailingMetadata(grpc_error* /*error*/,
                                     MetadataInterface* recv_trailing_metadata,
                                     CallState* call_state) {
       GPR_ASSERT(recv_trailing_metadata != nullptr);
@@ -226,7 +226,7 @@ class InterceptTrailingFactory : public LoadBalancingPolicyFactory {
   }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const grpc_json* json, grpc_error** error) const override {
+      const grpc_json* /*json*/, grpc_error** /*error*/) const override {
     return nullptr;
   }
 

--- a/test/core/util/trickle_endpoint.cc
+++ b/test/core/util/trickle_endpoint.cc
@@ -62,7 +62,7 @@ static void maybe_call_write_cb_locked(trickle_endpoint* te) {
 }
 
 static void te_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                     grpc_closure* cb, void* arg) {
+                     grpc_closure* cb, void* /*arg*/) {
   trickle_endpoint* te = reinterpret_cast<trickle_endpoint*>(ep);
   gpr_mu_lock(&te->mu);
   GPR_ASSERT(te->write_cb == nullptr);
@@ -131,9 +131,9 @@ static int te_get_fd(grpc_endpoint* ep) {
   return grpc_endpoint_get_fd(te->wrapped);
 }
 
-static bool te_can_track_err(grpc_endpoint* ep) { return false; }
+static bool te_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
-static void te_finish_write(void* arg, grpc_error* error) {
+static void te_finish_write(void* arg, grpc_error* /*error*/) {
   trickle_endpoint* te = static_cast<trickle_endpoint*>(arg);
   gpr_mu_lock(&te->mu);
   te->writing = false;

--- a/test/cpp/end2end/test_health_check_service_impl.cc
+++ b/test/cpp/end2end/test_health_check_service_impl.cc
@@ -26,7 +26,7 @@ using grpc::health::v1::HealthCheckResponse;
 namespace grpc {
 namespace testing {
 
-Status HealthCheckServiceImpl::Check(ServerContext* context,
+Status HealthCheckServiceImpl::Check(ServerContext* /*context*/,
                                      const HealthCheckRequest* request,
                                      HealthCheckResponse* response) {
   std::lock_guard<std::mutex> lock(mu_);

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -246,9 +246,9 @@ Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
   return Status::OK;
 }
 
-Status TestServiceImpl::CheckClientInitialMetadata(ServerContext* context,
-                                                   const SimpleRequest* request,
-                                                   SimpleResponse* response) {
+Status TestServiceImpl::CheckClientInitialMetadata(
+    ServerContext* context, const SimpleRequest* /*request*/,
+    SimpleResponse* /*response*/) {
   EXPECT_EQ(MetadataMatchCount(context->client_metadata(),
                                kCheckClientInitialMetadataKey,
                                kCheckClientInitialMetadataVal),
@@ -296,8 +296,8 @@ void CallbackTestServiceImpl::Echo(
 }
 
 void CallbackTestServiceImpl::CheckClientInitialMetadata(
-    ServerContext* context, const SimpleRequest* request,
-    SimpleResponse* response,
+    ServerContext* context, const SimpleRequest* /*request*/,
+    SimpleResponse* /*response*/,
     experimental::ServerCallbackRpcController* controller) {
   EXPECT_EQ(MetadataMatchCount(context->client_metadata(),
                                kCheckClientInitialMetadataKey,
@@ -741,7 +741,7 @@ CallbackTestServiceImpl::ResponseStream() {
       EXPECT_TRUE(ctx_->IsCancelled());
       FinishOnce(Status::CANCELLED);
     }
-    void OnWriteDone(bool ok) override {
+    void OnWriteDone(bool /*ok*/) override {
       if (num_msgs_sent_ < server_responses_to_send_) {
         NextWrite();
       } else if (server_coalescing_api_ != 0) {
@@ -854,7 +854,7 @@ CallbackTestServiceImpl::BidiStream() {
         FinishOnce(Status::OK);
       }
     }
-    void OnWriteDone(bool ok) override {
+    void OnWriteDone(bool /*ok*/) override {
       std::lock_guard<std::mutex> l(finish_mu_);
       if (!finished_) {
         StartRead(&request_);

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -92,7 +92,7 @@ class AdditionalMetadataInterceptorFactory
       : additional_metadata_(std::move(additional_metadata)) {}
 
   experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
+      experimental::ClientRpcInfo* /*info*/) override {
     return new AdditionalMetadataInterceptor(additional_metadata_);
   }
 

--- a/test/cpp/microbenchmarks/callback_test_service.cc
+++ b/test/cpp/microbenchmarks/callback_test_service.cc
@@ -47,7 +47,8 @@ int GetIntValueFromMetadata(
 }  // namespace
 
 void CallbackStreamingTestService::Echo(
-    ServerContext* context, const EchoRequest* request, EchoResponse* response,
+    ServerContext* context, const EchoRequest* /*request*/,
+    EchoResponse* response,
     experimental::ServerCallbackRpcController* controller) {
   int response_msgs_size = GetIntValueFromMetadata(
       kServerMessageSize, context->client_metadata(), 0);

--- a/test/cpp/microbenchmarks/helpers.cc
+++ b/test/cpp/microbenchmarks/helpers.cc
@@ -64,6 +64,10 @@ void TrackCounters::AddLabel(const grpc::string& label) {
 }
 
 void TrackCounters::AddToLabel(std::ostream& out, benchmark::State& state) {
+  // Use the parameters to avoid unused-parameter warnings depending on the
+  // #define's present
+  (void)out;
+  (void)state;
 #ifdef GRPC_COLLECT_STATS
   grpc_stats_data stats_end;
   grpc_stats_collect(&stats_end);

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -54,7 +54,7 @@ namespace testing {
 template <class RequestType>
 class ClientRequestCreator {
  public:
-  ClientRequestCreator(RequestType* req, const PayloadConfig&) {
+  ClientRequestCreator(RequestType* /*req*/, const PayloadConfig&) {
     // this template must be specialized
     // fail with an assertion rather than a compile-time
     // check since these only happen at the beginning anyway

--- a/test/cpp/qps/usage_timer.cc
+++ b/test/cpp/qps/usage_timer.cc
@@ -69,6 +69,9 @@ static void get_cpu_usage(unsigned long long* total_cpu_time,
     }
   }
 #else
+  // Use the parameters to avoid unused-parameter warning
+  (void)total_cpu_time;
+  (void)idle_cpu_time;
   gpr_log(GPR_INFO, "get_cpu_usage(): Non-linux platform is not supported.");
 #endif
 }

--- a/test/cpp/util/create_test_channel.cc
+++ b/test/cpp/util/create_test_channel.cc
@@ -33,7 +33,7 @@ const char kProdTlsCredentialsType[] = "prod_ssl";
 class SslCredentialProvider : public testing::CredentialTypeProvider {
  public:
   std::shared_ptr<ChannelCredentials> GetChannelCredentials(
-      grpc::ChannelArguments* args) override {
+      grpc::ChannelArguments* /*args*/) override {
     return grpc::SslCredentials(SslCredentialsOptions());
   }
   std::shared_ptr<ServerCredentials> GetServerCredentials() override {


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform.  It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, `(void)` expressions were added to convince the compiler that a parameter was indeed being used.