### PR TITLE
gRPC-C++ podspec follows gRPC versioning

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -23,19 +23,16 @@
 Pod::Spec.new do |s|
   s.name     = 'gRPC-C++'
   # TODO (mxyan): use version that match gRPC version when pod is stabilized
-  # version = '1.26.0-dev'
-  version = '0.0.9-dev'
+  version = '1.26.0-dev'
   s.version  = version
   s.summary  = 'gRPC C++ library'
   s.homepage = 'https://grpc.io'
   s.license  = 'Apache License, Version 2.0'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 
-  grpc_version = '1.26.0-dev'
-
   s.source = {
     :git => 'https://github.com/grpc/grpc.git',
-    :tag => "v#{grpc_version}",
+    :tag => "v#{version}",
   }
 
   s.ios.deployment_target = '7.0'
@@ -216,7 +213,7 @@ Pod::Spec.new do |s|
   s.subspec 'Implementation' do |ss|
     ss.header_mappings_dir = '.'
     ss.dependency "#{s.name}/Interface", version
-    ss.dependency 'gRPC-Core', grpc_version
+    ss.dependency 'gRPC-Core', version
 
     ss.source_files = 'include/grpcpp/impl/codegen/core_codegen.h',
                       'src/cpp/client/channel_cc.cc',

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -128,30 +128,20 @@
   def ruby_multiline_list(files, indent):
     return (',\n' + indent*' ').join('\'%s\'' % f for f in files)
 
-  def modify_podspec_version_string(pod_version, grpc_version):
-    # Append -preX when it is a pre-release
-    if len(str(grpc_version).split('-')) > 1:
-      return pod_version + '-' + str(grpc_version).split('-')[-1]
-    else:
-      return pod_version
-
   %>
   Pod::Spec.new do |s|
     s.name     = 'gRPC-C++'
     # TODO (mxyan): use version that match gRPC version when pod is stabilized
-    # version = '${settings.version}'
-    version = '${modify_podspec_version_string('0.0.9', settings.version)}'
+    version = '${settings.version}'
     s.version  = version
     s.summary  = 'gRPC C++ library'
     s.homepage = 'https://grpc.io'
     s.license  = 'Apache License, Version 2.0'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 
-    grpc_version = '${settings.version}'
-
     s.source = {
       :git => 'https://github.com/grpc/grpc.git',
-      :tag => "v#{grpc_version}",
+      :tag => "v#{version}",
     }
 
     s.ios.deployment_target = '7.0'
@@ -201,7 +191,7 @@
     s.subspec 'Implementation' do |ss|
       ss.header_mappings_dir = '.'
       ss.dependency "#{s.name}/Interface", version
-      ss.dependency 'gRPC-Core', grpc_version
+      ss.dependency 'gRPC-Core', version
 
       ss.source_files = ${ruby_multiline_list(grpcpp_private_files(libs, filegroups), 22)}
 


### PR DESCRIPTION
Now that we have CI tests for C++ library on iOS, we can make `gRPC-C++.podspec` follow gRPC versioning and follow the same release schedule as other components.

cc: @srini100, @wilhuff 