### PR TITLE
Add buildifier sanity check

### DIFF
--- a/templates/tools/dockerfile/buildifier.include
+++ b/templates/tools/dockerfile/buildifier.include
@@ -1,0 +1,4 @@
+# Install buildifier v0.29.0
+RUN wget https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+RUN chmod +x buildifier
+RUN mv buildifier /usr/local/bin

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -33,6 +33,7 @@
 
   <%include file="../../clang5.include"/>
   <%include file="../../bazel.include"/>
+  <%include file="../../buildifier.include"/>
 
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -105,6 +105,11 @@ RUN wget "https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/b
   bash ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
   rm bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
+# Install buildifier v0.29.0
+RUN wget https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
+RUN chmod +x buildifier
+RUN mv buildifier /usr/local/bin
+
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -1,0 +1,3 @@
+#! /bin/bash -ex
+
+buildifier -r -v "$(dirname "$0")/../../.."

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -1,3 +1,6 @@
 #! /bin/bash -ex
 
-buildifier -r -v "$(dirname "$0")/../../.."
+GIT_ROOT="$(dirname "$0")/../../.."
+TMP_ROOT="/tmp/buildifier_grpc"
+git clone -- "$GIT_ROOT" "$TMP_ROOT"
+buildifier -r -v -mode=diff $TMP_ROOT

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -1,4 +1,19 @@
 #! /bin/bash -ex
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The script to sanitize Bazel files
 
 GIT_ROOT="$(dirname "$0")/../../.."
 TMP_ROOT="/tmp/buildifier_grpc"

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -1,6 +1,7 @@
 # a set of tests that are run in parallel for sanity tests
 - script: tools/run_tests/sanity/check_bad_dependencies.sh
 - script: tools/run_tests/sanity/check_bazel_workspace.py
+- script: tools/run_tests/sanity/check_buildifier.sh
 - script: tools/run_tests/sanity/check_cache_mk.sh
 - script: tools/run_tests/sanity/check_deprecated_grpc++.py
 - script: tools/run_tests/sanity/check_owners.sh


### PR DESCRIPTION
This is a two step change.
1. Make sure the `buildifier` is working properly with Kokoro;
2. Format all existing BUILD files with the `buildifier`, and checked in atomically.