### PR TITLE
Replaced unique_ptr<char> with string for channelz

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <string>
+
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/channel_trace.h"
@@ -34,7 +36,7 @@ namespace channelz {
 
 class SubchannelNode : public BaseNode {
  public:
-  SubchannelNode(const char* target_address, size_t channel_tracer_max_nodes);
+  SubchannelNode(std::string target_address, size_t channel_tracer_max_nodes);
   ~SubchannelNode() override;
 
   // Sets the subchannel's connectivity state without health checking.
@@ -67,7 +69,7 @@ class SubchannelNode : public BaseNode {
   Atomic<grpc_connectivity_state> connectivity_state_{GRPC_CHANNEL_IDLE};
   Mutex socket_mu_;
   RefCountedPtr<SocketNode> child_socket_;
-  UniquePtr<char> target_;
+  std::string target_;
   CallCountingHelper call_counter_;
   ChannelTrace trace_;
 };

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -417,8 +417,10 @@ grpc_error* grpc_chttp2_server_add_port(grpc_server* server, const char* addr,
     gpr_asprintf(&socket_name, "chttp2 listener %s", addr);
     state->channelz_listen_socket =
         grpc_core::MakeRefCounted<grpc_core::channelz::ListenSocketNode>(
-            grpc_core::UniquePtr<char>(gpr_strdup(addr)),
-            grpc_core::UniquePtr<char>(socket_name));
+            addr, socket_name);
+    // TODO(veblush): Remove this once gpr_asprintf is replaced by
+    // absl::StrFormat
+    gpr_free(socket_name);
   }
 
   /* Register with the server only upon success */

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -382,9 +382,10 @@ static bool read_channel_args(grpc_chttp2_transport* t,
     gpr_asprintf(&socket_name, "%s %s", get_vtable()->name, t->peer_string);
     t->channelz_socket =
         grpc_core::MakeRefCounted<grpc_core::channelz::SocketNode>(
-            grpc_core::UniquePtr<char>(),
-            grpc_core::UniquePtr<char>(gpr_strdup(t->peer_string)),
-            grpc_core::UniquePtr<char>(socket_name));
+            "", t->peer_string, socket_name);
+    // TODO(veblush): Remove this once gpr_asprintf is replaced by
+    // absl::StrFormat
+    gpr_free(socket_name);
   }
   return enable_bdp;
 }

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -85,7 +85,7 @@ intptr_t GetParentUuidFromArgs(const grpc_channel_args& args) {
 // BaseNode
 //
 
-BaseNode::BaseNode(EntityType type, UniquePtr<char> name)
+BaseNode::BaseNode(EntityType type, std::string name)
     : type_(type), uuid_(-1), name_(std::move(name)) {
   // The registry will set uuid_ under its lock.
   ChannelzRegistry::Register(this);
@@ -180,11 +180,11 @@ void CallCountingHelper::PopulateCallCounts(grpc_json* json) {
 // ChannelNode
 //
 
-ChannelNode::ChannelNode(UniquePtr<char> target,
-                         size_t channel_tracer_max_nodes, intptr_t parent_uuid)
+ChannelNode::ChannelNode(std::string target, size_t channel_tracer_max_nodes,
+                         intptr_t parent_uuid)
     : BaseNode(parent_uuid == 0 ? EntityType::kTopLevelChannel
                                 : EntityType::kInternalChannel,
-               UniquePtr<char>(gpr_strdup(target.get()))),
+               target),
       target_(std::move(target)),
       trace_(channel_tracer_max_nodes),
       parent_uuid_(parent_uuid) {}
@@ -239,8 +239,8 @@ grpc_json* ChannelNode::RenderJson() {
     json = data;
   }
   // populate the target.
-  GPR_ASSERT(target_.get() != nullptr);
-  grpc_json_create_child(nullptr, json, "target", target_.get(),
+  GPR_ASSERT(!target_.empty());
+  grpc_json_create_child(nullptr, json, "target", target_.c_str(),
                          GRPC_JSON_STRING, false);
   // fill in the channel trace if applicable
   grpc_json* trace_json = trace_.RenderJson();
@@ -316,8 +316,7 @@ void ChannelNode::RemoveChildSubchannel(intptr_t child_uuid) {
 //
 
 ServerNode::ServerNode(grpc_server* /*server*/, size_t channel_tracer_max_nodes)
-    : BaseNode(EntityType::kServer, /* name */ nullptr),
-      trace_(channel_tracer_max_nodes) {}
+    : BaseNode(EntityType::kServer, ""), trace_(channel_tracer_max_nodes) {}
 
 ServerNode::~ServerNode() {}
 
@@ -363,7 +362,8 @@ char* ServerNode::RenderServerSockets(intptr_t start_socket_id,
       json_iterator = grpc_json_add_number_string_child(
           socket_ref_json, nullptr, "socketId", it->first);
       grpc_json_create_child(json_iterator, socket_ref_json, "name",
-                             it->second->name(), GRPC_JSON_STRING, false);
+                             it->second->name().c_str(), GRPC_JSON_STRING,
+                             false);
     }
   }
   if (sockets_rendered == child_sockets_.size()) {
@@ -416,7 +416,8 @@ grpc_json* ServerNode::RenderJson() {
       grpc_json* sibling_iterator = grpc_json_add_number_string_child(
           json_iterator, nullptr, "socketId", it.first);
       grpc_json_create_child(sibling_iterator, json_iterator, "name",
-                             it.second->name(), GRPC_JSON_STRING, false);
+                             it.second->name().c_str(), GRPC_JSON_STRING,
+                             false);
     }
   }
   return top_level_json;
@@ -479,8 +480,7 @@ void PopulateSocketAddressJson(grpc_json* json, const char* name,
 
 }  // namespace
 
-SocketNode::SocketNode(UniquePtr<char> local, UniquePtr<char> remote,
-                       UniquePtr<char> name)
+SocketNode::SocketNode(std::string local, std::string remote, std::string name)
     : BaseNode(EntityType::kSocket, std::move(name)),
       local_(std::move(local)),
       remote_(std::move(remote)) {}
@@ -520,11 +520,11 @@ grpc_json* SocketNode::RenderJson() {
   json_iterator = nullptr;
   json_iterator = grpc_json_add_number_string_child(json, json_iterator,
                                                     "socketId", uuid());
-  json_iterator = grpc_json_create_child(json_iterator, json, "name", name(),
-                                         GRPC_JSON_STRING, false);
+  json_iterator = grpc_json_create_child(
+      json_iterator, json, "name", name().c_str(), GRPC_JSON_STRING, false);
   json = top_level_json;
-  PopulateSocketAddressJson(json, "remote", remote_.get());
-  PopulateSocketAddressJson(json, "local", local_.get());
+  PopulateSocketAddressJson(json, "remote", remote_.c_str());
+  PopulateSocketAddressJson(json, "local", local_.c_str());
   // reset json iterators to top level object
   json = top_level_json;
   json_iterator = nullptr;
@@ -605,8 +605,7 @@ grpc_json* SocketNode::RenderJson() {
 // ListenSocketNode
 //
 
-ListenSocketNode::ListenSocketNode(UniquePtr<char> local_addr,
-                                   UniquePtr<char> name)
+ListenSocketNode::ListenSocketNode(std::string local_addr, std::string name)
     : BaseNode(EntityType::kSocket, std::move(name)),
       local_addr_(std::move(local_addr)) {}
 
@@ -622,10 +621,10 @@ grpc_json* ListenSocketNode::RenderJson() {
   json_iterator = nullptr;
   json_iterator = grpc_json_add_number_string_child(json, json_iterator,
                                                     "socketId", uuid());
-  json_iterator = grpc_json_create_child(json_iterator, json, "name", name(),
-                                         GRPC_JSON_STRING, false);
+  json_iterator = grpc_json_create_child(
+      json_iterator, json, "name", name().c_str(), GRPC_JSON_STRING, false);
   json = top_level_json;
-  PopulateSocketAddressJson(json, "local", local_addr_.get());
+  PopulateSocketAddressJson(json, "local", local_addr_.c_str());
 
   return top_level_json;
 }

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -23,6 +23,8 @@
 
 #include <grpc/grpc.h>
 
+#include <string>
+
 #include "src/core/lib/channel/channel_trace.h"
 #include "src/core/lib/gpr/time_precise.h"
 #include "src/core/lib/gprpp/inlined_vector.h"
@@ -82,7 +84,7 @@ class BaseNode : public RefCounted<BaseNode> {
   };
 
  protected:
-  BaseNode(EntityType type, UniquePtr<char> name);
+  BaseNode(EntityType type, std::string name);
 
  public:
   virtual ~BaseNode();
@@ -96,14 +98,14 @@ class BaseNode : public RefCounted<BaseNode> {
 
   EntityType type() const { return type_; }
   intptr_t uuid() const { return uuid_; }
-  const char* name() const { return name_.get(); }
+  const std::string& name() const { return name_; }
 
  private:
   // to allow the ChannelzRegistry to set uuid_ under its lock.
   friend class ChannelzRegistry;
   const EntityType type_;
   intptr_t uuid_;
-  UniquePtr<char> name_;
+  std::string name_;
 };
 
 // This class is a helper class for channelz entities that deal with Channels,
@@ -165,7 +167,7 @@ class CallCountingHelper {
 // Handles channelz bookkeeping for channels
 class ChannelNode : public BaseNode {
  public:
-  ChannelNode(UniquePtr<char> target, size_t channel_tracer_max_nodes,
+  ChannelNode(std::string target, size_t channel_tracer_max_nodes,
               intptr_t parent_uuid);
 
   // Returns the string description of the given connectivity state.
@@ -208,7 +210,7 @@ class ChannelNode : public BaseNode {
   // to allow the channel trace test to access trace_.
   friend class testing::ChannelNodePeer;
 
-  UniquePtr<char> target_;
+  std::string target_;
   CallCountingHelper call_counter_;
   ChannelTrace trace_;
   const intptr_t parent_uuid_;
@@ -269,8 +271,7 @@ class ServerNode : public BaseNode {
 // Handles channelz bookkeeping for sockets
 class SocketNode : public BaseNode {
  public:
-  SocketNode(UniquePtr<char> local, UniquePtr<char> remote,
-             UniquePtr<char> name);
+  SocketNode(std::string local, std::string remote, std::string name);
   ~SocketNode() override {}
 
   grpc_json* RenderJson() override;
@@ -289,7 +290,7 @@ class SocketNode : public BaseNode {
     gpr_atm_no_barrier_fetch_add(&keepalives_sent_, static_cast<gpr_atm>(1));
   }
 
-  const char* remote() { return remote_.get(); }
+  const std::string& remote() { return remote_; }
 
  private:
   gpr_atm streams_started_ = 0;
@@ -302,20 +303,20 @@ class SocketNode : public BaseNode {
   gpr_atm last_remote_stream_created_cycle_ = 0;
   gpr_atm last_message_sent_cycle_ = 0;
   gpr_atm last_message_received_cycle_ = 0;
-  UniquePtr<char> local_;
-  UniquePtr<char> remote_;
+  std::string local_;
+  std::string remote_;
 };
 
 // Handles channelz bookkeeping for listen sockets
 class ListenSocketNode : public BaseNode {
  public:
-  ListenSocketNode(UniquePtr<char> local_addr, UniquePtr<char> name);
+  ListenSocketNode(std::string local_addr, std::string name);
   ~ListenSocketNode() override {}
 
   grpc_json* RenderJson() override;
 
  private:
-  UniquePtr<char> local_addr_;
+  std::string local_addr_;
 };
 
 }  // namespace channelz

--- a/src/core/lib/gprpp/string_view.h
+++ b/src/core/lib/gprpp/string_view.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <string>
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/useful.h"
@@ -109,6 +110,15 @@ class StringView final {
   void clear() {
     ptr_ = nullptr;
     size_ = 0;
+  }
+
+  // Converts to `std::basic_string`.
+  template <typename Allocator>
+  explicit operator std::basic_string<char, std::char_traits<char>, Allocator>()
+      const {
+    if (data() == nullptr) return {};
+    return std::basic_string<char, std::char_traits<char>, Allocator>(data(),
+                                                                      size());
   }
 
  private:

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -202,11 +202,11 @@ void CreateChannelzNode(grpc_channel_stack_builder* builder) {
   const intptr_t channelz_parent_uuid =
       grpc_core::channelz::GetParentUuidFromArgs(*args);
   // Create the channelz node.
+  const char* target = grpc_channel_stack_builder_get_target(builder);
   grpc_core::RefCountedPtr<grpc_core::channelz::ChannelNode> channelz_node =
       grpc_core::MakeRefCounted<grpc_core::channelz::ChannelNode>(
-          grpc_core::UniquePtr<char>(
-              gpr_strdup(grpc_channel_stack_builder_get_target(builder))),
-          channel_tracer_max_memory, channelz_parent_uuid);
+          target != nullptr ? target : "", channel_tracer_max_memory,
+          channelz_parent_uuid);
   channelz_node->AddTraceEvent(
       grpc_core::channelz::ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("Channel created"));

--- a/test/core/channel/channel_trace_test.cc
+++ b/test/core/channel/channel_trace_test.cc
@@ -174,8 +174,8 @@ TEST(ChannelTracerTest, ComplexTest) {
   AddSimpleTrace(&tracer);
   AddSimpleTrace(&tracer);
   ChannelFixture channel1(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc1 = MakeRefCounted<ChannelNode>(
-      UniquePtr<char>(gpr_strdup("fake_target")), kEventListMemoryLimit, 0);
+  RefCountedPtr<ChannelNode> sc1 =
+      MakeRefCounted<ChannelNode>("fake_target", kEventListMemoryLimit, 0);
   ChannelNodePeer sc1_peer(sc1.get());
   tracer.AddTraceEventWithReference(
       ChannelTrace::Severity::Info,
@@ -193,8 +193,8 @@ TEST(ChannelTracerTest, ComplexTest) {
   AddSimpleTrace(&tracer);
   ValidateChannelTrace(&tracer, 5);
   ChannelFixture channel2(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc2 = MakeRefCounted<ChannelNode>(
-      UniquePtr<char>(gpr_strdup("fake_target")), kEventListMemoryLimit, 0);
+  RefCountedPtr<ChannelNode> sc2 =
+      MakeRefCounted<ChannelNode>("fake_target", kEventListMemoryLimit, 0);
   tracer.AddTraceEventWithReference(
       ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("LB channel two created"), sc2);
@@ -222,8 +222,8 @@ TEST(ChannelTracerTest, TestNesting) {
   AddSimpleTrace(&tracer);
   ValidateChannelTrace(&tracer, 2);
   ChannelFixture channel1(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc1 = MakeRefCounted<ChannelNode>(
-      UniquePtr<char>(gpr_strdup("fake_target")), kEventListMemoryLimit, 0);
+  RefCountedPtr<ChannelNode> sc1 =
+      MakeRefCounted<ChannelNode>("fake_target", kEventListMemoryLimit, 0);
   ChannelNodePeer sc1_peer(sc1.get());
   tracer.AddTraceEventWithReference(
       ChannelTrace::Severity::Info,
@@ -231,8 +231,8 @@ TEST(ChannelTracerTest, TestNesting) {
   ValidateChannelTrace(&tracer, 3);
   AddSimpleTrace(sc1_peer.trace());
   ChannelFixture channel2(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> conn1 = MakeRefCounted<ChannelNode>(
-      UniquePtr<char>(gpr_strdup("fake_target")), kEventListMemoryLimit, 0);
+  RefCountedPtr<ChannelNode> conn1 =
+      MakeRefCounted<ChannelNode>("fake_target", kEventListMemoryLimit, 0);
   ChannelNodePeer conn1_peer(conn1.get());
   // nesting one level deeper.
   sc1_peer.trace()->AddTraceEventWithReference(
@@ -245,8 +245,8 @@ TEST(ChannelTracerTest, TestNesting) {
   ValidateChannelTrace(&tracer, 5);
   ValidateChannelTrace(conn1_peer.trace(), 1);
   ChannelFixture channel3(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc2 = MakeRefCounted<ChannelNode>(
-      UniquePtr<char>(gpr_strdup("fake_target")), kEventListMemoryLimit, 0);
+  RefCountedPtr<ChannelNode> sc2 =
+      MakeRefCounted<ChannelNode>("fake_target", kEventListMemoryLimit, 0);
   tracer.AddTraceEventWithReference(
       ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("subchannel two created"), sc2);

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -52,8 +52,7 @@ class ChannelzRegistryTest : public ::testing::Test {
 };
 
 static RefCountedPtr<BaseNode> CreateTestNode() {
-  return MakeRefCounted<ListenSocketNode>(UniquePtr<char>(gpr_strdup("test")),
-                                          UniquePtr<char>(gpr_strdup("test")));
+  return MakeRefCounted<ListenSocketNode>("test", "test");
 }
 
 TEST_F(ChannelzRegistryTest, UuidStartsAboveZeroTest) {


### PR DESCRIPTION
SideNote: Once absl is enabled, code  

```
char* socket_name = nullptr;
gpr_asprintf(&socket_name, "chttp2 listener %s", addr);
new grpc_core::channelz::ListenSocketNode(addr, socket_name);
```

can be replaced with

```
new grpc_core::channelz::ListenSocketNode(
  addr, 
  absl::StrFormat("chttp2 listener %s", addr));
```

This would be better because i) constructed string can move to member variable and ii) it looks more readable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/20965)
<!-- Reviewable:end -->
