### PR TITLE
 Replaced grpc_core::UniquePtr with std::unique_ptr

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -228,7 +228,7 @@ class ChannelData {
 
   void UpdateStateAndPickerLocked(
       grpc_connectivity_state state, const char* reason,
-      UniquePtr<LoadBalancingPolicy::SubchannelPicker> picker);
+      std::unique_ptr<LoadBalancingPolicy::SubchannelPicker> picker);
 
   void UpdateServiceConfigLocked(
       RefCountedPtr<ServerRetryThrottleData> retry_throttle_data,
@@ -252,7 +252,7 @@ class ChannelData {
   void ProcessLbPolicy(
       const Resolver::Result& resolver_result,
       const internal::ClientChannelGlobalParsedConfig* parsed_service_config,
-      UniquePtr<char>* lb_policy_name,
+      std::unique_ptr<char>* lb_policy_name,
       RefCountedPtr<LoadBalancingPolicy::Config>* lb_policy_config);
 
   //
@@ -265,15 +265,15 @@ class ChannelData {
   ClientChannelFactory* client_channel_factory_;
   const grpc_channel_args* channel_args_;
   RefCountedPtr<ServiceConfig> default_service_config_;
-  UniquePtr<char> server_name_;
-  UniquePtr<char> target_uri_;
+  std::unique_ptr<char> server_name_;
+  std::unique_ptr<char> target_uri_;
   channelz::ChannelNode* channelz_node_;
 
   //
   // Fields used in the data plane.  Guarded by data_plane_mu.
   //
   mutable Mutex data_plane_mu_;
-  UniquePtr<LoadBalancingPolicy::SubchannelPicker> picker_;
+  std::unique_ptr<LoadBalancingPolicy::SubchannelPicker> picker_;
   QueuedPick* queued_picks_ = nullptr;  // Linked list of queued picks.
   // Data from service config.
   bool received_service_config_data_ = false;
@@ -288,7 +288,7 @@ class ChannelData {
   RefCountedPtr<SubchannelPoolInterface> subchannel_pool_;
   OrphanablePtr<ResolvingLoadBalancingPolicy> resolving_lb_policy_;
   ConnectivityStateTracker state_tracker_;
-  UniquePtr<char> health_check_service_name_;
+  std::unique_ptr<char> health_check_service_name_;
   RefCountedPtr<ServiceConfig> saved_service_config_;
   bool received_first_resolver_result_ = false;
   // The number of SubchannelWrapper instances referencing a given Subchannel.
@@ -314,8 +314,8 @@ class ChannelData {
   // synchronously via get_channel_info().
   //
   gpr_mu info_mu_;
-  UniquePtr<char> info_lb_policy_name_;
-  UniquePtr<char> info_service_config_json_;
+  std::unique_ptr<char> info_lb_policy_name_;
+  std::unique_ptr<char> info_service_config_json_;
 
   //
   // Fields guarded by a mutex, since they need to be accessed
@@ -843,7 +843,7 @@ class CallData {
 class ChannelData::SubchannelWrapper : public SubchannelInterface {
  public:
   SubchannelWrapper(ChannelData* chand, Subchannel* subchannel,
-                    UniquePtr<char> health_check_service_name)
+                    std::unique_ptr<char> health_check_service_name)
       : SubchannelInterface(&grpc_client_channel_routing_trace),
         chand_(chand),
         subchannel_(subchannel),
@@ -898,7 +898,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
 
   void WatchConnectivityState(
       grpc_connectivity_state initial_state,
-      UniquePtr<ConnectivityStateWatcherInterface> watcher) override {
+      std::unique_ptr<ConnectivityStateWatcherInterface> watcher) override {
     auto& watcher_wrapper = watcher_map_[watcher.get()];
     GPR_ASSERT(watcher_wrapper == nullptr);
     watcher_wrapper = new WatcherWrapper(std::move(watcher),
@@ -906,7 +906,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
                                          initial_state);
     subchannel_->WatchConnectivityState(
         initial_state,
-        UniquePtr<char>(gpr_strdup(health_check_service_name_.get())),
+        std::unique_ptr<char>(gpr_strdup(health_check_service_name_.get())),
         OrphanablePtr<Subchannel::ConnectivityStateWatcherInterface>(
             watcher_wrapper));
   }
@@ -928,7 +928,8 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
     return subchannel_->channel_args();
   }
 
-  void UpdateHealthCheckServiceName(UniquePtr<char> health_check_service_name) {
+  void UpdateHealthCheckServiceName(
+      std::unique_ptr<char> health_check_service_name) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
       gpr_log(GPR_INFO,
               "chand=%p: subchannel wrapper %p: updating health check service "
@@ -954,7 +955,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
       watcher_wrapper = replacement;
       subchannel_->WatchConnectivityState(
           replacement->last_seen_state(),
-          UniquePtr<char>(gpr_strdup(health_check_service_name.get())),
+          std::unique_ptr<char>(gpr_strdup(health_check_service_name.get())),
           OrphanablePtr<Subchannel::ConnectivityStateWatcherInterface>(
               replacement));
     }
@@ -994,7 +995,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
   class WatcherWrapper : public Subchannel::ConnectivityStateWatcherInterface {
    public:
     WatcherWrapper(
-        UniquePtr<SubchannelInterface::ConnectivityStateWatcherInterface>
+        std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>
             watcher,
         RefCountedPtr<SubchannelWrapper> parent,
         grpc_connectivity_state initial_state)
@@ -1083,7 +1084,8 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
       grpc_closure closure_;
     };
 
-    UniquePtr<SubchannelInterface::ConnectivityStateWatcherInterface> watcher_;
+    std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>
+        watcher_;
     RefCountedPtr<SubchannelWrapper> parent_;
     grpc_connectivity_state last_seen_state_;
     WatcherWrapper* replacement_ = nullptr;
@@ -1112,7 +1114,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
 
   ChannelData* chand_;
   Subchannel* subchannel_;
-  UniquePtr<char> health_check_service_name_;
+  std::unique_ptr<char> health_check_service_name_;
   // Maps from the address of the watcher passed to us by the LB policy
   // to the address of the WrapperWatcher that we passed to the underlying
   // subchannel.  This is needed so that when the LB policy calls
@@ -1298,7 +1300,7 @@ class ChannelData::ClientChannelControlHelper
       const grpc_channel_args& args) override {
     bool inhibit_health_checking = grpc_channel_arg_get_bool(
         grpc_channel_args_find(&args, GRPC_ARG_INHIBIT_HEALTH_CHECKING), false);
-    UniquePtr<char> health_check_service_name;
+    std::unique_ptr<char> health_check_service_name;
     if (!inhibit_health_checking) {
       health_check_service_name.reset(
           gpr_strdup(chand_->health_check_service_name_.get()));
@@ -1321,7 +1323,7 @@ class ChannelData::ClientChannelControlHelper
 
   void UpdateState(
       grpc_connectivity_state state,
-      UniquePtr<LoadBalancingPolicy::SubchannelPicker> picker) override {
+      std::unique_ptr<LoadBalancingPolicy::SubchannelPicker> picker) override {
     grpc_error* disconnect_error = chand_->disconnect_error();
     if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
       const char* extra = disconnect_error == GRPC_ERROR_NONE
@@ -1494,7 +1496,7 @@ ChannelData::~ChannelData() {
 
 void ChannelData::UpdateStateAndPickerLocked(
     grpc_connectivity_state state, const char* reason,
-    UniquePtr<LoadBalancingPolicy::SubchannelPicker> picker) {
+    std::unique_ptr<LoadBalancingPolicy::SubchannelPicker> picker) {
   // Clean the control plane when entering IDLE.
   if (picker_ == nullptr) {
     health_check_service_name_.reset();
@@ -1594,7 +1596,7 @@ void ChannelData::CreateResolvingLoadBalancingPolicyLocked() {
   lb_args.combiner = combiner_;
   lb_args.channel_control_helper = MakeUnique<ClientChannelControlHelper>(this);
   lb_args.args = channel_args_;
-  UniquePtr<char> target_uri(gpr_strdup(target_uri_.get()));
+  std::unique_ptr<char> target_uri(gpr_strdup(target_uri_.get()));
   resolving_lb_policy_.reset(new ResolvingLoadBalancingPolicy(
       std::move(lb_args), &grpc_client_channel_routing_trace,
       std::move(target_uri), ProcessResolverResultLocked, this));
@@ -1617,7 +1619,7 @@ void ChannelData::DestroyResolvingLoadBalancingPolicyLocked() {
 void ChannelData::ProcessLbPolicy(
     const Resolver::Result& resolver_result,
     const internal::ClientChannelGlobalParsedConfig* parsed_service_config,
-    UniquePtr<char>* lb_policy_name,
+    std::unique_ptr<char>* lb_policy_name,
     RefCountedPtr<LoadBalancingPolicy::Config>* lb_policy_config) {
   // Prefer the LB policy name found in the service config.
   if (parsed_service_config != nullptr &&
@@ -1712,7 +1714,7 @@ bool ChannelData::ProcessResolverResultLocked(
     return false;
   }
   // Process service config.
-  UniquePtr<char> service_config_json;
+  std::unique_ptr<char> service_config_json;
   const internal::ClientChannelGlobalParsedConfig* parsed_service_config =
       nullptr;
   if (service_config != nullptr) {
@@ -1746,8 +1748,8 @@ bool ChannelData::ProcessResolverResultLocked(
     }
     // Update health check service name used by existing subchannel wrappers.
     for (auto* subchannel_wrapper : chand->subchannel_wrappers_) {
-      subchannel_wrapper->UpdateHealthCheckServiceName(
-          UniquePtr<char>(gpr_strdup(chand->health_check_service_name_.get())));
+      subchannel_wrapper->UpdateHealthCheckServiceName(std::unique_ptr<char>(
+          gpr_strdup(chand->health_check_service_name_.get())));
     }
     // Save service config.
     chand->saved_service_config_ = std::move(service_config);
@@ -1772,7 +1774,7 @@ bool ChannelData::ProcessResolverResultLocked(
     chand->UpdateServiceConfigLocked(std::move(retry_throttle_data),
                                      chand->saved_service_config_);
   }
-  UniquePtr<char> processed_lb_policy_name;
+  std::unique_ptr<char> processed_lb_policy_name;
   chand->ProcessLbPolicy(result, parsed_service_config,
                          &processed_lb_policy_name, lb_policy_config);
   // Swap out the data used by GetChannelInfo().

--- a/src/core/ext/filters/client_channel/health/health_check_client.cc
+++ b/src/core/ext/filters/client_channel/health/health_check_client.cc
@@ -200,7 +200,7 @@ bool DecodeResponse(grpc_slice_buffer* slice_buffer, grpc_error** error) {
     return false;
   }
   // Concatenate the slices to form a single string.
-  UniquePtr<uint8_t> recv_message_deleter;
+  std::unique_ptr<uint8_t> recv_message_deleter;
   uint8_t* recv_message;
   if (slice_buffer->count == 1) {
     recv_message = GRPC_SLICE_START_PTR(slice_buffer->slices[0]);

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -130,8 +130,8 @@ static bool proxy_mapper_map_name(grpc_proxy_mapper* /*mapper*/,
   if (no_proxy_str != nullptr) {
     static const char* NO_PROXY_SEPARATOR = ",";
     bool use_proxy = true;
-    grpc_core::UniquePtr<char> server_host;
-    grpc_core::UniquePtr<char> server_port;
+    std::unique_ptr<char> server_host;
+    std::unique_ptr<char> server_port;
     if (!grpc_core::SplitHostPort(
             uri->path[0] == '/' ? uri->path + 1 : uri->path, &server_host,
             &server_port)) {

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -269,7 +269,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     /// Sets the connectivity state and returns a new picker to be used
     /// by the client channel.
     virtual void UpdateState(grpc_connectivity_state state,
-                             UniquePtr<SubchannelPicker>) = 0;
+                             std::unique_ptr<SubchannelPicker>) = 0;
 
     /// Requests that the resolver re-resolve.
     virtual void RequestReresolution() = 0;
@@ -318,7 +318,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     /// Channel control helper.
     /// Note: LB policies MUST NOT call any method on the helper from
     /// their constructor.
-    UniquePtr<ChannelControlHelper> channel_control_helper;
+    std::unique_ptr<ChannelControlHelper> channel_control_helper;
     /// Channel args.
     // TODO(roth): Find a better channel args representation for this API.
     // TODO(roth): Clarify ownership semantics here -- currently, this
@@ -404,7 +404,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
   /// Owned pointer to interested parties in load balancing decisions.
   grpc_pollset_set* interested_parties_;
   /// Channel control helper.
-  UniquePtr<ChannelControlHelper> channel_control_helper_;
+  std::unique_ptr<ChannelControlHelper> channel_control_helper_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -237,7 +237,7 @@ class GrpcLb : public LoadBalancingPolicy {
     const grpc_grpclb_serverlist* serverlist() const { return serverlist_; }
 
     // Returns a text representation suitable for logging.
-    UniquePtr<char> AsText() const;
+    std::unique_ptr<char> AsText() const;
 
     // Extracts all non-drop entries into a ServerAddressList.
     ServerAddressList GetServerAddressList(
@@ -268,7 +268,7 @@ class GrpcLb : public LoadBalancingPolicy {
   class Picker : public SubchannelPicker {
    public:
     Picker(GrpcLb* parent, RefCountedPtr<Serverlist> serverlist,
-           UniquePtr<SubchannelPicker> child_picker,
+           std::unique_ptr<SubchannelPicker> child_picker,
            RefCountedPtr<GrpcLbClientStats> client_stats)
         : parent_(parent),
           serverlist_(std::move(serverlist)),
@@ -285,7 +285,7 @@ class GrpcLb : public LoadBalancingPolicy {
     // Serverlist to be used for determining drops.
     RefCountedPtr<Serverlist> serverlist_;
 
-    UniquePtr<SubchannelPicker> child_picker_;
+    std::unique_ptr<SubchannelPicker> child_picker_;
     RefCountedPtr<GrpcLbClientStats> client_stats_;
   };
 
@@ -297,7 +297,7 @@ class GrpcLb : public LoadBalancingPolicy {
     RefCountedPtr<SubchannelInterface> CreateSubchannel(
         const grpc_channel_args& args) override;
     void UpdateState(grpc_connectivity_state state,
-                     UniquePtr<SubchannelPicker> picker) override;
+                     std::unique_ptr<SubchannelPicker> picker) override;
     void RequestReresolution() override;
     void AddTraceEvent(TraceSeverity severity, StringView message) override;
 
@@ -430,7 +430,7 @@ void ParseServer(const grpc_grpclb_server* server,
   }
 }
 
-UniquePtr<char> GrpcLb::Serverlist::AsText() const {
+std::unique_ptr<char> GrpcLb::Serverlist::AsText() const {
   gpr_strvec entries;
   gpr_strvec_init(&entries);
   for (size_t i = 0; i < serverlist_->num_servers; ++i) {
@@ -449,7 +449,7 @@ UniquePtr<char> GrpcLb::Serverlist::AsText() const {
     gpr_free(ipport);
     gpr_strvec_add(&entries, entry);
   }
-  UniquePtr<char> result(gpr_strvec_flatten(&entries, nullptr));
+  std::unique_ptr<char> result(gpr_strvec_flatten(&entries, nullptr));
   gpr_strvec_destroy(&entries);
   return result;
 }
@@ -657,7 +657,7 @@ RefCountedPtr<SubchannelInterface> GrpcLb::Helper::CreateSubchannel(
 }
 
 void GrpcLb::Helper::UpdateState(grpc_connectivity_state state,
-                                 UniquePtr<SubchannelPicker> picker) {
+                                 std::unique_ptr<SubchannelPicker> picker) {
   if (parent_->shutting_down_) return;
   // If this request is from the pending child policy, ignore it until
   // it reports READY, at which point we swap it into place.
@@ -1099,7 +1099,7 @@ void GrpcLb::BalancerCallState::OnBalancerMessageReceivedLocked(
     GPR_ASSERT(lb_calld->lb_call_ != nullptr);
     auto serverlist_wrapper = MakeRefCounted<Serverlist>(serverlist);
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_glb_trace)) {
-      UniquePtr<char> serverlist_text = serverlist_wrapper->AsText();
+      std::unique_ptr<char> serverlist_text = serverlist_wrapper->AsText();
       gpr_log(GPR_INFO,
               "[grpclb %p] lb_calld=%p: Serverlist with %" PRIuPTR
               " servers received:\n%s",
@@ -1729,7 +1729,7 @@ OrphanablePtr<LoadBalancingPolicy> GrpcLb::CreateChildPolicyLocked(
   lb_policy_args.combiner = combiner();
   lb_policy_args.args = args;
   lb_policy_args.channel_control_helper =
-      UniquePtr<ChannelControlHelper>(helper);
+      std::unique_ptr<ChannelControlHelper>(helper);
   OrphanablePtr<LoadBalancingPolicy> lb_policy =
       LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
           name, std::move(lb_policy_args));

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -39,8 +39,8 @@ namespace grpc_core {
 
 namespace {
 
-int BalancerNameCmp(const grpc_core::UniquePtr<char>& a,
-                    const grpc_core::UniquePtr<char>& b) {
+int BalancerNameCmp(const std::unique_ptr<char>& a,
+                    const std::unique_ptr<char>& b) {
   return strcmp(a.get(), b.get());
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.cc
@@ -61,7 +61,7 @@ void GrpcLbClientStats::AddCallDropped(const char* token) {
     }
   }
   // Not found, so add a new entry.
-  drop_token_counts_->emplace_back(UniquePtr<char>(gpr_strdup(token)), 1);
+  drop_token_counts_->emplace_back(std::unique_ptr<char>(gpr_strdup(token)), 1);
 }
 
 namespace {
@@ -76,7 +76,7 @@ void GrpcLbClientStats::Get(
     int64_t* num_calls_started, int64_t* num_calls_finished,
     int64_t* num_calls_finished_with_client_failed_to_send,
     int64_t* num_calls_finished_known_received,
-    UniquePtr<DroppedCallCounts>* drop_token_counts) {
+    std::unique_ptr<DroppedCallCounts>* drop_token_counts) {
   AtomicGetAndResetCounter(num_calls_started, &num_calls_started_);
   AtomicGetAndResetCounter(num_calls_finished, &num_calls_finished_);
   AtomicGetAndResetCounter(num_calls_finished_with_client_failed_to_send,

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h
@@ -33,10 +33,10 @@ namespace grpc_core {
 class GrpcLbClientStats : public RefCounted<GrpcLbClientStats> {
  public:
   struct DropTokenCount {
-    UniquePtr<char> token;
+    std::unique_ptr<char> token;
     int64_t count;
 
-    DropTokenCount(UniquePtr<char> token, int64_t count)
+    DropTokenCount(std::unique_ptr<char> token, int64_t count)
         : token(std::move(token)), count(count) {}
   };
 
@@ -51,7 +51,7 @@ class GrpcLbClientStats : public RefCounted<GrpcLbClientStats> {
   void Get(int64_t* num_calls_started, int64_t* num_calls_finished,
            int64_t* num_calls_finished_with_client_failed_to_send,
            int64_t* num_calls_finished_known_received,
-           UniquePtr<DroppedCallCounts>* drop_token_counts);
+           std::unique_ptr<DroppedCallCounts>* drop_token_counts);
 
   // A destruction function to use as the user_data key when attaching
   // client stats to a grpc_mdelem.
@@ -65,7 +65,7 @@ class GrpcLbClientStats : public RefCounted<GrpcLbClientStats> {
   gpr_atm num_calls_finished_with_client_failed_to_send_ = 0;
   gpr_atm num_calls_finished_known_received_ = 0;
   Mutex drop_count_mu_;  // Guards drop_token_counts_.
-  UniquePtr<DroppedCallCounts> drop_token_counts_;
+  std::unique_ptr<DroppedCallCounts> drop_token_counts_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
@@ -63,7 +63,7 @@ grpc_grpclb_request* grpc_grpclb_load_report_request_create(
   int64_t num_calls_finished;
   int64_t num_calls_finished_with_client_failed_to_send;
   int64_t num_calls_finished_known_received;
-  UniquePtr<GrpcLbClientStats::DroppedCallCounts> drop_token_counts;
+  std::unique_ptr<GrpcLbClientStats::DroppedCallCounts> drop_token_counts;
   client_stats->Get(&num_calls_started, &num_calls_finished,
                     &num_calls_finished_with_client_failed_to_send,
                     &num_calls_finished_known_received, &drop_token_counts);

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -316,7 +316,7 @@ void SubchannelData<SubchannelListType,
       new Watcher(this, subchannel_list()->Ref(DEBUG_LOCATION, "Watcher"));
   subchannel_->WatchConnectivityState(
       connectivity_state_,
-      UniquePtr<SubchannelInterface::ConnectivityStateWatcherInterface>(
+      std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>(
           pending_watcher_));
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -39,13 +39,13 @@ constexpr char kCds[] = "cds_experimental";
 // Parsed config for this LB policy.
 class ParsedCdsConfig : public LoadBalancingPolicy::Config {
  public:
-  explicit ParsedCdsConfig(UniquePtr<char> cluster)
+  explicit ParsedCdsConfig(std::unique_ptr<char> cluster)
       : cluster_(std::move(cluster)) {}
   const char* cluster() const { return cluster_.get(); }
   const char* name() const override { return kCds; }
 
  private:
-  UniquePtr<char> cluster_;
+  std::unique_ptr<char> cluster_;
 };
 
 // CDS LB policy.
@@ -78,7 +78,7 @@ class CdsLb : public LoadBalancingPolicy {
     RefCountedPtr<SubchannelInterface> CreateSubchannel(
         const grpc_channel_args& args) override;
     void UpdateState(grpc_connectivity_state state,
-                     UniquePtr<SubchannelPicker> picker) override;
+                     std::unique_ptr<SubchannelPicker> picker) override;
     void RequestReresolution() override;
     void AddTraceEvent(TraceSeverity severity, StringView message) override;
 
@@ -136,7 +136,7 @@ void CdsLb::ClusterWatcher::OnClusterChanged(CdsUpdate cluster_data) {
                     ? parent_->config_->cluster()
                     : cluster_data.eds_service_name.get()));
   gpr_free(lrs_str);
-  UniquePtr<char> json_str_deleter(json_str);
+  std::unique_ptr<char> json_str_deleter(json_str);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_cds_lb_trace)) {
     gpr_log(GPR_INFO, "[cdslb %p] generated config for child policy: %s",
             parent_.get(), json_str);
@@ -203,7 +203,7 @@ RefCountedPtr<SubchannelInterface> CdsLb::Helper::CreateSubchannel(
 }
 
 void CdsLb::Helper::UpdateState(grpc_connectivity_state state,
-                                UniquePtr<SubchannelPicker> picker) {
+                                std::unique_ptr<SubchannelPicker> picker) {
   if (parent_->shutting_down_) return;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_cds_lb_trace)) {
     gpr_log(GPR_INFO, "[cdslb %p] state updated by child: %s", this,
@@ -343,7 +343,7 @@ class CdsFactory : public LoadBalancingPolicyFactory {
     }
     if (error_list.empty()) {
       return MakeRefCounted<ParsedCdsConfig>(
-          UniquePtr<char>(gpr_strdup(cluster)));
+          std::unique_ptr<char>(gpr_strdup(cluster)));
     } else {
       *error = GRPC_ERROR_CREATE_FROM_VECTOR("Cds Parser", &error_list);
       return nullptr;

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -78,8 +78,8 @@ class ParsedXdsConfig : public LoadBalancingPolicy::Config {
  public:
   ParsedXdsConfig(RefCountedPtr<LoadBalancingPolicy::Config> child_policy,
                   RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy,
-                  UniquePtr<char> eds_service_name,
-                  UniquePtr<char> lrs_load_reporting_server_name)
+                  std::unique_ptr<char> eds_service_name,
+                  std::unique_ptr<char> lrs_load_reporting_server_name)
       : child_policy_(std::move(child_policy)),
         fallback_policy_(std::move(fallback_policy)),
         eds_service_name_(std::move(eds_service_name)),
@@ -105,8 +105,8 @@ class ParsedXdsConfig : public LoadBalancingPolicy::Config {
  private:
   RefCountedPtr<LoadBalancingPolicy::Config> child_policy_;
   RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy_;
-  UniquePtr<char> eds_service_name_;
-  UniquePtr<char> lrs_load_reporting_server_name_;
+  std::unique_ptr<char> eds_service_name_;
+  std::unique_ptr<char> lrs_load_reporting_server_name_;
 };
 
 class XdsLb : public LoadBalancingPolicy {
@@ -123,12 +123,13 @@ class XdsLb : public LoadBalancingPolicy {
 
   // We need this wrapper for the following reasons:
   // 1. To process per-locality load reporting.
-  // 2. Since pickers are UniquePtrs we use this RefCounted wrapper to control
+  // 2. Since pickers are std::unique_ptrs we use this RefCounted wrapper to
+  // control
   //     references to it by the xds picker and the locality.
   class EndpointPickerWrapper : public RefCounted<EndpointPickerWrapper> {
    public:
     EndpointPickerWrapper(
-        UniquePtr<SubchannelPicker> picker,
+        std::unique_ptr<SubchannelPicker> picker,
         RefCountedPtr<XdsClientStats::LocalityStats> locality_stats)
         : picker_(std::move(picker)),
           locality_stats_(std::move(locality_stats)) {
@@ -139,7 +140,7 @@ class XdsLb : public LoadBalancingPolicy {
     PickResult Pick(PickArgs args);
 
    private:
-    UniquePtr<SubchannelPicker> picker_;
+    std::unique_ptr<SubchannelPicker> picker_;
     RefCountedPtr<XdsClientStats::LocalityStats> locality_stats_;
   };
 
@@ -180,7 +181,7 @@ class XdsLb : public LoadBalancingPolicy {
     RefCountedPtr<SubchannelInterface> CreateSubchannel(
         const grpc_channel_args& args) override;
     void UpdateState(grpc_connectivity_state state,
-                     UniquePtr<SubchannelPicker> picker) override;
+                     std::unique_ptr<SubchannelPicker> picker) override;
     void RequestReresolution() override;
     void AddTraceEvent(TraceSeverity severity, StringView message) override;
 
@@ -238,7 +239,7 @@ class XdsLb : public LoadBalancingPolicy {
           RefCountedPtr<SubchannelInterface> CreateSubchannel(
               const grpc_channel_args& args) override;
           void UpdateState(grpc_connectivity_state state,
-                           UniquePtr<SubchannelPicker> picker) override;
+                           std::unique_ptr<SubchannelPicker> picker) override;
           // This is a no-op, because we get the addresses from the xds
           // client, which is a watch-based API.
           void RequestReresolution() override {}
@@ -405,7 +406,7 @@ class XdsLb : public LoadBalancingPolicy {
   }
 
   // Server name from target URI.
-  UniquePtr<char> server_name_;
+  std::unique_ptr<char> server_name_;
 
   // Current channel args and config from the resolver.
   const grpc_channel_args* args_ = nullptr;
@@ -494,7 +495,7 @@ LoadBalancingPolicy::PickResult XdsLb::EndpointPickerWrapper::Pick(
 
 XdsLb::PickResult XdsLb::LocalityPicker::Pick(PickArgs args) {
   // Handle drop.
-  const UniquePtr<char>* drop_category;
+  const std::unique_ptr<char>* drop_category;
   if (drop_config_->ShouldDrop(&drop_category)) {
     xds_policy_->client_stats_.AddCallDropped(*drop_category);
     PickResult result;
@@ -553,8 +554,8 @@ RefCountedPtr<SubchannelInterface> XdsLb::FallbackHelper::CreateSubchannel(
   return parent_->channel_control_helper()->CreateSubchannel(args);
 }
 
-void XdsLb::FallbackHelper::UpdateState(grpc_connectivity_state state,
-                                        UniquePtr<SubchannelPicker> picker) {
+void XdsLb::FallbackHelper::UpdateState(
+    grpc_connectivity_state state, std::unique_ptr<SubchannelPicker> picker) {
   if (parent_->shutting_down_) return;
   // If this request is from the pending fallback policy, ignore it until
   // it reports READY, at which point we swap it into place.
@@ -997,7 +998,7 @@ OrphanablePtr<LoadBalancingPolicy> XdsLb::CreateFallbackPolicyLocked(
   lb_policy_args.combiner = combiner();
   lb_policy_args.args = args;
   lb_policy_args.channel_control_helper =
-      UniquePtr<ChannelControlHelper>(helper);
+      std::unique_ptr<ChannelControlHelper>(helper);
   OrphanablePtr<LoadBalancingPolicy> lb_policy =
       LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
           name, std::move(lb_policy_args));
@@ -1505,7 +1506,7 @@ XdsLb::PriorityList::LocalityMap::Locality::CreateChildPolicyLocked(
   lb_policy_args.combiner = xds_policy()->combiner();
   lb_policy_args.args = args;
   lb_policy_args.channel_control_helper =
-      UniquePtr<ChannelControlHelper>(helper);
+      std::unique_ptr<ChannelControlHelper>(helper);
   OrphanablePtr<LoadBalancingPolicy> lb_policy =
       LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
           name, std::move(lb_policy_args));
@@ -1741,7 +1742,7 @@ XdsLb::PriorityList::LocalityMap::Locality::Helper::CreateSubchannel(
 }
 
 void XdsLb::PriorityList::LocalityMap::Locality::Helper::UpdateState(
-    grpc_connectivity_state state, UniquePtr<SubchannelPicker> picker) {
+    grpc_connectivity_state state, std::unique_ptr<SubchannelPicker> picker) {
   if (locality_->xds_policy()->shutting_down_) return;
   // If this request is from the pending child policy, ignore it until
   // it reports READY, at which point we swap it into place.
@@ -1870,8 +1871,8 @@ class XdsFactory : public LoadBalancingPolicyFactory {
     if (error_list.empty()) {
       return MakeRefCounted<ParsedXdsConfig>(
           std::move(child_policy), std::move(fallback_policy),
-          UniquePtr<char>(gpr_strdup(eds_service_name)),
-          UniquePtr<char>(gpr_strdup(lrs_load_reporting_server_name)));
+          std::unique_ptr<char>(gpr_strdup(eds_service_name)),
+          std::unique_ptr<char>(gpr_strdup(lrs_load_reporting_server_name)));
     } else {
       *error = GRPC_ERROR_CREATE_FROM_VECTOR("Xds Parser", &error_list);
       return nullptr;

--- a/src/core/ext/filters/client_channel/lb_policy_registry.cc
+++ b/src/core/ext/filters/client_channel/lb_policy_registry.cc
@@ -34,7 +34,7 @@ class RegistryState {
   RegistryState() {}
 
   void RegisterLoadBalancingPolicyFactory(
-      UniquePtr<LoadBalancingPolicyFactory> factory) {
+      std::unique_ptr<LoadBalancingPolicyFactory> factory) {
     for (size_t i = 0; i < factories_.size(); ++i) {
       GPR_ASSERT(strcmp(factories_[i]->name(), factory->name()) != 0);
     }
@@ -52,7 +52,7 @@ class RegistryState {
   }
 
  private:
-  InlinedVector<UniquePtr<LoadBalancingPolicyFactory>, 10> factories_;
+  InlinedVector<std::unique_ptr<LoadBalancingPolicyFactory>, 10> factories_;
 };
 
 RegistryState* g_state = nullptr;
@@ -73,7 +73,7 @@ void LoadBalancingPolicyRegistry::Builder::ShutdownRegistry() {
 }
 
 void LoadBalancingPolicyRegistry::Builder::RegisterLoadBalancingPolicyFactory(
-    UniquePtr<LoadBalancingPolicyFactory> factory) {
+    std::unique_ptr<LoadBalancingPolicyFactory> factory) {
   InitRegistry();
   g_state->RegisterLoadBalancingPolicyFactory(std::move(factory));
 }

--- a/src/core/ext/filters/client_channel/lb_policy_registry.h
+++ b/src/core/ext/filters/client_channel/lb_policy_registry.h
@@ -41,7 +41,7 @@ class LoadBalancingPolicyRegistry {
     /// Registers an LB policy factory.  The factory will be used to create an
     /// LB policy whose name matches that of the factory.
     static void RegisterLoadBalancingPolicyFactory(
-        UniquePtr<LoadBalancingPolicyFactory> factory);
+        std::unique_ptr<LoadBalancingPolicyFactory> factory);
   };
 
   /// Creates an LB policy of the type specified by \a name.

--- a/src/core/ext/filters/client_channel/parse_address.cc
+++ b/src/core/ext/filters/client_channel/parse_address.cc
@@ -73,8 +73,8 @@ bool grpc_parse_ipv4_hostport(const char* hostport, grpc_resolved_address* addr,
                               bool log_errors) {
   bool success = false;
   // Split host and port.
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   if (!grpc_core::SplitHostPort(hostport, &host, &port)) {
     if (log_errors) {
       gpr_log(GPR_ERROR, "Failed gpr_split_host_port(%s, ...)", hostport);
@@ -125,8 +125,8 @@ bool grpc_parse_ipv6_hostport(const char* hostport, grpc_resolved_address* addr,
                               bool log_errors) {
   bool success = false;
   // Split host and port.
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   if (!grpc_core::SplitHostPort(hostport, &host, &port)) {
     if (log_errors) {
       gpr_log(GPR_ERROR, "Failed gpr_split_host_port(%s, ...)", hostport);

--- a/src/core/ext/filters/client_channel/resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver.cc
@@ -30,7 +30,8 @@ namespace grpc_core {
 // Resolver
 //
 
-Resolver::Resolver(Combiner* combiner, UniquePtr<ResultHandler> result_handler)
+Resolver::Resolver(Combiner* combiner,
+                   std::unique_ptr<ResultHandler> result_handler)
     : InternallyRefCounted(&grpc_trace_resolver_refcount),
       result_handler_(std::move(result_handler)),
       combiner_(GRPC_COMBINER_REF(combiner, "resolver")) {}

--- a/src/core/ext/filters/client_channel/resolver.h
+++ b/src/core/ext/filters/client_channel/resolver.h
@@ -127,7 +127,7 @@ class Resolver : public InternallyRefCounted<Resolver> {
   // API should change to take a RefCountedPtr<>, so that we always take
   // ownership of a new ref.
   explicit Resolver(Combiner* combiner,
-                    UniquePtr<ResultHandler> result_handler);
+                    std::unique_ptr<ResultHandler> result_handler);
 
   /// Shuts down the resolver.
   virtual void ShutdownLocked() = 0;
@@ -137,7 +137,7 @@ class Resolver : public InternallyRefCounted<Resolver> {
   ResultHandler* result_handler() const { return result_handler_.get(); }
 
  private:
-  UniquePtr<ResultHandler> result_handler_;
+  std::unique_ptr<ResultHandler> result_handler_;
   Combiner* combiner_;
 };
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -108,7 +108,7 @@ class AresDnsResolver : public Resolver {
   /// retry backoff state
   BackOff backoff_;
   /// currently resolving addresses
-  UniquePtr<ServerAddressList> addresses_;
+  std::unique_ptr<ServerAddressList> addresses_;
   /// currently resolving service config
   char* service_config_json_ = nullptr;
   // has shutdown been initiated
@@ -496,8 +496,7 @@ static bool should_use_ares(const char* resolver_env) {
 static bool g_use_ares_dns_resolver;
 
 void grpc_resolver_dns_ares_init() {
-  grpc_core::UniquePtr<char> resolver =
-      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (should_use_ares(resolver.get())) {
     g_use_ares_dns_resolver = true;
     gpr_log(GPR_DEBUG, "Using ares dns resolver");

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
@@ -77,7 +77,7 @@ struct grpc_ares_ev_driver {
   /** request object that's using this ev driver */
   grpc_ares_request* request;
   /** Owned by the ev_driver. Creates new GrpcPolledFd's */
-  grpc_core::UniquePtr<grpc_core::GrpcPolledFdFactory> polled_fd_factory;
+  std::unique_ptr<grpc_core::GrpcPolledFdFactory> polled_fd_factory;
   /** query timeout in milliseconds */
   int query_timeout_ms;
   /** alarm to cancel active queries */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
@@ -95,7 +95,7 @@ class GrpcPolledFdFactory {
   virtual void ConfigureAresChannelLocked(ares_channel channel) = 0;
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner);
+std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner);
 
 }  // namespace grpc_core
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
@@ -122,7 +122,7 @@ struct AresUvPollCbArg {
 };
 
 static void ares_uv_poll_cb_locked(void* arg, grpc_error* error) {
-  grpc_core::UniquePtr<AresUvPollCbArg> arg_struct(
+  std::unique_ptr<AresUvPollCbArg> arg_struct(
       reinterpret_cast<AresUvPollCbArg*>(arg));
   uv_poll_t* handle = arg_struct->handle;
   int status = arg_struct->status;
@@ -171,7 +171,8 @@ class GrpcPolledFdFactoryLibuv : public GrpcPolledFdFactory {
   void ConfigureAresChannelLocked(ares_channel channel) override {}
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner) {
+std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(
+    Combiner* combiner) {
   return MakeUnique<GrpcPolledFdFactoryLibuv>();
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -97,7 +97,8 @@ class GrpcPolledFdFactoryPosix : public GrpcPolledFdFactory {
   void ConfigureAresChannelLocked(ares_channel /*channel*/) override {}
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* /*combiner*/) {
+std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(
+    Combiner* /*combiner*/) {
   return MakeUnique<GrpcPolledFdFactoryPosix>();
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -932,7 +932,8 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
   SockToPolledFdMap sock_to_polled_fd_map_;
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner) {
+std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(
+    Combiner* combiner) {
   return MakeUnique<GrpcPolledFdFactoryWindows>(combiner);
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -59,7 +59,7 @@ struct grpc_ares_request {
   /** closure to call when the request completes */
   grpc_closure* on_done;
   /** the pointer to receive the resolved addresses */
-  grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses_out;
+  std::unique_ptr<grpc_core::ServerAddressList>* addresses_out;
   /** the pointer to receive the service config in JSON */
   char** service_config_json_out;
   /** the evernt driver used by this request */
@@ -355,8 +355,8 @@ void grpc_dns_lookup_ares_continue_after_check_localhost_and_ip_literals_locked(
   grpc_ares_hostbyname_request* hr = nullptr;
   ares_channel* channel = nullptr;
   /* parse name, splitting it into host and port parts */
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   grpc_core::SplitHostPort(name, &host, &port);
   if (host == nullptr) {
     error = grpc_error_set_str(
@@ -452,9 +452,9 @@ error_cleanup:
 
 static bool inner_resolve_as_ip_literal_locked(
     const char* name, const char* default_port,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
-    grpc_core::UniquePtr<char>* host, grpc_core::UniquePtr<char>* port,
-    grpc_core::UniquePtr<char>* hostport) {
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs,
+    std::unique_ptr<char>* host, std::unique_ptr<char>* port,
+    std::unique_ptr<char>* hostport) {
   grpc_core::SplitHostPort(name, host, port);
   if (*host == nullptr) {
     gpr_log(GPR_ERROR,
@@ -489,18 +489,18 @@ static bool inner_resolve_as_ip_literal_locked(
 
 static bool resolve_as_ip_literal_locked(
     const char* name, const char* default_port,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs) {
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
-  grpc_core::UniquePtr<char> hostport;
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs) {
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
+  std::unique_ptr<char> hostport;
   bool out = inner_resolve_as_ip_literal_locked(name, default_port, addrs,
                                                 &host, &port, &hostport);
   return out;
 }
 
 static bool target_matches_localhost_inner(const char* name,
-                                           grpc_core::UniquePtr<char>* host,
-                                           grpc_core::UniquePtr<char>* port) {
+                                           std::unique_ptr<char>* host,
+                                           std::unique_ptr<char>* port) {
   if (!grpc_core::SplitHostPort(name, host, port)) {
     gpr_log(GPR_ERROR, "Unable to split host and port for name: %s", name);
     return false;
@@ -513,16 +513,16 @@ static bool target_matches_localhost_inner(const char* name,
 }
 
 static bool target_matches_localhost(const char* name) {
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   return target_matches_localhost_inner(name, &host, &port);
 }
 
 #ifdef GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY
 static bool inner_maybe_resolve_localhost_manually_locked(
     const char* name, const char* default_port,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
-    grpc_core::UniquePtr<char>* host, grpc_core::UniquePtr<char>* port) {
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs,
+    std::unique_ptr<char>* host, std::unique_ptr<char>* port) {
   grpc_core::SplitHostPort(name, host, port);
   if (*host == nullptr) {
     gpr_log(GPR_ERROR,
@@ -571,16 +571,16 @@ static bool inner_maybe_resolve_localhost_manually_locked(
 
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
     const char* name, const char* default_port,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs) {
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs) {
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   return inner_maybe_resolve_localhost_manually_locked(name, default_port,
                                                        addrs, &host, &port);
 }
 #else  /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
     const char* /*name*/, const char* /*default_port*/,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* /*addrs*/) {
+    std::unique_ptr<grpc_core::ServerAddressList>* /*addrs*/) {
   return false;
 }
 #endif /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
@@ -588,8 +588,8 @@ static bool grpc_ares_maybe_resolve_localhost_manually_locked(
 static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner) {
   grpc_ares_request* r =
       static_cast<grpc_ares_request*>(gpr_zalloc(sizeof(grpc_ares_request)));
@@ -631,8 +631,8 @@ static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
 grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner) = grpc_dns_lookup_ares_locked_impl;
 
 static void grpc_cancel_ares_request_locked_impl(grpc_ares_request* r) {
@@ -678,7 +678,7 @@ typedef struct grpc_resolve_address_ares_request {
   /** the pointer to receive the resolved addresses */
   grpc_resolved_addresses** addrs_out;
   /** currently resolving addresses */
-  grpc_core::UniquePtr<ServerAddressList> addresses;
+  std::unique_ptr<ServerAddressList> addresses;
   /** closure to call when the resolve_address_ares request completes */
   grpc_closure* on_resolve_address_done;
   /** a closure wrapping on_resolve_address_done, which should be invoked when

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -63,8 +63,8 @@ extern void (*grpc_resolve_address_ares)(const char* name,
 extern grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner);
 
 /* Cancel the pending grpc_ares_request \a request */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
@@ -29,8 +29,8 @@ struct grpc_ares_request {
 static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner) {
   return NULL;
 }
@@ -38,8 +38,8 @@ static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
 grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addrs, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner) = grpc_dns_lookup_ares_locked_impl;
 
 static void grpc_cancel_ares_request_locked_impl(grpc_ares_request* r) {}

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -300,8 +300,7 @@ class NativeDnsResolverFactory : public ResolverFactory {
 }  // namespace grpc_core
 
 void grpc_resolver_dns_native_init() {
-  grpc_core::UniquePtr<char> resolver =
-      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (gpr_stricmp(resolver.get(), "native") == 0) {
     gpr_log(GPR_DEBUG, "Using native dns resolver");
     grpc_core::ResolverRegistry::Builder::RegisterResolverFactory(

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -97,7 +97,8 @@ bool ParseUri(const grpc_uri* uri,
   bool errors_found = false;
   for (size_t i = 0; i < path_parts.count; i++) {
     grpc_uri ith_uri = *uri;
-    UniquePtr<char> part_str(grpc_slice_to_c_string(path_parts.slices[i]));
+    std::unique_ptr<char> part_str(
+        grpc_slice_to_c_string(path_parts.slices[i]));
     ith_uri.path = part_str.get();
     grpc_resolved_address addr;
     if (!parse(&ith_uri, &addr)) {
@@ -160,8 +161,8 @@ class UnixResolverFactory : public ResolverFactory {
     return CreateSockaddrResolver(std::move(args), grpc_parse_unix);
   }
 
-  UniquePtr<char> GetDefaultAuthority(grpc_uri* /*uri*/) const override {
-    return UniquePtr<char>(gpr_strdup("localhost"));
+  std::unique_ptr<char> GetDefaultAuthority(grpc_uri* /*uri*/) const override {
+    return std::unique_ptr<char>(gpr_strdup("localhost"));
   }
 
   const char* scheme() const override { return "unix"; }

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -60,7 +60,7 @@ class XdsResolver : public Resolver {
     RefCountedPtr<XdsResolver> resolver_;
   };
 
-  UniquePtr<char> server_name_;
+  std::unique_ptr<char> server_name_;
   const grpc_channel_args* args_;
   grpc_pollset_set* interested_parties_;
   OrphanablePtr<XdsClient> xds_client_;

--- a/src/core/ext/filters/client_channel/resolver_factory.h
+++ b/src/core/ext/filters/client_channel/resolver_factory.h
@@ -41,7 +41,7 @@ struct ResolverArgs {
   /// The combiner under which all resolver calls will be run.
   Combiner* combiner = nullptr;
   /// The result handler to be used by the resolver.
-  UniquePtr<Resolver::ResultHandler> result_handler;
+  std::unique_ptr<Resolver::ResultHandler> result_handler;
 };
 
 class ResolverFactory {
@@ -55,10 +55,10 @@ class ResolverFactory {
 
   /// Returns a string representing the default authority to use for this
   /// scheme.
-  virtual UniquePtr<char> GetDefaultAuthority(grpc_uri* uri) const {
+  virtual std::unique_ptr<char> GetDefaultAuthority(grpc_uri* uri) const {
     const char* path = uri->path;
     if (path[0] == '/') ++path;
-    return UniquePtr<char>(gpr_strdup(path));
+    return std::unique_ptr<char>(gpr_strdup(path));
   }
 
   /// Returns the URI scheme that this factory implements.

--- a/src/core/ext/filters/client_channel/resolver_registry.cc
+++ b/src/core/ext/filters/client_channel/resolver_registry.cc
@@ -40,7 +40,7 @@ class RegistryState {
     default_prefix_.reset(gpr_strdup(default_resolver_prefix));
   }
 
-  void RegisterResolverFactory(UniquePtr<ResolverFactory> factory) {
+  void RegisterResolverFactory(std::unique_ptr<ResolverFactory> factory) {
     for (size_t i = 0; i < factories_.size(); ++i) {
       GPR_ASSERT(strcmp(factories_[i]->scheme(), factory->scheme()) != 0);
     }
@@ -90,8 +90,8 @@ class RegistryState {
   // more factories are needed and the additional allocations are
   // hurting performance (which is unlikely, since these allocations
   // only occur at gRPC initialization time).
-  InlinedVector<UniquePtr<ResolverFactory>, 10> factories_;
-  UniquePtr<char> default_prefix_;
+  InlinedVector<std::unique_ptr<ResolverFactory>, 10> factories_;
+  std::unique_ptr<char> default_prefix_;
 };
 
 static RegistryState* g_state = nullptr;
@@ -118,7 +118,7 @@ void ResolverRegistry::Builder::SetDefaultPrefix(
 }
 
 void ResolverRegistry::Builder::RegisterResolverFactory(
-    UniquePtr<ResolverFactory> factory) {
+    std::unique_ptr<ResolverFactory> factory) {
   InitRegistry();
   g_state->RegisterResolverFactory(std::move(factory));
 }
@@ -146,7 +146,7 @@ bool ResolverRegistry::IsValidTarget(const char* target) {
 OrphanablePtr<Resolver> ResolverRegistry::CreateResolver(
     const char* target, const grpc_channel_args* args,
     grpc_pollset_set* pollset_set, Combiner* combiner,
-    UniquePtr<Resolver::ResultHandler> result_handler) {
+    std::unique_ptr<Resolver::ResultHandler> result_handler) {
   GPR_ASSERT(g_state != nullptr);
   grpc_uri* uri = nullptr;
   char* canonical_target = nullptr;
@@ -166,27 +166,29 @@ OrphanablePtr<Resolver> ResolverRegistry::CreateResolver(
   return resolver;
 }
 
-UniquePtr<char> ResolverRegistry::GetDefaultAuthority(const char* target) {
+std::unique_ptr<char> ResolverRegistry::GetDefaultAuthority(
+    const char* target) {
   GPR_ASSERT(g_state != nullptr);
   grpc_uri* uri = nullptr;
   char* canonical_target = nullptr;
   ResolverFactory* factory =
       g_state->FindResolverFactory(target, &uri, &canonical_target);
-  UniquePtr<char> authority =
+  std::unique_ptr<char> authority =
       factory == nullptr ? nullptr : factory->GetDefaultAuthority(uri);
   grpc_uri_destroy(uri);
   gpr_free(canonical_target);
   return authority;
 }
 
-UniquePtr<char> ResolverRegistry::AddDefaultPrefixIfNeeded(const char* target) {
+std::unique_ptr<char> ResolverRegistry::AddDefaultPrefixIfNeeded(
+    const char* target) {
   GPR_ASSERT(g_state != nullptr);
   grpc_uri* uri = nullptr;
   char* canonical_target = nullptr;
   g_state->FindResolverFactory(target, &uri, &canonical_target);
   grpc_uri_destroy(uri);
-  return UniquePtr<char>(canonical_target == nullptr ? gpr_strdup(target)
-                                                     : canonical_target);
+  return std::unique_ptr<char>(canonical_target == nullptr ? gpr_strdup(target)
+                                                           : canonical_target);
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver_registry.h
+++ b/src/core/ext/filters/client_channel/resolver_registry.h
@@ -47,7 +47,8 @@ class ResolverRegistry {
     /// Registers a resolver factory.  The factory will be used to create a
     /// resolver for any URI whose scheme matches that of the factory.
     /// Calls InitRegistry() if it has not already been called.
-    static void RegisterResolverFactory(UniquePtr<ResolverFactory> factory);
+    static void RegisterResolverFactory(
+        std::unique_ptr<ResolverFactory> factory);
   };
 
   /// Checks whether the user input \a target is valid to create a resolver.
@@ -69,13 +70,13 @@ class ResolverRegistry {
   static OrphanablePtr<Resolver> CreateResolver(
       const char* target, const grpc_channel_args* args,
       grpc_pollset_set* pollset_set, Combiner* combiner,
-      UniquePtr<Resolver::ResultHandler> result_handler);
+      std::unique_ptr<Resolver::ResultHandler> result_handler);
 
   /// Returns the default authority to pass from a client for \a target.
-  static UniquePtr<char> GetDefaultAuthority(const char* target);
+  static std::unique_ptr<char> GetDefaultAuthority(const char* target);
 
   /// Returns \a target with the default prefix prepended, if needed.
-  static UniquePtr<char> AddDefaultPrefixIfNeeded(const char* target);
+  static std::unique_ptr<char> AddDefaultPrefixIfNeeded(const char* target);
 
   /// Returns the resolver factory for \a scheme.
   /// Caller does NOT own the return value.

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -66,7 +66,7 @@ bool ParseDuration(grpc_json* field, grpc_millis* duration) {
   if (field->type != GRPC_JSON_STRING) return false;
   size_t len = strlen(field->value);
   if (field->value[len - 1] != 's') return false;
-  UniquePtr<char> buf(gpr_strdup(field->value));
+  std::unique_ptr<char> buf(gpr_strdup(field->value));
   *(buf.get() + len - 1) = '\0';  // Remove trailing 's'.
   char* decimal_point = strchr(buf.get(), '.');
   int nanos = 0;
@@ -91,7 +91,7 @@ bool ParseDuration(grpc_json* field, grpc_millis* duration) {
   return true;
 }
 
-UniquePtr<ClientChannelMethodParsedConfig::RetryPolicy> ParseRetryPolicy(
+std::unique_ptr<ClientChannelMethodParsedConfig::RetryPolicy> ParseRetryPolicy(
     grpc_json* field, grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   auto retry_policy =
@@ -262,13 +262,13 @@ const char* ParseHealthCheckConfig(const grpc_json* field, grpc_error** error) {
 
 }  // namespace
 
-UniquePtr<ServiceConfig::ParsedConfig>
+std::unique_ptr<ServiceConfig::ParsedConfig>
 ClientChannelServiceConfigParser::ParseGlobalParams(const grpc_json* json,
                                                     grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   InlinedVector<grpc_error*, 4> error_list;
   RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config;
-  UniquePtr<char> lb_policy_name;
+  std::unique_ptr<char> lb_policy_name;
   Optional<ClientChannelGlobalParsedConfig::RetryThrottling> retry_throttling;
   const char* health_check_service_name = nullptr;
   for (grpc_json* field = json->child; field != nullptr; field = field->next) {
@@ -445,14 +445,14 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const grpc_json* json,
   return nullptr;
 }
 
-UniquePtr<ServiceConfig::ParsedConfig>
+std::unique_ptr<ServiceConfig::ParsedConfig>
 ClientChannelServiceConfigParser::ParsePerMethodParams(const grpc_json* json,
                                                        grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   InlinedVector<grpc_error*, 4> error_list;
   Optional<bool> wait_for_ready;
   grpc_millis timeout = 0;
-  UniquePtr<ClientChannelMethodParsedConfig::RetryPolicy> retry_policy;
+  std::unique_ptr<ClientChannelMethodParsedConfig::RetryPolicy> retry_policy;
   for (grpc_json* field = json->child; field != nullptr; field = field->next) {
     if (field->key == nullptr) continue;
     if (strcmp(field->key, "waitForReady") == 0) {

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.h
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.h
@@ -46,7 +46,7 @@ class ClientChannelGlobalParsedConfig : public ServiceConfig::ParsedConfig {
 
   ClientChannelGlobalParsedConfig(
       RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config,
-      UniquePtr<char> parsed_deprecated_lb_policy,
+      std::unique_ptr<char> parsed_deprecated_lb_policy,
       const Optional<RetryThrottling>& retry_throttling,
       const char* health_check_service_name)
       : parsed_lb_config_(std::move(parsed_lb_config)),
@@ -72,7 +72,7 @@ class ClientChannelGlobalParsedConfig : public ServiceConfig::ParsedConfig {
 
  private:
   RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config_;
-  UniquePtr<char> parsed_deprecated_lb_policy_;
+  std::unique_ptr<char> parsed_deprecated_lb_policy_;
   Optional<RetryThrottling> retry_throttling_;
   const char* health_check_service_name_;
 };
@@ -89,7 +89,7 @@ class ClientChannelMethodParsedConfig : public ServiceConfig::ParsedConfig {
 
   ClientChannelMethodParsedConfig(grpc_millis timeout,
                                   const Optional<bool>& wait_for_ready,
-                                  UniquePtr<RetryPolicy> retry_policy)
+                                  std::unique_ptr<RetryPolicy> retry_policy)
       : timeout_(timeout),
         wait_for_ready_(wait_for_ready),
         retry_policy_(std::move(retry_policy)) {}
@@ -103,15 +103,15 @@ class ClientChannelMethodParsedConfig : public ServiceConfig::ParsedConfig {
  private:
   grpc_millis timeout_ = 0;
   Optional<bool> wait_for_ready_;
-  UniquePtr<RetryPolicy> retry_policy_;
+  std::unique_ptr<RetryPolicy> retry_policy_;
 };
 
 class ClientChannelServiceConfigParser : public ServiceConfig::Parser {
  public:
-  UniquePtr<ServiceConfig::ParsedConfig> ParseGlobalParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParseGlobalParams(
       const grpc_json* json, grpc_error** error) override;
 
-  UniquePtr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
       const grpc_json* json, grpc_error** error) override;
 
   static size_t ParserIndex();

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -114,7 +114,7 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
   }
 
   void UpdateState(grpc_connectivity_state state,
-                   UniquePtr<SubchannelPicker> picker) override {
+                   std::unique_ptr<SubchannelPicker> picker) override {
     if (parent_->resolver_ == nullptr) return;  // Shutting down.
     // If this request is from the pending child policy, ignore it until
     // it reports READY, at which point we swap it into place.
@@ -177,7 +177,7 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
 //
 
 ResolvingLoadBalancingPolicy::ResolvingLoadBalancingPolicy(
-    Args args, TraceFlag* tracer, UniquePtr<char> target_uri,
+    Args args, TraceFlag* tracer, std::unique_ptr<char> target_uri,
     ProcessResolverResultCallback process_resolver_result,
     void* process_resolver_result_user_data)
     : LoadBalancingPolicy(std::move(args)),
@@ -375,7 +375,7 @@ ResolvingLoadBalancingPolicy::CreateLbPolicyLocked(
   LoadBalancingPolicy::Args lb_policy_args;
   lb_policy_args.combiner = combiner();
   lb_policy_args.channel_control_helper =
-      UniquePtr<ChannelControlHelper>(helper);
+      std::unique_ptr<ChannelControlHelper>(helper);
   lb_policy_args.args = &args;
   OrphanablePtr<LoadBalancingPolicy> lb_policy =
       LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
@@ -425,7 +425,7 @@ void ResolvingLoadBalancingPolicy::ConcatenateAndAddChannelTraceLocked(
       gpr_strvec_add(&v, (*trace_strings)[i]);
     }
     size_t len = 0;
-    UniquePtr<char> message(gpr_strvec_flatten(&v, &len));
+    std::unique_ptr<char> message(gpr_strvec_flatten(&v, &len));
     channel_control_helper()->AddTraceEvent(ChannelControlHelper::TRACE_INFO,
                                             StringView(message.get()));
     gpr_strvec_destroy(&v);

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -65,7 +65,7 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
   // If error is set when this returns, then construction failed, and
   // the caller may not use the new object.
   ResolvingLoadBalancingPolicy(
-      Args args, TraceFlag* tracer, UniquePtr<char> target_uri,
+      Args args, TraceFlag* tracer, std::unique_ptr<char> target_uri,
       ProcessResolverResultCallback process_resolver_result,
       void* process_resolver_result_user_data);
 
@@ -106,10 +106,10 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
 
   // Passed in from caller at construction time.
   TraceFlag* tracer_;
-  UniquePtr<char> target_uri_;
+  std::unique_ptr<char> target_uri_;
   ProcessResolverResultCallback process_resolver_result_ = nullptr;
   void* process_resolver_result_user_data_ = nullptr;
-  UniquePtr<char> child_policy_name_;
+  std::unique_ptr<char> child_policy_name_;
   RefCountedPtr<LoadBalancingPolicy::Config> child_lb_config_;
 
   // Resolver and associated state.

--- a/src/core/ext/filters/client_channel/service_config.cc
+++ b/src/core/ext/filters/client_channel/service_config.cc
@@ -34,7 +34,7 @@
 namespace grpc_core {
 
 namespace {
-typedef InlinedVector<UniquePtr<ServiceConfig::Parser>,
+typedef InlinedVector<std::unique_ptr<ServiceConfig::Parser>,
                       ServiceConfig::kNumPreallocatedParsers>
     ServiceConfigParserList;
 ServiceConfigParserList* g_registered_parsers;
@@ -42,8 +42,8 @@ ServiceConfigParserList* g_registered_parsers;
 
 RefCountedPtr<ServiceConfig> ServiceConfig::Create(const char* json,
                                                    grpc_error** error) {
-  UniquePtr<char> service_config_json(gpr_strdup(json));
-  UniquePtr<char> json_string(gpr_strdup(json));
+  std::unique_ptr<char> service_config_json(gpr_strdup(json));
+  std::unique_ptr<char> json_string(gpr_strdup(json));
   GPR_DEBUG_ASSERT(error != nullptr);
   grpc_json* json_tree = grpc_json_parse_string(json_string.get());
   if (json_tree == nullptr) {
@@ -55,9 +55,9 @@ RefCountedPtr<ServiceConfig> ServiceConfig::Create(const char* json,
       std::move(service_config_json), std::move(json_string), json_tree, error);
 }
 
-ServiceConfig::ServiceConfig(UniquePtr<char> service_config_json,
-                             UniquePtr<char> json_string, grpc_json* json_tree,
-                             grpc_error** error)
+ServiceConfig::ServiceConfig(std::unique_ptr<char> service_config_json,
+                             std::unique_ptr<char> json_string,
+                             grpc_json* json_tree, grpc_error** error)
     : service_config_json_(std::move(service_config_json)),
       json_string_(std::move(json_string)),
       json_tree_(json_tree) {
@@ -121,7 +121,7 @@ grpc_error* ServiceConfig::ParseJsonMethodConfigToServiceConfigVectorTable(
           [parsed_method_config_vectors_storage_.size() - 1]
               .get();
   // Construct list of paths.
-  InlinedVector<UniquePtr<char>, 10> paths;
+  InlinedVector<std::unique_ptr<char>, 10> paths;
   for (grpc_json* child = json->child; child != nullptr; child = child->next) {
     if (child->key == nullptr) continue;
     if (strcmp(child->key, "name") == 0) {
@@ -132,7 +132,7 @@ grpc_error* ServiceConfig::ParseJsonMethodConfigToServiceConfigVectorTable(
       }
       for (grpc_json* name = child->child; name != nullptr; name = name->next) {
         grpc_error* parse_error = GRPC_ERROR_NONE;
-        UniquePtr<char> path = ParseJsonMethodName(name, &parse_error);
+        std::unique_ptr<char> path = ParseJsonMethodName(name, &parse_error);
         if (path == nullptr) {
           error_list.push_back(parse_error);
         } else {
@@ -228,8 +228,8 @@ int ServiceConfig::CountNamesInMethodConfig(grpc_json* json) {
   return num_names;
 }
 
-UniquePtr<char> ServiceConfig::ParseJsonMethodName(grpc_json* json,
-                                                   grpc_error** error) {
+std::unique_ptr<char> ServiceConfig::ParseJsonMethodName(grpc_json* json,
+                                                         grpc_error** error) {
   if (json->type != GRPC_JSON_OBJECT) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "field:name error:type is not object");
@@ -282,7 +282,7 @@ UniquePtr<char> ServiceConfig::ParseJsonMethodName(grpc_json* json,
   char* path;
   gpr_asprintf(&path, "/%s/%s", service_name,
                method_name == nullptr ? "*" : method_name);
-  return UniquePtr<char>(path);
+  return std::unique_ptr<char>(path);
 }
 
 const ServiceConfig::ParsedConfigVector*
@@ -311,7 +311,7 @@ ServiceConfig::GetMethodParsedConfigVector(const grpc_slice& path) {
   return *value;
 }
 
-size_t ServiceConfig::RegisterParser(UniquePtr<Parser> parser) {
+size_t ServiceConfig::RegisterParser(std::unique_ptr<Parser> parser) {
   g_registered_parsers->push_back(std::move(parser));
   return g_registered_parsers->size() - 1;
 }

--- a/src/core/ext/filters/client_channel/service_config.h
+++ b/src/core/ext/filters/client_channel/service_config.h
@@ -69,7 +69,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
    public:
     virtual ~Parser() = default;
 
-    virtual UniquePtr<ParsedConfig> ParseGlobalParams(
+    virtual std::unique_ptr<ParsedConfig> ParseGlobalParams(
         const grpc_json* /* json */, grpc_error** error) {
       // Avoid unused parameter warning on debug-only parameter
       (void)error;
@@ -77,7 +77,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
       return nullptr;
     }
 
-    virtual UniquePtr<ParsedConfig> ParsePerMethodParams(
+    virtual std::unique_ptr<ParsedConfig> ParsePerMethodParams(
         const grpc_json* /* json */, grpc_error** error) {
       // Avoid unused parameter warning on debug-only parameter
       (void)error;
@@ -87,7 +87,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
   };
 
   static constexpr int kNumPreallocatedParsers = 4;
-  typedef InlinedVector<UniquePtr<ParsedConfig>, kNumPreallocatedParsers>
+  typedef InlinedVector<std::unique_ptr<ParsedConfig>, kNumPreallocatedParsers>
       ParsedConfigVector;
 
   /// When a service config is applied to a call in the client_channel_filter,
@@ -129,8 +129,8 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
                                              grpc_error** error);
 
   // Takes ownership of \a json_tree.
-  ServiceConfig(UniquePtr<char> service_config_json,
-                UniquePtr<char> json_string, grpc_json* json_tree,
+  ServiceConfig(std::unique_ptr<char> service_config_json,
+                std::unique_ptr<char> json_string, grpc_json* json_tree,
                 grpc_error** error);
   ~ServiceConfig();
 
@@ -155,7 +155,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
   /// registered parser. Each parser is responsible for reading the service
   /// config json and returning a parsed config. This parsed config can later be
   /// retrieved using the same index that was returned at registration time.
-  static size_t RegisterParser(UniquePtr<Parser> parser);
+  static size_t RegisterParser(std::unique_ptr<Parser> parser);
 
   static void Init();
 
@@ -171,18 +171,18 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
 
   // Returns a path string for the JSON name object specified by \a json.
   // Returns null on error, and stores error in \a error.
-  static UniquePtr<char> ParseJsonMethodName(grpc_json* json,
-                                             grpc_error** error);
+  static std::unique_ptr<char> ParseJsonMethodName(grpc_json* json,
+                                                   grpc_error** error);
 
   grpc_error* ParseJsonMethodConfigToServiceConfigVectorTable(
       const grpc_json* json,
       SliceHashTable<const ParsedConfigVector*>::Entry* entries, size_t* idx);
 
-  UniquePtr<char> service_config_json_;
-  UniquePtr<char> json_string_;  // Underlying storage for json_tree.
+  std::unique_ptr<char> service_config_json_;
+  std::unique_ptr<char> json_string_;  // Underlying storage for json_tree.
   grpc_json* json_tree_;
 
-  InlinedVector<UniquePtr<ParsedConfig>, kNumPreallocatedParsers>
+  InlinedVector<std::unique_ptr<ParsedConfig>, kNumPreallocatedParsers>
       parsed_global_configs_;
   // A map from the method name to the parsed config vector. Note that we are
   // using a raw pointer and not a unique pointer so that we can use the same
@@ -191,7 +191,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
       parsed_method_configs_table_;
   // Storage for all the vectors that are being used in
   // parsed_method_configs_table_.
-  InlinedVector<UniquePtr<ParsedConfigVector>, 32>
+  InlinedVector<std::unique_ptr<ParsedConfigVector>, 32>
       parsed_method_config_vectors_storage_;
 };
 

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -404,7 +404,7 @@ void Subchannel::ConnectivityStateWatcherList::NotifyLocked(
 class Subchannel::HealthWatcherMap::HealthWatcher
     : public AsyncConnectivityStateWatcherInterface {
  public:
-  HealthWatcher(Subchannel* c, UniquePtr<char> health_check_service_name,
+  HealthWatcher(Subchannel* c, std::unique_ptr<char> health_check_service_name,
                 grpc_connectivity_state subchannel_state)
       : subchannel_(c),
         health_check_service_name_(std::move(health_check_service_name)),
@@ -489,7 +489,7 @@ class Subchannel::HealthWatcherMap::HealthWatcher
   }
 
   Subchannel* subchannel_;
-  UniquePtr<char> health_check_service_name_;
+  std::unique_ptr<char> health_check_service_name_;
   OrphanablePtr<HealthCheckClient> health_check_client_;
   grpc_connectivity_state state_;
   ConnectivityStateWatcherList watcher_list_;
@@ -501,7 +501,7 @@ class Subchannel::HealthWatcherMap::HealthWatcher
 
 void Subchannel::HealthWatcherMap::AddWatcherLocked(
     Subchannel* subchannel, grpc_connectivity_state initial_state,
-    UniquePtr<char> health_check_service_name,
+    std::unique_ptr<char> health_check_service_name,
     OrphanablePtr<ConnectivityStateWatcherInterface> watcher) {
   // If the health check service name is not already present in the map,
   // add it.
@@ -786,7 +786,7 @@ grpc_connectivity_state Subchannel::CheckConnectivityState(
 
 void Subchannel::WatchConnectivityState(
     grpc_connectivity_state initial_state,
-    UniquePtr<char> health_check_service_name,
+    std::unique_ptr<char> health_check_service_name,
     OrphanablePtr<ConnectivityStateWatcherInterface> watcher) {
   MutexLock lock(&mu_);
   grpc_pollset_set* interested_parties = watcher->interested_parties();

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -242,7 +242,7 @@ class Subchannel {
   // destroyed or when CancelConnectivityStateWatch() is called.
   void WatchConnectivityState(
       grpc_connectivity_state initial_state,
-      UniquePtr<char> health_check_service_name,
+      std::unique_ptr<char> health_check_service_name,
       OrphanablePtr<ConnectivityStateWatcherInterface> watcher);
 
   // Cancels a connectivity state watch.
@@ -311,7 +311,7 @@ class Subchannel {
    public:
     void AddWatcherLocked(
         Subchannel* subchannel, grpc_connectivity_state initial_state,
-        UniquePtr<char> health_check_service_name,
+        std::unique_ptr<char> health_check_service_name,
         OrphanablePtr<ConnectivityStateWatcherInterface> watcher);
     void RemoveWatcherLocked(const char* health_check_service_name,
                              ConnectivityStateWatcherInterface* watcher);

--- a/src/core/ext/filters/client_channel/subchannel_interface.h
+++ b/src/core/ext/filters/client_channel/subchannel_interface.h
@@ -66,7 +66,7 @@ class SubchannelInterface : public RefCounted<SubchannelInterface> {
   // the previous watcher using CancelConnectivityStateWatch().
   virtual void WatchConnectivityState(
       grpc_connectivity_state initial_state,
-      UniquePtr<ConnectivityStateWatcherInterface> watcher) = 0;
+      std::unique_ptr<ConnectivityStateWatcherInterface> watcher) = 0;
 
   // Cancels a connectivity state watch.
   // If the watcher has already been destroyed, this is a no-op.

--- a/src/core/ext/filters/client_channel/xds/xds_api.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_api.cc
@@ -88,7 +88,8 @@ bool XdsPriorityListUpdate::Contains(
   return false;
 }
 
-bool XdsDropConfig::ShouldDrop(const UniquePtr<char>** category_name) const {
+bool XdsDropConfig::ShouldDrop(
+    const std::unique_ptr<char>** category_name) const {
   for (size_t i = 0; i < drop_category_list_.size(); ++i) {
     const auto& drop_category = drop_category_list_[i];
     // Generate a random number in [0, 1000000).
@@ -258,11 +259,11 @@ grpc_error* ServerAddressParseAndAppend(
 
 namespace {
 
-UniquePtr<char> StringCopy(const upb_strview& strview) {
+std::unique_ptr<char> StringCopy(const upb_strview& strview) {
   char* str = static_cast<char*>(gpr_malloc(strview.size + 1));
   memcpy(str, strview.data, strview.size);
   str[strview.size] = '\0';
-  return UniquePtr<char>(str);
+  return std::unique_ptr<char>(str);
 }
 
 }  // namespace
@@ -542,7 +543,7 @@ grpc_slice XdsLrsRequestCreateAndEncode(const char* server_name,
 }
 
 grpc_error* XdsLrsResponseDecodeAndParse(const grpc_slice& encoded_response,
-                                         UniquePtr<char>* cluster_name,
+                                         std::unique_ptr<char>* cluster_name,
                                          grpc_millis* load_reporting_interval) {
   upb::Arena arena;
   // Decode the response.

--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -101,19 +101,19 @@ class XdsDropConfig : public RefCounted<XdsDropConfig> {
              parts_per_million == other.parts_per_million;
     }
 
-    UniquePtr<char> name;
+    std::unique_ptr<char> name;
     const uint32_t parts_per_million;
   };
 
   using DropCategoryList = InlinedVector<DropCategory, 2>;
 
-  void AddCategory(UniquePtr<char> name, uint32_t parts_per_million) {
+  void AddCategory(std::unique_ptr<char> name, uint32_t parts_per_million) {
     drop_category_list_.emplace_back(
         DropCategory{std::move(name), parts_per_million});
   }
 
   // The only method invoked from the data plane combiner.
-  bool ShouldDrop(const UniquePtr<char>** category_name) const;
+  bool ShouldDrop(const std::unique_ptr<char>** category_name) const;
 
   const DropCategoryList& drop_category_list() const {
     return drop_category_list_;
@@ -139,12 +139,12 @@ struct EdsUpdate {
 struct CdsUpdate {
   // The name to use in the EDS request.
   // If null, the cluster name will be used.
-  UniquePtr<char> eds_service_name;
+  std::unique_ptr<char> eds_service_name;
   // The LRS server to use for load reporting.
   // If null, load reporting will be disabled.
   // If set to the empty string, will use the same server we obtained
   // the CDS data from.
-  UniquePtr<char> lrs_load_reporting_server_name;
+  std::unique_ptr<char> lrs_load_reporting_server_name;
 };
 
 // Creates an EDS request querying \a service_name.
@@ -171,7 +171,7 @@ grpc_slice XdsLrsRequestCreateAndEncode(const char* server_name,
 // load_reporting_interval for client-side load reporting. If there is any
 // error, the output config is invalid.
 grpc_error* XdsLrsResponseDecodeAndParse(const grpc_slice& encoded_response,
-                                         UniquePtr<char>* cluster_name,
+                                         std::unique_ptr<char>* cluster_name,
                                          grpc_millis* load_reporting_interval);
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/xds/xds_bootstrap.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_bootstrap.cc
@@ -29,8 +29,8 @@
 
 namespace grpc_core {
 
-UniquePtr<XdsBootstrap> XdsBootstrap::ReadFromFile(grpc_error** error) {
-  UniquePtr<char> path(gpr_getenv("GRPC_XDS_BOOTSTRAP"));
+std::unique_ptr<XdsBootstrap> XdsBootstrap::ReadFromFile(grpc_error** error) {
+  std::unique_ptr<char> path(gpr_getenv("GRPC_XDS_BOOTSTRAP"));
   if (path == nullptr) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "GRPC_XDS_BOOTSTRAP env var not set");

--- a/src/core/ext/filters/client_channel/xds/xds_bootstrap.h
+++ b/src/core/ext/filters/client_channel/xds/xds_bootstrap.h
@@ -60,7 +60,7 @@ class XdsBootstrap {
 
   // If *error is not GRPC_ERROR_NONE after returning, then there was an
   // error reading the file.
-  static UniquePtr<XdsBootstrap> ReadFromFile(grpc_error** error);
+  static std::unique_ptr<XdsBootstrap> ReadFromFile(grpc_error** error);
 
   // Do not instantiate directly -- use ReadFromFile() above instead.
   XdsBootstrap(grpc_slice contents, grpc_error** error);
@@ -92,7 +92,7 @@ class XdsBootstrap {
 
   const char* server_uri_ = nullptr;
   InlinedVector<ChannelCreds, 1> channel_creds_;
-  UniquePtr<Node> node_;
+  std::unique_ptr<Node> node_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -244,7 +244,7 @@ class XdsClient::ChannelState::LrsCallState
   grpc_closure on_status_received_;
 
   // Load reporting state.
-  UniquePtr<char> cluster_name_;
+  std::unique_ptr<char> cluster_name_;
   grpc_millis load_reporting_interval_ = 0;
   OrphanablePtr<Reporter> reporter_;
 };
@@ -1124,7 +1124,7 @@ void XdsClient::ChannelState::LrsCallState::OnResponseReceivedLocked(
   // This anonymous lambda is a hack to avoid the usage of goto.
   [&]() {
     // Parse the response.
-    UniquePtr<char> new_cluster_name;
+    std::unique_ptr<char> new_cluster_name;
     grpc_millis new_load_reporting_interval;
     grpc_error* parse_error = XdsLrsResponseDecodeAndParse(
         response_slice, &new_cluster_name, &new_load_reporting_interval);
@@ -1240,18 +1240,18 @@ bool XdsClient::ChannelState::LrsCallState::IsCurrentCallOnChannel() const {
 
 namespace {
 
-UniquePtr<char> GenerateBuildVersionString() {
+std::unique_ptr<char> GenerateBuildVersionString() {
   char* build_version_str;
   gpr_asprintf(&build_version_str, "gRPC C-core %s %s", grpc_version_string(),
                GPR_PLATFORM_STRING);
-  return UniquePtr<char>(build_version_str);
+  return std::unique_ptr<char>(build_version_str);
 }
 
 }  // namespace
 
 XdsClient::XdsClient(Combiner* combiner, grpc_pollset_set* interested_parties,
                      StringView server_name,
-                     UniquePtr<ServiceConfigWatcherInterface> watcher,
+                     std::unique_ptr<ServiceConfigWatcherInterface> watcher,
                      const grpc_channel_args& channel_args, grpc_error** error)
     : build_version_(GenerateBuildVersionString()),
       combiner_(GRPC_COMBINER_REF(combiner, "xds_client")),
@@ -1289,8 +1289,8 @@ void XdsClient::Orphan() {
   Unref(DEBUG_LOCATION, "XdsClient::Orphan()");
 }
 
-void XdsClient::WatchClusterData(StringView cluster,
-                                 UniquePtr<ClusterWatcherInterface> watcher) {
+void XdsClient::WatchClusterData(
+    StringView cluster, std::unique_ptr<ClusterWatcherInterface> watcher) {
   ClusterWatcherInterface* w = watcher.get();
   cluster_state_.cluster_watchers[w] = std::move(watcher);
   // TODO(juanlishen): Start CDS call if not already started and return
@@ -1312,8 +1312,8 @@ void XdsClient::CancelClusterDataWatch(StringView cluster,
   }
 }
 
-void XdsClient::WatchEndpointData(StringView /*cluster*/,
-                                  UniquePtr<EndpointWatcherInterface> watcher) {
+void XdsClient::WatchEndpointData(
+    StringView /*cluster*/, std::unique_ptr<EndpointWatcherInterface> watcher) {
   EndpointWatcherInterface* w = watcher.get();
   cluster_state_.endpoint_watchers[w] = std::move(watcher);
   // If we've already received an EDS update, notify the new watcher

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -74,7 +74,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   // an error initializing the client.
   XdsClient(Combiner* combiner, grpc_pollset_set* interested_parties,
             StringView server_name,
-            UniquePtr<ServiceConfigWatcherInterface> watcher,
+            std::unique_ptr<ServiceConfigWatcherInterface> watcher,
             const grpc_channel_args& channel_args, grpc_error** error);
   ~XdsClient();
 
@@ -86,7 +86,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   // cancellation.  (Because the caller does not own the watcher, the
   // pointer must not be used for any other purpose.)
   void WatchClusterData(StringView cluster,
-                        UniquePtr<ClusterWatcherInterface> watcher);
+                        std::unique_ptr<ClusterWatcherInterface> watcher);
   void CancelClusterDataWatch(StringView cluster,
                               ClusterWatcherInterface* watcher);
 
@@ -96,7 +96,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   // cancellation.  (Because the caller does not own the watcher, the
   // pointer must not be used for any other purpose.)
   void WatchEndpointData(StringView cluster,
-                         UniquePtr<EndpointWatcherInterface> watcher);
+                         std::unique_ptr<EndpointWatcherInterface> watcher);
   void CancelEndpointDataWatch(StringView cluster,
                                EndpointWatcherInterface* watcher);
 
@@ -172,9 +172,10 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   };
 
   struct ClusterState {
-    std::map<ClusterWatcherInterface*, UniquePtr<ClusterWatcherInterface>>
+    std::map<ClusterWatcherInterface*, std::unique_ptr<ClusterWatcherInterface>>
         cluster_watchers;
-    std::map<EndpointWatcherInterface*, UniquePtr<EndpointWatcherInterface>>
+    std::map<EndpointWatcherInterface*,
+             std::unique_ptr<EndpointWatcherInterface>>
         endpoint_watchers;
     std::set<XdsClientStats*> client_stats;
     // The latest data seen from EDS.
@@ -195,15 +196,15 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
 
   static const grpc_arg_pointer_vtable kXdsClientVtable;
 
-  UniquePtr<char> build_version_;
+  std::unique_ptr<char> build_version_;
 
   Combiner* combiner_;
   grpc_pollset_set* interested_parties_;
 
-  UniquePtr<XdsBootstrap> bootstrap_;
+  std::unique_ptr<XdsBootstrap> bootstrap_;
 
-  UniquePtr<char> server_name_;
-  UniquePtr<ServiceConfigWatcherInterface> service_config_watcher_;
+  std::unique_ptr<char> server_name_;
+  std::unique_ptr<ServiceConfigWatcherInterface> service_config_watcher_;
   // TODO(juanlishen): Once we implement LDS support, this will no
   // longer be needed.
   grpc_closure service_config_notify_;

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.cc
@@ -90,7 +90,7 @@ XdsClientStats::LocalityStats::GetSnapshotAndReset() {
       const char* metric_name = p.first.get();
       LoadMetric& metric_value = p.second;
       snapshot.load_metric_stats.emplace(
-          UniquePtr<char>(gpr_strdup(metric_name)),
+          std::unique_ptr<char>(gpr_strdup(metric_name)),
           metric_value.GetSnapshotAndReset());
     }
   }
@@ -178,12 +178,13 @@ void XdsClientStats::PruneLocalityStats() {
   }
 }
 
-void XdsClientStats::AddCallDropped(const UniquePtr<char>& category) {
+void XdsClientStats::AddCallDropped(const std::unique_ptr<char>& category) {
   total_dropped_requests_.FetchAdd(1, MemoryOrder::RELAXED);
   MutexLock lock(&dropped_requests_mu_);
   auto iter = dropped_requests_.find(category);
   if (iter == dropped_requests_.end()) {
-    dropped_requests_.emplace(UniquePtr<char>(gpr_strdup(category.get())), 1);
+    dropped_requests_.emplace(std::unique_ptr<char>(gpr_strdup(category.get())),
+                              1);
   } else {
     ++iter->second;
   }

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.h
@@ -46,8 +46,8 @@ class XdsLocalityName : public RefCounted<XdsLocalityName> {
     }
   };
 
-  XdsLocalityName(UniquePtr<char> region, UniquePtr<char> zone,
-                  UniquePtr<char> subzone)
+  XdsLocalityName(std::unique_ptr<char> region, std::unique_ptr<char> zone,
+                  std::unique_ptr<char> subzone)
       : region_(std::move(region)),
         zone_(std::move(zone)),
         sub_zone_(std::move(subzone)) {}
@@ -73,10 +73,10 @@ class XdsLocalityName : public RefCounted<XdsLocalityName> {
   }
 
  private:
-  UniquePtr<char> region_;
-  UniquePtr<char> zone_;
-  UniquePtr<char> sub_zone_;
-  UniquePtr<char> human_readable_string_;
+  std::unique_ptr<char> region_;
+  std::unique_ptr<char> zone_;
+  std::unique_ptr<char> sub_zone_;
+  std::unique_ptr<char> human_readable_string_;
 };
 
 // The stats classes (i.e., XdsClientStats, LocalityStats, and LoadMetric) can
@@ -111,9 +111,10 @@ class XdsClientStats {
       double total_metric_value_{0};
     };
 
-    using LoadMetricMap = std::map<UniquePtr<char>, LoadMetric, StringLess>;
+    using LoadMetricMap =
+        std::map<std::unique_ptr<char>, LoadMetric, StringLess>;
     using LoadMetricSnapshotMap =
-        std::map<UniquePtr<char>, LoadMetric::Snapshot, StringLess>;
+        std::map<std::unique_ptr<char>, LoadMetric::Snapshot, StringLess>;
 
     struct Snapshot {
       // TODO(juanlishen): Change this to const method when const_iterator is
@@ -177,7 +178,7 @@ class XdsClientStats {
 
   // TODO(juanlishen): The value type of Map<> must be movable in current
   // implementation. To avoid making LocalityStats movable, we wrap it by
-  // UniquePtr<>. We should remove this wrapper if the value type of Map<>
+  // std::unique_ptr<>. We should remove this wrapper if the value type of Map<>
   // doesn't have to be movable.
   using LocalityStatsMap =
       std::map<RefCountedPtr<XdsLocalityName>, RefCountedPtr<LocalityStats>,
@@ -185,7 +186,8 @@ class XdsClientStats {
   using LocalityStatsSnapshotMap =
       std::map<RefCountedPtr<XdsLocalityName>, LocalityStats::Snapshot,
                XdsLocalityName::Less>;
-  using DroppedRequestsMap = std::map<UniquePtr<char>, uint64_t, StringLess>;
+  using DroppedRequestsMap =
+      std::map<std::unique_ptr<char>, uint64_t, StringLess>;
   using DroppedRequestsSnapshotMap = DroppedRequestsMap;
 
   struct Snapshot {
@@ -208,7 +210,7 @@ class XdsClientStats {
   RefCountedPtr<LocalityStats> FindLocalityStats(
       const RefCountedPtr<XdsLocalityName>& locality_name);
   void PruneLocalityStats();
-  void AddCallDropped(const UniquePtr<char>& category);
+  void AddCallDropped(const std::unique_ptr<char>& category);
 
  private:
   // The stats for each locality.

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -44,8 +44,9 @@ namespace {
 size_t g_message_size_parser_index;
 }  // namespace
 
-UniquePtr<ServiceConfig::ParsedConfig> MessageSizeParser::ParsePerMethodParams(
-    const grpc_json* json, grpc_error** error) {
+std::unique_ptr<ServiceConfig::ParsedConfig>
+MessageSizeParser::ParsePerMethodParams(const grpc_json* json,
+                                        grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   int max_request_message_bytes = -1;
   int max_response_message_bytes = -1;

--- a/src/core/ext/filters/message_size/message_size_filter.h
+++ b/src/core/ext/filters/message_size/message_size_filter.h
@@ -46,7 +46,7 @@ class MessageSizeParsedConfig : public ServiceConfig::ParsedConfig {
 
 class MessageSizeParser : public ServiceConfig::Parser {
  public:
-  UniquePtr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
       const grpc_json* json, grpc_error** error) override;
 
   static void Register();

--- a/src/core/ext/transport/chttp2/client/authority.cc
+++ b/src/core/ext/transport/chttp2/client/authority.cc
@@ -26,7 +26,7 @@ grpc_channel_args* grpc_default_authority_add_if_not_present(
       grpc_channel_args_find(args, GRPC_ARG_DEFAULT_AUTHORITY) != nullptr;
   grpc_arg new_args[1];
   size_t num_new_args = 0;
-  grpc_core::UniquePtr<char> default_authority;
+  std::unique_ptr<char> default_authority;
   if (!has_default_authority) {
     const grpc_arg* server_uri_arg =
         grpc_channel_args_find(args, GRPC_ARG_SERVER_URI);

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -56,7 +56,7 @@ grpc_channel* CreateChannel(const char* target, const grpc_channel_args* args) {
     return nullptr;
   }
   // Add channel arg containing the server URI.
-  UniquePtr<char> canonical_target =
+  std::unique_ptr<char> canonical_target =
       ResolverRegistry::AddDefaultPrefixIfNeeded(target);
   grpc_arg arg = grpc_channel_arg_string_create(
       const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -86,7 +86,7 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
     GPR_ASSERT(server_uri != nullptr);
     const TargetAuthorityTable* target_authority_table =
         FindTargetAuthorityTableInArgs(args);
-    UniquePtr<char> authority;
+    std::unique_ptr<char> authority;
     if (target_authority_table != nullptr) {
       // Find the authority for the target.
       const char* target_uri_str =
@@ -98,7 +98,7 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
         const grpc_slice key = grpc_slice_from_static_string(
             target_uri->path[0] == '/' ? target_uri->path + 1
                                        : target_uri->path);
-        const UniquePtr<char>* value = target_authority_table->Get(key);
+        const std::unique_ptr<char>* value = target_authority_table->Get(key);
         if (value != nullptr) authority.reset(gpr_strdup(value->get()));
         grpc_slice_unref_internal(key);
       }
@@ -158,7 +158,7 @@ grpc_channel* CreateChannel(const char* target, const grpc_channel_args* args) {
     return nullptr;
   }
   // Add channel arg containing the server URI.
-  UniquePtr<char> canonical_target =
+  std::unique_ptr<char> canonical_target =
       ResolverRegistry::AddDefaultPrefixIfNeeded(target);
   grpc_arg arg = grpc_channel_arg_string_create(
       const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -138,7 +138,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
             gpr_free(msg);
             p->error = grpc_error_set_str(
                 p->error, GRPC_ERROR_STR_RAW_BYTES,
-                grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(
+                grpc_slice_from_moved_string(std::unique_ptr<char>(
                     grpc_dump_slice(*slice, GPR_DUMP_HEX | GPR_DUMP_ASCII))));
             p->error =
                 grpc_error_set_int(p->error, GRPC_ERROR_INT_OFFSET, cur - beg);

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -109,10 +109,10 @@ grpc_error* grpc_chttp2_rst_stream_parser_parse(void* parser,
       char* message;
       gpr_asprintf(&message, "Received RST_STREAM with error code %d", reason);
       error = grpc_error_set_int(
-          grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
-                             GRPC_ERROR_STR_GRPC_MESSAGE,
-                             grpc_slice_from_moved_string(
-                                 grpc_core::UniquePtr<char>(message))),
+          grpc_error_set_str(
+              GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
+              GRPC_ERROR_STR_GRPC_MESSAGE,
+              grpc_slice_from_moved_string(std::unique_ptr<char>(message))),
           GRPC_ERROR_INT_HTTP2_ERROR, static_cast<intptr_t>(reason));
     }
     grpc_chttp2_mark_stream_closed(t, s, true, true, error);

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -442,8 +442,8 @@ void PopulateSocketAddressJson(grpc_json* json, const char* name,
                            (strcmp(uri->scheme, "ipv6") == 0))) {
     const char* host_port = uri->path;
     if (*host_port == '/') ++host_port;
-    UniquePtr<char> host;
-    UniquePtr<char> port;
+    std::unique_ptr<char> host;
+    std::unique_ptr<char> port;
     GPR_ASSERT(SplitHostPort(host_port, &host, &port));
     int port_num = -1;
     if (port != nullptr) {

--- a/src/core/lib/channel/handshaker_registry.cc
+++ b/src/core/lib/channel/handshaker_registry.cc
@@ -38,21 +38,21 @@ namespace {
 
 class HandshakerFactoryList {
  public:
-  void Register(bool at_start, UniquePtr<HandshakerFactory> factory);
+  void Register(bool at_start, std::unique_ptr<HandshakerFactory> factory);
   void AddHandshakers(const grpc_channel_args* args,
                       grpc_pollset_set* interested_parties,
                       HandshakeManager* handshake_mgr);
 
  private:
-  InlinedVector<UniquePtr<HandshakerFactory>, 2> factories_;
+  InlinedVector<std::unique_ptr<HandshakerFactory>, 2> factories_;
 };
 
 HandshakerFactoryList* g_handshaker_factory_lists = nullptr;
 
 }  // namespace
 
-void HandshakerFactoryList::Register(bool at_start,
-                                     UniquePtr<HandshakerFactory> factory) {
+void HandshakerFactoryList::Register(
+    bool at_start, std::unique_ptr<HandshakerFactory> factory) {
   factories_.push_back(std::move(factory));
   if (at_start) {
     auto* end = &factories_[factories_.size() - 1];
@@ -99,7 +99,7 @@ void HandshakerRegistry::Shutdown() {
 
 void HandshakerRegistry::RegisterHandshakerFactory(
     bool at_start, HandshakerType handshaker_type,
-    UniquePtr<HandshakerFactory> factory) {
+    std::unique_ptr<HandshakerFactory> factory) {
   GPR_ASSERT(g_handshaker_factory_lists != nullptr);
   auto& factory_list = g_handshaker_factory_lists[handshaker_type];
   factory_list.Register(at_start, std::move(factory));

--- a/src/core/lib/channel/handshaker_registry.h
+++ b/src/core/lib/channel/handshaker_registry.h
@@ -38,9 +38,9 @@ class HandshakerRegistry {
   /// Registers a new handshaker factory.  Takes ownership.
   /// If \a at_start is true, the new handshaker will be at the beginning of
   /// the list.  Otherwise, it will be added to the end.
-  static void RegisterHandshakerFactory(bool at_start,
-                                        HandshakerType handshaker_type,
-                                        UniquePtr<HandshakerFactory> factory);
+  static void RegisterHandshakerFactory(
+      bool at_start, HandshakerType handshaker_type,
+      std::unique_ptr<HandshakerFactory> factory);
   static void AddHandshakers(HandshakerType handshaker_type,
                              const grpc_channel_args* args,
                              grpc_pollset_set* interested_parties,

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -143,7 +143,7 @@ void grpc_tracer_init(const char* env_var_name) {
 }
 
 void grpc_tracer_init() {
-  grpc_core::UniquePtr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_trace);
+  std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_trace);
   parse(value.get());
 }
 

--- a/src/core/lib/gpr/log.cc
+++ b/src/core/lib/gpr/log.cc
@@ -75,7 +75,7 @@ void gpr_set_log_verbosity(gpr_log_severity min_severity_to_print) {
 }
 
 void gpr_log_verbosity_init() {
-  grpc_core::UniquePtr<char> verbosity = GPR_GLOBAL_CONFIG_GET(grpc_verbosity);
+  std::unique_ptr<char> verbosity = GPR_GLOBAL_CONFIG_GET(grpc_verbosity);
 
   gpr_atm min_severity_to_print = GPR_LOG_SEVERITY_ERROR;
   if (strlen(verbosity.get()) > 0) {

--- a/src/core/lib/gprpp/global_config_env.cc
+++ b/src/core/lib/gprpp/global_config_env.cc
@@ -56,8 +56,8 @@ void SetGlobalConfigEnvErrorFunction(GlobalConfigEnvErrorFunctionType func) {
   g_global_config_env_error_func = func;
 }
 
-UniquePtr<char> GlobalConfigEnv::GetValue() {
-  return UniquePtr<char>(gpr_getenv(GetName()));
+std::unique_ptr<char> GlobalConfigEnv::GetValue() {
+  return std::unique_ptr<char>(gpr_getenv(GetName()));
 }
 
 void GlobalConfigEnv::SetValue(const char* value) {
@@ -78,7 +78,7 @@ static_assert(std::is_trivially_destructible<GlobalConfigEnvBool>::value,
               "GlobalConfigEnvBool needs to be trivially destructible.");
 
 bool GlobalConfigEnvBool::Get() {
-  UniquePtr<char> str = GetValue();
+  std::unique_ptr<char> str = GetValue();
   if (str == nullptr) {
     return default_value_;
   }
@@ -99,7 +99,7 @@ static_assert(std::is_trivially_destructible<GlobalConfigEnvInt32>::value,
               "GlobalConfigEnvInt32 needs to be trivially destructible.");
 
 int32_t GlobalConfigEnvInt32::Get() {
-  UniquePtr<char> str = GetValue();
+  std::unique_ptr<char> str = GetValue();
   if (str == nullptr) {
     return default_value_;
   }
@@ -122,10 +122,10 @@ void GlobalConfigEnvInt32::Set(int32_t value) {
 static_assert(std::is_trivially_destructible<GlobalConfigEnvString>::value,
               "GlobalConfigEnvString needs to be trivially destructible.");
 
-UniquePtr<char> GlobalConfigEnvString::Get() {
-  UniquePtr<char> str = GetValue();
+std::unique_ptr<char> GlobalConfigEnvString::Get() {
+  std::unique_ptr<char> str = GetValue();
   if (str == nullptr) {
-    return UniquePtr<char>(gpr_strdup(default_value_));
+    return std::unique_ptr<char>(gpr_strdup(default_value_));
   }
   return str;
 }

--- a/src/core/lib/gprpp/global_config_env.h
+++ b/src/core/lib/gprpp/global_config_env.h
@@ -43,7 +43,7 @@ class GlobalConfigEnv {
 
  public:
   // Returns the value of `name` variable.
-  UniquePtr<char> GetValue();
+  std::unique_ptr<char> GetValue();
 
   // Sets the value of `name` variable.
   void SetValue(const char* value);
@@ -87,7 +87,7 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
   constexpr GlobalConfigEnvString(char* name, const char* default_value)
       : GlobalConfigEnv(name), default_value_(default_value) {}
 
-  UniquePtr<char> Get();
+  std::unique_ptr<char> Get();
   void Set(const char* value);
 
  private:
@@ -121,7 +121,7 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
   static char g_env_str_##name[] = #name;                                  \
   static ::grpc_core::GlobalConfigEnvString g_env_##name(g_env_str_##name, \
                                                          default_value);   \
-  ::grpc_core::UniquePtr<char> gpr_global_config_get_##name() {            \
+  ::std::unique_ptr<char> gpr_global_config_get_##name() {                 \
     return g_env_##name.Get();                                             \
   }                                                                        \
   void gpr_global_config_set_##name(const char* value) {                   \

--- a/src/core/lib/gprpp/global_config_generic.h
+++ b/src/core/lib/gprpp/global_config_generic.h
@@ -37,8 +37,8 @@
   extern int32_t gpr_global_config_get_##name(); \
   extern void gpr_global_config_set_##name(int32_t value)
 
-#define GPR_GLOBAL_CONFIG_DECLARE_STRING(name)                      \
-  extern grpc_core::UniquePtr<char> gpr_global_config_get_##name(); \
+#define GPR_GLOBAL_CONFIG_DECLARE_STRING(name)                 \
+  extern std::unique_ptr<char> gpr_global_config_get_##name(); \
   extern void gpr_global_config_set_##name(const char* value)
 
 #endif /* GRPC_CORE_LIB_GPRPP_GLOBAL_CONFIG_GENERIC_H */

--- a/src/core/lib/gprpp/host_port.cc
+++ b/src/core/lib/gprpp/host_port.cc
@@ -30,7 +30,7 @@
 #include "src/core/lib/gprpp/string_view.h"
 
 namespace grpc_core {
-int JoinHostPort(UniquePtr<char>* out, const char* host, int port) {
+int JoinHostPort(std::unique_ptr<char>* out, const char* host, int port) {
   char* tmp;
   int ret;
   if (host[0] != '[' && strchr(host, ':') != nullptr) {
@@ -96,8 +96,8 @@ bool SplitHostPort(StringView name, StringView* host, StringView* port) {
   return DoSplitHostPort(name, host, port, &unused);
 }
 
-bool SplitHostPort(StringView name, UniquePtr<char>* host,
-                   UniquePtr<char>* port) {
+bool SplitHostPort(StringView name, std::unique_ptr<char>* host,
+                   std::unique_ptr<char>* port) {
   GPR_DEBUG_ASSERT(host != nullptr && *host == nullptr);
   GPR_DEBUG_ASSERT(port != nullptr && *port == nullptr);
   StringView host_view;

--- a/src/core/lib/gprpp/host_port.h
+++ b/src/core/lib/gprpp/host_port.h
@@ -35,7 +35,7 @@ namespace grpc_core {
    (excluding the final '\0'), and *out points to a string.
 
    In the unlikely event of an error, returns -1 and sets *out to NULL. */
-int JoinHostPort(UniquePtr<char>* out, const char* host, int port);
+int JoinHostPort(std::unique_ptr<char>* out, const char* host, int port);
 
 /** Given a name in the form "host:port" or "[ho:st]:port", split into hostname
    and port number.
@@ -51,8 +51,8 @@ int JoinHostPort(UniquePtr<char>* out, const char* host, int port);
    Return true on success, false on failure. Guarantees *host and *port are
    cleared on failure. */
 bool SplitHostPort(StringView name, StringView* host, StringView* port);
-bool SplitHostPort(StringView name, UniquePtr<char>* host,
-                   UniquePtr<char>* port);
+bool SplitHostPort(StringView name, std::unique_ptr<char>* host,
+                   std::unique_ptr<char>* port);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/gprpp/map.h
+++ b/src/core/lib/gprpp/map.h
@@ -34,7 +34,8 @@ struct StringLess {
   bool operator()(const char* a, const char* b) const {
     return strcmp(a, b) < 0;
   }
-  bool operator()(const UniquePtr<char>& a, const UniquePtr<char>& b) const {
+  bool operator()(const std::unique_ptr<char>& a,
+                  const std::unique_ptr<char>& b) const {
     return strcmp(a.get(), b.get()) < 0;
   }
   bool operator()(const StringView& a, const StringView& b) const {

--- a/src/core/lib/gprpp/memory.h
+++ b/src/core/lib/gprpp/memory.h
@@ -30,67 +30,10 @@
 
 namespace grpc_core {
 
-template <typename T>
-using UniquePtr = std::unique_ptr<T>;
-
+// TODO(veblush): Replace this with absl::make_unique once abseil is added.
 template <typename T, typename... Args>
-inline UniquePtr<T> MakeUnique(Args&&... args) {
-  return UniquePtr<T>(new T(std::forward<Args>(args)...));
-}
-
-// an allocator that uses gpr_malloc/gpr_free
-template <class T>
-class Allocator {
- public:
-  typedef T value_type;
-  typedef T* pointer;
-  typedef const T* const_pointer;
-  typedef T& reference;
-  typedef const T& const_reference;
-  typedef std::size_t size_type;
-  typedef std::ptrdiff_t difference_type;
-  typedef std::false_type propagate_on_container_move_assignment;
-  template <class U>
-  struct rebind {
-    typedef Allocator<U> other;
-  };
-  typedef std::true_type is_always_equal;
-
-  Allocator() = default;
-
-  template <class U>
-  Allocator(const Allocator<U>&) {}
-
-  pointer address(reference x) const { return &x; }
-  const_pointer address(const_reference x) const { return &x; }
-  pointer allocate(std::size_t n,
-                   std::allocator<void>::const_pointer /*hint*/ = nullptr) {
-    return static_cast<pointer>(gpr_malloc(n * sizeof(T)));
-  }
-  void deallocate(T* p, std::size_t /* n */) { gpr_free(p); }
-  size_t max_size() const {
-    return std::numeric_limits<size_type>::max() / sizeof(value_type);
-  }
-  void construct(pointer p, const_reference val) { new ((void*)p) T(val); }
-  template <class U, class... Args>
-  void construct(U* p, Args&&... args) {
-    ::new ((void*)p) U(std::forward<Args>(args)...);
-  }
-  void destroy(pointer p) { p->~T(); }
-  template <class U>
-  void destroy(U* p) {
-    p->~U();
-  }
-};
-
-template <class T, class U>
-bool operator==(Allocator<T> const&, Allocator<U> const&) noexcept {
-  return true;
-}
-
-template <class T, class U>
-bool operator!=(Allocator<T> const& /*x*/, Allocator<U> const& /*y*/) noexcept {
-  return false;
+inline std::unique_ptr<T> MakeUnique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/gprpp/string_view.h
+++ b/src/core/lib/gprpp/string_view.h
@@ -143,11 +143,11 @@ inline StringView StringViewFromSlice(const grpc_slice& slice) {
 
 // Creates a dup of the string viewed by this class.
 // Return value is null-terminated and never nullptr.
-inline grpc_core::UniquePtr<char> StringViewToCString(const StringView sv) {
+inline std::unique_ptr<char> StringViewToCString(const StringView sv) {
   char* str = static_cast<char*>(gpr_malloc(sv.size() + 1));
   if (sv.size() > 0) memcpy(str, sv.data(), sv.size());
   str[sv.size()] = '\0';
-  return grpc_core::UniquePtr<char>(str);
+  return std::unique_ptr<char>(str);
 }
 
 // Compares lhs and rhs.

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -113,7 +113,7 @@ static void append_error(internal_request* req, grpc_error* error) {
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed HTTP/1 client request");
   }
   grpc_resolved_address* addr = &req->addresses->addrs[req->next_address - 1];
-  grpc_core::UniquePtr<char> addr_text(grpc_sockaddr_to_uri(addr));
+  std::unique_ptr<char> addr_text(grpc_sockaddr_to_uri(addr));
   req->overall_error = grpc_error_add_child(
       req->overall_error,
       grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,

--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -211,7 +211,7 @@ void grpc_register_event_engine_factory(const char* name,
 const char* grpc_get_poll_strategy_name() { return g_poll_strategy_name; }
 
 void grpc_event_engine_init(void) {
-  grpc_core::UniquePtr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
 
   char** strings = nullptr;
   size_t nstrings = 0;

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -88,8 +88,8 @@ void grpc_custom_resolve_callback(grpc_custom_resolver* r,
 
 static grpc_error* try_split_host_port(const char* name,
                                        const char* default_port,
-                                       grpc_core::UniquePtr<char>* host,
-                                       grpc_core::UniquePtr<char>* port) {
+                                       std::unique_ptr<char>* host,
+                                       std::unique_ptr<char>* port) {
   /* parse name, splitting it into host and port parts */
   grpc_error* error;
   grpc_core::SplitHostPort(name, host, port);
@@ -117,8 +117,8 @@ static grpc_error* try_split_host_port(const char* name,
 static grpc_error* blocking_resolve_address_impl(
     const char* name, const char* default_port,
     grpc_resolved_addresses** addresses) {
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   grpc_error* err;
 
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
@@ -155,8 +155,8 @@ static void resolve_address_impl(const char* name, const char* default_port,
                                  grpc_closure* on_done,
                                  grpc_resolved_addresses** addrs) {
   grpc_custom_resolver* r = nullptr;
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   grpc_error* err;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   err = try_split_host_port(name, default_port, &host, &port);

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -57,8 +57,8 @@ static grpc_error* posix_blocking_resolve_address(
     return grpc_resolve_unix_domain_address(name + 5, addresses);
   }
 
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   /* parse name, splitting it into host and port parts */
   grpc_core::SplitHostPort(name, &host, &port);
   if (host == nullptr) {

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -62,8 +62,8 @@ static grpc_error* windows_blocking_resolve_address(
   grpc_error* error = GRPC_ERROR_NONE;
 
   /* parse name, splitting it into host and port parts */
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   grpc_core::SplitHostPort(name, &host, &port);
   if (host == NULL) {
     char* msg;

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -181,7 +181,7 @@ int grpc_sockaddr_to_string(char** out,
   }
   if (ip != nullptr && grpc_inet_ntop(addr->sa_family, ip, ntop_buf,
                                       sizeof(ntop_buf)) != nullptr) {
-    grpc_core::UniquePtr<char> tmp_out;
+    std::unique_ptr<char> tmp_out;
     if (sin6_scope_id != 0) {
       char* host_with_scope;
       /* Enclose sin6_scope_id with the format defined in RFC 6784 section 2. */

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -145,8 +145,8 @@ static void ParseResolvedAddress(const grpc_resolved_address* addr,
                                  CFStringRef* host, int* port) {
   char* host_port;
   grpc_sockaddr_to_string(&host_port, addr, 1);
-  grpc_core::UniquePtr<char> host_string;
-  grpc_core::UniquePtr<char> port_string;
+  std::unique_ptr<char> host_string;
+  std::unique_ptr<char> port_string;
   grpc_core::SplitHostPort(host_port, &host_string, &port_string);
   *host =
       CFStringCreateWithCString(NULL, host_string.get(), kCFStringEncodingUTF8);

--- a/src/core/lib/profiling/basic_timers.cc
+++ b/src/core/lib/profiling/basic_timers.cc
@@ -80,8 +80,7 @@ GPR_GLOBAL_CONFIG_DEFINE_STRING(grpc_latency_trace, "latency_trace.txt",
 
 static const char* output_filename() {
   if (output_filename_or_null == NULL) {
-    grpc_core::UniquePtr<char> value =
-        GPR_GLOBAL_CONFIG_GET(grpc_latency_trace);
+    std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_latency_trace);
     if (strlen(value.get()) > 0) {
       output_filename_or_null = value.release();
     } else {

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -45,7 +45,7 @@ void grpc_channel_credentials_release(grpc_channel_credentials* creds) {
   if (creds) creds->Unref();
 }
 
-static std::map<grpc_core::UniquePtr<char>,
+static std::map<std::unique_ptr<char>,
                 grpc_core::RefCountedPtr<grpc_channel_credentials>,
                 grpc_core::StringLess>* g_grpc_control_plane_creds;
 static gpr_mu g_control_plane_creds_mu;
@@ -54,7 +54,7 @@ static void do_control_plane_creds_init() {
   gpr_mu_init(&g_control_plane_creds_mu);
   GPR_ASSERT(g_grpc_control_plane_creds == nullptr);
   g_grpc_control_plane_creds =
-      new std::map<grpc_core::UniquePtr<char>,
+      new std::map<std::unique_ptr<char>,
                    grpc_core::RefCountedPtr<grpc_channel_credentials>,
                    grpc_core::StringLess>();
 }
@@ -88,7 +88,7 @@ bool grpc_control_plane_credentials_register(
   grpc_core::ExecCtx exec_ctx;
   {
     grpc_core::MutexLock lock(&g_control_plane_creds_mu);
-    auto key = grpc_core::UniquePtr<char>(gpr_strdup(authority));
+    auto key = std::unique_ptr<char>(gpr_strdup(authority));
     if (g_grpc_control_plane_creds->find(key) !=
         g_grpc_control_plane_creds->end()) {
       return false;
@@ -101,7 +101,7 @@ bool grpc_control_plane_credentials_register(
 bool grpc_channel_credentials::attach_credentials(
     const char* authority,
     grpc_core::RefCountedPtr<grpc_channel_credentials> control_plane_creds) {
-  auto key = grpc_core::UniquePtr<char>(gpr_strdup(authority));
+  auto key = std::unique_ptr<char>(gpr_strdup(authority));
   if (local_control_plane_creds_.find(key) !=
       local_control_plane_creds_.end()) {
     return false;
@@ -113,7 +113,7 @@ bool grpc_channel_credentials::attach_credentials(
 grpc_core::RefCountedPtr<grpc_channel_credentials>
 grpc_channel_credentials::get_control_plane_credentials(const char* authority) {
   {
-    auto key = grpc_core::UniquePtr<char>(gpr_strdup(authority));
+    auto key = std::unique_ptr<char>(gpr_strdup(authority));
     auto local_lookup = local_control_plane_creds_.find(key);
     if (local_lookup != local_control_plane_creds_.end()) {
       return local_lookup->second;

--- a/src/core/lib/security/credentials/credentials.h
+++ b/src/core/lib/security/credentials/credentials.h
@@ -148,7 +148,7 @@ struct grpc_channel_credentials
 
  private:
   const char* type_;
-  std::map<grpc_core::UniquePtr<char>,
+  std::map<std::unique_ptr<char>,
            grpc_core::RefCountedPtr<grpc_channel_credentials>,
            grpc_core::StringLess>
       local_control_plane_creds_;

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -624,14 +624,14 @@ class StsTokenFetcherCredentials
 
   grpc_uri* sts_url_;
   grpc_closure http_post_cb_closure_;
-  grpc_core::UniquePtr<char> resource_;
-  grpc_core::UniquePtr<char> audience_;
-  grpc_core::UniquePtr<char> scope_;
-  grpc_core::UniquePtr<char> requested_token_type_;
-  grpc_core::UniquePtr<char> subject_token_path_;
-  grpc_core::UniquePtr<char> subject_token_type_;
-  grpc_core::UniquePtr<char> actor_token_path_;
-  grpc_core::UniquePtr<char> actor_token_type_;
+  std::unique_ptr<char> resource_;
+  std::unique_ptr<char> audience_;
+  std::unique_ptr<char> scope_;
+  std::unique_ptr<char> requested_token_type_;
+  std::unique_ptr<char> subject_token_path_;
+  std::unique_ptr<char> subject_token_type_;
+  std::unique_ptr<char> actor_token_path_;
+  std::unique_ptr<char> actor_token_type_;
 };
 
 }  // namespace

--- a/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc
@@ -29,7 +29,7 @@
 
 /** -- gRPC TLS key materials config API implementation. -- **/
 void grpc_tls_key_materials_config::set_key_materials(
-    grpc_core::UniquePtr<char> pem_root_certs,
+    std::unique_ptr<char> pem_root_certs,
     PemKeyCertPairList pem_key_cert_pair_list) {
   pem_key_cert_pair_list_ = std::move(pem_key_cert_pair_list);
   pem_root_certs_ = std::move(pem_root_certs);
@@ -145,7 +145,7 @@ int grpc_tls_key_materials_config_set_key_materials(
             "grpc_tls_key_materials_config_set_key_materials()");
     return 0;
   }
-  grpc_core::UniquePtr<char> pem_root(const_cast<char*>(root_certs));
+  std::unique_ptr<char> pem_root(const_cast<char*>(root_certs));
   grpc_tls_key_materials_config::PemKeyCertPairList cert_pair_list;
   for (size_t i = 0; i < num; i++) {
     grpc_core::PemKeyCertPair key_cert_pair(

--- a/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
@@ -42,20 +42,20 @@ struct grpc_tls_key_materials_config
   int version() const { return version_; }
 
   /** Setters for member fields. **/
-  void set_pem_root_certs(grpc_core::UniquePtr<char> pem_root_certs) {
+  void set_pem_root_certs(std::unique_ptr<char> pem_root_certs) {
     pem_root_certs_ = std::move(pem_root_certs);
   }
   void add_pem_key_cert_pair(grpc_core::PemKeyCertPair pem_key_cert_pair) {
     pem_key_cert_pair_list_.push_back(pem_key_cert_pair);
   }
-  void set_key_materials(grpc_core::UniquePtr<char> pem_root_certs,
+  void set_key_materials(std::unique_ptr<char> pem_root_certs,
                          PemKeyCertPairList pem_key_cert_pair_list);
   void set_version(int version) { version_ = version; }
 
  private:
   int version_ = 0;
   PemKeyCertPairList pem_key_cert_pair_list_;
-  grpc_core::UniquePtr<char> pem_root_certs_;
+  std::unique_ptr<char> pem_root_certs_;
 };
 
 /** TLS credential reload config. **/

--- a/src/core/lib/security/security_connector/load_system_roots_linux.cc
+++ b/src/core/lib/security/security_connector/load_system_roots_linux.cc
@@ -144,7 +144,8 @@ grpc_slice CreateRootCertsBundle(const char* certs_directory) {
 grpc_slice LoadSystemRootCerts() {
   grpc_slice result = grpc_empty_slice();
   // Prioritize user-specified custom directory if flag is set.
-  UniquePtr<char> custom_dir = GPR_GLOBAL_CONFIG_GET(grpc_system_ssl_roots_dir);
+  std::unique_ptr<char> custom_dir =
+      GPR_GLOBAL_CONFIG_GET(grpc_system_ssl_roots_dir);
   if (strlen(custom_dir.get()) > 0) {
     result = CreateRootCertsBundle(custom_dir.get());
   }

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -138,7 +138,7 @@ class grpc_channel_security_connector : public grpc_security_connector {
  private:
   grpc_core::RefCountedPtr<grpc_channel_credentials> channel_creds_;
   grpc_core::RefCountedPtr<grpc_call_credentials> request_metadata_creds_;
-  grpc_core::UniquePtr<grpc_channel_args> channel_args_;
+  std::unique_ptr<grpc_channel_args> channel_args_;
 };
 
 /* --- server_security_connector object. ---

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -214,8 +214,8 @@ class grpc_ssl_channel_security_connector final
 
  private:
   tsi_ssl_client_handshaker_factory* client_handshaker_factory_;
-  grpc_core::UniquePtr<char> target_name_;
-  grpc_core::UniquePtr<char> overridden_target_name_;
+  std::unique_ptr<char> target_name_;
+  std::unique_ptr<char> overridden_target_name_;
   const verify_peer_options* verify_options_;
 };
 

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -72,8 +72,7 @@ GPR_GLOBAL_CONFIG_DEFINE_STRING(
     "A colon separated list of cipher suites to use with OpenSSL")
 
 static void init_cipher_suites(void) {
-  grpc_core::UniquePtr<char> value =
-      GPR_GLOBAL_CONFIG_GET(grpc_ssl_cipher_suites);
+  std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_ssl_cipher_suites);
   cipher_suites = value.release();
 }
 
@@ -423,7 +422,7 @@ grpc_slice DefaultSslRootStore::ComputePemRootCerts() {
   const bool not_use_system_roots =
       GPR_GLOBAL_CONFIG_GET(grpc_not_use_system_ssl_roots);
   // First try to load the roots from the configuration.
-  UniquePtr<char> default_root_certs_path =
+  std::unique_ptr<char> default_root_certs_path =
       GPR_GLOBAL_CONFIG_GET(grpc_default_ssl_roots_file_path);
   if (strlen(default_root_certs_path.get()) > 0) {
     GRPC_LOG_IF_ERROR(

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -152,8 +152,8 @@ class PemKeyCertPair {
       : private_key_(gpr_strdup(other.private_key())),
         cert_chain_(gpr_strdup(other.cert_chain())) {}
   PemKeyCertPair& operator=(const PemKeyCertPair& other) {
-    private_key_ = grpc_core::UniquePtr<char>(gpr_strdup(other.private_key()));
-    cert_chain_ = grpc_core::UniquePtr<char>(gpr_strdup(other.cert_chain()));
+    private_key_ = std::unique_ptr<char>(gpr_strdup(other.private_key()));
+    cert_chain_ = std::unique_ptr<char>(gpr_strdup(other.cert_chain()));
     return *this;
   }
 
@@ -161,8 +161,8 @@ class PemKeyCertPair {
   char* cert_chain() const { return cert_chain_.get(); }
 
  private:
-  grpc_core::UniquePtr<char> private_key_;
-  grpc_core::UniquePtr<char> cert_chain_;
+  std::unique_ptr<char> private_key_;
+  std::unique_ptr<char> cert_chain_;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
@@ -300,7 +300,7 @@ SpiffeChannelSecurityConnector::InitializeHandshakerFactory(
   if (key_materials_config != nullptr) {
     grpc_tls_key_materials_config::PemKeyCertPairList cert_pair_list =
         key_materials_config->pem_key_cert_pair_list();
-    auto pem_root_certs = grpc_core::UniquePtr<char>(
+    auto pem_root_certs = std::unique_ptr<char>(
         gpr_strdup(key_materials_config->pem_root_certs()));
     key_materials_config_->set_key_materials(std::move(pem_root_certs),
                                              std::move(cert_pair_list));
@@ -505,7 +505,7 @@ SpiffeServerSecurityConnector::InitializeHandshakerFactory() {
   if (key_materials_config != nullptr) {
     grpc_tls_key_materials_config::PemKeyCertPairList cert_pair_list =
         key_materials_config->pem_key_cert_pair_list();
-    auto pem_root_certs = grpc_core::UniquePtr<char>(
+    auto pem_root_certs = std::unique_ptr<char>(
         gpr_strdup(key_materials_config->pem_root_certs()));
     key_materials_config_->set_key_materials(std::move(pem_root_certs),
                                              std::move(cert_pair_list));

--- a/src/core/lib/security/security_connector/tls/spiffe_security_connector.h
+++ b/src/core/lib/security/security_connector/tls/spiffe_security_connector.h
@@ -98,8 +98,8 @@ class SpiffeChannelSecurityConnector final
 
   grpc_core::Mutex mu_;
   grpc_closure* on_peer_checked_;
-  grpc_core::UniquePtr<char> target_name_;
-  grpc_core::UniquePtr<char> overridden_target_name_;
+  std::unique_ptr<char> target_name_;
+  std::unique_ptr<char> overridden_target_name_;
   tsi_ssl_client_handshaker_factory* client_handshaker_factory_ = nullptr;
   grpc_tls_server_authorization_check_arg* check_arg_;
   grpc_core::RefCountedPtr<grpc_tls_key_materials_config> key_materials_config_;

--- a/src/core/lib/security/transport/target_authority_table.h
+++ b/src/core/lib/security/transport/target_authority_table.h
@@ -26,7 +26,7 @@
 namespace grpc_core {
 
 /// A hash table mapping target addresses to authorities.
-typedef SliceHashTable<UniquePtr<char>> TargetAuthorityTable;
+typedef SliceHashTable<std::unique_ptr<char>> TargetAuthorityTable;
 
 /// Returns a channel argument containing \a table.
 grpc_arg CreateTargetAuthorityTableChannelArg(TargetAuthorityTable* table);

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -156,7 +156,7 @@ class NewWithLenSliceRefcount {
 /** grpc_slice_from_moved_(string|buffer) ref count .*/
 class MovedStringSliceRefCount {
  public:
-  MovedStringSliceRefCount(grpc_core::UniquePtr<char>&& str)
+  MovedStringSliceRefCount(std::unique_ptr<char>&& str)
       : base_(grpc_slice_refcount::Type::REGULAR, &refs_, Destroy, this,
               &base_),
         str_(std::move(str)) {}
@@ -170,7 +170,7 @@ class MovedStringSliceRefCount {
 
   grpc_slice_refcount base_;
   grpc_core::RefCount refs_;
-  grpc_core::UniquePtr<char> str_;
+  std::unique_ptr<char> str_;
 };
 
 }  // namespace grpc_core
@@ -210,8 +210,7 @@ grpc_slice grpc_slice_from_copied_string(const char* source) {
   return grpc_core::UnmanagedMemorySlice(source, strlen(source));
 }
 
-grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
-                                        size_t len) {
+grpc_slice grpc_slice_from_moved_buffer(std::unique_ptr<char> p, size_t len) {
   uint8_t* ptr = reinterpret_cast<uint8_t*>(p.get());
   grpc_slice slice;
   if (len <= sizeof(slice.data.inlined.bytes)) {
@@ -227,7 +226,7 @@ grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
   return slice;
 }
 
-grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p) {
+grpc_slice grpc_slice_from_moved_string(std::unique_ptr<char> p) {
   const size_t len = strlen(p.get());
   return grpc_slice_from_moved_buffer(std::move(p), len);
 }

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -335,9 +335,8 @@ inline uint32_t grpc_slice_hash_internal(const grpc_slice& s) {
                                : grpc_slice_hash_refcounted(s);
 }
 
-grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
-                                        size_t len);
-grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p);
+grpc_slice grpc_slice_from_moved_buffer(std::unique_ptr<char> p, size_t len);
+grpc_slice grpc_slice_from_moved_string(std::unique_ptr<char> p);
 
 // Returns the memory used by this slice, not counting the slice structure
 // itself. This means that inlined and slices from static strings will return

--- a/src/core/lib/slice/slice_string_helpers.cc
+++ b/src/core/lib/slice/slice_string_helpers.cc
@@ -35,7 +35,7 @@ char* grpc_dump_slice(const grpc_slice& s, uint32_t flags) {
 
 grpc_slice grpc_dump_slice_to_slice(const grpc_slice& s, uint32_t flags) {
   size_t len;
-  grpc_core::UniquePtr<char> ptr(
+  std::unique_ptr<char> ptr(
       gpr_dump_return_len(reinterpret_cast<const char*> GRPC_SLICE_START_PTR(s),
                           GRPC_SLICE_LENGTH(s), flags, &len));
   return grpc_slice_from_moved_buffer(std::move(ptr), len);

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -138,11 +138,11 @@ grpc_channel* grpc_channel_create_with_builder(
   return channel;
 }
 
-static grpc_core::UniquePtr<char> get_default_authority(
+static std::unique_ptr<char> get_default_authority(
     const grpc_channel_args* input_args) {
   bool has_default_authority = false;
   char* ssl_override = nullptr;
-  grpc_core::UniquePtr<char> default_authority;
+  std::unique_ptr<char> default_authority;
   const size_t num_args = input_args != nullptr ? input_args->num_args : 0;
   for (size_t i = 0; i < num_args; ++i) {
     if (0 == strcmp(input_args->args[i].key, GRPC_ARG_DEFAULT_AUTHORITY)) {
@@ -257,7 +257,7 @@ grpc_channel* grpc_channel_create(const char* target,
   // ensuring that shutdown is deferred until that point.
   grpc_init();
   grpc_channel_stack_builder* builder = grpc_channel_stack_builder_create();
-  const grpc_core::UniquePtr<char> default_authority =
+  const std::unique_ptr<char> default_authority =
       get_default_authority(input_args);
   grpc_channel_args* args =
       build_channel_args(input_args, default_authority.get());

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -355,7 +355,7 @@ static tsi_result alts_tsi_handshaker_continue_handshaker_next(
 
 struct alts_tsi_handshaker_continue_handshaker_next_args {
   alts_tsi_handshaker* handshaker;
-  grpc_core::UniquePtr<unsigned char> received_bytes;
+  std::unique_ptr<unsigned char> received_bytes;
   size_t received_bytes_size;
   tsi_handshaker_on_next_done_cb cb;
   void* user_data;
@@ -406,7 +406,7 @@ static tsi_result handshaker_next(
     args->received_bytes = nullptr;
     args->received_bytes_size = received_bytes_size;
     if (received_bytes_size > 0) {
-      args->received_bytes = grpc_core::UniquePtr<unsigned char>(
+      args->received_bytes = std::unique_ptr<unsigned char>(
           static_cast<unsigned char*>(gpr_zalloc(received_bytes_size)));
       memcpy(args->received_bytes.get(), received_bytes, received_bytes_size);
     }

--- a/src/core/tsi/ssl/session_cache/ssl_session.h
+++ b/src/core/tsi/ssl/session_cache/ssl_session.h
@@ -57,7 +57,7 @@ class SslCachedSession {
   SslCachedSession& operator=(const SslCachedSession&) = delete;
 
   /// Create single cached instance of \a session.
-  static grpc_core::UniquePtr<SslCachedSession> Create(SslSessionPtr session);
+  static std::unique_ptr<SslCachedSession> Create(SslSessionPtr session);
 
   virtual ~SslCachedSession() = default;
 

--- a/src/core/tsi/ssl/session_cache/ssl_session_boringssl.cc
+++ b/src/core/tsi/ssl/session_cache/ssl_session_boringssl.cc
@@ -47,7 +47,7 @@ class BoringSslCachedSession : public SslCachedSession {
 
 }  // namespace
 
-grpc_core::UniquePtr<SslCachedSession> SslCachedSession::Create(
+std::unique_ptr<SslCachedSession> SslCachedSession::Create(
     SslSessionPtr session) {
   return grpc_core::MakeUnique<BoringSslCachedSession>(std::move(session));
 }

--- a/src/core/tsi/ssl/session_cache/ssl_session_cache.cc
+++ b/src/core/tsi/ssl/session_cache/ssl_session_cache.cc
@@ -76,7 +76,7 @@ class SslSessionLRUCache::Node {
   friend class SslSessionLRUCache;
 
   grpc_slice key_;
-  grpc_core::UniquePtr<SslCachedSession> session_;
+  std::unique_ptr<SslCachedSession> session_;
 
   Node* next_ = nullptr;
   Node* prev_ = nullptr;

--- a/src/core/tsi/ssl/session_cache/ssl_session_openssl.cc
+++ b/src/core/tsi/ssl/session_cache/ssl_session_openssl.cc
@@ -65,7 +65,7 @@ class OpenSslCachedSession : public SslCachedSession {
 
 }  // namespace
 
-grpc_core::UniquePtr<SslCachedSession> SslCachedSession::Create(
+std::unique_ptr<SslCachedSession> SslCachedSession::Create(
     SslSessionPtr session) {
   return grpc_core::MakeUnique<OpenSslCachedSession>(std::move(session));
 }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1543,7 +1543,7 @@ static int does_entry_match_name(grpc_core::StringView entry,
   entry.remove_prefix(2);                  /* Remove *. */
   size_t dot = name_subdomain.find('.');
   if (dot == grpc_core::StringView::npos || dot == name_subdomain.size() - 1) {
-    grpc_core::UniquePtr<char> name_subdomain_cstr(
+    std::unique_ptr<char> name_subdomain_cstr(
         grpc_core::StringViewToCString(name_subdomain));
     gpr_log(GPR_ERROR, "Invalid toplevel subdomain: %s",
             name_subdomain_cstr.get());

--- a/src/cpp/common/tls_credentials_options.cc
+++ b/src/cpp/common/tls_credentials_options.cc
@@ -80,8 +80,7 @@ void TlsCredentialReloadArg::set_cb_user_data(void* cb_user_data) {
 
 void TlsCredentialReloadArg::set_pem_root_certs(
     const grpc::string& pem_root_certs) {
-  ::grpc_core::UniquePtr<char> c_pem_root_certs(
-      gpr_strdup(pem_root_certs.c_str()));
+  ::std::unique_ptr<char> c_pem_root_certs(gpr_strdup(pem_root_certs.c_str()));
   c_arg_->key_materials_config->set_pem_root_certs(std::move(c_pem_root_certs));
 }
 
@@ -117,7 +116,7 @@ void TlsCredentialReloadArg::set_key_materials_config(
         ::grpc_core::PemKeyCertPair(ssl_pair);
     c_pem_key_cert_pair_list.emplace_back(std::move(c_pem_key_cert_pair));
   }
-  ::grpc_core::UniquePtr<char> c_pem_root_certs(
+  ::std::unique_ptr<char> c_pem_root_certs(
       gpr_strdup(key_materials_config->pem_root_certs().c_str()));
   if (c_arg_->key_materials_config == nullptr) {
     c_arg_->key_materials_config = grpc_tls_key_materials_config_create();

--- a/src/cpp/common/tls_credentials_options_util.cc
+++ b/src/cpp/common/tls_credentials_options_util.cc
@@ -25,8 +25,9 @@ namespace experimental {
 /** Converts the Cpp key materials to C key materials; this allocates memory for
  * the C key materials. Note that the user must free
  * the underlying pointer to private key and cert chain duplicates; they are not
- * freed when the UniquePtr<char> member variables of PemKeyCertPair are unused.
- * Similarly, the user must free the underlying pointer to c_pem_root_certs. **/
+ * freed when the std::unique_ptr<char> member variables of PemKeyCertPair are
+ * unused. Similarly, the user must free the underlying pointer to
+ * c_pem_root_certs. **/
 grpc_tls_key_materials_config* ConvertToCKeyMaterialsConfig(
     const std::shared_ptr<TlsKeyMaterialsConfig>& config) {
   if (config == nullptr) {
@@ -46,7 +47,7 @@ grpc_tls_key_materials_config* ConvertToCKeyMaterialsConfig(
         ::grpc_core::PemKeyCertPair(ssl_pair);
     c_pem_key_cert_pair_list.push_back(::std::move(c_pem_key_cert_pair));
   }
-  ::grpc_core::UniquePtr<char> c_pem_root_certs(
+  ::std::unique_ptr<char> c_pem_root_certs(
       gpr_strdup(config->pem_root_certs().c_str()));
   c_config->set_key_materials(std::move(c_pem_root_certs),
                               std::move(c_pem_key_cert_pair_list));

--- a/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
+++ b/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
@@ -52,7 +52,7 @@
 #import "../ConfigureCronet.h"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -133,7 +133,7 @@ unsigned int parse_h2_length(const char *field) {
                               {{NULL, NULL, NULL, NULL}}}};
 
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
   grpc_completion_queue *cq = grpc_completion_queue_create_for_next(NULL);
   stream_engine *cronetEngine = [Cronet getGlobalEngine];
@@ -264,7 +264,7 @@ unsigned int parse_h2_length(const char *field) {
                               {{NULL, NULL, NULL, NULL}}}};
 
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
   grpc_completion_queue *cq = grpc_completion_queue_create_for_next(NULL);
   stream_engine *cronetEngine = [Cronet getGlobalEngine];

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
   gpr_asprintf(&args[0], "%s/bad_ssl_%s_server%s", root, test,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  grpc_core::UniquePtr<char> joined;
+  std::unique_ptr<char> joined;
   grpc_core::JoinHostPort(&joined, "::", port);
   args[2] = joined.get();
   svr = gpr_subprocess_create(4, (const char**)args);

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -459,10 +459,10 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMoreGaps) {
 TEST_F(ChannelzRegistryBasedTest, GetTopChannelsUuidAfterCompaction) {
   const intptr_t kLoopIterations = 50;
   grpc_core::ExecCtx exec_ctx;
-  std::vector<UniquePtr<ChannelFixture>> even_channels;
+  std::vector<std::unique_ptr<ChannelFixture>> even_channels;
   {
     // these will delete and unregister themselves after this block.
-    std::vector<UniquePtr<ChannelFixture>> odd_channels;
+    std::vector<std::unique_ptr<ChannelFixture>> odd_channels;
     for (int i = 0; i < kLoopIterations; i++) {
       odd_channels.push_back(MakeUnique<ChannelFixture>());
       even_channels.push_back(MakeUnique<ChannelFixture>());

--- a/test/core/client_channel/parse_address_with_named_scope_id_test.cc
+++ b/test/core/client_channel/parse_address_with_named_scope_id_test.cc
@@ -61,8 +61,8 @@ static void test_grpc_parse_ipv6_parity_with_getaddrinfo(
 
 struct sockaddr_in6 resolve_with_gettaddrinfo(const char* uri_text) {
   grpc_uri* uri = grpc_uri_parse(uri_text, 0);
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   grpc_core::SplitHostPort(uri->path, &host, &port);
   struct addrinfo hints;
   memset(&hints, 0, sizeof(hints));

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
@@ -63,7 +63,7 @@ static grpc_address_resolver_vtable test_resolver = {my_resolve_address,
 static grpc_ares_request* my_dns_lookup_ares_locked(
     const char* /*dns_server*/, const char* addr, const char* /*default_port*/,
     grpc_pollset_set* /*interested_parties*/, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses,
     bool /*check_grpclb*/, char** /*service_config_json*/,
     int /*query_timeout_ms*/, grpc_core::Combiner* /*combiner*/) {
   gpr_mu_lock(&g_mu);
@@ -91,7 +91,7 @@ static void my_cancel_ares_request_locked(grpc_ares_request* request) {
 
 static grpc_core::OrphanablePtr<grpc_core::Resolver> create_resolver(
     const char* name,
-    grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> result_handler) {
+    std::unique_ptr<grpc_core::Resolver::ResultHandler> result_handler) {
   grpc_core::ResolverFactory* factory =
       grpc_core::ResolverRegistry::LookupResolverFactory("dns");
   grpc_uri* uri = grpc_uri_parse(name, 0);
@@ -169,8 +169,8 @@ int main(int argc, char** argv) {
     grpc_core::ExecCtx exec_ctx;
     ResultHandler* result_handler = new ResultHandler();
     grpc_core::OrphanablePtr<grpc_core::Resolver> resolver = create_resolver(
-        "dns:test", grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(
-                        result_handler));
+        "dns:test",
+        std::unique_ptr<grpc_core::Resolver::ResultHandler>(result_handler));
     ResultHandler::ResolverOutput output1;
     result_handler->SetOutput(&output1);
     resolver->StartLocked();

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -42,8 +42,8 @@ static grpc_core::Combiner* g_combiner;
 static grpc_ares_request* (*g_default_dns_lookup_ares_locked)(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner);
 
 // Counter incremented by test_resolve_address_impl indicating the number of
@@ -93,8 +93,8 @@ static grpc_address_resolver_vtable test_resolver = {
 static grpc_ares_request* test_dns_lookup_ares_locked(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* /*interested_parties*/, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner) {
   grpc_ares_request* result = g_default_dns_lookup_ares_locked(
       dns_server, name, default_port, g_iomgr_args.pollset_set, on_done,
@@ -284,9 +284,8 @@ static void start_test_under_combiner(void* arg, grpc_error* /*error*/) {
   grpc_core::ResolverArgs args;
   args.uri = uri;
   args.combiner = g_combiner;
-  args.result_handler =
-      grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(
-          res_cb_arg->result_handler);
+  args.result_handler = std::unique_ptr<grpc_core::Resolver::ResultHandler>(
+      res_cb_arg->result_handler);
   g_resolution_count = 0;
 
   grpc_arg cooldown_arg = grpc_channel_arg_integer_create(

--- a/test/core/client_channel/resolvers/dns_resolver_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_test.cc
@@ -82,8 +82,7 @@ int main(int argc, char** argv) {
   test_succeeds(dns, "dns:10.2.1.1:1234");
   test_succeeds(dns, "dns:www.google.com");
   test_succeeds(dns, "dns:///www.google.com");
-  grpc_core::UniquePtr<char> resolver =
-      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (gpr_stricmp(resolver.get(), "native") == 0) {
     test_fails(dns, "dns://8.8.8.8/8.8.8.8:8888");
   } else {

--- a/test/core/client_channel/resolvers/fake_resolver_test.cc
+++ b/test/core/client_channel/resolvers/fake_resolver_test.cc
@@ -65,7 +65,7 @@ class ResultHandler : public grpc_core::Resolver::ResultHandler {
 static grpc_core::OrphanablePtr<grpc_core::Resolver> build_fake_resolver(
     grpc_core::Combiner* combiner,
     grpc_core::FakeResolverResponseGenerator* response_generator,
-    grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> result_handler) {
+    std::unique_ptr<grpc_core::Resolver::ResultHandler> result_handler) {
   grpc_core::ResolverFactory* factory =
       grpc_core::ResolverRegistry::LookupResolverFactory("fake");
   grpc_arg generator_arg =
@@ -126,7 +126,7 @@ static void test_fake_resolver() {
           grpc_core::MakeRefCounted<grpc_core::FakeResolverResponseGenerator>();
   grpc_core::OrphanablePtr<grpc_core::Resolver> resolver = build_fake_resolver(
       combiner, response_generator.get(),
-      grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(result_handler));
+      std::unique_ptr<grpc_core::Resolver::ResultHandler>(result_handler));
   GPR_ASSERT(resolver.get() != nullptr);
   resolver->StartLocked();
   // Test 1: normal resolution.

--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -43,7 +43,7 @@ class TestParsedConfig1 : public ServiceConfig::ParsedConfig {
 
 class TestParser1 : public ServiceConfig::Parser {
  public:
-  UniquePtr<ServiceConfig::ParsedConfig> ParseGlobalParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParseGlobalParams(
       const grpc_json* json, grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
     for (grpc_json* field = json->child; field != nullptr;
@@ -77,7 +77,7 @@ class TestParser1 : public ServiceConfig::Parser {
 
 class TestParser2 : public ServiceConfig::Parser {
  public:
-  UniquePtr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
       const grpc_json* json, grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
     for (grpc_json* field = json->child; field != nullptr;
@@ -115,14 +115,14 @@ class TestParser2 : public ServiceConfig::Parser {
 // This parser always adds errors
 class ErrorParser : public ServiceConfig::Parser {
  public:
-  UniquePtr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParsePerMethodParams(
       const grpc_json* /*json*/, grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(MethodError());
     return nullptr;
   }
 
-  UniquePtr<ServiceConfig::ParsedConfig> ParseGlobalParams(
+  std::unique_ptr<ServiceConfig::ParsedConfig> ParseGlobalParams(
       const grpc_json* /*json*/, grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(GlobalError());

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -71,7 +71,7 @@
 #define SERVER_INCOMING_DATA_LENGTH_LOWER_THRESHOLD (size_t)200
 
 struct rpc_state {
-  grpc_core::UniquePtr<char> target;
+  std::unique_ptr<char> target;
   grpc_completion_queue* cq;
   grpc_channel* channel;
   grpc_call* call;
@@ -287,7 +287,7 @@ static void run_test(const char* response_payload,
   state.response_payload_length = response_payload_length;
 
   /* poll server until sending out the response */
-  grpc_core::UniquePtr<grpc_core::Thread> thdptr(
+  std::unique_ptr<grpc_core::Thread> thdptr(
       poll_server_until_read_done(&test_server, &ev));
   start_rpc(server_port, expected_status, expected_detail);
   gpr_event_wait(&ev, gpr_inf_future(GPR_CLOCK_REALTIME));

--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -77,7 +77,7 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
 
   /* create a call, channel to a port which will refuse connection */
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
   gpr_log(GPR_INFO, "server: %s", addr.get());
   chan = grpc_insecure_channel_create(addr.get(), args, nullptr);

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -97,7 +97,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
     picked_port = 1;
   }
 
-  grpc_core::UniquePtr<char> server_hostport;
+  std::unique_ptr<char> server_hostport;
   grpc_core::JoinHostPort(&server_hostport, server_host, port);
 
   grpc_metadata_array_init(&initial_metadata_recv);
@@ -120,7 +120,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
   cqv = cq_verifier_create(cq);
 
   /* Create client. */
-  grpc_core::UniquePtr<char> client_hostport;
+  std::unique_ptr<char> client_hostport;
   if (client_host[0] == 'i') {
     /* for ipv4:/ipv6: addresses, concatenate the port to each of the parts */
     size_t i;

--- a/test/core/end2end/fixtures/h2_census.cc
+++ b/test/core/end2end/fixtures/h2_census.cc
@@ -36,7 +36,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_compress.cc
+++ b/test/core/end2end/fixtures/h2_compress.cc
@@ -41,7 +41,7 @@ struct fullstack_compression_fixture_data {
     grpc_channel_args_destroy(client_args_compression);
     grpc_channel_args_destroy(server_args_compression);
   }
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
   grpc_channel_args* client_args_compression = nullptr;
   grpc_channel_args* server_args_compression = nullptr;
 };

--- a/test/core/end2end/fixtures/h2_fakesec.cc
+++ b/test/core/end2end/fixtures/h2_fakesec.cc
@@ -32,7 +32,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/test/core/end2end/fixtures/h2_full+pipe.cc
+++ b/test/core/end2end/fixtures/h2_full+pipe.cc
@@ -41,7 +41,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_full+trace.cc
+++ b/test/core/end2end/fixtures/h2_full+trace.cc
@@ -41,7 +41,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_full+workarounds.cc
+++ b/test/core/end2end/fixtures/h2_full+workarounds.cc
@@ -40,7 +40,7 @@ static char* workarounds_arg[GRPC_MAX_WORKAROUND_ID] = {
     const_cast<char*>(GRPC_ARG_WORKAROUND_CRONET_COMPRESSION)};
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_full.cc
+++ b/test/core/end2end/fixtures/h2_full.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_http_proxy.cc
+++ b/test/core/end2end/fixtures/h2_http_proxy.cc
@@ -39,7 +39,7 @@
 
 struct fullstack_fixture_data {
   ~fullstack_fixture_data() { grpc_end2end_http_proxy_destroy(proxy); }
-  grpc_core::UniquePtr<char> server_addr;
+  std::unique_ptr<char> server_addr;
   grpc_end2end_http_proxy* proxy = nullptr;
 };
 

--- a/test/core/end2end/fixtures/h2_oauth2.cc
+++ b/test/core/end2end/fixtures/h2_oauth2.cc
@@ -37,7 +37,7 @@ static const char* client_identity_property_name = "smurf_name";
 static const char* client_identity = "Brainy Smurf";
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static const grpc_metadata* find_metadata(const grpc_metadata* md,

--- a/test/core/end2end/fixtures/h2_spiffe.cc
+++ b/test/core/end2end/fixtures/h2_spiffe.cc
@@ -48,7 +48,7 @@ struct fullstack_secure_fixture_data {
       thd_list[ind].Join();
     }
   }
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
   ThreadList thd_list;
 };
 

--- a/test/core/end2end/fixtures/h2_ssl.cc
+++ b/test/core/end2end/fixtures/h2_ssl.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
+++ b/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
   bool server_credential_reloaded = false;
 };
 

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -61,7 +61,7 @@ struct grpc_end2end_http_proxy {
     gpr_ref_init(&users, 1);
     combiner = grpc_combiner_create();
   }
-  grpc_core::UniquePtr<char> proxy_name;
+  std::unique_ptr<char> proxy_name;
   grpc_core::Thread thd;
   grpc_tcp_server* server;
   grpc_channel_args* channel_args;

--- a/test/core/end2end/fixtures/local_util.h
+++ b/test/core/end2end/fixtures/local_util.h
@@ -23,7 +23,7 @@
 #include "src/core/lib/surface/channel.h"
 
 struct grpc_end2end_local_fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 /* Utility functions shared by h2_local tests. */

--- a/test/core/end2end/fixtures/proxy.cc
+++ b/test/core/end2end/fixtures/proxy.cc
@@ -41,8 +41,8 @@ struct grpc_end2end_proxy {
     memset(&new_call_metadata, 0, sizeof(new_call_metadata));
   }
   grpc_core::Thread thd;
-  grpc_core::UniquePtr<char> proxy_port;
-  grpc_core::UniquePtr<char> server_port;
+  std::unique_ptr<char> proxy_port;
+  std::unique_ptr<char> server_port;
   grpc_completion_queue* cq;
   grpc_server* server;
   grpc_channel* client;

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -325,7 +325,7 @@ typedef struct addr_req {
   char* addr;
   grpc_closure* on_done;
   grpc_resolved_addresses** addrs;
-  grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses;
+  std::unique_ptr<grpc_core::ServerAddressList>* addresses;
 } addr_req;
 
 static void finish_resolve(void* arg, grpc_error* error) {
@@ -377,7 +377,7 @@ static grpc_address_resolver_vtable fuzzer_resolver = {my_resolve_address,
 grpc_ares_request* my_dns_lookup_ares_locked(
     const char* /*dns_server*/, const char* addr, const char* /*default_port*/,
     grpc_pollset_set* /*interested_parties*/, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses,
     bool /*check_grpclb*/, char** /*service_config_json*/,
     int /*query_timeout*/, grpc_core::Combiner* /*combiner*/) {
   addr_req* r = static_cast<addr_req*>(gpr_malloc(sizeof(*r)));

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -47,8 +47,8 @@ static int g_resolve_port = -1;
 static grpc_ares_request* (*iomgr_dns_lookup_ares_locked)(
     const char* dns_server, const char* addr, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner);
 
 static void (*iomgr_cancel_ares_request_locked)(grpc_ares_request* request);
@@ -104,8 +104,8 @@ static grpc_address_resolver_vtable test_resolver = {
 static grpc_ares_request* my_dns_lookup_ares_locked(
     const char* dns_server, const char* addr, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
-    grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
-    bool check_grpclb, char** service_config_json, int query_timeout_ms,
+    std::unique_ptr<grpc_core::ServerAddressList>* addresses, bool check_grpclb,
+    char** service_config_json, int query_timeout_ms,
     grpc_core::Combiner* combiner) {
   if (0 != strcmp(addr, "test")) {
     return iomgr_dns_lookup_ares_locked(

--- a/test/core/end2end/h2_ssl_cert_test.cc
+++ b/test/core/end2end/h2_ssl_cert_test.cc
@@ -41,7 +41,7 @@ namespace grpc {
 namespace testing {
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::unique_ptr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/test/core/end2end/h2_ssl_session_reuse_test.cc
+++ b/test/core/end2end/h2_ssl_session_reuse_test.cc
@@ -215,7 +215,7 @@ void drain_cq(grpc_completion_queue* cq) {
 TEST(H2SessionReuseTest, SingleReuse) {
   int port = grpc_pick_unused_port_or_die();
 
-  grpc_core::UniquePtr<char> server_addr;
+  std::unique_ptr<char> server_addr;
   grpc_core::JoinHostPort(&server_addr, "localhost", port);
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);

--- a/test/core/end2end/invalid_call_argument_test.cc
+++ b/test/core/end2end/invalid_call_argument_test.cc
@@ -77,7 +77,7 @@ static void prepare_test(int is_client) {
   } else {
     g_state.server = grpc_server_create(nullptr, nullptr);
     grpc_server_register_completion_queue(g_state.server, g_state.cq, nullptr);
-    grpc_core::UniquePtr<char> server_hostport;
+    std::unique_ptr<char> server_hostport;
     grpc_core::JoinHostPort(&server_hostport, "0.0.0.0", port);
     grpc_server_add_insecure_http2_port(g_state.server, server_hostport.get());
     grpc_server_start(g_state.server);

--- a/test/core/end2end/tests/keepalive_timeout.cc
+++ b/test/core/end2end/tests/keepalive_timeout.cc
@@ -230,7 +230,7 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
  * that the keepalive ping is never sent. */
 static void test_read_delays_keepalive(grpc_end2end_test_config config) {
 #ifdef GRPC_POSIX_SOCKET
-  grpc_core::UniquePtr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  std::unique_ptr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
   /* It is hard to get the timing right for the polling engine poll. */
   if ((0 == strcmp(poller.get(), "poll"))) {
     return;

--- a/test/core/fling/fling_stream_test.cc
+++ b/test/core/fling/fling_stream_test.cc
@@ -46,7 +46,7 @@ int main(int /*argc*/, char** argv) {
   gpr_asprintf(&args[0], "%s/fling_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  grpc_core::UniquePtr<char> joined;
+  std::unique_ptr<char> joined;
   grpc_core::JoinHostPort(&joined, "::", port);
   args[2] = joined.get();
   args[3] = const_cast<char*>("--no-secure");

--- a/test/core/fling/fling_test.cc
+++ b/test/core/fling/fling_test.cc
@@ -47,7 +47,7 @@ int main(int /*argc*/, const char** argv) {
   gpr_asprintf(&args[0], "%s/fling_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  grpc_core::UniquePtr<char> joined;
+  std::unique_ptr<char> joined;
   grpc_core::JoinHostPort(&joined, "::", port);
   args[2] = joined.get();
   args[3] = const_cast<char*>("--no-secure");

--- a/test/core/fling/server.cc
+++ b/test/core/fling/server.cc
@@ -172,7 +172,7 @@ static void sigint_handler(int /*x*/) { _exit(0); }
 int main(int argc, char** argv) {
   grpc_event ev;
   call_state* s;
-  grpc_core::UniquePtr<char> addr_buf;
+  std::unique_ptr<char> addr_buf;
   gpr_cmdline* cl;
   grpc_completion_queue* shutdown_cq;
   int shutdown_started = 0;

--- a/test/core/gprpp/global_config_env_test.cc
+++ b/test/core/gprpp/global_config_env_test.cc
@@ -105,7 +105,7 @@ TEST_F(GlobalConfigEnvTest, Int32WithEnvTest) {
 
 TEST_F(GlobalConfigEnvTest, StringWithEnvTest) {
   const char* string_var_name = "STRING_VAR";
-  grpc_core::UniquePtr<char> value;
+  std::unique_ptr<char> value;
 
   gpr_unsetenv(string_var_name);
   value = GPR_GLOBAL_CONFIG_GET(string_var);

--- a/test/core/gprpp/global_config_test.cc
+++ b/test/core/gprpp/global_config_test.cc
@@ -47,7 +47,7 @@ TEST(GlobalConfigTest, Int32Test) {
 }
 
 TEST(GlobalConfigTest, StringTest) {
-  grpc_core::UniquePtr<char> value;
+  std::unique_ptr<char> value;
 
   value = GPR_GLOBAL_CONFIG_GET(string_var);
   EXPECT_EQ(0, strcmp(value.get(), ""));

--- a/test/core/gprpp/host_port_test.cc
+++ b/test/core/gprpp/host_port_test.cc
@@ -26,7 +26,7 @@
 
 static void join_host_port_expect(const char* host, int port,
                                   const char* expected) {
-  grpc_core::UniquePtr<char> buf;
+  std::unique_ptr<char> buf;
   int len;
   len = grpc_core::JoinHostPort(&buf, host, port);
   GPR_ASSERT(len >= 0);
@@ -50,8 +50,8 @@ static void test_join_host_port_garbage(void) {
 
 static void split_host_port_expect(const char* name, const char* host,
                                    const char* port, bool ret) {
-  grpc_core::UniquePtr<char> actual_host;
-  grpc_core::UniquePtr<char> actual_port;
+  std::unique_ptr<char> actual_host;
+  std::unique_ptr<char> actual_port;
   const bool actual_ret =
       grpc_core::SplitHostPort(name, &actual_host, &actual_port);
   GPR_ASSERT(actual_ret == ret);

--- a/test/core/gprpp/inlined_vector_test.cc
+++ b/test/core/gprpp/inlined_vector_test.cc
@@ -62,8 +62,8 @@ TEST(InlinedVectorTest, ValuesAreInlined) {
 }
 
 TEST(InlinedVectorTest, PushBackWithMove) {
-  InlinedVector<UniquePtr<int>, 1> v;
-  UniquePtr<int> i = MakeUnique<int>(3);
+  InlinedVector<std::unique_ptr<int>, 1> v;
+  std::unique_ptr<int> i = MakeUnique<int>(3);
   v.push_back(std::move(i));
   EXPECT_EQ(nullptr, i.get());
   EXPECT_EQ(1UL, v.size());
@@ -71,7 +71,7 @@ TEST(InlinedVectorTest, PushBackWithMove) {
 }
 
 TEST(InlinedVectorTest, EmplaceBack) {
-  InlinedVector<UniquePtr<int>, 1> v;
+  InlinedVector<std::unique_ptr<int>, 1> v;
   v.emplace_back(new int(3));
   EXPECT_EQ(1UL, v.size());
   EXPECT_EQ(3, *v[0]);
@@ -328,12 +328,12 @@ class Value {
     return *this;
   }
 
-  const UniquePtr<int>& value() const { return value_; }
+  const std::unique_ptr<int>& value() const { return value_; }
   bool copied() const { return copied_; }
   bool moved() const { return moved_; }
 
  private:
-  UniquePtr<int> value_;
+  std::unique_ptr<int> value_;
   bool copied_ = false;
   bool moved_ = false;
 };
@@ -461,7 +461,7 @@ TEST(InlinedVectorTest, MoveAssignmentMovesElementsAllocated) {
 }
 
 TEST(InlinedVectorTest, PopBackInlined) {
-  InlinedVector<UniquePtr<int>, 2> v;
+  InlinedVector<std::unique_ptr<int>, 2> v;
   // Add two elements, pop one out
   v.push_back(MakeUnique<int>(3));
   EXPECT_EQ(1UL, v.size());
@@ -475,7 +475,7 @@ TEST(InlinedVectorTest, PopBackInlined) {
 
 TEST(InlinedVectorTest, PopBackAllocated) {
   const int kInlinedSize = 2;
-  InlinedVector<UniquePtr<int>, kInlinedSize> v;
+  InlinedVector<std::unique_ptr<int>, kInlinedSize> v;
   // Add elements to ensure allocated backing.
   for (size_t i = 0; i < kInlinedSize + 1; ++i) {
     v.push_back(MakeUnique<int>(3));
@@ -488,7 +488,7 @@ TEST(InlinedVectorTest, PopBackAllocated) {
 
 TEST(InlinedVectorTest, Resize) {
   const int kInlinedSize = 2;
-  InlinedVector<UniquePtr<int>, kInlinedSize> v;
+  InlinedVector<std::unique_ptr<int>, kInlinedSize> v;
   // Size up.
   v.resize(5);
   EXPECT_EQ(5UL, v.size());

--- a/test/core/gprpp/string_view_test.cc
+++ b/test/core/gprpp/string_view_test.cc
@@ -74,7 +74,7 @@ TEST(StringViewTest, Dup) {
   constexpr char kStr[] = "foo";
   grpc_core::StringView slice(
       grpc_core::StringViewFromSlice(grpc_slice_from_static_string(kStr)));
-  grpc_core::UniquePtr<char> dup = grpc_core::StringViewToCString(slice);
+  std::unique_ptr<char> dup = grpc_core::StringViewToCString(slice);
   EXPECT_EQ(0, strcmp(kStr, dup.get()));
   EXPECT_EQ(slice.size(), strlen(kStr));
 }

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -225,8 +225,7 @@ int main(int argc, char** argv) {
   // --resolver will always be the first one, so only parse the first argument
   // (other arguments may be unknown to cl)
   gpr_cmdline_parse(cl, argc > 2 ? 2 : argc, argv);
-  grpc_core::UniquePtr<char> resolver =
-      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (strlen(resolver.get()) != 0) {
     gpr_log(GPR_INFO, "Warning: overriding resolver setting of %s",
             resolver.get());
@@ -248,8 +247,7 @@ int main(int argc, char** argv) {
     // c-ares resolver doesn't support UDS (ability for native DNS resolver
     // to handle this is only expected to be used by servers, which
     // unconditionally use the native DNS resolver).
-    grpc_core::UniquePtr<char> resolver =
-        GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+    std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
     if (gpr_stricmp(resolver.get(), "native") == 0) {
       test_unix_socket();
       test_unix_socket_path_name_too_long();

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -347,8 +347,7 @@ int main(int argc, char** argv) {
   // --resolver will always be the first one, so only parse the first argument
   // (other arguments may be unknown to cl)
   gpr_cmdline_parse(cl, argc > 2 ? 2 : argc, argv);
-  grpc_core::UniquePtr<char> resolver =
-      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (strlen(resolver.get()) != 0) {
     gpr_log(GPR_INFO, "Warning: overriding resolver setting of %s",
             resolver.get());

--- a/test/core/security/control_plane_credentials_test.cc
+++ b/test/core/security/control_plane_credentials_test.cc
@@ -83,10 +83,10 @@ grpc_server_credentials* create_test_ssl_server_creds() {
 // Perform a simple RPC and capture the ASCII value of the
 // authorization metadata sent to the server, if any. Return
 // nullptr if no authorization metadata was sent to the server.
-grpc_core::UniquePtr<char> perform_call_and_get_authorization_header(
+std::unique_ptr<char> perform_call_and_get_authorization_header(
     grpc_channel_credentials* channel_creds) {
   // Create a new channel and call
-  grpc_core::UniquePtr<char> server_addr = nullptr;
+  std::unique_ptr<char> server_addr = nullptr;
   grpc_core::JoinHostPort(&server_addr, "localhost", g_port);
   grpc_arg ssl_name_override = {
       GRPC_ARG_STRING,
@@ -196,7 +196,7 @@ grpc_core::UniquePtr<char> perform_call_and_get_authorization_header(
   cq_verify(cqv);
   GPR_ASSERT(status == GRPC_STATUS_OK);
   // Extract the ascii value of the authorization header, if present
-  grpc_core::UniquePtr<char> authorization_header_val;
+  std::unique_ptr<char> authorization_header_val;
   gpr_log(GPR_DEBUG, "RPC done. Now examine received metadata on server...");
   for (size_t i = 0; i < request_metadata_recv.count; i++) {
     char* cur_key =
@@ -239,10 +239,10 @@ void test_attach_and_get() {
       create_test_ssl_plus_token_channel_creds("foo-auth-header");
   grpc_channel_credentials* bar_creds =
       create_test_ssl_plus_token_channel_creds("bar-auth-header");
-  auto foo_key = grpc_core::UniquePtr<char>(gpr_strdup("foo"));
+  auto foo_key = std::unique_ptr<char>(gpr_strdup("foo"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, foo_key.get(), foo_creds) == true);
-  auto bar_key = grpc_core::UniquePtr<char>(gpr_strdup("bar"));
+  auto bar_key = std::unique_ptr<char>(gpr_strdup("bar"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, bar_key.get(), bar_creds) == true);
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(main_creds, "foo",
@@ -295,10 +295,10 @@ void test_registering_same_creds_under_different_keys() {
       create_test_ssl_plus_token_channel_creds("main-auth-header");
   grpc_channel_credentials* foo_creds =
       create_test_ssl_plus_token_channel_creds("foo-auth-header");
-  auto foo_key = grpc_core::UniquePtr<char>(gpr_strdup("foo"));
+  auto foo_key = std::unique_ptr<char>(gpr_strdup("foo"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, foo_key.get(), foo_creds) == true);
-  auto foo2_key = grpc_core::UniquePtr<char>(gpr_strdup("foo2"));
+  auto foo2_key = std::unique_ptr<char>(gpr_strdup("foo2"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, foo2_key.get(), foo_creds) == true);
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(main_creds, "foo",
@@ -335,7 +335,7 @@ void test_attach_and_get_with_global_registry() {
       create_test_ssl_plus_token_channel_creds("global-override-auth-header");
   grpc_channel_credentials* random_creds =
       create_test_ssl_plus_token_channel_creds("random-auth-header");
-  auto global_key = grpc_core::UniquePtr<char>(gpr_strdup("global"));
+  auto global_key = std::unique_ptr<char>(gpr_strdup("global"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, global_key.get(), global_override_creds) == true);
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
@@ -392,7 +392,7 @@ int main(int argc, char** argv) {
     g_server = grpc_server_create(nullptr, nullptr);
     g_port = grpc_pick_unused_port_or_die();
     grpc_server_register_completion_queue(g_server, g_cq, nullptr);
-    grpc_core::UniquePtr<char> localaddr;
+    std::unique_ptr<char> localaddr;
     grpc_core::JoinHostPort(&localaddr, "localhost", g_port);
     GPR_ASSERT(grpc_server_add_secure_http2_port(g_server, localaddr.get(),
                                                  server_creds));
@@ -403,7 +403,7 @@ int main(int argc, char** argv) {
       // will have access.
       grpc_channel_credentials* global_creds =
           create_test_ssl_plus_token_channel_creds("global-auth-header");
-      auto global_key = grpc_core::UniquePtr<char>(gpr_strdup("global"));
+      auto global_key = std::unique_ptr<char>(gpr_strdup("global"));
       GPR_ASSERT(grpc_control_plane_credentials_register(global_key.get(),
                                                          global_creds) == true);
       GPR_ASSERT(grpc_control_plane_credentials_register(
@@ -439,7 +439,7 @@ int main(int argc, char** argv) {
     // a full shutdown and restart of the library.
     grpc_channel_credentials* global_creds =
         create_test_ssl_plus_token_channel_creds("global-auth-header");
-    auto global_key = grpc_core::UniquePtr<char>(gpr_strdup("global"));
+    auto global_key = std::unique_ptr<char>(gpr_strdup("global"));
     GPR_ASSERT(grpc_control_plane_credentials_register(global_key.get(),
                                                        global_creds) == false);
     grpc_channel_credentials_release(global_creds);

--- a/test/core/security/spiffe_security_connector_test.cc
+++ b/test/core/security/spiffe_security_connector_test.cc
@@ -223,7 +223,7 @@ TEST_F(SpiffeSecurityConnectorTest, WithKeyUnchangedReload) {
 
 TEST_F(SpiffeSecurityConnectorTest, CreateChannelSecurityConnectorSuccess) {
   SetOptions(SUCCESS);
-  auto cred = grpc_core::UniquePtr<grpc_channel_credentials>(
+  auto cred = std::unique_ptr<grpc_channel_credentials>(
       grpc_tls_spiffe_credentials_create(options_.get()));
   const char* target_name = "some_target";
   grpc_channel_args* new_args = nullptr;
@@ -236,7 +236,7 @@ TEST_F(SpiffeSecurityConnectorTest, CreateChannelSecurityConnectorSuccess) {
 TEST_F(SpiffeSecurityConnectorTest,
        CreateChannelSecurityConnectorFailNoTargetName) {
   SetOptions(SUCCESS);
-  auto cred = grpc_core::UniquePtr<grpc_channel_credentials>(
+  auto cred = std::unique_ptr<grpc_channel_credentials>(
       grpc_tls_spiffe_credentials_create(options_.get()));
   grpc_channel_args* new_args = nullptr;
   auto connector =
@@ -246,7 +246,7 @@ TEST_F(SpiffeSecurityConnectorTest,
 
 TEST_F(SpiffeSecurityConnectorTest, CreateChannelSecurityConnectorFailInit) {
   SetOptions(FAIL);
-  auto cred = grpc_core::UniquePtr<grpc_channel_credentials>(
+  auto cred = std::unique_ptr<grpc_channel_credentials>(
       grpc_tls_spiffe_credentials_create(options_.get()));
   grpc_channel_args* new_args = nullptr;
   auto connector =
@@ -256,7 +256,7 @@ TEST_F(SpiffeSecurityConnectorTest, CreateChannelSecurityConnectorFailInit) {
 
 TEST_F(SpiffeSecurityConnectorTest, CreateServerSecurityConnectorSuccess) {
   SetOptions(SUCCESS);
-  auto cred = grpc_core::UniquePtr<grpc_server_credentials>(
+  auto cred = std::unique_ptr<grpc_server_credentials>(
       grpc_tls_spiffe_server_credentials_create(options_.get()));
   auto connector = cred->create_security_connector();
   EXPECT_NE(connector, nullptr);
@@ -264,7 +264,7 @@ TEST_F(SpiffeSecurityConnectorTest, CreateServerSecurityConnectorSuccess) {
 
 TEST_F(SpiffeSecurityConnectorTest, CreateServerSecurityConnectorFailInit) {
   SetOptions(FAIL);
-  auto cred = grpc_core::UniquePtr<grpc_server_credentials>(
+  auto cred = std::unique_ptr<grpc_server_credentials>(
       grpc_tls_spiffe_server_credentials_create(options_.get()));
   auto connector = cred->create_security_connector();
   EXPECT_EQ(connector, nullptr);

--- a/test/core/slice/slice_hash_table_test.cc
+++ b/test/core/slice/slice_hash_table_test.cc
@@ -35,7 +35,7 @@
 namespace grpc_core {
 namespace {
 
-typedef SliceHashTable<UniquePtr<char>> TestHashTable;
+typedef SliceHashTable<std::unique_ptr<char>> TestHashTable;
 
 struct TestEntry {
   const char* key;
@@ -46,7 +46,7 @@ void CheckValues(const std::vector<TestEntry>& input,
                  const TestHashTable& table) {
   for (const TestEntry& expected : input) {
     grpc_slice key = grpc_slice_from_static_string(expected.key);
-    const UniquePtr<char>* actual = table.Get(key);
+    const std::unique_ptr<char>* actual = table.Get(key);
     ASSERT_NE(actual, nullptr);
     EXPECT_STREQ(expected.value, actual->get());
     grpc_slice_unref(key);
@@ -63,7 +63,7 @@ void PopulateEntries(const std::vector<TestEntry>& input,
                      TestHashTable::Entry* output) {
   for (size_t i = 0; i < input.size(); ++i) {
     output[i].key = grpc_slice_from_copied_string(input[i].key);
-    output[i].value = UniquePtr<char>(gpr_strdup(input[i].value));
+    output[i].value = std::unique_ptr<char>(gpr_strdup(input[i].value));
   }
 }
 
@@ -123,11 +123,11 @@ TEST(SliceHashTable, Basic) {
   CheckNonExistentValue("XX", *table);
 }
 
-int StringCmp(const UniquePtr<char>& a, const UniquePtr<char>& b) {
+int StringCmp(const std::unique_ptr<char>& a, const std::unique_ptr<char>& b) {
   return strcmp(a.get(), b.get());
 }
 
-int PointerCmp(const UniquePtr<char>& a, const UniquePtr<char>& b) {
+int PointerCmp(const std::unique_ptr<char>& a, const std::unique_ptr<char>& b) {
   return GPR_ICMP(a.get(), b.get());
 }
 

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -301,7 +301,7 @@ static void test_moved_string_slice(void) {
   constexpr char kSmallStr[] = "hello12345";
   char* small_ptr = strdup(kSmallStr);
   grpc_slice small =
-      grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(small_ptr));
+      grpc_slice_from_moved_string(std::unique_ptr<char>(small_ptr));
   GPR_ASSERT(GRPC_SLICE_LENGTH(small) == strlen(kSmallStr));
   GPR_ASSERT(GRPC_SLICE_START_PTR(small) !=
              reinterpret_cast<uint8_t*>(small_ptr));
@@ -311,7 +311,7 @@ static void test_moved_string_slice(void) {
   constexpr char kSLargeStr[] = "hello123456789123456789123456789";
   char* large_ptr = strdup(kSLargeStr);
   grpc_slice large =
-      grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(large_ptr));
+      grpc_slice_from_moved_string(std::unique_ptr<char>(large_ptr));
   GPR_ASSERT(GRPC_SLICE_LENGTH(large) == strlen(kSLargeStr));
   GPR_ASSERT(GRPC_SLICE_START_PTR(large) ==
              reinterpret_cast<uint8_t*>(large_ptr));
@@ -320,7 +320,7 @@ static void test_moved_string_slice(void) {
   // Moved buffer must respect the provided length not the actual length of the
   // string.
   large_ptr = strdup(kSLargeStr);
-  small = grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char>(large_ptr),
+  small = grpc_slice_from_moved_buffer(std::unique_ptr<char>(large_ptr),
                                        strlen(kSmallStr));
   GPR_ASSERT(GRPC_SLICE_LENGTH(small) == strlen(kSmallStr));
   GPR_ASSERT(GRPC_SLICE_START_PTR(small) !=

--- a/test/core/slice/slice_weak_hash_table_test.cc
+++ b/test/core/slice/slice_weak_hash_table_test.cc
@@ -43,11 +43,11 @@ grpc_slice BuildRefCountedKey(const char* key_str) {
 }
 
 TEST(SliceWeakHashTable, Basic) {
-  auto table = SliceWeakHashTable<UniquePtr<char>, 10>::Create();
+  auto table = SliceWeakHashTable<std::unique_ptr<char>, 10>::Create();
   // Single key-value insertion.
   grpc_slice key = BuildRefCountedKey("key");
   grpc_slice_ref(key);  // Get doesn't own.
-  table->Add(key, UniquePtr<char>(gpr_strdup("value")));
+  table->Add(key, std::unique_ptr<char>(gpr_strdup("value")));
   ASSERT_NE(table->Get(key), nullptr);
   ASSERT_STREQ(table->Get(key)->get(), "value");
   grpc_slice_unref(key);
@@ -70,7 +70,7 @@ TEST(SliceWeakHashTable, ValueTypeConstructor) {
 
 TEST(SliceWeakHashTable, ForceOverload) {
   constexpr int kTableSize = 10;
-  auto table = SliceWeakHashTable<UniquePtr<char>, kTableSize>::Create();
+  auto table = SliceWeakHashTable<std::unique_ptr<char>, kTableSize>::Create();
   // Insert a multiple of the maximum size table.
   for (int i = 0; i < kTableSize * 2; ++i) {
     std::ostringstream oss;
@@ -78,7 +78,7 @@ TEST(SliceWeakHashTable, ForceOverload) {
     grpc_slice key = BuildRefCountedKey(oss.str().c_str());
     oss.clear();
     oss << "value-" << i;
-    table->Add(key, UniquePtr<char>(gpr_strdup(oss.str().c_str())));
+    table->Add(key, std::unique_ptr<char>(gpr_strdup(oss.str().c_str())));
   }
   // Verify that some will have been replaced.
   int num_missing = 0;

--- a/test/core/surface/num_external_connectivity_watchers_test.cc
+++ b/test/core/surface/num_external_connectivity_watchers_test.cc
@@ -67,7 +67,7 @@ static void channel_idle_poll_for_timeout(grpc_channel* channel,
 static void run_timeouts_test(const test_fixture* fixture) {
   gpr_log(GPR_INFO, "TEST: %s", fixture->name);
 
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_init();
   grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
 
@@ -118,7 +118,7 @@ static void run_channel_shutdown_before_timeout_test(
     const test_fixture* fixture) {
   gpr_log(GPR_INFO, "TEST: %s", fixture->name);
 
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_init();
   grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
 

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -56,7 +56,7 @@ static void run_test(const test_fixture* fixture) {
 
   grpc_init();
 
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
 
   grpc_server* server = grpc_server_create(nullptr, nullptr);

--- a/test/core/surface/server_chttp2_test.cc
+++ b/test/core/surface/server_chttp2_test.cc
@@ -47,7 +47,7 @@ void test_add_same_port_twice() {
   grpc_channel_args args = {1, &a};
 
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_completion_queue* cq = grpc_completion_queue_create_for_pluck(nullptr);
   grpc_server* server = grpc_server_create(&args, nullptr);
   grpc_server_credentials* fake_creds =

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -106,7 +106,7 @@ void test_bind_server_twice(void) {
 
 void test_bind_server_to_addr(const char* host, bool secure) {
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
+  std::unique_ptr<char> addr;
   grpc_core::JoinHostPort(&addr, host, port);
   gpr_log(GPR_INFO, "Test bind to %s", addr.get());
 

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -109,7 +109,7 @@ class FakeHandshakeServer {
   const char* address() { return address_.get(); }
 
  private:
-  grpc_core::UniquePtr<char> address_;
+  std::unique_ptr<char> address_;
   std::unique_ptr<grpc::Service> service_;
   std::unique_ptr<grpc::Server> server_;
 };
@@ -163,7 +163,7 @@ class TestServer {
   grpc_server* server_;
   grpc_completion_queue* server_cq_;
   std::unique_ptr<std::thread> server_thd_;
-  grpc_core::UniquePtr<char> server_addr_;
+  std::unique_ptr<char> server_addr_;
 };
 
 class ConnectLoopRunner {
@@ -172,9 +172,9 @@ class ConnectLoopRunner {
       const char* server_address, const char* fake_handshake_server_addr,
       int per_connect_deadline_seconds, size_t loops,
       grpc_connectivity_state expected_connectivity_states)
-      : server_address_(grpc_core::UniquePtr<char>(gpr_strdup(server_address))),
+      : server_address_(std::unique_ptr<char>(gpr_strdup(server_address))),
         fake_handshake_server_addr_(
-            grpc_core::UniquePtr<char>(gpr_strdup(fake_handshake_server_addr))),
+            std::unique_ptr<char>(gpr_strdup(fake_handshake_server_addr))),
         per_connect_deadline_seconds_(per_connect_deadline_seconds),
         loops_(loops),
         expected_connectivity_states_(expected_connectivity_states) {
@@ -222,8 +222,8 @@ class ConnectLoopRunner {
   }
 
  private:
-  grpc_core::UniquePtr<char> server_address_;
-  grpc_core::UniquePtr<char> fake_handshake_server_addr_;
+  std::unique_ptr<char> server_address_;
+  std::unique_ptr<char> fake_handshake_server_addr_;
   int per_connect_deadline_seconds_;
   size_t loops_;
   grpc_connectivity_state expected_connectivity_states_;
@@ -286,7 +286,7 @@ class FakeTcpServer {
     accept_socket_ = socket(AF_INET6, SOCK_STREAM, 0);
     char* addr_str;
     GPR_ASSERT(gpr_asprintf(&addr_str, "[::]:%d", port_));
-    address_ = grpc_core::UniquePtr<char>(addr_str);
+    address_ = std::unique_ptr<char>(addr_str);
     GPR_ASSERT(accept_socket_ != -1);
     if (accept_socket_ == -1) {
       gpr_log(GPR_ERROR, "Failed to create socket: %d", errno);
@@ -426,7 +426,7 @@ class FakeTcpServer {
   int accept_socket_;
   int port_;
   gpr_event stop_ev_;
-  grpc_core::UniquePtr<char> address_;
+  std::unique_ptr<char> address_;
   std::unique_ptr<std::thread> run_server_loop_thd_;
   std::function<ProcessReadResult(int, int, int)> process_read_cb_;
 };

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -51,7 +51,7 @@ namespace {
 class ForwardingLoadBalancingPolicy : public LoadBalancingPolicy {
  public:
   ForwardingLoadBalancingPolicy(
-      UniquePtr<ChannelControlHelper> delegating_helper, Args args,
+      std::unique_ptr<ChannelControlHelper> delegating_helper, Args args,
       const std::string& delegate_policy_name, intptr_t initial_refcount = 1)
       : LoadBalancingPolicy(std::move(args), initial_refcount) {
     Args delegate_args;
@@ -93,7 +93,7 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
   InterceptRecvTrailingMetadataLoadBalancingPolicy(
       Args args, InterceptRecvTrailingMetadataCallback cb, void* user_data)
       : ForwardingLoadBalancingPolicy(
-            UniquePtr<ChannelControlHelper>(new Helper(
+            std::unique_ptr<ChannelControlHelper>(new Helper(
                 RefCountedPtr<InterceptRecvTrailingMetadataLoadBalancingPolicy>(
                     this),
                 cb, user_data)),
@@ -110,7 +110,7 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
  private:
   class Picker : public SubchannelPicker {
    public:
-    explicit Picker(UniquePtr<SubchannelPicker> delegate_picker,
+    explicit Picker(std::unique_ptr<SubchannelPicker> delegate_picker,
                     InterceptRecvTrailingMetadataCallback cb, void* user_data)
         : delegate_picker_(std::move(delegate_picker)),
           cb_(cb),
@@ -133,7 +133,7 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
     }
 
    private:
-    UniquePtr<SubchannelPicker> delegate_picker_;
+    std::unique_ptr<SubchannelPicker> delegate_picker_;
     InterceptRecvTrailingMetadataCallback cb_;
     void* user_data_;
   };
@@ -151,9 +151,9 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
     }
 
     void UpdateState(grpc_connectivity_state state,
-                     UniquePtr<SubchannelPicker> picker) override {
+                     std::unique_ptr<SubchannelPicker> picker) override {
       parent_->channel_control_helper()->UpdateState(
-          state, UniquePtr<SubchannelPicker>(
+          state, std::unique_ptr<SubchannelPicker>(
                      new Picker(std::move(picker), cb_, user_data_)));
     }
 
@@ -240,7 +240,7 @@ class InterceptTrailingFactory : public LoadBalancingPolicyFactory {
 void RegisterInterceptRecvTrailingMetadataLoadBalancingPolicy(
     InterceptRecvTrailingMetadataCallback cb, void* user_data) {
   LoadBalancingPolicyRegistry::Builder::RegisterLoadBalancingPolicyFactory(
-      UniquePtr<LoadBalancingPolicyFactory>(
+      std::unique_ptr<LoadBalancingPolicyFactory>(
           new InterceptTrailingFactory(cb, user_data)));
 }
 

--- a/test/cpp/client/credentials_test.cc
+++ b/test/cpp/client/credentials_test.cc
@@ -397,7 +397,7 @@ TEST_F(CredentialsTest, TlsCredentialReloadConfigCppToC) {
   pem_key_cert_pair_list.push_back(pem_key_cert_pair);
   grpc::string test_pem_root_certs = "pem_root_certs";
   c_key_materials.set_key_materials(
-      ::grpc_core::UniquePtr<char>(gpr_strdup(test_pem_root_certs.c_str())),
+      ::std::unique_ptr<char>(gpr_strdup(test_pem_root_certs.c_str())),
       pem_key_cert_pair_list);
   c_arg.key_materials_config = &c_key_materials;
   c_arg.status = GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_UNCHANGED;

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -365,7 +365,7 @@ TEST_P(AsyncEnd2endTest, ReconnectChannel) {
 #ifdef GRPC_POSIX_SOCKET
   // It needs 2 pollset_works to reconnect the channel with polling engine
   // "poll"
-  grpc_core::UniquePtr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  std::unique_ptr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
   if (0 == strcmp(poller.get(), "poll")) {
     poller_slowdown_factor = 2;
   }

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1669,13 +1669,11 @@ class ClientLbInterceptTrailingMetadataTest : public ClientLbEnd2endTest {
           backend_metric_data->mem_utilization);
       self->load_report_->set_rps(backend_metric_data->requests_per_second);
       for (const auto& p : backend_metric_data->request_cost) {
-        grpc_core::UniquePtr<char> name =
-            grpc_core::StringViewToCString(p.first);
+        std::unique_ptr<char> name = grpc_core::StringViewToCString(p.first);
         (*self->load_report_->mutable_request_cost())[name.get()] = p.second;
       }
       for (const auto& p : backend_metric_data->utilization) {
-        grpc_core::UniquePtr<char> name =
-            grpc_core::StringViewToCString(p.first);
+        std::unique_ptr<char> name = grpc_core::StringViewToCString(p.first);
         (*self->load_report_->mutable_utilization())[name.get()] = p.second;
       }
     }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -834,7 +834,7 @@ TEST_P(End2endTest, ReconnectChannel) {
   // It needs 2 pollset_works to reconnect the channel with polling engine
   // "poll"
 #ifdef GRPC_POSIX_SOCKET
-  grpc_core::UniquePtr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  std::unique_ptr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
   if (0 == strcmp(poller.get(), "poll")) {
     poller_slowdown_factor = 2;
   }

--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -64,8 +64,8 @@ struct TestAddress {
 };
 
 grpc_resolved_address TestAddressToGrpcResolvedAddress(TestAddress test_addr) {
-  grpc_core::UniquePtr<char> host;
-  grpc_core::UniquePtr<char> port;
+  std::unique_ptr<char> host;
+  std::unique_ptr<char> port;
   grpc_resolved_address resolved_addr;
   grpc_core::SplitHostPort(test_addr.dest_addr.c_str(), &host, &port);
   if (test_addr.family == AF_INET) {
@@ -827,8 +827,7 @@ TEST_F(AddressSortingTest, TestSorterKnowsIpv6LoopbackIsAvailable) {
 }  // namespace
 
 int main(int argc, char** argv) {
-  grpc_core::UniquePtr<char> resolver =
-      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (strlen(resolver.get()) == 0) {
     GPR_GLOBAL_CONFIG_SET(grpc_dns_resolver, "ares");
   } else if (strcmp("ares", resolver.get())) {

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -164,7 +164,7 @@ void TestCancelActiveDNSQuery(ArgsStruct* args) {
   grpc_core::OrphanablePtr<grpc_core::Resolver> resolver =
       grpc_core::ResolverRegistry::CreateResolver(
           client_target, nullptr, args->pollset_set, args->lock,
-          grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(
+          std::unique_ptr<grpc_core::Resolver::ResultHandler>(
               new AssertFailureResultHandler(args)));
   gpr_free(client_target);
   resolver->StartLocked();

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -420,9 +420,9 @@ void OpenAndCloseSocketsStressLoop(int dummy_port, gpr_event* done_ev) {
 
 class ResultHandler : public grpc_core::Resolver::ResultHandler {
  public:
-  static grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> Create(
+  static std::unique_ptr<grpc_core::Resolver::ResultHandler> Create(
       ArgsStruct* args) {
-    return grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(
+    return std::unique_ptr<grpc_core::Resolver::ResultHandler>(
         new ResultHandler(args));
   }
 
@@ -453,9 +453,9 @@ class ResultHandler : public grpc_core::Resolver::ResultHandler {
 
 class CheckingResultHandler : public ResultHandler {
  public:
-  static grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> Create(
+  static std::unique_ptr<grpc_core::Resolver::ResultHandler> Create(
       ArgsStruct* args) {
-    return grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(
+    return std::unique_ptr<grpc_core::Resolver::ResultHandler>(
         new CheckingResultHandler(args));
   }
 
@@ -506,8 +506,8 @@ int g_fake_non_responsive_dns_server_port = -1;
 void InjectBrokenNameServerList(ares_channel channel) {
   struct ares_addr_port_node dns_server_addrs[2];
   memset(dns_server_addrs, 0, sizeof(dns_server_addrs));
-  grpc_core::UniquePtr<char> unused_host;
-  grpc_core::UniquePtr<char> local_dns_server_port;
+  std::unique_ptr<char> unused_host;
+  std::unique_ptr<char> local_dns_server_port;
   GPR_ASSERT(grpc_core::SplitHostPort(FLAGS_local_dns_server_address.c_str(),
                                       &unused_host, &local_dns_server_port));
   gpr_log(GPR_DEBUG,
@@ -540,8 +540,8 @@ void StartResolvingLocked(void* arg, grpc_error* /*unused*/) {
 }
 
 void RunResolvesRelevantRecordsTest(
-    grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> (
-        *CreateResultHandler)(ArgsStruct* args)) {
+    std::unique_ptr<grpc_core::Resolver::ResultHandler> (*CreateResultHandler)(
+        ArgsStruct* args)) {
   grpc_core::ExecCtx exec_ctx;
   ArgsStruct args;
   ArgsInit(&args);
@@ -554,7 +554,7 @@ void RunResolvesRelevantRecordsTest(
   gpr_log(GPR_DEBUG,
           "resolver_component_test: --inject_broken_nameserver_list: %s",
           FLAGS_inject_broken_nameserver_list.c_str());
-  grpc_core::UniquePtr<grpc::testing::FakeNonResponsiveDNSServer>
+  std::unique_ptr<grpc::testing::FakeNonResponsiveDNSServer>
       fake_non_responsive_dns_server;
   if (FLAGS_inject_broken_nameserver_list == "True") {
     g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -333,7 +333,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
       client_config.add_server_targets(cli_target);
     } else {
       std::string host;
-      grpc_core::UniquePtr<char> cli_target;
+      std::unique_ptr<char> cli_target;
       host = get_host(workers[i]);
       grpc_core::JoinHostPort(&cli_target, host.c_str(), init_status.port());
       client_config.add_server_targets(cli_target.get());

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -279,7 +279,7 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
 
   std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
   if (driver_port >= 0) {
-    grpc_core::UniquePtr<char> server_address;
+    std::unique_ptr<char> server_address;
     grpc_core::JoinHostPort(&server_address, "::", driver_port);
     builder->AddListeningPort(
         server_address.get(),

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -80,7 +80,7 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      grpc_core::UniquePtr<char> server_address;
+      std::unique_ptr<char> server_address;
       grpc_core::JoinHostPort(&server_address, "::", port_num);
       builder->AddListeningPort(server_address.get(),
                                 Server::CreateServerCredentials(config));

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -105,7 +105,7 @@ class CallbackServer final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      grpc_core::UniquePtr<char> server_address;
+      std::unique_ptr<char> server_address;
       grpc_core::JoinHostPort(&server_address, "::", port_num);
       builder->AddListeningPort(server_address.get(),
                                 Server::CreateServerCredentials(config));

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -160,7 +160,7 @@ class SynchronousServer final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      grpc_core::UniquePtr<char> server_address;
+      std::unique_ptr<char> server_address;
       grpc_core::JoinHostPort(&server_address, "::", port_num);
       builder->AddListeningPort(server_address.get(),
                                 Server::CreateServerCredentials(config));


### PR DESCRIPTION
`grpc_core::make_unique` will be replaced with `absl::make_unique` once absl is fully integrated. (because std::make_unique is available since C++14.)