### PR TITLE
Remove unused-parameter warnings, round 2 (17 of 19)

### DIFF
--- a/test/core/iomgr/ev_epollex_linux_test.cc
+++ b/test/core/iomgr/ev_epollex_linux_test.cc
@@ -111,5 +111,5 @@ int main(int argc, char** argv) {
   return 0;
 }
 #else /* defined(GRPC_LINUX_EPOLL_CREATE1) && defined(GRPC_LINUX_EVENTFD) */
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 #endif

--- a/test/core/iomgr/tcp_client_uv_test.cc
+++ b/test/core/iomgr/tcp_client_uv_test.cc
@@ -209,6 +209,6 @@ int main(int argc, char** argv) {
 
 #else /* GRPC_UV */
 
-int main(int argc, char** argv) { return 1; }
+int main(int /*argc*/, char** /*argv*/) { return 1; }
 
 #endif /* GRPC_UV */

--- a/test/core/iomgr/tcp_server_uv_test.cc
+++ b/test/core/iomgr/tcp_server_uv_test.cc
@@ -314,6 +314,6 @@ int main(int argc, char** argv) {
 
 #else /* GRPC_UV */
 
-int main(int argc, char** argv) { return 1; }
+int main(int /*argc*/, char** /*argv*/) { return 1; }
 
 #endif /* GRPC_UV */

--- a/test/core/json/json_stream_error_test.cc
+++ b/test/core/json/json_stream_error_test.cc
@@ -28,12 +28,14 @@
 
 static int g_string_clear_once = 0;
 
-static void string_clear(void* userdata) {
+static void string_clear(void* /*userdata*/) {
   GPR_ASSERT(!g_string_clear_once);
   g_string_clear_once = 1;
 }
 
-static uint32_t read_char(void* userdata) { return GRPC_JSON_READ_CHAR_ERROR; }
+static uint32_t read_char(void* /*userdata*/) {
+  return GRPC_JSON_READ_CHAR_ERROR;
+}
 
 static grpc_json_reader_vtable reader_vtable = {
     string_clear, nullptr, nullptr, read_char, nullptr, nullptr,

--- a/test/core/security/check_gcp_environment_linux_test.cc
+++ b/test/core/security/check_gcp_environment_linux_test.cc
@@ -72,7 +72,7 @@ static void test_gcp_environment_check_failure() {
   GPR_ASSERT(!check_bios_data_linux_test("\n"));
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   /* Tests. */
   test_gcp_environment_check_success();
   test_gcp_environment_check_failure();
@@ -81,6 +81,6 @@ int main(int argc, char** argv) {
 
 #else  // GPR_LINUX
 
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 
 #endif  // GPR_LINUX

--- a/test/core/security/check_gcp_environment_windows_test.cc
+++ b/test/core/security/check_gcp_environment_windows_test.cc
@@ -68,6 +68,6 @@ int main(int argc, char** argv) {
 }
 #else  // GPR_WINDOWS
 
-int main(int argc, char** argv) { return 0; }
+int main(int /*argc*/, char** /*argv*/) { return 0; }
 
 #endif  // GPR_WINDOWS

--- a/test/core/security/grpc_alts_credentials_options_test.cc
+++ b/test/core/security/grpc_alts_credentials_options_test.cc
@@ -87,7 +87,7 @@ static void test_client_options_api_success() {
   grpc_alts_credentials_options_destroy(new_options);
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   /* Test. */
   test_copy_client_options_failure();
   test_client_options_api_success();

--- a/test/core/security/oauth2_utils.cc
+++ b/test/core/security/oauth2_utils.cc
@@ -63,7 +63,7 @@ static void on_oauth2_response(void* arg, grpc_error* error) {
   gpr_mu_unlock(request->mu);
 }
 
-static void destroy_after_shutdown(void* pollset, grpc_error* error) {
+static void destroy_after_shutdown(void* pollset, grpc_error* /*error*/) {
   grpc_pollset_destroy(reinterpret_cast<grpc_pollset*>(pollset));
   gpr_free(pollset);
 }

--- a/test/core/transport/chttp2/bin_encoder_test.cc
+++ b/test/core/transport/chttp2/bin_encoder_test.cc
@@ -98,7 +98,7 @@ static void expect_binary_header(const char* hdr, int binary) {
   }
 }
 
-int main(int argc, char** argv) {
+int main(int /*argc*/, char** /*argv*/) {
   grpc_init();
 
   /* Base64 test vectors from RFC 4648, with padding removed */


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.