### PR TITLE
Fuzz base64 encoding and decoding

### DIFF
--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -21,6 +21,28 @@ licenses(["notice"])  # Apache v2
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 grpc_fuzzer(
+    name = "b64_encode_fuzzer",
+    srcs = ["b64_encode_fuzzer.cc"],
+    corpus = "b64_encode_corpus",
+    language = "C++",
+    tags = ["no_windows"],
+    deps = [
+        "//:grpc",
+    ],
+)
+
+grpc_fuzzer(
+    name = "b64_decode_fuzzer",
+    srcs = ["b64_decode_fuzzer.cc"],
+    corpus = "b64_decode_corpus",
+    language = "C++",
+    tags = ["no_windows"],
+    deps = [
+        "//:grpc",
+    ],
+)
+
+grpc_fuzzer(
     name = "percent_encode_fuzzer",
     srcs = ["percent_encode_fuzzer.cc"],
     corpus = "percent_encode_corpus",

--- a/test/core/slice/b64_decode_fuzzer.cc
+++ b/test/core/slice/b64_decode_fuzzer.cc
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "src/core/lib/slice/b64.h"
+
+bool squelch = true;
+bool leak_check = true;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  if (size < 1) return 0;
+  const bool url_safe = static_cast<uint8_t>(0x100) < data[0];
+  grpc_base64_decode_with_len(reinterpret_cast<const char*>(data + 1), size - 1,
+                              url_safe);
+  return 0;
+}

--- a/test/core/slice/b64_encode_fuzzer.cc
+++ b/test/core/slice/b64_encode_fuzzer.cc
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "src/core/lib/slice/b64.h"
+
+bool squelch = true;
+bool leak_check = true;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  if (size < 2) return 0;
+  const bool url_safe = static_cast<uint8_t>(0x100) < data[0];
+  const bool multiline = static_cast<uint8_t>(0x100) < data[1];
+  grpc_base64_encode(reinterpret_cast<const char*>(data + 2), size - 2,
+                     url_safe, multiline);
+  return 0;
+}


### PR DESCRIPTION
Google had a company-wide FuzzIt hackathon recently, so I went digging
in gRPC and found this, which means I probably don't know what I'm doing :)

The initial corpus files I'm checking in were generated via local runs
and appear to consistently cause leaks. Please let me know if these are
actual bugs, or if they're a false positive.

@hcaseyal 