### PR TITLE
Remove unused-parameter warnings, round 2 (10 of 19)

### DIFF
--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -154,7 +154,7 @@ static void on_metadata_server_detection_http_response(void* user_data,
   gpr_mu_unlock(g_polling_mu);
 }
 
-static void destroy_pollset(void* p, grpc_error* e) {
+static void destroy_pollset(void* p, grpc_error* /*e*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/src/core/lib/security/credentials/iam/iam_credentials.cc
+++ b/src/core/lib/security/credentials/iam/iam_credentials.cc
@@ -35,15 +35,15 @@ grpc_google_iam_credentials::~grpc_google_iam_credentials() {
 }
 
 bool grpc_google_iam_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
-    grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context /*context*/,
+    grpc_credentials_mdelem_array* md_array,
+    grpc_closure* /*on_request_metadata*/, grpc_error** /*error*/) {
   grpc_credentials_mdelem_array_append(md_array, &md_array_);
   return true;
 }
 
 void grpc_google_iam_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/jwt/jwt_credentials.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_credentials.cc
@@ -50,9 +50,9 @@ grpc_service_account_jwt_access_credentials::
 }
 
 bool grpc_service_account_jwt_access_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
-    grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context context,
+    grpc_credentials_mdelem_array* md_array,
+    grpc_closure* /*on_request_metadata*/, grpc_error** error) {
   gpr_timespec refresh_threshold = gpr_time_from_seconds(
       GRPC_SECURE_TOKEN_REFRESH_THRESHOLD_SECS, GPR_TIMESPAN);
 
@@ -104,7 +104,7 @@ bool grpc_service_account_jwt_access_credentials::get_request_metadata(
 }
 
 void grpc_service_account_jwt_access_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -636,7 +636,7 @@ end:
   return result;
 }
 
-static void on_keys_retrieved(void* user_data, grpc_error* error) {
+static void on_keys_retrieved(void* user_data, grpc_error* /*error*/) {
   verifier_cb_ctx* ctx = static_cast<verifier_cb_ctx*>(user_data);
   grpc_json* json = json_from_http(&ctx->responses[HTTP_RESPONSE_KEYS]);
   EVP_PKEY* verification_key = nullptr;
@@ -676,7 +676,7 @@ end:
   verifier_cb_ctx_destroy(ctx);
 }
 
-static void on_openid_config_retrieved(void* user_data, grpc_error* error) {
+static void on_openid_config_retrieved(void* user_data, grpc_error* /*error*/) {
   const grpc_json* cur;
   verifier_cb_ctx* ctx = static_cast<verifier_cb_ctx*>(user_data);
   const grpc_http_response* response = &ctx->responses[HTTP_RESPONSE_OPENID];

--- a/src/core/lib/security/credentials/local/local_credentials.cc
+++ b/src/core/lib/security/credentials/local/local_credentials.cc
@@ -33,7 +33,7 @@ grpc_core::RefCountedPtr<grpc_channel_security_connector>
 grpc_local_credentials::create_security_connector(
     grpc_core::RefCountedPtr<grpc_call_credentials> request_metadata_creds,
     const char* target_name, const grpc_channel_args* args,
-    grpc_channel_args** new_args) {
+    grpc_channel_args** /*new_args*/) {
   return grpc_local_channel_security_connector_create(
       this->Ref(), std::move(request_metadata_creds), args, target_name);
 }

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -269,9 +269,9 @@ void grpc_oauth2_token_fetcher_credentials::on_http_response(
 }
 
 bool grpc_oauth2_token_fetcher_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
+    grpc_polling_entity* pollent, grpc_auth_metadata_context /*context*/,
     grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_error** /*error*/) {
   // Check if we can use the cached token.
   grpc_millis refresh_threshold =
       GRPC_SECURE_TOKEN_REFRESH_THRESHOLD_SECS * GPR_MS_PER_SEC;
@@ -702,15 +702,15 @@ grpc_access_token_credentials::~grpc_access_token_credentials() {
 }
 
 bool grpc_access_token_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
-    grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context /*context*/,
+    grpc_credentials_mdelem_array* md_array,
+    grpc_closure* /*on_request_metadata*/, grpc_error** /*error*/) {
   grpc_credentials_mdelem_array_add(md_array, access_token_md_);
   return true;
 }
 
 void grpc_access_token_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 

--- a/src/core/lib/security/credentials/plugin/plugin_credentials.cc
+++ b/src/core/lib/security/credentials/plugin/plugin_credentials.cc
@@ -142,7 +142,7 @@ static void plugin_md_request_metadata_ready(void* request,
 }
 
 bool grpc_plugin_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context context,
     grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
     grpc_error** error) {
   bool retval = true;  // Synchronous return.

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -94,7 +94,7 @@ class grpc_alts_channel_security_connector final
         grpc_core::SecurityHandshakerCreate(handshaker, this, args));
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     alts_check_peer(peer, auth_context, on_peer_checked);
@@ -109,8 +109,8 @@ class grpc_alts_channel_security_connector final
   }
 
   bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     if (host.empty() || host != target_name_) {
       *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -119,7 +119,7 @@ class grpc_alts_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -154,7 +154,7 @@ class grpc_alts_server_security_connector final
         grpc_core::SecurityHandshakerCreate(handshaker, this, args));
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     alts_check_peer(peer, auth_context, on_peer_checked);

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -97,16 +97,16 @@ class grpc_fake_channel_security_connector final
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     handshake_mgr->Add(grpc_core::SecurityHandshakerCreate(
         tsi_create_fake_handshaker(/*is_client=*/true), this, args));
   }
 
   bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
