### PR TITLE
Remove unused-parameter warnings, round 2 (6 of 19)

### DIFF
--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -312,13 +312,13 @@ static grpc_error* init_frame_parser(grpc_chttp2_transport* t) {
   }
 }
 
-static grpc_error* skip_parser(void* parser, grpc_chttp2_transport* t,
-                               grpc_chttp2_stream* s, const grpc_slice& slice,
-                               int is_last) {
+static grpc_error* skip_parser(void* /*parser*/, grpc_chttp2_transport* /*t*/,
+                               grpc_chttp2_stream* /*s*/,
+                               const grpc_slice& /*slice*/, int /*is_last*/) {
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error* skip_header(void* tp, grpc_mdelem md) {
+static grpc_error* skip_header(void* /*tp*/, grpc_mdelem md) {
   GRPC_MDELEM_UNREF(md);
   return GRPC_ERROR_NONE;
 }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -176,7 +176,7 @@ static void report_stall(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 }
 
 /* How many bytes would we like to put on the wire during a single syscall */
-static uint32_t target_write_size(grpc_chttp2_transport* t) {
+static uint32_t target_write_size(grpc_chttp2_transport* /*t*/) {
   return 1024 * 1024;
 }
 

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -900,7 +900,7 @@ bool cancel_stream_locked(inproc_stream* s, grpc_error* error) {
   return ret;
 }
 
-void do_nothing(void* arg, grpc_error* error) {}
+void do_nothing(void* /*arg*/, grpc_error* /*error*/) {}
 
 void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
                        grpc_transport_stream_op_batch* op) {
@@ -1140,7 +1140,7 @@ void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   gpr_mu_unlock(&t->mu->mu);
 }
 
-void destroy_stream(grpc_transport* gt, grpc_stream* gs,
+void destroy_stream(grpc_transport* /*gt*/, grpc_stream* gs,
                     grpc_closure* then_schedule_closure) {
   INPROC_LOG(GPR_INFO, "destroy_stream %p %p", gs, then_schedule_closure);
   inproc_stream* s = reinterpret_cast<inproc_stream*>(gs);
@@ -1162,16 +1162,17 @@ void destroy_transport(grpc_transport* gt) {
  * INTEGRATION GLUE
  */
 
-void set_pollset(grpc_transport* gt, grpc_stream* gs, grpc_pollset* pollset) {
+void set_pollset(grpc_transport* /*gt*/, grpc_stream* /*gs*/,
+                 grpc_pollset* /*pollset*/) {
   // Nothing to do here
 }
 
-void set_pollset_set(grpc_transport* gt, grpc_stream* gs,
-                     grpc_pollset_set* pollset_set) {
+void set_pollset_set(grpc_transport* /*gt*/, grpc_stream* /*gs*/,
+                     grpc_pollset_set* /*pollset_set*/) {
   // Nothing to do here
 }
 
-grpc_endpoint* get_endpoint(grpc_transport* t) { return nullptr; }
+grpc_endpoint* get_endpoint(grpc_transport* /*t*/) { return nullptr; }
 
 const grpc_transport_vtable inproc_vtable = {
     sizeof(inproc_stream), "inproc",        init_stream,
@@ -1183,9 +1184,9 @@ const grpc_transport_vtable inproc_vtable = {
  * Main inproc transport functions
  */
 void inproc_transports_create(grpc_transport** server_transport,
-                              const grpc_channel_args* server_args,
+                              const grpc_channel_args* /*server_args*/,
                               grpc_transport** client_transport,
-                              const grpc_channel_args* client_args) {
+                              const grpc_channel_args* /*client_args*/) {
   INPROC_LOG(GPR_INFO, "inproc_transports_create");
   shared_mu* mu = new (gpr_malloc(sizeof(*mu))) shared_mu();
   inproc_transport* st = new (gpr_malloc(sizeof(*st)))
@@ -1221,7 +1222,7 @@ void grpc_inproc_transport_init(void) {
 
 grpc_channel* grpc_inproc_channel_create(grpc_server* server,
                                          grpc_channel_args* args,
-                                         void* reserved) {
+                                         void* /*reserved*/) {
   GRPC_API_TRACE("grpc_inproc_channel_create(server=%p, args=%p)", 2,
                  (server, args));
 

--- a/src/core/lib/avl/avl.cc
+++ b/src/core/lib/avl/avl.cc
@@ -294,7 +294,7 @@ grpc_avl grpc_avl_remove(grpc_avl avl, void* key, void* user_data) {
   return avl;
 }
 
-grpc_avl grpc_avl_ref(grpc_avl avl, void* user_data) {
+grpc_avl grpc_avl_ref(grpc_avl avl, void* /*user_data*/) {
   ref_node(avl.root);
   return avl;
 }

--- a/src/core/lib/channel/channel_stack.cc
+++ b/src/core/lib/channel/channel_stack.cc
@@ -203,7 +203,7 @@ void grpc_call_stack_set_pollset_or_pollset_set(grpc_call_stack* call_stack,
 }
 
 void grpc_call_stack_ignore_set_pollset_or_pollset_set(
-    grpc_call_element* elem, grpc_polling_entity* pollent) {}
+    grpc_call_element* /*elem*/, grpc_polling_entity* /*pollent*/) {}
 
 void grpc_call_stack_destroy(grpc_call_stack* stack,
                              const grpc_call_final_info* final_info,

--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -235,13 +235,25 @@ void grpc_call_stack_set_pollset_or_pollset_set(grpc_call_stack* call_stack,
   grpc_stream_unref(&(channel_stack)->refcount, reason)
 #else
 #define GRPC_CALL_STACK_REF(call_stack, reason) \
-  grpc_stream_ref(&(call_stack)->refcount)
+  do {                                          \
+    grpc_stream_ref(&(call_stack)->refcount);   \
+    (void)(reason);                             \
+  } while (0);
 #define GRPC_CALL_STACK_UNREF(call_stack, reason) \
-  grpc_stream_unref(&(call_stack)->refcount)
+  do {                                            \
+    grpc_stream_unref(&(call_stack)->refcount);   \
+    (void)(reason);                               \
+  } while (0);
 #define GRPC_CHANNEL_STACK_REF(channel_stack, reason) \
-  grpc_stream_ref(&(channel_stack)->refcount)
+  do {                                                \
+    grpc_stream_ref(&(channel_stack)->refcount);      \
+    (void)(reason);                                   \
+  } while (0);
 #define GRPC_CHANNEL_STACK_UNREF(channel_stack, reason) \
-  grpc_stream_unref(&(channel_stack)->refcount)
+  do {                                                  \
+    grpc_stream_unref(&(channel_stack)->refcount);      \
+    (void)(reason);                                     \
+  } while (0);
 #endif
 
 /* Destroy a call stack */

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -54,7 +54,7 @@ namespace channelz {
 namespace {
 
 void* parent_uuid_copy(void* p) { return p; }
-void parent_uuid_destroy(void* p) {}
+void parent_uuid_destroy(void* /*p*/) {}
 int parent_uuid_cmp(void* p1, void* p2) { return GPR_ICMP(p1, p2); }
 const grpc_arg_pointer_vtable parent_uuid_vtable = {
     parent_uuid_copy, parent_uuid_destroy, parent_uuid_cmp};
@@ -315,7 +315,7 @@ void ChannelNode::RemoveChildSubchannel(intptr_t child_uuid) {
 // ServerNode
 //
 
-ServerNode::ServerNode(grpc_server* server, size_t channel_tracer_max_nodes)
+ServerNode::ServerNode(grpc_server* /*server*/, size_t channel_tracer_max_nodes)
     : BaseNode(EntityType::kServer, /* name */ nullptr),
       trace_(channel_tracer_max_nodes) {}
 

--- a/src/core/lib/channel/connected_channel.cc
+++ b/src/core/lib/channel/connected_channel.cc
@@ -167,7 +167,7 @@ static void set_pollset_or_pollset_set(grpc_call_element* elem,
 
 /* Destructor for call_data */
 static void connected_channel_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
     grpc_closure* then_schedule_closure) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
@@ -195,7 +195,8 @@ static void connected_channel_destroy_channel_elem(grpc_channel_element* elem) {
 
 /* No-op. */
 static void connected_channel_get_channel_info(
-    grpc_channel_element* elem, const grpc_channel_info* channel_info) {}
+    grpc_channel_element* /*elem*/, const grpc_channel_info* /*channel_info*/) {
+}
 
 const grpc_channel_filter grpc_connected_filter = {
     connected_channel_start_transport_stream_op_batch,

--- a/src/core/lib/compression/message_compress.cc
+++ b/src/core/lib/compression/message_compress.cc
@@ -80,11 +80,12 @@ error:
   return 0;
 }
 
-static void* zalloc_gpr(void* opaque, unsigned int items, unsigned int size) {
+static void* zalloc_gpr(void* /*opaque*/, unsigned int items,
+                        unsigned int size) {
   return gpr_malloc(items * size);
 }
 
-static void zfree_gpr(void* opaque, void* address) { gpr_free(address); }
+static void zfree_gpr(void* /*opaque*/, void* address) { gpr_free(address); }
 
 static int zlib_compress(grpc_slice_buffer* input, grpc_slice_buffer* output,
                          int gzip) {

--- a/src/core/lib/compression/stream_compression_identity.cc
+++ b/src/core/lib/compression/stream_compression_identity.cc
@@ -47,12 +47,10 @@ static void grpc_stream_compression_pass_through(grpc_slice_buffer* in,
   }
 }
 
-static bool grpc_stream_compress_identity(grpc_stream_compression_context* ctx,
-                                          grpc_slice_buffer* in,
-                                          grpc_slice_buffer* out,
-                                          size_t* output_size,
-                                          size_t max_output_size,
-                                          grpc_stream_compression_flush flush) {
+static bool grpc_stream_compress_identity(
+    grpc_stream_compression_context* ctx, grpc_slice_buffer* in,
+    grpc_slice_buffer* out, size_t* output_size, size_t max_output_size,
+    grpc_stream_compression_flush /*flush*/) {
   if (ctx == nullptr) {
     return false;
   }
@@ -84,7 +82,7 @@ grpc_stream_compression_context_create_identity(
 }
 
 static void grpc_stream_compression_context_destroy_identity(
-    grpc_stream_compression_context* ctx) {
+    grpc_stream_compression_context* /*ctx*/) {
   return;
 }
 


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.