### PR TITLE
Revert "Fix error object memory leak in GetSystemRootCerts"

### DIFF
--- a/src/core/lib/security/security_connector/load_system_roots_linux.cc
+++ b/src/core/lib/security/security_connector/load_system_roots_linux.cc
@@ -69,7 +69,6 @@ grpc_slice GetSystemRootCerts() {
     } else {
       GRPC_ERROR_UNREF(error);
     }
-    GRPC_ERROR_UNREF(error);
   }
   return grpc_empty_slice();
 }


### PR DESCRIPTION
Reverts grpc/grpc#20584

The same thing was done in https://github.com/grpc/grpc/pull/20735