### PR TITLE
Remove unused-parameter warnings, round 2 (13 of 19)

### DIFF
--- a/src/core/lib/transport/status_conversion.cc
+++ b/src/core/lib/transport/status_conversion.cc
@@ -97,4 +97,4 @@ grpc_status_code grpc_http2_status_to_grpc_status(int status) {
   }
 }
 
-int grpc_status_to_http2_status(grpc_status_code status) { return 200; }
+int grpc_status_to_http2_status(grpc_status_code /*status*/) { return 200; }

--- a/src/core/lib/transport/status_metadata.cc
+++ b/src/core/lib/transport/status_metadata.cc
@@ -28,7 +28,7 @@
    */
 #define STATUS_OFFSET 1
 
-static void destroy_status(void* ignored) {}
+static void destroy_status(void* /*ignored*/) {}
 
 grpc_status_code grpc_get_status_code_from_metadata(grpc_mdelem md) {
   if (grpc_mdelem_static_value_eq(md, GRPC_MDELEM_GRPC_STATUS_0)) {

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -80,12 +80,12 @@ grpc_slice grpc_slice_from_stream_owned_buffer(grpc_stream_refcount* refcount,
 }
 
 #ifndef NDEBUG
-void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
+void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
                           grpc_iomgr_cb_func cb, void* cb_arg,
                           const char* object_type) {
   refcount->object_type = object_type;
 #else
-void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
+void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
                           grpc_iomgr_cb_func cb, void* cb_arg) {
 #endif
   GRPC_CLOSURE_INIT(&refcount->destroy, cb, cb_arg, grpc_schedule_on_exec_ctx);

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -72,7 +72,10 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
 void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
                           grpc_iomgr_cb_func cb, void* cb_arg);
 #define GRPC_STREAM_REF_INIT(rc, ir, cb, cb_arg, objtype) \
-  grpc_stream_ref_init(rc, ir, cb, cb_arg)
+  do {                                                    \
+    grpc_stream_ref_init(rc, ir, cb, cb_arg);             \
+    (void)(objtype);                                      \
+  } while (0)
 #endif
 
 #ifndef NDEBUG

--- a/src/core/tsi/alts/frame_protector/alts_unseal_privacy_integrity_crypter.cc
+++ b/src/core/tsi/alts/frame_protector/alts_unseal_privacy_integrity_crypter.cc
@@ -33,7 +33,7 @@ static void maybe_copy_error_msg(const char* src, char** dst) {
 
 /* Perform input santity check. */
 static grpc_status_code unseal_check(alts_crypter* c, const unsigned char* data,
-                                     size_t data_allocated_size,
+                                     size_t /*data_allocated_size*/,
                                      size_t data_size, size_t* output_size,
                                      char** error_details) {
   /* Do common input sanity check. */

--- a/src/core/tsi/alts/handshaker/alts_shared_resource.cc
+++ b/src/core/tsi/alts/handshaker/alts_shared_resource.cc
@@ -30,7 +30,7 @@ alts_shared_resource_dedicated* grpc_alts_get_shared_resource_dedicated(void) {
   return &g_alts_resource_dedicated;
 }
 
-static void thread_worker(void* arg) {
+static void thread_worker(void* /*arg*/) {
   while (true) {
     grpc_event event =
         grpc_completion_queue_next(g_alts_resource_dedicated.cq,

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -264,18 +264,18 @@ static void on_handshaker_service_resp_recv(void* arg, grpc_error* error) {
 /* gRPC provided callback used when dedicatd CQ and thread are used.
  * It serves to safely bring the control back to application. */
 static void on_handshaker_service_resp_recv_dedicated(void* arg,
-                                                      grpc_error* error) {
+                                                      grpc_error* /*error*/) {
   alts_shared_resource_dedicated* resource =
       grpc_alts_get_shared_resource_dedicated();
   grpc_cq_end_op(resource->cq, arg, GRPC_ERROR_NONE,
-                 [](void* done_arg, grpc_cq_completion* storage) {}, nullptr,
-                 &resource->storage);
+                 [](void* /*done_arg*/, grpc_cq_completion* /*storage*/) {},
+                 nullptr, &resource->storage);
 }
 
 static tsi_result handshaker_next(
     tsi_handshaker* self, const unsigned char* received_bytes,
-    size_t received_bytes_size, const unsigned char** bytes_to_send,
-    size_t* bytes_to_send_size, tsi_handshaker_result** result,
+    size_t received_bytes_size, const unsigned char** /*bytes_to_send*/,
+    size_t* /*bytes_to_send_size*/, tsi_handshaker_result** /*result*/,
     tsi_handshaker_on_next_done_cb cb, void* user_data) {
   if (self == nullptr || cb == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to handshaker_next()");

--- a/src/core/tsi/fake_transport_security.cc
+++ b/src/core/tsi/fake_transport_security.cc
@@ -495,7 +495,7 @@ typedef struct {
 } fake_handshaker_result;
 
 static tsi_result fake_handshaker_result_extract_peer(
-    const tsi_handshaker_result* self, tsi_peer* peer) {
+    const tsi_handshaker_result* /*self*/, tsi_peer* peer) {
   /* Construct a tsi_peer with 1 property: certificate type. */
   tsi_result result = tsi_construct_peer(1, peer);
   if (result != TSI_OK) return result;
@@ -507,7 +507,8 @@ static tsi_result fake_handshaker_result_extract_peer(
 }
 
 static tsi_result fake_handshaker_result_create_zero_copy_grpc_protector(
-    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
+    const tsi_handshaker_result* /*self*/,
+    size_t* max_output_protected_frame_size,
     tsi_zero_copy_grpc_protector** protector) {
   *protector =
       tsi_create_fake_zero_copy_grpc_protector(max_output_protected_frame_size);
@@ -515,8 +516,8 @@ static tsi_result fake_handshaker_result_create_zero_copy_grpc_protector(
 }
 
 static tsi_result fake_handshaker_result_create_frame_protector(
-    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
-    tsi_frame_protector** protector) {
+    const tsi_handshaker_result* /*self*/,
+    size_t* max_output_protected_frame_size, tsi_frame_protector** protector) {
   *protector = tsi_create_fake_frame_protector(max_output_protected_frame_size);
   return TSI_OK;
 }
@@ -670,7 +671,7 @@ static tsi_result fake_handshaker_next(
     tsi_handshaker* self, const unsigned char* received_bytes,
     size_t received_bytes_size, const unsigned char** bytes_to_send,
     size_t* bytes_to_send_size, tsi_handshaker_result** handshaker_result,
-    tsi_handshaker_on_next_done_cb cb, void* user_data) {
+    tsi_handshaker_on_next_done_cb /*cb*/, void* /*user_data*/) {
   /* Sanity check the arguments. */
   if ((received_bytes_size > 0 && received_bytes == nullptr) ||
       bytes_to_send == nullptr || bytes_to_send_size == nullptr ||

--- a/src/core/tsi/local_transport_security.cc
+++ b/src/core/tsi/local_transport_security.cc
@@ -105,12 +105,13 @@ tsi_result local_zero_copy_grpc_protector_create(
 /* --- tsi_handshaker_result methods implementation. --- */
 
 static tsi_result handshaker_result_extract_peer(
-    const tsi_handshaker_result* self, tsi_peer* peer) {
+    const tsi_handshaker_result* /*self*/, tsi_peer* /*peer*/) {
   return TSI_OK;
 }
 
 static tsi_result handshaker_result_create_zero_copy_grpc_protector(
-    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
+    const tsi_handshaker_result* self,
+    size_t* /*max_output_protected_frame_size*/,
     tsi_zero_copy_grpc_protector** protector) {
   if (self == nullptr || protector == nullptr) {
     gpr_log(GPR_ERROR,
@@ -158,10 +159,10 @@ static tsi_result create_handshaker_result(bool is_client,
 /* --- tsi_handshaker methods implementation. --- */
 
 static tsi_result handshaker_next(
-    tsi_handshaker* self, const unsigned char* received_bytes,
-    size_t received_bytes_size, const unsigned char** bytes_to_send,
+    tsi_handshaker* self, const unsigned char* /*received_bytes*/,
+    size_t /*received_bytes_size*/, const unsigned char** /*bytes_to_send*/,
     size_t* bytes_to_send_size, tsi_handshaker_result** result,
-    tsi_handshaker_on_next_done_cb cb, void* user_data) {
+    tsi_handshaker_on_next_done_cb /*cb*/, void* /*user_data*/) {
   if (self == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to handshaker_next()");
     return TSI_INVALID_ARGUMENT;

--- a/src/core/tsi/ssl/session_cache/ssl_session_cache.cc
+++ b/src/core/tsi/ssl/session_cache/ssl_session_cache.cc
@@ -28,18 +28,20 @@
 
 namespace tsi {
 
-static void cache_key_avl_destroy(void* key, void* unused) {}
+static void cache_key_avl_destroy(void* /*key*/, void* /*unused*/) {}
 
-static void* cache_key_avl_copy(void* key, void* unused) { return key; }
+static void* cache_key_avl_copy(void* key, void* /*unused*/) { return key; }
 
-static long cache_key_avl_compare(void* key1, void* key2, void* unused) {
+static long cache_key_avl_compare(void* key1, void* key2, void* /*unused*/) {
   return grpc_slice_cmp(*static_cast<grpc_slice*>(key1),
                         *static_cast<grpc_slice*>(key2));
 }
 
-static void cache_value_avl_destroy(void* value, void* unused) {}
+static void cache_value_avl_destroy(void* /*value*/, void* /*unused*/) {}
 
-static void* cache_value_avl_copy(void* value, void* unused) { return value; }
+static void* cache_value_avl_copy(void* value, void* /*unused*/) {
+  return value;
+}
 
 // AVL only stores pointers, ownership belonges to the linked list.
 static const grpc_avl_vtable cache_avl_vtable = {


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.