### PR TITLE
Remove unused-parameter warnings, round 2 (3 of 19)

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -451,7 +451,7 @@ void AresDnsResolver::StartResolvingLocked() {
 
 class AresDnsResolverFactory : public ResolverFactory {
  public:
-  bool IsValidUri(const grpc_uri* uri) const override { return true; }
+  bool IsValidUri(const grpc_uri* /*uri*/) const override { return true; }
 
   OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
     return MakeOrphanable<AresDnsResolver>(std::move(args));

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
@@ -138,7 +138,7 @@ static void on_timeout_locked(void* arg, grpc_error* error);
 static void on_ares_backup_poll_alarm(void* arg, grpc_error* error);
 static void on_ares_backup_poll_alarm_locked(void* arg, grpc_error* error);
 
-static void noop_inject_channel_config(ares_channel channel) {}
+static void noop_inject_channel_config(ares_channel /*channel*/) {}
 
 void (*grpc_ares_test_only_inject_config)(ares_channel channel) =
     noop_inject_channel_config;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -90,14 +90,14 @@ class GrpcPolledFdFactoryPosix : public GrpcPolledFdFactory {
  public:
   GrpcPolledFd* NewGrpcPolledFdLocked(ares_socket_t as,
                                       grpc_pollset_set* driver_pollset_set,
-                                      Combiner* combiner) override {
+                                      Combiner* /*combiner*/) override {
     return New<GrpcPolledFdPosix>(as, driver_pollset_set);
   }
 
-  void ConfigureAresChannelLocked(ares_channel channel) override {}
+  void ConfigureAresChannelLocked(ares_channel /*channel*/) override {}
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner) {
+UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* /*combiner*/) {
   return MakeUnique<GrpcPolledFdFactoryPosix>();
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -175,7 +175,7 @@ static void destroy_hostbyname_request_locked(
   gpr_free(hr);
 }
 
-static void on_hostbyname_done_locked(void* arg, int status, int timeouts,
+static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
                                       struct hostent* hostent) {
   grpc_ares_hostbyname_request* hr =
       static_cast<grpc_ares_hostbyname_request*>(arg);
@@ -248,7 +248,7 @@ static void on_hostbyname_done_locked(void* arg, int status, int timeouts,
   destroy_hostbyname_request_locked(hr);
 }
 
-static void on_srv_query_done_locked(void* arg, int status, int timeouts,
+static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
                                      unsigned char* abuf, int alen) {
   grpc_ares_request* r = static_cast<grpc_ares_request*>(arg);
   if (status == ARES_SUCCESS) {
@@ -293,7 +293,7 @@ static void on_srv_query_done_locked(void* arg, int status, int timeouts,
 
 static const char g_service_config_attribute_prefix[] = "grpc_config=";
 
-static void on_txt_done_locked(void* arg, int status, int timeouts,
+static void on_txt_done_locked(void* arg, int status, int /*timeouts*/,
                                unsigned char* buf, int len) {
   char* error_msg;
   grpc_ares_request* r = static_cast<grpc_ares_request*>(arg);
@@ -579,8 +579,8 @@ static bool grpc_ares_maybe_resolve_localhost_manually_locked(
 }
 #else  /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
-    const char* name, const char* default_port,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs) {
+    const char* /*name*/, const char* /*default_port*/,
+    grpc_core::UniquePtr<grpc_core::ServerAddressList>* /*addrs*/) {
   return false;
 }
 #endif /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
@@ -728,7 +728,7 @@ static void on_dns_lookup_done(void* arg, grpc_error* error) {
 }
 
 static void grpc_resolve_address_invoke_dns_lookup_ares_locked(
-    void* arg, grpc_error* unused_error) {
+    void* arg, grpc_error* /*unused_error*/) {
   grpc_resolve_address_ares_request* r =
       static_cast<grpc_resolve_address_ares_request*>(arg);
   GRPC_CLOSURE_INIT(&r->on_dns_lookup_done_locked, on_dns_lookup_done, r,

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -159,7 +159,7 @@ void FakeResolver::MaybeSendResultLocked() {
   }
 }
 
-void FakeResolver::ReturnReresolutionResult(void* arg, grpc_error* error) {
+void FakeResolver::ReturnReresolutionResult(void* arg, grpc_error* /*error*/) {
   FakeResolver* self = static_cast<FakeResolver*>(arg);
   self->reresolution_closure_pending_ = false;
   self->MaybeSendResultLocked();
@@ -183,7 +183,7 @@ struct SetResponseClosureArg {
 };
 
 void FakeResolverResponseGenerator::SetResponseLocked(void* arg,
-                                                      grpc_error* error) {
+                                                      grpc_error* /*error*/) {
   SetResponseClosureArg* closure_arg = static_cast<SetResponseClosureArg*>(arg);
   auto& resolver = closure_arg->resolver;
   if (!resolver->shutdown_) {
@@ -215,7 +215,7 @@ void FakeResolverResponseGenerator::SetResponse(Resolver::Result result) {
 }
 
 void FakeResolverResponseGenerator::SetReresolutionResponseLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   SetResponseClosureArg* closure_arg = static_cast<SetResponseClosureArg*>(arg);
   auto& resolver = closure_arg->resolver;
   if (!resolver->shutdown_) {
@@ -259,7 +259,7 @@ void FakeResolverResponseGenerator::UnsetReresolutionResponse() {
 }
 
 void FakeResolverResponseGenerator::SetFailureLocked(void* arg,
-                                                     grpc_error* error) {
+                                                     grpc_error* /*error*/) {
   SetResponseClosureArg* closure_arg = static_cast<SetResponseClosureArg*>(arg);
   auto& resolver = closure_arg->resolver;
   if (!resolver->shutdown_) {
@@ -371,7 +371,7 @@ namespace {
 
 class FakeResolverFactory : public ResolverFactory {
  public:
-  bool IsValidUri(const grpc_uri* uri) const override { return true; }
+  bool IsValidUri(const grpc_uri* /*uri*/) const override { return true; }
 
   OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
     return MakeOrphanable<FakeResolver>(std::move(args));

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -78,7 +78,7 @@ void SockaddrResolver::StartLocked() {
 // Factory
 //
 
-void DoNothing(void* ignored) {}
+void DoNothing(void* /*ignored*/) {}
 
 bool ParseUri(const grpc_uri* uri,
               bool parse(const grpc_uri* uri, grpc_resolved_address* dst),
@@ -160,7 +160,7 @@ class UnixResolverFactory : public ResolverFactory {
     return CreateSockaddrResolver(std::move(args), grpc_parse_unix);
   }
 
-  UniquePtr<char> GetDefaultAuthority(grpc_uri* uri) const override {
+  UniquePtr<char> GetDefaultAuthority(grpc_uri* /*uri*/) const override {
     return UniquePtr<char>(gpr_strdup("localhost"));
   }
 

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -152,7 +152,8 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
     }
   }
 
-  void AddTraceEvent(TraceSeverity severity, StringView message) override {}
+  void AddTraceEvent(TraceSeverity /*severity*/,
+                     StringView /*message*/) override {}
 
   void set_child(LoadBalancingPolicy* child) { child_ = child; }
 

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -74,7 +74,7 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
   // No-op -- should never get updates from the channel.
   // TODO(roth): Need to support updating child LB policy's config for xds
   // use case.
-  void UpdateLocked(UpdateArgs args) override {}
+  void UpdateLocked(UpdateArgs /*args*/) override {}
 
   void ExitIdleLocked() override;
 

--- a/src/core/ext/filters/client_channel/retry_throttle.cc
+++ b/src/core/ext/filters/client_channel/retry_throttle.cc
@@ -118,27 +118,27 @@ void ServerRetryThrottleData::RecordSuccess() {
 
 namespace {
 
-void* copy_server_name(void* key, void* unused) {
+void* copy_server_name(void* key, void* /*unused*/) {
   return gpr_strdup(static_cast<const char*>(key));
 }
 
-long compare_server_name(void* key1, void* key2, void* unused) {
+long compare_server_name(void* key1, void* key2, void* /*unused*/) {
   return strcmp(static_cast<const char*>(key1), static_cast<const char*>(key2));
 }
 
-void destroy_server_retry_throttle_data(void* value, void* unused) {
+void destroy_server_retry_throttle_data(void* value, void* /*unused*/) {
   ServerRetryThrottleData* throttle_data =
       static_cast<ServerRetryThrottleData*>(value);
   throttle_data->Unref();
 }
 
-void* copy_server_retry_throttle_data(void* value, void* unused) {
+void* copy_server_retry_throttle_data(void* value, void* /*unused*/) {
   ServerRetryThrottleData* throttle_data =
       static_cast<ServerRetryThrottleData*>(value);
   return throttle_data->Ref().release();
 }
 
-void destroy_server_name(void* key, void* unused) { gpr_free(key); }
+void destroy_server_name(void* key, void* /*unused*/) { gpr_free(key); }
 
 const grpc_avl_vtable avl_vtable = {
     destroy_server_name, copy_server_name, compare_server_name,

--- a/src/core/ext/filters/client_channel/service_config.h
+++ b/src/core/ext/filters/client_channel/service_config.h
@@ -71,12 +71,16 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
 
     virtual UniquePtr<ParsedConfig> ParseGlobalParams(
         const grpc_json* /* json */, grpc_error** error) {
+      // Avoid unused parameter warning on debug-only parameter
+      (void)error;
       GPR_DEBUG_ASSERT(error != nullptr);
       return nullptr;
     }
 
     virtual UniquePtr<ParsedConfig> ParsePerMethodParams(
         const grpc_json* /* json */, grpc_error** error) {
+      // Avoid unused parameter warning on debug-only parameter
+      (void)error;
       GPR_DEBUG_ASSERT(error != nullptr);
       return nullptr;
     }


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.