### PR TITLE
PHP: backport dockerfile fixes

### DIFF
--- a/src/php/docker/alpine/Dockerfile
+++ b/src/php/docker/alpine/Dockerfile
@@ -16,6 +16,8 @@ FROM php:7.2-alpine3.9
 
 RUN apk add autoconf g++ make zlib-dev git bash wget
 
+ARG MAKEFLAGS=-j8
+
 
 WORKDIR /tmp
 
@@ -26,10 +28,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/grpc-ext/Dockerfile
+++ b/src/php/docker/grpc-ext/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \
   valgrind wget zlib1g-dev
 
+ARG MAKEFLAGS=-j8
+
 
 WORKDIR /tmp
 
@@ -28,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/grpc-src/Dockerfile
+++ b/src/php/docker/grpc-src/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \
   valgrind wget zlib1g-dev
 
+ARG MAKEFLAGS=-j8
+
 
 WORKDIR /tmp
 
@@ -28,16 +30,12 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init && \
-  make && make install
+COPY . .
+
+RUN make && make install
 
 
 WORKDIR /github/grpc/src/php/ext/grpc
-
-COPY src/php/ext/grpc/*.c ./
-COPY src/php/ext/grpc/*.h ./
-COPY src/php/ext/grpc/config.m4 ./
 
 RUN phpize && \
   ./configure --enable-tests && \

--- a/src/php/docker/php-future/Dockerfile
+++ b/src/php/docker/php-future/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \
   wget zlib1g-dev
 
+ARG MAKEFLAGS=-j8
+
 
 WORKDIR /tmp
 
@@ -28,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/php-src/Dockerfile
+++ b/src/php/docker/php-src/Dockerfile
@@ -36,6 +36,8 @@ RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz && \
 
 WORKDIR /github/php-src
 
+ARG MAKEFLAGS=-j8
+
 RUN git clone https://github.com/php/php-src .
 
 RUN git checkout php-7.2.22 && \
@@ -50,10 +52,7 @@ RUN git checkout php-7.2.22 && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/php-zts/Dockerfile
+++ b/src/php/docker/php-zts/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \
   wget zlib1g-dev
 
+ARG MAKEFLAGS=-j8
+
 
 WORKDIR /tmp
 
@@ -28,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/src/php/docker/php5/Dockerfile
+++ b/src/php/docker/php5/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \
   valgrind wget zlib1g-dev
 
+ARG MAKEFLAGS=-j8
+
 
 WORKDIR /tmp
 
@@ -28,10 +30,7 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/templates/src/php/docker/alpine/Dockerfile.template
+++ b/templates/src/php/docker/alpine/Dockerfile.template
@@ -18,6 +18,8 @@
 
   RUN apk add autoconf g++ make zlib-dev git bash wget
 
+  ARG MAKEFLAGS=-j8
+
 
   WORKDIR /tmp
 

--- a/templates/src/php/docker/grpc-ext/Dockerfile.template
+++ b/templates/src/php/docker/grpc-ext/Dockerfile.template
@@ -20,6 +20,8 @@
     autoconf automake git libtool pkg-config ${'\\'}
     valgrind wget zlib1g-dev
 
+  ARG MAKEFLAGS=-j8
+
 
   WORKDIR /tmp
 

--- a/templates/src/php/docker/grpc-src/Dockerfile.template
+++ b/templates/src/php/docker/grpc-src/Dockerfile.template
@@ -20,6 +20,8 @@
     autoconf automake git libtool pkg-config ${'\\'}
     valgrind wget zlib1g-dev
 
+  ARG MAKEFLAGS=-j8
+
 
   WORKDIR /tmp
 
@@ -27,16 +29,12 @@
 
   WORKDIR /github/grpc
 
-  RUN git clone https://github.com/grpc/grpc . && ${'\\'}
-    git submodule update --init && ${'\\'}
-    make && make install
+  COPY . .
+
+  RUN make && make install
 
 
   WORKDIR /github/grpc/src/php/ext/grpc
-
-  COPY src/php/ext/grpc/*.c ./
-  COPY src/php/ext/grpc/*.h ./
-  COPY src/php/ext/grpc/config.m4 ./
 
   RUN phpize && ${'\\'}
     ./configure --enable-tests && ${'\\'}

--- a/templates/src/php/docker/pecl_ext_build_src.include
+++ b/templates/src/php/docker/pecl_ext_build_src.include
@@ -1,9 +1,6 @@
 WORKDIR /github/grpc
 
-RUN git clone https://github.com/grpc/grpc . && ${'\\'}
-  git submodule update --init
-
-COPY src/ ./src
+COPY . .
 
 RUN pear package && ${'\\'}
   find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/templates/src/php/docker/php-future/Dockerfile.template
+++ b/templates/src/php/docker/php-future/Dockerfile.template
@@ -20,6 +20,8 @@
     autoconf automake git libtool pkg-config ${'\\'}
     wget zlib1g-dev
 
+  ARG MAKEFLAGS=-j8
+
 
   WORKDIR /tmp
 

--- a/templates/src/php/docker/php-src/Dockerfile.template
+++ b/templates/src/php/docker/php-src/Dockerfile.template
@@ -35,6 +35,8 @@
 
   WORKDIR /github/php-src
 
+  ARG MAKEFLAGS=-j8
+
   RUN git clone https://github.com/php/php-src .
 
   RUN git checkout php-7.2.22 && ${'\\'}

--- a/templates/src/php/docker/php-zts/Dockerfile.template
+++ b/templates/src/php/docker/php-zts/Dockerfile.template
@@ -20,6 +20,8 @@
     autoconf automake git libtool pkg-config ${'\\'}
     wget zlib1g-dev
 
+  ARG MAKEFLAGS=-j8
+
 
   WORKDIR /tmp
 

--- a/templates/src/php/docker/php5/Dockerfile.template
+++ b/templates/src/php/docker/php5/Dockerfile.template
@@ -20,6 +20,8 @@
     autoconf automake git libtool pkg-config ${'\\'}
     valgrind wget zlib1g-dev
 
+  ARG MAKEFLAGS=-j8
+
 
   WORKDIR /tmp
 


### PR DESCRIPTION
Backport a couple of PHP fixes to the `v1.25.x` branch:
#20944 : allow the dockerfiles to be built on release branches
#20811: make building these dockerfiles faster