### PR TITLE
Don't run xds_end2end_test on iOS

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -508,7 +508,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
+    tags = ["no_windows", "no_test_ios"],  # TODO(jtattermusch): fix test on windows
 )
 
 grpc_cc_test(


### PR DESCRIPTION
Fixes #20755