### PR TITLE
[Exposing ALTS Context 1/2] Fill in context on TSI and Security Connector Layer

### DIFF
--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -210,6 +210,13 @@ grpc_alts_auth_context_from_tsi_peer(const tsi_peer* peer) {
     gpr_log(GPR_ERROR, "Mismatch of local and peer rpc protocol versions.");
     return nullptr;
   }
+  /* Validate ALTS Context. */
+  const tsi_peer_property* alts_context_prop =
+      tsi_peer_get_property_by_name(peer, TSI_ALTS_CONTEXT);
+  if (alts_context_prop == nullptr) {
+    gpr_log(GPR_ERROR, "Missing alts context property.");
+    return nullptr;
+  }
   /* Create auth context. */
   auto ctx = grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
   grpc_auth_context_add_cstring_property(
@@ -225,6 +232,12 @@ grpc_alts_auth_context_from_tsi_peer(const tsi_peer* peer) {
           tsi_prop->value.data, tsi_prop->value.length);
       GPR_ASSERT(grpc_auth_context_set_peer_identity_property_name(
                      ctx.get(), TSI_ALTS_SERVICE_ACCOUNT_PEER_PROPERTY) == 1);
+    }
+    /* Add alts context to auth context. */
+    if (strcmp(tsi_prop->name, TSI_ALTS_CONTEXT) == 0) {
+      grpc_auth_context_add_property(
+          ctx.get(), TSI_ALTS_CONTEXT,
+          tsi_prop->value.data, tsi_prop->value.length);
     }
   }
   if (!grpc_auth_context_peer_is_authenticated(ctx.get())) {

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -235,9 +235,9 @@ grpc_alts_auth_context_from_tsi_peer(const tsi_peer* peer) {
     }
     /* Add alts context to auth context. */
     if (strcmp(tsi_prop->name, TSI_ALTS_CONTEXT) == 0) {
-      grpc_auth_context_add_property(
-          ctx.get(), TSI_ALTS_CONTEXT,
-          tsi_prop->value.data, tsi_prop->value.length);
+      grpc_auth_context_add_property(ctx.get(), TSI_ALTS_CONTEXT,
+                                     tsi_prop->value.data,
+                                     tsi_prop->value.length);
     }
   }
   if (!grpc_auth_context_peer_is_authenticated(ctx.get())) {

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -30,11 +30,12 @@
 #include "src/core/tsi/transport_security_interface.h"
 #include "src/proto/grpc/gcp/handshaker.upb.h"
 
-#define TSI_ALTS_SERVICE_ACCOUNT_PEER_PROPERTY "service_accont"
+#define TSI_ALTS_SERVICE_ACCOUNT_PEER_PROPERTY "service_account"
 #define TSI_ALTS_CERTIFICATE_TYPE "ALTS"
 #define TSI_ALTS_RPC_VERSIONS "rpc_versions"
+#define TSI_ALTS_CONTEXT "alts_context"
 
-const size_t kTsiAltsNumOfPeerProperties = 3;
+const size_t kTsiAltsNumOfPeerProperties = 4;
 
 typedef struct alts_tsi_handshaker alts_tsi_handshaker;
 

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -28,6 +28,7 @@
 #include "src/core/tsi/alts/handshaker/alts_handshaker_client.h"
 #include "src/core/tsi/transport_security.h"
 #include "src/core/tsi/transport_security_interface.h"
+#include "src/proto/grpc/gcp/altscontext.upb.h"
 #include "src/proto/grpc/gcp/handshaker.upb.h"
 
 #define TSI_ALTS_SERVICE_ACCOUNT_PEER_PROPERTY "service_account"

--- a/test/core/security/alts_security_connector_test.cc
+++ b/test/core/security/alts_security_connector_test.cc
@@ -129,13 +129,19 @@ static void test_alts_peer_to_auth_context_success() {
   grpc_slice serialized_peer_versions;
   GPR_ASSERT(grpc_gcp_rpc_protocol_versions_encode(&peer_versions,
                                                    &serialized_peer_versions));
-
   GPR_ASSERT(tsi_construct_string_peer_property(
                  TSI_ALTS_RPC_VERSIONS,
                  reinterpret_cast<char*>(
                      GRPC_SLICE_START_PTR(serialized_peer_versions)),
                  GRPC_SLICE_LENGTH(serialized_peer_versions),
                  &peer.properties[2]) == TSI_OK);
+  grpc_slice serialized_alts_ctx;
+  GPR_ASSERT(tsi_construct_string_peer_property(
+                 TSI_ALTS_CONTEXT,
+                 reinterpret_cast<char*>(
+                     GRPC_SLICE_START_PTR(serialized_alts_ctx)),
+                 GRPC_SLICE_LENGTH(serialized_alts_ctx),
+                 &peer.properties[3]) == TSI_OK);
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
       grpc_alts_auth_context_from_tsi_peer(&peer);
   GPR_ASSERT(ctx != nullptr);
@@ -143,6 +149,7 @@ static void test_alts_peer_to_auth_context_success() {
                            "alice"));
   ctx.reset(DEBUG_LOCATION, "test");
   grpc_slice_unref(serialized_peer_versions);
+  grpc_slice_unref(serialized_alts_ctx);
   tsi_peer_destruct(&peer);
 }
 

