### PR TITLE
Remove unnecessary owners in client_channel tree.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 /**/OWNERS @markdroth @nicolasnoble @a11r
 /bazel/** @nicolasnoble @jtattermusch @veblush @gnossen
 /cmake/** @jtattermusch @nicolasnoble @apolcyn
-/src/core/ext/filters/client_channel/** @markdroth @apolcyn @AspirinSJL
+/src/core/ext/filters/client_channel/** @markdroth
 /tools/dockerfile/** @jtattermusch @apolcyn @nicolasnoble

--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,4 @@
 # Top level ownership
-
-# nothing listed here until GitHub CODEOWNERS gets better
-# we need:
-# 1. owners to be able to self-approve
-# 2. authors to be able to select approvers
-
-# OWNERS file approvers
-# POLICY: at least three owners are needed before adding any OWNERS
-# REASON: GitHub does not recognize an author as able to give approval
-#         for a change; without this policy authors that are owners would
-#         be forced to rely on one reviewer, which would consequently
-#         lead to a bus factor of one to changes to that code
 @markdroth **/OWNERS
 @nicolasnoble **/OWNERS
 @a11r **/OWNERS

--- a/src/core/ext/filters/client_channel/OWNERS
+++ b/src/core/ext/filters/client_channel/OWNERS
@@ -1,4 +1,2 @@
 set noparent
 @markdroth
-@apolcyn
-@AspirinSJL


### PR DESCRIPTION
Now that ownership does not require approval, being an owner does nothing more than automatically tagging people as reviewers on a PR.  This means that there is no more bus-factor issue, so there is no more requirement to have at least 3 people as owners for a given directory.