### PR TITLE
Use the RECV_STATUS op in ALTS handshake RPCs

### DIFF
--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -195,6 +195,7 @@ void SecurityHandshaker::HandshakeFailedLocked(grpc_error* error) {
   gpr_log(GPR_DEBUG, "Security handshake failed: %s", msg);
 
   if (!is_shutdown_) {
+    tsi_handshaker_shutdown(handshaker_);
     // TODO(ctiller): It is currently necessary to shutdown endpoints
     // before destroying them, even if we know that there are no
     // pending read/write callbacks.  This should be fixed, at which

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -736,7 +736,7 @@ void alts_handshaker_client_on_status_received_for_testing(
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
   client->handshake_status_code = status;
   client->handshake_status_details = grpc_empty_slice();
-  GRPC_CLOSURE_RUN(&client->on_status_received, error);
+  grpc_core::Closure::Run(DEBUG_LOCATION, &client->on_status_received, error);
 }
 
 }  // namespace internal

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -514,7 +514,9 @@ static void handshaker_shutdown(tsi_handshaker* self) {
   if (handshaker->shutdown) {
     return;
   }
-  alts_handshaker_client_shutdown(handshaker->client);
+  if (handshaker->client != nullptr) {
+    alts_handshaker_client_shutdown(handshaker->client);
+  }
   handshaker->shutdown = true;
 }
 

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
@@ -77,6 +77,11 @@ void alts_handshaker_client_set_cb_for_testing(
 grpc_closure* alts_handshaker_client_get_closure_for_testing(
     alts_handshaker_client* client);
 
+void alts_handshaker_client_on_status_received_for_testing(
+    alts_handshaker_client* client, grpc_status_code status, grpc_error* error);
+
+void alts_handshaker_client_ref_for_testing(alts_handshaker_client* c);
+
 }  // namespace internal
 }  // namespace grpc_core
 

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -61,6 +61,8 @@
 
 namespace {
 
+const int kFakeHandshakeServerMaxConcurrentStreams = 40;
+
 void drain_cq(grpc_completion_queue* cq) {
   grpc_event ev;
   do {
@@ -70,7 +72,8 @@ void drain_cq(grpc_completion_queue* cq) {
 }
 
 grpc_channel* create_secure_channel_for_test(
-    const char* server_addr, const char* fake_handshake_server_addr) {
+    const char* server_addr, const char* fake_handshake_server_addr,
+    int reconnect_backoff_ms) {
   grpc_alts_credentials_options* alts_options =
       grpc_alts_credentials_client_options_create();
   grpc_channel_credentials* channel_creds =
@@ -80,11 +83,19 @@ grpc_channel* create_secure_channel_for_test(
   grpc_alts_credentials_options_destroy(alts_options);
   // The main goal of these tests are to stress concurrent ALTS handshakes,
   // so we prevent subchnannel sharing.
-  grpc_arg disable_subchannel_sharing_arg = grpc_channel_arg_integer_create(
-      const_cast<char*>(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL), true);
-  grpc_channel_args channel_args = {1, &disable_subchannel_sharing_arg};
+  std::vector<grpc_arg> new_args;
+  new_args.push_back(grpc_channel_arg_integer_create(
+      const_cast<char*>(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL), true));
+  if (reconnect_backoff_ms != 0) {
+    new_args.push_back(grpc_channel_arg_integer_create(
+        const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms"),
+        reconnect_backoff_ms));
+  }
+  grpc_channel_args* channel_args =
+      grpc_channel_args_copy_and_add(nullptr, new_args.data(), new_args.size());
   grpc_channel* channel = grpc_secure_channel_create(channel_creds, server_addr,
-                                                     &channel_args, nullptr);
+                                                     channel_args, nullptr);
+  grpc_channel_args_destroy(channel_args);
   grpc_channel_credentials_release(channel_creds);
   return channel;
 }
@@ -98,6 +109,8 @@ class FakeHandshakeServer {
     grpc::ServerBuilder builder;
     builder.AddListeningPort(address_.get(), grpc::InsecureServerCredentials());
     builder.RegisterService(service_.get());
+    builder.AddChannelArgument(GRPC_ARG_MAX_CONCURRENT_STREAMS,
+                               kFakeHandshakeServerMaxConcurrentStreams);
     server_ = builder.BuildAndStart();
     gpr_log(GPR_INFO, "Fake handshaker server listening on %s", address_.get());
   }
@@ -116,12 +129,12 @@ class FakeHandshakeServer {
 
 class TestServer {
  public:
-  explicit TestServer(const char* fake_handshake_server_address) {
+  explicit TestServer() {
     grpc_alts_credentials_options* alts_options =
         grpc_alts_credentials_server_options_create();
     grpc_server_credentials* server_creds =
         grpc_alts_server_credentials_create_customized(
-            alts_options, fake_handshake_server_address,
+            alts_options, fake_handshake_server_.address(),
             true /* enable_untrusted_alts */);
     grpc_alts_credentials_options_destroy(alts_options);
     server_ = grpc_server_create(nullptr, nullptr);
@@ -164,6 +177,15 @@ class TestServer {
   grpc_completion_queue* server_cq_;
   std::unique_ptr<std::thread> server_thd_;
   grpc_core::UniquePtr<char> server_addr_;
+  // Give this test server its own ALTS handshake server
+  // so that we avoid competing for ALTS handshake server resources (e.g.
+  // available HTTP2 streams on a globally shared handshaker subchannel)
+  // with clients that are trying to do mutual ALTS handshakes
+  // with this server (which could "deadlock" mutual handshakes).
+  // TODO(apolcyn): remove this workaround from this test and have
+  // clients/servers share a single fake handshake server if
+  // the underlying issue needs to be fixed.
+  FakeHandshakeServer fake_handshake_server_;
 };
 
 class ConnectLoopRunner {
@@ -171,13 +193,15 @@ class ConnectLoopRunner {
   explicit ConnectLoopRunner(
       const char* server_address, const char* fake_handshake_server_addr,
       int per_connect_deadline_seconds, size_t loops,
-      grpc_connectivity_state expected_connectivity_states)
+      grpc_connectivity_state expected_connectivity_states,
+      int reconnect_backoff_ms)
       : server_address_(grpc_core::UniquePtr<char>(gpr_strdup(server_address))),
         fake_handshake_server_addr_(
             grpc_core::UniquePtr<char>(gpr_strdup(fake_handshake_server_addr))),
         per_connect_deadline_seconds_(per_connect_deadline_seconds),
         loops_(loops),
-        expected_connectivity_states_(expected_connectivity_states) {
+        expected_connectivity_states_(expected_connectivity_states),
+        reconnect_backoff_ms_(reconnect_backoff_ms) {
     thd_ = std::unique_ptr<std::thread>(new std::thread(ConnectLoop, this));
   }
 
@@ -189,7 +213,8 @@ class ConnectLoopRunner {
       grpc_completion_queue* cq =
           grpc_completion_queue_create_for_next(nullptr);
       grpc_channel* channel = create_secure_channel_for_test(
-          self->server_address_.get(), self->fake_handshake_server_addr_.get());
+          self->server_address_.get(), self->fake_handshake_server_addr_.get(),
+          self->reconnect_backoff_ms_);
       // Connect, forcing an ALTS handshake
       gpr_timespec connect_deadline =
           grpc_timeout_seconds_to_deadline(self->per_connect_deadline_seconds_);
@@ -228,18 +253,20 @@ class ConnectLoopRunner {
   size_t loops_;
   grpc_connectivity_state expected_connectivity_states_;
   std::unique_ptr<std::thread> thd_;
+  int reconnect_backoff_ms_;
 };
 
 // Perform a few ALTS handshakes sequentially (using the fake, in-process ALTS
 // handshake server).
 TEST(AltsConcurrentConnectivityTest, TestBasicClientServerHandshakes) {
   FakeHandshakeServer fake_handshake_server;
-  TestServer test_server(fake_handshake_server.address());
+  TestServer test_server;
   {
     ConnectLoopRunner runner(
         test_server.address(), fake_handshake_server.address(),
         5 /* per connect deadline seconds */, 10 /* loops */,
-        GRPC_CHANNEL_READY /* expected connectivity states */);
+        GRPC_CHANNEL_READY /* expected connectivity states */,
+        0 /* reconnect_backoff_ms unset */);
   }
 }
 
@@ -249,7 +276,7 @@ TEST(AltsConcurrentConnectivityTest, TestConcurrentClientServerHandshakes) {
   FakeHandshakeServer fake_handshake_server;
   // Test
   {
-    TestServer test_server(fake_handshake_server.address());
+    TestServer test_server;
     gpr_timespec test_deadline = grpc_timeout_seconds_to_deadline(20);
     size_t num_concurrent_connects = 50;
     std::vector<std::unique_ptr<ConnectLoopRunner>> connect_loop_runners;
@@ -260,7 +287,8 @@ TEST(AltsConcurrentConnectivityTest, TestConcurrentClientServerHandshakes) {
           std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
               test_server.address(), fake_handshake_server.address(),
               15 /* per connect deadline seconds */, 5 /* loops */,
-              GRPC_CHANNEL_READY /* expected connectivity states */)));
+              GRPC_CHANNEL_READY /* expected connectivity states */,
+              0 /* reconnect_backoff_ms unset */)));
     }
     connect_loop_runners.clear();
     gpr_log(GPR_DEBUG,
@@ -447,11 +475,12 @@ TEST(AltsConcurrentConnectivityTest,
     size_t num_concurrent_connects = 100;
     gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
     for (size_t i = 0; i < num_concurrent_connects; i++) {
-      connect_loop_runners.push_back(std::unique_ptr<
-                                     ConnectLoopRunner>(new ConnectLoopRunner(
-          fake_tcp_server.address(), fake_handshake_server.address(),
-          10 /* per connect deadline seconds */, 3 /* loops */,
-          GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */)));
+      connect_loop_runners.push_back(
+          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
+              fake_tcp_server.address(), fake_handshake_server.address(),
+              10 /* per connect deadline seconds */, 3 /* loops */,
+              GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
+              0 /* reconnect_backoff_ms unset */)));
     }
     connect_loop_runners.clear();
     gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");
@@ -459,6 +488,69 @@ TEST(AltsConcurrentConnectivityTest,
       gpr_log(GPR_ERROR,
               "Exceeded test deadline. ALTS handshakes might not be failing "
               "fast when the peer endpoint closes the connection abruptly");
+      abort();
+    }
+  }
+}
+
+/* This test is intended to make sure that ALTS handshakes correctly
+ * fail fast when the ALTS handshake server fails incoming handshakes fast. */
+TEST(AltsConcurrentConnectivityTest,
+     TestHandshakeFailsFastWhenHandshakeServerClosesConnectionAfterAccepting) {
+  FakeTcpServer fake_handshake_server(
+      FakeTcpServer::CloseSocketUponReceivingBytesFromPeer);
+  FakeTcpServer fake_tcp_server(FakeTcpServer::CloseSocketUponCloseFromPeer);
+  {
+    gpr_timespec test_deadline = grpc_timeout_seconds_to_deadline(20);
+    std::vector<std::unique_ptr<ConnectLoopRunner>> connect_loop_runners;
+    size_t num_concurrent_connects = 100;
+    gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
+    for (size_t i = 0; i < num_concurrent_connects; i++) {
+      connect_loop_runners.push_back(
+          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
+              fake_tcp_server.address(), fake_handshake_server.address(),
+              10 /* per connect deadline seconds */, 2 /* loops */,
+              GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
+              0 /* reconnect_backoff_ms unset */)));
+    }
+    connect_loop_runners.clear();
+    gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");
+    if (gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), test_deadline) > 0) {
+      gpr_log(GPR_ERROR,
+              "Exceeded test deadline. ALTS handshakes might not be failing "
+              "fast when the handshake server closes new connections");
+      abort();
+    }
+  }
+}
+
+/* This test is intended to make sure that ALTS handshakes correctly
+ * fail fast when the ALTS handshake server is non-responsive, in which case
+ * the overall connection deadline kicks in. */
+TEST(AltsConcurrentConnectivityTest,
+     TestHandshakeFailsFastWhenHandshakeServerHangsAfterAccepting) {
+  FakeTcpServer fake_handshake_server(
+      FakeTcpServer::CloseSocketUponCloseFromPeer);
+  FakeTcpServer fake_tcp_server(FakeTcpServer::CloseSocketUponCloseFromPeer);
+  {
+    gpr_timespec test_deadline = grpc_timeout_seconds_to_deadline(20);
+    std::vector<std::unique_ptr<ConnectLoopRunner>> connect_loop_runners;
+    size_t num_concurrent_connects = 100;
+    gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
+    for (size_t i = 0; i < num_concurrent_connects; i++) {
+      connect_loop_runners.push_back(
+          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
+              fake_tcp_server.address(), fake_handshake_server.address(),
+              10 /* per connect deadline seconds */, 2 /* loops */,
+              GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
+              100 /* reconnect_backoff_ms */)));
+    }
+    connect_loop_runners.clear();
+    gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");
+    if (gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), test_deadline) > 0) {
+      gpr_log(GPR_ERROR,
+              "Exceeded test deadline. ALTS handshakes might not be failing "
+              "fast when the handshake server is non-response timeout occurs");
       abort();
     }
   }

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -52,6 +52,9 @@ using grpc_core::internal::alts_handshaker_client_check_fields_for_testing;
 using grpc_core::internal::alts_handshaker_client_get_handshaker_for_testing;
 using grpc_core::internal::
     alts_handshaker_client_get_recv_buffer_addr_for_testing;
