### PR TITLE
Remove unused-parameter warnings, round 2 (7 of 19)

### DIFF
--- a/src/core/lib/debug/trace.h
+++ b/src/core/lib/debug/trace.h
@@ -116,12 +116,13 @@ typedef TraceFlag DebugOnlyTraceFlag;
 #else
 class DebugOnlyTraceFlag {
  public:
-  constexpr DebugOnlyTraceFlag(bool default_enabled, const char* name) {}
+  constexpr DebugOnlyTraceFlag(bool /*default_enabled*/, const char* /*name*/) {
+  }
   constexpr bool enabled() const { return false; }
   constexpr const char* name() const { return "DebugOnlyTraceFlag"; }
 
  private:
-  void set_enabled(bool enabled) {}
+  void set_enabled(bool /*enabled*/) {}
 };
 #endif
 

--- a/src/core/lib/gprpp/memory.h
+++ b/src/core/lib/gprpp/memory.h
@@ -107,7 +107,7 @@ class Allocator {
   pointer address(reference x) const { return &x; }
   const_pointer address(const_reference x) const { return &x; }
   pointer allocate(std::size_t n,
-                   std::allocator<void>::const_pointer hint = nullptr) {
+                   std::allocator<void>::const_pointer /*hint*/ = nullptr) {
     return static_cast<pointer>(gpr_malloc(n * sizeof(T)));
   }
   void deallocate(T* p, std::size_t /* n */) { gpr_free(p); }
@@ -132,7 +132,7 @@ bool operator==(Allocator<T> const&, Allocator<U> const&) noexcept {
 }
 
 template <class T, class U>
-bool operator!=(Allocator<T> const& x, Allocator<U> const& y) noexcept {
+bool operator!=(Allocator<T> const& /*x*/, Allocator<U> const& /*y*/) noexcept {
   return false;
 }
 

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -69,7 +69,14 @@ class RefCount {
   // Note: RefCount tracing is only enabled on debug builds, even when a
   //       TraceFlag is used.
   template <typename TraceFlagT = TraceFlag>
-  constexpr explicit RefCount(Value init = 1, TraceFlagT* trace_flag = nullptr)
+  constexpr explicit RefCount(
+      Value init = 1,
+      TraceFlagT*
+#ifndef NDEBUG
+          // Leave unnamed if NDEBUG to avoid unused parameter warning
+          trace_flag
+#endif
+      = nullptr)
       :
 #ifndef NDEBUG
         trace_flag_(trace_flag),
@@ -98,6 +105,10 @@ class RefCount {
               prior, prior + n, reason);
     }
 #else
+    // Use conditionally-important parameters
+    (void)location;
+    (void)reason;
+
     value_.FetchAdd(n, MemoryOrder::RELAXED);
 #endif
   }
@@ -125,6 +136,9 @@ class RefCount {
     }
     assert(prior > 0);
 #else
+    // Avoid unused-parameter warnings for debug-only parameters
+    (void)location;
+    (void)reason;
     RefNonZero();
 #endif
   }
@@ -150,6 +164,9 @@ class RefCount {
               prior, prior + 1, reason);
     }
 #endif
+    // Avoid unused-parameter warnings for debug-only parameters
+    (void)location;
+    (void)reason;
     return value_.IncrementIfNonzero();
   }
 
@@ -184,6 +201,10 @@ class RefCount {
               prior - 1, reason);
     }
     GPR_DEBUG_ASSERT(prior > 0);
+#else
+    // Avoid unused-parameter warnings for debug-only parameters
+    (void)location;
+    (void)reason;
 #endif
     return prior == 1;
   }

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -66,7 +66,7 @@ static grpc_httpcli_get_override g_get_override = nullptr;
 static grpc_httpcli_post_override g_post_override = nullptr;
 
 static void plaintext_handshake(void* arg, grpc_endpoint* endpoint,
-                                const char* host, grpc_millis deadline,
+                                const char* /*host*/, grpc_millis /*deadline*/,
                                 void (*on_done)(void* arg,
                                                 grpc_endpoint* endpoint)) {
   on_done(arg, endpoint);

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -67,7 +67,7 @@ class grpc_httpcli_ssl_channel_security_connector final
   }
 
   void add_handshakers(const grpc_channel_args* args,
-                       grpc_pollset_set* interested_parties,
+                       grpc_pollset_set* /*interested_parties*/,
                        grpc_core::HandshakeManager* handshake_mgr) override {
     tsi_handshaker* handshaker = nullptr;
     if (handshaker_factory_ != nullptr) {
@@ -86,7 +86,7 @@ class grpc_httpcli_ssl_channel_security_connector final
     return handshaker_factory_;
   }
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* /*auth_context*/,
                   grpc_closure* on_peer_checked) override {
     grpc_error* error = GRPC_ERROR_NONE;
@@ -111,15 +111,15 @@ class grpc_httpcli_ssl_channel_security_connector final
     return strcmp(secure_peer_name_, other->secure_peer_name_);
   }
 
