### PR TITLE
init ssl roots only once

### DIFF
--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -101,6 +101,17 @@ PHP_METHOD(ChannelCredentials, setDefaultRootsPem) {
 }
 
 /**
+ * if default roots pem is set
+ * @return TRUE/FALSE 
+ */
+PHP_METHOD(ChannelCredentials, isDefaultRootsPemSet) {
+  if (default_pem_root_certs) {
+    RETURN_TRUE;
+  }
+  RETURN_FALSE;
+}
+
+/**
  * Create a default channel credentials object.
  * @return ChannelCredentials The new default channel credentials object
  */
@@ -214,6 +225,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_setDefaultRootsPem, 0, 0, 1)
   ZEND_ARG_INFO(0, pem_roots)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_isDefaultRootsPemSet, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_createDefault, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -233,6 +247,8 @@ ZEND_END_ARG_INFO()
 
 static zend_function_entry channel_credentials_methods[] = {
   PHP_ME(ChannelCredentials, setDefaultRootsPem, arginfo_setDefaultRootsPem,
+         ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+  PHP_ME(ChannelCredentials, isDefaultRootsPemSet, arginfo_isDefaultRootsPemSet,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_ME(ChannelCredentials, createDefault, arginfo_createDefault,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -43,10 +43,12 @@ class BaseStub
      */
     public function __construct($hostname, $opts, $channel = null)
     {
-        $ssl_roots = file_get_contents(
-            dirname(__FILE__).'/../../../../etc/roots.pem'
-        );
-        ChannelCredentials::setDefaultRootsPem($ssl_roots);
+        if (!ChannelCredentials::isDefaultRootsPemSet()) {
+            $ssl_roots = file_get_contents(
+                dirname(__FILE__).'/../../../../etc/roots.pem'
+            );
+            ChannelCredentials::setDefaultRootsPem($ssl_roots);
+        }
 
         $this->hostname = $hostname;
         $this->update_metadata = null;


### PR DESCRIPTION
Set default ssl pem roots cert only once so that we can avoid calling `file_get_contents()` at the PHP level over and over again.