### PR TITLE
Measure benchmark results more accurately in qps_driver

### DIFF
--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -479,8 +479,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Collect the client final run results before finish server
-  // otherwise, we will include client shutdown process in benchmark results
+  // Collect the client final run results after clients stop sending new rpcs
   for (size_t i = 0; i < num_clients; i++) {
     auto client = &clients[i];
     // Read the client final status
@@ -512,8 +511,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Collect the server final run results before checking client status
-  // otherwise, we will wait for the benchmark 
+  // Collect the server final run results after servers stop receiving rpcs
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     // Read the server final status
@@ -527,7 +525,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
       gpr_log(GPR_ERROR, "Couldn't get final status from server %zu", i);
     }
   }
-  
+
   // Get final rpc status from clients
   for (size_t i = 0; i < num_clients; i++) {
     auto client = &clients[i];
@@ -542,7 +540,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
               s.error_message().c_str());
     }
   }
-  
+
   // Get final rpc status from servers
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -463,7 +463,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
   gpr_timer_set_enabled(0);
 
   // Finish a run
-  // Finish clients
   std::unique_ptr<ScenarioResult> result(new ScenarioResult);
   Histogram merged_latencies;
   std::unordered_map<int, int64_t> merged_statuses;
@@ -479,7 +478,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Collect the client final run results after clients stop sending new rpcs
+  // Collect the client final run results right after finishing clients
   for (size_t i = 0; i < num_clients; i++) {
     auto client = &clients[i];
     // Read the client final status
@@ -499,7 +498,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Finish servers
   gpr_log(GPR_INFO, "Finishing servers");
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
@@ -511,7 +509,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Collect the server final run results after servers stop receiving rpcs
+  // Collect the server final run results right after finishing server
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     // Read the server final status

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -491,8 +491,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
             stats.request_results(i).count();
       }
       result->add_client_stats()->CopyFrom(stats);
-      // That final status should be the last message on the client stream
-      GPR_ASSERT(!client->stream->Read(&client_status));
     } else {
       gpr_log(GPR_ERROR, "Couldn't get final status from client %zu", i);
     }

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -533,7 +533,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     rrc->set_count(it->second);
   }
 
-   // Collect servers' final run results right after finishing server
+  // Collect servers' final run results right after finishing server
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     // Read the server final status

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -478,7 +478,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Collect the client final run results right after finishing clients
+  // Collect clients' final run results right after finishing clients
   for (size_t i = 0; i < num_clients; i++) {
     auto client = &clients[i];
     // Read the client final status
@@ -509,7 +509,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     }
   }
 
-  // Collect the server final run results right after finishing server
+  // Collect servers' final run results right after finishing server
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     // Read the server final status


### PR DESCRIPTION
After making server and client shutdown at the same time in #20328, some of the rpcs receive "connection broken" error and got cancelled. But the amount of rpcs got cancelled is stochastic, and it will cause inaccuracy in the benchmark results. 

The solution here is to collect benchmark results right after finishing client and server, and it will still maintain the purpose of shutting down server before all the client channels are closed. 