### PR TITLE
Boringssl podspec clean-up

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -185,7 +185,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     ss.libraries = 'z'
     ss.dependency "#{s.name}/Interface", version
-    ss.dependency 'BoringSSL-GRPC', '0.0.4'
+    ss.dependency 'BoringSSL-GRPC', '0.0.5'
     ss.compiler_flags = '-DGRPC_SHADOW_BORINGSSL_SYMBOLS'
 
     ss.source_files = 'src/core/ext/filters/census/grpc_context.cc',

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -142,8 +142,11 @@ Pod::Spec.new do |s|
                               'crypto/*.h',
                               'crypto/**/*.h',
                               'third_party/fiat/*.h'
+    # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
+    # explicitly exclude it from the pod.
     # TODO (mxyan): Work with BoringSSL team to remove this hack.
-    ss.exclude_files = '**/*_test.*',
+    ss.exclude_files = 'crypto/fipsmodule/bcm.c',
+                       '**/*_test.*',
                        '**/test_*.*',
                        '**/test/*.*'
 

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -41,7 +41,7 @@
 
 Pod::Spec.new do |s|
   s.name     = 'BoringSSL-GRPC'
-  version = '0.0.4'
+  version = '0.0.5'
   s.version  = version
   s.summary  = 'BoringSSL is a fork of OpenSSL that is designed to meet Google\'s needs.'
   # Adapted from the homepage:

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -130,14 +130,15 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     ss.source_files = 'ssl/*.{h,c,cc}',
                       'ssl/**/*.{h,c,cc}',
-                      '*.{h,c,cc}', # for generated file such as err_data.c
                       'crypto/*.{h,c,cc}',
                       'crypto/**/*.{h,c,cc}',
-                      'third_party/fiat/*.{h,c,cc}' # has to include fiat because spake25519 depends
-                                                    # on it
+                      # We have to include fiat because spake25519 depends on it
+                      'third_party/fiat/*.{h,c,cc}',
+                      # Include the err_data.c generated in prepare_command below
+                      'err_data.c'
+
     ss.private_header_files = 'ssl/*.h',
                               'ssl/**/*.h',
-                              '*.h',
                               'crypto/*.h',
                               'crypto/**/*.h',
                               'third_party/fiat/*.h'

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -142,8 +142,6 @@ Pod::Spec.new do |s|
                               'crypto/*.h',
                               'crypto/**/*.h',
                               'third_party/fiat/*.h'
-    # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
-    # explicitly exclude it from the pod.
     # TODO (mxyan): Work with BoringSSL team to remove this hack.
     ss.exclude_files = '**/*_test.*',
                        '**/test_*.*',
@@ -1621,11 +1619,12 @@ Pod::Spec.new do |s|
       
     EOF
 
-    # The symbol prefixing mechanism is performed by redefining BoringSSL symbols with
-    # "#define SOME_BORINGSSL_SYMBOL GRPC_SHADOW_SOME_BORINGSSL_SYMBOL". Unfortunately, some symbols are already
-    # redefined as macros in BoringSSL headers in the form "#define SOME_BORINGSSL_SYMBOL SOME_BORINGSSL_SYMBOL"
-    # Such type of redefinition will cause "duplicate symbols" when using together with our prefix header. So
-    # the workaround in the below lines removes all such type of #define directives.
+    # The symbol prefixing mechanism is performed by redefining BoringSSL symbols with "#define
+    # SOME_BORINGSSL_SYMBOL GRPC_SHADOW_SOME_BORINGSSL_SYMBOL". Unfortunately, some symbols are
+    # already redefined as macros in BoringSSL headers in the form "#define SOME_BORINGSSL_SYMBOL
+    # SOME_BORINGSSL_SYMBOL" Such type of redefinition will cause "SOME_BORINGSSL_SYMBOL redefined"
+    # error when using together with our prefix header. So the workaround in the below lines removes
+    # all such type of #define directives.
     sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/*.h
     # Remove lines of the format below for the same reason above
     #     #define SOME_BORINGSSL_SYMBOL \

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -128,22 +128,23 @@ Pod::Spec.new do |s|
   end
   s.subspec 'Implementation' do |ss|
     ss.header_mappings_dir = '.'
-    ss.source_files = 'ssl/*.{h,cc}',
-                      'ssl/**/*.{h,cc}',
-                      '*.{h,c}',
-                      'crypto/*.{h,c}',
-                      'crypto/**/*.{h,c}',
-                      'third_party/fiat/*.{h,c}'
+    ss.source_files = 'ssl/*.{h,c,cc}',
+                      'ssl/**/*.{h,c,cc}',
+                      '*.{h,c,cc}', # for generated file such as err_data.c
+                      'crypto/*.{h,c,cc}',
+                      'crypto/**/*.{h,c,cc}',
+                      'third_party/fiat/*.{h,c,cc}' # has to include fiat because spake25519 depends
+                                                    # on it
     ss.private_header_files = 'ssl/*.h',
                               'ssl/**/*.h',
                               '*.h',
                               'crypto/*.h',
