### PR TITLE
Set high --remote_timeout for RBE builds

### DIFF
--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -30,6 +30,7 @@ build --spawn_strategy=remote
 build --strategy=Javac=remote
 build --strategy=Closure=remote
 build --genrule_strategy=remote
+build --remote_timeout=7200  # very large value to avoid problems like https://github.com/grpc/grpc/issues/20777
 
 build --remote_instance_name=projects/grpc-testing/instances/default_instance
 

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -24,6 +24,7 @@ build --spawn_strategy=remote
 build --strategy=Javac=remote
 build --strategy=Closure=remote
 build --genrule_strategy=remote
+build --remote_timeout=7200  # very large value to avoid problems like https://github.com/grpc/grpc/issues/20777
 
 build --remote_instance_name=projects/grpc-testing/instances/grpc-windows-rbe-test
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/20777 which was introduces by https://github.com/grpc/grpc/pull/20758/files#diff-caf6876ad86b4eda47d7152ba8d93ebeL33 which turned out to be a bad advice.