### PR TITLE
Fix the memory new/delete mismatch for unique_ptr<char>

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -252,7 +252,7 @@ class ChannelData {
   void ProcessLbPolicy(
       const Resolver::Result& resolver_result,
       const internal::ClientChannelGlobalParsedConfig* parsed_service_config,
-      std::unique_ptr<char>* lb_policy_name,
+      grpc_core::UniquePtr<char>* lb_policy_name,
       RefCountedPtr<LoadBalancingPolicy::Config>* lb_policy_config);
 
   //
@@ -265,8 +265,8 @@ class ChannelData {
   ClientChannelFactory* client_channel_factory_;
   const grpc_channel_args* channel_args_;
   RefCountedPtr<ServiceConfig> default_service_config_;
-  std::unique_ptr<char> server_name_;
-  std::unique_ptr<char> target_uri_;
+  grpc_core::UniquePtr<char> server_name_;
+  grpc_core::UniquePtr<char> target_uri_;
   channelz::ChannelNode* channelz_node_;
 
   //
@@ -288,7 +288,7 @@ class ChannelData {
   RefCountedPtr<SubchannelPoolInterface> subchannel_pool_;
   OrphanablePtr<ResolvingLoadBalancingPolicy> resolving_lb_policy_;
   ConnectivityStateTracker state_tracker_;
-  std::unique_ptr<char> health_check_service_name_;
+  grpc_core::UniquePtr<char> health_check_service_name_;
   RefCountedPtr<ServiceConfig> saved_service_config_;
   bool received_first_resolver_result_ = false;
   // The number of SubchannelWrapper instances referencing a given Subchannel.
@@ -314,8 +314,8 @@ class ChannelData {
   // synchronously via get_channel_info().
   //
   gpr_mu info_mu_;
-  std::unique_ptr<char> info_lb_policy_name_;
-  std::unique_ptr<char> info_service_config_json_;
+  grpc_core::UniquePtr<char> info_lb_policy_name_;
+  grpc_core::UniquePtr<char> info_service_config_json_;
 
   //
   // Fields guarded by a mutex, since they need to be accessed
@@ -843,7 +843,7 @@ class CallData {
 class ChannelData::SubchannelWrapper : public SubchannelInterface {
  public:
   SubchannelWrapper(ChannelData* chand, Subchannel* subchannel,
-                    std::unique_ptr<char> health_check_service_name)
+                    grpc_core::UniquePtr<char> health_check_service_name)
       : SubchannelInterface(&grpc_client_channel_routing_trace),
         chand_(chand),
         subchannel_(subchannel),
@@ -906,7 +906,8 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
                                          initial_state);
     subchannel_->WatchConnectivityState(
         initial_state,
-        std::unique_ptr<char>(gpr_strdup(health_check_service_name_.get())),
+        grpc_core::UniquePtr<char>(
+            gpr_strdup(health_check_service_name_.get())),
         OrphanablePtr<Subchannel::ConnectivityStateWatcherInterface>(
             watcher_wrapper));
   }
@@ -929,7 +930,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
   }
 
   void UpdateHealthCheckServiceName(
-      std::unique_ptr<char> health_check_service_name) {
+      grpc_core::UniquePtr<char> health_check_service_name) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
       gpr_log(GPR_INFO,
               "chand=%p: subchannel wrapper %p: updating health check service "
@@ -955,7 +956,8 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
       watcher_wrapper = replacement;
       subchannel_->WatchConnectivityState(
           replacement->last_seen_state(),
-          std::unique_ptr<char>(gpr_strdup(health_check_service_name.get())),
+          grpc_core::UniquePtr<char>(
+              gpr_strdup(health_check_service_name.get())),
           OrphanablePtr<Subchannel::ConnectivityStateWatcherInterface>(
               replacement));
     }
@@ -1114,7 +1116,7 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
 
   ChannelData* chand_;
   Subchannel* subchannel_;
-  std::unique_ptr<char> health_check_service_name_;
+  grpc_core::UniquePtr<char> health_check_service_name_;
   // Maps from the address of the watcher passed to us by the LB policy
   // to the address of the WrapperWatcher that we passed to the underlying
   // subchannel.  This is needed so that when the LB policy calls
@@ -1300,7 +1302,7 @@ class ChannelData::ClientChannelControlHelper
       const grpc_channel_args& args) override {
     bool inhibit_health_checking = grpc_channel_arg_get_bool(
         grpc_channel_args_find(&args, GRPC_ARG_INHIBIT_HEALTH_CHECKING), false);
-    std::unique_ptr<char> health_check_service_name;
+    grpc_core::UniquePtr<char> health_check_service_name;
     if (!inhibit_health_checking) {
       health_check_service_name.reset(
           gpr_strdup(chand_->health_check_service_name_.get()));
@@ -1596,7 +1598,7 @@ void ChannelData::CreateResolvingLoadBalancingPolicyLocked() {
   lb_args.combiner = combiner_;
   lb_args.channel_control_helper = MakeUnique<ClientChannelControlHelper>(this);
   lb_args.args = channel_args_;
-  std::unique_ptr<char> target_uri(gpr_strdup(target_uri_.get()));
+  grpc_core::UniquePtr<char> target_uri(gpr_strdup(target_uri_.get()));
   resolving_lb_policy_.reset(new ResolvingLoadBalancingPolicy(
       std::move(lb_args), &grpc_client_channel_routing_trace,
       std::move(target_uri), ProcessResolverResultLocked, this));
@@ -1619,7 +1621,7 @@ void ChannelData::DestroyResolvingLoadBalancingPolicyLocked() {
 void ChannelData::ProcessLbPolicy(
     const Resolver::Result& resolver_result,
     const internal::ClientChannelGlobalParsedConfig* parsed_service_config,
-    std::unique_ptr<char>* lb_policy_name,
+    grpc_core::UniquePtr<char>* lb_policy_name,
     RefCountedPtr<LoadBalancingPolicy::Config>* lb_policy_config) {
   // Prefer the LB policy name found in the service config.
   if (parsed_service_config != nullptr &&
@@ -1714,7 +1716,7 @@ bool ChannelData::ProcessResolverResultLocked(
     return false;
   }
   // Process service config.
-  std::unique_ptr<char> service_config_json;
+  grpc_core::UniquePtr<char> service_config_json;
   const internal::ClientChannelGlobalParsedConfig* parsed_service_config =
       nullptr;
   if (service_config != nullptr) {
@@ -1748,8 +1750,9 @@ bool ChannelData::ProcessResolverResultLocked(
     }
     // Update health check service name used by existing subchannel wrappers.
     for (auto* subchannel_wrapper : chand->subchannel_wrappers_) {
-      subchannel_wrapper->UpdateHealthCheckServiceName(std::unique_ptr<char>(
-          gpr_strdup(chand->health_check_service_name_.get())));
+      subchannel_wrapper->UpdateHealthCheckServiceName(
+          grpc_core::UniquePtr<char>(
+              gpr_strdup(chand->health_check_service_name_.get())));
     }
     // Save service config.
     chand->saved_service_config_ = std::move(service_config);
@@ -1774,7 +1777,7 @@ bool ChannelData::ProcessResolverResultLocked(
     chand->UpdateServiceConfigLocked(std::move(retry_throttle_data),
                                      chand->saved_service_config_);
   }
-  std::unique_ptr<char> processed_lb_policy_name;
+  grpc_core::UniquePtr<char> processed_lb_policy_name;
   chand->ProcessLbPolicy(result, parsed_service_config,
                          &processed_lb_policy_name, lb_policy_config);
   // Swap out the data used by GetChannelInfo().

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -130,8 +130,8 @@ static bool proxy_mapper_map_name(grpc_proxy_mapper* /*mapper*/,
   if (no_proxy_str != nullptr) {
     static const char* NO_PROXY_SEPARATOR = ",";
     bool use_proxy = true;
-    std::unique_ptr<char> server_host;
-    std::unique_ptr<char> server_port;
+    grpc_core::UniquePtr<char> server_host;
+    grpc_core::UniquePtr<char> server_port;
     if (!grpc_core::SplitHostPort(
             uri->path[0] == '/' ? uri->path + 1 : uri->path, &server_host,
             &server_port)) {

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -237,7 +237,7 @@ class GrpcLb : public LoadBalancingPolicy {
     const grpc_grpclb_serverlist* serverlist() const { return serverlist_; }
 
     // Returns a text representation suitable for logging.
-    std::unique_ptr<char> AsText() const;
+    grpc_core::UniquePtr<char> AsText() const;
 
     // Extracts all non-drop entries into a ServerAddressList.
     ServerAddressList GetServerAddressList(
@@ -430,7 +430,7 @@ void ParseServer(const grpc_grpclb_server* server,
   }
 }
 
-std::unique_ptr<char> GrpcLb::Serverlist::AsText() const {
+grpc_core::UniquePtr<char> GrpcLb::Serverlist::AsText() const {
   gpr_strvec entries;
   gpr_strvec_init(&entries);
   for (size_t i = 0; i < serverlist_->num_servers; ++i) {
@@ -449,7 +449,7 @@ std::unique_ptr<char> GrpcLb::Serverlist::AsText() const {
     gpr_free(ipport);
     gpr_strvec_add(&entries, entry);
   }
-  std::unique_ptr<char> result(gpr_strvec_flatten(&entries, nullptr));
+  grpc_core::UniquePtr<char> result(gpr_strvec_flatten(&entries, nullptr));
   gpr_strvec_destroy(&entries);
   return result;
 }
@@ -1099,7 +1099,7 @@ void GrpcLb::BalancerCallState::OnBalancerMessageReceivedLocked(
     GPR_ASSERT(lb_calld->lb_call_ != nullptr);
     auto serverlist_wrapper = MakeRefCounted<Serverlist>(serverlist);
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_glb_trace)) {
-      std::unique_ptr<char> serverlist_text = serverlist_wrapper->AsText();
+      grpc_core::UniquePtr<char> serverlist_text = serverlist_wrapper->AsText();
       gpr_log(GPR_INFO,
               "[grpclb %p] lb_calld=%p: Serverlist with %" PRIuPTR
               " servers received:\n%s",

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -39,8 +39,8 @@ namespace grpc_core {
 
 namespace {
 
-int BalancerNameCmp(const std::unique_ptr<char>& a,
-                    const std::unique_ptr<char>& b) {
+int BalancerNameCmp(const grpc_core::UniquePtr<char>& a,
+                    const grpc_core::UniquePtr<char>& b) {
   return strcmp(a.get(), b.get());
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.cc
@@ -61,7 +61,8 @@ void GrpcLbClientStats::AddCallDropped(const char* token) {
     }
   }
   // Not found, so add a new entry.
-  drop_token_counts_->emplace_back(std::unique_ptr<char>(gpr_strdup(token)), 1);
+  drop_token_counts_->emplace_back(
+      grpc_core::UniquePtr<char>(gpr_strdup(token)), 1);
 }
 
 namespace {

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h
@@ -33,10 +33,10 @@ namespace grpc_core {
 class GrpcLbClientStats : public RefCounted<GrpcLbClientStats> {
  public:
   struct DropTokenCount {
-    std::unique_ptr<char> token;
+    grpc_core::UniquePtr<char> token;
     int64_t count;
 
-    DropTokenCount(std::unique_ptr<char> token, int64_t count)
+    DropTokenCount(grpc_core::UniquePtr<char> token, int64_t count)
         : token(std::move(token)), count(count) {}
   };
 

--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -39,13 +39,13 @@ constexpr char kCds[] = "cds_experimental";
 // Parsed config for this LB policy.
 class ParsedCdsConfig : public LoadBalancingPolicy::Config {
  public:
-  explicit ParsedCdsConfig(std::unique_ptr<char> cluster)
+  explicit ParsedCdsConfig(grpc_core::UniquePtr<char> cluster)
       : cluster_(std::move(cluster)) {}
   const char* cluster() const { return cluster_.get(); }
   const char* name() const override { return kCds; }
 
  private:
-  std::unique_ptr<char> cluster_;
+  grpc_core::UniquePtr<char> cluster_;
 };
 
 // CDS LB policy.
@@ -136,7 +136,7 @@ void CdsLb::ClusterWatcher::OnClusterChanged(CdsUpdate cluster_data) {
                     ? parent_->config_->cluster()
                     : cluster_data.eds_service_name.get()));
   gpr_free(lrs_str);
-  std::unique_ptr<char> json_str_deleter(json_str);
+  grpc_core::UniquePtr<char> json_str_deleter(json_str);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_cds_lb_trace)) {
     gpr_log(GPR_INFO, "[cdslb %p] generated config for child policy: %s",
             parent_.get(), json_str);
@@ -343,7 +343,7 @@ class CdsFactory : public LoadBalancingPolicyFactory {
     }
     if (error_list.empty()) {
       return MakeRefCounted<ParsedCdsConfig>(
-          std::unique_ptr<char>(gpr_strdup(cluster)));
+          grpc_core::UniquePtr<char>(gpr_strdup(cluster)));
     } else {
       *error = GRPC_ERROR_CREATE_FROM_VECTOR("Cds Parser", &error_list);
       return nullptr;

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -78,8 +78,8 @@ class ParsedXdsConfig : public LoadBalancingPolicy::Config {
  public:
   ParsedXdsConfig(RefCountedPtr<LoadBalancingPolicy::Config> child_policy,
                   RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy,
-                  std::unique_ptr<char> eds_service_name,
-                  std::unique_ptr<char> lrs_load_reporting_server_name)
+                  grpc_core::UniquePtr<char> eds_service_name,
+                  grpc_core::UniquePtr<char> lrs_load_reporting_server_name)
       : child_policy_(std::move(child_policy)),
         fallback_policy_(std::move(fallback_policy)),
         eds_service_name_(std::move(eds_service_name)),
@@ -105,8 +105,8 @@ class ParsedXdsConfig : public LoadBalancingPolicy::Config {
  private:
   RefCountedPtr<LoadBalancingPolicy::Config> child_policy_;
   RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy_;
-  std::unique_ptr<char> eds_service_name_;
-  std::unique_ptr<char> lrs_load_reporting_server_name_;
+  grpc_core::UniquePtr<char> eds_service_name_;
+  grpc_core::UniquePtr<char> lrs_load_reporting_server_name_;
 };
 
 class XdsLb : public LoadBalancingPolicy {
@@ -406,7 +406,7 @@ class XdsLb : public LoadBalancingPolicy {
   }
 
   // Server name from target URI.
-  std::unique_ptr<char> server_name_;
+  grpc_core::UniquePtr<char> server_name_;
 
   // Current channel args and config from the resolver.
   const grpc_channel_args* args_ = nullptr;
@@ -495,7 +495,7 @@ LoadBalancingPolicy::PickResult XdsLb::EndpointPickerWrapper::Pick(
 
 XdsLb::PickResult XdsLb::LocalityPicker::Pick(PickArgs args) {
   // Handle drop.
-  const std::unique_ptr<char>* drop_category;
+  const grpc_core::UniquePtr<char>* drop_category;
   if (drop_config_->ShouldDrop(&drop_category)) {
     xds_policy_->client_stats_.AddCallDropped(*drop_category);
     PickResult result;
@@ -1871,8 +1871,9 @@ class XdsFactory : public LoadBalancingPolicyFactory {
     if (error_list.empty()) {
       return MakeRefCounted<ParsedXdsConfig>(
           std::move(child_policy), std::move(fallback_policy),
-          std::unique_ptr<char>(gpr_strdup(eds_service_name)),
-          std::unique_ptr<char>(gpr_strdup(lrs_load_reporting_server_name)));
+          grpc_core::UniquePtr<char>(gpr_strdup(eds_service_name)),
+          grpc_core::UniquePtr<char>(
+              gpr_strdup(lrs_load_reporting_server_name)));
     } else {
       *error = GRPC_ERROR_CREATE_FROM_VECTOR("Xds Parser", &error_list);
       return nullptr;

--- a/src/core/ext/filters/client_channel/parse_address.cc
+++ b/src/core/ext/filters/client_channel/parse_address.cc
@@ -73,8 +73,8 @@ bool grpc_parse_ipv4_hostport(const char* hostport, grpc_resolved_address* addr,
                               bool log_errors) {
   bool success = false;
   // Split host and port.
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   if (!grpc_core::SplitHostPort(hostport, &host, &port)) {
     if (log_errors) {
       gpr_log(GPR_ERROR, "Failed gpr_split_host_port(%s, ...)", hostport);
@@ -125,8 +125,8 @@ bool grpc_parse_ipv6_hostport(const char* hostport, grpc_resolved_address* addr,
                               bool log_errors) {
   bool success = false;
   // Split host and port.
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   if (!grpc_core::SplitHostPort(hostport, &host, &port)) {
     if (log_errors) {
       gpr_log(GPR_ERROR, "Failed gpr_split_host_port(%s, ...)", hostport);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -496,7 +496,8 @@ static bool should_use_ares(const char* resolver_env) {
 static bool g_use_ares_dns_resolver;
 
 void grpc_resolver_dns_ares_init() {
-  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  grpc_core::UniquePtr<char> resolver =
+      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (should_use_ares(resolver.get())) {
     g_use_ares_dns_resolver = true;
     gpr_log(GPR_DEBUG, "Using ares dns resolver");

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -355,8 +355,8 @@ void grpc_dns_lookup_ares_continue_after_check_localhost_and_ip_literals_locked(
   grpc_ares_hostbyname_request* hr = nullptr;
   ares_channel* channel = nullptr;
   /* parse name, splitting it into host and port parts */
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   grpc_core::SplitHostPort(name, &host, &port);
   if (host == nullptr) {
     error = grpc_error_set_str(
@@ -453,8 +453,8 @@ error_cleanup:
 static bool inner_resolve_as_ip_literal_locked(
     const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs,
-    std::unique_ptr<char>* host, std::unique_ptr<char>* port,
-    std::unique_ptr<char>* hostport) {
+    grpc_core::UniquePtr<char>* host, grpc_core::UniquePtr<char>* port,
+    grpc_core::UniquePtr<char>* hostport) {
   grpc_core::SplitHostPort(name, host, port);
   if (*host == nullptr) {
     gpr_log(GPR_ERROR,
@@ -490,17 +490,17 @@ static bool inner_resolve_as_ip_literal_locked(
 static bool resolve_as_ip_literal_locked(
     const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs) {
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
-  std::unique_ptr<char> hostport;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
+  grpc_core::UniquePtr<char> hostport;
   bool out = inner_resolve_as_ip_literal_locked(name, default_port, addrs,
                                                 &host, &port, &hostport);
   return out;
 }
 
 static bool target_matches_localhost_inner(const char* name,
-                                           std::unique_ptr<char>* host,
-                                           std::unique_ptr<char>* port) {
+                                           grpc_core::UniquePtr<char>* host,
+                                           grpc_core::UniquePtr<char>* port) {
   if (!grpc_core::SplitHostPort(name, host, port)) {
     gpr_log(GPR_ERROR, "Unable to split host and port for name: %s", name);
     return false;
@@ -513,8 +513,8 @@ static bool target_matches_localhost_inner(const char* name,
 }
 
 static bool target_matches_localhost(const char* name) {
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   return target_matches_localhost_inner(name, &host, &port);
 }
 
@@ -522,7 +522,7 @@ static bool target_matches_localhost(const char* name) {
 static bool inner_maybe_resolve_localhost_manually_locked(
     const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs,
-    std::unique_ptr<char>* host, std::unique_ptr<char>* port) {
+    grpc_core::UniquePtr<char>* host, grpc_core::UniquePtr<char>* port) {
   grpc_core::SplitHostPort(name, host, port);
   if (*host == nullptr) {
     gpr_log(GPR_ERROR,
@@ -572,8 +572,8 @@ static bool inner_maybe_resolve_localhost_manually_locked(
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
     const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs) {
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   return inner_maybe_resolve_localhost_manually_locked(name, default_port,
                                                        addrs, &host, &port);
 }

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -300,7 +300,8 @@ class NativeDnsResolverFactory : public ResolverFactory {
 }  // namespace grpc_core
 
 void grpc_resolver_dns_native_init() {
-  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  grpc_core::UniquePtr<char> resolver =
+      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (gpr_stricmp(resolver.get(), "native") == 0) {
     gpr_log(GPR_DEBUG, "Using native dns resolver");
     grpc_core::ResolverRegistry::Builder::RegisterResolverFactory(

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -97,7 +97,7 @@ bool ParseUri(const grpc_uri* uri,
   bool errors_found = false;
   for (size_t i = 0; i < path_parts.count; i++) {
     grpc_uri ith_uri = *uri;
-    std::unique_ptr<char> part_str(
+    grpc_core::UniquePtr<char> part_str(
         grpc_slice_to_c_string(path_parts.slices[i]));
     ith_uri.path = part_str.get();
     grpc_resolved_address addr;
@@ -161,8 +161,9 @@ class UnixResolverFactory : public ResolverFactory {
     return CreateSockaddrResolver(std::move(args), grpc_parse_unix);
   }
 
-  std::unique_ptr<char> GetDefaultAuthority(grpc_uri* /*uri*/) const override {
-    return std::unique_ptr<char>(gpr_strdup("localhost"));
+  grpc_core::UniquePtr<char> GetDefaultAuthority(
+      grpc_uri* /*uri*/) const override {
+    return grpc_core::UniquePtr<char>(gpr_strdup("localhost"));
   }
 
   const char* scheme() const override { return "unix"; }

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -60,7 +60,7 @@ class XdsResolver : public Resolver {
     RefCountedPtr<XdsResolver> resolver_;
   };
 
-  std::unique_ptr<char> server_name_;
+  grpc_core::UniquePtr<char> server_name_;
   const grpc_channel_args* args_;
   grpc_pollset_set* interested_parties_;
   OrphanablePtr<XdsClient> xds_client_;

--- a/src/core/ext/filters/client_channel/resolver_factory.h
+++ b/src/core/ext/filters/client_channel/resolver_factory.h
@@ -55,10 +55,10 @@ class ResolverFactory {
 
   /// Returns a string representing the default authority to use for this
   /// scheme.
-  virtual std::unique_ptr<char> GetDefaultAuthority(grpc_uri* uri) const {
+  virtual grpc_core::UniquePtr<char> GetDefaultAuthority(grpc_uri* uri) const {
     const char* path = uri->path;
     if (path[0] == '/') ++path;
-    return std::unique_ptr<char>(gpr_strdup(path));
+    return grpc_core::UniquePtr<char>(gpr_strdup(path));
   }
 
   /// Returns the URI scheme that this factory implements.

--- a/src/core/ext/filters/client_channel/resolver_registry.cc
+++ b/src/core/ext/filters/client_channel/resolver_registry.cc
@@ -91,7 +91,7 @@ class RegistryState {
   // hurting performance (which is unlikely, since these allocations
   // only occur at gRPC initialization time).
   InlinedVector<std::unique_ptr<ResolverFactory>, 10> factories_;
-  std::unique_ptr<char> default_prefix_;
+  grpc_core::UniquePtr<char> default_prefix_;
 };
 
 static RegistryState* g_state = nullptr;
@@ -166,29 +166,29 @@ OrphanablePtr<Resolver> ResolverRegistry::CreateResolver(
   return resolver;
 }
 
-std::unique_ptr<char> ResolverRegistry::GetDefaultAuthority(
+grpc_core::UniquePtr<char> ResolverRegistry::GetDefaultAuthority(
     const char* target) {
   GPR_ASSERT(g_state != nullptr);
   grpc_uri* uri = nullptr;
   char* canonical_target = nullptr;
   ResolverFactory* factory =
       g_state->FindResolverFactory(target, &uri, &canonical_target);
-  std::unique_ptr<char> authority =
+  grpc_core::UniquePtr<char> authority =
       factory == nullptr ? nullptr : factory->GetDefaultAuthority(uri);
   grpc_uri_destroy(uri);
   gpr_free(canonical_target);
   return authority;
 }
 
-std::unique_ptr<char> ResolverRegistry::AddDefaultPrefixIfNeeded(
+grpc_core::UniquePtr<char> ResolverRegistry::AddDefaultPrefixIfNeeded(
     const char* target) {
   GPR_ASSERT(g_state != nullptr);
   grpc_uri* uri = nullptr;
   char* canonical_target = nullptr;
   g_state->FindResolverFactory(target, &uri, &canonical_target);
   grpc_uri_destroy(uri);
-  return std::unique_ptr<char>(canonical_target == nullptr ? gpr_strdup(target)
-                                                           : canonical_target);
+  return grpc_core::UniquePtr<char>(
+      canonical_target == nullptr ? gpr_strdup(target) : canonical_target);
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver_registry.h
+++ b/src/core/ext/filters/client_channel/resolver_registry.h
@@ -73,10 +73,11 @@ class ResolverRegistry {
       std::unique_ptr<Resolver::ResultHandler> result_handler);
 
   /// Returns the default authority to pass from a client for \a target.
-  static std::unique_ptr<char> GetDefaultAuthority(const char* target);
+  static grpc_core::UniquePtr<char> GetDefaultAuthority(const char* target);
 
   /// Returns \a target with the default prefix prepended, if needed.
-  static std::unique_ptr<char> AddDefaultPrefixIfNeeded(const char* target);
+  static grpc_core::UniquePtr<char> AddDefaultPrefixIfNeeded(
+      const char* target);
 
   /// Returns the resolver factory for \a scheme.
   /// Caller does NOT own the return value.

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -66,7 +66,7 @@ bool ParseDuration(grpc_json* field, grpc_millis* duration) {
   if (field->type != GRPC_JSON_STRING) return false;
   size_t len = strlen(field->value);
   if (field->value[len - 1] != 's') return false;
-  std::unique_ptr<char> buf(gpr_strdup(field->value));
+  grpc_core::UniquePtr<char> buf(gpr_strdup(field->value));
   *(buf.get() + len - 1) = '\0';  // Remove trailing 's'.
   char* decimal_point = strchr(buf.get(), '.');
   int nanos = 0;
@@ -268,7 +268,7 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const grpc_json* json,
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   InlinedVector<grpc_error*, 4> error_list;
   RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config;
-  std::unique_ptr<char> lb_policy_name;
+  grpc_core::UniquePtr<char> lb_policy_name;
   Optional<ClientChannelGlobalParsedConfig::RetryThrottling> retry_throttling;
   const char* health_check_service_name = nullptr;
   for (grpc_json* field = json->child; field != nullptr; field = field->next) {

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.h
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.h
@@ -46,7 +46,7 @@ class ClientChannelGlobalParsedConfig : public ServiceConfig::ParsedConfig {
 
   ClientChannelGlobalParsedConfig(
       RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config,
-      std::unique_ptr<char> parsed_deprecated_lb_policy,
+      grpc_core::UniquePtr<char> parsed_deprecated_lb_policy,
       const Optional<RetryThrottling>& retry_throttling,
       const char* health_check_service_name)
       : parsed_lb_config_(std::move(parsed_lb_config)),
@@ -72,7 +72,7 @@ class ClientChannelGlobalParsedConfig : public ServiceConfig::ParsedConfig {
 
  private:
   RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config_;
-  std::unique_ptr<char> parsed_deprecated_lb_policy_;
+  grpc_core::UniquePtr<char> parsed_deprecated_lb_policy_;
   Optional<RetryThrottling> retry_throttling_;
   const char* health_check_service_name_;
 };

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -177,7 +177,7 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
 //
 
 ResolvingLoadBalancingPolicy::ResolvingLoadBalancingPolicy(
-    Args args, TraceFlag* tracer, std::unique_ptr<char> target_uri,
+    Args args, TraceFlag* tracer, grpc_core::UniquePtr<char> target_uri,
     ProcessResolverResultCallback process_resolver_result,
     void* process_resolver_result_user_data)
     : LoadBalancingPolicy(std::move(args)),
@@ -425,7 +425,7 @@ void ResolvingLoadBalancingPolicy::ConcatenateAndAddChannelTraceLocked(
       gpr_strvec_add(&v, (*trace_strings)[i]);
     }
     size_t len = 0;
-    std::unique_ptr<char> message(gpr_strvec_flatten(&v, &len));
+    grpc_core::UniquePtr<char> message(gpr_strvec_flatten(&v, &len));
     channel_control_helper()->AddTraceEvent(ChannelControlHelper::TRACE_INFO,
                                             StringView(message.get()));
     gpr_strvec_destroy(&v);

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -65,7 +65,7 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
   // If error is set when this returns, then construction failed, and
   // the caller may not use the new object.
   ResolvingLoadBalancingPolicy(
-      Args args, TraceFlag* tracer, std::unique_ptr<char> target_uri,
+      Args args, TraceFlag* tracer, grpc_core::UniquePtr<char> target_uri,
       ProcessResolverResultCallback process_resolver_result,
       void* process_resolver_result_user_data);
 
@@ -106,10 +106,10 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
 
   // Passed in from caller at construction time.
   TraceFlag* tracer_;
-  std::unique_ptr<char> target_uri_;
+  grpc_core::UniquePtr<char> target_uri_;
   ProcessResolverResultCallback process_resolver_result_ = nullptr;
   void* process_resolver_result_user_data_ = nullptr;
-  std::unique_ptr<char> child_policy_name_;
+  grpc_core::UniquePtr<char> child_policy_name_;
   RefCountedPtr<LoadBalancingPolicy::Config> child_lb_config_;
 
   // Resolver and associated state.

--- a/src/core/ext/filters/client_channel/service_config.cc
+++ b/src/core/ext/filters/client_channel/service_config.cc
@@ -42,8 +42,8 @@ ServiceConfigParserList* g_registered_parsers;
 
 RefCountedPtr<ServiceConfig> ServiceConfig::Create(const char* json,
                                                    grpc_error** error) {
-  std::unique_ptr<char> service_config_json(gpr_strdup(json));
-  std::unique_ptr<char> json_string(gpr_strdup(json));
+  grpc_core::UniquePtr<char> service_config_json(gpr_strdup(json));
+  grpc_core::UniquePtr<char> json_string(gpr_strdup(json));
   GPR_DEBUG_ASSERT(error != nullptr);
   grpc_json* json_tree = grpc_json_parse_string(json_string.get());
   if (json_tree == nullptr) {
@@ -55,8 +55,8 @@ RefCountedPtr<ServiceConfig> ServiceConfig::Create(const char* json,
       std::move(service_config_json), std::move(json_string), json_tree, error);
 }
 
-ServiceConfig::ServiceConfig(std::unique_ptr<char> service_config_json,
-                             std::unique_ptr<char> json_string,
+ServiceConfig::ServiceConfig(grpc_core::UniquePtr<char> service_config_json,
+                             grpc_core::UniquePtr<char> json_string,
                              grpc_json* json_tree, grpc_error** error)
     : service_config_json_(std::move(service_config_json)),
       json_string_(std::move(json_string)),
@@ -121,7 +121,7 @@ grpc_error* ServiceConfig::ParseJsonMethodConfigToServiceConfigVectorTable(
           [parsed_method_config_vectors_storage_.size() - 1]
               .get();
   // Construct list of paths.
-  InlinedVector<std::unique_ptr<char>, 10> paths;
+  InlinedVector<grpc_core::UniquePtr<char>, 10> paths;
   for (grpc_json* child = json->child; child != nullptr; child = child->next) {
     if (child->key == nullptr) continue;
     if (strcmp(child->key, "name") == 0) {
@@ -132,7 +132,8 @@ grpc_error* ServiceConfig::ParseJsonMethodConfigToServiceConfigVectorTable(
       }
       for (grpc_json* name = child->child; name != nullptr; name = name->next) {
         grpc_error* parse_error = GRPC_ERROR_NONE;
-        std::unique_ptr<char> path = ParseJsonMethodName(name, &parse_error);
+        grpc_core::UniquePtr<char> path =
+            ParseJsonMethodName(name, &parse_error);
         if (path == nullptr) {
           error_list.push_back(parse_error);
         } else {
@@ -228,8 +229,8 @@ int ServiceConfig::CountNamesInMethodConfig(grpc_json* json) {
   return num_names;
 }
 
-std::unique_ptr<char> ServiceConfig::ParseJsonMethodName(grpc_json* json,
-                                                         grpc_error** error) {
+grpc_core::UniquePtr<char> ServiceConfig::ParseJsonMethodName(
+    grpc_json* json, grpc_error** error) {
   if (json->type != GRPC_JSON_OBJECT) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "field:name error:type is not object");
@@ -282,7 +283,7 @@ std::unique_ptr<char> ServiceConfig::ParseJsonMethodName(grpc_json* json,
   char* path;
   gpr_asprintf(&path, "/%s/%s", service_name,
                method_name == nullptr ? "*" : method_name);
-  return std::unique_ptr<char>(path);
+  return grpc_core::UniquePtr<char>(path);
 }
 
 const ServiceConfig::ParsedConfigVector*

--- a/src/core/ext/filters/client_channel/service_config.h
+++ b/src/core/ext/filters/client_channel/service_config.h
@@ -129,8 +129,8 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
                                              grpc_error** error);
 
   // Takes ownership of \a json_tree.
-  ServiceConfig(std::unique_ptr<char> service_config_json,
-                std::unique_ptr<char> json_string, grpc_json* json_tree,
+  ServiceConfig(grpc_core::UniquePtr<char> service_config_json,
+                grpc_core::UniquePtr<char> json_string, grpc_json* json_tree,
                 grpc_error** error);
   ~ServiceConfig();
 
@@ -171,15 +171,15 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
 
   // Returns a path string for the JSON name object specified by \a json.
   // Returns null on error, and stores error in \a error.
-  static std::unique_ptr<char> ParseJsonMethodName(grpc_json* json,
-                                                   grpc_error** error);
+  static grpc_core::UniquePtr<char> ParseJsonMethodName(grpc_json* json,
+                                                        grpc_error** error);
 
   grpc_error* ParseJsonMethodConfigToServiceConfigVectorTable(
       const grpc_json* json,
       SliceHashTable<const ParsedConfigVector*>::Entry* entries, size_t* idx);
 
-  std::unique_ptr<char> service_config_json_;
-  std::unique_ptr<char> json_string_;  // Underlying storage for json_tree.
+  grpc_core::UniquePtr<char> service_config_json_;
+  grpc_core::UniquePtr<char> json_string_;  // Underlying storage for json_tree.
   grpc_json* json_tree_;
 
   InlinedVector<std::unique_ptr<ParsedConfig>, kNumPreallocatedParsers>

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -404,7 +404,8 @@ void Subchannel::ConnectivityStateWatcherList::NotifyLocked(
 class Subchannel::HealthWatcherMap::HealthWatcher
     : public AsyncConnectivityStateWatcherInterface {
  public:
-  HealthWatcher(Subchannel* c, std::unique_ptr<char> health_check_service_name,
+  HealthWatcher(Subchannel* c,
+                grpc_core::UniquePtr<char> health_check_service_name,
                 grpc_connectivity_state subchannel_state)
       : subchannel_(c),
         health_check_service_name_(std::move(health_check_service_name)),
@@ -489,7 +490,7 @@ class Subchannel::HealthWatcherMap::HealthWatcher
   }
 
   Subchannel* subchannel_;
-  std::unique_ptr<char> health_check_service_name_;
+  grpc_core::UniquePtr<char> health_check_service_name_;
   OrphanablePtr<HealthCheckClient> health_check_client_;
   grpc_connectivity_state state_;
   ConnectivityStateWatcherList watcher_list_;
@@ -501,7 +502,7 @@ class Subchannel::HealthWatcherMap::HealthWatcher
 
 void Subchannel::HealthWatcherMap::AddWatcherLocked(
     Subchannel* subchannel, grpc_connectivity_state initial_state,
-    std::unique_ptr<char> health_check_service_name,
+    grpc_core::UniquePtr<char> health_check_service_name,
     OrphanablePtr<ConnectivityStateWatcherInterface> watcher) {
   // If the health check service name is not already present in the map,
   // add it.
@@ -786,7 +787,7 @@ grpc_connectivity_state Subchannel::CheckConnectivityState(
 
 void Subchannel::WatchConnectivityState(
     grpc_connectivity_state initial_state,
-    std::unique_ptr<char> health_check_service_name,
+    grpc_core::UniquePtr<char> health_check_service_name,
     OrphanablePtr<ConnectivityStateWatcherInterface> watcher) {
   MutexLock lock(&mu_);
   grpc_pollset_set* interested_parties = watcher->interested_parties();

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -242,7 +242,7 @@ class Subchannel {
   // destroyed or when CancelConnectivityStateWatch() is called.
   void WatchConnectivityState(
       grpc_connectivity_state initial_state,
-      std::unique_ptr<char> health_check_service_name,
+      grpc_core::UniquePtr<char> health_check_service_name,
       OrphanablePtr<ConnectivityStateWatcherInterface> watcher);
 
   // Cancels a connectivity state watch.
@@ -311,7 +311,7 @@ class Subchannel {
    public:
     void AddWatcherLocked(
         Subchannel* subchannel, grpc_connectivity_state initial_state,
-        std::unique_ptr<char> health_check_service_name,
+        grpc_core::UniquePtr<char> health_check_service_name,
         OrphanablePtr<ConnectivityStateWatcherInterface> watcher);
     void RemoveWatcherLocked(const char* health_check_service_name,
                              ConnectivityStateWatcherInterface* watcher);

--- a/src/core/ext/filters/client_channel/xds/xds_api.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_api.cc
@@ -89,7 +89,7 @@ bool XdsPriorityListUpdate::Contains(
 }
 
 bool XdsDropConfig::ShouldDrop(
-    const std::unique_ptr<char>** category_name) const {
+    const grpc_core::UniquePtr<char>** category_name) const {
   for (size_t i = 0; i < drop_category_list_.size(); ++i) {
     const auto& drop_category = drop_category_list_[i];
     // Generate a random number in [0, 1000000).
@@ -259,11 +259,11 @@ grpc_error* ServerAddressParseAndAppend(
 
 namespace {
 
-std::unique_ptr<char> StringCopy(const upb_strview& strview) {
+grpc_core::UniquePtr<char> StringCopy(const upb_strview& strview) {
   char* str = static_cast<char*>(gpr_malloc(strview.size + 1));
   memcpy(str, strview.data, strview.size);
   str[strview.size] = '\0';
-  return std::unique_ptr<char>(str);
+  return grpc_core::UniquePtr<char>(str);
 }
 
 }  // namespace
@@ -542,9 +542,10 @@ grpc_slice XdsLrsRequestCreateAndEncode(const char* server_name,
   return LrsRequestEncode(request, arena.ptr());
 }
 
-grpc_error* XdsLrsResponseDecodeAndParse(const grpc_slice& encoded_response,
-                                         std::unique_ptr<char>* cluster_name,
-                                         grpc_millis* load_reporting_interval) {
+grpc_error* XdsLrsResponseDecodeAndParse(
+    const grpc_slice& encoded_response,
+    grpc_core::UniquePtr<char>* cluster_name,
+    grpc_millis* load_reporting_interval) {
   upb::Arena arena;
   // Decode the response.
   const envoy_service_load_stats_v2_LoadStatsResponse* decoded_response =

--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -101,19 +101,20 @@ class XdsDropConfig : public RefCounted<XdsDropConfig> {
              parts_per_million == other.parts_per_million;
     }
 
-    std::unique_ptr<char> name;
+    grpc_core::UniquePtr<char> name;
     const uint32_t parts_per_million;
   };
 
   using DropCategoryList = InlinedVector<DropCategory, 2>;
 
-  void AddCategory(std::unique_ptr<char> name, uint32_t parts_per_million) {
+  void AddCategory(grpc_core::UniquePtr<char> name,
+                   uint32_t parts_per_million) {
     drop_category_list_.emplace_back(
         DropCategory{std::move(name), parts_per_million});
   }
 
   // The only method invoked from the data plane combiner.
-  bool ShouldDrop(const std::unique_ptr<char>** category_name) const;
+  bool ShouldDrop(const grpc_core::UniquePtr<char>** category_name) const;
 
   const DropCategoryList& drop_category_list() const {
     return drop_category_list_;
@@ -139,12 +140,12 @@ struct EdsUpdate {
 struct CdsUpdate {
   // The name to use in the EDS request.
   // If null, the cluster name will be used.
-  std::unique_ptr<char> eds_service_name;
+  grpc_core::UniquePtr<char> eds_service_name;
   // The LRS server to use for load reporting.
   // If null, load reporting will be disabled.
   // If set to the empty string, will use the same server we obtained
   // the CDS data from.
-  std::unique_ptr<char> lrs_load_reporting_server_name;
+  grpc_core::UniquePtr<char> lrs_load_reporting_server_name;
 };
 
 // Creates an EDS request querying \a service_name.
@@ -170,9 +171,10 @@ grpc_slice XdsLrsRequestCreateAndEncode(const char* server_name,
 // Parses the LRS response and returns \a cluster_name and \a
 // load_reporting_interval for client-side load reporting. If there is any
 // error, the output config is invalid.
-grpc_error* XdsLrsResponseDecodeAndParse(const grpc_slice& encoded_response,
-                                         std::unique_ptr<char>* cluster_name,
-                                         grpc_millis* load_reporting_interval);
+grpc_error* XdsLrsResponseDecodeAndParse(
+    const grpc_slice& encoded_response,
+    grpc_core::UniquePtr<char>* cluster_name,
+    grpc_millis* load_reporting_interval);
 
 }  // namespace grpc_core
 

--- a/src/core/ext/filters/client_channel/xds/xds_bootstrap.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_bootstrap.cc
@@ -30,7 +30,7 @@
 namespace grpc_core {
 
 std::unique_ptr<XdsBootstrap> XdsBootstrap::ReadFromFile(grpc_error** error) {
-  std::unique_ptr<char> path(gpr_getenv("GRPC_XDS_BOOTSTRAP"));
+  grpc_core::UniquePtr<char> path(gpr_getenv("GRPC_XDS_BOOTSTRAP"));
   if (path == nullptr) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "GRPC_XDS_BOOTSTRAP env var not set");

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -244,7 +244,7 @@ class XdsClient::ChannelState::LrsCallState
   grpc_closure on_status_received_;
 
   // Load reporting state.
-  std::unique_ptr<char> cluster_name_;
+  grpc_core::UniquePtr<char> cluster_name_;
   grpc_millis load_reporting_interval_ = 0;
   OrphanablePtr<Reporter> reporter_;
 };
@@ -1124,7 +1124,7 @@ void XdsClient::ChannelState::LrsCallState::OnResponseReceivedLocked(
   // This anonymous lambda is a hack to avoid the usage of goto.
   [&]() {
     // Parse the response.
-    std::unique_ptr<char> new_cluster_name;
+    grpc_core::UniquePtr<char> new_cluster_name;
     grpc_millis new_load_reporting_interval;
     grpc_error* parse_error = XdsLrsResponseDecodeAndParse(
         response_slice, &new_cluster_name, &new_load_reporting_interval);
@@ -1240,11 +1240,11 @@ bool XdsClient::ChannelState::LrsCallState::IsCurrentCallOnChannel() const {
 
 namespace {
 
-std::unique_ptr<char> GenerateBuildVersionString() {
+grpc_core::UniquePtr<char> GenerateBuildVersionString() {
   char* build_version_str;
   gpr_asprintf(&build_version_str, "gRPC C-core %s %s", grpc_version_string(),
                GPR_PLATFORM_STRING);
-  return std::unique_ptr<char>(build_version_str);
+  return grpc_core::UniquePtr<char>(build_version_str);
 }
 
 }  // namespace

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -196,14 +196,14 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
 
   static const grpc_arg_pointer_vtable kXdsClientVtable;
 
-  std::unique_ptr<char> build_version_;
+  grpc_core::UniquePtr<char> build_version_;
 
   Combiner* combiner_;
   grpc_pollset_set* interested_parties_;
 
   std::unique_ptr<XdsBootstrap> bootstrap_;
 
-  std::unique_ptr<char> server_name_;
+  grpc_core::UniquePtr<char> server_name_;
   std::unique_ptr<ServiceConfigWatcherInterface> service_config_watcher_;
   // TODO(juanlishen): Once we implement LDS support, this will no
   // longer be needed.

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.cc
@@ -90,7 +90,7 @@ XdsClientStats::LocalityStats::GetSnapshotAndReset() {
       const char* metric_name = p.first.get();
       LoadMetric& metric_value = p.second;
       snapshot.load_metric_stats.emplace(
-          std::unique_ptr<char>(gpr_strdup(metric_name)),
+          grpc_core::UniquePtr<char>(gpr_strdup(metric_name)),
           metric_value.GetSnapshotAndReset());
     }
   }
@@ -178,13 +178,14 @@ void XdsClientStats::PruneLocalityStats() {
   }
 }
 
-void XdsClientStats::AddCallDropped(const std::unique_ptr<char>& category) {
+void XdsClientStats::AddCallDropped(
+    const grpc_core::UniquePtr<char>& category) {
   total_dropped_requests_.FetchAdd(1, MemoryOrder::RELAXED);
   MutexLock lock(&dropped_requests_mu_);
   auto iter = dropped_requests_.find(category);
   if (iter == dropped_requests_.end()) {
-    dropped_requests_.emplace(std::unique_ptr<char>(gpr_strdup(category.get())),
-                              1);
+    dropped_requests_.emplace(
+        grpc_core::UniquePtr<char>(gpr_strdup(category.get())), 1);
   } else {
     ++iter->second;
   }

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.h
@@ -46,8 +46,9 @@ class XdsLocalityName : public RefCounted<XdsLocalityName> {
     }
   };
 
-  XdsLocalityName(std::unique_ptr<char> region, std::unique_ptr<char> zone,
-                  std::unique_ptr<char> subzone)
+  XdsLocalityName(grpc_core::UniquePtr<char> region,
+                  grpc_core::UniquePtr<char> zone,
+                  grpc_core::UniquePtr<char> subzone)
       : region_(std::move(region)),
         zone_(std::move(zone)),
         sub_zone_(std::move(subzone)) {}
@@ -73,10 +74,10 @@ class XdsLocalityName : public RefCounted<XdsLocalityName> {
   }
 
  private:
-  std::unique_ptr<char> region_;
-  std::unique_ptr<char> zone_;
-  std::unique_ptr<char> sub_zone_;
-  std::unique_ptr<char> human_readable_string_;
+  grpc_core::UniquePtr<char> region_;
+  grpc_core::UniquePtr<char> zone_;
+  grpc_core::UniquePtr<char> sub_zone_;
+  grpc_core::UniquePtr<char> human_readable_string_;
 };
 
 // The stats classes (i.e., XdsClientStats, LocalityStats, and LoadMetric) can
@@ -112,9 +113,9 @@ class XdsClientStats {
     };
 
     using LoadMetricMap =
-        std::map<std::unique_ptr<char>, LoadMetric, StringLess>;
+        std::map<grpc_core::UniquePtr<char>, LoadMetric, StringLess>;
     using LoadMetricSnapshotMap =
-        std::map<std::unique_ptr<char>, LoadMetric::Snapshot, StringLess>;
+        std::map<grpc_core::UniquePtr<char>, LoadMetric::Snapshot, StringLess>;
 
     struct Snapshot {
       // TODO(juanlishen): Change this to const method when const_iterator is
@@ -187,7 +188,7 @@ class XdsClientStats {
       std::map<RefCountedPtr<XdsLocalityName>, LocalityStats::Snapshot,
                XdsLocalityName::Less>;
   using DroppedRequestsMap =
-      std::map<std::unique_ptr<char>, uint64_t, StringLess>;
+      std::map<grpc_core::UniquePtr<char>, uint64_t, StringLess>;
   using DroppedRequestsSnapshotMap = DroppedRequestsMap;
 
   struct Snapshot {
@@ -210,7 +211,7 @@ class XdsClientStats {
   RefCountedPtr<LocalityStats> FindLocalityStats(
       const RefCountedPtr<XdsLocalityName>& locality_name);
   void PruneLocalityStats();
-  void AddCallDropped(const std::unique_ptr<char>& category);
+  void AddCallDropped(const grpc_core::UniquePtr<char>& category);
 
  private:
   // The stats for each locality.

--- a/src/core/ext/transport/chttp2/client/authority.cc
+++ b/src/core/ext/transport/chttp2/client/authority.cc
@@ -26,7 +26,7 @@ grpc_channel_args* grpc_default_authority_add_if_not_present(
       grpc_channel_args_find(args, GRPC_ARG_DEFAULT_AUTHORITY) != nullptr;
   grpc_arg new_args[1];
   size_t num_new_args = 0;
-  std::unique_ptr<char> default_authority;
+  grpc_core::UniquePtr<char> default_authority;
   if (!has_default_authority) {
     const grpc_arg* server_uri_arg =
         grpc_channel_args_find(args, GRPC_ARG_SERVER_URI);

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -56,7 +56,7 @@ grpc_channel* CreateChannel(const char* target, const grpc_channel_args* args) {
     return nullptr;
   }
   // Add channel arg containing the server URI.
-  std::unique_ptr<char> canonical_target =
+  grpc_core::UniquePtr<char> canonical_target =
       ResolverRegistry::AddDefaultPrefixIfNeeded(target);
   grpc_arg arg = grpc_channel_arg_string_create(
       const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -86,7 +86,7 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
     GPR_ASSERT(server_uri != nullptr);
     const TargetAuthorityTable* target_authority_table =
         FindTargetAuthorityTableInArgs(args);
-    std::unique_ptr<char> authority;
+    grpc_core::UniquePtr<char> authority;
     if (target_authority_table != nullptr) {
       // Find the authority for the target.
       const char* target_uri_str =
@@ -98,7 +98,8 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
         const grpc_slice key = grpc_slice_from_static_string(
             target_uri->path[0] == '/' ? target_uri->path + 1
                                        : target_uri->path);
-        const std::unique_ptr<char>* value = target_authority_table->Get(key);
+        const grpc_core::UniquePtr<char>* value =
+            target_authority_table->Get(key);
         if (value != nullptr) authority.reset(gpr_strdup(value->get()));
         grpc_slice_unref_internal(key);
       }
@@ -158,7 +159,7 @@ grpc_channel* CreateChannel(const char* target, const grpc_channel_args* args) {
     return nullptr;
   }
   // Add channel arg containing the server URI.
-  std::unique_ptr<char> canonical_target =
+  grpc_core::UniquePtr<char> canonical_target =
       ResolverRegistry::AddDefaultPrefixIfNeeded(target);
   grpc_arg arg = grpc_channel_arg_string_create(
       const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -138,7 +138,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
             gpr_free(msg);
             p->error = grpc_error_set_str(
                 p->error, GRPC_ERROR_STR_RAW_BYTES,
-                grpc_slice_from_moved_string(std::unique_ptr<char>(
+                grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(
                     grpc_dump_slice(*slice, GPR_DUMP_HEX | GPR_DUMP_ASCII))));
             p->error =
                 grpc_error_set_int(p->error, GRPC_ERROR_INT_OFFSET, cur - beg);

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -109,10 +109,10 @@ grpc_error* grpc_chttp2_rst_stream_parser_parse(void* parser,
       char* message;
       gpr_asprintf(&message, "Received RST_STREAM with error code %d", reason);
       error = grpc_error_set_int(
-          grpc_error_set_str(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
-              GRPC_ERROR_STR_GRPC_MESSAGE,
-              grpc_slice_from_moved_string(std::unique_ptr<char>(message))),
+          grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
+                             GRPC_ERROR_STR_GRPC_MESSAGE,
+                             grpc_slice_from_moved_string(
+                                 grpc_core::UniquePtr<char>(message))),
           GRPC_ERROR_INT_HTTP2_ERROR, static_cast<intptr_t>(reason));
     }
     grpc_chttp2_mark_stream_closed(t, s, true, true, error);

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -442,8 +442,8 @@ void PopulateSocketAddressJson(grpc_json* json, const char* name,
                            (strcmp(uri->scheme, "ipv6") == 0))) {
     const char* host_port = uri->path;
     if (*host_port == '/') ++host_port;
-    std::unique_ptr<char> host;
-    std::unique_ptr<char> port;
+    grpc_core::UniquePtr<char> host;
+    grpc_core::UniquePtr<char> port;
     GPR_ASSERT(SplitHostPort(host_port, &host, &port));
     int port_num = -1;
     if (port != nullptr) {

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -143,7 +143,7 @@ void grpc_tracer_init(const char* env_var_name) {
 }
 
 void grpc_tracer_init() {
-  std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_trace);
+  grpc_core::UniquePtr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_trace);
   parse(value.get());
 }
 

--- a/src/core/lib/gpr/log.cc
+++ b/src/core/lib/gpr/log.cc
@@ -75,7 +75,7 @@ void gpr_set_log_verbosity(gpr_log_severity min_severity_to_print) {
 }
 
 void gpr_log_verbosity_init() {
-  std::unique_ptr<char> verbosity = GPR_GLOBAL_CONFIG_GET(grpc_verbosity);
+  grpc_core::UniquePtr<char> verbosity = GPR_GLOBAL_CONFIG_GET(grpc_verbosity);
 
   gpr_atm min_severity_to_print = GPR_LOG_SEVERITY_ERROR;
   if (strlen(verbosity.get()) > 0) {

--- a/src/core/lib/gprpp/global_config_env.cc
+++ b/src/core/lib/gprpp/global_config_env.cc
@@ -56,8 +56,8 @@ void SetGlobalConfigEnvErrorFunction(GlobalConfigEnvErrorFunctionType func) {
   g_global_config_env_error_func = func;
 }
 
-std::unique_ptr<char> GlobalConfigEnv::GetValue() {
-  return std::unique_ptr<char>(gpr_getenv(GetName()));
+grpc_core::UniquePtr<char> GlobalConfigEnv::GetValue() {
+  return grpc_core::UniquePtr<char>(gpr_getenv(GetName()));
 }
 
 void GlobalConfigEnv::SetValue(const char* value) {
@@ -78,7 +78,7 @@ static_assert(std::is_trivially_destructible<GlobalConfigEnvBool>::value,
               "GlobalConfigEnvBool needs to be trivially destructible.");
 
 bool GlobalConfigEnvBool::Get() {
-  std::unique_ptr<char> str = GetValue();
+  grpc_core::UniquePtr<char> str = GetValue();
   if (str == nullptr) {
     return default_value_;
   }
@@ -99,7 +99,7 @@ static_assert(std::is_trivially_destructible<GlobalConfigEnvInt32>::value,
               "GlobalConfigEnvInt32 needs to be trivially destructible.");
 
 int32_t GlobalConfigEnvInt32::Get() {
-  std::unique_ptr<char> str = GetValue();
+  grpc_core::UniquePtr<char> str = GetValue();
   if (str == nullptr) {
     return default_value_;
   }
@@ -122,10 +122,10 @@ void GlobalConfigEnvInt32::Set(int32_t value) {
 static_assert(std::is_trivially_destructible<GlobalConfigEnvString>::value,
               "GlobalConfigEnvString needs to be trivially destructible.");
 
-std::unique_ptr<char> GlobalConfigEnvString::Get() {
-  std::unique_ptr<char> str = GetValue();
+grpc_core::UniquePtr<char> GlobalConfigEnvString::Get() {
+  grpc_core::UniquePtr<char> str = GetValue();
   if (str == nullptr) {
-    return std::unique_ptr<char>(gpr_strdup(default_value_));
+    return grpc_core::UniquePtr<char>(gpr_strdup(default_value_));
   }
   return str;
 }

--- a/src/core/lib/gprpp/global_config_env.h
+++ b/src/core/lib/gprpp/global_config_env.h
@@ -43,7 +43,7 @@ class GlobalConfigEnv {
 
  public:
   // Returns the value of `name` variable.
-  std::unique_ptr<char> GetValue();
+  grpc_core::UniquePtr<char> GetValue();
 
   // Sets the value of `name` variable.
   void SetValue(const char* value);
@@ -87,7 +87,7 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
   constexpr GlobalConfigEnvString(char* name, const char* default_value)
       : GlobalConfigEnv(name), default_value_(default_value) {}
 
-  std::unique_ptr<char> Get();
+  grpc_core::UniquePtr<char> Get();
   void Set(const char* value);
 
  private:
@@ -121,7 +121,7 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
   static char g_env_str_##name[] = #name;                                  \
   static ::grpc_core::GlobalConfigEnvString g_env_##name(g_env_str_##name, \
                                                          default_value);   \
-  ::std::unique_ptr<char> gpr_global_config_get_##name() {                 \
+  ::grpc_core::UniquePtr<char> gpr_global_config_get_##name() {            \
     return g_env_##name.Get();                                             \
   }                                                                        \
   void gpr_global_config_set_##name(const char* value) {                   \

--- a/src/core/lib/gprpp/global_config_generic.h
+++ b/src/core/lib/gprpp/global_config_generic.h
@@ -37,8 +37,8 @@
   extern int32_t gpr_global_config_get_##name(); \
   extern void gpr_global_config_set_##name(int32_t value)
 
-#define GPR_GLOBAL_CONFIG_DECLARE_STRING(name)                 \
-  extern std::unique_ptr<char> gpr_global_config_get_##name(); \
+#define GPR_GLOBAL_CONFIG_DECLARE_STRING(name)                      \
+  extern grpc_core::UniquePtr<char> gpr_global_config_get_##name(); \
   extern void gpr_global_config_set_##name(const char* value)
 
 #endif /* GRPC_CORE_LIB_GPRPP_GLOBAL_CONFIG_GENERIC_H */

--- a/src/core/lib/gprpp/host_port.cc
+++ b/src/core/lib/gprpp/host_port.cc
@@ -30,7 +30,7 @@
 #include "src/core/lib/gprpp/string_view.h"
 
 namespace grpc_core {
-int JoinHostPort(std::unique_ptr<char>* out, const char* host, int port) {
+int JoinHostPort(grpc_core::UniquePtr<char>* out, const char* host, int port) {
   char* tmp;
   int ret;
   if (host[0] != '[' && strchr(host, ':') != nullptr) {
@@ -96,8 +96,8 @@ bool SplitHostPort(StringView name, StringView* host, StringView* port) {
   return DoSplitHostPort(name, host, port, &unused);
 }
 
-bool SplitHostPort(StringView name, std::unique_ptr<char>* host,
-                   std::unique_ptr<char>* port) {
+bool SplitHostPort(StringView name, grpc_core::UniquePtr<char>* host,
+                   grpc_core::UniquePtr<char>* port) {
   GPR_DEBUG_ASSERT(host != nullptr && *host == nullptr);
   GPR_DEBUG_ASSERT(port != nullptr && *port == nullptr);
   StringView host_view;

--- a/src/core/lib/gprpp/host_port.h
+++ b/src/core/lib/gprpp/host_port.h
@@ -35,7 +35,7 @@ namespace grpc_core {
    (excluding the final '\0'), and *out points to a string.
 
    In the unlikely event of an error, returns -1 and sets *out to NULL. */
-int JoinHostPort(std::unique_ptr<char>* out, const char* host, int port);
+int JoinHostPort(grpc_core::UniquePtr<char>* out, const char* host, int port);
 
 /** Given a name in the form "host:port" or "[ho:st]:port", split into hostname
    and port number.
@@ -51,8 +51,8 @@ int JoinHostPort(std::unique_ptr<char>* out, const char* host, int port);
    Return true on success, false on failure. Guarantees *host and *port are
    cleared on failure. */
 bool SplitHostPort(StringView name, StringView* host, StringView* port);
-bool SplitHostPort(StringView name, std::unique_ptr<char>* host,
-                   std::unique_ptr<char>* port);
+bool SplitHostPort(StringView name, grpc_core::UniquePtr<char>* host,
+                   grpc_core::UniquePtr<char>* port);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/gprpp/map.h
+++ b/src/core/lib/gprpp/map.h
@@ -34,8 +34,8 @@ struct StringLess {
   bool operator()(const char* a, const char* b) const {
     return strcmp(a, b) < 0;
   }
-  bool operator()(const std::unique_ptr<char>& a,
-                  const std::unique_ptr<char>& b) const {
+  bool operator()(const grpc_core::UniquePtr<char>& a,
+                  const grpc_core::UniquePtr<char>& b) const {
     return strcmp(a.get(), b.get()) < 0;
   }
   bool operator()(const StringView& a, const StringView& b) const {

--- a/src/core/lib/gprpp/string_view.h
+++ b/src/core/lib/gprpp/string_view.h
@@ -143,11 +143,11 @@ inline StringView StringViewFromSlice(const grpc_slice& slice) {
 
 // Creates a dup of the string viewed by this class.
 // Return value is null-terminated and never nullptr.
-inline std::unique_ptr<char> StringViewToCString(const StringView sv) {
+inline grpc_core::UniquePtr<char> StringViewToCString(const StringView sv) {
   char* str = static_cast<char*>(gpr_malloc(sv.size() + 1));
   if (sv.size() > 0) memcpy(str, sv.data(), sv.size());
   str[sv.size()] = '\0';
-  return std::unique_ptr<char>(str);
+  return grpc_core::UniquePtr<char>(str);
 }
 
 // Compares lhs and rhs.

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -113,7 +113,7 @@ static void append_error(internal_request* req, grpc_error* error) {
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed HTTP/1 client request");
   }
   grpc_resolved_address* addr = &req->addresses->addrs[req->next_address - 1];
-  std::unique_ptr<char> addr_text(grpc_sockaddr_to_uri(addr));
+  grpc_core::UniquePtr<char> addr_text(grpc_sockaddr_to_uri(addr));
   req->overall_error = grpc_error_add_child(
       req->overall_error,
       grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,

--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -211,7 +211,7 @@ void grpc_register_event_engine_factory(const char* name,
 const char* grpc_get_poll_strategy_name() { return g_poll_strategy_name; }
 
 void grpc_event_engine_init(void) {
-  std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  grpc_core::UniquePtr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
 
   char** strings = nullptr;
   size_t nstrings = 0;

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -88,8 +88,8 @@ void grpc_custom_resolve_callback(grpc_custom_resolver* r,
 
 static grpc_error* try_split_host_port(const char* name,
                                        const char* default_port,
-                                       std::unique_ptr<char>* host,
-                                       std::unique_ptr<char>* port) {
+                                       grpc_core::UniquePtr<char>* host,
+                                       grpc_core::UniquePtr<char>* port) {
   /* parse name, splitting it into host and port parts */
   grpc_error* error;
   grpc_core::SplitHostPort(name, host, port);
@@ -117,8 +117,8 @@ static grpc_error* try_split_host_port(const char* name,
 static grpc_error* blocking_resolve_address_impl(
     const char* name, const char* default_port,
     grpc_resolved_addresses** addresses) {
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   grpc_error* err;
 
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
@@ -155,8 +155,8 @@ static void resolve_address_impl(const char* name, const char* default_port,
                                  grpc_closure* on_done,
                                  grpc_resolved_addresses** addrs) {
   grpc_custom_resolver* r = nullptr;
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   grpc_error* err;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   err = try_split_host_port(name, default_port, &host, &port);

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -57,8 +57,8 @@ static grpc_error* posix_blocking_resolve_address(
     return grpc_resolve_unix_domain_address(name + 5, addresses);
   }
 
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   /* parse name, splitting it into host and port parts */
   grpc_core::SplitHostPort(name, &host, &port);
   if (host == nullptr) {

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -62,8 +62,8 @@ static grpc_error* windows_blocking_resolve_address(
   grpc_error* error = GRPC_ERROR_NONE;
 
   /* parse name, splitting it into host and port parts */
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   grpc_core::SplitHostPort(name, &host, &port);
   if (host == NULL) {
     char* msg;

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -181,7 +181,7 @@ int grpc_sockaddr_to_string(char** out,
   }
   if (ip != nullptr && grpc_inet_ntop(addr->sa_family, ip, ntop_buf,
                                       sizeof(ntop_buf)) != nullptr) {
-    std::unique_ptr<char> tmp_out;
+    grpc_core::UniquePtr<char> tmp_out;
     if (sin6_scope_id != 0) {
       char* host_with_scope;
       /* Enclose sin6_scope_id with the format defined in RFC 6784 section 2. */

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -145,8 +145,8 @@ static void ParseResolvedAddress(const grpc_resolved_address* addr,
                                  CFStringRef* host, int* port) {
   char* host_port;
   grpc_sockaddr_to_string(&host_port, addr, 1);
-  std::unique_ptr<char> host_string;
-  std::unique_ptr<char> port_string;
+  grpc_core::UniquePtr<char> host_string;
+  grpc_core::UniquePtr<char> port_string;
   grpc_core::SplitHostPort(host_port, &host_string, &port_string);
   *host =
       CFStringCreateWithCString(NULL, host_string.get(), kCFStringEncodingUTF8);

--- a/src/core/lib/profiling/basic_timers.cc
+++ b/src/core/lib/profiling/basic_timers.cc
@@ -80,7 +80,8 @@ GPR_GLOBAL_CONFIG_DEFINE_STRING(grpc_latency_trace, "latency_trace.txt",
 
 static const char* output_filename() {
   if (output_filename_or_null == NULL) {
-    std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_latency_trace);
+    grpc_core::UniquePtr<char> value =
+        GPR_GLOBAL_CONFIG_GET(grpc_latency_trace);
     if (strlen(value.get()) > 0) {
       output_filename_or_null = value.release();
     } else {

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -45,7 +45,7 @@ void grpc_channel_credentials_release(grpc_channel_credentials* creds) {
   if (creds) creds->Unref();
 }
 
-static std::map<std::unique_ptr<char>,
+static std::map<grpc_core::UniquePtr<char>,
                 grpc_core::RefCountedPtr<grpc_channel_credentials>,
                 grpc_core::StringLess>* g_grpc_control_plane_creds;
 static gpr_mu g_control_plane_creds_mu;
@@ -54,7 +54,7 @@ static void do_control_plane_creds_init() {
   gpr_mu_init(&g_control_plane_creds_mu);
   GPR_ASSERT(g_grpc_control_plane_creds == nullptr);
   g_grpc_control_plane_creds =
-      new std::map<std::unique_ptr<char>,
+      new std::map<grpc_core::UniquePtr<char>,
                    grpc_core::RefCountedPtr<grpc_channel_credentials>,
                    grpc_core::StringLess>();
 }
@@ -88,7 +88,7 @@ bool grpc_control_plane_credentials_register(
   grpc_core::ExecCtx exec_ctx;
   {
     grpc_core::MutexLock lock(&g_control_plane_creds_mu);
-    auto key = std::unique_ptr<char>(gpr_strdup(authority));
+    auto key = grpc_core::UniquePtr<char>(gpr_strdup(authority));
     if (g_grpc_control_plane_creds->find(key) !=
         g_grpc_control_plane_creds->end()) {
       return false;
@@ -101,7 +101,7 @@ bool grpc_control_plane_credentials_register(
 bool grpc_channel_credentials::attach_credentials(
     const char* authority,
     grpc_core::RefCountedPtr<grpc_channel_credentials> control_plane_creds) {
-  auto key = std::unique_ptr<char>(gpr_strdup(authority));
+  auto key = grpc_core::UniquePtr<char>(gpr_strdup(authority));
   if (local_control_plane_creds_.find(key) !=
       local_control_plane_creds_.end()) {
     return false;
@@ -113,7 +113,7 @@ bool grpc_channel_credentials::attach_credentials(
 grpc_core::RefCountedPtr<grpc_channel_credentials>
 grpc_channel_credentials::get_control_plane_credentials(const char* authority) {
   {
-    auto key = std::unique_ptr<char>(gpr_strdup(authority));
+    auto key = grpc_core::UniquePtr<char>(gpr_strdup(authority));
     auto local_lookup = local_control_plane_creds_.find(key);
     if (local_lookup != local_control_plane_creds_.end()) {
       return local_lookup->second;

--- a/src/core/lib/security/credentials/credentials.h
+++ b/src/core/lib/security/credentials/credentials.h
@@ -148,7 +148,7 @@ struct grpc_channel_credentials
 
  private:
   const char* type_;
-  std::map<std::unique_ptr<char>,
+  std::map<grpc_core::UniquePtr<char>,
            grpc_core::RefCountedPtr<grpc_channel_credentials>,
            grpc_core::StringLess>
       local_control_plane_creds_;

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -624,14 +624,14 @@ class StsTokenFetcherCredentials
 
   grpc_uri* sts_url_;
   grpc_closure http_post_cb_closure_;
-  std::unique_ptr<char> resource_;
-  std::unique_ptr<char> audience_;
-  std::unique_ptr<char> scope_;
-  std::unique_ptr<char> requested_token_type_;
-  std::unique_ptr<char> subject_token_path_;
-  std::unique_ptr<char> subject_token_type_;
-  std::unique_ptr<char> actor_token_path_;
-  std::unique_ptr<char> actor_token_type_;
+  grpc_core::UniquePtr<char> resource_;
+  grpc_core::UniquePtr<char> audience_;
+  grpc_core::UniquePtr<char> scope_;
+  grpc_core::UniquePtr<char> requested_token_type_;
+  grpc_core::UniquePtr<char> subject_token_path_;
+  grpc_core::UniquePtr<char> subject_token_type_;
+  grpc_core::UniquePtr<char> actor_token_path_;
+  grpc_core::UniquePtr<char> actor_token_type_;
 };
 
 }  // namespace

--- a/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc
@@ -29,7 +29,7 @@
 
 /** -- gRPC TLS key materials config API implementation. -- **/
 void grpc_tls_key_materials_config::set_key_materials(
-    std::unique_ptr<char> pem_root_certs,
+    grpc_core::UniquePtr<char> pem_root_certs,
     PemKeyCertPairList pem_key_cert_pair_list) {
   pem_key_cert_pair_list_ = std::move(pem_key_cert_pair_list);
   pem_root_certs_ = std::move(pem_root_certs);
@@ -145,7 +145,7 @@ int grpc_tls_key_materials_config_set_key_materials(
             "grpc_tls_key_materials_config_set_key_materials()");
     return 0;
   }
-  std::unique_ptr<char> pem_root(const_cast<char*>(root_certs));
+  grpc_core::UniquePtr<char> pem_root(const_cast<char*>(root_certs));
   grpc_tls_key_materials_config::PemKeyCertPairList cert_pair_list;
   for (size_t i = 0; i < num; i++) {
     grpc_core::PemKeyCertPair key_cert_pair(

--- a/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
@@ -42,20 +42,20 @@ struct grpc_tls_key_materials_config
   int version() const { return version_; }
 
   /** Setters for member fields. **/
-  void set_pem_root_certs(std::unique_ptr<char> pem_root_certs) {
+  void set_pem_root_certs(grpc_core::UniquePtr<char> pem_root_certs) {
     pem_root_certs_ = std::move(pem_root_certs);
   }
   void add_pem_key_cert_pair(grpc_core::PemKeyCertPair pem_key_cert_pair) {
     pem_key_cert_pair_list_.push_back(pem_key_cert_pair);
   }
-  void set_key_materials(std::unique_ptr<char> pem_root_certs,
+  void set_key_materials(grpc_core::UniquePtr<char> pem_root_certs,
                          PemKeyCertPairList pem_key_cert_pair_list);
   void set_version(int version) { version_ = version; }
 
  private:
   int version_ = 0;
   PemKeyCertPairList pem_key_cert_pair_list_;
-  std::unique_ptr<char> pem_root_certs_;
+  grpc_core::UniquePtr<char> pem_root_certs_;
 };
 
 /** TLS credential reload config. **/

--- a/src/core/lib/security/security_connector/load_system_roots_linux.cc
+++ b/src/core/lib/security/security_connector/load_system_roots_linux.cc
@@ -144,7 +144,7 @@ grpc_slice CreateRootCertsBundle(const char* certs_directory) {
 grpc_slice LoadSystemRootCerts() {
   grpc_slice result = grpc_empty_slice();
   // Prioritize user-specified custom directory if flag is set.
-  std::unique_ptr<char> custom_dir =
+  grpc_core::UniquePtr<char> custom_dir =
       GPR_GLOBAL_CONFIG_GET(grpc_system_ssl_roots_dir);
   if (strlen(custom_dir.get()) > 0) {
     result = CreateRootCertsBundle(custom_dir.get());

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -214,8 +214,8 @@ class grpc_ssl_channel_security_connector final
 
  private:
   tsi_ssl_client_handshaker_factory* client_handshaker_factory_;
-  std::unique_ptr<char> target_name_;
-  std::unique_ptr<char> overridden_target_name_;
+  grpc_core::UniquePtr<char> target_name_;
+  grpc_core::UniquePtr<char> overridden_target_name_;
   const verify_peer_options* verify_options_;
 };
 

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -72,7 +72,8 @@ GPR_GLOBAL_CONFIG_DEFINE_STRING(
     "A colon separated list of cipher suites to use with OpenSSL")
 
 static void init_cipher_suites(void) {
-  std::unique_ptr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_ssl_cipher_suites);
+  grpc_core::UniquePtr<char> value =
+      GPR_GLOBAL_CONFIG_GET(grpc_ssl_cipher_suites);
   cipher_suites = value.release();
 }
 
@@ -422,7 +423,7 @@ grpc_slice DefaultSslRootStore::ComputePemRootCerts() {
   const bool not_use_system_roots =
       GPR_GLOBAL_CONFIG_GET(grpc_not_use_system_ssl_roots);
   // First try to load the roots from the configuration.
-  std::unique_ptr<char> default_root_certs_path =
+  grpc_core::UniquePtr<char> default_root_certs_path =
       GPR_GLOBAL_CONFIG_GET(grpc_default_ssl_roots_file_path);
   if (strlen(default_root_certs_path.get()) > 0) {
     GRPC_LOG_IF_ERROR(

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -152,8 +152,8 @@ class PemKeyCertPair {
       : private_key_(gpr_strdup(other.private_key())),
         cert_chain_(gpr_strdup(other.cert_chain())) {}
   PemKeyCertPair& operator=(const PemKeyCertPair& other) {
-    private_key_ = std::unique_ptr<char>(gpr_strdup(other.private_key()));
-    cert_chain_ = std::unique_ptr<char>(gpr_strdup(other.cert_chain()));
+    private_key_ = grpc_core::UniquePtr<char>(gpr_strdup(other.private_key()));
+    cert_chain_ = grpc_core::UniquePtr<char>(gpr_strdup(other.cert_chain()));
     return *this;
   }
 
@@ -161,8 +161,8 @@ class PemKeyCertPair {
   char* cert_chain() const { return cert_chain_.get(); }
 
  private:
-  std::unique_ptr<char> private_key_;
-  std::unique_ptr<char> cert_chain_;
+  grpc_core::UniquePtr<char> private_key_;
+  grpc_core::UniquePtr<char> cert_chain_;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
@@ -300,7 +300,7 @@ SpiffeChannelSecurityConnector::InitializeHandshakerFactory(
   if (key_materials_config != nullptr) {
     grpc_tls_key_materials_config::PemKeyCertPairList cert_pair_list =
         key_materials_config->pem_key_cert_pair_list();
-    auto pem_root_certs = std::unique_ptr<char>(
+    auto pem_root_certs = grpc_core::UniquePtr<char>(
         gpr_strdup(key_materials_config->pem_root_certs()));
     key_materials_config_->set_key_materials(std::move(pem_root_certs),
                                              std::move(cert_pair_list));
@@ -505,7 +505,7 @@ SpiffeServerSecurityConnector::InitializeHandshakerFactory() {
   if (key_materials_config != nullptr) {
     grpc_tls_key_materials_config::PemKeyCertPairList cert_pair_list =
         key_materials_config->pem_key_cert_pair_list();
-    auto pem_root_certs = std::unique_ptr<char>(
+    auto pem_root_certs = grpc_core::UniquePtr<char>(
         gpr_strdup(key_materials_config->pem_root_certs()));
     key_materials_config_->set_key_materials(std::move(pem_root_certs),
                                              std::move(cert_pair_list));

--- a/src/core/lib/security/security_connector/tls/spiffe_security_connector.h
+++ b/src/core/lib/security/security_connector/tls/spiffe_security_connector.h
@@ -98,8 +98,8 @@ class SpiffeChannelSecurityConnector final
 
   grpc_core::Mutex mu_;
   grpc_closure* on_peer_checked_;
-  std::unique_ptr<char> target_name_;
-  std::unique_ptr<char> overridden_target_name_;
+  grpc_core::UniquePtr<char> target_name_;
+  grpc_core::UniquePtr<char> overridden_target_name_;
   tsi_ssl_client_handshaker_factory* client_handshaker_factory_ = nullptr;
   grpc_tls_server_authorization_check_arg* check_arg_;
   grpc_core::RefCountedPtr<grpc_tls_key_materials_config> key_materials_config_;

--- a/src/core/lib/security/transport/target_authority_table.h
+++ b/src/core/lib/security/transport/target_authority_table.h
@@ -26,7 +26,7 @@
 namespace grpc_core {
 
 /// A hash table mapping target addresses to authorities.
-typedef SliceHashTable<std::unique_ptr<char>> TargetAuthorityTable;
+typedef SliceHashTable<grpc_core::UniquePtr<char>> TargetAuthorityTable;
 
 /// Returns a channel argument containing \a table.
 grpc_arg CreateTargetAuthorityTableChannelArg(TargetAuthorityTable* table);

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -156,7 +156,7 @@ class NewWithLenSliceRefcount {
 /** grpc_slice_from_moved_(string|buffer) ref count .*/
 class MovedStringSliceRefCount {
  public:
-  MovedStringSliceRefCount(std::unique_ptr<char>&& str)
+  MovedStringSliceRefCount(grpc_core::UniquePtr<char>&& str)
       : base_(grpc_slice_refcount::Type::REGULAR, &refs_, Destroy, this,
               &base_),
         str_(std::move(str)) {}
@@ -170,7 +170,7 @@ class MovedStringSliceRefCount {
 
   grpc_slice_refcount base_;
   grpc_core::RefCount refs_;
-  std::unique_ptr<char> str_;
+  grpc_core::UniquePtr<char> str_;
 };
 
 }  // namespace grpc_core
@@ -210,7 +210,8 @@ grpc_slice grpc_slice_from_copied_string(const char* source) {
   return grpc_core::UnmanagedMemorySlice(source, strlen(source));
 }
 
-grpc_slice grpc_slice_from_moved_buffer(std::unique_ptr<char> p, size_t len) {
+grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
+                                        size_t len) {
   uint8_t* ptr = reinterpret_cast<uint8_t*>(p.get());
   grpc_slice slice;
   if (len <= sizeof(slice.data.inlined.bytes)) {
@@ -226,7 +227,7 @@ grpc_slice grpc_slice_from_moved_buffer(std::unique_ptr<char> p, size_t len) {
   return slice;
 }
 
-grpc_slice grpc_slice_from_moved_string(std::unique_ptr<char> p) {
+grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p) {
   const size_t len = strlen(p.get());
   return grpc_slice_from_moved_buffer(std::move(p), len);
 }

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -335,8 +335,9 @@ inline uint32_t grpc_slice_hash_internal(const grpc_slice& s) {
                                : grpc_slice_hash_refcounted(s);
 }
 
-grpc_slice grpc_slice_from_moved_buffer(std::unique_ptr<char> p, size_t len);
-grpc_slice grpc_slice_from_moved_string(std::unique_ptr<char> p);
+grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
+                                        size_t len);
+grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p);
 
 // Returns the memory used by this slice, not counting the slice structure
 // itself. This means that inlined and slices from static strings will return

--- a/src/core/lib/slice/slice_string_helpers.cc
+++ b/src/core/lib/slice/slice_string_helpers.cc
@@ -35,7 +35,7 @@ char* grpc_dump_slice(const grpc_slice& s, uint32_t flags) {
 
 grpc_slice grpc_dump_slice_to_slice(const grpc_slice& s, uint32_t flags) {
   size_t len;
-  std::unique_ptr<char> ptr(
+  grpc_core::UniquePtr<char> ptr(
       gpr_dump_return_len(reinterpret_cast<const char*> GRPC_SLICE_START_PTR(s),
                           GRPC_SLICE_LENGTH(s), flags, &len));
   return grpc_slice_from_moved_buffer(std::move(ptr), len);

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -138,11 +138,11 @@ grpc_channel* grpc_channel_create_with_builder(
   return channel;
 }
 
-static std::unique_ptr<char> get_default_authority(
+static grpc_core::UniquePtr<char> get_default_authority(
     const grpc_channel_args* input_args) {
   bool has_default_authority = false;
   char* ssl_override = nullptr;
-  std::unique_ptr<char> default_authority;
+  grpc_core::UniquePtr<char> default_authority;
   const size_t num_args = input_args != nullptr ? input_args->num_args : 0;
   for (size_t i = 0; i < num_args; ++i) {
     if (0 == strcmp(input_args->args[i].key, GRPC_ARG_DEFAULT_AUTHORITY)) {
@@ -257,7 +257,7 @@ grpc_channel* grpc_channel_create(const char* target,
   // ensuring that shutdown is deferred until that point.
   grpc_init();
   grpc_channel_stack_builder* builder = grpc_channel_stack_builder_create();
-  const std::unique_ptr<char> default_authority =
+  const grpc_core::UniquePtr<char> default_authority =
       get_default_authority(input_args);
   grpc_channel_args* args =
       build_channel_args(input_args, default_authority.get());

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1543,7 +1543,7 @@ static int does_entry_match_name(grpc_core::StringView entry,
   entry.remove_prefix(2);                  /* Remove *. */
   size_t dot = name_subdomain.find('.');
   if (dot == grpc_core::StringView::npos || dot == name_subdomain.size() - 1) {
-    std::unique_ptr<char> name_subdomain_cstr(
+    grpc_core::UniquePtr<char> name_subdomain_cstr(
         grpc_core::StringViewToCString(name_subdomain));
     gpr_log(GPR_ERROR, "Invalid toplevel subdomain: %s",
             name_subdomain_cstr.get());

--- a/src/cpp/common/tls_credentials_options.cc
+++ b/src/cpp/common/tls_credentials_options.cc
@@ -80,7 +80,8 @@ void TlsCredentialReloadArg::set_cb_user_data(void* cb_user_data) {
 
 void TlsCredentialReloadArg::set_pem_root_certs(
     const grpc::string& pem_root_certs) {
-  ::std::unique_ptr<char> c_pem_root_certs(gpr_strdup(pem_root_certs.c_str()));
+  ::grpc_core::UniquePtr<char> c_pem_root_certs(
+      gpr_strdup(pem_root_certs.c_str()));
   c_arg_->key_materials_config->set_pem_root_certs(std::move(c_pem_root_certs));
 }
 
@@ -116,7 +117,7 @@ void TlsCredentialReloadArg::set_key_materials_config(
         ::grpc_core::PemKeyCertPair(ssl_pair);
     c_pem_key_cert_pair_list.emplace_back(std::move(c_pem_key_cert_pair));
   }
-  ::std::unique_ptr<char> c_pem_root_certs(
+  ::grpc_core::UniquePtr<char> c_pem_root_certs(
       gpr_strdup(key_materials_config->pem_root_certs().c_str()));
   if (c_arg_->key_materials_config == nullptr) {
     c_arg_->key_materials_config = grpc_tls_key_materials_config_create();

--- a/src/cpp/common/tls_credentials_options_util.cc
+++ b/src/cpp/common/tls_credentials_options_util.cc
@@ -25,8 +25,8 @@ namespace experimental {
 /** Converts the Cpp key materials to C key materials; this allocates memory for
  * the C key materials. Note that the user must free
  * the underlying pointer to private key and cert chain duplicates; they are not
- * freed when the std::unique_ptr<char> member variables of PemKeyCertPair are
- * unused. Similarly, the user must free the underlying pointer to
+ * freed when the grpc_core::UniquePtr<char> member variables of PemKeyCertPair
+ * are unused. Similarly, the user must free the underlying pointer to
  * c_pem_root_certs. **/
 grpc_tls_key_materials_config* ConvertToCKeyMaterialsConfig(
     const std::shared_ptr<TlsKeyMaterialsConfig>& config) {
@@ -47,7 +47,7 @@ grpc_tls_key_materials_config* ConvertToCKeyMaterialsConfig(
         ::grpc_core::PemKeyCertPair(ssl_pair);
     c_pem_key_cert_pair_list.push_back(::std::move(c_pem_key_cert_pair));
   }
-  ::std::unique_ptr<char> c_pem_root_certs(
+  ::grpc_core::UniquePtr<char> c_pem_root_certs(
       gpr_strdup(config->pem_root_certs().c_str()));
   c_config->set_key_materials(std::move(c_pem_root_certs),
                               std::move(c_pem_key_cert_pair_list));

--- a/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
+++ b/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
@@ -52,7 +52,7 @@
 #import "../ConfigureCronet.h"
 
 struct fullstack_secure_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -133,7 +133,7 @@ unsigned int parse_h2_length(const char *field) {
                               {{NULL, NULL, NULL, NULL}}}};
 
   int port = grpc_pick_unused_port_or_die();
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
   grpc_completion_queue *cq = grpc_completion_queue_create_for_next(NULL);
   stream_engine *cronetEngine = [Cronet getGlobalEngine];
@@ -264,7 +264,7 @@ unsigned int parse_h2_length(const char *field) {
                               {{NULL, NULL, NULL, NULL}}}};
 
   int port = grpc_pick_unused_port_or_die();
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
   grpc_completion_queue *cq = grpc_completion_queue_create_for_next(NULL);
   stream_engine *cronetEngine = [Cronet getGlobalEngine];

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
   gpr_asprintf(&args[0], "%s/bad_ssl_%s_server%s", root, test,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  std::unique_ptr<char> joined;
+  grpc_core::UniquePtr<char> joined;
   grpc_core::JoinHostPort(&joined, "::", port);
   args[2] = joined.get();
   svr = gpr_subprocess_create(4, (const char**)args);

--- a/test/core/client_channel/parse_address_with_named_scope_id_test.cc
+++ b/test/core/client_channel/parse_address_with_named_scope_id_test.cc
@@ -61,8 +61,8 @@ static void test_grpc_parse_ipv6_parity_with_getaddrinfo(
 
 struct sockaddr_in6 resolve_with_gettaddrinfo(const char* uri_text) {
   grpc_uri* uri = grpc_uri_parse(uri_text, 0);
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   grpc_core::SplitHostPort(uri->path, &host, &port);
   struct addrinfo hints;
   memset(&hints, 0, sizeof(hints));

--- a/test/core/client_channel/resolvers/dns_resolver_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_test.cc
@@ -82,7 +82,8 @@ int main(int argc, char** argv) {
   test_succeeds(dns, "dns:10.2.1.1:1234");
   test_succeeds(dns, "dns:www.google.com");
   test_succeeds(dns, "dns:///www.google.com");
-  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  grpc_core::UniquePtr<char> resolver =
+      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (gpr_stricmp(resolver.get(), "native") == 0) {
     test_fails(dns, "dns://8.8.8.8/8.8.8.8:8888");
   } else {

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -71,7 +71,7 @@
 #define SERVER_INCOMING_DATA_LENGTH_LOWER_THRESHOLD (size_t)200
 
 struct rpc_state {
-  std::unique_ptr<char> target;
+  grpc_core::UniquePtr<char> target;
   grpc_completion_queue* cq;
   grpc_channel* channel;
   grpc_call* call;

--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -77,7 +77,7 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
 
   /* create a call, channel to a port which will refuse connection */
   int port = grpc_pick_unused_port_or_die();
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
   gpr_log(GPR_INFO, "server: %s", addr.get());
   chan = grpc_insecure_channel_create(addr.get(), args, nullptr);

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -97,7 +97,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
     picked_port = 1;
   }
 
-  std::unique_ptr<char> server_hostport;
+  grpc_core::UniquePtr<char> server_hostport;
   grpc_core::JoinHostPort(&server_hostport, server_host, port);
 
   grpc_metadata_array_init(&initial_metadata_recv);
@@ -120,7 +120,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
   cqv = cq_verifier_create(cq);
 
   /* Create client. */
-  std::unique_ptr<char> client_hostport;
+  grpc_core::UniquePtr<char> client_hostport;
   if (client_host[0] == 'i') {
     /* for ipv4:/ipv6: addresses, concatenate the port to each of the parts */
     size_t i;

--- a/test/core/end2end/fixtures/h2_census.cc
+++ b/test/core/end2end/fixtures/h2_census.cc
@@ -36,7 +36,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_compress.cc
+++ b/test/core/end2end/fixtures/h2_compress.cc
@@ -41,7 +41,7 @@ struct fullstack_compression_fixture_data {
     grpc_channel_args_destroy(client_args_compression);
     grpc_channel_args_destroy(server_args_compression);
   }
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
   grpc_channel_args* client_args_compression = nullptr;
   grpc_channel_args* server_args_compression = nullptr;
 };

--- a/test/core/end2end/fixtures/h2_fakesec.cc
+++ b/test/core/end2end/fixtures/h2_fakesec.cc
@@ -32,7 +32,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/test/core/end2end/fixtures/h2_full+pipe.cc
+++ b/test/core/end2end/fixtures/h2_full+pipe.cc
@@ -41,7 +41,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_full+trace.cc
+++ b/test/core/end2end/fixtures/h2_full+trace.cc
@@ -41,7 +41,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_full+workarounds.cc
+++ b/test/core/end2end/fixtures/h2_full+workarounds.cc
@@ -40,7 +40,7 @@ static char* workarounds_arg[GRPC_MAX_WORKAROUND_ID] = {
     const_cast<char*>(GRPC_ARG_WORKAROUND_CRONET_COMPRESSION)};
 
 struct fullstack_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_full.cc
+++ b/test/core/end2end/fixtures/h2_full.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(

--- a/test/core/end2end/fixtures/h2_http_proxy.cc
+++ b/test/core/end2end/fixtures/h2_http_proxy.cc
@@ -39,7 +39,7 @@
 
 struct fullstack_fixture_data {
   ~fullstack_fixture_data() { grpc_end2end_http_proxy_destroy(proxy); }
-  std::unique_ptr<char> server_addr;
+  grpc_core::UniquePtr<char> server_addr;
   grpc_end2end_http_proxy* proxy = nullptr;
 };
 

--- a/test/core/end2end/fixtures/h2_oauth2.cc
+++ b/test/core/end2end/fixtures/h2_oauth2.cc
@@ -37,7 +37,7 @@ static const char* client_identity_property_name = "smurf_name";
 static const char* client_identity = "Brainy Smurf";
 
 struct fullstack_secure_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static const grpc_metadata* find_metadata(const grpc_metadata* md,

--- a/test/core/end2end/fixtures/h2_spiffe.cc
+++ b/test/core/end2end/fixtures/h2_spiffe.cc
@@ -48,7 +48,7 @@ struct fullstack_secure_fixture_data {
       thd_list[ind].Join();
     }
   }
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
   ThreadList thd_list;
 };
 

--- a/test/core/end2end/fixtures/h2_ssl.cc
+++ b/test/core/end2end/fixtures/h2_ssl.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
+++ b/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
   bool server_credential_reloaded = false;
 };
 

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -61,7 +61,7 @@ struct grpc_end2end_http_proxy {
     gpr_ref_init(&users, 1);
     combiner = grpc_combiner_create();
   }
-  std::unique_ptr<char> proxy_name;
+  grpc_core::UniquePtr<char> proxy_name;
   grpc_core::Thread thd;
   grpc_tcp_server* server;
   grpc_channel_args* channel_args;

--- a/test/core/end2end/fixtures/local_util.h
+++ b/test/core/end2end/fixtures/local_util.h
@@ -23,7 +23,7 @@
 #include "src/core/lib/surface/channel.h"
 
 struct grpc_end2end_local_fullstack_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 /* Utility functions shared by h2_local tests. */

--- a/test/core/end2end/fixtures/proxy.cc
+++ b/test/core/end2end/fixtures/proxy.cc
@@ -41,8 +41,8 @@ struct grpc_end2end_proxy {
     memset(&new_call_metadata, 0, sizeof(new_call_metadata));
   }
   grpc_core::Thread thd;
-  std::unique_ptr<char> proxy_port;
-  std::unique_ptr<char> server_port;
+  grpc_core::UniquePtr<char> proxy_port;
+  grpc_core::UniquePtr<char> server_port;
   grpc_completion_queue* cq;
   grpc_server* server;
   grpc_channel* client;

--- a/test/core/end2end/h2_ssl_cert_test.cc
+++ b/test/core/end2end/h2_ssl_cert_test.cc
@@ -41,7 +41,7 @@ namespace grpc {
 namespace testing {
 
 struct fullstack_secure_fixture_data {
-  std::unique_ptr<char> localaddr;
+  grpc_core::UniquePtr<char> localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(

--- a/test/core/end2end/h2_ssl_session_reuse_test.cc
+++ b/test/core/end2end/h2_ssl_session_reuse_test.cc
@@ -215,7 +215,7 @@ void drain_cq(grpc_completion_queue* cq) {
 TEST(H2SessionReuseTest, SingleReuse) {
   int port = grpc_pick_unused_port_or_die();
 
-  std::unique_ptr<char> server_addr;
+  grpc_core::UniquePtr<char> server_addr;
   grpc_core::JoinHostPort(&server_addr, "localhost", port);
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);

--- a/test/core/end2end/invalid_call_argument_test.cc
+++ b/test/core/end2end/invalid_call_argument_test.cc
@@ -77,7 +77,7 @@ static void prepare_test(int is_client) {
   } else {
     g_state.server = grpc_server_create(nullptr, nullptr);
     grpc_server_register_completion_queue(g_state.server, g_state.cq, nullptr);
-    std::unique_ptr<char> server_hostport;
+    grpc_core::UniquePtr<char> server_hostport;
     grpc_core::JoinHostPort(&server_hostport, "0.0.0.0", port);
     grpc_server_add_insecure_http2_port(g_state.server, server_hostport.get());
     grpc_server_start(g_state.server);

--- a/test/core/end2end/tests/keepalive_timeout.cc
+++ b/test/core/end2end/tests/keepalive_timeout.cc
@@ -230,7 +230,7 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
  * that the keepalive ping is never sent. */
 static void test_read_delays_keepalive(grpc_end2end_test_config config) {
 #ifdef GRPC_POSIX_SOCKET
-  std::unique_ptr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  grpc_core::UniquePtr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
   /* It is hard to get the timing right for the polling engine poll. */
   if ((0 == strcmp(poller.get(), "poll"))) {
     return;

--- a/test/core/fling/fling_stream_test.cc
+++ b/test/core/fling/fling_stream_test.cc
@@ -46,7 +46,7 @@ int main(int /*argc*/, char** argv) {
   gpr_asprintf(&args[0], "%s/fling_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  std::unique_ptr<char> joined;
+  grpc_core::UniquePtr<char> joined;
   grpc_core::JoinHostPort(&joined, "::", port);
   args[2] = joined.get();
   args[3] = const_cast<char*>("--no-secure");

--- a/test/core/fling/fling_test.cc
+++ b/test/core/fling/fling_test.cc
@@ -47,7 +47,7 @@ int main(int /*argc*/, const char** argv) {
   gpr_asprintf(&args[0], "%s/fling_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  std::unique_ptr<char> joined;
+  grpc_core::UniquePtr<char> joined;
   grpc_core::JoinHostPort(&joined, "::", port);
   args[2] = joined.get();
   args[3] = const_cast<char*>("--no-secure");

--- a/test/core/fling/server.cc
+++ b/test/core/fling/server.cc
@@ -172,7 +172,7 @@ static void sigint_handler(int /*x*/) { _exit(0); }
 int main(int argc, char** argv) {
   grpc_event ev;
   call_state* s;
-  std::unique_ptr<char> addr_buf;
+  grpc_core::UniquePtr<char> addr_buf;
   gpr_cmdline* cl;
   grpc_completion_queue* shutdown_cq;
   int shutdown_started = 0;

--- a/test/core/gprpp/global_config_env_test.cc
+++ b/test/core/gprpp/global_config_env_test.cc
@@ -105,7 +105,7 @@ TEST_F(GlobalConfigEnvTest, Int32WithEnvTest) {
 
 TEST_F(GlobalConfigEnvTest, StringWithEnvTest) {
   const char* string_var_name = "STRING_VAR";
-  std::unique_ptr<char> value;
+  grpc_core::UniquePtr<char> value;
 
   gpr_unsetenv(string_var_name);
   value = GPR_GLOBAL_CONFIG_GET(string_var);

--- a/test/core/gprpp/global_config_test.cc
+++ b/test/core/gprpp/global_config_test.cc
@@ -47,7 +47,7 @@ TEST(GlobalConfigTest, Int32Test) {
 }
 
 TEST(GlobalConfigTest, StringTest) {
-  std::unique_ptr<char> value;
+  grpc_core::UniquePtr<char> value;
 
   value = GPR_GLOBAL_CONFIG_GET(string_var);
   EXPECT_EQ(0, strcmp(value.get(), ""));

--- a/test/core/gprpp/host_port_test.cc
+++ b/test/core/gprpp/host_port_test.cc
@@ -26,7 +26,7 @@
 
 static void join_host_port_expect(const char* host, int port,
                                   const char* expected) {
-  std::unique_ptr<char> buf;
+  grpc_core::UniquePtr<char> buf;
   int len;
   len = grpc_core::JoinHostPort(&buf, host, port);
   GPR_ASSERT(len >= 0);
@@ -50,8 +50,8 @@ static void test_join_host_port_garbage(void) {
 
 static void split_host_port_expect(const char* name, const char* host,
                                    const char* port, bool ret) {
-  std::unique_ptr<char> actual_host;
-  std::unique_ptr<char> actual_port;
+  grpc_core::UniquePtr<char> actual_host;
+  grpc_core::UniquePtr<char> actual_port;
   const bool actual_ret =
       grpc_core::SplitHostPort(name, &actual_host, &actual_port);
   GPR_ASSERT(actual_ret == ret);

--- a/test/core/gprpp/string_view_test.cc
+++ b/test/core/gprpp/string_view_test.cc
@@ -74,7 +74,7 @@ TEST(StringViewTest, Dup) {
   constexpr char kStr[] = "foo";
   grpc_core::StringView slice(
       grpc_core::StringViewFromSlice(grpc_slice_from_static_string(kStr)));
-  std::unique_ptr<char> dup = grpc_core::StringViewToCString(slice);
+  grpc_core::UniquePtr<char> dup = grpc_core::StringViewToCString(slice);
   EXPECT_EQ(0, strcmp(kStr, dup.get()));
   EXPECT_EQ(slice.size(), strlen(kStr));
 }

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -225,7 +225,8 @@ int main(int argc, char** argv) {
   // --resolver will always be the first one, so only parse the first argument
   // (other arguments may be unknown to cl)
   gpr_cmdline_parse(cl, argc > 2 ? 2 : argc, argv);
-  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  grpc_core::UniquePtr<char> resolver =
+      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (strlen(resolver.get()) != 0) {
     gpr_log(GPR_INFO, "Warning: overriding resolver setting of %s",
             resolver.get());
@@ -247,7 +248,8 @@ int main(int argc, char** argv) {
     // c-ares resolver doesn't support UDS (ability for native DNS resolver
     // to handle this is only expected to be used by servers, which
     // unconditionally use the native DNS resolver).
-    std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+    grpc_core::UniquePtr<char> resolver =
+        GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
     if (gpr_stricmp(resolver.get(), "native") == 0) {
       test_unix_socket();
       test_unix_socket_path_name_too_long();

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -347,7 +347,8 @@ int main(int argc, char** argv) {
   // --resolver will always be the first one, so only parse the first argument
   // (other arguments may be unknown to cl)
   gpr_cmdline_parse(cl, argc > 2 ? 2 : argc, argv);
-  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  grpc_core::UniquePtr<char> resolver =
+      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (strlen(resolver.get()) != 0) {
     gpr_log(GPR_INFO, "Warning: overriding resolver setting of %s",
             resolver.get());

--- a/test/core/security/control_plane_credentials_test.cc
+++ b/test/core/security/control_plane_credentials_test.cc
@@ -83,10 +83,10 @@ grpc_server_credentials* create_test_ssl_server_creds() {
 // Perform a simple RPC and capture the ASCII value of the
 // authorization metadata sent to the server, if any. Return
 // nullptr if no authorization metadata was sent to the server.
-std::unique_ptr<char> perform_call_and_get_authorization_header(
+grpc_core::UniquePtr<char> perform_call_and_get_authorization_header(
     grpc_channel_credentials* channel_creds) {
   // Create a new channel and call
-  std::unique_ptr<char> server_addr = nullptr;
+  grpc_core::UniquePtr<char> server_addr = nullptr;
   grpc_core::JoinHostPort(&server_addr, "localhost", g_port);
   grpc_arg ssl_name_override = {
       GRPC_ARG_STRING,
@@ -196,7 +196,7 @@ std::unique_ptr<char> perform_call_and_get_authorization_header(
   cq_verify(cqv);
   GPR_ASSERT(status == GRPC_STATUS_OK);
   // Extract the ascii value of the authorization header, if present
-  std::unique_ptr<char> authorization_header_val;
+  grpc_core::UniquePtr<char> authorization_header_val;
   gpr_log(GPR_DEBUG, "RPC done. Now examine received metadata on server...");
   for (size_t i = 0; i < request_metadata_recv.count; i++) {
     char* cur_key =
@@ -239,10 +239,10 @@ void test_attach_and_get() {
       create_test_ssl_plus_token_channel_creds("foo-auth-header");
   grpc_channel_credentials* bar_creds =
       create_test_ssl_plus_token_channel_creds("bar-auth-header");
-  auto foo_key = std::unique_ptr<char>(gpr_strdup("foo"));
+  auto foo_key = grpc_core::UniquePtr<char>(gpr_strdup("foo"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, foo_key.get(), foo_creds) == true);
-  auto bar_key = std::unique_ptr<char>(gpr_strdup("bar"));
+  auto bar_key = grpc_core::UniquePtr<char>(gpr_strdup("bar"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, bar_key.get(), bar_creds) == true);
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(main_creds, "foo",
@@ -295,10 +295,10 @@ void test_registering_same_creds_under_different_keys() {
       create_test_ssl_plus_token_channel_creds("main-auth-header");
   grpc_channel_credentials* foo_creds =
       create_test_ssl_plus_token_channel_creds("foo-auth-header");
-  auto foo_key = std::unique_ptr<char>(gpr_strdup("foo"));
+  auto foo_key = grpc_core::UniquePtr<char>(gpr_strdup("foo"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, foo_key.get(), foo_creds) == true);
-  auto foo2_key = std::unique_ptr<char>(gpr_strdup("foo2"));
+  auto foo2_key = grpc_core::UniquePtr<char>(gpr_strdup("foo2"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, foo2_key.get(), foo_creds) == true);
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(main_creds, "foo",
@@ -335,7 +335,7 @@ void test_attach_and_get_with_global_registry() {
       create_test_ssl_plus_token_channel_creds("global-override-auth-header");
   grpc_channel_credentials* random_creds =
       create_test_ssl_plus_token_channel_creds("random-auth-header");
-  auto global_key = std::unique_ptr<char>(gpr_strdup("global"));
+  auto global_key = grpc_core::UniquePtr<char>(gpr_strdup("global"));
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
                  main_creds, global_key.get(), global_override_creds) == true);
   GPR_ASSERT(grpc_channel_credentials_attach_credentials(
@@ -392,7 +392,7 @@ int main(int argc, char** argv) {
     g_server = grpc_server_create(nullptr, nullptr);
     g_port = grpc_pick_unused_port_or_die();
     grpc_server_register_completion_queue(g_server, g_cq, nullptr);
-    std::unique_ptr<char> localaddr;
+    grpc_core::UniquePtr<char> localaddr;
     grpc_core::JoinHostPort(&localaddr, "localhost", g_port);
     GPR_ASSERT(grpc_server_add_secure_http2_port(g_server, localaddr.get(),
                                                  server_creds));
@@ -403,7 +403,7 @@ int main(int argc, char** argv) {
       // will have access.
       grpc_channel_credentials* global_creds =
           create_test_ssl_plus_token_channel_creds("global-auth-header");
-      auto global_key = std::unique_ptr<char>(gpr_strdup("global"));
+      auto global_key = grpc_core::UniquePtr<char>(gpr_strdup("global"));
       GPR_ASSERT(grpc_control_plane_credentials_register(global_key.get(),
                                                          global_creds) == true);
       GPR_ASSERT(grpc_control_plane_credentials_register(
@@ -439,7 +439,7 @@ int main(int argc, char** argv) {
     // a full shutdown and restart of the library.
     grpc_channel_credentials* global_creds =
         create_test_ssl_plus_token_channel_creds("global-auth-header");
-    auto global_key = std::unique_ptr<char>(gpr_strdup("global"));
+    auto global_key = grpc_core::UniquePtr<char>(gpr_strdup("global"));
     GPR_ASSERT(grpc_control_plane_credentials_register(global_key.get(),
                                                        global_creds) == false);
     grpc_channel_credentials_release(global_creds);

--- a/test/core/slice/slice_hash_table_test.cc
+++ b/test/core/slice/slice_hash_table_test.cc
@@ -35,7 +35,7 @@
 namespace grpc_core {
 namespace {
 
-typedef SliceHashTable<std::unique_ptr<char>> TestHashTable;
+typedef SliceHashTable<grpc_core::UniquePtr<char>> TestHashTable;
 
 struct TestEntry {
   const char* key;
@@ -46,7 +46,7 @@ void CheckValues(const std::vector<TestEntry>& input,
                  const TestHashTable& table) {
   for (const TestEntry& expected : input) {
     grpc_slice key = grpc_slice_from_static_string(expected.key);
-    const std::unique_ptr<char>* actual = table.Get(key);
+    const grpc_core::UniquePtr<char>* actual = table.Get(key);
     ASSERT_NE(actual, nullptr);
     EXPECT_STREQ(expected.value, actual->get());
     grpc_slice_unref(key);
@@ -63,7 +63,7 @@ void PopulateEntries(const std::vector<TestEntry>& input,
                      TestHashTable::Entry* output) {
   for (size_t i = 0; i < input.size(); ++i) {
     output[i].key = grpc_slice_from_copied_string(input[i].key);
-    output[i].value = std::unique_ptr<char>(gpr_strdup(input[i].value));
+    output[i].value = grpc_core::UniquePtr<char>(gpr_strdup(input[i].value));
   }
 }
 
@@ -123,11 +123,13 @@ TEST(SliceHashTable, Basic) {
   CheckNonExistentValue("XX", *table);
 }
 
-int StringCmp(const std::unique_ptr<char>& a, const std::unique_ptr<char>& b) {
+int StringCmp(const grpc_core::UniquePtr<char>& a,
+              const grpc_core::UniquePtr<char>& b) {
   return strcmp(a.get(), b.get());
 }
 
-int PointerCmp(const std::unique_ptr<char>& a, const std::unique_ptr<char>& b) {
+int PointerCmp(const grpc_core::UniquePtr<char>& a,
+               const grpc_core::UniquePtr<char>& b) {
   return GPR_ICMP(a.get(), b.get());
 }
 

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -301,7 +301,7 @@ static void test_moved_string_slice(void) {
   constexpr char kSmallStr[] = "hello12345";
   char* small_ptr = strdup(kSmallStr);
   grpc_slice small =
-      grpc_slice_from_moved_string(std::unique_ptr<char>(small_ptr));
+      grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(small_ptr));
   GPR_ASSERT(GRPC_SLICE_LENGTH(small) == strlen(kSmallStr));
   GPR_ASSERT(GRPC_SLICE_START_PTR(small) !=
              reinterpret_cast<uint8_t*>(small_ptr));
@@ -311,7 +311,7 @@ static void test_moved_string_slice(void) {
   constexpr char kSLargeStr[] = "hello123456789123456789123456789";
   char* large_ptr = strdup(kSLargeStr);
   grpc_slice large =
-      grpc_slice_from_moved_string(std::unique_ptr<char>(large_ptr));
+      grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(large_ptr));
   GPR_ASSERT(GRPC_SLICE_LENGTH(large) == strlen(kSLargeStr));
   GPR_ASSERT(GRPC_SLICE_START_PTR(large) ==
              reinterpret_cast<uint8_t*>(large_ptr));
@@ -320,7 +320,7 @@ static void test_moved_string_slice(void) {
   // Moved buffer must respect the provided length not the actual length of the
   // string.
   large_ptr = strdup(kSLargeStr);
-  small = grpc_slice_from_moved_buffer(std::unique_ptr<char>(large_ptr),
+  small = grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char>(large_ptr),
                                        strlen(kSmallStr));
   GPR_ASSERT(GRPC_SLICE_LENGTH(small) == strlen(kSmallStr));
   GPR_ASSERT(GRPC_SLICE_START_PTR(small) !=

--- a/test/core/slice/slice_weak_hash_table_test.cc
+++ b/test/core/slice/slice_weak_hash_table_test.cc
@@ -43,11 +43,11 @@ grpc_slice BuildRefCountedKey(const char* key_str) {
 }
 
 TEST(SliceWeakHashTable, Basic) {
-  auto table = SliceWeakHashTable<std::unique_ptr<char>, 10>::Create();
+  auto table = SliceWeakHashTable<grpc_core::UniquePtr<char>, 10>::Create();
   // Single key-value insertion.
   grpc_slice key = BuildRefCountedKey("key");
   grpc_slice_ref(key);  // Get doesn't own.
-  table->Add(key, std::unique_ptr<char>(gpr_strdup("value")));
+  table->Add(key, grpc_core::UniquePtr<char>(gpr_strdup("value")));
   ASSERT_NE(table->Get(key), nullptr);
   ASSERT_STREQ(table->Get(key)->get(), "value");
   grpc_slice_unref(key);
@@ -70,7 +70,8 @@ TEST(SliceWeakHashTable, ValueTypeConstructor) {
 
 TEST(SliceWeakHashTable, ForceOverload) {
   constexpr int kTableSize = 10;
-  auto table = SliceWeakHashTable<std::unique_ptr<char>, kTableSize>::Create();
+  auto table =
+      SliceWeakHashTable<grpc_core::UniquePtr<char>, kTableSize>::Create();
   // Insert a multiple of the maximum size table.
   for (int i = 0; i < kTableSize * 2; ++i) {
     std::ostringstream oss;
@@ -78,7 +79,7 @@ TEST(SliceWeakHashTable, ForceOverload) {
     grpc_slice key = BuildRefCountedKey(oss.str().c_str());
     oss.clear();
     oss << "value-" << i;
-    table->Add(key, std::unique_ptr<char>(gpr_strdup(oss.str().c_str())));
+    table->Add(key, grpc_core::UniquePtr<char>(gpr_strdup(oss.str().c_str())));
   }
   // Verify that some will have been replaced.
   int num_missing = 0;

--- a/test/core/surface/num_external_connectivity_watchers_test.cc
+++ b/test/core/surface/num_external_connectivity_watchers_test.cc
@@ -67,7 +67,7 @@ static void channel_idle_poll_for_timeout(grpc_channel* channel,
 static void run_timeouts_test(const test_fixture* fixture) {
   gpr_log(GPR_INFO, "TEST: %s", fixture->name);
 
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_init();
   grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
 
@@ -118,7 +118,7 @@ static void run_channel_shutdown_before_timeout_test(
     const test_fixture* fixture) {
   gpr_log(GPR_INFO, "TEST: %s", fixture->name);
 
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_init();
   grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
 

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -56,7 +56,7 @@ static void run_test(const test_fixture* fixture) {
 
   grpc_init();
 
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
 
   grpc_server* server = grpc_server_create(nullptr, nullptr);

--- a/test/core/surface/server_chttp2_test.cc
+++ b/test/core/surface/server_chttp2_test.cc
@@ -47,7 +47,7 @@ void test_add_same_port_twice() {
   grpc_channel_args args = {1, &a};
 
   int port = grpc_pick_unused_port_or_die();
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_completion_queue* cq = grpc_completion_queue_create_for_pluck(nullptr);
   grpc_server* server = grpc_server_create(&args, nullptr);
   grpc_server_credentials* fake_creds =

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -106,7 +106,7 @@ void test_bind_server_twice(void) {
 
 void test_bind_server_to_addr(const char* host, bool secure) {
   int port = grpc_pick_unused_port_or_die();
-  std::unique_ptr<char> addr;
+  grpc_core::UniquePtr<char> addr;
   grpc_core::JoinHostPort(&addr, host, port);
   gpr_log(GPR_INFO, "Test bind to %s", addr.get());
 

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -109,7 +109,7 @@ class FakeHandshakeServer {
   const char* address() { return address_.get(); }
 
  private:
-  std::unique_ptr<char> address_;
+  grpc_core::UniquePtr<char> address_;
   std::unique_ptr<grpc::Service> service_;
   std::unique_ptr<grpc::Server> server_;
 };
@@ -163,7 +163,7 @@ class TestServer {
   grpc_server* server_;
   grpc_completion_queue* server_cq_;
   std::unique_ptr<std::thread> server_thd_;
-  std::unique_ptr<char> server_addr_;
+  grpc_core::UniquePtr<char> server_addr_;
 };
 
 class ConnectLoopRunner {
@@ -172,9 +172,9 @@ class ConnectLoopRunner {
       const char* server_address, const char* fake_handshake_server_addr,
       int per_connect_deadline_seconds, size_t loops,
       grpc_connectivity_state expected_connectivity_states)
-      : server_address_(std::unique_ptr<char>(gpr_strdup(server_address))),
+      : server_address_(grpc_core::UniquePtr<char>(gpr_strdup(server_address))),
         fake_handshake_server_addr_(
-            std::unique_ptr<char>(gpr_strdup(fake_handshake_server_addr))),
+            grpc_core::UniquePtr<char>(gpr_strdup(fake_handshake_server_addr))),
         per_connect_deadline_seconds_(per_connect_deadline_seconds),
         loops_(loops),
         expected_connectivity_states_(expected_connectivity_states) {
@@ -222,8 +222,8 @@ class ConnectLoopRunner {
   }
 
  private:
-  std::unique_ptr<char> server_address_;
-  std::unique_ptr<char> fake_handshake_server_addr_;
+  grpc_core::UniquePtr<char> server_address_;
+  grpc_core::UniquePtr<char> fake_handshake_server_addr_;
   int per_connect_deadline_seconds_;
   size_t loops_;
   grpc_connectivity_state expected_connectivity_states_;
@@ -286,7 +286,7 @@ class FakeTcpServer {
     accept_socket_ = socket(AF_INET6, SOCK_STREAM, 0);
     char* addr_str;
     GPR_ASSERT(gpr_asprintf(&addr_str, "[::]:%d", port_));
-    address_ = std::unique_ptr<char>(addr_str);
+    address_ = grpc_core::UniquePtr<char>(addr_str);
     GPR_ASSERT(accept_socket_ != -1);
     if (accept_socket_ == -1) {
       gpr_log(GPR_ERROR, "Failed to create socket: %d", errno);
@@ -426,7 +426,7 @@ class FakeTcpServer {
   int accept_socket_;
   int port_;
   gpr_event stop_ev_;
-  std::unique_ptr<char> address_;
+  grpc_core::UniquePtr<char> address_;
   std::unique_ptr<std::thread> run_server_loop_thd_;
   std::function<ProcessReadResult(int, int, int)> process_read_cb_;
 };

--- a/test/cpp/client/credentials_test.cc
+++ b/test/cpp/client/credentials_test.cc
@@ -397,7 +397,7 @@ TEST_F(CredentialsTest, TlsCredentialReloadConfigCppToC) {
   pem_key_cert_pair_list.push_back(pem_key_cert_pair);
   grpc::string test_pem_root_certs = "pem_root_certs";
   c_key_materials.set_key_materials(
-      ::std::unique_ptr<char>(gpr_strdup(test_pem_root_certs.c_str())),
+      ::grpc_core::UniquePtr<char>(gpr_strdup(test_pem_root_certs.c_str())),
       pem_key_cert_pair_list);
   c_arg.key_materials_config = &c_key_materials;
   c_arg.status = GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_UNCHANGED;

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -365,7 +365,7 @@ TEST_P(AsyncEnd2endTest, ReconnectChannel) {
 #ifdef GRPC_POSIX_SOCKET
   // It needs 2 pollset_works to reconnect the channel with polling engine
   // "poll"
-  std::unique_ptr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  grpc_core::UniquePtr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
   if (0 == strcmp(poller.get(), "poll")) {
     poller_slowdown_factor = 2;
   }
@@ -1378,7 +1378,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
 
     if (server_try_cancel == CANCEL_DURING_PROCESSING) {
       server_try_cancel_thd =
-          new std::thread([&srv_ctx] { srv_ctx.TryCancel(); });
+          new std::thread(&ServerContext::TryCancel, &srv_ctx);
       // Server will cancel the RPC in a parallel thread while reading the
       // requests from the client. Since the cancellation can happen at anytime,
       // some of the cq results (i.e those until cancellation) might be true but
@@ -1526,7 +1526,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
 
     if (server_try_cancel == CANCEL_DURING_PROCESSING) {
       server_try_cancel_thd =
-          new std::thread([&srv_ctx] { srv_ctx.TryCancel(); });
+          new std::thread(&ServerContext::TryCancel, &srv_ctx);
 
       // Server will cancel the RPC in a parallel thread while writing responses
       // to the client. Since the cancellation can happen at anytime, some of
@@ -1673,7 +1673,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
 
     if (server_try_cancel == CANCEL_DURING_PROCESSING) {
       server_try_cancel_thd =
-          new std::thread([&srv_ctx] { srv_ctx.TryCancel(); });
+          new std::thread(&ServerContext::TryCancel, &srv_ctx);
 
       // Since server is going to cancel the RPC in a parallel thread, some of
       // the cq results (i.e those until the cancellation) might be true. Since

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1669,11 +1669,13 @@ class ClientLbInterceptTrailingMetadataTest : public ClientLbEnd2endTest {
           backend_metric_data->mem_utilization);
       self->load_report_->set_rps(backend_metric_data->requests_per_second);
       for (const auto& p : backend_metric_data->request_cost) {
-        std::unique_ptr<char> name = grpc_core::StringViewToCString(p.first);
+        grpc_core::UniquePtr<char> name =
+            grpc_core::StringViewToCString(p.first);
         (*self->load_report_->mutable_request_cost())[name.get()] = p.second;
       }
       for (const auto& p : backend_metric_data->utilization) {
-        std::unique_ptr<char> name = grpc_core::StringViewToCString(p.first);
+        grpc_core::UniquePtr<char> name =
+            grpc_core::StringViewToCString(p.first);
         (*self->load_report_->mutable_utilization())[name.get()] = p.second;
       }
     }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -834,7 +834,7 @@ TEST_P(End2endTest, ReconnectChannel) {
   // It needs 2 pollset_works to reconnect the channel with polling engine
   // "poll"
 #ifdef GRPC_POSIX_SOCKET
-  std::unique_ptr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  grpc_core::UniquePtr<char> poller = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
   if (0 == strcmp(poller.get(), "poll")) {
     poller_slowdown_factor = 2;
   }

--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -64,8 +64,8 @@ struct TestAddress {
 };
 
 grpc_resolved_address TestAddressToGrpcResolvedAddress(TestAddress test_addr) {
-  std::unique_ptr<char> host;
-  std::unique_ptr<char> port;
+  grpc_core::UniquePtr<char> host;
+  grpc_core::UniquePtr<char> port;
   grpc_resolved_address resolved_addr;
   grpc_core::SplitHostPort(test_addr.dest_addr.c_str(), &host, &port);
   if (test_addr.family == AF_INET) {
@@ -827,7 +827,8 @@ TEST_F(AddressSortingTest, TestSorterKnowsIpv6LoopbackIsAvailable) {
 }  // namespace
 
 int main(int argc, char** argv) {
-  std::unique_ptr<char> resolver = GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
+  grpc_core::UniquePtr<char> resolver =
+      GPR_GLOBAL_CONFIG_GET(grpc_dns_resolver);
   if (strlen(resolver.get()) == 0) {
     GPR_GLOBAL_CONFIG_SET(grpc_dns_resolver, "ares");
   } else if (strcmp("ares", resolver.get())) {

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -506,8 +506,8 @@ int g_fake_non_responsive_dns_server_port = -1;
 void InjectBrokenNameServerList(ares_channel channel) {
   struct ares_addr_port_node dns_server_addrs[2];
   memset(dns_server_addrs, 0, sizeof(dns_server_addrs));
-  std::unique_ptr<char> unused_host;
-  std::unique_ptr<char> local_dns_server_port;
+  grpc_core::UniquePtr<char> unused_host;
+  grpc_core::UniquePtr<char> local_dns_server_port;
   GPR_ASSERT(grpc_core::SplitHostPort(FLAGS_local_dns_server_address.c_str(),
                                       &unused_host, &local_dns_server_port));
   gpr_log(GPR_DEBUG,

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -333,7 +333,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
       client_config.add_server_targets(cli_target);
     } else {
       std::string host;
-      std::unique_ptr<char> cli_target;
+      grpc_core::UniquePtr<char> cli_target;
       host = get_host(workers[i]);
       grpc_core::JoinHostPort(&cli_target, host.c_str(), init_status.port());
       client_config.add_server_targets(cli_target.get());

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -279,7 +279,7 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
 
   std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
   if (driver_port >= 0) {
-    std::unique_ptr<char> server_address;
+    grpc_core::UniquePtr<char> server_address;
     grpc_core::JoinHostPort(&server_address, "::", driver_port);
     builder->AddListeningPort(
         server_address.get(),

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -80,7 +80,7 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      std::unique_ptr<char> server_address;
+      grpc_core::UniquePtr<char> server_address;
       grpc_core::JoinHostPort(&server_address, "::", port_num);
       builder->AddListeningPort(server_address.get(),
                                 Server::CreateServerCredentials(config));

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -105,7 +105,7 @@ class CallbackServer final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      std::unique_ptr<char> server_address;
+      grpc_core::UniquePtr<char> server_address;
       grpc_core::JoinHostPort(&server_address, "::", port_num);
       builder->AddListeningPort(server_address.get(),
                                 Server::CreateServerCredentials(config));

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -160,7 +160,7 @@ class SynchronousServer final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      std::unique_ptr<char> server_address;
+      grpc_core::UniquePtr<char> server_address;
       grpc_core::JoinHostPort(&server_address, "::", port_num);
       builder->AddListeningPort(server_address.get(),
                                 Server::CreateServerCredentials(config));


### PR DESCRIPTION
Since `std::unique_ptr` start being used in gRPC Core, one thing overlooked is that it cannot properly free `UniquePtr<char>` which carries a buffer allocated by `gpr_alloc`. This violates the rule `new & delete` and `malloc & free`. Luckily only `unique_ptr<char>` uses `gpr_alloc` so `UniquePtr` is reintroduced to address this by using delete resolver. `std::unique_ptr` keeps used for non-char type.