### PR TITLE
Remove unused-parameter warnings, round 2 (18 of 19)

### DIFF
--- a/test/core/tsi/alts/crypt/aes_gcm_test.cc
+++ b/test/core/tsi/alts/crypt/aes_gcm_test.cc
@@ -2093,7 +2093,7 @@ static void gsec_test_do_vector_tests_ieee() {
   gsec_aead_free_test_vector(test_vector_20);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   grpc_init();
   gsec_test_do_generic_crypter_tests();
   gsec_test_do_vector_tests_nist();

--- a/test/core/tsi/alts/frame_protector/alts_counter_test.cc
+++ b/test/core/tsi/alts/frame_protector/alts_counter_test.cc
@@ -27,8 +27,8 @@ const size_t kSmallOverflowSize = 1;
 const size_t kGcmCounterSize = 12;
 const size_t kGcmOverflowSize = 5;
 
-static bool do_bytes_represent_client(alts_counter* ctr, unsigned char* counter,
-                                      size_t size) {
+static bool do_bytes_represent_client(alts_counter* ctr,
+                                      unsigned char* /*counter*/, size_t size) {
   return (ctr->counter[size - 1] & 0x80) == 0x80;
 }
 
@@ -165,7 +165,7 @@ static void alts_counter_test_overflow_single_increment(bool is_client,
   alts_counter_destroy(ctr);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   alts_counter_test_input_sanity_check(kGcmCounterSize, kGcmOverflowSize);
   alts_counter_test_overflow_full_range(true, kSmallCounterSize,
                                         kSmallOverflowSize);

--- a/test/core/tsi/alts/frame_protector/alts_crypter_test.cc
+++ b/test/core/tsi/alts/frame_protector/alts_crypter_test.cc
@@ -128,10 +128,9 @@ static void alts_crypter_test_multiple_random_seal_unseal(
   gpr_free(duplicate_buffer2);
 }
 
-static void alts_crypter_test_corrupted_unseal(alts_crypter* server_seal,
-                                               alts_crypter* server_unseal,
-                                               alts_crypter* client_seal,
-                                               alts_crypter* client_unseal) {
+static void alts_crypter_test_corrupted_unseal(
+    alts_crypter* server_seal, alts_crypter* server_unseal,
+    alts_crypter* client_seal, alts_crypter* /*client_unseal*/) {
   size_t data_size = gsec_test_bias_random_uint32(1024) + 1;
   size_t num_overhead_bytes = alts_crypter_num_overhead_bytes(server_seal);
   size_t protected_data_size = data_size + num_overhead_bytes;
@@ -487,7 +486,7 @@ static void alts_crypter_do_generic_tests() {
                                    client_unseal);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   alts_crypter_do_generic_tests();
   return 0;
 }

--- a/test/core/tsi/alts/frame_protector/frame_handler_test.cc
+++ b/test/core/tsi/alts/frame_protector/frame_handler_test.cc
@@ -228,7 +228,7 @@ static void frame_handler_test_null_reader_bytes() {
   destroy_frame_handler(handler);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   frame_handler_test_frame_deframe();
   frame_handler_test_small_buffer();
   frame_handler_test_null_input_stream();

--- a/test/core/tsi/alts/handshaker/transport_security_common_api_test.cc
+++ b/test/core/tsi/alts/handshaker/transport_security_common_api_test.cc
@@ -155,7 +155,7 @@ static void test_check_failure() {
                  &highest_common_version) == 0);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   /* Run tests. */
   test_success();
   test_failure();

--- a/test/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol_test.cc
+++ b/test/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol_test.cc
@@ -917,7 +917,7 @@ static void alts_iovec_record_protocol_mix_operations_tests() {
   alts_iovec_record_protocol_test_fixture_destroy(fixture_2);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   alts_iovec_record_protocol_random_seal_unseal_tests();
   alts_iovec_record_protocol_empty_seal_unseal_tests();
   alts_iovec_record_protocol_unsync_seal_unseal_tests();

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -41,7 +41,7 @@ typedef struct mock_endpoint {
 } mock_endpoint;
 
 static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                    grpc_closure* cb, bool urgent) {
+                    grpc_closure* cb, bool /*urgent*/) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   gpr_mu_lock(&m->mu);
   if (m->read_buffer.count > 0) {
@@ -55,7 +55,7 @@ static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
 }
 
 static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                     grpc_closure* cb, void* arg) {
+                     grpc_closure* cb, void* /*arg*/) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   for (size_t i = 0; i < slices->count; i++) {
     m->on_write(slices->slices[i]);
@@ -63,13 +63,14 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   GRPC_CLOSURE_SCHED(cb, GRPC_ERROR_NONE);
 }
 
-static void me_add_to_pollset(grpc_endpoint* ep, grpc_pollset* pollset) {}
+static void me_add_to_pollset(grpc_endpoint* /*ep*/,
+                              grpc_pollset* /*pollset*/) {}
 
-static void me_add_to_pollset_set(grpc_endpoint* ep,
-                                  grpc_pollset_set* pollset) {}
+static void me_add_to_pollset_set(grpc_endpoint* /*ep*/,
+                                  grpc_pollset_set* /*pollset*/) {}
 
-static void me_delete_from_pollset_set(grpc_endpoint* ep,
-                                       grpc_pollset_set* pollset) {}
+static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
+                                       grpc_pollset_set* /*pollset*/) {}
 
 static void me_shutdown(grpc_endpoint* ep, grpc_error* why) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
@@ -93,7 +94,7 @@ static void me_destroy(grpc_endpoint* ep) {
   gpr_free(m);
 }
 
-static char* me_get_peer(grpc_endpoint* ep) {
+static char* me_get_peer(grpc_endpoint* /*ep*/) {
   return gpr_strdup("fake:mock_endpoint");
 }
 
@@ -102,9 +103,9 @@ static grpc_resource_user* me_get_resource_user(grpc_endpoint* ep) {
   return m->resource_user;
 }
 
-static int me_get_fd(grpc_endpoint* ep) { return -1; }
+static int me_get_fd(grpc_endpoint* /*ep*/) { return -1; }
 
-static bool me_can_track_err(grpc_endpoint* ep) { return false; }
+static bool me_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
 static const grpc_endpoint_vtable vtable = {me_read,
                                             me_write,

--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -54,7 +54,7 @@ struct passthru_endpoint {
 };
 
 static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                    grpc_closure* cb, bool urgent) {
+                    grpc_closure* cb, bool /*urgent*/) {
   half* m = reinterpret_cast<half*>(ep);
   gpr_mu_lock(&m->parent->mu);
   if (m->parent->shutdown) {
@@ -76,7 +76,7 @@ static half* other_half(half* h) {
 }
 
 static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                     grpc_closure* cb, void* arg) {
+                     grpc_closure* cb, void* /*arg*/) {
   half* m = other_half(reinterpret_cast<half*>(ep));
   gpr_mu_lock(&m->parent->mu);
   grpc_error* error = GRPC_ERROR_NONE;
@@ -99,13 +99,14 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   GRPC_CLOSURE_SCHED(cb, error);
 }
 
-static void me_add_to_pollset(grpc_endpoint* ep, grpc_pollset* pollset) {}
+static void me_add_to_pollset(grpc_endpoint* /*ep*/,
+                              grpc_pollset* /*pollset*/) {}
 
-static void me_add_to_pollset_set(grpc_endpoint* ep,
-                                  grpc_pollset_set* pollset) {}
+static void me_add_to_pollset_set(grpc_endpoint* /*ep*/,
+                                  grpc_pollset_set* /*pollset*/) {}
 
-static void me_delete_from_pollset_set(grpc_endpoint* ep,
-                                       grpc_pollset_set* pollset) {}
+static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
+                                       grpc_pollset_set* /*pollset*/) {}
 
 static void me_shutdown(grpc_endpoint* ep, grpc_error* why) {
   half* m = reinterpret_cast<half*>(ep);
@@ -153,9 +154,9 @@ static char* me_get_peer(grpc_endpoint* ep) {
              : gpr_strdup("fake:mock_server_endpoint");
 }
 
-static int me_get_fd(grpc_endpoint* ep) { return -1; }
+static int me_get_fd(grpc_endpoint* /*ep*/) { return -1; }
 
-static bool me_can_track_err(grpc_endpoint* ep) { return false; }
+static bool me_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
 static grpc_resource_user* me_get_resource_user(grpc_endpoint* ep) {
   half* m = reinterpret_cast<half*>(ep);

--- a/test/core/util/port_server_client.cc
+++ b/test/core/util/port_server_client.cc
@@ -40,14 +40,14 @@ typedef struct freereq {
   int done = 0;
 } freereq;
 
-static void destroy_pops_and_shutdown(void* p, grpc_error* error) {
+static void destroy_pops_and_shutdown(void* p, grpc_error* /*error*/) {
   grpc_pollset* pollset =
       grpc_polling_entity_pollset(static_cast<grpc_polling_entity*>(p));
   grpc_pollset_destroy(pollset);
   gpr_free(pollset);
 }
 
-static void freed_port_from_server(void* arg, grpc_error* error) {
+static void freed_port_from_server(void* arg, grpc_error* /*error*/) {
   freereq* pr = static_cast<freereq*>(arg);
   gpr_mu_lock(pr->mu);
   pr->done = 1;

--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -231,7 +231,7 @@ static void output_num(long num) {
   output_string(buf);
 }
 
-static void crash_handler(int signum, siginfo_t* info, void* data) {
+static void crash_handler(int signum, siginfo_t* /*info*/, void* /*data*/) {
   void* addrlist[MAX_FRAMES + 1];
   int addrlen;
 
@@ -379,7 +379,7 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms) {
           GPR_TIMESPAN));
 }
 
-void grpc_test_init(int argc, char** argv) {
+void grpc_test_init(int /*argc*/, char** /*argv*/) {
   install_crash_handler();
   gpr_log(GPR_DEBUG,
           "test slowdown factor: sanitizer=%" PRId64 ", fixture=%" PRId64


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.