-                              'crypto/**/*.h'
+                              'crypto/**/*.h',
+                              'third_party/fiat/*.h'
     # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
     # explicitly exclude it from the pod.
     # TODO (mxyan): Work with BoringSSL team to remove this hack.
-    ss.exclude_files = 'crypto/fipsmodule/bcm.c',
-                       '**/*_test.*',
+    ss.exclude_files = '**/*_test.*',
                        '**/test_*.*',
                        '**/test/*.*'
 
@@ -1619,13 +1620,18 @@ Pod::Spec.new do |s|
       
     EOF
 
-    # Remove lines of the format "#define SOME_MACRO SOME_MACRO" because they mess up the symbol prefix
+    # The symbol prefixing mechanism is performed by redefining BoringSSL symbols with
+    # "#define SOME_BORINGSSL_SYMBOL GRPC_SHADOW_SOME_BORINGSSL_SYMBOL". Unfortunately, some symbols are already
+    # redefined as macros in BoringSSL headers in the form "#define SOME_BORINGSSL_SYMBOL SOME_BORINGSSL_SYMBOL"
+    # Such type of redefinition will cause "duplicate symbols" when using together with our prefix header. So
+    # the workaround in the below lines removes all such type of #define directives.
     sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/*.h
-    # Remove lines of the format below because they mess up the symbol prefix
-    #     #define SOME_MACRO \
-    #         SOME_MACRO
+    # Remove lines of the format below for the same reason above
+    #     #define SOME_BORINGSSL_SYMBOL \
+    #         SOME_BORINGSSL_SYMBOL
     sed -i'.back' '/^#define.*\\\\$/{N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d;}' include/openssl/*.h
-    sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
+
+    # We are renaming openssl to openssl_grpc so that there is no conflict with openssl if it exists
     find . -type f \\( -path '*.h' -or -path '*.cc' -or -path '*.c' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
   END_OF_COMMAND
 

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -172,7 +172,7 @@
       ss.header_mappings_dir = '.'
       ss.libraries = 'z'
       ss.dependency "#{s.name}/Interface", version
-      ss.dependency 'BoringSSL-GRPC', '0.0.4'
+      ss.dependency 'BoringSSL-GRPC', '0.0.5'
       ss.compiler_flags = '-DGRPC_SHADOW_BORINGSSL_SYMBOLS'
 
       ss.source_files = ${ruby_multiline_list(grpc_private_files(libs), 22)}

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -149,8 +149,11 @@
                                 'crypto/*.h',
                                 'crypto/**/*.h',
                                 'third_party/fiat/*.h'
+      # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
+      # explicitly exclude it from the pod.
       # TODO (mxyan): Work with BoringSSL team to remove this hack.
-      ss.exclude_files = '**/*_test.*',
+      ss.exclude_files = 'crypto/fipsmodule/bcm.c',
+                         '**/*_test.*',
                          '**/test_*.*',
                          '**/test/*.*'
 

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -46,7 +46,7 @@
 
   Pod::Spec.new do |s|
     s.name     = 'BoringSSL-GRPC'
-    version = '0.0.4'
+    version = '0.0.5'
     s.version  = version
     s.summary  = 'BoringSSL is a fork of OpenSSL that is designed to meet Google\'s needs.'
     # Adapted from the homepage:

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -137,14 +137,15 @@
       ss.header_mappings_dir = '.'
       ss.source_files = 'ssl/*.{h,c,cc}',
                         'ssl/**/*.{h,c,cc}',
-                        '*.{h,c,cc}', # for generated file such as err_data.c
                         'crypto/*.{h,c,cc}',
                         'crypto/**/*.{h,c,cc}',
-                        'third_party/fiat/*.{h,c,cc}' # has to include fiat because spake25519 depends
-                                                      # on it
+                        # We have to include fiat because spake25519 depends on it
+                        'third_party/fiat/*.{h,c,cc}',
+                        # Include the err_data.c generated in prepare_command below
+                        'err_data.c'
+
       ss.private_header_files = 'ssl/*.h',
                                 'ssl/**/*.h',
-                                '*.h',
                                 'crypto/*.h',
                                 'crypto/**/*.h',
                                 'third_party/fiat/*.h'

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -223,13 +223,18 @@
       % endfor
       EOF
 
-      # Remove lines of the format "#define SOME_MACRO SOME_MACRO" because they mess up the symbol prefix
+      # The symbol prefixing mechanism is performed by redefining BoringSSL symbols with
+      # "#define SOME_BORINGSSL_SYMBOL GRPC_SHADOW_SOME_BORINGSSL_SYMBOL". Unfortunately, some symbols are already
+      # redefined as macros in BoringSSL headers in the form "#define SOME_BORINGSSL_SYMBOL SOME_BORINGSSL_SYMBOL"
+      # Such type of redefinition will cause "duplicate symbols" when using together with our prefix header. So
+      # the workaround in the below lines removes all such type of #define directives.
       sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/*.h
-      # Remove lines of the format below because they mess up the symbol prefix
-      #     #define SOME_MACRO ${"\\"}
-      #         SOME_MACRO
+      # Remove lines of the format below for the same reason above
+      #     #define SOME_BORINGSSL_SYMBOL ${"\\"}
+      #         SOME_BORINGSSL_SYMBOL
       sed -i'.back' '/^#define.*\\\\$/{N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d;}' include/openssl/*.h
-      sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
+
+      # We are renaming openssl to openssl_grpc so that there is no conflict with openssl if it exists
       find . -type f \\( -path '*.h' -or -path '*.cc' -or -path '*.c' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
     END_OF_COMMAND
 

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -149,8 +149,6 @@
                                 'crypto/*.h',
                                 'crypto/**/*.h',
                                 'third_party/fiat/*.h'
