### PR TITLE
Make Windows test gRPC with Python 3.6

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -188,6 +188,7 @@ class TestGevent(setuptools.Command):
         'unit._cython._channel_test.ChannelTest.test_negative_deadline_connectivity',
         # TODO(https://github.com/grpc/grpc/issues/15411) enable this test
         'unit._local_credentials_test.LocalCredentialsTest',
+        'testing._time_test.StrictRealTimeTest',
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -191,9 +191,7 @@ class TestGevent(setuptools.Command):
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
-        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
-        'unit._channel_close_test.ChannelCloseTest',
-    )
+        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',)
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -191,7 +191,8 @@ class TestGevent(setuptools.Command):
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
-        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',)
+        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
+        'unit._channel_close_test.ChannelCloseTest',)
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -192,7 +192,8 @@ class TestGevent(setuptools.Command):
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
         'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
-        'unit._channel_close_test.ChannelCloseTest',)
+        'unit._channel_close_test.ChannelCloseTest',
+    )
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -166,7 +166,7 @@ pip_install_dir() {
 }
 
 case "$VENV" in
-  *py35_gevent*)
+  *py36_gevent*)
   # TODO(https://github.com/grpc/grpc/issues/15411) unpin this
   $VENV_PYTHON -m pip install gevent==1.3.b1
   ;;

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -872,7 +872,7 @@ class PythonLanguage(object):
 
         if args.compiler == 'default':
             if os.name == 'nt':
-                return (python35_config,)
+                return (python36_config,)
             else:
                 if args.iomgr_platform == 'asyncio':
                     return (python36_config,)
@@ -907,7 +907,7 @@ class PythonLanguage(object):
                 python35_config,
                 python36_config,
                 python37_config,
-                # TODO: Add Python 3.8 once it's released.
+                python38_config,
             )
         else:
             raise Exception('Compiler %s not supported.' % args.compiler)


### PR DESCRIPTION
As title. 

TIL that [ClassVar](https://docs.python.org/3/library/typing.html#typing.ClassVar) is only available after 3.5.3. The our Windows CI needs to either upgrade from 3.5.0 to 3.5.3 or use 3.6.0.