### PR TITLE
Fix Regression in Client-side Interceptors

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -264,7 +264,7 @@ def _rpc_state_string(class_name, rpc_state):
                 rpc_state.debug_error_string)
 
 
-class _RpcError(grpc.RpcError, grpc.Call, grpc.Future):
+class _InactiveRpcError(grpc.RpcError, grpc.Call, grpc.Future):
     """An RPC error not tied to the execution of a particular RPC.
 
     The RPC represented by the state object must not be in-progress or
@@ -703,7 +703,7 @@ def _start_unary_request(request, timeout, request_serializer):
     if serialized_request is None:
         state = _RPCState((), (), (), grpc.StatusCode.INTERNAL,
                           'Exception serializing request!')
-        error = _RpcError(state)
+        error = _InactiveRpcError(state)
         return deadline, None, error
     else:
         return deadline, serialized_request, None
@@ -717,7 +717,7 @@ def _end_unary_response_blocking(state, call, with_call, deadline):
         else:
             return state.response
     else:
-        raise _RpcError(state)
+        raise _InactiveRpcError(state)
 
 
 def _stream_unary_invocation_operationses(metadata, initial_metadata_flags):
@@ -875,7 +875,7 @@ class _SingleThreadedUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
         if serialized_request is None:
             state = _RPCState((), (), (), grpc.StatusCode.INTERNAL,
                               'Exception serializing request!')
-            raise _RpcError(state)
+            raise _InactiveRpcError(state)
 
         state = _RPCState(_UNARY_STREAM_INITIAL_DUE, None, None, None, None)
         call_credentials = None if credentials is None else credentials._credentials

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -277,11 +277,15 @@ class _RpcError(grpc.RpcError, grpc.Call, grpc.Future):
 
     def __init__(self, state):
         if state.cancelled:
-            raise ValueError("Cannot instantiate an _RpcError for a cancelled RPC.")
+            raise ValueError(
+                "Cannot instantiate an _RpcError for a cancelled RPC.")
         if state.code is grpc.StatusCode.OK:
-            raise ValueError("Cannot instantiate an _RpcError for a successfully completed RPC.")
+            raise ValueError(
+                "Cannot instantiate an _RpcError for a successfully completed RPC."
+            )
         if state.code is None:
-            raise ValueError("Cannot instantiate an _RpcError for an incomplete RPC.")
+            raise ValueError(
+                "Cannot instantiate an _RpcError for an incomplete RPC.")
         self._state = state
 
     def initial_metadata(self):
@@ -324,22 +328,22 @@ class _RpcError(grpc.RpcError, grpc.Call, grpc.Future):
         """See grpc.Future.done."""
         return True
 
-    def result(self, timeout=None):
+    def result(self, timeout=None):  # pylint: disable=unused-argument
         """See grpc.Future.result."""
         raise self
 
-    def exception(self, timeout=None):
+    def exception(self, timeout=None):  # pylint: disable=unused-argument
         """See grpc.Future.exception."""
         return self
 
-    def traceback(self, timeout=None):
+    def traceback(self, timeout=None):  # pylint: disable=unused-argument
         """See grpc.Future.traceback."""
         try:
             raise self
         except grpc.RpcError:
             return sys.exc_info()[2]
 
-    def add_done_callback(self, timeout=None):
+    def add_done_callback(self, fn, timeout=None):  # pylint: disable=unused-argument
         """See grpc.Future.add_done_callback."""
         fn(self)
 

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -243,8 +243,12 @@ class _LoggingInterceptor(
     def intercept_unary_unary(self, continuation, client_call_details, request):
         self.record.append(self.tag + ':intercept_unary_unary')
         result = continuation(client_call_details, request)
-        assert isinstance(result, grpc.Call), '{} is not an instance of grpc.Call'.format(result)
-        assert isinstance(result, grpc.Future), '{} is not an instance of grpc.Future'.format(result)
+        assert isinstance(
+            result,
+            grpc.Call), '{} is not an instance of grpc.Call'.format(result)
+        assert isinstance(
+            result,
+            grpc.Future), '{} is not an instance of grpc.Future'.format(result)
         return result
 
     def intercept_unary_stream(self, continuation, client_call_details,
@@ -256,8 +260,12 @@ class _LoggingInterceptor(
                                request_iterator):
         self.record.append(self.tag + ':intercept_stream_unary')
         result = continuation(client_call_details, request_iterator)
-        assert isinstance(result, grpc.Call), '{} is not an instance of grpc.Call'.format(result)
-        assert isinstance(result, grpc.Future), '{} is not an instance of grpc.Future'.format(result)
+        assert isinstance(
+            result,
+            grpc.Call), '{} is not an instance of grpc.Call'.format(result)
+        assert isinstance(
+            result,
+            grpc.Future), '{} is not an instance of grpc.Future'.format(result)
         return result
 
     def intercept_stream_stream(self, continuation, client_call_details,


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/20812 caused a regression for unary-unary client interceptors in the case of an exception. This PR fixes that regression and adds tests for error conditions with client-side interceptors.