### PR TITLE
Remove unused-parameter warnings, round 2 (5 of 19)

### DIFF
--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -286,8 +286,8 @@ static grpc_error* message_size_init_call_elem(
 
 // Destructor for call_data.
 static void message_size_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {
+    grpc_call_element* elem, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {
   call_data* calld = (call_data*)elem->call_data;
   calld->~call_data();
 }
@@ -375,7 +375,7 @@ const grpc_channel_filter grpc_message_size_filter = {
 
 // Used for GRPC_CLIENT_SUBCHANNEL
 static bool maybe_add_message_size_filter_subchannel(
-    grpc_channel_stack_builder* builder, void* arg) {
+    grpc_channel_stack_builder* builder, void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   if (grpc_channel_args_want_minimal_stack(channel_args)) {
@@ -388,7 +388,7 @@ static bool maybe_add_message_size_filter_subchannel(
 // Used for GRPC_CLIENT_DIRECT_CHANNEL and GRPC_SERVER_CHANNEL. Adds the filter
 // only if message size limits or service config is specified.
 static bool maybe_add_message_size_filter(grpc_channel_stack_builder* builder,
-                                          void* arg) {
+                                          void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   bool enable = false;

--- a/src/core/ext/filters/workarounds/workaround_cronet_compression_filter.cc
+++ b/src/core/ext/filters/workarounds/workaround_cronet_compression_filter.cc
@@ -105,7 +105,7 @@ static void cronet_compression_start_transport_stream_op_batch(
 
 // Constructor for call_data.
 static grpc_error* cronet_compression_init_call_elem(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+    grpc_call_element* elem, const grpc_call_element_args* /*args*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->next_recv_initial_metadata_ready = nullptr;
   calld->workaround_active = false;
@@ -117,18 +117,18 @@ static grpc_error* cronet_compression_init_call_elem(
 
 // Destructor for call_data.
 static void cronet_compression_destroy_call_elem(
-    grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* ignored) {}
+    grpc_call_element* /*elem*/, const grpc_call_final_info* /*final_info*/,
+    grpc_closure* /*ignored*/) {}
 
 // Constructor for channel_data.
 static grpc_error* cronet_compression_init_channel_elem(
-    grpc_channel_element* elem, grpc_channel_element_args* args) {
+    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
 // Destructor for channel_data.
 static void cronet_compression_destroy_channel_elem(
-    grpc_channel_element* elem) {}
+    grpc_channel_element* /*elem*/) {}
 
 // Parse the user agent
 static bool parse_user_agent(grpc_mdelem md) {
@@ -183,7 +183,7 @@ const grpc_channel_filter grpc_workaround_cronet_compression_filter = {
     "workaround_cronet_compression"};
 
 static bool register_workaround_cronet_compression(
-    grpc_channel_stack_builder* builder, void* arg) {
+    grpc_channel_stack_builder* builder, void* /*arg*/) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
   const grpc_arg* a = grpc_channel_args_find(

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -240,7 +240,7 @@ static void on_accept(void* arg, grpc_endpoint* tcp,
 }
 
 /* Server callback: start listening on our ports */
-static void server_start_listener(grpc_server* server, void* arg,
+static void server_start_listener(grpc_server* /*server*/, void* arg,
                                   grpc_pollset** pollsets,
                                   size_t pollset_count) {
   server_state* state = static_cast<server_state*>(arg);
@@ -276,7 +276,7 @@ static void tcp_server_shutdown_complete(void* arg, grpc_error* error) {
 
 /* Server callback: destroy the tcp listener (so we don't generate further
    callbacks) */
-static void server_destroy_listener(grpc_server* server, void* arg,
+static void server_destroy_listener(grpc_server* /*server*/, void* arg,
                                     grpc_closure* destroy_done) {
   server_state* state = static_cast<server_state*>(arg);
   gpr_mu_lock(&state->mu);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -525,7 +525,7 @@ grpc_chttp2_transport::grpc_chttp2_transport(
   post_benign_reclaimer(this);
 }
 
-static void destroy_transport_locked(void* tp, grpc_error* error) {
+static void destroy_transport_locked(void* tp, grpc_error* /*error*/) {
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(tp);
   t->destroying = 1;
   close_transport_locked(
@@ -718,7 +718,7 @@ static int init_stream(grpc_transport* gt, grpc_stream* gs,
   return 0;
 }
 
-static void destroy_stream_locked(void* sp, grpc_error* error) {
+static void destroy_stream_locked(void* sp, grpc_error* /*error*/) {
   GPR_TIMER_SCOPE("destroy_stream", 0);
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(sp);
   s->~grpc_chttp2_stream();
@@ -935,7 +935,7 @@ static const char* begin_writing_desc(bool partial) {
   }
 }
 
-static void write_action_begin_locked(void* gt, grpc_error* error_ignored) {
+static void write_action_begin_locked(void* gt, grpc_error* /*error_ignored*/) {
   GPR_TIMER_SCOPE("write_action_begin_locked", 0);
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(gt);
   GPR_ASSERT(t->write_state != GRPC_CHTTP2_WRITE_STATE_IDLE);
@@ -974,7 +974,7 @@ static void write_action_begin_locked(void* gt, grpc_error* error_ignored) {
   }
 }
 
-static void write_action(void* gt, grpc_error* error) {
+static void write_action(void* gt, grpc_error* /*error*/) {
   GPR_TIMER_SCOPE("write_action", 0);
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(gt);
   void* cl = t->cl;
@@ -1181,7 +1181,7 @@ static void null_then_sched_closure(grpc_closure** closure) {
 }
 
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
-                                       grpc_chttp2_stream* s,
+                                       grpc_chttp2_stream* /*s*/,
                                        grpc_closure** pclosure,
                                        grpc_error* error, const char* desc) {
   grpc_closure* closure = *pclosure;
@@ -1338,7 +1338,7 @@ static void log_metadata(const grpc_metadata_batch* md_batch, uint32_t id,
 }
 
 static void perform_stream_op_locked(void* stream_op,
-                                     grpc_error* error_ignored) {
+                                     grpc_error* /*error_ignored*/) {
   GPR_TIMER_SCOPE("perform_stream_op_locked", 0);
 
   grpc_transport_stream_op_batch* op =
@@ -1792,7 +1792,7 @@ void grpc_chttp2_add_ping_strike(grpc_chttp2_transport* t) {
 }
 
 static void perform_transport_op_locked(void* stream_op,
-                                        grpc_error* error_ignored) {
+                                        grpc_error* /*error_ignored*/) {
   grpc_transport_op* op = static_cast<grpc_transport_op*>(stream_op);
   grpc_chttp2_transport* t =
       static_cast<grpc_chttp2_transport*>(op->handler_private.extra_arg);
@@ -1854,8 +1854,8 @@ static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
  * INPUT PROCESSING - GENERAL
  */
 
-void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
-                                                      grpc_chttp2_stream* s) {
+void grpc_chttp2_maybe_complete_recv_initial_metadata(
+    grpc_chttp2_transport* /*t*/, grpc_chttp2_stream* s) {
   if (s->recv_initial_metadata_ready != nullptr &&
       s->published_metadata[0] != GRPC_METADATA_NOT_PUBLISHED) {
     if (s->seen_error) {
@@ -1871,7 +1871,7 @@ void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
   }
 }
 
-void grpc_chttp2_maybe_complete_recv_message(grpc_chttp2_transport* t,
+void grpc_chttp2_maybe_complete_recv_message(grpc_chttp2_transport* /*t*/,
                                              grpc_chttp2_stream* s) {
   grpc_error* error = GRPC_ERROR_NONE;
   if (s->recv_message_ready != nullptr) {
@@ -2400,7 +2400,7 @@ typedef struct {
   grpc_chttp2_transport* t;
 } cancel_stream_cb_args;
 
-static void cancel_stream_cb(void* user_data, uint32_t key, void* stream) {
+static void cancel_stream_cb(void* user_data, uint32_t /*key*/, void* stream) {
   cancel_stream_cb_args* args = static_cast<cancel_stream_cb_args*>(user_data);
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(stream);
   grpc_chttp2_cancel_stream(args->t, s, GRPC_ERROR_REF(args->error));
@@ -2909,13 +2909,13 @@ static void connectivity_state_set(grpc_chttp2_transport* t,
  * POLLSET STUFF
  */
 
-static void set_pollset(grpc_transport* gt, grpc_stream* gs,
+static void set_pollset(grpc_transport* gt, grpc_stream* /*gs*/,
                         grpc_pollset* pollset) {
   grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
   grpc_endpoint_add_to_pollset(t->ep, pollset);
 }
 
-static void set_pollset_set(grpc_transport* gt, grpc_stream* gs,
+static void set_pollset_set(grpc_transport* gt, grpc_stream* /*gs*/,
                             grpc_pollset_set* pollset_set) {
   grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
   grpc_endpoint_add_to_pollset_set(t->ep, pollset_set);
@@ -2957,7 +2957,7 @@ Chttp2IncomingByteStream::Chttp2IncomingByteStream(
 }
 
 void Chttp2IncomingByteStream::OrphanLocked(void* arg,
-                                            grpc_error* error_ignored) {
+                                            grpc_error* /*error_ignored*/) {
   Chttp2IncomingByteStream* bs = static_cast<Chttp2IncomingByteStream*>(arg);
   grpc_chttp2_stream* s = bs->stream_;
   grpc_chttp2_transport* t = s->t;
@@ -2976,7 +2976,7 @@ void Chttp2IncomingByteStream::Orphan() {
 }
 
 void Chttp2IncomingByteStream::NextLocked(void* arg,
-                                          grpc_error* error_ignored) {
+                                          grpc_error* /*error_ignored*/) {
   Chttp2IncomingByteStream* bs = static_cast<Chttp2IncomingByteStream*>(arg);
   grpc_chttp2_transport* t = bs->transport_;
   grpc_chttp2_stream* s = bs->stream_;

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -40,10 +40,9 @@ grpc_chttp2_data_parser::~grpc_chttp2_data_parser() {
   GRPC_ERROR_UNREF(error);
 }
 
-grpc_error* grpc_chttp2_data_parser_begin_frame(grpc_chttp2_data_parser* parser,
-                                                uint8_t flags,
-                                                uint32_t stream_id,
-                                                grpc_chttp2_stream* s) {
+grpc_error* grpc_chttp2_data_parser_begin_frame(
+    grpc_chttp2_data_parser* /*parser*/, uint8_t flags, uint32_t stream_id,
+    grpc_chttp2_stream* s) {
   if (flags & ~GRPC_CHTTP2_DATA_FLAG_END_STREAM) {
     char* msg;
     gpr_asprintf(&msg, "unsupported data flags: 0x%02x", flags);
@@ -279,7 +278,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error* grpc_chttp2_data_parser_parse(void* parser,
+grpc_error* grpc_chttp2_data_parser_parse(void* /*parser*/,
                                           grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s,
                                           const grpc_slice& slice,

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -37,7 +37,7 @@ void grpc_chttp2_goaway_parser_destroy(grpc_chttp2_goaway_parser* p) {
 
 grpc_error* grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
                                                   uint32_t length,
-                                                  uint8_t flags) {
+                                                  uint8_t /*flags*/) {
   if (length < 8) {
     char* msg;
     gpr_asprintf(&msg, "goaway frame too short (%d bytes)", length);
@@ -56,7 +56,7 @@ grpc_error* grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
 
 grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
                                             grpc_chttp2_transport* t,
-                                            grpc_chttp2_stream* s,
+                                            grpc_chttp2_stream* /*s*/,
                                             const grpc_slice& slice,
                                             int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -72,7 +72,7 @@ grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,
 
 grpc_error* grpc_chttp2_ping_parser_parse(void* parser,
                                           grpc_chttp2_transport* t,
-                                          grpc_chttp2_stream* s,
+                                          grpc_chttp2_stream* /*s*/,
                                           const grpc_slice& slice,
                                           int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -110,7 +110,7 @@ grpc_error* grpc_chttp2_settings_parser_begin_frame(
 }
 
 grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
-                                              grpc_chttp2_stream* s,
+                                              grpc_chttp2_stream* /*s*/,
                                               const grpc_slice& slice,
                                               int is_last) {
   grpc_chttp2_settings_parser* parser =

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -224,7 +224,7 @@ static void UpdateAddOrEvict(Hashtable hashtable, const ValueType& value,
 }
 
 /* halve all counts because an element reached max */
-static void HalveFilter(uint8_t idx, uint32_t* sum, uint8_t* elems) {
+static void HalveFilter(uint8_t /*idx*/, uint32_t* sum, uint8_t* elems) {
   *sum = 0;
   for (int i = 0; i < GRPC_CHTTP2_HPACKC_NUM_VALUES; i++) {
     elems[i] /= 2;
@@ -452,8 +452,8 @@ static void add_key(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
   }
 }
 
-static void emit_indexed(grpc_chttp2_hpack_compressor* c, uint32_t elem_index,
-                         framer_state* st) {
+static void emit_indexed(grpc_chttp2_hpack_compressor* /*c*/,
+                         uint32_t elem_index, framer_state* st) {
   GRPC_STATS_INC_HPACK_SEND_INDEXED();
   uint32_t len = GRPC_CHTTP2_VARINT_LENGTH(elem_index, 1);
   GRPC_CHTTP2_WRITE_VARINT(elem_index, 1, 0x80, add_tiny_header_data(st, len),
@@ -511,7 +511,7 @@ enum class EmitLitHdrVType { INC_IDX_V, NO_IDX_V };
 }  // namespace
 
 template <EmitLitHdrType type>
-static void emit_lithdr(grpc_chttp2_hpack_compressor* c, uint32_t key_index,
+static void emit_lithdr(grpc_chttp2_hpack_compressor* /*c*/, uint32_t key_index,
                         grpc_mdelem elem, framer_state* st) {
   switch (type) {
     case EmitLitHdrType::INC_IDX:
@@ -549,7 +549,7 @@ static void emit_lithdr(grpc_chttp2_hpack_compressor* c, uint32_t key_index,
 }
 
 template <EmitLitHdrVType type>
-static void emit_lithdr_v(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
+static void emit_lithdr_v(grpc_chttp2_hpack_compressor* /*c*/, grpc_mdelem elem,
                           framer_state* st) {
   switch (type) {
     case EmitLitHdrVType::INC_IDX_V:

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -659,7 +659,7 @@ static grpc_error* on_hdr(grpc_chttp2_hpack_parser* p, grpc_mdelem md) {
 }
 
 static grpc_core::UnmanagedMemorySlice take_string_extern(
-    grpc_chttp2_hpack_parser* p, grpc_chttp2_hpack_parser_string* str) {
+    grpc_chttp2_hpack_parser* /*p*/, grpc_chttp2_hpack_parser_string* str) {
   grpc_core::UnmanagedMemorySlice s;
   if (!str->copied) {
     GPR_DEBUG_ASSERT(!grpc_slice_is_interned(str->data.referenced));
@@ -675,7 +675,7 @@ static grpc_core::UnmanagedMemorySlice take_string_extern(
 }
 
 static grpc_core::ManagedMemorySlice take_string_intern(
-    grpc_chttp2_hpack_parser* p, grpc_chttp2_hpack_parser_string* str) {
+    grpc_chttp2_hpack_parser* /*p*/, grpc_chttp2_hpack_parser_string* str) {
   grpc_core::ManagedMemorySlice s;
   if (!str->copied) {
     s = grpc_core::ManagedMemorySlice(&str->data.referenced);
@@ -811,11 +811,11 @@ static grpc_error* parse_indexed_field_x(grpc_chttp2_hpack_parser* p,
    cached metadata corresponds with the index we are examining. */
 static grpc_mdelem get_precomputed_md_for_idx(grpc_chttp2_hpack_parser* p) {
   GPR_DEBUG_ASSERT(p->md_for_index.payload != 0);
-  GPR_DEBUG_ASSERT(static_cast<int64_t>(p->index) == p->precomputed_md_index);
   grpc_mdelem md = p->md_for_index;
   GPR_DEBUG_ASSERT(!GRPC_MDISNULL(md)); /* handled in string parsing */
   p->md_for_index.payload = 0; /* Invalidate cached md when index changes. */
 #ifndef NDEBUG
+  GPR_DEBUG_ASSERT(static_cast<int64_t>(p->index) == p->precomputed_md_index);
   p->precomputed_md_index = -1;
 #endif
   return md;
@@ -1067,8 +1067,9 @@ static grpc_error* parse_max_tbl_size_x(grpc_chttp2_hpack_parser* p,
 }
 
 /* a parse error: jam the parse state into parse_error, and return error */
-static grpc_error* parse_error(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
-                               const uint8_t* end, grpc_error* err) {
+static grpc_error* parse_error(grpc_chttp2_hpack_parser* p,
+                               const uint8_t* /*cur*/, const uint8_t* /*end*/,
+                               grpc_error* err) {
   GPR_ASSERT(err != GRPC_ERROR_NONE);
   if (p->last_error == GRPC_ERROR_NONE) {
     p->last_error = GRPC_ERROR_REF(err);
@@ -1078,7 +1079,8 @@ static grpc_error* parse_error(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
 }
 
 static grpc_error* still_parse_error(grpc_chttp2_hpack_parser* p,
-                                     const uint8_t* cur, const uint8_t* end) {
+                                     const uint8_t* /*cur*/,
+                                     const uint8_t* /*end*/) {
   return GRPC_ERROR_REF(p->last_error);
 }
 
@@ -1541,9 +1543,9 @@ static bool is_binary_literal_header(grpc_chttp2_hpack_parser* p) {
 static void set_precomputed_md_idx(grpc_chttp2_hpack_parser* p,
                                    grpc_mdelem md) {
   GPR_DEBUG_ASSERT(p->md_for_index.payload == 0);
-  GPR_DEBUG_ASSERT(p->precomputed_md_index == -1);
   p->md_for_index = md;
 #ifndef NDEBUG
+  GPR_DEBUG_ASSERT(p->precomputed_md_index == -1);
   p->precomputed_md_index = p->index;
 #endif
 }
@@ -1593,7 +1595,8 @@ static grpc_error* parse_value_string_with_literal_key(
 }
 
 /* "Uninitialized" header parser to save us a branch in on_hdr().  */
-static grpc_error* on_header_uninitialized(void* user_data, grpc_mdelem md) {
+static grpc_error* on_header_uninitialized(void* /*user_data*/,
+                                           grpc_mdelem md) {
   GRPC_MDELEM_UNREF(md);
   return GRPC_ERROR_CREATE_FROM_STATIC_STRING("on_header callback not set");
 }
@@ -1666,7 +1669,7 @@ static const maybe_complete_func_type maybe_complete_funcs[] = {
     grpc_chttp2_maybe_complete_recv_initial_metadata,
     grpc_chttp2_maybe_complete_recv_trailing_metadata};
 
-static void force_client_rst_stream(void* sp, grpc_error* error) {
+static void force_client_rst_stream(void* sp, grpc_error* /*error*/) {
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(sp);
   grpc_chttp2_transport* t = s->t;
   if (!s->write_closed) {
@@ -1678,7 +1681,7 @@ static void force_client_rst_stream(void* sp, grpc_error* error) {
   GRPC_CHTTP2_STREAM_UNREF(s, "final_rst");
 }
 
-static void parse_stream_compression_md(grpc_chttp2_transport* t,
+static void parse_stream_compression_md(grpc_chttp2_transport* /*t*/,
                                         grpc_chttp2_stream* s,
                                         grpc_metadata_batch* initial_metadata) {
   if (initial_metadata->idx.named.content_encoding == nullptr ||

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -811,11 +811,11 @@ static grpc_error* parse_indexed_field_x(grpc_chttp2_hpack_parser* p,
    cached metadata corresponds with the index we are examining. */
 static grpc_mdelem get_precomputed_md_for_idx(grpc_chttp2_hpack_parser* p) {
   GPR_DEBUG_ASSERT(p->md_for_index.payload != 0);
+  GPR_DEBUG_ASSERT(static_cast<int64_t>(p->index) == p->precomputed_md_index);
   grpc_mdelem md = p->md_for_index;
   GPR_DEBUG_ASSERT(!GRPC_MDISNULL(md)); /* handled in string parsing */
   p->md_for_index.payload = 0; /* Invalidate cached md when index changes. */
 #ifndef NDEBUG
-  GPR_DEBUG_ASSERT(static_cast<int64_t>(p->index) == p->precomputed_md_index);
   p->precomputed_md_index = -1;
 #endif
   return md;
@@ -1543,9 +1543,9 @@ static bool is_binary_literal_header(grpc_chttp2_hpack_parser* p) {
 static void set_precomputed_md_idx(grpc_chttp2_hpack_parser* p,
                                    grpc_mdelem md) {
   GPR_DEBUG_ASSERT(p->md_for_index.payload == 0);
+  GPR_DEBUG_ASSERT(p->precomputed_md_index == -1);
   p->md_for_index = md;
 #ifndef NDEBUG
-  GPR_DEBUG_ASSERT(p->precomputed_md_index == -1);
   p->precomputed_md_index = p->index;
 #endif
 }


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.