### PR TITLE
Clean up headers

### DIFF
--- a/include/grpcpp/channel_impl.h
+++ b/include/grpcpp/channel_impl.h
@@ -20,7 +20,6 @@
 #define GRPCPP_CHANNEL_IMPL_H
 
 #include <memory>
-#include <mutex>
 
 #include <grpc/grpc.h>
 #include <grpcpp/impl/call.h>

--- a/include/grpcpp/impl/codegen/client_context_impl.h
+++ b/include/grpcpp/impl/codegen/client_context_impl.h
@@ -36,7 +36,6 @@
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 
 #include <grpc/impl/codegen/compression_types.h>

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -19,10 +19,8 @@
 #ifndef GRPCPP_SERVER_IMPL_H
 #define GRPCPP_SERVER_IMPL_H
 
-#include <condition_variable>
 #include <list>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include <grpc/compression.h>

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -20,7 +20,6 @@
 
 #include <cstring>
 #include <memory>
-#include <mutex>
 
 #include <grpc/grpc.h>
 #include <grpc/slice.h>

--- a/src/cpp/server/dynamic_thread_pool.cc
+++ b/src/cpp/server/dynamic_thread_pool.cc
@@ -18,8 +18,6 @@
 
 #include "src/cpp/server/dynamic_thread_pool.h"
 
-#include <mutex>
-
 #include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/sync.h>
 

--- a/src/cpp/server/dynamic_thread_pool.h
+++ b/src/cpp/server/dynamic_thread_pool.h
@@ -19,10 +19,8 @@
 #ifndef GRPC_INTERNAL_CPP_DYNAMIC_THREAD_POOL_H
 #define GRPC_INTERNAL_CPP_DYNAMIC_THREAD_POOL_H
 
-#include <condition_variable>
 #include <list>
 #include <memory>
-#include <mutex>
 #include <queue>
 
 #include <grpcpp/support/config.h>

--- a/src/cpp/server/health/default_health_check_service.cc
+++ b/src/cpp/server/health/default_health_check_service.cc
@@ -17,7 +17,6 @@
  */
 
 #include <memory>
-#include <mutex>
 
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>

--- a/src/cpp/server/health/default_health_check_service.h
+++ b/src/cpp/server/health/default_health_check_service.h
@@ -20,7 +20,6 @@
 #define GRPC_INTERNAL_CPP_SERVER_DEFAULT_HEALTH_CHECK_SERVICE_H
 
 #include <atomic>
-#include <mutex>
 #include <set>
 
 #include <grpc/support/log.h>

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -19,7 +19,6 @@
 #include <grpcpp/impl/codegen/server_context_impl.h>
 
 #include <algorithm>
-#include <mutex>
 #include <utility>
 
 #include <grpc/compression.h>

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -19,7 +19,6 @@
 #include "src/cpp/thread_manager/thread_manager.h"
 
 #include <climits>
-#include <mutex>
 
 #include <grpc/support/log.h>
 #include "src/core/lib/gprpp/thd.h"

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -19,10 +19,8 @@
 #ifndef GRPC_INTERNAL_CPP_THREAD_MANAGER_H
 #define GRPC_INTERNAL_CPP_THREAD_MANAGER_H
 
-#include <condition_variable>
 #include <list>
 #include <memory>
-#include <mutex>
 
 #include <grpcpp/support/config.h>
 

--- a/test/cpp/end2end/message_allocator_end2end_test.cc
+++ b/test/cpp/end2end/message_allocator_end2end_test.cc
@@ -17,6 +17,7 @@
  */
 
 #include <algorithm>
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/tools/run_tests/sanity/cpp_banned_constructs.sh
+++ b/tools/run_tests/sanity/cpp_banned_constructs.sh
@@ -29,3 +29,12 @@ egrep -Irn \
     egrep -v include/grpcpp/impl/codegen/sync.h | \
     diff - /dev/null
 
+#
+# Prevent the include of disallowed C++ headers.
+#
+
+egrep -Irn \
+    '^#include (<mutex>|<condition_variable>|<thread>|<ratio>|<filesystem>|<future>|<system_error>)' \
+    include/grpc include/grpcpp src/core src/cpp | \
+    egrep -v include/grpcpp/impl/codegen/sync.h | \
+    diff - /dev/null


### PR DESCRIPTION
Clean up public header files not to include `<mutex>` and `<condition_variable>` because i) it's not used and ii) discouraged to use in gRPC libraries.