### PR TITLE
Add documentation in ClientContext

### DIFF
--- a/include/grpcpp/impl/codegen/client_context_impl.h
+++ b/include/grpcpp/impl/codegen/client_context_impl.h
@@ -293,7 +293,8 @@ class ClientContext {
   /// https://tools.ietf.org/html/rfc7540#section-8.1.2.3).
   void set_authority(const grpc::string& authority) { authority_ = authority; }
 
-  /// Return the authentication context for this client call.
+  /// Return the authentication context for the associated client call.
+  /// It is only valid to call this during the lifetime of the client call.
   ///
   /// \see grpc::AuthContext.
   std::shared_ptr<const grpc::AuthContext> auth_context() const {
@@ -350,6 +351,7 @@ class ClientContext {
   }
 
   /// Return the peer uri in a string.
+  /// It is only valid to call this during the lifetime of the client call.
   ///
   /// \warning This value is never authenticated or subject to any security
   /// related code. It must not be used for any authentication related
@@ -358,8 +360,13 @@ class ClientContext {
   /// \return The call's peer URI.
   grpc::string peer() const;
 
-  /// Get and set census context.
+  /// Sets the census context.
+  /// It is only valid to call this before the client call is created. A common
+  /// place of setting census context is from within the DefaultConstructor
+  /// method of GlobalCallbacks.
   void set_census_context(struct census_context* ccp) { census_context_ = ccp; }
+
+  /// Returns the census context that has been set, or nullptr if not set.
   struct census_context* census_context() const {
     return census_context_;
   }


### PR DESCRIPTION
Add documentation around peer, auth_context and census_context properties of ClientContext