-  bool check_call_host(grpc_core::StringView host,
-                       grpc_auth_context* auth_context,
-                       grpc_closure* on_call_host_checked,
+  bool check_call_host(grpc_core::StringView /*host*/,
+                       grpc_auth_context* /*auth_context*/,
+                       grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     *error = GRPC_ERROR_NONE;
     return true;
   }
 
-  void cancel_check_call_host(grpc_closure* on_call_host_checked,
+  void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,
                               grpc_error* error) override {
     GRPC_ERROR_UNREF(error);
   }
@@ -134,7 +134,7 @@ class grpc_httpcli_ssl_channel_security_connector final
 static grpc_core::RefCountedPtr<grpc_channel_security_connector>
 httpcli_ssl_channel_security_connector_create(
     const char* pem_root_certs, const tsi_ssl_root_certs_store* root_store,
-    const char* secure_peer_name, grpc_channel_args* channel_args) {
+    const char* secure_peer_name, grpc_channel_args* /*channel_args*/) {
   if (secure_peer_name != nullptr && pem_root_certs == nullptr) {
     gpr_log(GPR_ERROR,
             "Cannot assert a secure peer name without a trust root.");

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -327,7 +327,7 @@ void grpc_http_parser_init(grpc_http_parser* parser, grpc_http_type type,
   parser->cur_line_end_length = 2;
 }
 
-void grpc_http_parser_destroy(grpc_http_parser* parser) {}
+void grpc_http_parser_destroy(grpc_http_parser* /*parser*/) {}
 
 void grpc_http_request_destroy(grpc_http_request* request) {
   size_t i;

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -39,8 +39,8 @@ void fill_gpr_from_timestamp(gpr_timespec* gts, const struct timespec* ts) {
   gts->clock_type = GPR_CLOCK_REALTIME;
 }
 
-void default_timestamps_callback(void* arg, grpc_core::Timestamps* ts,
-                                 grpc_error* shudown_err) {
+void default_timestamps_callback(void* /*arg*/, grpc_core::Timestamps* /*ts*/,
+                                 grpc_error* /*shudown_err*/) {
   gpr_log(GPR_DEBUG, "Timestamps callback has not been registered");
 }
 
@@ -293,9 +293,8 @@ void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
 #else /* GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_core {
-void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
-                                                       grpc_core::Timestamps*,
-                                                       grpc_error* error)) {
+void grpc_tcp_set_write_timestamps_callback(
+    void (*/*fn*/)(void*, grpc_core::Timestamps*, grpc_error* error)) {
   gpr_log(GPR_DEBUG, "Timestamps callback is not enabled for this platform");
 }
 } /* namespace grpc_core */

--- a/src/core/lib/iomgr/buffer_list.h
+++ b/src/core/lib/iomgr/buffer_list.h
@@ -146,7 +146,7 @@ class TracedBuffer {
 class TracedBuffer {
  public:
   /* Dummy shutdown function */
-  static void Shutdown(grpc_core::TracedBuffer** head, void* remaining,
+  static void Shutdown(grpc_core::TracedBuffer** /*head*/, void* /*remaining*/,
                        grpc_error* shutdown_err) {
     GRPC_ERROR_UNREF(shutdown_err);
   }

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -168,7 +168,7 @@ static void move_next() {
   }
 }
 
-static void offload(void* arg, grpc_error* error) {
+static void offload(void* arg, grpc_error* /*error*/) {
   grpc_core::Combiner* lock = static_cast<grpc_core::Combiner*>(arg);
   push_last_on_exec_ctx(lock);
 }

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -658,7 +658,7 @@ static int poll_deadline_to_millis_timeout(grpc_millis millis) {
    NOTE ON SYNCRHONIZATION: Similar to do_epoll_wait(), this function is only
    called by g_active_poller thread. So there is no need for synchronization
    when accessing fields in g_epoll_set */
-static grpc_error* process_epoll_events(grpc_pollset* pollset) {
+static grpc_error* process_epoll_events(grpc_pollset* /*pollset*/) {
   GPR_TIMER_SCOPE("process_epoll_events", 0);
 
   static const char* err_desc = "process_events";
@@ -1219,7 +1219,7 @@ done:
   return ret_err;
 }
 
-static void pollset_add_fd(grpc_pollset* pollset, grpc_fd* fd) {}
+static void pollset_add_fd(grpc_pollset* /*pollset*/, grpc_fd* /*fd*/) {}
 
 /*******************************************************************************
  * Pollset-set Definitions
@@ -1229,21 +1229,23 @@ static grpc_pollset_set* pollset_set_create(void) {
   return (grpc_pollset_set*)(static_cast<intptr_t>(0xdeafbeef));
 }
 
-static void pollset_set_destroy(grpc_pollset_set* pss) {}
+static void pollset_set_destroy(grpc_pollset_set* /*pss*/) {}
 
-static void pollset_set_add_fd(grpc_pollset_set* pss, grpc_fd* fd) {}
+static void pollset_set_add_fd(grpc_pollset_set* /*pss*/, grpc_fd* /*fd*/) {}
 
-static void pollset_set_del_fd(grpc_pollset_set* pss, grpc_fd* fd) {}
+static void pollset_set_del_fd(grpc_pollset_set* /*pss*/, grpc_fd* /*fd*/) {}
 
-static void pollset_set_add_pollset(grpc_pollset_set* pss, grpc_pollset* ps) {}
+static void pollset_set_add_pollset(grpc_pollset_set* /*pss*/,
+                                    grpc_pollset* /*ps*/) {}
 
-static void pollset_set_del_pollset(grpc_pollset_set* pss, grpc_pollset* ps) {}
+static void pollset_set_del_pollset(grpc_pollset_set* /*pss*/,
+                                    grpc_pollset* /*ps*/) {}
 
-static void pollset_set_add_pollset_set(grpc_pollset_set* bag,
-                                        grpc_pollset_set* item) {}
+static void pollset_set_add_pollset_set(grpc_pollset_set* /*bag*/,
+                                        grpc_pollset_set* /*item*/) {}
 
-static void pollset_set_del_pollset_set(grpc_pollset_set* bag,
-                                        grpc_pollset_set* item) {}
+static void pollset_set_del_pollset_set(grpc_pollset_set* /*bag*/,
+                                        grpc_pollset_set* /*item*/) {}
 
 /*******************************************************************************
  * Event engine binding
@@ -1253,8 +1255,8 @@ static bool is_any_background_poller_thread(void) { return false; }
 
 static void shutdown_background_closure(void) {}
 
-static bool add_closure_to_background_poller(grpc_closure* closure,
-                                             grpc_error* error) {
+static bool add_closure_to_background_poller(grpc_closure* /*closure*/,
+                                             grpc_error* /*error*/) {
   return false;
 }
 
@@ -1325,7 +1327,8 @@ static void reset_event_manager_on_fork() {
 /* It is possible that GLIBC has epoll but the underlying kernel doesn't.
  * Create epoll_fd (epoll_set_init() takes care of that) to make sure epoll
  * support is available */
-const grpc_event_engine_vtable* grpc_init_epoll1_linux(bool explicit_request) {
+const grpc_event_engine_vtable* grpc_init_epoll1_linux(
+    bool /*explicit_request*/) {
   if (!grpc_has_wakeup_fd()) {
     gpr_log(GPR_ERROR, "Skipping epoll1 because of no wakeup fd.");
     return nullptr;
@@ -1356,7 +1359,8 @@ const grpc_event_engine_vtable* grpc_init_epoll1_linux(bool explicit_request) {
 #include "src/core/lib/iomgr/ev_epoll1_linux.h"
 /* If GRPC_LINUX_EPOLL is not defined, it means epoll is not available. Return
  * NULL */
-const grpc_event_engine_vtable* grpc_init_epoll1_linux(bool explicit_request) {
+const grpc_event_engine_vtable* grpc_init_epoll1_linux(
+    bool /*explicit_request*/) {
   return nullptr;
 }
 #endif /* defined(GRPC_POSIX_SOCKET_EV_EPOLL1) */


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.