### PR TITLE
Add GRPC_USE_ABSL flag

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -69,6 +69,11 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
+config_setting(
+    name = "grpc_use_absl",
+    values = {"define": "GRPC_USE_ABSL=1"},
+)
+
 python_config_settings()
 
 # This should be updated along with build.yaml

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -88,11 +88,19 @@ def grpc_cc_library(
     linkopts = if_not_windows(["-pthread"])
     if use_cfstream:
         linkopts = linkopts + if_mac(["-framework CoreFoundation"])
-    # Temporary hack for GRPC_USE_ABSL {
+
+    # This is a temporary solution to enable absl dependency only for
+    # Bazel-build with grpc_use_absl enabled to abseilfy in-house classes
+    # such as inlined_vector before absl is fully supported.
+    # When https://github.com/grpc/grpc/pull/20184 is merged, it will
+    # be removed.
     more_external_deps = []
     if name == "inlined_vector":
-        more_external_deps += ["absl/container:inlined_vector"]
-    # Temporary hack for GRPC_USE_ABSL }
+        more_external_deps += select({
+            "//:grpc_use_absl": ["@com_google_absl//absl/container:inlined_vector"],
+            "//conditions:default": [],
+        })
+
     native.cc_library(
         name = name,
         srcs = srcs,
@@ -109,12 +117,12 @@ def grpc_cc_library(
                       "//:grpc_disallow_exceptions": ["GRPC_ALLOW_EXCEPTIONS=0"],
                       "//conditions:default": [],
                   }) +
-                  select({	
-                      "//:grpc_use_absl": ["GRPC_USE_ABSL=1"],	
-                      "//conditions:default": [],	
+                  select({
+                      "//:grpc_use_absl": ["GRPC_USE_ABSL=1"],
+                      "//conditions:default": [],
                   }),
         hdrs = hdrs + public_hdrs,
-        deps = deps + _get_external_deps(external_deps + more_external_deps),
+        deps = deps + _get_external_deps(external_deps) + more_external_deps,
         copts = copts,
         visibility = visibility,
         testonly = testonly,

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -27,6 +27,13 @@
  *  - some syscalls to be made directly
  */
 
+/*
+ * Defines GRPC_USE_ABSL to use Abseil Common Libraries (C++)
+ */
+#ifndef GRPC_USE_ABSL
+#define GRPC_USE_ABSL 0
+#endif
+
 /* Get windows.h included everywhere (we need it) */
 #if defined(_WIN64) || defined(WIN64) || defined(_WIN32) || defined(WIN32)
 #ifndef WIN32_LEAN_AND_MEAN

--- a/src/core/lib/gprpp/inlined_vector.h
+++ b/src/core/lib/gprpp/inlined_vector.h
@@ -233,14 +233,7 @@ class InlinedVector {
     }
   }
 
-#if 1
   typename std::aligned_storage<sizeof(T)>::type inline_[N];
-#else
-  // Alignment attribute should be used like this but it has a problem
-  // with current gRPC source. It has to be disabled until other gRPC part
-  // goes well with this.
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type inline_[N];
-#endif
   T* dynamic_;
   size_t size_;
   size_t capacity_;

--- a/src/core/lib/gprpp/inlined_vector.h
+++ b/src/core/lib/gprpp/inlined_vector.h
@@ -26,7 +26,18 @@
 
 #include "src/core/lib/gprpp/memory.h"
 
+#if GRPC_USE_ABSL
+#include "absl/container/inlined_vector.h"
+#endif
+
 namespace grpc_core {
+
+#if GRPC_USE_ABSL
+
+template <typename T, size_t N, typename A = std::allocator<T>>
+using InlinedVector = absl::InlinedVector<T, N, A>;
+
+#else
 
 // NOTE: We eventually want to use absl::InlinedVector here.  However,
 // there are currently build problems that prevent us from using absl.
@@ -222,11 +233,20 @@ class InlinedVector {
     }
   }
 
+#if 1
   typename std::aligned_storage<sizeof(T)>::type inline_[N];
+#else
+  // Alignment attribute should be used like this but it has a problem
+  // with current gRPC source. It has to be disabled until other gRPC part
+  // goes well with this.
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type inline_[N];
+#endif
   T* dynamic_;
   size_t size_;
   size_t capacity_;
 };
+
+#endif
 
 }  // namespace grpc_core
 

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -25,4 +25,7 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 bazel build --spawn_strategy=standalone --genrule_strategy=standalone :all test/... examples/...
+
+# This is a temporary build test before full absl support is done
+# with https://github.com/grpc/grpc/pull/20918.
 bazel build --spawn_strategy=standalone --genrule_strategy=standalone --define=GRPC_USE_ABSL=1 :grpc

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -25,3 +25,4 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 bazel build --spawn_strategy=standalone --genrule_strategy=standalone :all test/... examples/...
+bazel build --spawn_strategy=standalone --genrule_strategy=standalone --define=GRPC_USE_ABSL=1 :grpc


### PR DESCRIPTION
This is part of #20184. Before having full absl integration, this enables us to work abseilifcation work such as making existing classes compatible with the ones in abseil in parallel. All changes for build and test are temporary and will be replaced with #20184 but code changes will remain. (e.g. `InlinedVector`)

Changes:
- Added `GRPC_USE_ABSL` C flag to enable absl
- Replaced `gpr::InlinedVector` with `absl::InlinedVector` when the flag is on
- Added `GRPC_USE_ABSL` build flag to enable absl when building with Bazel
- Added build test with `GRPC_USE_ABSL`

