### PR TITLE
[bazel] Add an ability to call an optional custom plugin for py_proto_library and py_grpc_library

### DIFF
--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -89,7 +89,12 @@ def get_include_directory(source_file):
     else:
         return source_file.root.path if source_file.root.path else "."
 
-def get_plugin_args(plugin, flags, dir_out, generate_mocks):
+def get_plugin_args(
+        plugin,
+        flags,
+        dir_out,
+        generate_mocks,
+        plugin_name = "PLUGIN"):
     """Returns arguments configuring protoc to use a plugin for a language.
 
     Args:
@@ -97,16 +102,28 @@ def get_plugin_args(plugin, flags, dir_out, generate_mocks):
       flags: The plugin flags to be passed to protoc.
       dir_out: The output directory for the plugin.
       generate_mocks: A bool indicating whether to generate mocks.
-
+      plugin_name: A name of the plugin, it is required to be unique when there
+      are more than one plugin used in a single protoc command.
     Returns:
       A list of protoc arguments configuring the plugin.
     """
     augmented_flags = list(flags)
     if generate_mocks:
         augmented_flags.append("generate_mock_code=true")
+
+    augmented_dir_out = dir_out
+    if augmented_flags:
+        augmented_dir_out = ",".join(augmented_flags) + ":" + dir_out
+
     return [
-        "--plugin=protoc-gen-PLUGIN=" + plugin.path,
-        "--PLUGIN_out=" + ",".join(augmented_flags) + ":" + dir_out,
+        "--plugin=protoc-gen-{plugin_name}={plugin_path}".format(
+            plugin_name = plugin_name,
+            plugin_path = plugin.path,
+        ),
+        "--{plugin_name}_out={dir_out}".format(
+            plugin_name = plugin_name,
+            dir_out = augmented_dir_out,
+        )
     ]
 
 def _get_staged_proto_file(context, source_file):

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -72,6 +72,7 @@ _generate_pb2_src = rule(
         "plugin": attr.label(
             mandatory = False,
             executable = True,
+            providers = ["files_to_run"],
             cfg = "host",
         ),
         "_protoc": attr.label(
@@ -186,6 +187,7 @@ _generate_pb2_grpc_src = rule(
         "plugin": attr.label(
             mandatory = False,
             executable = True,
+            providers = ["files_to_run"],
             cfg = "host",
         ),
         "_grpc_plugin": attr.label(

--- a/bazel/test/python_test_repo/BUILD
+++ b/bazel/test/python_test_repo/BUILD
@@ -108,7 +108,6 @@ py_binary(
     name = "dummy_plugin",
     srcs = [":dummy_plugin.py"],
     deps = [
-        "@com_github_grpc_grpc//src/python/grpcio/grpc/_cython:cygrpc",
         "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/bazel/test/python_test_repo/BUILD
+++ b/bazel/test/python_test_repo/BUILD
@@ -79,9 +79,11 @@ proto_library(
     strip_import_prefix = ""
 )
 
+# Also test the custom plugin execution parameter
 py_proto_library(
     name = "helloworld_moved_py_pb2",
     deps = [":helloworld_moved_proto"],
+    plugin = ":dummy_plugin"
 )
 
 py_grpc_library(
@@ -99,5 +101,14 @@ py2and3_test(
         ":helloworld_moved_py_pb2_grpc",
         ":duration_py_pb2",
         ":timestamp_py_pb2",
+    ],
+)
+
+py_binary(
+    name = "dummy_plugin",
+    srcs = [":dummy_plugin.py"],
+    deps = [
+        "@com_github_grpc_grpc//src/python/grpcio/grpc/_cython:cygrpc",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )

--- a/bazel/test/python_test_repo/dummy_plugin.py
+++ b/bazel/test/python_test_repo/dummy_plugin.py
@@ -1,0 +1,37 @@
+# Copyright 2019 the gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A dummy plugin for testing"""
+
+import sys
+
+from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest
+from google.protobuf.compiler.plugin_pb2 import CodeGeneratorResponse
+
+
+def main(input_file=sys.stdin, output_file=sys.stdout):
+    request = CodeGeneratorRequest.FromString(input_file.buffer.read())
+    answer = []
+    for fname in request.file_to_generate:
+        answer.append(CodeGeneratorResponse.File(
+            name=fname.replace('.proto', '_pb2.py'),
+            insertion_point='module_scope',
+            content="# Hello {}, I'm a dummy plugin!".format(fname),
+        ))
+
+    cgr = CodeGeneratorResponse(file=answer)
+    output_file.buffer.write(cgr.SerializeToString())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is needed for googleapis (it uses a special doc formatter plugin to fix and pritify the docs (comments) in the generated stubs).

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
