### PR TITLE
Workaround the ExternalDnsWithTracingClientServerTest flake on Linux

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/ExternalDnsWithTracingClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ExternalDnsWithTracingClientServerTest.cs
@@ -31,7 +31,7 @@ using NUnit.Framework;
 namespace Grpc.IntegrationTesting
 {
     /// <summary>
-    /// See https://github.com/grpc/issues/18074, this test is meant to
+    /// See https://github.com/grpc/grpc/issues/18074, this test is meant to
     /// try to trigger the described bug.
     /// Runs interop tests in-process, with that client using a target
     /// name that using a target name that triggers interaction with
@@ -48,9 +48,9 @@ namespace Grpc.IntegrationTesting
         public void Init()
         {
             // TODO(https://github.com/grpc/grpc/issues/14963): on linux, setting
-            // these environment variables might not actually have any affect.
+            // these environment variables might not actually have any effect.
             // This is OK because we only really care about running this test on
-            // Windows, however, a fix made for $14963 should be applied here.
+            // Windows, however, a fix made for #14963 should be applied here.
             Environment.SetEnvironmentVariable("GRPC_TRACE", "all");
             Environment.SetEnvironmentVariable("GRPC_VERBOSITY", "DEBUG");
             newLogger = new SocketUsingLogger(GrpcEnvironment.Logger);
@@ -59,10 +59,12 @@ namespace Grpc.IntegrationTesting
             server = new Server(new[] { new ChannelOption(ChannelOptions.SoReuseport, 0) })
             {
                 Services = { TestService.BindService(new TestServiceImpl()) },
-                Ports = { { "[::1]", ServerPort.PickUnused, ServerCredentials.Insecure } }
+                Ports = { { "[::1]", ServerPort.PickUnused, ServerCredentials.Insecure } },
+                // reduce the number of request call tokens to
+                // avoid flooding the logs with token-related messages
+                RequestCallTokensPerCompletionQueue = 3,
             };
             server.Start();
-
             int port = server.Ports.Single().BoundPort;
             channel = new Channel("loopback6.unittest.grpc.io", port, ChannelCredentials.Insecure);
             client = new TestService.TestServiceClient(channel);

--- a/src/csharp/Grpc.IntegrationTesting/ExternalDnsWithTracingClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ExternalDnsWithTracingClientServerTest.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Logging;
 using Grpc.Core.Utils;
+using Grpc.Core.Internal;
 using Grpc.Testing;
 using NUnit.Framework;
 
@@ -42,19 +43,25 @@ namespace Grpc.IntegrationTesting
         Server server;
         Channel channel;
         TestService.TestServiceClient client;
-        SocketUsingLogger newLogger;
 
         [OneTimeSetUp]
         public void Init()
         {
-            // TODO(https://github.com/grpc/grpc/issues/14963): on linux, setting
-            // these environment variables might not actually have any effect.
-            // This is OK because we only really care about running this test on
-            // Windows, however, a fix made for #14963 should be applied here.
-            Environment.SetEnvironmentVariable("GRPC_TRACE", "all");
-            Environment.SetEnvironmentVariable("GRPC_VERBOSITY", "DEBUG");
-            newLogger = new SocketUsingLogger(GrpcEnvironment.Logger);
-            GrpcEnvironment.SetLogger(newLogger);
+            // We only care about running this test on Windows (see #18074)
+            // TODO(jtattermusch): We could run it on Linux and Mac as well,
+            // but there are two issues.
+            // 1. Due to https://github.com/grpc/grpc/issues/14963, setting the
+            // enviroment variables actually has no effect on CoreCLR.
+            // 2. On mono the test with enabled tracing sometimes times out
+            // due to suspected mono-related issue on shutdown
+            // See https://github.com/grpc/grpc/issues/18126
+            if (PlatformApis.IsWindows)
+            {
+                Environment.SetEnvironmentVariable("GRPC_TRACE", "all");
+                Environment.SetEnvironmentVariable("GRPC_VERBOSITY", "DEBUG");
+                var newLogger = new SocketUsingLogger(GrpcEnvironment.Logger);
+                GrpcEnvironment.SetLogger(newLogger);
+            }
             // Disable SO_REUSEPORT to prevent https://github.com/grpc/grpc/issues/10755
             server = new Server(new[] { new ChannelOption(ChannelOptions.SoReuseport, 0) })
             {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/18126

I've done quite a bit of experimenting with the test on mono on linux:
The test itself always finishes fine, but the mono binary gets stuck on shutdown. I attached gdb and didn't see anything suspicious and it seemed that all the managed threads have finished. My theory is that the binary fails to exit because of this:
- mono runtime keeps track of "managed" and "native" threads and the main thread won't exit until all the managed threads have finished.
- when a managed callback is invoked on an otherwise "native" thread (this happens when the log handler callback runs), mono promotes the native thread to a "managed" thread.
- when the test's Main returns, some of the native threads (e.g. timer thread) that usually don't prevent the process from exiting have been promoted to "managed" and they keep the process alive. (forever, which eventually leads to the test timeout).

The workaround is to disable the logging/tracing part of the test on Linux and Mac, because we are interested in testing on Windows only anyway (where the test passes reliably, according to the test result history)

The PR also fixes a few typos.

