### PR TITLE
bazel: prefer using "size" over "timeout" for bazel tests

### DIFF
--- a/src/python/grpcio_tests/tests/reflection/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/reflection/BUILD.bazel
@@ -5,8 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 py2and3_test(
     name = "_reflection_servicer_test",
-    size = "small",
-    timeout = "moderate",
+    size = "medium",
     srcs = ["_reflection_servicer_test.py"],
     imports = ["../../"],
     main = "_reflection_servicer_test.py",

--- a/test/core/end2end/fuzzers/BUILD
+++ b/test/core/end2end/fuzzers/BUILD
@@ -23,7 +23,6 @@ load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 grpc_fuzzer(
     name = "api_fuzzer",
     size = "enormous",
-    timeout = "eternal",
     srcs = ["api_fuzzer.cc"],
     corpus = "api_fuzzer_corpus",
     language = "C++",

--- a/test/core/util/grpc_fuzzer.bzl
+++ b/test/core/util/grpc_fuzzer.bzl
@@ -14,7 +14,7 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
-def grpc_fuzzer(name, corpus, srcs = [], deps = [], size = "large", timeout = "long", **kwargs):
+def grpc_fuzzer(name, corpus, srcs = [], deps = [], size = "large", **kwargs):
     grpc_cc_test(
         name = name,
         srcs = srcs,
@@ -24,7 +24,6 @@ def grpc_fuzzer(name, corpus, srcs = [], deps = [], size = "large", timeout = "l
             "gtest",
         ],
         size = size,
-        timeout = timeout,
         args = ["--directory=" + native.package_name() + "/" + corpus],
         **kwargs
     )

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -494,7 +494,7 @@ grpc_cc_test(
 
 grpc_cc_test(
     name = "xds_end2end_test",
-    timeout = "long",
+    size = "large",
     srcs = ["xds_end2end_test.cc"],
     external_deps = [
         "gtest",
@@ -704,7 +704,7 @@ grpc_cc_test(
 
 grpc_cc_test(
     name = "thread_stress_test",
-    timeout = "long",
+    size = "large",
     srcs = ["thread_stress_test.cc"],
     external_deps = [
         "gtest",

--- a/tools/remote_build/manual.bazelrc
+++ b/tools/remote_build/manual.bazelrc
@@ -29,7 +29,7 @@ build --auth_enabled=true
 # Set flags for uploading to BES in order to view results in the Bazel Build
 # Results UI.
 build --bes_backend=grpcs://buildeventservice.googleapis.com
-build --bes_timeout=60s
+build --bes_timeout=600s
 build --bes_results_url="https://source.cloud.google.com/results/invocations/"
 build --project_id=grpc-testing
 

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -47,7 +47,7 @@ test --test_env=GRPC_VERBOSITY=debug
 # Set flags for uploading to BES in order to view results in the Bazel Build
 # Results UI.
 build --bes_backend=grpcs://buildeventservice.googleapis.com
-build --bes_timeout=60s
+build --bes_timeout=600s
 build --bes_results_url="https://source.cloud.google.com/results/invocations/"
 build --project_id=grpc-testing
 


### PR DESCRIPTION
In our build files, we're using both `size` and `timeout` properties for tests. This PR unifies all the tests to use `size`
- it is more common to use `size` both internally and externally
- uniformity is desirable
- the `size` implies value of `timeout` (see "implied timeout label" in https://docs.bazel.build/versions/master/test-encyclopedia.html).


