### PR TITLE
Remove memory_usage test from CI

### DIFF
--- a/tools/internal_ci/linux/grpc_performance_profile_daily.sh
+++ b/tools/internal_ci/linux/grpc_performance_profile_daily.sh
@@ -24,10 +24,6 @@ CPUS=`python -c 'import multiprocessing; print multiprocessing.cpu_count()'`
 
 ./tools/run_tests/start_port_server.py || true
 
-make CONFIG=opt memory_usage_test memory_usage_client memory_usage_server -j $CPUS
-bins/opt/memory_usage_test
-bq load microbenchmarks.memory memory_usage.csv
-
 tools/run_tests/run_microbenchmark.py --collect summary --bigquery_upload || FAILED="true"
 
 # kill port_server.py to prevent the build from hanging

--- a/tools/internal_ci/linux/run_performance_profile_hourly.sh
+++ b/tools/internal_ci/linux/run_performance_profile_hourly.sh
@@ -21,8 +21,4 @@ cd $(dirname $0)/../../..
 
 CPUS=`python -c 'import multiprocessing; print multiprocessing.cpu_count()'`
 
-make CONFIG=opt memory_usage_test memory_usage_client memory_usage_server -j $CPUS
-bins/opt/memory_usage_test
-bq load microbenchmarks.memory memory_usage.csv
-
 tools/run_tests/run_microbenchmark.py --collect summary --bigquery_upload


### PR DESCRIPTION
From #20462, there is no more `memory_usage` test so test should be removed from CI. Without this, `grpc_performance_profile_daily` and `grpc_performance_profile_master` fail. ([log](https://source.cloud.google.com/results/invocations/ddb33f07-33c5-4423-b7fc-509ad92cfba2/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_performance_profile_daily/log))