### PR TITLE
Fix differing parameter name clang tidy warning

### DIFF
--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
@@ -31,7 +31,7 @@ namespace gcp {
 // will track the number of concurrent RPCs that it handles and abort
 // if if ever exceeds that number.
 std::unique_ptr<grpc::Service> CreateFakeHandshakerService(
-    int max_expected_concurrent_rpcs);
+    int expected_max_concurrent_rpcs);
 
 }  // namespace gcp
 }  // namespace grpc


### PR DESCRIPTION
Fixes internal clang tidy warning
