### PR TITLE
Remove unused-parameter warnings, round 2 (19 of 19)

### DIFF
--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -185,7 +185,7 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
     }
 
    private:
-    void RecordRecvTrailingMetadata(grpc_error* error,
+    void RecordRecvTrailingMetadata(grpc_error* /*error*/,
                                     MetadataInterface* recv_trailing_metadata,
                                     CallState* call_state) {
       GPR_ASSERT(recv_trailing_metadata != nullptr);
@@ -226,7 +226,7 @@ class InterceptTrailingFactory : public LoadBalancingPolicyFactory {
   }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const grpc_json* json, grpc_error** error) const override {
+      const grpc_json* /*json*/, grpc_error** /*error*/) const override {
     return nullptr;
   }
 

--- a/test/core/util/trickle_endpoint.cc
+++ b/test/core/util/trickle_endpoint.cc
@@ -62,7 +62,7 @@ static void maybe_call_write_cb_locked(trickle_endpoint* te) {
 }
 
 static void te_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                     grpc_closure* cb, void* arg) {
+                     grpc_closure* cb, void* /*arg*/) {
   trickle_endpoint* te = reinterpret_cast<trickle_endpoint*>(ep);
   gpr_mu_lock(&te->mu);
   GPR_ASSERT(te->write_cb == nullptr);
@@ -131,9 +131,9 @@ static int te_get_fd(grpc_endpoint* ep) {
   return grpc_endpoint_get_fd(te->wrapped);
 }
 
-static bool te_can_track_err(grpc_endpoint* ep) { return false; }
+static bool te_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
-static void te_finish_write(void* arg, grpc_error* error) {
+static void te_finish_write(void* arg, grpc_error* /*error*/) {
   trickle_endpoint* te = static_cast<trickle_endpoint*>(arg);
   gpr_mu_lock(&te->mu);
   te->writing = false;

--- a/test/cpp/end2end/test_health_check_service_impl.cc
+++ b/test/cpp/end2end/test_health_check_service_impl.cc
@@ -26,7 +26,7 @@ using grpc::health::v1::HealthCheckResponse;
 namespace grpc {
 namespace testing {
 
-Status HealthCheckServiceImpl::Check(ServerContext* context,
+Status HealthCheckServiceImpl::Check(ServerContext* /*context*/,
                                      const HealthCheckRequest* request,
                                      HealthCheckResponse* response) {
   std::lock_guard<std::mutex> lock(mu_);

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -246,9 +246,9 @@ Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
   return Status::OK;
 }
 
-Status TestServiceImpl::CheckClientInitialMetadata(ServerContext* context,
-                                                   const SimpleRequest* request,
-                                                   SimpleResponse* response) {
+Status TestServiceImpl::CheckClientInitialMetadata(
+    ServerContext* context, const SimpleRequest* /*request*/,
+    SimpleResponse* /*response*/) {
   EXPECT_EQ(MetadataMatchCount(context->client_metadata(),
                                kCheckClientInitialMetadataKey,
                                kCheckClientInitialMetadataVal),
@@ -296,8 +296,8 @@ void CallbackTestServiceImpl::Echo(
 }
 
 void CallbackTestServiceImpl::CheckClientInitialMetadata(
-    ServerContext* context, const SimpleRequest* request,
-    SimpleResponse* response,
+    ServerContext* context, const SimpleRequest* /*request*/,
+    SimpleResponse* /*response*/,
     experimental::ServerCallbackRpcController* controller) {
   EXPECT_EQ(MetadataMatchCount(context->client_metadata(),
                                kCheckClientInitialMetadataKey,
@@ -741,7 +741,7 @@ CallbackTestServiceImpl::ResponseStream() {
       EXPECT_TRUE(ctx_->IsCancelled());
       FinishOnce(Status::CANCELLED);
     }
-    void OnWriteDone(bool ok) override {
+    void OnWriteDone(bool /*ok*/) override {
       if (num_msgs_sent_ < server_responses_to_send_) {
         NextWrite();
       } else if (server_coalescing_api_ != 0) {
@@ -854,7 +854,7 @@ CallbackTestServiceImpl::BidiStream() {
         FinishOnce(Status::OK);
       }
     }
-    void OnWriteDone(bool ok) override {
+    void OnWriteDone(bool /*ok*/) override {
       std::lock_guard<std::mutex> l(finish_mu_);
       if (!finished_) {
         StartRead(&request_);

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -92,7 +92,7 @@ class AdditionalMetadataInterceptorFactory
       : additional_metadata_(std::move(additional_metadata)) {}
 
   experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
+      experimental::ClientRpcInfo* /*info*/) override {
     return new AdditionalMetadataInterceptor(additional_metadata_);
   }
 

--- a/test/cpp/microbenchmarks/callback_test_service.cc
+++ b/test/cpp/microbenchmarks/callback_test_service.cc
@@ -47,7 +47,8 @@ int GetIntValueFromMetadata(
 }  // namespace
 
 void CallbackStreamingTestService::Echo(
-    ServerContext* context, const EchoRequest* request, EchoResponse* response,
+    ServerContext* context, const EchoRequest* /*request*/,
+    EchoResponse* response,
     experimental::ServerCallbackRpcController* controller) {
   int response_msgs_size = GetIntValueFromMetadata(
       kServerMessageSize, context->client_metadata(), 0);

--- a/test/cpp/microbenchmarks/helpers.cc
+++ b/test/cpp/microbenchmarks/helpers.cc
@@ -64,6 +64,10 @@ void TrackCounters::AddLabel(const grpc::string& label) {
 }
 
 void TrackCounters::AddToLabel(std::ostream& out, benchmark::State& state) {
+  // Use the parameters to avoid unused-parameter warnings depending on the
+  // #define's present
+  (void)out;
+  (void)state;
 #ifdef GRPC_COLLECT_STATS
   grpc_stats_data stats_end;
   grpc_stats_collect(&stats_end);

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -54,7 +54,7 @@ namespace testing {
 template <class RequestType>
 class ClientRequestCreator {
  public:
-  ClientRequestCreator(RequestType* req, const PayloadConfig&) {
+  ClientRequestCreator(RequestType* /*req*/, const PayloadConfig&) {
     // this template must be specialized
     // fail with an assertion rather than a compile-time
     // check since these only happen at the beginning anyway

--- a/test/cpp/qps/usage_timer.cc
+++ b/test/cpp/qps/usage_timer.cc
@@ -69,6 +69,9 @@ static void get_cpu_usage(unsigned long long* total_cpu_time,
     }
   }
 #else
+  // Use the parameters to avoid unused-parameter warning
+  (void)total_cpu_time;
+  (void)idle_cpu_time;
   gpr_log(GPR_INFO, "get_cpu_usage(): Non-linux platform is not supported.");
 #endif
 }

--- a/test/cpp/util/create_test_channel.cc
+++ b/test/cpp/util/create_test_channel.cc
@@ -33,7 +33,7 @@ const char kProdTlsCredentialsType[] = "prod_ssl";
 class SslCredentialProvider : public testing::CredentialTypeProvider {
  public:
   std::shared_ptr<ChannelCredentials> GetChannelCredentials(
-      grpc::ChannelArguments* args) override {
+      grpc::ChannelArguments* /*args*/) override {
     return grpc::SslCredentials(SslCredentialsOptions());
   }
   std::shared_ptr<ServerCredentials> GetServerCredentials() override {


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.