### PR TITLE
Use C/C++ default timeout for windows portability test

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -351,7 +351,8 @@ def _create_portability_test_jobs(extra_args=[],
         compiler='default',
         labels=['portability', 'corelang'],
         extra_args=extra_args + ['--build_only'],
-        inner_jobs=inner_jobs)
+        inner_jobs=inner_jobs,
+        timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     # portability C and C++ on Windows using VS2017 (build only)
     # TODO(jtattermusch): some of the tests are failing, so we force --build_only
@@ -363,7 +364,8 @@ def _create_portability_test_jobs(extra_args=[],
         compiler='cmake_vs2017',
         labels=['portability', 'corelang'],
         extra_args=extra_args + ['--build_only'],
-        inner_jobs=inner_jobs)
+        inner_jobs=inner_jobs,
+        timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     # C and C++ with the c-ares DNS resolver on Linux
     test_jobs += _generate_jobs(


### PR DESCRIPTION
`run_tests_c++_windows_dbg_native_default_default_buildonly` has been flaky due to timeout. It spent 55 minutes or so recently. Because we already have timeout for test suite (by kokoro configuration), it can be considered okay to increase the default timeout for docker job.

Ref: Failure case [link](https://source.cloud.google.com/results/invocations/43760543-9344-49aa-8d0d-c461a1c95813/targets/github%2Fgrpc%2Ftoplevel_run_tests_invocations%2Frun_tests_c%2B%2B_windows_dbg_native_x64_cmake_vs2017_buildonly/tests)