### PR TITLE
Remove OWNERS for client_channel.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,4 @@
 /**/OWNERS @markdroth @nicolasnoble @a11r
 /bazel/** @nicolasnoble @jtattermusch @veblush @gnossen
 /cmake/** @jtattermusch @nicolasnoble @apolcyn
-/src/core/ext/filters/client_channel/** @markdroth @apolcyn @AspirinSJL
 /tools/dockerfile/** @jtattermusch @apolcyn @nicolasnoble

--- a/src/core/ext/filters/client_channel/OWNERS
+++ b/src/core/ext/filters/client_channel/OWNERS
@@ -1,4 +1,0 @@
-set noparent
-@markdroth
-@apolcyn
-@AspirinSJL


### PR DESCRIPTION
With @AspirinSJL leaving the team, there are not enough people to sustain OWNERs for the client_channel tree.

This makes me sad but will make @vjpai very happy.