### PR TITLE
Remove unused-parameter warnings, round 2 (8 of 19)

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -323,8 +323,16 @@ static void ref_by(grpc_fd* fd, int n, const char* reason, const char* file,
             gpr_atm_no_barrier_load(&fd->refst) + n, reason, file, line);
   }
 #else
-#define REF_BY(fd, n, reason) ref_by(fd, n)
-#define UNREF_BY(fd, n, reason) unref_by(fd, n)
+#define REF_BY(fd, n, reason) \
+  do {                        \
+    ref_by(fd, n);            \
+    (void)(reason);           \
+  } while (0)
+#define UNREF_BY(fd, n, reason) \
+  do {                          \
+    unref_by(fd, n);            \
+    (void)(reason);             \
+  } while (0)
 static void ref_by(grpc_fd* fd, int n) {
 #endif
   GPR_ASSERT(gpr_atm_no_barrier_fetch_add(&fd->refst, n) > 0);
@@ -355,6 +363,8 @@ static void unref_by(grpc_fd* fd, int n) {
 }
 
 static grpc_fd* fd_create(int fd, const char* name, bool track_err) {
+  // Avoid unused-parameter warning for debug-only parameter
+  (void)track_err;
   GPR_DEBUG_ASSERT(track_err == false);
   grpc_fd* r = static_cast<grpc_fd*>(gpr_malloc(sizeof(*r)));
   gpr_mu_init(&r->mu);
@@ -560,7 +570,7 @@ static void fd_notify_on_write(grpc_fd* fd, grpc_closure* closure) {
   gpr_mu_unlock(&fd->mu);
 }
 
-static void fd_notify_on_error(grpc_fd* fd, grpc_closure* closure) {
+static void fd_notify_on_error(grpc_fd* /*fd*/, grpc_closure* closure) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     gpr_log(GPR_ERROR, "Polling engine does not support tracking errors.");
   }
@@ -579,7 +589,7 @@ static void fd_set_writable(grpc_fd* fd) {
   gpr_mu_unlock(&fd->mu);
 }
 
-static void fd_set_error(grpc_fd* fd) {
+static void fd_set_error(grpc_fd* /*fd*/) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     gpr_log(GPR_ERROR, "Polling engine does not support tracking errors.");
   }
@@ -696,7 +706,7 @@ static void fd_end_poll(grpc_fd_watcher* watcher, int got_read, int got_write) {
 GPR_TLS_DECL(g_current_thread_poller);
 GPR_TLS_DECL(g_current_thread_worker);
 
-static void remove_worker(grpc_pollset* p, grpc_pollset_worker* worker) {
+static void remove_worker(grpc_pollset* /*p*/, grpc_pollset_worker* worker) {
   worker->prev->next = worker->next;
   worker->next->prev = worker->prev;
 }
@@ -1320,8 +1330,8 @@ static bool is_any_background_poller_thread(void) { return false; }
 
 static void shutdown_background_closure(void) {}
 
-static bool add_closure_to_background_poller(grpc_closure* closure,
-                                             grpc_error* error) {
+static bool add_closure_to_background_poller(grpc_closure* /*closure*/,
+                                             grpc_error* /*error*/) {
   return false;
 }
 
@@ -1392,7 +1402,8 @@ static void reset_event_manager_on_fork() {
   gpr_mu_unlock(&fork_fd_list_mu);
 }
 
-const grpc_event_engine_vtable* grpc_init_poll_posix(bool explicit_request) {
+const grpc_event_engine_vtable* grpc_init_poll_posix(
+    bool /*explicit_request*/) {
   if (!grpc_has_wakeup_fd()) {
     gpr_log(GPR_ERROR, "Skipping poll because of no wakeup fd.");
     return nullptr;

--- a/src/core/lib/iomgr/iomgr_custom.cc
+++ b/src/core/lib/iomgr/iomgr_custom.cc
@@ -45,7 +45,7 @@ static bool iomgr_platform_is_any_background_poller_thread(void) {
   return false;
 }
 static bool iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error* error) {
+    grpc_closure* /*closure*/, grpc_error* /*error*/) {
   return false;
 }
 

--- a/src/core/lib/iomgr/pollset_custom.cc
+++ b/src/core/lib/iomgr/pollset_custom.cc
@@ -53,7 +53,7 @@ static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
   *mu = &pollset->mu;
 }
 
-static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
+static void pollset_shutdown(grpc_pollset* /*pollset*/, grpc_closure* closure) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   GRPC_CLOSURE_SCHED(closure, GRPC_ERROR_NONE);
 }
@@ -64,7 +64,7 @@ static void pollset_destroy(grpc_pollset* pollset) {
 }
 
 static grpc_error* pollset_work(grpc_pollset* pollset,
-                                grpc_pollset_worker** worker_hdl,
+                                grpc_pollset_worker** /*worker_hdl*/,
                                 grpc_millis deadline) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   gpr_mu_unlock(&pollset->mu);
@@ -87,8 +87,8 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error* pollset_kick(grpc_pollset* pollset,
-                                grpc_pollset_worker* specific_worker) {
+static grpc_error* pollset_kick(grpc_pollset* /*pollset*/,
+                                grpc_pollset_worker* /*specific_worker*/) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   poller_vtable->kick();
   return GRPC_ERROR_NONE;

--- a/src/core/lib/iomgr/pollset_set_custom.cc
+++ b/src/core/lib/iomgr/pollset_set_custom.cc
@@ -26,19 +26,19 @@ grpc_pollset_set* pollset_set_create(void) {
   return (grpc_pollset_set*)((intptr_t)0xdeafbeef);
 }
 
-void pollset_set_destroy(grpc_pollset_set* pollset_set) {}
+void pollset_set_destroy(grpc_pollset_set* /*pollset_set*/) {}
 
-void pollset_set_add_pollset(grpc_pollset_set* pollset_set,
-                             grpc_pollset* pollset) {}
+void pollset_set_add_pollset(grpc_pollset_set* /*pollset_set*/,
+                             grpc_pollset* /*pollset*/) {}
 
-void pollset_set_del_pollset(grpc_pollset_set* pollset_set,
-                             grpc_pollset* pollset) {}
+void pollset_set_del_pollset(grpc_pollset_set* /*pollset_set*/,
+                             grpc_pollset* /*pollset*/) {}
 
-void pollset_set_add_pollset_set(grpc_pollset_set* bag,
-                                 grpc_pollset_set* item) {}
+void pollset_set_add_pollset_set(grpc_pollset_set* /*bag*/,
+                                 grpc_pollset_set* /*item*/) {}
 
-void pollset_set_del_pollset_set(grpc_pollset_set* bag,
-                                 grpc_pollset_set* item) {}
+void pollset_set_del_pollset_set(grpc_pollset_set* /*bag*/,
+                                 grpc_pollset_set* /*item*/) {}
 
 static grpc_pollset_set_vtable vtable = {
     pollset_set_create,          pollset_set_destroy,

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -151,7 +151,7 @@ static grpc_error* blocking_resolve_address_impl(
 }
 
 static void resolve_address_impl(const char* name, const char* default_port,
-                                 grpc_pollset_set* interested_parties,
+                                 grpc_pollset_set* /*interested_parties*/,
                                  grpc_closure* on_done,
                                  grpc_resolved_addresses** addrs) {
   grpc_custom_resolver* r = nullptr;

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -150,7 +150,7 @@ typedef struct {
 
 /* Callback to be passed to grpc Executor to asynch-ify
  * grpc_blocking_resolve_address */
-static void do_request_thread(void* rp, grpc_error* error) {
+static void do_request_thread(void* rp, grpc_error* /*error*/) {
   request* r = static_cast<request*>(rp);
   GRPC_CLOSURE_SCHED(r->on_done, grpc_blocking_resolve_address(
                                      r->name, r->default_port, r->addrs_out));
@@ -160,7 +160,7 @@ static void do_request_thread(void* rp, grpc_error* error) {
 }
 
 static void posix_resolve_address(const char* name, const char* default_port,
-                                  grpc_pollset_set* interested_parties,
+                                  grpc_pollset_set* /*interested_parties*/,
                                   grpc_closure* on_done,
                                   grpc_resolved_addresses** addrs) {
   request* r = static_cast<request*>(gpr_malloc(sizeof(request)));

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -274,7 +274,7 @@ static bool rq_reclaim_from_per_user_free_pool(
     grpc_resource_quota* resource_quota);
 static bool rq_reclaim(grpc_resource_quota* resource_quota, bool destructive);
 
-static void rq_step(void* rq, grpc_error* error) {
+static void rq_step(void* rq, grpc_error* /*error*/) {
   grpc_resource_quota* resource_quota = static_cast<grpc_resource_quota*>(rq);
   resource_quota->step_scheduled = false;
   do {
@@ -479,7 +479,7 @@ static grpc_slice ru_slice_create(grpc_resource_user* resource_user,
  * the combiner
  */
 
-static void ru_allocate(void* ru, grpc_error* error) {
+static void ru_allocate(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (rulist_empty(resource_user->resource_quota,
                    GRPC_RULIST_AWAITING_ALLOCATION)) {
@@ -488,7 +488,7 @@ static void ru_allocate(void* ru, grpc_error* error) {
   rulist_add_tail(resource_user, GRPC_RULIST_AWAITING_ALLOCATION);
 }
 
-static void ru_add_to_free_pool(void* ru, grpc_error* error) {
+static void ru_add_to_free_pool(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (!rulist_empty(resource_user->resource_quota,
                     GRPC_RULIST_AWAITING_ALLOCATION) &&
@@ -513,7 +513,7 @@ static bool ru_post_reclaimer(grpc_resource_user* resource_user,
   return true;
 }
 
-static void ru_post_benign_reclaimer(void* ru, grpc_error* error) {
+static void ru_post_benign_reclaimer(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (!ru_post_reclaimer(resource_user, false)) return;
   if (!rulist_empty(resource_user->resource_quota,
@@ -527,7 +527,7 @@ static void ru_post_benign_reclaimer(void* ru, grpc_error* error) {
   rulist_add_tail(resource_user, GRPC_RULIST_RECLAIMER_BENIGN);
 }
 
-static void ru_post_destructive_reclaimer(void* ru, grpc_error* error) {
+static void ru_post_destructive_reclaimer(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   if (!ru_post_reclaimer(resource_user, true)) return;
   if (!rulist_empty(resource_user->resource_quota,
@@ -543,7 +543,7 @@ static void ru_post_destructive_reclaimer(void* ru, grpc_error* error) {
   rulist_add_tail(resource_user, GRPC_RULIST_RECLAIMER_DESTRUCTIVE);
 }
 
-static void ru_shutdown(void* ru, grpc_error* error) {
+static void ru_shutdown(void* ru, grpc_error* /*error*/) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
     gpr_log(GPR_INFO, "RU shutdown %p", ru);
   }
@@ -561,7 +561,7 @@ static void ru_shutdown(void* ru, grpc_error* error) {
   gpr_mu_unlock(&resource_user->mu);
 }
 
-static void ru_destroy(void* ru, grpc_error* error) {
+static void ru_destroy(void* ru, grpc_error* /*error*/) {
   grpc_resource_user* resource_user = static_cast<grpc_resource_user*>(ru);
   GPR_ASSERT(gpr_atm_no_barrier_load(&resource_user->refs) == 0);
   // Free all the remaining thread quota
@@ -611,7 +611,7 @@ typedef struct {
   grpc_closure closure;
 } rq_resize_args;
 
-static void rq_resize(void* args, grpc_error* error) {
+static void rq_resize(void* args, grpc_error* /*error*/) {
   rq_resize_args* a = static_cast<rq_resize_args*>(args);
   int64_t delta = a->size - a->resource_quota->size;
   a->resource_quota->size += delta;
@@ -622,7 +622,7 @@ static void rq_resize(void* args, grpc_error* error) {
   gpr_free(a);
 }
 
-static void rq_reclamation_done(void* rq, grpc_error* error) {
+static void rq_reclamation_done(void* rq, grpc_error* /*error*/) {
   grpc_resource_quota* resource_quota = static_cast<grpc_resource_quota*>(rq);
   resource_quota->reclaiming = false;
   rq_step_sched(resource_quota);

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -84,11 +84,16 @@ grpc_error* grpc_set_socket_no_sigpipe_if_possible(int fd) {
   if ((newval != 0) != (val != 0)) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_NOSIGPIPE");
   }
+#else
+  // Avoid unused parameter warning for conditional parameter
+  (void)fd;
 #endif
   return GRPC_ERROR_NONE;
 }
 
 grpc_error* grpc_set_socket_ip_pktinfo_if_possible(int fd) {
+  // Use conditionally-important parameter to avoid warning
+  (void)fd;
 #ifdef GRPC_HAVE_IP_PKTINFO
   int get_local_ip = 1;
   if (0 != setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &get_local_ip,
@@ -100,6 +105,8 @@ grpc_error* grpc_set_socket_ip_pktinfo_if_possible(int fd) {
 }
 
 grpc_error* grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
+  // Use conditionally-important parameter to avoid warning
+  (void)fd;
 #ifdef GRPC_HAVE_IPV6_RECVPKTINFO
   int get_local_ip = 1;
   if (0 != setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &get_local_ip,
@@ -256,6 +263,10 @@ void config_default_tcp_user_timeout(bool enable, int timeout, bool is_client) {
 /* Set TCP_USER_TIMEOUT */
 grpc_error* grpc_set_socket_tcp_user_timeout(
     int fd, const grpc_channel_args* channel_args, bool is_client) {
+  // Use conditionally-important parameter to avoid warning
+  (void)fd;
+  (void)channel_args;
+  (void)is_client;
 #ifdef GRPC_HAVE_TCP_USER_TIMEOUT
   bool enable;
   int timeout;

--- a/src/core/lib/iomgr/tcp_client_custom.cc
+++ b/src/core/lib/iomgr/tcp_client_custom.cc
@@ -58,7 +58,7 @@ static void custom_tcp_connect_cleanup(grpc_custom_tcp_connect* connect) {
   }
 }
 
-static void custom_close_callback(grpc_custom_socket* socket) {}
+static void custom_close_callback(grpc_custom_socket* /*socket*/) {}
 
 static void on_alarm(void* acp, grpc_error* error) {
   int done;


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.