### PR TITLE
Do not build channelz when gRPC_USE_PROTO_LITE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4831,7 +4831,7 @@ if(gRPC_INSTALL)
 endif()
 
 
-if(gRPC_BUILD_CODEGEN)
+if(gRPC_BUILD_CODEGEN AND NOT gRPC_USE_PROTO_LITE)
 add_library(grpcpp_channelz
   src/cpp/server/channelz/channelz_service.cc
   src/cpp/server/channelz/channelz_service_plugin.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4831,6 +4831,8 @@ if(gRPC_INSTALL)
 endif()
 
 
+# grpcpp_channelz doesn't build with protobuf-lite
+# See https://github.com/grpc/grpc/issues/19473
 if(gRPC_BUILD_CODEGEN AND NOT gRPC_USE_PROTO_LITE)
 add_library(grpcpp_channelz
   src/cpp/server/channelz/channelz_service.cc

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -438,7 +438,11 @@
 
   <%def name="cc_library(lib)">
   % if any(proto_re.match(src) for src in lib.src):
+  % if lib.name == 'grpcpp_channelz':
+  if(gRPC_BUILD_CODEGEN AND NOT gRPC_USE_PROTO_LITE)
+  % else:
   if(gRPC_BUILD_CODEGEN)
+  % endif
   % endif
   add_library(${lib.name}${' SHARED' if lib.get('dll', None) == 'only' else ''}
   % for src in lib.src:

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -439,6 +439,8 @@
   <%def name="cc_library(lib)">
   % if any(proto_re.match(src) for src in lib.src):
   % if lib.name == 'grpcpp_channelz':
+  # grpcpp_channelz doesn't build with protobuf-lite
+  # See https://github.com/grpc/grpc/issues/19473
   if(gRPC_BUILD_CODEGEN AND NOT gRPC_USE_PROTO_LITE)
   % else:
   if(gRPC_BUILD_CODEGEN)


### PR DESCRIPTION
Prior to this commit, the CMake build of gRPC would encounter compile errors when `gRPC_USE_PROTO_LITE` is turned on. This is a simpler version of #20919.

@jtattermusch 
