### PR TITLE
Properly handle thread creation race: roll-forward of #20376

### DIFF
--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -34,8 +34,10 @@ ThreadManager::WorkerThread::WorkerThread(ThreadManager* thd_mgr)
   thd_ = grpc_core::Thread(
       "grpcpp_sync_server",
       [](void* th) { static_cast<ThreadManager::WorkerThread*>(th)->Run(); },
-      this);
-  thd_.Start();
+      this, &created_);
+  if (!created_) {
+    gpr_log(GPR_ERROR, "Could not create grpc_sync_server worker-thread");
+  }
 }
 
 void ThreadManager::WorkerThread::Run() {
@@ -139,7 +141,9 @@ void ThreadManager::Initialize() {
   }
 
   for (int i = 0; i < min_pollers_; i++) {
-    new WorkerThread(this);
+    WorkerThread* worker = new WorkerThread(this);
+    GPR_ASSERT(worker->created());  // Must be able to create the minimum
+    worker->Start();
   }
 }
 
@@ -177,7 +181,15 @@ void ThreadManager::MainWorkLoop() {
             }
             // Drop lock before spawning thread to avoid contention
             lock.Unlock();
-            new WorkerThread(this);
+            WorkerThread* worker = new WorkerThread(this);
+            if (worker->created()) {
+              worker->Start();
+            } else {
+              num_pollers_--;
+              num_threads_--;
+              resource_exhausted = true;
+              delete worker;
+            }
           } else if (num_pollers_ > 0) {
             // There is still at least some thread polling, so we can go on
             // even though we are below the number of pollers that we would

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -124,6 +124,9 @@ class ThreadManager {
     WorkerThread(ThreadManager* thd_mgr);
     ~WorkerThread();
 
+    bool created() const { return created_; }
+    void Start() { thd_.Start(); }
+
    private:
     // Calls thd_mgr_->MainWorkLoop() and once that completes, calls
     // thd_mgr_>MarkAsCompleted(this) to mark the thread as completed
@@ -131,6 +134,7 @@ class ThreadManager {
 
     ThreadManager* const thd_mgr_;
     grpc_core::Thread thd_;
+    bool created_;
   };
 
   // The main function in ThreadManager


### PR DESCRIPTION
If we're going to check something about the thread creation, we need to do so before calling Start since once started, the thread could finish and put itself up for deletion before we even get a chance to execute the next line of code that checks whether it was created.  This was missing from #20376 because we didn't (and still don't) have good test coverage for this case. Also need to delete the thread if it wasn't successfully created.


Cc: @chrisse74 