### PR TITLE
Remove GRPC_CLOSURE_LIST_SCHED and remove scheduler field from grpc_closure

### DIFF
--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -107,7 +107,8 @@ static void maybe_initiate_ping(grpc_chttp2_transport* t) {
 
   pq->inflight_id = t->ping_ctr;
   t->ping_ctr++;
-  GRPC_CLOSURE_LIST_SCHED(&pq->lists[GRPC_CHTTP2_PCL_INITIATE]);
+  grpc_core::ExecCtx::RunList(DEBUG_LOCATION,
+                              &pq->lists[GRPC_CHTTP2_PCL_INITIATE]);
   grpc_closure_list_move(&pq->lists[GRPC_CHTTP2_PCL_NEXT],
                          &pq->lists[GRPC_CHTTP2_PCL_INFLIGHT]);
   grpc_slice_buffer_add(&t->outbuf,

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -308,9 +308,9 @@ static void combiner_finally_exec(grpc_core::Combiner* lock,
       grpc_core::ExecCtx::Get()->combiner_data()->active_combiner));
   if (grpc_core::ExecCtx::Get()->combiner_data()->active_combiner != lock) {
     GPR_TIMER_MARK("slowpath", 0);
-    // Reusing scheduler to store the combiner so that it can be accessed in
-    // enqueue_finally
-    closure->scheduler = reinterpret_cast<grpc_closure_scheduler*>(lock);
+    // Using error_data.scratch to store the combiner so that it can be accessed
+    // in enqueue_finally.
+    closure->error_data.scratch = reinterpret_cast<uintptr_t>(lock);
     lock->Run(GRPC_CLOSURE_CREATE(enqueue_finally, closure, nullptr), error);
     return;
   }
@@ -323,22 +323,17 @@ static void combiner_finally_exec(grpc_core::Combiner* lock,
 
 static void enqueue_finally(void* closure, grpc_error* error) {
   grpc_closure* cl = static_cast<grpc_closure*>(closure);
-  combiner_finally_exec(reinterpret_cast<grpc_core::Combiner*>(cl->scheduler),
-                        cl, GRPC_ERROR_REF(error));
+  combiner_finally_exec(
+      reinterpret_cast<grpc_core::Combiner*>(cl->error_data.scratch), cl,
+      GRPC_ERROR_REF(error));
 }
 
 namespace grpc_core {
 void Combiner::Run(grpc_closure* closure, grpc_error* error) {
-  GPR_ASSERT(closure->scheduler == nullptr ||
-             closure->scheduler ==
-                 reinterpret_cast<grpc_closure_scheduler*>(this));
   combiner_exec(this, closure, error);
 }
 
 void Combiner::FinallyRun(grpc_closure* closure, grpc_error* error) {
-  GPR_ASSERT(closure->scheduler == nullptr ||
-             closure->scheduler ==
-                 reinterpret_cast<grpc_closure_scheduler*>(this));
   combiner_finally_exec(this, closure, error);
 }
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/combiner.h
+++ b/src/core/lib/iomgr/combiner.h
@@ -36,8 +36,6 @@ class Combiner {
   // TODO(yashkt) : Remove this method
   void FinallyRun(grpc_closure* closure, grpc_error* error);
   Combiner* next_combiner_on_this_exec_ctx = nullptr;
-  grpc_closure_scheduler scheduler;
-  grpc_closure_scheduler finally_scheduler;
   MultiProducerSingleConsumerQueue queue;
   // either:
   // a pointer to the initiating exec ctx if that is the only exec_ctx that has

--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -180,11 +180,10 @@ void ExecCtx::Run(const DebugLocation& location, grpc_closure* closure,
   if (closure->scheduled) {
     gpr_log(GPR_ERROR,
             "Closure already scheduled. (closure: %p, created: [%s:%d], "
-            "previously scheduled at: [%s: %d], newly scheduled at [%s: %d], "
-            "run?: %s",
+            "previously scheduled at: [%s: %d], newly scheduled at [%s: %d]",
             closure, closure->file_created, closure->line_created,
             closure->file_initiated, closure->line_initiated, location.file(),
-            location.line(), closure->run ? "true" : "false");
+            location.line());
     abort();
   }
   closure->scheduled = true;
@@ -205,9 +204,9 @@ void ExecCtx::RunList(const DebugLocation& location, grpc_closure_list* list) {
     if (c->scheduled) {
       gpr_log(GPR_ERROR,
               "Closure already scheduled. (closure: %p, created: [%s:%d], "
-              "previously scheduled at: [%s: %d] run?: %s",
+              "previously scheduled at: [%s: %d], newly scheduled at [%s:%d]",
               c, c->file_created, c->line_created, c->file_initiated,
-              c->line_initiated, c->run ? "true" : "false");
+              c->line_initiated, location.file(), location.line());
       abort();
     }
     c->scheduled = true;

--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -118,11 +118,6 @@ grpc_millis grpc_cycle_counter_to_millis_round_up(gpr_cycle_counter cycles) {
       gpr_cycle_counter_sub(cycles, g_start_cycle));
 }
 
-static const grpc_closure_scheduler_vtable exec_ctx_scheduler_vtable = {
-    exec_ctx_run, exec_ctx_sched, "exec_ctx"};
-static grpc_closure_scheduler exec_ctx_scheduler = {&exec_ctx_scheduler_vtable};
-grpc_closure_scheduler* grpc_schedule_on_exec_ctx = &exec_ctx_scheduler;
-
 namespace grpc_core {
 GPR_TLS_CLASS_DEF(ExecCtx::exec_ctx_);
 GPR_TLS_CLASS_DEF(ApplicationCallbackExecCtx::callback_exec_ctx_);
@@ -176,6 +171,7 @@ grpc_millis ExecCtx::Now() {
 
 void ExecCtx::Run(const DebugLocation& location, grpc_closure* closure,
                   grpc_error* error) {
+  (void)location;
   if (closure == nullptr) {
     GRPC_ERROR_UNREF(error);
     return;
@@ -198,6 +194,32 @@ void ExecCtx::Run(const DebugLocation& location, grpc_closure* closure,
   GPR_ASSERT(closure->cb != nullptr);
 #endif
   exec_ctx_sched(closure, error);
+}
+
+void ExecCtx::RunList(const DebugLocation& location, grpc_closure_list* list) {
+  (void)location;
+  grpc_closure* c = list->head;
+  while (c != nullptr) {
+    grpc_closure* next = c->next_data.next;
+#ifndef NDEBUG
+    if (c->scheduled) {
+      gpr_log(GPR_ERROR,
+              "Closure already scheduled. (closure: %p, created: [%s:%d], "
+              "previously scheduled at: [%s: %d] run?: %s",
+              c, c->file_created, c->line_created, c->file_initiated,
+              c->line_initiated, c->run ? "true" : "false");
+      abort();
+    }
+    c->scheduled = true;
+    c->file_initiated = location.file();
+    c->line_initiated = location.line();
+    c->run = false;
+    GPR_ASSERT(c->cb != nullptr);
+#endif
+    exec_ctx_sched(c, c->error_data.error);
+    c = next;
+  }
+  list->head = list->tail = nullptr;
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -55,8 +55,6 @@ typedef struct grpc_combiner grpc_combiner;
    should not be counted by fork handlers */
 #define GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD 1
 
-extern grpc_closure_scheduler* grpc_schedule_on_exec_ctx;
-
 gpr_timespec grpc_millis_to_timespec(grpc_millis millis, gpr_clock_type clock);
 grpc_millis grpc_timespec_to_millis_round_down(gpr_timespec timespec);
 grpc_millis grpc_timespec_to_millis_round_up(gpr_timespec timespec);
@@ -224,6 +222,8 @@ class ExecCtx {
 
   static void Run(const DebugLocation& location, grpc_closure* closure,
                   grpc_error* error);
+
+  static void RunList(const DebugLocation& location, grpc_closure_list* list);
 
  protected:
   /** Check if ready to finish. */

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -333,7 +333,7 @@ static bool rq_alloc(grpc_resource_quota* resource_quota) {
       int64_t aborted_allocations = resource_user->outstanding_allocations;
       resource_user->outstanding_allocations = 0;
       resource_user->free_pool += aborted_allocations;
-      GRPC_CLOSURE_LIST_SCHED(&resource_user->on_allocated);
+      grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &resource_user->on_allocated);
       gpr_mu_unlock(&resource_user->mu);
       ru_unref_by(resource_user, static_cast<gpr_atm>(aborted_allocations));
       continue;
@@ -359,7 +359,7 @@ static bool rq_alloc(grpc_resource_quota* resource_quota) {
     if (resource_user->free_pool >= 0) {
       resource_user->allocating = false;
       resource_user->outstanding_allocations = 0;
-      GRPC_CLOSURE_LIST_SCHED(&resource_user->on_allocated);
+      grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &resource_user->on_allocated);
       gpr_mu_unlock(&resource_user->mu);
     } else {
       rulist_add_head(resource_user, GRPC_RULIST_AWAITING_ALLOCATION);

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -196,7 +196,7 @@ static void tcp_server_unref(grpc_tcp_server* s) {
   if (gpr_unref(&s->refs)) {
     /* Complete shutdown_starting work before destroying. */
     grpc_core::ExecCtx exec_ctx;
-    GRPC_CLOSURE_LIST_SCHED(&s->shutdown_starting);
+    grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &s->shutdown_starting);
     grpc_core::ExecCtx::Get()->Flush();
     tcp_server_destroy(s);
   }

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -547,7 +547,7 @@ static void tcp_server_unref(grpc_tcp_server* s) {
   if (gpr_unref(&s->refs)) {
     grpc_tcp_server_shutdown_listeners(s);
     gpr_mu_lock(&s->mu);
-    GRPC_CLOSURE_LIST_SCHED(&s->shutdown_starting);
+    grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &s->shutdown_starting);
     gpr_mu_unlock(&s->mu);
     tcp_server_destroy(s);
   }

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -179,7 +179,7 @@ static void tcp_server_unref(grpc_tcp_server* s) {
   if (gpr_unref(&s->refs)) {
     grpc_tcp_server_shutdown_listeners(s);
     gpr_mu_lock(&s->mu);
-    GRPC_CLOSURE_LIST_SCHED(&s->shutdown_starting);
+    grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &s->shutdown_starting);
     gpr_mu_unlock(&s->mu);
     tcp_server_destroy(s);
   }

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -548,9 +548,8 @@ static grpc_timer* pop_one(timer_shard* shard, grpc_millis now) {
     }
     if (timer->deadline > now) return nullptr;
     if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_trace)) {
-      gpr_log(GPR_INFO, "TIMER %p: FIRE %" PRId64 "ms late via %s scheduler",
-              timer, now - timer->deadline,
-              timer->closure->scheduler->vtable->name);
+      gpr_log(GPR_INFO, "TIMER %p: FIRE %" PRId64 "ms late", timer,
+              now - timer->deadline);
     }
     timer->pending = false;
     grpc_timer_heap_pop(&shard->heap);

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -162,7 +162,9 @@ class Closure : public grpc_closure {
 template <class F>
 std::unique_ptr<Closure> MakeClosure(F f) {
   struct C : public Closure {
-    C(const F& f) : f_(f) { GRPC_CLOSURE_INIT(this, Execute, this, nullptr); }
+    explicit C(const F& f) : f_(f) {
+      GRPC_CLOSURE_INIT(this, Execute, this, nullptr);
+    }
     F f_;
     static void Execute(void* arg, grpc_error* error) {
       static_cast<C*>(arg)->f_(error);

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -160,23 +160,19 @@ class Closure : public grpc_closure {
 };
 
 template <class F>
-std::unique_ptr<Closure> MakeClosure(
-    F f, grpc_closure_scheduler* sched = grpc_schedule_on_exec_ctx) {
+std::unique_ptr<Closure> MakeClosure(F f) {
   struct C : public Closure {
-    C(const F& f, grpc_closure_scheduler* sched) : f_(f) {
-      GRPC_CLOSURE_INIT(this, Execute, this, sched);
-    }
+    C(const F& f) : f_(f) { GRPC_CLOSURE_INIT(this, Execute, this, nullptr); }
     F f_;
     static void Execute(void* arg, grpc_error* error) {
       static_cast<C*>(arg)->f_(error);
     }
   };
-  return std::unique_ptr<Closure>(new C(f, sched));
+  return std::unique_ptr<Closure>(new C(f));
 }
 
 template <class F>
-grpc_closure* MakeOnceClosure(
-    F f, grpc_closure_scheduler* sched = grpc_schedule_on_exec_ctx) {
+grpc_closure* MakeOnceClosure(F f) {
   struct C : public grpc_closure {
     C(const F& f) : f_(f) {}
     F f_;
@@ -186,7 +182,7 @@ grpc_closure* MakeOnceClosure(
     }
   };
   auto* c = new C{f};
-  return GRPC_CLOSURE_INIT(c, C::Execute, c, sched);
+  return GRPC_CLOSURE_INIT(c, C::Execute, c, nullptr);
 }
 
 class Stream {

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -350,7 +350,7 @@ BENCHMARK(BM_ClosureSched4OnTwoCombiners);
 // the benchmark is complete
 class Rescheduler {
  public:
-  Rescheduler(benchmark::State& state) : state_(state) {
+  explicit Rescheduler(benchmark::State& state) : state_(state) {
     GRPC_CLOSURE_INIT(&closure_, Step, this, nullptr);
   }
 

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -350,19 +350,17 @@ BENCHMARK(BM_ClosureSched4OnTwoCombiners);
 // the benchmark is complete
 class Rescheduler {
  public:
-  Rescheduler(benchmark::State& state, grpc_closure_scheduler* scheduler)
-      : state_(state) {
-    GRPC_CLOSURE_INIT(&closure_, Step, this, scheduler);
+  Rescheduler(benchmark::State& state) : state_(state) {
+    GRPC_CLOSURE_INIT(&closure_, Step, this, nullptr);
   }
 
   void ScheduleFirst() {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
   }
 
-  void ScheduleFirstAgainstDifferentScheduler(
-      grpc_closure_scheduler* scheduler) {
+  void ScheduleFirstAgainstDifferentScheduler() {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION,
-                            GRPC_CLOSURE_CREATE(Step, this, scheduler),
+                            GRPC_CLOSURE_CREATE(Step, this, nullptr),
                             GRPC_ERROR_NONE);
   }
 
@@ -381,7 +379,7 @@ class Rescheduler {
 static void BM_ClosureReschedOnExecCtx(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
-  Rescheduler r(state, grpc_schedule_on_exec_ctx);
+  Rescheduler r(state);
   r.ScheduleFirst();
   grpc_core::ExecCtx::Get()->Flush();
   track_counters.Finish(state);

--- a/test/cpp/microbenchmarks/bm_pollset.cc
+++ b/test/cpp/microbenchmarks/bm_pollset.cc
@@ -163,18 +163,16 @@ class Closure : public grpc_closure {
 };
 
 template <class F>
-Closure* MakeClosure(F f, grpc_closure_scheduler* scheduler) {
+Closure* MakeClosure(F f) {
   struct C : public Closure {
-    C(F f, grpc_closure_scheduler* scheduler) : f_(f) {
-      GRPC_CLOSURE_INIT(this, C::cbfn, this, scheduler);
-    }
+    C(F f) : f_(f) { GRPC_CLOSURE_INIT(this, C::cbfn, this, nullptr); }
     static void cbfn(void* arg, grpc_error* /*error*/) {
       C* p = static_cast<C*>(arg);
       p->f_();
     }
     F f_;
   };
-  return new C(f, scheduler);
+  return new C(f);
 }
 
 #ifdef GRPC_LINUX_MULTIPOLL_WITH_EPOLL
@@ -223,17 +221,15 @@ static void BM_SingleThreadPollOneFd(benchmark::State& state) {
   grpc_fd* wakeup = grpc_fd_create(wakeup_fd.read_fd, "wakeup_read", false);
   grpc_pollset_add_fd(ps, wakeup);
   bool done = false;
-  Closure* continue_closure = MakeClosure(
-      [&]() {
-        GRPC_ERROR_UNREF(grpc_wakeup_fd_consume_wakeup(&wakeup_fd));
-        if (!state.KeepRunning()) {
-          done = true;
-          return;
-        }
-        GRPC_ERROR_UNREF(grpc_wakeup_fd_wakeup(&wakeup_fd));
-        grpc_fd_notify_on_read(wakeup, continue_closure);
-      },
-      grpc_schedule_on_exec_ctx);
+  Closure* continue_closure = MakeClosure([&]() {
+    GRPC_ERROR_UNREF(grpc_wakeup_fd_consume_wakeup(&wakeup_fd));
+    if (!state.KeepRunning()) {
+      done = true;
+      return;
+    }
+    GRPC_ERROR_UNREF(grpc_wakeup_fd_wakeup(&wakeup_fd));
+    grpc_fd_notify_on_read(wakeup, continue_closure);
+  });
   GRPC_ERROR_UNREF(grpc_wakeup_fd_wakeup(&wakeup_fd));
   grpc_fd_notify_on_read(wakeup, continue_closure);
   gpr_mu_lock(mu);

--- a/test/cpp/microbenchmarks/bm_pollset.cc
+++ b/test/cpp/microbenchmarks/bm_pollset.cc
@@ -165,7 +165,7 @@ class Closure : public grpc_closure {
 template <class F>
 Closure* MakeClosure(F f) {
   struct C : public Closure {
-    C(F f) : f_(f) { GRPC_CLOSURE_INIT(this, C::cbfn, this, nullptr); }
+    explicit C(F f) : f_(f) { GRPC_CLOSURE_INIT(this, C::cbfn, this, nullptr); }
     static void cbfn(void* arg, grpc_error* /*error*/) {
       C* p = static_cast<C*>(arg);
       p->f_();


### PR DESCRIPTION
This PR makes two changes -
1) GRPC_CLOSURE_LIST_SCHED() and is replaced with grpc_core::ExecCtx::RunList().
2) scheduler field is removed from grpc_closure. No more scheduler!!

Note that currently grpc_schedule_on_exec_ctx still exists, but it is unused and undefined. It is just marco'ed out from GRPC_CLOSURE_INIT and GRPC_CLOSURE_CREATE. In a subsequent PR, I'll be able to remove the last scheduler field from GRPC_CLOSURE_INIT and GRPC_CLOSURE_CREATE.

IMPORTANT : THIS PR NEEDS INTERNAL CHANGES

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/21119)
<!-- Reviewable:end -->
