### PR TITLE
Ban use of std::sync constructs

### DIFF
--- a/src/cpp/server/external_connection_acceptor_impl.cc
+++ b/src/cpp/server/external_connection_acceptor_impl.cc
@@ -52,7 +52,7 @@ ExternalConnectionAcceptorImpl::ExternalConnectionAcceptorImpl(
 
 std::unique_ptr<experimental::ExternalConnectionAcceptor>
 ExternalConnectionAcceptorImpl::GetAcceptor() {
-  std::lock_guard<std::mutex> lock(mu_);
+  grpc_core::MutexLock lock(&mu_);
   GPR_ASSERT(!has_acceptor_);
   has_acceptor_ = true;
   return std::unique_ptr<experimental::ExternalConnectionAcceptor>(
@@ -61,7 +61,7 @@ ExternalConnectionAcceptorImpl::GetAcceptor() {
 
 void ExternalConnectionAcceptorImpl::HandleNewConnection(
     experimental::ExternalConnectionAcceptor::NewConnectionParameters* p) {
-  std::lock_guard<std::mutex> lock(mu_);
+  grpc_core::MutexLock lock(&mu_);
   if (shutdown_ || !started_) {
     // TODO(yangg) clean up.
     gpr_log(
@@ -76,12 +76,12 @@ void ExternalConnectionAcceptorImpl::HandleNewConnection(
 }
 
 void ExternalConnectionAcceptorImpl::Shutdown() {
-  std::lock_guard<std::mutex> lock(mu_);
+  grpc_core::MutexLock lock(&mu_);
   shutdown_ = true;
 }
 
 void ExternalConnectionAcceptorImpl::Start() {
-  std::lock_guard<std::mutex> lock(mu_);
+  grpc_core::MutexLock lock(&mu_);
   GPR_ASSERT(!started_);
   GPR_ASSERT(has_acceptor_);
   GPR_ASSERT(!shutdown_);

--- a/src/cpp/server/external_connection_acceptor_impl.h
+++ b/src/cpp/server/external_connection_acceptor_impl.h
@@ -20,7 +20,6 @@
 #define SRC_CPP_SERVER_EXTERNAL_CONNECTION_ACCEPTOR_IMPL_H_
 
 #include <memory>
-#include <mutex>
 
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpcpp/security/server_credentials.h>
@@ -28,6 +27,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/support/channel_arguments.h>
 
+#include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/tcp_server.h"
 
 namespace grpc {
@@ -60,7 +60,7 @@ class ExternalConnectionAcceptorImpl
   const grpc::string name_;
   std::shared_ptr<ServerCredentials> creds_;
   grpc_core::TcpServerFdHandler* handler_ = nullptr;  // not owned
-  std::mutex mu_;
+  grpc_core::Mutex mu_;
   bool has_acceptor_ = false;
   bool started_ = false;
   bool shutdown_ = false;

--- a/tools/run_tests/sanity/cpp_banned_constructs.sh
+++ b/tools/run_tests/sanity/cpp_banned_constructs.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+cd "$(dirname "$0")/../../.."
+
+#
+# Prevent the use of synchronization and threading constructs from std:: since
+# the code should be using grpc_core::Mutex, grpc::internal::Mutex,
+# grpc_core::Thread, etc.
+#
+
+egrep -Irn \
+    'std::(mutex|condition_variable|lock_guard|unique_lock|thread)' \
+    include/grpc include/grpcpp src/core src/cpp | \
+    egrep -v include/grpcpp/impl/codegen/sync.h | \
+    diff - /dev/null
+

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -13,6 +13,7 @@
 - script: tools/run_tests/sanity/check_tracer_sanity.py
 - script: tools/run_tests/sanity/core_banned_functions.py
 - script: tools/run_tests/sanity/core_untyped_structs.sh
+- script: tools/run_tests/sanity/cpp_banned_constructs.sh
 - script: tools/buildgen/generate_projects.sh -j 3
   cpu_cost: 3
 - script: tools/distrib/check_copyright.py


### PR DESCRIPTION
This revives #18688 which was rolled back as part of #18734.
