### PR TITLE
Change unused parameter name comment to cast

### DIFF
--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -294,7 +294,11 @@ void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
 
 namespace grpc_core {
 void grpc_tcp_set_write_timestamps_callback(
-    void (*/*fn*/)(void*, grpc_core::Timestamps*, grpc_error* error)) {
+    void (*fn)(void*, grpc_core::Timestamps*, grpc_error* error)) {
+  // Cast value of fn to void to avoid unused parameter warning.
+  // Can't comment out the name because some compilers and formatters don't
+  // like the sequence */* , which would arise from */*fn*/.
+  (void)fn;
   gpr_log(GPR_DEBUG, "Timestamps callback is not enabled for this platform");
 }
 } /* namespace grpc_core */

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -293,8 +293,9 @@ void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
 #else /* GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_core {
-void grpc_tcp_set_write_timestamps_callback(
-    void (*fn)(void*, grpc_core::Timestamps*, grpc_error* error)) {
+void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*,
+                                                       grpc_core::Timestamps*,
+                                                       grpc_error* error)) {
   // Cast value of fn to void to avoid unused parameter warning.
   // Can't comment out the name because some compilers and formatters don't
   // like the sequence */* , which would arise from */*fn*/.


### PR DESCRIPTION
Visual Studio gave a warning on the use of 

```
void (*/*fn*/)(...)
```

and Github formatting didn't understand it either because of the sequence `*/*` . So, convert it to an evaluated void cast.