### PR TITLE
PHP: init ssl roots only once

### DIFF
--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -112,6 +112,16 @@ PHP_METHOD(ChannelCredentials, isDefaultRootsPemSet) {
 }
 
 /**
+ * free default roots pem, if it is set
+ */
+PHP_METHOD(ChannelCredentials, invalidateDefaultRootsPem) {
+  if (default_pem_root_certs) {
+    gpr_free(default_pem_root_certs);
+    default_pem_root_certs = NULL;
+  }
+}
+
+/**
  * Create a default channel credentials object.
  * @return ChannelCredentials The new default channel credentials object
  */
@@ -228,6 +238,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_isDefaultRootsPemSet, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_invalidateDefaultRootsPem, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_createDefault, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -249,6 +262,8 @@ static zend_function_entry channel_credentials_methods[] = {
   PHP_ME(ChannelCredentials, setDefaultRootsPem, arginfo_setDefaultRootsPem,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_ME(ChannelCredentials, isDefaultRootsPemSet, arginfo_isDefaultRootsPemSet,
+         ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+  PHP_ME(ChannelCredentials, invalidateDefaultRootsPem, arginfo_invalidateDefaultRootsPem,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_ME(ChannelCredentials, createDefault, arginfo_createDefault,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -101,6 +101,17 @@ PHP_METHOD(ChannelCredentials, setDefaultRootsPem) {
 }
 
 /**
+ * if default roots pem is set
+ * @return TRUE/FALSE
+ */
+PHP_METHOD(ChannelCredentials, isDefaultRootsPemSet) {
+  if (default_pem_root_certs) {
+    RETURN_TRUE;
+  }
+  RETURN_FALSE;
+}
+
+/**
  * Create a default channel credentials object.
  * @return ChannelCredentials The new default channel credentials object
  */
@@ -214,6 +225,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_setDefaultRootsPem, 0, 0, 1)
   ZEND_ARG_INFO(0, pem_roots)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_isDefaultRootsPemSet, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_createDefault, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -233,6 +247,8 @@ ZEND_END_ARG_INFO()
 
 static zend_function_entry channel_credentials_methods[] = {
   PHP_ME(ChannelCredentials, setDefaultRootsPem, arginfo_setDefaultRootsPem,
+         ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+  PHP_ME(ChannelCredentials, isDefaultRootsPemSet, arginfo_isDefaultRootsPemSet,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_ME(ChannelCredentials, createDefault, arginfo_createDefault,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -34,13 +34,6 @@ class BaseStub
     private $update_metadata;
 
     /**
-     * invalidate default roots.pem, before set a different default cert after the first time
-     */
-    public function invalidateDefaultRootsPem()
-    {
-        ChannelCredentials::invalidateDefaultRootsPem();
-    }
-    /**
      * @param string  $hostname
      * @param array   $opts
      *  - 'update_metadata': (optional) a callback function which takes in a

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -34,6 +34,13 @@ class BaseStub
     private $update_metadata;
 
     /**
+     * invalidate default roots.pem, before set a different default cert after the first time
+     */
+    public function invalidateDefaultRootsPem()
+    {
+        ChannelCredentials::invalidateDefaultRootsPem();
+    }
+    /**
      * @param string  $hostname
      * @param array   $opts
      *  - 'update_metadata': (optional) a callback function which takes in a

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -43,10 +43,12 @@ class BaseStub
      */
     public function __construct($hostname, $opts, $channel = null)
     {
-        $ssl_roots = file_get_contents(
-            dirname(__FILE__).'/../../../../etc/roots.pem'
-        );
-        ChannelCredentials::setDefaultRootsPem($ssl_roots);
+        if (!ChannelCredentials::isDefaultRootsPemSet()) {
+            $ssl_roots = file_get_contents(
+                dirname(__FILE__).'/../../../../etc/roots.pem'
+            );
+	    ChannelCredentials::setDefaultRootsPem($ssl_roots);
+        }
 
         $this->hostname = $hostname;
         $this->update_metadata = null;

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -47,7 +47,7 @@ class BaseStub
             $ssl_roots = file_get_contents(
                 dirname(__FILE__).'/../../../../etc/roots.pem'
             );
-	    ChannelCredentials::setDefaultRootsPem($ssl_roots);
+            ChannelCredentials::setDefaultRootsPem($ssl_roots);
         }
 
         $this->hostname = $hostname;

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -46,6 +46,16 @@ class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
         $this->assertNull($channel_credentials);
     }
 
+    public function testDefaultRootsPem()
+    {
+        Grpc\ChannelCredentials::setDefaultRootsPem("Pem-Content-Not-Verified");
+        $this->assertTrue(Grpc\ChannelCredentials::isDefaultRootsPemSet());
+        Grpc\ChannelCredentials::invalidateDefaultRootsPem();
+        $this->assertFalse(Grpc\ChannelCredentials::isDefaultRootsPemSet());
+        Grpc\ChannelCredentials::setDefaultRootsPem("Content-Not-Verified");
+        $this->assertTrue(Grpc\ChannelCredentials::isDefaultRootsPemSet());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
Don't call `file_get_contents()` over and over again after `setDefaultRootsPem()` is already called. Fixes #18291
