### PR TITLE
Use more reasonable timeouts for bazel RBE tests

### DIFF
--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -457,6 +457,7 @@ static tsi_test_fixture* ssl_tsi_test_fixture_create() {
 }
 
 void ssl_tsi_test_do_handshake_tiny_handshake_buffer() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_tiny_handshake_buffer");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   fixture->handshake_buffer_size = TSI_TEST_TINY_HANDSHAKE_BUFFER_SIZE;
   tsi_test_do_handshake(fixture);
@@ -464,6 +465,7 @@ void ssl_tsi_test_do_handshake_tiny_handshake_buffer() {
 }
 
 void ssl_tsi_test_do_handshake_small_handshake_buffer() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_small_handshake_buffer");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   fixture->handshake_buffer_size = TSI_TEST_SMALL_HANDSHAKE_BUFFER_SIZE;
   tsi_test_do_handshake(fixture);
@@ -471,12 +473,14 @@ void ssl_tsi_test_do_handshake_small_handshake_buffer() {
 }
 
 void ssl_tsi_test_do_handshake() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   tsi_test_do_handshake(fixture);
   tsi_test_fixture_destroy(fixture);
 }
 
 void ssl_tsi_test_do_handshake_with_root_store() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_with_root_store");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -486,6 +490,7 @@ void ssl_tsi_test_do_handshake_with_root_store() {
 }
 
 void ssl_tsi_test_do_handshake_with_client_authentication() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_with_client_authentication");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -495,6 +500,9 @@ void ssl_tsi_test_do_handshake_with_client_authentication() {
 }
 
 void ssl_tsi_test_do_handshake_with_client_authentication_and_root_store() {
+  gpr_log(
+      GPR_INFO,
+      "ssl_tsi_test_do_handshake_with_client_authentication_and_root_store");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -505,6 +513,8 @@ void ssl_tsi_test_do_handshake_with_client_authentication_and_root_store() {
 }
 
 void ssl_tsi_test_do_handshake_with_server_name_indication_exact_domain() {
+  gpr_log(GPR_INFO,
+          "ssl_tsi_test_do_handshake_with_server_name_indication_exact_domain");
   /* server1 cert contains "waterzooi.test.google.be" in SAN. */
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
@@ -516,6 +526,9 @@ void ssl_tsi_test_do_handshake_with_server_name_indication_exact_domain() {
 }
 
 void ssl_tsi_test_do_handshake_with_server_name_indication_wild_star_domain() {
+  gpr_log(
+      GPR_INFO,
+      "ssl_tsi_test_do_handshake_with_server_name_indication_wild_star_domain");
   /* server1 cert contains "*.test.google.fr" in SAN. */
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
@@ -527,6 +540,7 @@ void ssl_tsi_test_do_handshake_with_server_name_indication_wild_star_domain() {
 }
 
 void ssl_tsi_test_do_handshake_with_bad_server_cert() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_with_bad_server_cert");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -536,6 +550,7 @@ void ssl_tsi_test_do_handshake_with_bad_server_cert() {
 }
 
 void ssl_tsi_test_do_handshake_with_bad_client_cert() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_with_bad_client_cert");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -546,6 +561,7 @@ void ssl_tsi_test_do_handshake_with_bad_client_cert() {
 }
 
 void ssl_tsi_test_do_handshake_alpn_client_no_server() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_alpn_client_no_server");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -555,6 +571,7 @@ void ssl_tsi_test_do_handshake_alpn_client_no_server() {
 }
 
 void ssl_tsi_test_do_handshake_alpn_server_no_client() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_alpn_server_no_client");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -564,6 +581,7 @@ void ssl_tsi_test_do_handshake_alpn_server_no_client() {
 }
 
 void ssl_tsi_test_do_handshake_alpn_client_server_mismatch() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_alpn_server_no_client");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -573,6 +591,7 @@ void ssl_tsi_test_do_handshake_alpn_client_server_mismatch() {
 }
 
 void ssl_tsi_test_do_handshake_alpn_client_server_ok() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_alpn_client_server_ok");
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
@@ -582,6 +601,7 @@ void ssl_tsi_test_do_handshake_alpn_client_server_ok() {
 }
 
 void ssl_tsi_test_do_round_trip_for_all_configs() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_round_trip_for_all_configs");
   unsigned int* bit_array = static_cast<unsigned int*>(
       gpr_zalloc(sizeof(unsigned int) * TSI_TEST_NUM_OF_ARGUMENTS));
   const unsigned int mask = 1U << (TSI_TEST_NUM_OF_ARGUMENTS - 1);
@@ -605,7 +625,13 @@ void ssl_tsi_test_do_round_trip_for_all_configs() {
 }
 
 void ssl_tsi_test_do_round_trip_odd_buffer_size() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_round_trip_odd_buffer_size");
+#ifndef MEMORY_SANITIZER
   const size_t odd_sizes[] = {1025, 2051, 4103, 8207, 16409};
