### PR TITLE
[AIO] Implement the shutdown process for AIO server and completion queue.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callbackcontext.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callbackcontext.pxd.pxi
@@ -15,6 +15,15 @@
 cimport cpython
 
 cdef struct CallbackContext:
+    # C struct to store callback context in the form of pointers.
+    #    
+    #   Attributes:
+    #     functor: A grpc_experimental_completion_queue_functor represents the
+    #       callback function in the only way C-Core understands.
+    #     waiter: An asyncio.Future object that fulfills when the callback is
+    #       invoked by C-Core.
+    #     failure_handler: A CallbackFailureHandler object that called when C-Core
+    #       returns 'success == 0' state.
     grpc_experimental_completion_queue_functor functor
-    cpython.PyObject *waiter  # asyncio.Future
-    cpython.PyObject *failure_handler  # cygrpc.CallbackFailureHandler
+    cpython.PyObject *waiter
+    cpython.PyObject *failure_handler

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callbackcontext.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callbackcontext.pxd.pxi
@@ -16,5 +16,5 @@ cimport cpython
 
 cdef struct CallbackContext:
     grpc_experimental_completion_queue_functor functor
-    cpython.PyObject *waiter
-
+    cpython.PyObject *waiter  # asyncio.Future
+    cpython.PyObject *failure_handler  # cygrpc.CallbackFailureHandler

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
@@ -154,6 +154,11 @@ cdef class _AsyncioSocket:
             self._writer.close()
         if self._server:
             self._server.close()
