### PR TITLE
Avoid "Unevaluated target" problems when RBE tests timeout.

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe_asan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_asan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_asan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_dbg.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/grpc_bazel_rbe_msan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_msan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_msan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_opt.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/grpc_bazel_rbe_tsan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_tsan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_tsan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/grpc_bazel_rbe_ubsan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_ubsan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_ubsan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_asan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_asan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_asan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_msan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_msan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_msan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_tsan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_tsan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_tsan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_ubsan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_ubsan.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_ubsan_on_foundry.sh"
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/bazel_rbe.bat"
 
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/windows/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_opt.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/bazel_rbe.bat"
 
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/bazel_rbe.bat"
 
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_opt.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/bazel_rbe.bat"
 
-timeout_mins: 60
+timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -30,7 +30,7 @@ build --spawn_strategy=remote
 build --strategy=Javac=remote
 build --strategy=Closure=remote
 build --genrule_strategy=remote
-build --remote_timeout=3600
+build --remote_timeout=7200  # the theory is that this needs to be bigger than max test_timeout otherwise you can get weird "Unevaluated target" errors
 
 build --remote_instance_name=projects/grpc-testing/instances/default_instance
 

--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -30,7 +30,6 @@ build --spawn_strategy=remote
 build --strategy=Javac=remote
 build --strategy=Closure=remote
 build --genrule_strategy=remote
-build --remote_timeout=7200  # the theory is that this needs to be bigger than max test_timeout otherwise you can get weird "Unevaluated target" errors
 
 build --remote_instance_name=projects/grpc-testing/instances/default_instance
 

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -24,7 +24,7 @@ build --spawn_strategy=remote
 build --strategy=Javac=remote
 build --strategy=Closure=remote
 build --genrule_strategy=remote
-build --remote_timeout=3600
+build --remote_timeout=7200  # the theory is that this needs to be bigger than max test_timeout otherwise you can get weird "Unevaluated target" errors
 
 build --remote_instance_name=projects/grpc-testing/instances/grpc-windows-rbe-test
 

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -24,7 +24,6 @@ build --spawn_strategy=remote
 build --strategy=Javac=remote
 build --strategy=Closure=remote
 build --genrule_strategy=remote
-build --remote_timeout=7200  # the theory is that this needs to be bigger than max test_timeout otherwise you can get weird "Unevaluated target" errors
 
 build --remote_instance_name=projects/grpc-testing/instances/grpc-windows-rbe-test
 


### PR DESCRIPTION
The theory is that because of some tests (under xSAN config) are configured with --test_timeout=3600  (which is crazy high and should not be necessary at all, but that's how we set it in long time in the past and never revisited), the kokoro job running the build can timeout right around the time the bazel build is finishing (trying to report timeout of a test) and then "Unevaluate target" results shows up in resultstore UI.