### PR TITLE
PHP: update dockerfiles to allow them to be run on release branches

### DIFF
--- a/src/php/docker/alpine/Dockerfile
+++ b/src/php/docker/alpine/Dockerfile
@@ -28,10 +28,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/grpc-ext/Dockerfile
+++ b/src/php/docker/grpc-ext/Dockerfile
@@ -30,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/grpc-src/Dockerfile
+++ b/src/php/docker/grpc-src/Dockerfile
@@ -30,16 +30,12 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init && \
-  make && make install
+COPY . .
+
+RUN make && make install
 
 
 WORKDIR /github/grpc/src/php/ext/grpc
-
-COPY src/php/ext/grpc/*.c ./
-COPY src/php/ext/grpc/*.h ./
-COPY src/php/ext/grpc/config.m4 ./
 
 RUN phpize && \
   ./configure --enable-tests && \

--- a/src/php/docker/php-future/Dockerfile
+++ b/src/php/docker/php-future/Dockerfile
@@ -30,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/php-src/Dockerfile
+++ b/src/php/docker/php-src/Dockerfile
@@ -52,10 +52,7 @@ RUN git checkout php-7.2.22 && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/php-zts/Dockerfile
+++ b/src/php/docker/php-zts/Dockerfile
@@ -30,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/php5/Dockerfile
+++ b/src/php/docker/php5/Dockerfile
@@ -30,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/templates/src/php/docker/grpc-src/Dockerfile.template
+++ b/templates/src/php/docker/grpc-src/Dockerfile.template
@@ -29,16 +29,12 @@
 
   WORKDIR /github/grpc
 
-  RUN git clone https://github.com/grpc/grpc . && ${'\\'}
-    git submodule update --init && ${'\\'}
-    make && make install
+  COPY . .
+
+  RUN make && make install
 
 
   WORKDIR /github/grpc/src/php/ext/grpc
-
-  COPY src/php/ext/grpc/*.c ./
-  COPY src/php/ext/grpc/*.h ./
-  COPY src/php/ext/grpc/config.m4 ./
 
   RUN phpize && ${'\\'}
     ./configure --enable-tests && ${'\\'}

--- a/templates/src/php/docker/pecl_ext_build_src.include
+++ b/templates/src/php/docker/pecl_ext_build_src.include
@@ -1,9 +1,6 @@
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && ${'\\'}
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && ${'\\'}
   find . -name grpc-*.tgz | xargs -I{} pecl install {}


### PR DESCRIPTION
Without this change, all these PHP dockerfiles will essentially only work with the `master` branch because we were doing a `git clone` without specifying which branch. 

With this change, we will just copy the entire current repo into the docker image before we build