--- a/test/core/security/alts_security_connector_test.cc
+++ b/test/core/security/alts_security_connector_test.cc
@@ -135,13 +135,14 @@ static void test_alts_peer_to_auth_context_success() {
                      GRPC_SLICE_START_PTR(serialized_peer_versions)),
                  GRPC_SLICE_LENGTH(serialized_peer_versions),
                  &peer.properties[2]) == TSI_OK);
-  grpc_slice serialized_alts_ctx;
-  GPR_ASSERT(tsi_construct_string_peer_property(
-                 TSI_ALTS_CONTEXT,
-                 reinterpret_cast<char*>(
-                     GRPC_SLICE_START_PTR(serialized_alts_ctx)),
-                 GRPC_SLICE_LENGTH(serialized_alts_ctx),
-                 &peer.properties[3]) == TSI_OK);
+  char test_ctx[] = "test serialized context";
+  grpc_slice serialized_alts_ctx = grpc_slice_from_copied_string(test_ctx);
+  GPR_ASSERT(
+      tsi_construct_string_peer_property(
+          TSI_ALTS_CONTEXT,
+          reinterpret_cast<char*>(GRPC_SLICE_START_PTR(serialized_alts_ctx)),
+          GRPC_SLICE_LENGTH(serialized_alts_ctx),
+          &peer.properties[3]) == TSI_OK);
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
       grpc_alts_auth_context_from_tsi_peer(&peer);
   GPR_ASSERT(ctx != nullptr);

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -28,6 +28,7 @@
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h"
 #include "test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.h"
+#include "src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.h"
 
 #define ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES "Hello World"
 #define ALTS_TSI_HANDSHAKER_TEST_OUT_FRAME "Hello Google"
@@ -42,6 +43,9 @@
 #define ALTS_TSI_HANDSHAKER_TEST_MAX_RPC_VERSION_MINOR 2
 #define ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MAJOR 2
 #define ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MINOR 1
+#define ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY "chapilocal@service.google.com"
+#define ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL "test application protocol"
+#define ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL "test record protocol"
 
 using grpc_core::internal::alts_handshaker_client_check_fields_for_testing;
 using grpc_core::internal::alts_handshaker_client_get_handshaker_for_testing;
@@ -117,6 +121,7 @@ static grpc_byte_buffer* generate_handshaker_response(
   grpc_gcp_HandshakerStatus* status =
       grpc_gcp_HandshakerResp_mutable_status(resp, arena.ptr());
   grpc_gcp_HandshakerStatus_set_code(status, 0);
+  grpc_gcp_Identity* local_identity;
   switch (type) {
     case INVALID:
       break;
@@ -143,6 +148,15 @@ static grpc_byte_buffer* generate_handshaker_response(
           ALTS_TSI_HANDSHAKER_TEST_MAX_RPC_VERSION_MINOR,
           ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MAJOR,
           ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MINOR));
+      local_identity =
+          grpc_gcp_HandshakerResult_mutable_local_identity(result, arena.ptr());
+      grpc_gcp_Identity_set_service_account(
+          local_identity,
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY));
+      grpc_gcp_HandshakerResult_set_application_protocol(
+          result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
+      grpc_gcp_HandshakerResult_set_record_protocol(
+          result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL));
       break;
     case SERVER_NEXT:
       grpc_gcp_HandshakerResp_set_bytes_consumed(
@@ -160,6 +174,15 @@ static grpc_byte_buffer* generate_handshaker_response(
           ALTS_TSI_HANDSHAKER_TEST_MAX_RPC_VERSION_MINOR,
           ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MAJOR,
           ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MINOR));
+      local_identity =
+          grpc_gcp_HandshakerResult_mutable_local_identity(result, arena.ptr());
+      grpc_gcp_Identity_set_service_account(
+          local_identity,
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY));
+      grpc_gcp_HandshakerResult_set_application_protocol(
+          result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
+      grpc_gcp_HandshakerResult_set_record_protocol(
+          result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL));
       break;
     case FAILED:
       grpc_gcp_HandshakerStatus_set_code(status, 3 /* INVALID ARGUMENT */);
@@ -261,6 +284,27 @@ static void on_client_next_success_cb(tsi_result status, void* user_data,
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY,
                     peer.properties[1].value.data,
                     peer.properties[1].value.length) == 0);
+  /* Validate alts context. */
+  upb::Arena context_arena;
+  grpc_gcp_AltsContext* ctx =
+      grpc_gcp_AltsContext_parse(peer.properties[3].value.data, peer.properties[3].value.length, context_arena.ptr());
+  GPR_ASSERT(ctx != nullptr);
+  upb_strview application_protocol = grpc_gcp_AltsContext_application_protocol(ctx);
+  upb_strview record_protocol = grpc_gcp_AltsContext_record_protocol(ctx);
+  upb_strview peer_account = grpc_gcp_AltsContext_peer_service_account(ctx);
+  upb_strview local_account = grpc_gcp_AltsContext_local_service_account(ctx);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL,
+                    application_protocol.data,
+                    application_protocol.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL,
+                    record_protocol.data,
+                    record_protocol.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY,
+                    peer_account.data,
+                    peer_account.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY,
+                    local_account.data,
+                    local_account.size) == 0);
   tsi_peer_destruct(&peer);
   /* Validate unused bytes. */
   const unsigned char* bytes = nullptr;

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -27,8 +27,8 @@
 #include "src/core/tsi/alts/handshaker/alts_shared_resource.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h"
