### PR TITLE
Globally limit the number of outstanding ALTS handshakes

### DIFF
--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -372,9 +372,7 @@ class HandshakeQueue {
       client = queued_handshakes_.front();
       queued_handshakes_.pop_front();
     }
-    if (client != nullptr) {
-      continue_make_grpc_call(client, true /* is_start */);
-    }
+    continue_make_grpc_call(client, true /* is_start */);
   }
 
  private:
@@ -397,10 +395,11 @@ HandshakeQueue* g_client_handshake_queue;
 HandshakeQueue* g_server_handshake_queue;
 
 void DoHandshakeQueuesInit(void) {
+  const size_t per_queue_max_outstanding_handshakes = 40;
   g_client_handshake_queue =
-      new HandshakeQueue(40 /* max outstanding handshakes */);
+      new HandshakeQueue(per_queue_max_outstanding_handshakes);
   g_server_handshake_queue =
-      new HandshakeQueue(40 /* max outstanding handshakes */);
+      new HandshakeQueue(per_queue_max_outstanding_handshakes);
 }
 
 void RequestHandshake(alts_grpc_handshaker_client* client, bool is_client) {

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -18,6 +18,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <list>
+
 #include "src/core/tsi/alts/handshaker/alts_handshaker_client.h"
 
 #include <grpc/byte_buffer.h>
@@ -171,26 +173,6 @@ static void maybe_complete_tsi_next(
   gpr_free(r);
 }
 
-static void on_status_received(void* arg, grpc_error* error) {
-  alts_grpc_handshaker_client* client =
-      static_cast<alts_grpc_handshaker_client*>(arg);
-  if (client->handshake_status_code != GRPC_STATUS_OK) {
-    // TODO(apolcyn): consider overriding the handshake result's
-    // status from the final ALTS message with the status here.
-    char* status_details =
-        grpc_slice_to_c_string(client->handshake_status_details);
-    gpr_log(GPR_INFO,
-            "alts_grpc_handshaker_client:%p on_status_received "
-            "status:%d details:|%s| error:|%s|",
-            client, client->handshake_status_code, status_details,
-            grpc_error_string(error));
-    gpr_free(status_details);
-  }
-  maybe_complete_tsi_next(client, true /* receive_status_finished */,
-                          nullptr /* pending_recv_message_result */);
-  alts_grpc_handshaker_client_unref(client);
-}
-
 static void handle_response_done(alts_grpc_handshaker_client* client,
                                  tsi_result status,
                                  const unsigned char* bytes_to_send,
@@ -301,14 +283,9 @@ void alts_handshaker_client_handle_response(alts_handshaker_client* c,
                        bytes_to_send, bytes_to_send_size, result);
 }
 
-/**
- * Populate grpc operation data with the fields of ALTS handshaker client and
- * make a grpc call.
- */
-static tsi_result make_grpc_call(alts_handshaker_client* c, bool is_start) {
-  GPR_ASSERT(c != nullptr);
-  alts_grpc_handshaker_client* client =
-      reinterpret_cast<alts_grpc_handshaker_client*>(c);
+static tsi_result continue_make_grpc_call(alts_grpc_handshaker_client* client,
+                                          bool is_start) {
+  GPR_ASSERT(client != nullptr);
   grpc_op ops[kHandshakerClientOpNum];
   memset(ops, 0, sizeof(ops));
   grpc_op* op = ops;
@@ -356,6 +333,126 @@ static tsi_result make_grpc_call(alts_handshaker_client* c, bool is_start) {
     return TSI_INTERNAL_ERROR;
   }
   return TSI_OK;
+}
+
+// TODO(apolcyn): remove this global queue when we can safely rely
+// on a MAX_CONCURRENT_STREAMS setting in the ALTS handshake server to
+// limit the number of concurrent handshakes.
+namespace {
+
+class HandshakeQueue {
+ public:
+  explicit HandshakeQueue(size_t max_outstanding_handshakes)
+      : max_outstanding_handshakes_(max_outstanding_handshakes) {}
+
+  void RequestHandshake(alts_grpc_handshaker_client* client) {
+    {
+      grpc_core::MutexLock lock(&mu_);
+      if (outstanding_handshakes_ == max_outstanding_handshakes_) {
+        // Max number already running, add to queue.
+        queued_handshakes_.push_back(client);
+        return;
+      }
+      // Start the handshake immediately.
+      ++outstanding_handshakes_;
+    }
+    continue_make_grpc_call(client, true /* is_start */);
+  }
+
+  void HandshakeDone() {
+    alts_grpc_handshaker_client* client = nullptr;
+    {
+      grpc_core::MutexLock lock(&mu_);
+      if (queued_handshakes_.empty()) {
+        // Nothing more in queue.  Decrement count and return immediately.
+        --outstanding_handshakes_;
+        return;
+      }
+      // Remove next entry from queue and start the handshake.
+      client = queued_handshakes_.front();
+      queued_handshakes_.pop_front();
+    }
+    if (client != nullptr) {
+      continue_make_grpc_call(client, true /* is_start */);
+    }
+  }
+
+ private:
+  grpc_core::Mutex mu_;
+  std::list<alts_grpc_handshaker_client*> queued_handshakes_;
+  size_t outstanding_handshakes_ = 0;
+  const size_t max_outstanding_handshakes_;
+};
+
+gpr_once g_queued_handshakes_init = GPR_ONCE_INIT;
+/* Using separate queues for client and server handshakes is a
+ * hack that's mainly intended to satisfy the alts_concurrent_connectivity_test,
+ * which runs many concurrent handshakes where both endpoints
+ * are in the same process; this situation is problematic with a
+ * single queue because we have a high chance of using up all outstanding
+ * slots in the queue, such that there aren't any
+ * mutual client/server handshakes outstanding at the same time and
+ * able to make progress. */
+HandshakeQueue* g_client_handshake_queue;
+HandshakeQueue* g_server_handshake_queue;
+
+void DoHandshakeQueuesInit(void) {
+  g_client_handshake_queue =
+      new HandshakeQueue(40 /* max outstanding handshakes */);
+  g_server_handshake_queue =
+      new HandshakeQueue(40 /* max outstanding handshakes */);
+}
+
+void RequestHandshake(alts_grpc_handshaker_client* client, bool is_client) {
+  gpr_once_init(&g_queued_handshakes_init, DoHandshakeQueuesInit);
+  HandshakeQueue* queue =
+      is_client ? g_client_handshake_queue : g_server_handshake_queue;
+  queue->RequestHandshake(client);
+}
+
+void HandshakeDone(bool is_client) {
+  HandshakeQueue* queue =
+      is_client ? g_client_handshake_queue : g_server_handshake_queue;
+  queue->HandshakeDone();
+}
+
+};  // namespace
+
+/**
+ * Populate grpc operation data with the fields of ALTS handshaker client and
+ * make a grpc call.
+ */
+static tsi_result make_grpc_call(alts_handshaker_client* c, bool is_start) {
+  GPR_ASSERT(c != nullptr);
+  alts_grpc_handshaker_client* client =
+      reinterpret_cast<alts_grpc_handshaker_client*>(c);
+  if (is_start) {
+    RequestHandshake(client, client->is_client);
+    return TSI_OK;
+  } else {
+    return continue_make_grpc_call(client, is_start);
+  }
+}
+
+static void on_status_received(void* arg, grpc_error* error) {
+  alts_grpc_handshaker_client* client =
+      static_cast<alts_grpc_handshaker_client*>(arg);
+  if (client->handshake_status_code != GRPC_STATUS_OK) {
+    // TODO(apolcyn): consider overriding the handshake result's
+    // status from the final ALTS message with the status here.
+    char* status_details =
+        grpc_slice_to_c_string(client->handshake_status_details);
+    gpr_log(GPR_INFO,
+            "alts_grpc_handshaker_client:%p on_status_received "
+            "status:%d details:|%s| error:|%s|",
+            client, client->handshake_status_code, status_details,
+            grpc_error_string(error));
+    gpr_free(status_details);
+  }
+  maybe_complete_tsi_next(client, true /* receive_status_finished */,
+                          nullptr /* pending_recv_message_result */);
+  HandshakeDone(client->is_client);
+  alts_grpc_handshaker_client_unref(client);
 }
 
 /* Serializes a grpc_gcp_HandshakerReq message into a buffer and returns newly

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -829,6 +829,12 @@ void alts_handshaker_client_ref_for_testing(alts_handshaker_client* c) {
 
 void alts_handshaker_client_on_status_received_for_testing(
     alts_handshaker_client* c, grpc_status_code status, grpc_error* error) {
+  // We first make sure that the handshake queue has been initialized
+  // here because there are tests that use this API that mock out
+  // other parts of the alts_handshaker_client in such a way that the
+  // code path that would normally ensure that the handshake queue
+  // has been initialized isn't taken.
+  gpr_once_init(&g_queued_handshakes_init, DoHandshakeQueuesInit);
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
   client->handshake_status_code = status;

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
@@ -27,7 +27,11 @@
 namespace grpc {
 namespace gcp {
 
-std::unique_ptr<grpc::Service> CreateFakeHandshakerService();
+// If max_expected_concurrent_rpcs is non-zero, the fake handshake service
+// will track the number of concurrent RPCs that it handles and abort
+// if if ever exceeds that number.
+std::unique_ptr<grpc::Service> CreateFakeHandshakerService(
+    int max_expected_concurrent_rpcs);
 
 }  // namespace gcp
 }  // namespace grpc

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server_main.cc
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server_main.cc
@@ -31,7 +31,8 @@ DEFINE_int32(handshaker_port, 55056,
 
 static void RunFakeHandshakerServer(const std::string& server_address) {
   std::unique_ptr<grpc::Service> service =
-      grpc::gcp::CreateFakeHandshakerService();
+      grpc::gcp::CreateFakeHandshakerService(
+          0 /* expected max concurrent rpcs unset */);
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(service.get());

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -102,11 +102,16 @@ grpc_channel* create_secure_channel_for_test(
 
 class FakeHandshakeServer {
  public:
-  FakeHandshakeServer() {
+  FakeHandshakeServer(bool check_num_concurrent_rpcs) {
     int port = grpc_pick_unused_port_or_die();
     grpc_core::JoinHostPort(&address_, "localhost", port);
-    service_ = grpc::gcp::CreateFakeHandshakerService(
-        kFakeHandshakeServerMaxConcurrentStreams /* expected max concurrent rpcs */);
+    if (check_num_concurrent_rpcs) {
+      service_ = grpc::gcp::CreateFakeHandshakerService(
+          kFakeHandshakeServerMaxConcurrentStreams /* expected max concurrent rpcs */);
+    } else {
+      service_ = grpc::gcp::CreateFakeHandshakerService(
+          0 /* expected max concurrent rpcs unset */);
+    }
     grpc::ServerBuilder builder;
     builder.AddListeningPort(address_.get(), grpc::InsecureServerCredentials());
     builder.RegisterService(service_.get());
@@ -130,7 +135,8 @@ class FakeHandshakeServer {
 
 class TestServer {
  public:
-  explicit TestServer() {
+  explicit TestServer()
+      : fake_handshake_server_(true /* check num concurrent rpcs */) {
     grpc_alts_credentials_options* alts_options =
         grpc_alts_credentials_server_options_create();
     grpc_server_credentials* server_creds =
@@ -275,7 +281,8 @@ class ConnectLoopRunner {
 // Perform a few ALTS handshakes sequentially (using the fake, in-process ALTS
 // handshake server).
 TEST(AltsConcurrentConnectivityTest, TestBasicClientServerHandshakes) {
-  FakeHandshakeServer fake_handshake_server;
+  FakeHandshakeServer fake_handshake_server(
+      true /* check num concurrent rpcs */);
   TestServer test_server;
   {
     ConnectLoopRunner runner(
@@ -289,7 +296,8 @@ TEST(AltsConcurrentConnectivityTest, TestBasicClientServerHandshakes) {
 /* Run a bunch of concurrent ALTS handshakes on concurrent channels
  * (using the fake, in-process handshake server). */
 TEST(AltsConcurrentConnectivityTest, TestConcurrentClientServerHandshakes) {
-  FakeHandshakeServer fake_handshake_server;
+  FakeHandshakeServer fake_handshake_server(
+      true /* check num concurrent rpcs */);
   // Test
   {
     TestServer test_server;
@@ -482,7 +490,15 @@ class FakeTcpServer {
  * handshake. */
 TEST(AltsConcurrentConnectivityTest,
      TestHandshakeFailsFastWhenPeerEndpointClosesConnectionAfterAccepting) {
-  FakeHandshakeServer fake_handshake_server;
+  // Don't enforce the number of concurrent rpcs for the fake handshake
+  // server in this test, because this test will involve handshake RPCs
+  // getting cancelled. Because there isn't explicit synchronization between
+  // an ALTS handshake client's RECV_STATUS op completing after call
+  // cancellation, and the corresponding fake handshake server's sync
+  // method handler returning, enforcing a limit on the number of active
+  // RPCs at the fake handshake server would be inherently racey.
+  FakeHandshakeServer fake_handshake_server(
+      false /* check num concurrent rpcs */);
   FakeTcpServer fake_tcp_server(
       FakeTcpServer::CloseSocketUponReceivingBytesFromPeer);
   {

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -105,12 +105,13 @@ class FakeHandshakeServer {
   FakeHandshakeServer() {
     int port = grpc_pick_unused_port_or_die();
     grpc_core::JoinHostPort(&address_, "localhost", port);
-    service_ = grpc::gcp::CreateFakeHandshakerService();
+    service_ = grpc::gcp::CreateFakeHandshakerService(
+        kFakeHandshakeServerMaxConcurrentStreams /* expected max concurrent rpcs */);
     grpc::ServerBuilder builder;
     builder.AddListeningPort(address_.get(), grpc::InsecureServerCredentials());
     builder.RegisterService(service_.get());
-    builder.AddChannelArgument(GRPC_ARG_MAX_CONCURRENT_STREAMS,
-                               kFakeHandshakeServerMaxConcurrentStreams);
+    // TODO(apolcyn): when removing the global concurrent handshake limiting
+    // queue, set MAX_CONCURRENT_STREAMS on this server.
     server_ = builder.BuildAndStart();
     gpr_log(GPR_INFO, "Fake handshaker server listening on %s", address_.get());
   }

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -650,8 +650,11 @@ static void check_handle_response_nullptr_handshaker() {
    * because this test mocks out the grpc call in such a way that the code
    * path that would usually take this ref is skipped. */
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
-                                                        GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   grpc_slice_unref(slice);
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -680,8 +683,11 @@ static void check_handle_response_nullptr_recv_bytes() {
                                                 nullptr, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
-                                                        GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);
@@ -711,8 +717,11 @@ static void check_handle_response_failed_grpc_call_to_handshaker_service() {
       GRPC_STATUS_UNKNOWN);
   alts_handshaker_client_handle_response(client, true);
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(
-      client, GRPC_STATUS_UNKNOWN, GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_UNKNOWN, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   grpc_slice_unref(slice);
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -744,8 +753,11 @@ check_handle_response_failed_recv_message_from_handshaker_service() {
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, false);
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
-                                                        GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   grpc_slice_unref(slice);
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -786,8 +798,11 @@ static void check_handle_response_invalid_resp() {
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
-                                                        GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);
@@ -802,8 +817,11 @@ static void check_handle_response_success(void* /*unused*/) {
   wait(&caller_to_tsi_notification);
   alts_handshaker_client_handle_response(cb_event, true /* is_ok */);
   alts_handshaker_client_ref_for_testing(cb_event);
-  alts_handshaker_client_on_status_received_for_testing(
-      cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Server start. */
   wait(&caller_to_tsi_notification);
   alts_handshaker_client_handle_response(cb_event, true /* is_ok */);
@@ -811,8 +829,11 @@ static void check_handle_response_success(void* /*unused*/) {
   wait(&caller_to_tsi_notification);
   alts_handshaker_client_handle_response(cb_event, true /* is_ok */);
   alts_handshaker_client_ref_for_testing(cb_event);
-  alts_handshaker_client_on_status_received_for_testing(
-      cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
 }
 
 static void on_failed_resp_cb(tsi_result status, void* user_data,
@@ -848,8 +869,11 @@ static void check_handle_response_failure() {
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true /* is_ok*/);
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
-                                                        GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);
@@ -890,8 +914,11 @@ static void check_handle_response_after_shutdown() {
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
   alts_handshaker_client_ref_for_testing(client);
-  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
-                                                        GRPC_ERROR_NONE);
+  {
+    grpc_core::ExecCtx exec_ctx;
+    alts_handshaker_client_on_status_received_for_testing(
+        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+  }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);


### PR DESCRIPTION
Based on https://github.com/grpc/grpc/pull/20687

This is roughly a client-side max_concurrent_streams setting for ALTS handshakes. This is needed in order to reduce handshake service load in certain situations.

This PR has a couple of changes:
1) Add a global "max outstanding ALTS handshake" queue to the `alts_handshaker_client` code. This change is meant to be reverted when we find that we can safely rely on a "max concurrent streams" setting in ALTS gRPC servers.
2)) <i>mostly</i> mechanical changes to `alts_tsi_handshaker_test` and `alts_handshaker_client` test to ensure that some of the alts handshaker object methods are called with an `ExecCtx` active.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/20722)
<!-- Reviewable:end -->
