### PR TITLE
Increase MacOS C/C++ test limit

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_c_cpp.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_c_cpp.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_c_cpp.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_c_cpp.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Increase from 2 hours to 3 hours. Note that such test duration is way too much for a quick turnaround of PRs (so I'm not happy at all that we have to increase the timeout), but https://github.com/grpc/grpc/issues/20694 has been open for a while and it's one of the main sources of flakiness for macOS PR tests, so we need to fix it somehow.

- Due to a kokoro problem, whenever the kokoro job timeout happens on mac, the log is flooded with a lots of "file has vanished" messages, which basically renders the test result unusable, so hitting this timeout is particularly annoying for the developers.

Hopefully in the long run we will be able to reduce the test latency by using bazel and with other optimizations.

Fixes https://github.com/grpc/grpc/issues/20694