### PR TITLE
Constify parameter struct since all fields set at construction

### DIFF
--- a/include/grpcpp/impl/codegen/rpc_service_method.h
+++ b/include/grpcpp/impl/codegen/rpc_service_method.h
@@ -62,12 +62,12 @@ class MethodHandler {
           internal_data(handler_data),
           call_requester(std::move(requester)) {}
     ~HandlerParameter() {}
-    Call* call;
-    ::grpc_impl::ServerContext* server_context;
-    void* request;
-    Status status;
-    void* internal_data;
-    std::function<void()> call_requester;
+    Call* const call;
+    ::grpc_impl::ServerContext* const server_context;
+    void* const request;
+    const Status status;
+    void* const internal_data;
+    const std::function<void()> call_requester;
   };
   virtual void RunHandler(const HandlerParameter& param) = 0;
 


### PR DESCRIPTION
Improve readability
