### PR TITLE
Move alwayslink to lb_server_load_reporting_filter target.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1392,6 +1392,7 @@ grpc_cc_library(
         "grpc++_base",
         "grpc_secure",
     ],
+    alwayslink = 1,
 )
 
 grpc_cc_library(
@@ -1438,7 +1439,6 @@ grpc_cc_library(
         "lb_server_load_reporting_filter",
         "lb_server_load_reporting_service_server_builder_plugin",
     ],
-    alwayslink = 1,
 )
 
 grpc_cc_library(


### PR DESCRIPTION
The static initialization is in this target. Otherwise ServerLoadReportingFilterStaticRegistrar does not run on startup.

https://github.com/grpc/grpc/blob/aba7f7bd2b4dbace8a7e62d3bb10329cec03d5a3/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc#L347-L365




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yang-g @AspirinSJL
