### PR TITLE
Fix internal lint warnings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,6 @@
 workspace(name = "com_github_grpc_grpc")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 grpc_deps()
 
@@ -52,7 +50,6 @@ pip_import(
     requirements = "@com_github_grpc_grpc//:requirements.bazel.txt",
 )
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories")
 load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
 pip_repositories()
 pip_install()


### PR DESCRIPTION
Remove dependencies made unnecessary by https://github.com/grpc/grpc/pull/20586.

CC @karthikravis 