### PR TITLE
Support both v4 and v6 in test

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -93,11 +93,29 @@ class _GenericHandler(grpc.GenericRpcHandler):
             return None
 
 
+def _create_socket_ipv6(bind_address):
+    listen_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    listen_socket.bind((bind_address, 0, 0, 0))
+    return listen_socket
+
+
+def _create_socket_ipv4(bind_address):
+    listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listen_socket.bind((bind_address, 0))
+    return listen_socket
+
+
 def get_free_loopback_tcp_port():
-    tcp = socket.socket(socket.AF_INET)
-    tcp.bind(('', 0))
-    address_tuple = tcp.getsockname()
-    return tcp, "localhost:%s" % (address_tuple[1])
+    listen_socket = None
+    if socket.has_ipv6:
+        try:
+            listen_socket = _create_socket_ipv6('')
+        except socket.error:
+            listen_socket = _create_socket_ipv4('')
+    else:
+        listen_socket = _create_socket_ipv4('')
+    address_tuple = listen_socket.getsockname()
+    return listen_socket, "localhost:%s" % (address_tuple[1])
 
 
 def create_dummy_channel():


### PR DESCRIPTION
This fixes a breakage on internal test infrastructure. I will follow up by submitting another PR to factor this pattern out into a common framework for all Python tests.

CC @a11r 