### PR TITLE
Backport #20452 to fix the forking issue on macOS

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1379,7 +1379,9 @@ static void reset_event_manager_on_fork() {
   gpr_mu_lock(&fork_fd_list_mu);
   while (fork_fd_list_head != nullptr) {
     if (fork_fd_list_head->fd != nullptr) {
-      close(fork_fd_list_head->fd->fd);
+      if (!fork_fd_list_head->fd->closed) {
+        close(fork_fd_list_head->fd->fd);
+      }
       fork_fd_list_head->fd->fd = -1;
     } else {
       close(fork_fd_list_head->cached_wakeup_fd->fd.read_fd);


### PR DESCRIPTION
Original bug: https://github.com/grpc/grpc/issues/19208.
Original fix: #20452

---

I believe it is safe enough to be back-ported into `v1.25.0`. It added an additional safety condition in the fork handler, to cope with different forking behavior on macOS and Linux. 
@srini100 