+        # NOTE(lidiz) If the asyncio.Server is created from a Python socket,
+        # the server.close() won't release the fd until the close() is called
+        # for the Python socket.
+        if self._py_socket:
+            self._py_socket.close()
 
     def _new_connection_callback(self, object reader, object writer):
         client_socket = _AsyncioSocket.create(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
@@ -152,6 +152,8 @@ cdef class _AsyncioSocket:
     cdef void close(self):
         if self.is_connected():
             self._writer.close()
+        if self._server:
+            self._server.close()
 
     def _new_connection_callback(self, object reader, object writer):
         client_socket = _AsyncioSocket.create(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -30,6 +30,7 @@ cdef enum AioServerStatus:
     AIO_SERVER_STATUS_READY
     AIO_SERVER_STATUS_RUNNING
     AIO_SERVER_STATUS_STOPPED
+    AIO_SERVER_STATUS_STOPPING
 
 
 cdef class _CallbackCompletionQueue:
@@ -42,3 +43,4 @@ cdef class AioServer:
     cdef _CallbackCompletionQueue _cq
     cdef list _generic_handlers
     cdef AioServerStatus _status
+    cdef object _loop

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -25,6 +25,18 @@ cdef class RPCState:
     cdef bytes method(self)
 
 
+cdef class CallbackWrapper:
+    cdef CallbackContext context
+    cdef object _reference
+
+    @staticmethod
+    cdef void functor_run(
+            grpc_experimental_completion_queue_functor* functor,
+            int succeed)
+
+    cdef grpc_experimental_completion_queue_functor *c_functor(self)
+
+
 cdef enum AioServerStatus:
     AIO_SERVER_STATUS_UNKNOWN
     AIO_SERVER_STATUS_READY
@@ -36,6 +48,9 @@ cdef enum AioServerStatus:
 cdef class _CallbackCompletionQueue:
     cdef grpc_completion_queue *_cq
     cdef grpc_completion_queue* c_ptr(self)
+    cdef object _shutdown_completed
+    cdef CallbackWrapper _wrapper
+    cdef object _loop
 
 
 cdef class AioServer:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -61,3 +61,6 @@ cdef class AioServer:
     cdef AioServerStatus _status
     cdef object _loop  # asyncio.EventLoop
     cdef object _serving_task  # asyncio.Task
+    cdef object _shutdown_lock  # asyncio.Lock
+    cdef object _shutdown_completed  # asyncio.Future
+    cdef CallbackWrapper _shutdown_callback_wrapper

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -64,3 +64,4 @@ cdef class AioServer:
     cdef object _shutdown_lock  # asyncio.Lock
     cdef object _shutdown_completed  # asyncio.Future
     cdef CallbackWrapper _shutdown_callback_wrapper
+    cdef object _crash_exception  # Exception

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -27,7 +27,8 @@ cdef class RPCState:
 
 cdef class CallbackWrapper:
     cdef CallbackContext context
-    cdef object _reference
+    cdef object _reference_of_future
+    cdef object _reference_of_failure_handler
 
     @staticmethod
     cdef void functor_run(
@@ -48,9 +49,9 @@ cdef enum AioServerStatus:
 cdef class _CallbackCompletionQueue:
     cdef grpc_completion_queue *_cq
     cdef grpc_completion_queue* c_ptr(self)
-    cdef object _shutdown_completed
+    cdef object _shutdown_completed  # asyncio.Future
     cdef CallbackWrapper _wrapper
-    cdef object _loop
+    cdef object _loop  # asyncio.EventLoop
 
 
 cdef class AioServer:
@@ -58,4 +59,5 @@ cdef class AioServer:
     cdef _CallbackCompletionQueue _cq
     cdef list _generic_handlers
     cdef AioServerStatus _status
-    cdef object _loop
+    cdef object _loop  # asyncio.EventLoop
+    cdef object _serving_task  # asyncio.Task

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -305,8 +305,8 @@ cdef class AioServer:
     async def _server_main_loop(self,
                                 object server_started):
         self._server.start(backup_queue=False)
-        server_started.set_result(True)
         cdef RPCState rpc_state
+        server_started.set_result(True)
 
         while True:
             # When shutdown process starts, no more new connections.
@@ -377,7 +377,7 @@ cdef class AioServer:
             await shutdown_completed
         else:
             try:
-                await asyncio.wait_for(shutdown_completed, grace)
+                await asyncio.wait_for(asyncio.shield(shutdown_completed), grace)
             except asyncio.TimeoutError:
                 # Cancels all ongoing calls by the end of grace period.
                 grpc_server_cancel_all_calls(self._server.c_server)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -410,7 +410,7 @@ cdef class AioServer:
             await self._shutdown_completed
         else:
             try:
-                await asyncio.wait_for(self._shutdown_completed, timeout)
+                await asyncio.wait_for(asyncio.shield(self._shutdown_completed), timeout)
             except asyncio.TimeoutError:
                 if self._crash_exception is not None:
                     raise self._crash_exception

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -64,7 +64,7 @@ cdef class CallbackWrapper:
             grpc_experimental_completion_queue_functor* functor,
             int success):
         cdef CallbackContext *context = <CallbackContext *>functor
-        if succeed == 0:
+        if success == 0:
             (<_CallbackFailureHandler>context.failure_handler).handle(
                 <object>context.waiter)
         else:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -61,16 +61,25 @@ cdef class Server:
           self.c_server, queue.c_completion_queue, NULL)
     self.registered_completion_queues.append(queue)
 
-  def start(self):
+  def start(self, backup_queue=True):
+    """Start the Cython gRPC Server.
+    
+    Args:
+      backup_queue: a bool indicates whether to spawn a backup completion
+        queue. In case of no CQ is bound to the server, and the shutdown
+        process of server becomes un-observable.
+    """
     if self.is_started:
       raise ValueError("the server has already started")
-    self.backup_shutdown_queue = CompletionQueue(shutdown_cq=True)
-    self.register_completion_queue(self.backup_shutdown_queue)
+    if backup_queue:
+      self.backup_shutdown_queue = CompletionQueue(shutdown_cq=True)
+      self.register_completion_queue(self.backup_shutdown_queue)
     self.is_started = True
     with nogil:
       grpc_server_start(self.c_server)
-    # Ensure the core has gotten a chance to do the start-up work
-    self.backup_shutdown_queue.poll(deadline=time.time())
+    if backup_queue:
+      # Ensure the core has gotten a chance to do the start-up work
+      self.backup_shutdown_queue.poll(deadline=time.time())
 
   def add_http2_port(self, bytes address,
                      ServerCredentials server_credentials=None):
@@ -134,11 +143,14 @@ cdef class Server:
       elif self.is_shutdown:
         pass
       elif not self.is_shutting_down:
-        # the user didn't call shutdown - use our backup queue
-        self._c_shutdown(self.backup_shutdown_queue, None)
-        # and now we wait
-        while not self.is_shutdown:
-          self.backup_shutdown_queue.poll()
+        if self.backup_shutdown_queue is None:
+          raise RuntimeError('Server shutdown failed: no completion queue.')
+        else:
+          # the user didn't call shutdown - use our backup queue
+          self._c_shutdown(self.backup_shutdown_queue, None)
+          # and now we wait
+          while not self.is_shutdown:
+            self.backup_shutdown_queue.poll()
       else:
         # We're in the process of shutting down, but have not shutdown; can't do
         # much but repeatedly release the GIL and wait

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -66,8 +66,8 @@ cdef class Server:
     
     Args:
       backup_queue: a bool indicates whether to spawn a backup completion
-        queue. In case of no CQ is bound to the server, and the shutdown
-        process of server becomes un-observable.
+        queue. In the case that no CQ is bound to the server, and the shutdown
+        of server becomes un-observable.
     """
     if self.is_started:
       raise ValueError("the server has already started")

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -17,6 +17,11 @@ import abc
 import six
 
 import grpc
+<<<<<<< HEAD
+=======
+from grpc import _common
+from grpc._cython import cygrpc
+>>>>>>> Add 4 server tests and 1 channel tests
 from grpc._cython.cygrpc import init_grpc_aio
 
 from ._call import AioRpcError

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -17,11 +17,8 @@ import abc
 import six
 
 import grpc
-<<<<<<< HEAD
-=======
 from grpc import _common
 from grpc._cython import cygrpc
->>>>>>> Add 4 server tests and 1 channel tests
 from grpc._cython.cygrpc import init_grpc_aio
 
 from ._call import AioRpcError

--- a/src/python/grpcio/grpc/experimental/aio/_server.py
+++ b/src/python/grpcio/grpc/experimental/aio/_server.py
@@ -134,7 +134,7 @@ class Server:
 
     def __del__(self):
         """Schedules a graceful shutdown in current event loop.
-        
+
         The Cython AioServer doesn't hold a ref-count to this class. It should
         be safe to slightly extend the underlying Cython object's life span.
         """

--- a/src/python/grpcio/grpc/experimental/aio/_server.py
+++ b/src/python/grpcio/grpc/experimental/aio/_server.py
@@ -26,14 +26,9 @@ class Server:
     def __init__(self, thread_pool, generic_handlers, interceptors, options,
                  maximum_concurrent_rpcs, compression):
         self._loop = asyncio.get_event_loop()
-        self._server = cygrpc.AioServer(
-            self._loop,
-            thread_pool,
-            generic_handlers,
-            interceptors,
-            options,
-            maximum_concurrent_rpcs,
-            compression)
+        self._server = cygrpc.AioServer(self._loop, thread_pool,
+                                        generic_handlers, interceptors, options,
+                                        maximum_concurrent_rpcs, compression)
         self._shutdown_started = False
         self._shutdown_future = self._loop.create_future()
 
@@ -99,7 +94,7 @@ class Server:
 
         If a grace period is specified, all RPCs active at the end of the grace
         period are aborted.
-        
+
         If a grace period is not specified (by passing None for `grace`), all
         existing RPCs are aborted immediately and this method blocks until the
         last RPC handler terminates.
@@ -140,7 +135,7 @@ class Server:
         Returns:
           A bool indicates if the operation times out.
         """
-        if timeout == None:
+        if timeout is None:
             await self._shutdown_future
         else:
             try:

--- a/src/python/grpcio/grpc/experimental/aio/_server.py
+++ b/src/python/grpcio/grpc/experimental/aio/_server.py
@@ -132,6 +132,14 @@ class Server:
         """
         return await self._server.wait_for_termination(timeout)
 
+    def __del__(self):
+        """Schedules a graceful shutdown in current event loop.
+        
+        The Cython AioServer doesn't hold a ref-count to this class. It should
+        be safe to slightly extend the underlying Cython object's life span.
+        """
+        self._loop.create_task(self._server.shutdown(None))
+
 
 def server(migration_thread_pool=None,
            handlers=None,

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -108,7 +108,7 @@ class TestChannel(AioTestBase):
                 response_deserializer=messages_pb2.SimpleResponse.FromString)
             response = await hi(messages_pb2.SimpleRequest())
 
-            self.assertEqual(type(response), messages_pb2.SimpleResponse)
+            self.assertIs(type(response), messages_pb2.SimpleResponse)
 
             await channel.close()
 

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -97,7 +97,6 @@ class TestChannel(AioTestBase):
 
         self.loop.run_until_complete(coro())
 
-
     @unittest.skip('https://github.com/grpc/grpc/issues/20818')
     def test_call_to_the_void(self):
 

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -22,6 +22,9 @@ from tests.unit.framework.common import test_constants
 from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
 
+_UNARY_CALL_METHOD = '/grpc.testing.TestService/UnaryCall'
+_EMPTY_CALL_METHOD = '/grpc.testing.TestService/EmptyCall'
+
 
 class TestChannel(AioTestBase):
 
@@ -32,7 +35,7 @@ class TestChannel(AioTestBase):
 
             async with aio.insecure_channel(server_target) as channel:
                 hi = channel.unary_unary(
-                    '/grpc.testing.TestService/UnaryCall',
+                    _UNARY_CALL_METHOD,
                     request_serializer=messages_pb2.SimpleRequest.
                     SerializeToString,
                     response_deserializer=messages_pb2.SimpleResponse.FromString
@@ -48,7 +51,7 @@ class TestChannel(AioTestBase):
 
             channel = aio.insecure_channel(server_target)
             hi = channel.unary_unary(
-                '/grpc.testing.TestService/UnaryCall',
+                _UNARY_CALL_METHOD,
                 request_serializer=messages_pb2.SimpleRequest.SerializeToString,
                 response_deserializer=messages_pb2.SimpleResponse.FromString)
             response = await hi(messages_pb2.SimpleRequest())
@@ -66,7 +69,7 @@ class TestChannel(AioTestBase):
 
             async with aio.insecure_channel(server_target) as channel:
                 empty_call_with_sleep = channel.unary_unary(
-                    "/grpc.testing.TestService/EmptyCall",
+                    _EMPTY_CALL_METHOD,
                     request_serializer=messages_pb2.SimpleRequest.
                     SerializeToString,
                     response_deserializer=messages_pb2.SimpleResponse.
@@ -91,6 +94,24 @@ class TestChannel(AioTestBase):
                     exception_context.exception.initial_metadata())
                 self.assertIsNotNone(
                     exception_context.exception.trailing_metadata())
+
+        self.loop.run_until_complete(coro())
+
+
+    @unittest.skip('https://github.com/grpc/grpc/issues/20818')
+    def test_call_to_the_void(self):
+
+        async def coro():
+            channel = aio.insecure_channel('0.1.1.1:1111')
+            hi = channel.unary_unary(
+                _UNARY_CALL_METHOD,
+                request_serializer=messages_pb2.SimpleRequest.SerializeToString,
+                response_deserializer=messages_pb2.SimpleResponse.FromString)
+            response = await hi(messages_pb2.SimpleRequest())
+
+            self.assertEqual(type(response), messages_pb2.SimpleResponse)
+
+            await channel.close()
 
         self.loop.run_until_complete(coro())
 

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -19,6 +19,45 @@ from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
 
 
+class TestAioRpcError(unittest.TestCase):
+    _TEST_INITIAL_METADATA = ("initial metadata",)
+    _TEST_TRAILING_METADATA = ("trailing metadata",)
+
+    def test_attributes(self):
+        aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
+                                        "details", self._TEST_TRAILING_METADATA)
+        self.assertEqual(aio_rpc_error.initial_metadata(),
+                         self._TEST_INITIAL_METADATA)
+        self.assertEqual(aio_rpc_error.code(), grpc.StatusCode.OK)
+        self.assertEqual(aio_rpc_error.details(), "details")
+        self.assertEqual(aio_rpc_error.trailing_metadata(),
+                         self._TEST_TRAILING_METADATA)
+
+    def test_class_hierarchy(self):
+        aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
+                                        "details", self._TEST_TRAILING_METADATA)
+
+        self.assertIsInstance(aio_rpc_error, grpc.RpcError)
+
+    def test_class_attributes(self):
+        aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
+                                        "details", self._TEST_TRAILING_METADATA)
+        self.assertEqual(aio_rpc_error.__class__.__name__, "AioRpcError")
+        self.assertEqual(aio_rpc_error.__class__.__doc__,
+                         aio.AioRpcError.__doc__)
+
+    def test_class_singleton(self):
+        first_aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
+                                              "details",
+                                              self._TEST_TRAILING_METADATA)
+        second_aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
+                                               "details",
+                                               self._TEST_TRAILING_METADATA)
+
+        self.assertIs(first_aio_rpc_error.__class__,
+                      second_aio_rpc_error.__class__)
+
+
 class TestInsecureChannel(AioTestBase):
 
     def test_insecure_channel(self):

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -19,45 +19,6 @@ from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
 
 
-class TestAioRpcError(unittest.TestCase):
-    _TEST_INITIAL_METADATA = ("initial metadata",)
-    _TEST_TRAILING_METADATA = ("trailing metadata",)
-
-    def test_attributes(self):
-        aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
-                                        "details", self._TEST_TRAILING_METADATA)
-        self.assertEqual(aio_rpc_error.initial_metadata(),
-                         self._TEST_INITIAL_METADATA)
-        self.assertEqual(aio_rpc_error.code(), grpc.StatusCode.OK)
-        self.assertEqual(aio_rpc_error.details(), "details")
-        self.assertEqual(aio_rpc_error.trailing_metadata(),
-                         self._TEST_TRAILING_METADATA)
-
-    def test_class_hierarchy(self):
-        aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
-                                        "details", self._TEST_TRAILING_METADATA)
-
-        self.assertIsInstance(aio_rpc_error, grpc.RpcError)
-
-    def test_class_attributes(self):
-        aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
-                                        "details", self._TEST_TRAILING_METADATA)
-        self.assertEqual(aio_rpc_error.__class__.__name__, "AioRpcError")
-        self.assertEqual(aio_rpc_error.__class__.__doc__,
-                         aio.AioRpcError.__doc__)
-
-    def test_class_singleton(self):
-        first_aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
-                                              "details",
-                                              self._TEST_TRAILING_METADATA)
-        second_aio_rpc_error = aio.AioRpcError(self._TEST_INITIAL_METADATA, 0,
-                                               "details",
-                                               self._TEST_TRAILING_METADATA)
-
-        self.assertIs(first_aio_rpc_error.__class__,
-                      second_aio_rpc_error.__class__)
-
-
 class TestInsecureChannel(AioTestBase):
 
     def test_insecure_channel(self):

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -18,42 +18,62 @@ import unittest
 import grpc
 from grpc.experimental import aio
 from tests_aio.unit._test_base import AioTestBase
+from tests.unit.framework.common import test_constants
+
 
 _SIMPLE_UNARY_UNARY = '/test/SimpleUnaryUnary'
 _BLOCK_FOREVER = '/test/BlockForever'
+_BLOCK_SHORTLY = '/test/BlockShortly'
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x01\x01\x01'
 
 
-async def _unary_unary(unused_request, unused_context):
-    return _RESPONSE
-
-
-async def _block_forever(unused_request, unused_context):
-    await asyncio.get_event_loop().create_future()
-
-
 class _GenericHandler(grpc.GenericRpcHandler):
+    def __init__(self):
+        self._called = asyncio.get_event_loop().create_future()
+
+    @staticmethod
+    async def _unary_unary(unused_request, unused_context):
+        return _RESPONSE
+
+    async def _block_forever(self, unused_request, unused_context):
+        await asyncio.get_event_loop().create_future()
+
+
+    async def _block_shortly(self, unused_request, unused_context):
+        await asyncio.sleep(test_constants.SHORT_TIMEOUT/2)
+        return _RESPONSE
 
     def service(self, handler_details):
+        self._called.set_result(None)
         if handler_details.method == _SIMPLE_UNARY_UNARY:
-            return grpc.unary_unary_rpc_method_handler(_unary_unary)
+            return grpc.unary_unary_rpc_method_handler(self._unary_unary)
         if handler_details.method == _BLOCK_FOREVER:
-            return grpc.unary_unary_rpc_method_handler(_block_forever)
+            return grpc.unary_unary_rpc_method_handler(self._block_forever)
+        if handler_details.method == _BLOCK_SHORTLY:
+            return grpc.unary_unary_rpc_method_handler(self._block_shortly)
+
+    async def wait_for_call(self):
+        await self._called
+
+
+async def _start_test_server():
+    server = aio.server()
+    port = server.add_insecure_port('[::]:0')
+    generic_handler = _GenericHandler()
+    server.add_generic_rpc_handlers((generic_handler,))
+    await server.start()
+    return 'localhost:%d' % port, server, generic_handler
 
 
 class TestServer(AioTestBase):
 
     def test_unary_unary(self):
-
         async def test_unary_unary_body():
-            server = aio.server()
-            port = server.add_insecure_port('[::]:0')
-            server.add_generic_rpc_handlers((_GenericHandler(),))
-            await server.start()
+            server_target, _, _ = await _start_test_server()
 
-            async with aio.insecure_channel('localhost:%d' % port) as channel:
+            async with aio.insecure_channel(server_target) as channel:
                 unary_call = channel.unary_unary(_SIMPLE_UNARY_UNARY)
                 response = await unary_call(_REQUEST)
                 self.assertEqual(response, _RESPONSE)
@@ -61,55 +81,63 @@ class TestServer(AioTestBase):
         self.loop.run_until_complete(test_unary_unary_body())
     
     def test_shutdown(self):
-
         async def test_shutdown_body():
-            server = aio.server()
-            port = server.add_insecure_port('[::]:0')
-            await server.start()
+            _, server, _ = await _start_test_server()
             await server.stop(None)
         self.loop.run_until_complete(test_shutdown_body())
 
     def test_shutdown_after_call(self):
-
         async def test_shutdown_body():
-            server = aio.server()
-            port = server.add_insecure_port('[::]:0')
-            server.add_generic_rpc_handlers((_GenericHandler(),))
-            await server.start()
+            server_target, server, _ = await _start_test_server()
 
-            async with aio.insecure_channel('localhost:%d' % port) as channel:
+            async with aio.insecure_channel(server_target) as channel:
                 await channel.unary_unary(_SIMPLE_UNARY_UNARY)(_REQUEST)
 
             await server.stop(None)
         self.loop.run_until_complete(test_shutdown_body())
 
-    def test_shutdown_during_call(self):
+    def test_graceful_shutdown_success(self):
+        async def test_graceful_shutdown_success_body():
+            server_target, server, generic_handler = await _start_test_server()
 
-        async def test_shutdown_body():
-            server = aio.server()
-            port = server.add_insecure_port('[::]:0')
-            server.add_generic_rpc_handlers((_GenericHandler(),))
-            await server.start()
+            channel = aio.insecure_channel(server_target)
+            call_task = self.loop.create_task(channel.unary_unary(_BLOCK_SHORTLY)(_REQUEST))
+            await generic_handler.wait_for_call()
 
-            async with aio.insecure_channel('localhost:%d' % port) as channel:
-                self.loop.create_task(channel.unary_unary(_BLOCK_FOREVER)(_REQUEST))
-                await asyncio.sleep(0)
+            await server.stop(test_constants.SHORT_TIMEOUT)
+            await channel.close()
+            self.assertEqual(await call_task, _RESPONSE)
+            self.assertTrue(call_task.done())
+        self.loop.run_until_complete(test_graceful_shutdown_success_body())
 
-            await server.stop(None)
-        self.loop.run_until_complete(test_shutdown_body())
+    def test_graceful_shutdown_failed(self):
+        async def test_graceful_shutdown_failed_body():
+            server_target, server, generic_handler = await _start_test_server()
 
+            channel = aio.insecure_channel(server_target)
+            call_task = self.loop.create_task(channel.unary_unary(_BLOCK_FOREVER)(_REQUEST))
+            await generic_handler.wait_for_call()
+
+            await server.stop(test_constants.SHORT_TIMEOUT)
+
+            with self.assertRaises(aio.AioRpcError) as exception_context:
+                await call_task
+            self.assertEqual(exception_context.exception.code(), grpc.StatusCode.UNAVAILABLE)
+            self.assertIn('GOAWAY', exception_context.exception.details())
+            await channel.close()
+        self.loop.run_until_complete(test_graceful_shutdown_failed_body())
+
+    @unittest.skip('https://github.com/grpc/grpc/issues/20818')
     def test_shutdown_before_call(self):
 
         async def test_shutdown_body():
-            server = aio.server()
-            port = server.add_insecure_port('[::]:0')
-            server.add_generic_rpc_handlers((_GenericHandler(),))
-            await server.start()
+            server_target, server, _ =_start_test_server()
             await server.stop(None)
 
+            # Ensures the server is cleaned up at this point.
+            # Some proper exception should be raised.
             async with aio.insecure_channel('localhost:%d' % port) as channel:
                 await channel.unary_unary(_SIMPLE_UNARY_UNARY)(_REQUEST)
-
         self.loop.run_until_complete(test_shutdown_body())
 
 

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -51,6 +51,16 @@ class TestServer(AioTestBase):
                 self.assertEqual(response, _RESPONSE)
 
         self.loop.run_until_complete(test_unary_unary_body())
+    
+    def test_shutdown(self):
+
+        async def test_shutdown_body():
+            server = aio.server()
+            port = server.add_insecure_port('[::]:0')
+            server.add_generic_rpc_handlers((GenericHandler(),))
+            await server.start()
+            await server.stop(None)
+        asyncio.get_event_loop().run_until_complete(test_shutdown_body())
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -15,6 +15,7 @@
 import logging
 import unittest
 import time
+import gc
 
 import grpc
 from grpc.experimental import aio
@@ -72,7 +73,8 @@ class TestServer(AioTestBase):
     def test_unary_unary(self):
 
         async def test_unary_unary_body():
-            server_target, _, _ = await _start_test_server()
+            result = await _start_test_server()
+            server_target = result[0]
 
             async with aio.insecure_channel(server_target) as channel:
                 unary_call = channel.unary_unary(_SIMPLE_UNARY_UNARY)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/20668

---

In this PR
* Refactors the `AioRpcError` to a temporary solution (duplicated with #20824);
* Introduces debugging info propagation for callbacks (no longer `RuntimeError`);
* Introduces graceful shutdown process for both server and completion queue.
* Added 6 more test cases.