### PR TITLE
Improve ServerCallContext doc comments.

### DIFF
--- a/src/csharp/Grpc.Core.Api/ServerCallContext.cs
+++ b/src/csharp/Grpc.Core.Api/ServerCallContext.cs
@@ -66,13 +66,13 @@ namespace Grpc.Core
         /// <summary>Address of the remote endpoint in URI format.</summary>
         public string Peer => PeerCore;
 
-        /// <summary>Deadline for this RPC.</summary>
+        /// <summary>Deadline for this RPC. The call will be automatically cancelled once the deadline is exceeded.</summary>
         public DateTime Deadline => DeadlineCore;
 
         /// <summary>Initial metadata sent by client.</summary>
         public Metadata RequestHeaders => RequestHeadersCore;
 
-        /// <summary>Cancellation token signals when call is cancelled.</summary>
+        /// <summary>Cancellation token signals when call is cancelled. It is also triggered when the deadline is exceeeded or there was some other error (e.g. network problem).</summary>
         public CancellationToken CancellationToken => CancellationTokenCore;
 
         /// <summary>Trailers to send back to client after RPC finishes.</summary>


### PR DESCRIPTION
Original context: https://stackoverflow.com/questions/58718859/c-sharp-grpc-using-deadline-instead-of-cancellation-token
