### PR TITLE
Replace existing channel factory arg, if any

### DIFF
--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -99,7 +99,9 @@ grpc_channel* grpc_insecure_channel_create(const char* target,
   // Add channel arg containing the client channel factory.
   gpr_once_init(&g_factory_once, FactoryInit);
   grpc_arg arg = grpc_core::ClientChannelFactory::CreateChannelArg(g_factory);
-  grpc_channel_args* new_args = grpc_channel_args_copy_and_add(args, &arg, 1);
+  const char* arg_to_remove = arg.key;
+  grpc_channel_args* new_args = grpc_channel_args_copy_and_add_and_remove(
+      args, &arg_to_remove, 1, &arg, 1);
   // Create channel.
   grpc_channel* channel = grpc_core::CreateChannel(target, new_args);
   // Clean up.

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -205,11 +205,13 @@ grpc_channel* grpc_secure_channel_create(grpc_channel_credentials* creds,
     // Add channel args containing the client channel factory and channel
     // credentials.
     gpr_once_init(&g_factory_once, FactoryInit);
-    grpc_arg args_to_add[] = {
-        grpc_core::ClientChannelFactory::CreateChannelArg(g_factory),
-        grpc_channel_credentials_to_arg(creds)};
-    grpc_channel_args* new_args = grpc_channel_args_copy_and_add(
-        args, args_to_add, GPR_ARRAY_SIZE(args_to_add));
+    grpc_arg channel_factory_arg =
+        grpc_core::ClientChannelFactory::CreateChannelArg(g_factory);
+    grpc_arg args_to_add[] = {channel_factory_arg,
+                              grpc_channel_credentials_to_arg(creds)};
+    const char* arg_to_remove = channel_factory_arg.key;
+    grpc_channel_args* new_args = grpc_channel_args_copy_and_add_and_remove(
+        args, &arg_to_remove, 1, args_to_add, GPR_ARRAY_SIZE(args_to_add));
     new_args = creds->update_arguments(new_args);
     // Create channel.
     channel = grpc_core::CreateChannel(target, new_args);


### PR DESCRIPTION
This modifies `grpc_[in]secure_channel_create` to drop the existing ClientChannelFactory key in the channel args, if any. Without this change n invocation to `grpc_secure_channel_create` can actually creating an insecure channel if using copied args from a "parent" insecure channel (e.g., as is possible [here](https://github.com/grpc/grpc/blob/0bdeca47b620a7011cb6114026739be330518562/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel_secure.cc#L75) when creating an xds channel when using plaintext for the client-server connection but google default credentials for the lb channel).

@markdroth 