-      # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
-      # explicitly exclude it from the pod.
       # TODO (mxyan): Work with BoringSSL team to remove this hack.
       ss.exclude_files = '**/*_test.*',
                          '**/test_*.*',
@@ -224,11 +222,12 @@
       % endfor
       EOF
 
-      # The symbol prefixing mechanism is performed by redefining BoringSSL symbols with
-      # "#define SOME_BORINGSSL_SYMBOL GRPC_SHADOW_SOME_BORINGSSL_SYMBOL". Unfortunately, some symbols are already
-      # redefined as macros in BoringSSL headers in the form "#define SOME_BORINGSSL_SYMBOL SOME_BORINGSSL_SYMBOL"
-      # Such type of redefinition will cause "duplicate symbols" when using together with our prefix header. So
-      # the workaround in the below lines removes all such type of #define directives.
+      # The symbol prefixing mechanism is performed by redefining BoringSSL symbols with "#define
+      # SOME_BORINGSSL_SYMBOL GRPC_SHADOW_SOME_BORINGSSL_SYMBOL". Unfortunately, some symbols are
+      # already redefined as macros in BoringSSL headers in the form "#define SOME_BORINGSSL_SYMBOL
+      # SOME_BORINGSSL_SYMBOL" Such type of redefinition will cause "SOME_BORINGSSL_SYMBOL redefined"
+      # error when using together with our prefix header. So the workaround in the below lines removes
+      # all such type of #define directives.
       sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/*.h
       # Remove lines of the format below for the same reason above
       #     #define SOME_BORINGSSL_SYMBOL ${"\\"}

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -135,22 +135,23 @@
     end
     s.subspec 'Implementation' do |ss|
       ss.header_mappings_dir = '.'
-      ss.source_files = 'ssl/*.{h,cc}',
-                        'ssl/**/*.{h,cc}',
-                        '*.{h,c}',
-                        'crypto/*.{h,c}',
-                        'crypto/**/*.{h,c}',
-                        'third_party/fiat/*.{h,c}'
+      ss.source_files = 'ssl/*.{h,c,cc}',
+                        'ssl/**/*.{h,c,cc}',
+                        '*.{h,c,cc}', # for generated file such as err_data.c
+                        'crypto/*.{h,c,cc}',
+                        'crypto/**/*.{h,c,cc}',
+                        'third_party/fiat/*.{h,c,cc}' # has to include fiat because spake25519 depends
+                                                      # on it
       ss.private_header_files = 'ssl/*.h',
                                 'ssl/**/*.h',
                                 '*.h',
                                 'crypto/*.h',
-                                'crypto/**/*.h'
+                                'crypto/**/*.h',
+                                'third_party/fiat/*.h'
       # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
       # explicitly exclude it from the pod.
       # TODO (mxyan): Work with BoringSSL team to remove this hack.
-      ss.exclude_files = 'crypto/fipsmodule/bcm.c',
-                         '**/*_test.*',
+      ss.exclude_files = '**/*_test.*',
                          '**/test_*.*',
                          '**/test/*.*'
 

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -1,8 +1,10 @@
 %YAML 1.2
 --- |
   <%!
-  def expand_symbol_list(symbol_list):
-      return ',\n    '.join("'#define %s GRPC_SHADOW_%s'" % (symbol, symbol) for symbol in symbol_list)
+    def expand_symbol_list(symbol_list):
+        return ',\n    '.join("'#define %s GRPC_SHADOW_%s'" % (symbol, symbol) for symbol in symbol_list)
+    import subprocess
+    boringssl_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd='third_party/boringssl').decode().strip()
   %>
 
   # This file has been automatically generated from a template file.
@@ -83,7 +85,7 @@
 
     s.source = {
       :git => 'https://github.com/google/boringssl.git',
-      :commit => "7f02881e96e51f1873afcf384d02f782b48967ca",
+      :commit => "${boringssl_commit}",
     }
 
     s.ios.deployment_target = '7.0'


### PR DESCRIPTION
Clean-up BoringSSL Cocoapods podspec. This include:
* Update version number due to the recent commit number change.
* When running `generate_projects.sh`, automatically extracts BoringSSL commit number from `third_party/boringssl` 
* Clean-up and add comment to source file list
* Clean-up and add comment to the hacks for prefixing BoringSSL symbols