### PR TITLE
Automatically disable testing frameworks if gRPC_BUILD_TESTS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,16 @@ set_property(CACHE gRPC_PROTOBUF_PROVIDER PROPERTY STRINGS "module" "package")
 set(gRPC_PROTOBUF_PACKAGE_TYPE "" CACHE STRING "Algorithm for searching protobuf package")
 set_property(CACHE gRPC_PROTOBUF_PACKAGE_TYPE PROPERTY STRINGS "CONFIG" "MODULE")
 
-set(gRPC_GFLAGS_PROVIDER "module" CACHE STRING "Provider of gflags library")
-set_property(CACHE gRPC_GFLAGS_PROVIDER PROPERTY STRINGS "module" "package")
+if(gRPC_BUILD_TESTS)
+  set(gRPC_GFLAGS_PROVIDER "module" CACHE STRING "Provider of gflags library")
+  set_property(CACHE gRPC_GFLAGS_PROVIDER PROPERTY STRINGS "module" "package")
 
-set(gRPC_BENCHMARK_PROVIDER "module" CACHE STRING "Provider of benchmark library")
-set_property(CACHE gRPC_BENCHMARK_PROVIDER PROPERTY STRINGS "module" "package")
+  set(gRPC_BENCHMARK_PROVIDER "module" CACHE STRING "Provider of benchmark library")
+  set_property(CACHE gRPC_BENCHMARK_PROVIDER PROPERTY STRINGS "module" "package")
+else()
+  set(gRPC_GFLAGS_PROVIDER "none")
+  set(gRPC_BENCHMARK_PROVIDER "none")
+endif()
 
 set(gRPC_USE_PROTO_LITE OFF CACHE BOOL "Use the protobuf-lite library")
 

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -32,5 +32,6 @@ elseif(gRPC_BENCHMARK_PROVIDER STREQUAL "package")
     set(_gRPC_BENCHMARK_LIBRARIES benchmark::benchmark)
   endif()
   set(_gRPC_FIND_BENCHMARK "if(NOT benchmark_FOUND)\n  find_package(benchmark CONFIG)\nendif()")
+elseif(gRPC_BENCHMARK_PROVIDER STREQUAL "none")
+  # Benchmark is a test-only dependency and can be avoided if we're not building tests.
 endif()
-

--- a/cmake/gflags.cmake
+++ b/cmake/gflags.cmake
@@ -29,5 +29,6 @@ elseif(gRPC_GFLAGS_PROVIDER STREQUAL "package")
     set(_gRPC_GFLAGS_LIBRARIES gflags::gflags)
   endif()
   set(_gRPC_FIND_GFLAGS "if(NOT gflags_FOUND)\n  find_package(gflags CONFIG)\nendif()")
+elseif(gRPC_GFLAGS_PROVIDER STREQUAL "none")
+  # gflags is a test-only dependency and can be avoided if we're not building tests.
 endif()
-

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -170,11 +170,16 @@
   set(gRPC_PROTOBUF_PACKAGE_TYPE "" CACHE STRING "Algorithm for searching protobuf package")
   set_property(CACHE gRPC_PROTOBUF_PACKAGE_TYPE PROPERTY STRINGS "CONFIG" "MODULE")
 
-  set(gRPC_GFLAGS_PROVIDER "module" CACHE STRING "Provider of gflags library")
-  set_property(CACHE gRPC_GFLAGS_PROVIDER PROPERTY STRINGS "module" "package")
+  if(gRPC_BUILD_TESTS)
+    set(gRPC_GFLAGS_PROVIDER "module" CACHE STRING "Provider of gflags library")
+    set_property(CACHE gRPC_GFLAGS_PROVIDER PROPERTY STRINGS "module" "package")
 
-  set(gRPC_BENCHMARK_PROVIDER "module" CACHE STRING "Provider of benchmark library")
-  set_property(CACHE gRPC_BENCHMARK_PROVIDER PROPERTY STRINGS "module" "package")
+    set(gRPC_BENCHMARK_PROVIDER "module" CACHE STRING "Provider of benchmark library")
+    set_property(CACHE gRPC_BENCHMARK_PROVIDER PROPERTY STRINGS "module" "package")
+  else()
+    set(gRPC_GFLAGS_PROVIDER "none")
+    set(gRPC_BENCHMARK_PROVIDER "none")
+  endif()
 
   set(gRPC_USE_PROTO_LITE OFF CACHE BOOL "Use the protobuf-lite library")
 


### PR DESCRIPTION
If gRPC_BUILD_TESTS is set to OFF, automatically set
gRPC_BENCHMARK_PROVIDER and gRPC_GFLAGS_PROVIDER to "none" so that
they don't get built.

Fixes: #11068 

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@jtattermusch 