+#include "src/proto/grpc/gcp/altscontext.upb.h"
 #include "test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.h"
-#include "src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.h"
 
 #define ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES "Hello World"
 #define ALTS_TSI_HANDSHAKER_TEST_OUT_FRAME "Hello Google"
@@ -44,7 +44,8 @@
 #define ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MAJOR 2
 #define ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MINOR 1
 #define ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY "chapilocal@service.google.com"
-#define ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL "test application protocol"
+#define ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL \
+  "test application protocol"
 #define ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL "test record protocol"
 
 using grpc_core::internal::alts_handshaker_client_check_fields_for_testing;
@@ -154,7 +155,8 @@ static grpc_byte_buffer* generate_handshaker_response(
           local_identity,
           upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY));
       grpc_gcp_HandshakerResult_set_application_protocol(
-          result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
+          result,
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
       grpc_gcp_HandshakerResult_set_record_protocol(
           result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL));
       break;
@@ -180,7 +182,8 @@ static grpc_byte_buffer* generate_handshaker_response(
           local_identity,
           upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY));
       grpc_gcp_HandshakerResult_set_application_protocol(
-          result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
+          result,
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
       grpc_gcp_HandshakerResult_set_record_protocol(
           result, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL));
       break;
@@ -286,24 +289,22 @@ static void on_client_next_success_cb(tsi_result status, void* user_data,
                     peer.properties[1].value.length) == 0);
   /* Validate alts context. */
   upb::Arena context_arena;
-  grpc_gcp_AltsContext* ctx =
-      grpc_gcp_AltsContext_parse(peer.properties[3].value.data, peer.properties[3].value.length, context_arena.ptr());
+  grpc_gcp_AltsContext* ctx = grpc_gcp_AltsContext_parse(
+      peer.properties[3].value.data, peer.properties[3].value.length,
+      context_arena.ptr());
   GPR_ASSERT(ctx != nullptr);
-  upb_strview application_protocol = grpc_gcp_AltsContext_application_protocol(ctx);
+  upb_strview application_protocol =
+      grpc_gcp_AltsContext_application_protocol(ctx);
   upb_strview record_protocol = grpc_gcp_AltsContext_record_protocol(ctx);
   upb_strview peer_account = grpc_gcp_AltsContext_peer_service_account(ctx);
   upb_strview local_account = grpc_gcp_AltsContext_local_service_account(ctx);
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL,
-                    application_protocol.data,
-                    application_protocol.size) == 0);
+                    application_protocol.data, application_protocol.size) == 0);
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL,
-                    record_protocol.data,
-                    record_protocol.size) == 0);
-  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY,
-                    peer_account.data,
+                    record_protocol.data, record_protocol.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY, peer_account.data,
                     peer_account.size) == 0);
-  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY,
-                    local_account.data,
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY, local_account.data,
                     local_account.size) == 0);
   tsi_peer_destruct(&peer);
   /* Validate unused bytes. */
@@ -342,6 +343,25 @@ static void on_server_next_success_cb(tsi_result status, void* user_data,
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY,
                     peer.properties[1].value.data,
                     peer.properties[1].value.length) == 0);
+  /* Validate alts context. */
+  upb::Arena context_arena;
+  grpc_gcp_AltsContext* ctx = grpc_gcp_AltsContext_parse(
+      peer.properties[3].value.data, peer.properties[3].value.length,
+      context_arena.ptr());
+  GPR_ASSERT(ctx != nullptr);
+  upb_strview application_protocol =
+      grpc_gcp_AltsContext_application_protocol(ctx);
+  upb_strview record_protocol = grpc_gcp_AltsContext_record_protocol(ctx);
+  upb_strview peer_account = grpc_gcp_AltsContext_peer_service_account(ctx);
+  upb_strview local_account = grpc_gcp_AltsContext_local_service_account(ctx);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL,
+                    application_protocol.data, application_protocol.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL,
+                    record_protocol.data, record_protocol.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY, peer_account.data,
+                    peer_account.size) == 0);
+  GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY, local_account.data,
+                    local_account.size) == 0);
   tsi_peer_destruct(&peer);
   /* Validate unused bytes. */
   const unsigned char* bytes = nullptr;


### PR DESCRIPTION
This is the first PR to expose ALTS context for users. In includes changes in:

1. alts_tsi_handshaker.cc: convert the fields from alts handshaker result to a grpc_gcp_AltsContext, serialize it into a string, and put it into tsi_peer
2. alts_security_connector.cc: put the new field from tsi_peer to grpc_auth_context
3. corresponding tests

The next PR would be a util function for users to convert from the serialized context to a ProtocolBuffer-generated AltsContext class
