### PR TITLE
Remove unused-parameter warnings, round 2 (2 of 19)

### DIFF
--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -99,7 +99,7 @@ bool http_proxy_enabled(const grpc_channel_args* args) {
   return grpc_channel_arg_get_bool(arg, true);
 }
 
-static bool proxy_mapper_map_name(grpc_proxy_mapper* mapper,
+static bool proxy_mapper_map_name(grpc_proxy_mapper* /*mapper*/,
                                   const char* server_uri,
                                   const grpc_channel_args* args,
                                   char** name_to_resolve,
@@ -195,15 +195,15 @@ no_use_proxy:
   return false;
 }
 
-static bool proxy_mapper_map_address(grpc_proxy_mapper* mapper,
-                                     const grpc_resolved_address* address,
-                                     const grpc_channel_args* args,
-                                     grpc_resolved_address** new_address,
-                                     grpc_channel_args** new_args) {
+static bool proxy_mapper_map_address(grpc_proxy_mapper* /*mapper*/,
+                                     const grpc_resolved_address* /*address*/,
+                                     const grpc_channel_args* /*args*/,
+                                     grpc_resolved_address** /*new_address*/,
+                                     grpc_channel_args** /*new_args*/) {
   return false;
 }
 
-static void proxy_mapper_destroy(grpc_proxy_mapper* mapper) {}
+static void proxy_mapper_destroy(grpc_proxy_mapper* /*mapper*/) {}
 
 static const grpc_proxy_mapper_vtable proxy_mapper_vtable = {
     proxy_mapper_map_name, proxy_mapper_map_address, proxy_mapper_destroy};

--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -90,7 +90,7 @@ LoadBalancingPolicy::UpdateArgs& LoadBalancingPolicy::UpdateArgs::operator=(
 //
 
 LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
-    PickArgs args) {
+    PickArgs /*args*/) {
   // We invoke the parent's ExitIdleLocked() via a closure instead
   // of doing it directly here, for two reasons:
   // 1. ExitIdleLocked() may cause the policy's state to change and
@@ -115,7 +115,7 @@ LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
 }
 
 void LoadBalancingPolicy::QueuePicker::CallExitIdle(void* arg,
-                                                    grpc_error* error) {
+                                                    grpc_error* /*error*/) {
   LoadBalancingPolicy* parent = static_cast<LoadBalancingPolicy*>(arg);
   parent->ExitIdleLocked();
   parent->Unref();
@@ -126,7 +126,7 @@ void LoadBalancingPolicy::QueuePicker::CallExitIdle(void* arg,
 //
 
 LoadBalancingPolicy::PickResult
-LoadBalancingPolicy::TransientFailurePicker::Pick(PickArgs args) {
+LoadBalancingPolicy::TransientFailurePicker::Pick(PickArgs /*args*/) {
   PickResult result;
   result.type = PickResult::PICK_FAILED;
   result.error = GRPC_ERROR_REF(error_);

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
@@ -30,12 +30,12 @@
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/profiling/timers.h"
 
-static grpc_error* clr_init_channel_elem(grpc_channel_element* elem,
-                                         grpc_channel_element_args* args) {
+static grpc_error* clr_init_channel_elem(grpc_channel_element* /*elem*/,
+                                         grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
-static void clr_destroy_channel_elem(grpc_channel_element* elem) {}
+static void clr_destroy_channel_elem(grpc_channel_element* /*elem*/) {}
 
 namespace {
 
@@ -79,8 +79,8 @@ static grpc_error* clr_init_call_elem(grpc_call_element* elem,
 }
 
 static void clr_destroy_call_elem(grpc_call_element* elem,
-                                  const grpc_call_final_info* final_info,
-                                  grpc_closure* ignored) {
+                                  const grpc_call_final_info* /*final_info*/,
+                                  grpc_closure* /*ignored*/) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   if (calld->client_stats != nullptr) {
     // Record call finished, optionally setting client_failed_to_send and

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -468,7 +468,7 @@ void client_stats_destroy(void* p) {
   GrpcLbClientStats* client_stats = static_cast<GrpcLbClientStats*>(p);
   client_stats->Unref();
 }
-int equal_cmp(void* p1, void* p2) {
+int equal_cmp(void* /*p1*/, void* /*p2*/) {
   // Always indicate a match, since we don't want this channel arg to
   // affect the subchannel's key in the index.
   // TODO(roth): Is this right?  This does prevent us from needlessly
@@ -1025,8 +1025,8 @@ void GrpcLb::BalancerCallState::OnInitialRequestSent(void* arg,
       GRPC_ERROR_REF(error));
 }
 
-void GrpcLb::BalancerCallState::OnInitialRequestSentLocked(void* arg,
-                                                           grpc_error* error) {
+void GrpcLb::BalancerCallState::OnInitialRequestSentLocked(
+    void* arg, grpc_error* /*error*/) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   grpc_byte_buffer_destroy(lb_calld->send_message_payload_);
   lb_calld->send_message_payload_ = nullptr;
@@ -1050,7 +1050,7 @@ void GrpcLb::BalancerCallState::OnBalancerMessageReceived(void* arg,
 }
 
 void GrpcLb::BalancerCallState::OnBalancerMessageReceivedLocked(
-    void* arg, grpc_error* error) {
+    void* arg, grpc_error* /*error*/) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   GrpcLb* grpclb_policy = lb_calld->grpclb_policy();
   // Null payload means the LB call was cancelled.
@@ -1547,7 +1547,7 @@ void GrpcLb::OnBalancerChannelConnectivityChanged(void* arg,
 }
 
 void GrpcLb::OnBalancerChannelConnectivityChangedLocked(void* arg,
-                                                        grpc_error* error) {
+                                                        grpc_error* /*error*/) {
   GrpcLb* self = static_cast<GrpcLb*>(arg);
   if (!self->shutting_down_ && self->fallback_at_startup_checks_pending_) {
     if (self->lb_channel_connectivity_ != GRPC_CHANNEL_TRANSIENT_FAILURE) {

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
@@ -25,7 +25,7 @@
 namespace grpc_core {
 
 grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
-    const ServerAddressList& addresses, grpc_channel_args* args) {
+    const ServerAddressList& /*addresses*/, grpc_channel_args* args) {
   return args;
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -112,7 +112,7 @@ class PickFirst : public LoadBalancingPolicy {
     explicit Picker(RefCountedPtr<SubchannelInterface> subchannel)
         : subchannel_(std::move(subchannel)) {}
 
-    PickResult Pick(PickArgs args) override {
+    PickResult Pick(PickArgs /*args*/) override {
       PickResult result;
       result.type = PickResult::PICK_COMPLETE;
       result.subchannel = subchannel_;
@@ -490,7 +490,7 @@ class PickFirstFactory : public LoadBalancingPolicyFactory {
   const char* name() const override { return kPickFirst; }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const grpc_json* json, grpc_error** error) const override {
+      const grpc_json* json, grpc_error** /*error*/) const override {
     if (json != nullptr) {
       GPR_DEBUG_ASSERT(strcmp(json->key, name()) == 0);
     }

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -204,7 +204,7 @@ RoundRobin::Picker::Picker(RoundRobin* parent,
   }
 }
 
-RoundRobin::PickResult RoundRobin::Picker::Pick(PickArgs args) {
+RoundRobin::PickResult RoundRobin::Picker::Pick(PickArgs /*args*/) {
   last_picked_index_ = (last_picked_index_ + 1) % subchannels_.size();
   if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_round_robin_trace)) {
     gpr_log(GPR_INFO,
@@ -486,7 +486,7 @@ class RoundRobinFactory : public LoadBalancingPolicyFactory {
   const char* name() const override { return kRoundRobin; }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const grpc_json* json, grpc_error** error) const override {
+      const grpc_json* json, grpc_error** /*error*/) const override {
     if (json != nullptr) {
       GPR_DEBUG_ASSERT(strcmp(json->key, name()) == 0);
     }

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -282,15 +282,15 @@ SubchannelData<SubchannelListType, SubchannelDataType>::~SubchannelData() {
 
 template <typename SubchannelListType, typename SubchannelDataType>
 void SubchannelData<SubchannelListType, SubchannelDataType>::
-    UnrefSubchannelLocked(const char* /*reason*/) {
+    UnrefSubchannelLocked(const char* reason) {
   if (subchannel_ != nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(*subchannel_list_->tracer())) {
       gpr_log(GPR_INFO,
               "[%s %p] subchannel list %p index %" PRIuPTR " of %" PRIuPTR
-              " (subchannel %p): unreffing subchannel",
+              " (subchannel %p): unreffing subchannel (%s)",
               subchannel_list_->tracer()->name(), subchannel_list_->policy(),
               subchannel_list_, Index(), subchannel_list_->num_subchannels(),
-              subchannel_.get());
+              subchannel_.get(), reason);
     }
     subchannel_.reset();
   }

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -267,7 +267,8 @@ void SubchannelData<SubchannelListType, SubchannelDataType>::Watcher::
 template <typename SubchannelListType, typename SubchannelDataType>
 SubchannelData<SubchannelListType, SubchannelDataType>::SubchannelData(
     SubchannelList<SubchannelListType, SubchannelDataType>* subchannel_list,
-    const ServerAddress& address, RefCountedPtr<SubchannelInterface> subchannel)
+    const ServerAddress& /*address*/,
+    RefCountedPtr<SubchannelInterface> subchannel)
     : subchannel_list_(subchannel_list),
       subchannel_(std::move(subchannel)),
       // We assume that the current state is IDLE.  If not, we'll get a
@@ -281,7 +282,7 @@ SubchannelData<SubchannelListType, SubchannelDataType>::~SubchannelData() {
 
 template <typename SubchannelListType, typename SubchannelDataType>
 void SubchannelData<SubchannelListType, SubchannelDataType>::
-    UnrefSubchannelLocked(const char* reason) {
+    UnrefSubchannelLocked(const char* /*reason*/) {
   if (subchannel_ != nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(*subchannel_list_->tracer())) {
       gpr_log(GPR_INFO,

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -479,8 +479,8 @@ LoadBalancingPolicy::PickResult XdsLb::EndpointPickerWrapper::Pick(
   result.recv_trailing_metadata_ready =
       // Note: This callback does not run in either the control plane
       // combiner or in the data plane mutex.
-      [locality_stats](grpc_error* error, MetadataInterface* metadata,
-                       CallState* call_state) {
+      [locality_stats](grpc_error* error, MetadataInterface* /*metadata*/,
+                       CallState* /*call_state*/) {
         const bool call_failed = error != GRPC_ERROR_NONE;
         locality_stats->AddCallFinished(call_failed);
         locality_stats->Unref(DEBUG_LOCATION, "LocalityStats+call");

--- a/src/core/ext/filters/client_channel/local_subchannel_pool.cc
+++ b/src/core/ext/filters/client_channel/local_subchannel_pool.cc
@@ -62,26 +62,26 @@ Subchannel* LocalSubchannelPool::FindSubchannel(SubchannelKey* key) {
 
 namespace {
 
-void sck_avl_destroy(void* p, void* user_data) {
+void sck_avl_destroy(void* p, void* /*user_data*/) {
   SubchannelKey* key = static_cast<SubchannelKey*>(p);
   Delete(key);
 }
 
-void* sck_avl_copy(void* p, void* unused) {
+void* sck_avl_copy(void* p, void* /*unused*/) {
   const SubchannelKey* key = static_cast<const SubchannelKey*>(p);
   auto new_key = New<SubchannelKey>(*key);
   return static_cast<void*>(new_key);
 }
 
-long sck_avl_compare(void* a, void* b, void* unused) {
+long sck_avl_compare(void* a, void* b, void* /*unused*/) {
   const SubchannelKey* key_a = static_cast<const SubchannelKey*>(a);
   const SubchannelKey* key_b = static_cast<const SubchannelKey*>(b);
   return key_a->Cmp(*key_b);
 }
 
-void scv_avl_destroy(void* p, void* user_data) {}
+void scv_avl_destroy(void* /*p*/, void* /*user_data*/) {}
 
-void* scv_avl_copy(void* p, void* unused) { return p; }
+void* scv_avl_copy(void* p, void* /*unused*/) { return p; }
 
 }  // namespace
 


### PR DESCRIPTION
The last round of unused-parameter fixes was generated based on unused parameters in a DEBUG build on one platform (Linux? Mac? I forget). As a result, it didn't complain about all the debug-only parameters and also only saw usage from one platform. It also had other random omissions. This round has been run on both Linux and Mac (sorry, Windows, we'lll look at you soon).

This round of unused-parameter warnings was more complex in some cases because it wasn't just trivial commenting of parameter names. In some cases, function parameters were changed; in some others, (void) expressions were added to convince the compiler that a parameter was indeed being used.