+#else
+  // avoid test being extremely slow under MSAN
+  const size_t odd_sizes[] = {1025};
+#endif
   const size_t size = sizeof(odd_sizes) / sizeof(size_t);
   for (size_t ind1 = 0; ind1 < size; ind1++) {
     for (size_t ind2 = 0; ind2 < size; ind2++) {
@@ -628,6 +654,7 @@ void ssl_tsi_test_do_round_trip_odd_buffer_size() {
 }
 
 void ssl_tsi_test_do_handshake_session_cache() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_do_handshake_session_cache");
   tsi_ssl_session_cache* session_cache = tsi_ssl_session_cache_create_lru(16);
   char session_ticket_key[kSessionTicketEncryptionKeySize];
   auto do_handshake = [&session_ticket_key,
@@ -770,12 +797,14 @@ void test_tsi_ssl_client_handshaker_factory_bad_params() {
 }
 
 void ssl_tsi_test_handshaker_factory_internals() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_handshaker_factory_internals");
   test_tsi_ssl_client_handshaker_factory_refcounting();
   test_tsi_ssl_server_handshaker_factory_refcounting();
   test_tsi_ssl_client_handshaker_factory_bad_params();
 }
 
 void ssl_tsi_test_duplicate_root_certificates() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_duplicate_root_certificates");
   char* root_cert = load_file(SSL_TSI_TEST_CREDENTIALS_DIR, "ca.pem");
   char* dup_root_cert = static_cast<char*>(
       gpr_zalloc(sizeof(char) * (strlen(root_cert) * 2 + 1)));
@@ -791,6 +820,7 @@ void ssl_tsi_test_duplicate_root_certificates() {
 }
 
 void ssl_tsi_test_extract_x509_subject_names() {
+  gpr_log(GPR_INFO, "ssl_tsi_test_extract_x509_subject_names");
   char* cert = load_file(SSL_TSI_TEST_CREDENTIALS_DIR, "multi-domain.pem");
   tsi_peer peer;
   GPR_ASSERT(tsi_ssl_extract_x509_subject_names_from_pem_cert(cert, &peer) ==

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -724,6 +724,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
+    shard_count = 5,
 )
 
 grpc_cc_test(

--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -52,15 +52,16 @@ build --build_tag_filters=-no_linux
 # address sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:asan --copt=-gmlt
-# TODO(jtattermusch): use more reasonable test timeout
-build:asan --test_timeout=3600
+# use double the default value for "moderate" and "long" timeout as sanitizer
+# tests tend to be slower
+build:asan --test_timeout=60,600,1800,3600
 build:asan --test_tag_filters=-no_linux,-qps_json_driver
 
 # memory sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:msan --copt=-gmlt
-# TODO(jtattermusch): use more reasonable test timeout
-build:msan --test_timeout=3600
+# "moderate" timeout 3x the default, "long" timeout 2x the default
+build:msan --test_timeout=60,900,1800,3600
 # TODO(jtattermusch): revisit the disabled tests
 build:msan --test_tag_filters=-no_linux,-nomsan,-json_run_localhost
 build:msan --cxxopt=--stdlib=libc++
@@ -74,16 +75,18 @@ build:msan --crosstool_top=@rbe_msan//cc:toolchain
 # thread sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:tsan --copt=-gmlt
-# TODO(jtattermusch): use more reasonable test timeout
-build:tsan --test_timeout=3600
+# use double the default value for "moderate" and "long" timeout as sanitizer
+# tests tend to be slower
+build:tsan --test_timeout=60,600,1800,3600
 build:tsan --test_tag_filters=-no_linux,-qps_json_driver
 build:tsan --extra_execution_platforms=@rbe_default//config:platform
 
 # undefined behavior sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:ubsan --copt=-gmlt
-# TODO(jtattermusch): use more reasonable test timeout
-build:ubsan --test_timeout=3600
+# use double the default value for "moderate" and "long" timeout as sanitizer
+# tests tend to be slower
+build:ubsan --test_timeout=60,600,1800,3600
 # override the config-agnostic crosstool_top
 # how to update the bazel toolchain for ubsan:
 # - check for the latest released version in https://github.com/bazelbuild/bazel-toolchains/tree/master/configs/experimental/ubuntu16_04_clang

--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -49,10 +49,6 @@ test --test_env=GRPC_VERBOSITY=debug
 build --test_tag_filters=-no_linux
 build --build_tag_filters=-no_linux
 
-# Default test timeouts for all RBE tests (sanitizers override these values)
-# TODO(jtattermusch): revisit the non-standard test timeout values
-build --test_timeout=300,450,1200,3600
-
 # address sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:asan --copt=-gmlt


### PR DESCRIPTION
The current test timeout values have been chosen long time ago, and mostly arbitrarily.
I've looked at the actual test results history and set the timeout values to something as 
close to default as possible (but still allowing extra buffer so we don't get spurious timeouts).

- a test that gets stuck get reported as timeout more quickly
- it is generally better to use default configuration values where possible
- put some protection against bloating test latency without noticing

Based on https://github.com/grpc/grpc/pull/21294 as `shard_count` is set for a few long-running tests to avoid timeouts.