### PR TITLE
Explicitly set states for the fd after fork

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1391,6 +1391,9 @@ static void reset_event_manager_on_fork() {
     if (fork_fd_list_head->fd != nullptr) {
       if (!fork_fd_list_head->fd->closed) {
         close(fork_fd_list_head->fd->fd);
+        fd->closed = 1;
+        fd->released = 1;
+        fd->shutdown = 1;
       }
       fork_fd_list_head->fd->fd = -1;
     } else {


### PR DESCRIPTION
Fixes #19208
Related https://github.com/grpc/grpc/pull/20888

Let's see if tests are happy.