### PR TITLE
Remove unused-parameter warnings, round 2 (15 of 19)

### DIFF
--- a/test/core/debug/stats_test.cc
+++ b/test/core/debug/stats_test.cc
@@ -151,5 +151,9 @@ int main(int argc, char** argv) {
   int ret = RUN_ALL_TESTS();
   grpc_shutdown();
   return ret;
+#else
+  // Avoid unused parameter warning for conditional parameters.
+  (void)argc;
+  (void)argv;
 #endif
 }

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -119,12 +119,14 @@ typedef struct proxy_connection {
   grpc_http_request http_request;
 } proxy_connection;
 
-static void proxy_connection_ref(proxy_connection* conn, const char* reason) {
+static void proxy_connection_ref(proxy_connection* conn,
+                                 const char* /*reason*/) {
   gpr_ref(&conn->refcount);
 }
 
 // Helper function to destroy the proxy connection.
-static void proxy_connection_unref(proxy_connection* conn, const char* reason) {
+static void proxy_connection_unref(proxy_connection* conn,
+                                   const char* /*reason*/) {
   if (gpr_unref(&conn->refcount)) {
     gpr_log(GPR_DEBUG, "endpoints: %p %p", conn->client_endpoint,
             conn->server_endpoint);
@@ -554,7 +556,7 @@ static void on_read_request_done(void* arg, grpc_error* error) {
 }
 
 static void on_accept(void* arg, grpc_endpoint* endpoint,
-                      grpc_pollset* accepting_pollset,
+                      grpc_pollset* /*accepting_pollset*/,
                       grpc_tcp_server_acceptor* acceptor) {
   gpr_free(acceptor);
   grpc_end2end_http_proxy* proxy = static_cast<grpc_end2end_http_proxy*>(arg);
@@ -639,7 +641,7 @@ grpc_end2end_http_proxy* grpc_end2end_http_proxy_create(
   return proxy;
 }
 
-static void destroy_pollset(void* arg, grpc_error* error) {
+static void destroy_pollset(void* arg, grpc_error* /*error*/) {
   grpc_pollset* pollset = static_cast<grpc_pollset*>(arg);
   grpc_pollset_destroy(pollset);
   gpr_free(pollset);

--- a/test/core/end2end/fixtures/local_util.cc
+++ b/test/core/end2end/fixtures/local_util.cc
@@ -73,8 +73,9 @@ static bool fail_server_auth_check(grpc_channel_args* server_args) {
   return false;
 }
 
-static void process_auth_failure(void* state, grpc_auth_context* ctx,
-                                 const grpc_metadata* md, size_t md_count,
+static void process_auth_failure(void* state, grpc_auth_context* /*ctx*/,
+                                 const grpc_metadata* /*md*/,
+                                 size_t /*md_count*/,
                                  grpc_process_auth_metadata_done_cb cb,
                                  void* user_data) {
   GPR_ASSERT(state == nullptr);

--- a/test/core/end2end/fixtures/proxy.cc
+++ b/test/core/end2end/fixtures/proxy.cc
@@ -120,7 +120,7 @@ static closure* new_closure(void (*func)(void* arg, int success), void* arg) {
   return cl;
 }
 
-static void shutdown_complete(void* arg, int success) {
+static void shutdown_complete(void* arg, int /*success*/) {
   grpc_end2end_proxy* proxy = static_cast<grpc_end2end_proxy*>(arg);
   proxy->shutdown = 1;
   grpc_completion_queue_shutdown(proxy->cq);
@@ -137,7 +137,7 @@ void grpc_end2end_proxy_destroy(grpc_end2end_proxy* proxy) {
   grpc_core::Delete(proxy);
 }
 
-static void unrefpc(proxy_call* pc, const char* reason) {
+static void unrefpc(proxy_call* pc, const char* /*reason*/) {
   if (gpr_unref(&pc->refs)) {
     grpc_call_unref(pc->c2p);
     grpc_call_unref(pc->p2s);
@@ -149,14 +149,16 @@ static void unrefpc(proxy_call* pc, const char* reason) {
   }
 }
 
-static void refpc(proxy_call* pc, const char* reason) { gpr_ref(&pc->refs); }
+static void refpc(proxy_call* pc, const char* /*reason*/) {
+  gpr_ref(&pc->refs);
+}
 
-static void on_c2p_sent_initial_metadata(void* arg, int success) {
+static void on_c2p_sent_initial_metadata(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_c2p_sent_initial_metadata");
 }
 
-static void on_p2s_recv_initial_metadata(void* arg, int success) {
+static void on_p2s_recv_initial_metadata(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   grpc_op op;
   grpc_call_error err;
@@ -178,7 +180,7 @@ static void on_p2s_recv_initial_metadata(void* arg, int success) {
   unrefpc(pc, "on_p2s_recv_initial_metadata");
 }
 
-static void on_p2s_sent_initial_metadata(void* arg, int success) {
+static void on_p2s_sent_initial_metadata(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_p2s_sent_initial_metadata");
 }
@@ -205,7 +207,7 @@ static void on_p2s_sent_message(void* arg, int success) {
   unrefpc(pc, "on_p2s_sent_message");
 }
 
-static void on_p2s_sent_close(void* arg, int success) {
+static void on_p2s_sent_close(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_p2s_sent_close");
 }
@@ -285,7 +287,7 @@ static void on_p2s_recv_msg(void* arg, int success) {
   unrefpc(pc, "on_p2s_recv_msg");
 }
 
-static void on_c2p_sent_status(void* arg, int success) {
+static void on_c2p_sent_status(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_c2p_sent_status");
 }
@@ -315,7 +317,7 @@ static void on_p2s_status(void* arg, int success) {
   unrefpc(pc, "on_p2s_status");
 }
 
-static void on_c2p_closed(void* arg, int success) {
+static void on_c2p_closed(void* arg, int /*success*/) {
   proxy_call* pc = static_cast<proxy_call*>(arg);
   unrefpc(pc, "on_c2p_closed");
 }

--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -89,7 +89,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f, size_t num_ops) {
   grpc_call* c;
   cq_verifier* cqv = cq_verifier_create(f.cq);

--- a/test/core/end2end/tests/disappearing_server.cc
+++ b/test/core/end2end/tests/disappearing_server.cc
@@ -68,7 +68,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void do_request_and_shutdown_server(grpc_end2end_test_config config,
+static void do_request_and_shutdown_server(grpc_end2end_test_config /*config*/,
                                            grpc_end2end_test_fixture* f,
                                            cq_verifier* cqv) {
   grpc_call* c;

--- a/test/core/end2end/tests/empty_batch.cc
+++ b/test/core/end2end/tests/empty_batch.cc
@@ -85,7 +85,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void empty_batch_body(grpc_end2end_test_config config,
+static void empty_batch_body(grpc_end2end_test_config /*config*/,
                              grpc_end2end_test_fixture f) {
   grpc_call* c;
   cq_verifier* cqv = cq_verifier_create(f.cq);

--- a/test/core/end2end/tests/high_initial_seqno.cc
+++ b/test/core/end2end/tests/high_initial_seqno.cc
@@ -87,7 +87,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/hpack_size.cc
+++ b/test/core/end2end/tests/hpack_size.cc
@@ -228,7 +228,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f, size_t index) {
   grpc_call* c;
   grpc_call* s;

--- a/test/core/end2end/tests/idempotent_request.cc
+++ b/test/core/end2end/tests/idempotent_request.cc
@@ -86,7 +86,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /*config*/,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.