### PR TITLE
Fix to use immutable string literal

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -391,22 +391,21 @@ module GRPC
       # register signal handlers
       signals.each do |sig|
         # input validation
-        if sig.class == String
-          sig.upcase!
-          if sig.start_with?('SIG')
-            # cut out the SIG prefix to see if valid signal
-            sig = sig[3..-1]
-          end
-        end
+        target_sig = if sig.class == String
+                       # cut out the SIG prefix to see if valid signal
+                       sig.upcase.start_with?('SIG') ? sig.upcase[3..-1] : sig.upcase
+                     else
+                       sig
+                     end
 
         # register signal traps for all valid signals
-        if valid_signals.value?(sig) || valid_signals.key?(sig)
-          Signal.trap(sig) do
+        if valid_signals.value?(target_sig) || valid_signals.key?(target_sig)
+          Signal.trap(target_sig) do
             @stop_server = true
             @stop_server_cv.broadcast
           end
         else
-          fail "#{sig} not a valid signal"
+          fail "#{target_sig} not a valid signal"
         end
       end
 


### PR DESCRIPTION
When we use this `grpc` gem with a magic comment (`# frozen_string_literal: true`), 
it shows error like below.

> /vendor/bundle/gems/grpc-1.22.0-x86_64-linux/src/ruby/lib/grpc/generic/rpc_server.rb:395:in `upcase!': can't modify frozen String (FrozenError)

To fix it & follow https://bugs.ruby-lang.org/issues/11473, I want to merge this PR. Thank you.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
