### PR TITLE
PHP: update docker image PHP 7 version

### DIFF
--- a/templates/tools/dockerfile/php7_deps.include
+++ b/templates/tools/dockerfile/php7_deps.include
@@ -24,10 +24,10 @@ RUN apt-get update && apt-get install -y ${'\\'}
 
 # Install other dependencies
 RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-RUN wget http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz -O /var/local/bison-2.6.4.tar.gz
+RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz -O /var/local/bison-3.4.2.tar.gz
 RUN cd /var/local ${'\\'}
-  && tar -zxvf bison-2.6.4.tar.gz ${'\\'}
-  && cd /var/local/bison-2.6.4 ${'\\'}
+  && tar -zxvf bison-3.4.2.tar.gz ${'\\'}
+  && cd /var/local/bison-3.4.2 ${'\\'}
   && ./configure ${'\\'}
   && make ${'\\'}
   && make install
@@ -35,7 +35,7 @@ RUN cd /var/local ${'\\'}
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
 RUN cd /var/local/git/php-src ${'\\'}
-  && git checkout PHP-7.0.9 ${'\\'}
+  && git checkout PHP-7.2.22 ${'\\'}
   && ./buildconf --force ${'\\'}
   && ./configure ${'\\'}
   --with-gmp ${'\\'}

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -41,10 +41,10 @@ RUN apt-get update && apt-get install -y \
 
 # Install other dependencies
 RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-RUN wget http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz -O /var/local/bison-2.6.4.tar.gz
+RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz -O /var/local/bison-3.4.2.tar.gz
 RUN cd /var/local \
-  && tar -zxvf bison-2.6.4.tar.gz \
-  && cd /var/local/bison-2.6.4 \
+  && tar -zxvf bison-3.4.2.tar.gz \
+  && cd /var/local/bison-3.4.2 \
   && ./configure \
   && make \
   && make install
@@ -52,7 +52,7 @@ RUN cd /var/local \
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
 RUN cd /var/local/git/php-src \
-  && git checkout PHP-7.0.9 \
+  && git checkout PHP-7.2.22 \
   && ./buildconf --force \
   && ./configure \
   --with-gmp \

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -41,10 +41,10 @@ RUN apt-get update && apt-get install -y \
 
 # Install other dependencies
 RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-RUN wget http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz -O /var/local/bison-2.6.4.tar.gz
+RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz -O /var/local/bison-3.4.2.tar.gz
 RUN cd /var/local \
-  && tar -zxvf bison-2.6.4.tar.gz \
-  && cd /var/local/bison-2.6.4 \
+  && tar -zxvf bison-3.4.2.tar.gz \
+  && cd /var/local/bison-3.4.2 \
   && ./configure \
   && make \
   && make install
@@ -52,7 +52,7 @@ RUN cd /var/local \
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
 RUN cd /var/local/git/php-src \
-  && git checkout PHP-7.0.9 \
+  && git checkout PHP-7.2.22 \
   && ./buildconf --force \
   && ./configure \
   --with-gmp \


### PR DESCRIPTION
Update the PHP 7 version in our base docker image from `7.0` to `7.2` as PHP version `7.0` has been in the end-of-life state. PHP 7.2 is the current version.