### PR TITLE
Disable flaky timer_test on windows

### DIFF
--- a/test/cpp/common/timer_test.cc
+++ b/test/cpp/common/timer_test.cc
@@ -61,6 +61,10 @@ class TimerTest : public ::testing::Test {
   bool do_not_test_{false};
 };
 
+#ifndef GPR_WINDOWS
+// the test fails with too many wakeups on windows opt build
+// the mechanism by which that happens is described in
+// https://github.com/grpc/grpc/issues/20436
 TEST_F(TimerTest, NoTimers) {
   MAYBE_SKIP_TEST;
   grpc_core::ExecCtx exec_ctx;
@@ -71,6 +75,7 @@ TEST_F(TimerTest, NoTimers) {
   int64_t wakeups = grpc_timer_manager_get_wakeups_testonly();
   GPR_ASSERT(wakeups == 1 || wakeups == 2);
 }
+#endif
 
 TEST_F(TimerTest, OneTimerExpires) {
   MAYBE_SKIP_TEST;


### PR DESCRIPTION
Workaround for https://github.com/grpc/grpc/issues/20436 that has had high flakiness rate on windows opt build for a while.