+using grpc_core::internal::
+    alts_handshaker_client_on_status_received_for_testing;
+using grpc_core::internal::alts_handshaker_client_ref_for_testing;
 using grpc_core::internal::alts_handshaker_client_set_cb_for_testing;
 using grpc_core::internal::alts_handshaker_client_set_fields_for_testing;
 using grpc_core::internal::alts_handshaker_client_set_recv_bytes_for_testing;
@@ -620,7 +623,7 @@ static void on_failed_grpc_call_cb(tsi_result status, void* user_data,
   GPR_ASSERT(result == nullptr);
 }
 
-static void check_handle_response_invalid_input() {
+static void check_handle_response_nullptr_handshaker() {
   /* Initialization. */
   notification_init(&caller_to_tsi_notification);
   notification_init(&tsi_to_caller_notification);
@@ -642,20 +645,107 @@ static void check_handle_response_invalid_input() {
                                                 on_invalid_input_cb, nullptr,
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
+  /* Note: here and elsewhere in this test, we first ref the handshaker in order
+   * to match the unref that on_status_received will do. This necessary
+   * because this test mocks out the grpc call in such a way that the code
+   * path that would usually take this ref is skipped. */
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
+                                                        GRPC_ERROR_NONE);
+  /* Cleanup. */
+  grpc_slice_unref(slice);
+  run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
+  notification_destroy(&caller_to_tsi_notification);
+  notification_destroy(&tsi_to_caller_notification);
+}
+
+static void check_handle_response_nullptr_recv_bytes() {
+  /* Initialization. */
+  notification_init(&caller_to_tsi_notification);
+  notification_init(&tsi_to_caller_notification);
+  /**
+   * Create a handshaker at the client side, for which internal mock client is
+   * always going to fail.
+   */
+  tsi_handshaker* handshaker = create_test_handshaker(true /* is_client */);
+  tsi_handshaker_next(handshaker, nullptr, 0, nullptr, nullptr, nullptr,
+                      on_client_start_success_cb, nullptr);
+  alts_tsi_handshaker* alts_handshaker =
+      reinterpret_cast<alts_tsi_handshaker*>(handshaker);
+  alts_handshaker_client* client =
+      alts_tsi_handshaker_get_client_for_testing(alts_handshaker);
   /* Check nullptr recv_bytes. */
   alts_handshaker_client_set_fields_for_testing(client, alts_handshaker,
                                                 on_invalid_input_cb, nullptr,
                                                 nullptr, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
+                                                        GRPC_ERROR_NONE);
+  /* Cleanup. */
+  run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
+  notification_destroy(&caller_to_tsi_notification);
+  notification_destroy(&tsi_to_caller_notification);
+}
+
+static void check_handle_response_failed_grpc_call_to_handshaker_service() {
+  /* Initialization. */
+  notification_init(&caller_to_tsi_notification);
+  notification_init(&tsi_to_caller_notification);
+  /**
+   * Create a handshaker at the client side, for which internal mock client is
+   * always going to fail.
+   */
+  tsi_handshaker* handshaker = create_test_handshaker(true /* is_client */);
+  tsi_handshaker_next(handshaker, nullptr, 0, nullptr, nullptr, nullptr,
+                      on_client_start_success_cb, nullptr);
+  alts_tsi_handshaker* alts_handshaker =
+      reinterpret_cast<alts_tsi_handshaker*>(handshaker);
+  grpc_slice slice = grpc_empty_slice();
+  grpc_byte_buffer* recv_buffer = grpc_raw_byte_buffer_create(&slice, 1);
+  alts_handshaker_client* client =
+      alts_tsi_handshaker_get_client_for_testing(alts_handshaker);
   /* Check failed grpc call made to handshaker service. */
   alts_handshaker_client_set_fields_for_testing(
       client, alts_handshaker, on_failed_grpc_call_cb, nullptr, recv_buffer,
       GRPC_STATUS_UNKNOWN);
   alts_handshaker_client_handle_response(client, true);
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(
+      client, GRPC_STATUS_UNKNOWN, GRPC_ERROR_NONE);
+  /* Cleanup. */
+  grpc_slice_unref(slice);
+  run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
+  notification_destroy(&caller_to_tsi_notification);
+  notification_destroy(&tsi_to_caller_notification);
+}
+
+static void
+check_handle_response_failed_recv_message_from_handshaker_service() {
+  /* Initialization. */
+  notification_init(&caller_to_tsi_notification);
+  notification_init(&tsi_to_caller_notification);
+  /**
+   * Create a handshaker at the client side, for which internal mock client is
+   * always going to fail.
+   */
+  tsi_handshaker* handshaker = create_test_handshaker(true /* is_client */);
+  tsi_handshaker_next(handshaker, nullptr, 0, nullptr, nullptr, nullptr,
+                      on_client_start_success_cb, nullptr);
+  alts_tsi_handshaker* alts_handshaker =
+      reinterpret_cast<alts_tsi_handshaker*>(handshaker);
+  grpc_slice slice = grpc_empty_slice();
+  grpc_byte_buffer* recv_buffer = grpc_raw_byte_buffer_create(&slice, 1);
+  alts_handshaker_client* client =
+      alts_tsi_handshaker_get_client_for_testing(alts_handshaker);
+  /* Check failed recv message op from handshaker service. */
   alts_handshaker_client_set_fields_for_testing(client, alts_handshaker,
                                                 on_failed_grpc_call_cb, nullptr,
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, false);
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
+                                                        GRPC_ERROR_NONE);
   /* Cleanup. */
   grpc_slice_unref(slice);
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -695,6 +785,9 @@ static void check_handle_response_invalid_resp() {
                                                 on_invalid_resp_cb, nullptr,
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
+                                                        GRPC_ERROR_NONE);
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);
@@ -708,12 +801,18 @@ static void check_handle_response_success(void* /*unused*/) {
   /* Client next. */
   wait(&caller_to_tsi_notification);
   alts_handshaker_client_handle_response(cb_event, true /* is_ok */);
+  alts_handshaker_client_ref_for_testing(cb_event);
+  alts_handshaker_client_on_status_received_for_testing(
+      cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
   /* Server start. */
   wait(&caller_to_tsi_notification);
   alts_handshaker_client_handle_response(cb_event, true /* is_ok */);
   /* Server next. */
   wait(&caller_to_tsi_notification);
   alts_handshaker_client_handle_response(cb_event, true /* is_ok */);
+  alts_handshaker_client_ref_for_testing(cb_event);
+  alts_handshaker_client_on_status_received_for_testing(
+      cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
 }
 
 static void on_failed_resp_cb(tsi_result status, void* user_data,
@@ -748,6 +847,9 @@ static void check_handle_response_failure() {
                                                 on_failed_resp_cb, nullptr,
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true /* is_ok*/);
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
+                                                        GRPC_ERROR_NONE);
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);
@@ -787,6 +889,9 @@ static void check_handle_response_after_shutdown() {
                                                 on_shutdown_resp_cb, nullptr,
                                                 recv_buffer, GRPC_STATUS_OK);
   alts_handshaker_client_handle_response(client, true);
+  alts_handshaker_client_ref_for_testing(client);
+  alts_handshaker_client_on_status_received_for_testing(client, GRPC_STATUS_OK,
+                                                        GRPC_ERROR_NONE);
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
   notification_destroy(&caller_to_tsi_notification);
@@ -837,7 +942,10 @@ int main(int /*argc*/, char** /*argv*/) {
   should_handshaker_client_api_succeed = false;
   check_handshaker_shutdown_invalid_input();
   check_handshaker_next_failure();
-  check_handle_response_invalid_input();
+  check_handle_response_nullptr_handshaker();
+  check_handle_response_nullptr_recv_bytes();
+  check_handle_response_failed_grpc_call_to_handshaker_service();
+  check_handle_response_failed_recv_message_from_handshaker_service();
   check_handle_response_invalid_resp();
   check_handle_response_failure();
   /* Cleanup. */


### PR DESCRIPTION
This is a pre-req to https://github.com/grpc/grpc/pull/20722, which needs to make use of the RECV_STATUS op in order to manage a global queue. Note that though #20722 is meant to be a short-term change, this change is meant to be long term (the ALTS handshake RPC is currently somewhat unique in not doing this op).

Also, this is a replacement of https://github.com/grpc/grpc/pull/20687 (putting an explicit deadline on ALTS handshake  RPCs is likely unnecessary, since a customized reconnect backoff time can serve that same purpose).

Some changes had to be made to the `alts_handshaker_client_test` and `alts_tsi_handshaker_test`s in order to make room for the new internal behaviors of `alts_grpc_handshaker_client` regarding lifetimes and how exactly the TSI next callback to be invoked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/20929)
<!-- Reviewable:end -->
