### PR TITLE
Set timeout for time_jump_test

### DIFF
--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -45,6 +45,7 @@ grpc_cc_test(
 
 grpc_cc_test(
     name = "time_jump_test",
+    timeout = "short",
     srcs = ["time_jump_test.cc"],
     external_deps = [
         "gtest",


### PR DESCRIPTION
This fixes bazel WARNING: Test execution time outside of range for MODERATE tests. Consider setting timeout="short" or size="small".