-                       grpc_error** error) override {
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
+                       grpc_error** /*error*/) override {
     grpc_core::StringView authority_hostname;
     grpc_core::StringView authority_ignored_port;
     grpc_core::StringView target_hostname;
@@ -135,7 +135,7 @@ class grpc_fake_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -213,7 +213,7 @@ class grpc_fake_channel_security_connector final
 };
 
 static void fake_check_peer(
-    grpc_security_connector* sc, tsi_peer peer,
+    grpc_security_connector* /*sc*/, tsi_peer peer,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   const char* prop_name;
@@ -250,7 +250,7 @@ end:
 }
 
 void grpc_fake_channel_security_connector::check_peer(
-    tsi_peer peer, grpc_endpoint* ep,
+    tsi_peer peer, grpc_endpoint* /*ep*/,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   fake_check_peer(this, peer, auth_context, on_peer_checked);
@@ -266,14 +266,14 @@ class grpc_fake_server_security_connector
                                        std::move(server_creds)) {}
   ~grpc_fake_server_security_connector() override = default;
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     fake_check_peer(this, peer, auth_context, on_peer_checked);
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     handshake_mgr->Add(grpc_core::SecurityHandshakerCreate(
         tsi_create_fake_handshaker(/*=is_client*/ false), this, args));

--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -58,7 +58,7 @@ grpc_core::RefCountedPtr<grpc_auth_context> local_auth_context_create() {
   return ctx;
 }
 
-void local_check_peer(grpc_security_connector* sc, tsi_peer peer,
+void local_check_peer(grpc_security_connector* /*sc*/, tsi_peer /*peer*/,
                       grpc_endpoint* ep,
                       grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                       grpc_closure* on_peer_checked,
@@ -129,7 +129,7 @@ class grpc_local_channel_security_connector final
   ~grpc_local_channel_security_connector() override { gpr_free(target_name_); }
 
   void add_handshakers(
-      const grpc_channel_args* args, grpc_pollset_set* interested_parties,
+      const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
       grpc_core::HandshakeManager* handshake_manager) override {
     tsi_handshaker* handshaker = nullptr;
     GPR_ASSERT(local_tsi_handshaker_create(true /* is_client */, &handshaker) ==
@@ -157,8 +157,8 @@ class grpc_local_channel_security_connector final
   }
 
   bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     if (host.empty() || host != target_name_) {
       *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -167,7 +167,7 @@ class grpc_local_channel_security_connector final
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -187,7 +187,7 @@ class grpc_local_server_security_connector final
   ~grpc_local_server_security_connector() override = default;
 
   void add_handshakers(
-      const grpc_channel_args* args, grpc_pollset_set* interested_parties,
+      const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
       grpc_core::HandshakeManager* handshake_manager) override {
     tsi_handshaker* handshaker = nullptr;
     GPR_ASSERT(local_tsi_handshaker_create(false /* is_client */,


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.