### PR TITLE
Remove unused-parameter warnings, round 2 (9 of 19)

### DIFF
--- a/src/core/lib/iomgr/tcp_custom.cc
+++ b/src/core/lib/iomgr/tcp_custom.cc
@@ -193,7 +193,7 @@ static void tcp_read_allocation_done(void* tcpp, grpc_error* error) {
 }
 
 static void endpoint_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
-                          grpc_closure* cb, bool urgent) {
+                          grpc_closure* cb, bool /*urgent*/) {
   custom_tcp_endpoint* tcp = (custom_tcp_endpoint*)ep;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   GPR_ASSERT(tcp->read_cb == nullptr);
@@ -224,7 +224,7 @@ static void custom_write_callback(grpc_custom_socket* socket,
 }
 
 static void endpoint_write(grpc_endpoint* ep, grpc_slice_buffer* write_slices,
-                           grpc_closure* cb, void* arg) {
+                           grpc_closure* cb, void* /*arg*/) {
   custom_tcp_endpoint* tcp = (custom_tcp_endpoint*)ep;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
 
@@ -327,9 +327,9 @@ static grpc_resource_user* endpoint_get_resource_user(grpc_endpoint* ep) {
   return tcp->resource_user;
 }
 
-static int endpoint_get_fd(grpc_endpoint* ep) { return -1; }
+static int endpoint_get_fd(grpc_endpoint* /*ep*/) { return -1; }
 
-static bool endpoint_can_track_err(grpc_endpoint* ep) { return false; }
+static bool endpoint_can_track_err(grpc_endpoint* /*ep*/) { return false; }
 
 static grpc_endpoint_vtable vtable = {endpoint_read,
                                       endpoint_write,

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -161,7 +161,7 @@ static void tcp_handle_write(void* arg /* grpc_tcp */, grpc_error* error);
 static void tcp_drop_uncovered_then_handle_write(void* arg /* grpc_tcp */,
                                                  grpc_error* error);
 
-static void done_poller(void* bp, grpc_error* error_ignored) {
+static void done_poller(void* bp, grpc_error* /*error_ignored*/) {
   backup_poller* p = static_cast<backup_poller*>(bp);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_INFO, "BACKUP_POLLER:%p destroy", p);
@@ -170,7 +170,7 @@ static void done_poller(void* bp, grpc_error* error_ignored) {
   gpr_free(p);
 }
 
-static void run_poller(void* bp, grpc_error* error_ignored) {
+static void run_poller(void* bp, grpc_error* /*error_ignored*/) {
   backup_poller* p = static_cast<backup_poller*>(bp);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_INFO, "BACKUP_POLLER:%p run", p);
@@ -206,7 +206,7 @@ static void run_poller(void* bp, grpc_error* error_ignored) {
   }
 }
 
-static void drop_uncovered(grpc_tcp* tcp) {
+static void drop_uncovered(grpc_tcp* /*tcp*/) {
   backup_poller* p = (backup_poller*)gpr_atm_acq_load(&g_backup_poller);
   gpr_atm old_count =
       gpr_atm_full_fetch_add(&g_uncovered_notifications_pending, -1);
@@ -876,15 +876,16 @@ static void tcp_handle_error(void* arg /* grpc_tcp */, grpc_error* error) {
 }
 
 #else  /* GRPC_LINUX_ERRQUEUE */
-static bool tcp_write_with_timestamps(grpc_tcp* tcp, struct msghdr* msg,
-                                      size_t sending_length,
-                                      ssize_t* sent_length) {
+static bool tcp_write_with_timestamps(grpc_tcp* /*tcp*/, struct msghdr* /*msg*/,
+                                      size_t /*sending_length*/,
+                                      ssize_t* /*sent_length*/) {
   gpr_log(GPR_ERROR, "Write with timestamps not supported for this platform");
   GPR_ASSERT(0);
   return false;
 }
 
-static void tcp_handle_error(void* arg /* grpc_tcp */, grpc_error* error) {
+static void tcp_handle_error(void* /*arg*/ /* grpc_tcp */,
+                             grpc_error* /*error*/) {
   gpr_log(GPR_ERROR, "Error handling is not supported for this platform");
   GPR_ASSERT(0);
 }

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -439,13 +439,13 @@ static void tcp_server_start(grpc_tcp_server* server, grpc_pollset** pollsets,
   }
 }
 
-static unsigned tcp_server_port_fd_count(grpc_tcp_server* s,
-                                         unsigned port_index) {
+static unsigned tcp_server_port_fd_count(grpc_tcp_server* /*s*/,
+                                         unsigned /*port_index*/) {
   return 0;
 }
 
-static int tcp_server_port_fd(grpc_tcp_server* s, unsigned port_index,
-                              unsigned fd_index) {
+static int tcp_server_port_fd(grpc_tcp_server* /*s*/, unsigned /*port_index*/,
+                              unsigned /*fd_index*/) {
   return -1;
 }
 
@@ -459,7 +459,7 @@ static void tcp_server_shutdown_listeners(grpc_tcp_server* s) {
 }
 
 static grpc_core::TcpServerFdHandler* tcp_server_create_fd_handler(
-    grpc_tcp_server* s) {
+    grpc_tcp_server* /*s*/) {
   return nullptr;
 }
 

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -124,7 +124,7 @@ static void finish_shutdown(grpc_tcp_server* s) {
   gpr_free(s);
 }
 
-static void destroyed_port(void* server, grpc_error* error) {
+static void destroyed_port(void* server, grpc_error* /*error*/) {
   grpc_tcp_server* s = static_cast<grpc_tcp_server*>(server);
   gpr_mu_lock(&s->mu);
   s->destroyed_ports++;

--- a/src/core/lib/iomgr/timer_custom.cc
+++ b/src/core/lib/iomgr/timer_custom.cc
@@ -30,7 +30,7 @@
 
 static grpc_custom_timer_vtable* custom_timer_impl;
 
-void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error) {
+void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* /*error*/) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
@@ -75,7 +75,7 @@ static void timer_cancel(grpc_timer* timer) {
   }
 }
 
-static grpc_timer_check_result timer_check(grpc_millis* next) {
+static grpc_timer_check_result timer_check(grpc_millis* /*next*/) {
   return GRPC_TIMERS_NOT_CHECKED;
 }
 

--- a/src/core/lib/iomgr/udp_server.cc
+++ b/src/core/lib/iomgr/udp_server.cc
@@ -260,7 +260,7 @@ static void finish_shutdown(grpc_udp_server* s) {
   grpc_core::Delete(s);
 }
 
-static void destroyed_port(void* server, grpc_error* error) {
+static void destroyed_port(void* server, grpc_error* /*error*/) {
   grpc_udp_server* s = static_cast<grpc_udp_server*>(server);
   gpr_mu_lock(&s->mu);
   s->destroyed_ports++;
@@ -495,7 +495,8 @@ void GrpcUdpListener::OnRead(grpc_error* error, void* do_read_arg) {
 
 // static
 // Wrapper of grpc_fd_notify_on_write() with a grpc_closure callback interface.
-void GrpcUdpListener::fd_notify_on_write_wrapper(void* arg, grpc_error* error) {
+void GrpcUdpListener::fd_notify_on_write_wrapper(void* arg,
+                                                 grpc_error* /*error*/) {
   GrpcUdpListener* sp = static_cast<GrpcUdpListener*>(arg);
   gpr_mu_lock(sp->mutex());
   if (!sp->notify_on_write_armed_) {

--- a/src/core/lib/profiling/basic_timers.cc
+++ b/src/core/lib/profiling/basic_timers.cc
@@ -287,7 +287,7 @@ void gpr_timers_global_init(void) {}
 
 void gpr_timers_global_destroy(void) {}
 
-void gpr_timers_set_log_filename(const char* filename) {}
+void gpr_timers_set_log_filename(const char* /*filename*/) {}
 
-void gpr_timer_set_enabled(int enabled) {}
+void gpr_timer_set_enabled(int /*enabled*/) {}
 #endif /* GRPC_BASIC_PROFILER */

--- a/src/core/lib/security/credentials/alts/alts_credentials.cc
+++ b/src/core/lib/security/credentials/alts/alts_credentials.cc
@@ -50,8 +50,8 @@ grpc_alts_credentials::~grpc_alts_credentials() {
 grpc_core::RefCountedPtr<grpc_channel_security_connector>
 grpc_alts_credentials::create_security_connector(
     grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
-    const char* target_name, const grpc_channel_args* args,
-    grpc_channel_args** new_args) {
+    const char* target_name, const grpc_channel_args* /*args*/,
+    grpc_channel_args** /*new_args*/) {
   return grpc_alts_channel_security_connector_create(
       this->Ref(), std::move(call_creds), target_name);
 }

--- a/src/core/lib/security/credentials/alts/grpc_alts_credentials_server_options.cc
+++ b/src/core/lib/security/credentials/alts/grpc_alts_credentials_server_options.cc
@@ -31,7 +31,7 @@ static grpc_alts_credentials_options* alts_server_options_copy(
     const grpc_alts_credentials_options* options);
 
 static void alts_server_options_destroy(
-    grpc_alts_credentials_options* options) {}
+    grpc_alts_credentials_options* /*options*/) {}
 
 static const grpc_alts_credentials_options_vtable vtable = {
     alts_server_options_copy, alts_server_options_destroy};

--- a/src/core/lib/security/credentials/fake/fake_credentials.cc
+++ b/src/core/lib/security/credentials/fake/fake_credentials.cc
@@ -45,7 +45,7 @@ class grpc_fake_channel_credentials final : public grpc_channel_credentials {
   create_security_connector(
       grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
       const char* target, const grpc_channel_args* args,
-      grpc_channel_args** new_args) override {
+      grpc_channel_args** /*new_args*/) override {
     return grpc_fake_channel_security_connector_create(
         this->Ref(), std::move(call_creds), target, args);
   }
@@ -89,9 +89,9 @@ const char* grpc_fake_transport_get_expected_targets(
 /* -- Metadata-only test credentials. -- */
 
 bool grpc_md_only_test_credentials::get_request_metadata(
-    grpc_polling_entity* pollent, grpc_auth_metadata_context context,
+    grpc_polling_entity* /*pollent*/, grpc_auth_metadata_context /*context*/,
     grpc_credentials_mdelem_array* md_array, grpc_closure* on_request_metadata,
-    grpc_error** error) {
+    grpc_error** /*error*/) {
   grpc_credentials_mdelem_array_add(md_array, md_);
   if (is_async_) {
     GRPC_CLOSURE_SCHED(on_request_metadata, GRPC_ERROR_NONE);
@@ -101,7 +101,7 @@ bool grpc_md_only_test_credentials::get_request_metadata(
 }
 
 void grpc_md_only_test_credentials::cancel_get_request_metadata(
-    grpc_credentials_mdelem_array* md_array, grpc_error* error) {
+    grpc_credentials_mdelem_array* /*md_array*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.