### PR TITLE
Replace create_exec_properties_dict with create_rbe_exec_properties_dict

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,12 +18,12 @@ register_toolchains(
     "//third_party/toolchains/bazel_0.26.0_rbe_windows:cc-toolchain-x64_windows",
 )
 
-load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_exec_properties_dict", "custom_exec_properties")
+load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 
 custom_exec_properties(
     name = "grpc_custom_exec_properties",
     constants = {
-        "LARGE_MACHINE": create_exec_properties_dict(gce_machine_type = "n1-standard-8"),
+        "LARGE_MACHINE": create_rbe_exec_properties_dict(gce_machine_type = "n1-standard-8"),
     },
 )
 
@@ -32,7 +32,7 @@ load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 # Create toolchain configuration for remote execution.
 rbe_autoconfig(
     name = "rbe_default",
-    exec_properties = create_exec_properties_dict(
+    exec_properties = create_rbe_exec_properties_dict(
         docker_add_capabilities = "SYS_PTRACE",
         docker_privileged = True,
         # n1-highmem-2 is the default (small machine) machine type. Targets

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -174,11 +174,11 @@ def grpc_deps():
         # list of releases is at https://releases.bazel.build/bazel-toolchains.html
         http_archive(
             name = "bazel_toolchains",
-            sha256 = "0b36eef8a66f39c8dbae88e522d5bbbef49d5e66e834a982402c79962281be10",
-            strip_prefix = "bazel-toolchains-1.0.1",
+            sha256 = "3c1299efcf64a4ecf4f6def7564db28879ad2870632144d77932e7910686d3f3",
+            strip_prefix = "bazel-toolchains-1.1.2",
             urls = [
-                "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.0.1/bazel-toolchains-1.0.1.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1.0.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.1.2/bazel-toolchains-1.1.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1.1.2.tar.gz",
             ],
         )
 

--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -16,7 +16,7 @@ licenses(["notice"])  # Apache v2
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_exec_properties_dict")
+load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict")
 
 alias(
     name = "rbe_windows",
@@ -31,7 +31,7 @@ platform(
         "@bazel_tools//platforms:windows",
         "@bazel_tools//tools/cpp:msvc",
     ],
-    exec_properties = create_exec_properties_dict(
+    exec_properties = create_rbe_exec_properties_dict(
         container_image = "docker://gcr.io/grpc-testing/rbe_windows_toolchain@sha256:75728e7d6d804090f71095e5fec627b18cfa1f47adc52096c209f2a687e06b2e",
         gce_machine_type = "n1-highmem-2",
         os_family = "Windows",


### PR DESCRIPTION
The name change in bazel-toolchain is as a result of this function being specific to *RBE* remote execution properties.

Submitting this in anticipation of a breakage once you would have migrated to the newer version of bazel toolchains.

I expect that there should also be an analogous change in google3.

Note that it's okay to use bazel-toolchain 1.1.2 with bazel 1.0.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@gnossen 
