### PR TITLE
Revert "c++ check if workerthread could be spawned"

### DIFF
--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -34,12 +34,8 @@ ThreadManager::WorkerThread::WorkerThread(ThreadManager* thd_mgr)
   thd_ = grpc_core::Thread(
       "grpcpp_sync_server",
       [](void* th) { static_cast<ThreadManager::WorkerThread*>(th)->Run(); },
-      this, &created_);
-  if (!created_) {
-    gpr_log(GPR_ERROR, "Could not create grpc_sync_server worker-thread");
-  } else {
-    thd_.Start();
-  }
+      this);
+  thd_.Start();
 }
 
 void ThreadManager::WorkerThread::Run() {
@@ -181,12 +177,7 @@ void ThreadManager::MainWorkLoop() {
             }
             // Drop lock before spawning thread to avoid contention
             lock.Unlock();
-            WorkerThread* w = new WorkerThread(this);
-            if (!w->created()) {
-              num_pollers_--;
-              num_threads_--;
-              resource_exhausted = true;
-            }
+            new WorkerThread(this);
           } else if (num_pollers_ > 0) {
             // There is still at least some thread polling, so we can go on
             // even though we are below the number of pollers that we would

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -124,8 +124,6 @@ class ThreadManager {
     WorkerThread(ThreadManager* thd_mgr);
     ~WorkerThread();
 
-    bool created() const { return created_; }
-
    private:
     // Calls thd_mgr_->MainWorkLoop() and once that completes, calls
     // thd_mgr_>MarkAsCompleted(this) to mark the thread as completed
@@ -133,7 +131,6 @@ class ThreadManager {
 
     ThreadManager* const thd_mgr_;
     grpc_core::Thread thd_;
-    bool created_;
   };
 
   // The main function in ThreadManager


### PR DESCRIPTION
Reverts grpc/grpc#20376

Sorry to report that this broke some more stressful internal tests. In particular, the call to created() after the new WorkerThread causes a race as currently stated. I'm going to try to revert this revert ASAP. 