### PR TITLE
Comment out the test suites that has oversize port pool

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2343,7 +2343,7 @@ INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, LocalityMapTest, ::testing::Bool());
 
 INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, FailoverTest, ::testing::Bool());
 
-INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, DropTest, ::testing::Bool());
+// INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, DropTest, ::testing::Bool());
 
 // Fallback does not work with xds resolver.
 INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, FallbackTest,

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2355,11 +2355,15 @@ INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, FallbackTest,
 // INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, BalancerUpdateTest,
 //                         ::testing::Bool());
 
-INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingTest,
-                         ::testing::Bool());
+// Comment out this test suite because the ports size too large, should be less
+// than 200.
+// INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingTest,
+//                         ::testing::Bool());
 
-INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingWithDropTest,
-                         ::testing::Bool());
+// Comment out this test suite because the ports size too large, should be less
+// than 200.
+//INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingWithDropTest,
+//                         ::testing::Bool());
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2343,14 +2343,17 @@ INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, LocalityMapTest, ::testing::Bool());
 
 INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, FailoverTest, ::testing::Bool());
 
+// Comment out this test suite because the ports size too large, should be less
+// than 200.
 // INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, DropTest, ::testing::Bool());
 
 // Fallback does not work with xds resolver.
 INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, FallbackTest,
                          ::testing::Values(false));
-
-INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, BalancerUpdateTest,
-                         ::testing::Bool());
+// Comment out this test suite because the ports size too large, should be less
+// than 200.
+// INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, BalancerUpdateTest,
+//                         ::testing::Bool());
 
 INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingTest,
                          ::testing::Bool());

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2362,7 +2362,7 @@ INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, FallbackTest,
 
 // Comment out this test suite because the ports size too large, should be less
 // than 200.
-//INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingWithDropTest,
+// INSTANTIATE_TEST_SUITE_P(UsesXdsResolver, ClientLoadReportingWithDropTest,
 //                         ::testing::Bool());
 
 }  // namespace


### PR DESCRIPTION
This PR comments out the test suites that exceed the port limitation in #20476. I cannot revert that PR automatically, because of other changes are merged. So comment out the test suites that are failing. Wait for @markdroth to fix them later.