### PR TITLE
Fix alloc/dealloc mismatch in alts_concurrent_connectivity_test

### DIFF
--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -172,9 +172,9 @@ class ConnectLoopRunner {
       const char* server_address, const char* fake_handshake_server_addr,
       int per_connect_deadline_seconds, size_t loops,
       grpc_connectivity_state expected_connectivity_states)
-      : server_address_(std::unique_ptr<char>(gpr_strdup(server_address))),
+      : server_address_(grpc_core::UniquePtr<char>(gpr_strdup(server_address))),
         fake_handshake_server_addr_(
-            std::unique_ptr<char>(gpr_strdup(fake_handshake_server_addr))),
+            grpc_core::UniquePtr<char>(gpr_strdup(fake_handshake_server_addr))),
         per_connect_deadline_seconds_(per_connect_deadline_seconds),
         loops_(loops),
         expected_connectivity_states_(expected_connectivity_states) {
@@ -222,8 +222,8 @@ class ConnectLoopRunner {
   }
 
  private:
-  std::unique_ptr<char> server_address_;
-  std::unique_ptr<char> fake_handshake_server_addr_;
+  grpc_core::UniquePtr<char> server_address_;
+  grpc_core::UniquePtr<char> fake_handshake_server_addr_;
   int per_connect_deadline_seconds_;
   size_t loops_;
   grpc_connectivity_state expected_connectivity_states_;
@@ -286,7 +286,7 @@ class FakeTcpServer {
     accept_socket_ = socket(AF_INET6, SOCK_STREAM, 0);
     char* addr_str;
     GPR_ASSERT(gpr_asprintf(&addr_str, "[::]:%d", port_));
-    address_ = std::unique_ptr<char>(addr_str);
+    address_ = grpc_core::UniquePtr<char>(addr_str);
     GPR_ASSERT(accept_socket_ != -1);
     if (accept_socket_ == -1) {
       gpr_log(GPR_ERROR, "Failed to create socket: %d", errno);
@@ -426,7 +426,7 @@ class FakeTcpServer {
   int accept_socket_;
   int port_;
   gpr_event stop_ev_;
-  std::unique_ptr<char> address_;
+  grpc_core::UniquePtr<char> address_;
   std::unique_ptr<std::thread> run_server_loop_thd_;
   std::function<ProcessReadResult(int, int, int)> process_read_cb_;
 };


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/20596 is causing a build failure on master branch's `grpc/core/master/linux/sanitizer/grpc_cpp_asan` tests, with this error:

```
D1105 23:05:59.399054581   18709 alts_concurrent_connectivity_test.cc:220] runner:0x7ffcb5b90da0 connect_loop finished loop 9
=================================================================
[1m[31m==18701==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete) on 0x602000011070
[1m[0m    #0 0x7c1bd2 in operator delete(void*) /tmp/clang-build/src/compiler-rt/lib/asan/asan_new_delete.cc:149:3
    #1 0x8b4304 in std::default_delete<char>::operator()(char*) const /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/unique_ptr.h:76:2
    #2 0x8b41d3 in std::unique_ptr<char, std::default_delete<char> >::~unique_ptr() /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/unique_ptr.h:236:4
    #3 0x899871 in (anonymous namespace)::ConnectLoopRunner::~ConnectLoopRunner() /var/local/git/grpc/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc:184:40
    #4 0x8989bd in (anonymous namespace)::AltsConcurrentConnectivityTest_TestBasicClientServerHandshakes_Test::TestBody() /var/local/git/grpc/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc:243:3
    #5 0x1842062 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2439:10
    #6 0x1807ca1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2475:14
    #7 0x17c064e in testing::Test::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2514:5
    #8 0x17c2691 in testing::TestInfo::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2690:11
    #9 0x17c390b in testing::TestSuite::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2822:28
    #10 0x17df834 in testing::internal::UnitTestImpl::RunAllTests() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:5342:44
    #11 0x184c8dd in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2439:10
    #12 0x180e271 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2475:14
    #13 0x17deba6 in testing::UnitTest::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:4930:10
    #14 0x8abd5c in RUN_ALL_TESTS() /var/local/git/grpc/third_party/googletest/googletest/include/gtest/gtest.h:2472:46
    #15 0x898588 in main /var/local/git/grpc/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc:473:17
    #16 0x7fa3a09f0b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    #17 0x6f0608 in _start (/var/local/git/grpc/bins/asan/alts_concurrent_connectivity_test+0x6f0608)

[1m[32m0x602000011070 is located 0 bytes inside of 16-byte region [0x602000011070,0x602000011080)
[1m[0m[1m[35mallocated by thread T0 here:[1m[0m
    #0 0x794313 in __interceptor_malloc /tmp/clang-build/src/compiler-rt/lib/asan/asan_malloc_linux.cc:88:3
    #1 0xba02f2 in gpr_malloc /var/local/git/grpc/src/core/lib/gpr/alloc.cc:32:7
    #2 0xba29c1 in gpr_strdup /var/local/git/grpc/src/core/lib/gpr/string.cc:46:28
    #3 0x8995fe in (anonymous namespace)::ConnectLoopRunner::ConnectLoopRunner(char const*, char const*, int, unsigned long, grpc_connectivity_state) /var/local/git/grpc/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc:177:35
    #4 0x8989b4 in (anonymous namespace)::AltsConcurrentConnectivityTest_TestBasicClientServerHandshakes_Test::TestBody() /var/local/git/grpc/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc:239:23
    #5 0x1842062 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2439:10
    #6 0x1807ca1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2475:14
    #7 0x17c064e in testing::Test::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2514:5
    #8 0x17c2691 in testing::TestInfo::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2690:11
    #9 0x17c390b in testing::TestSuite::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2822:28
    #10 0x17df834 in testing::internal::UnitTestImpl::RunAllTests() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:5342:44
    #11 0x184c8dd in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2439:10
    #12 0x180e271 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:2475:14
    #13 0x17deba6 in testing::UnitTest::Run() /var/local/git/grpc/third_party/googletest/googletest/src/gtest.cc:4930:10
    #14 0x8abd5c in RUN_ALL_TESTS() /var/local/git/grpc/third_party/googletest/googletest/include/gtest/gtest.h:2472:46
    #15 0x898588 in main /var/local/git/grpc/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc:473:17
    #16 0x7fa3a09f0b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch /tmp/clang-build/src/compiler-rt/lib/asan/asan_new_delete.cc:149:3 in operator delete(void*)
==18701==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==18701==ABORTING
Command exited with non-zero status 1
```

(from https://source.cloud.google.com/results/invocations/f66078dc-2ea8-469f-afb7-5f14486609a1/targets/github%2Fgrpc%2Frun_tests%2Fcpp_linux_asan_native_x64_clang7.0/tests;group=cpp_linux_asan_native_x64_clang7_0;test=bins%2Fasan%2Falts_concurrent_connectivity_test%20GRPC_POLL_STRATEGY%3Depoll1;row=3)

@nanahpang 
