### PR TITLE
[Aio] Client unary unary interceptor

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -26,6 +26,6 @@ cdef class AioChannel:
     def close(self):
         grpc_channel_destroy(self.channel)
 
-    async def unary_unary(self, method, request, timeout, cancel_status):
+    async def unary_unary(self, method, request, deadline, cancel_status):
         call = _AioCall(self)
-        return await call.unary_unary(method, request, timeout, cancel_status)
+        return await call.unary_unary(method, request, deadline, cancel_status)

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -38,7 +38,7 @@ def insecure_channel(target, options=None, compression=None, interceptors=None):
         in gRPC Core runtime) to configure the channel.
       compression: An optional value indicating the compression method to be
         used over the lifetime of the channel. This is an EXPERIMENTAL option.
-      intereceptors: An optional list of interceptors that will be executed for
+      interceptors: An optional list of interceptors that will be executed for
         any call executed with this channel.
 
     Returns:

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -25,6 +25,7 @@ from ._call import AioRpcError
 from ._call import Call
 from ._channel import Channel
 from ._channel import UnaryUnaryMultiCallable
+from ._interceptor import ClientCallDetails
 from ._interceptor import UnaryUnaryClientInterceptor
 from ._server import server
 
@@ -54,5 +55,5 @@ def insecure_channel(target, options=None, compression=None, interceptors=None):
 ###################################  __all__  #################################
 
 __all__ = ('AioRpcError', 'Call', 'init_grpc_aio', 'Channel',
-           'UnaryUnaryClientInterceptor', 'UnaryUnaryMultiCallable',
-           'insecure_channel', 'server')
+           'ClientCallDetails', 'UnaryUnaryClientInterceptor',
+           'UnaryUnaryMultiCallable', 'insecure_channel', 'server')

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -25,10 +25,11 @@ from ._call import AioRpcError
 from ._call import Call
 from ._channel import Channel
 from ._channel import UnaryUnaryMultiCallable
+from ._interceptor import UnaryUnaryClientInterceptor
 from ._server import server
 
 
-def insecure_channel(target, options=None, compression=None):
+def insecure_channel(target, options=None, compression=None, interceptors=None):
     """Creates an insecure asynchronous Channel to a server.
 
     Args:
@@ -37,15 +38,21 @@ def insecure_channel(target, options=None, compression=None):
         in gRPC Core runtime) to configure the channel.
       compression: An optional value indicating the compression method to be
         used over the lifetime of the channel. This is an EXPERIMENTAL option.
+      intereceptors: An optional list of interceptors that will be executed for
+        any call executed with this channel.
 
     Returns:
       A Channel.
     """
-    return Channel(target, ()
-                   if options is None else options, None, compression)
+    return Channel(
+        target, () if options is None else options,
+        None,
+        compression,
+        interceptors=interceptors)
 
 
 ###################################  __all__  #################################
 
 __all__ = ('AioRpcError', 'Call', 'init_grpc_aio', 'Channel',
-           'UnaryUnaryMultiCallable', 'insecure_channel', 'server')
+           'UnaryUnaryClientInterceptor', 'UnaryUnaryMultiCallable',
+           'insecure_channel', 'server')

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -237,19 +237,14 @@ class Call:
 
         try:
             buffer_ = yield from self._call.__await__()
-        except cygrpc.AioRpcError as aio_rpc_error:
+        except AioRpcError as aio_rpc_error:
             self._state = _RpcState.ABORT
-            self._code = _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[
-                aio_rpc_error.code()]
+            self._exception = aio_rpc_error
+            self._code = aio_rpc_error.code()
             self._details = aio_rpc_error.details()
             self._initial_metadata = aio_rpc_error.initial_metadata()
             self._trailing_metadata = aio_rpc_error.trailing_metadata()
-
-            # Propagates the pure Python class
-            self._exception = AioRpcError(self._code, self._details,
-                                          self._initial_metadata,
-                                          self._trailing_metadata)
-            raise self._exception from aio_rpc_error
+            raise
         except asyncio.CancelledError as cancel_error:
             # _state, _code, _details are managed in the `cancel` method
             self._exception = cancel_error

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -14,7 +14,7 @@
 """Invocation-side implementation of gRPC Asyncio Python."""
 import asyncio
 import functools
-from typing import Callable, Optional, List, Sequence, Dict, TypeVar
+from typing import Callable, Optional, List, Sequence, Iterator, Dict, TypeVar
 
 from grpc import _common
 from grpc._cython import cygrpc
@@ -37,7 +37,7 @@ class UnaryUnaryMultiCallable:
     _method: bytes
     _request_serializer: SerializingFunction
     _response_deserializer: DeserializingFunction
-    _interceptors: Optional[List[UnaryUnaryClientInterceptor]]
+    _interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]]
     _loop: asyncio.AbstractEventLoop
 
     def __init__(
@@ -126,7 +126,7 @@ class UnaryUnaryMultiCallable:
         """Run the RPC call wraped in interceptors"""
 
         async def _run_interceptor(
-                interceptors: Sequence[UnaryUnaryClientInterceptor],
+                interceptors: Iterator[UnaryUnaryClientInterceptor],
                 client_call_details: ClientCallDetails, request: bytes):
             try:
                 interceptor = next(interceptors)

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 """Invocation-side implementation of gRPC Asyncio Python."""
 import asyncio
-from typing import Callable, Optional
+import functools
+from typing import Callable, Optional, List, Iterable, Dict
 
 from grpc import _common
+from grpc import ClientCallDetails
 from grpc._cython import cygrpc
+from grpc._interceptor import _ClientCallDetails
 
 from ._call import Call
+from ._call import AioRpcError
+from ._interceptor import UnaryUnaryClientInterceptor
 
 SerializingFunction = Callable[[str], bytes]
 DeserializingFunction = Callable[[bytes], str]
@@ -27,13 +32,26 @@ DeserializingFunction = Callable[[bytes], str]
 class UnaryUnaryMultiCallable:
     """Afford invoking a unary-unary RPC from client-side in an asynchronous way."""
 
-    def __init__(self, channel: cygrpc.AioChannel, method: bytes,
-                 request_serializer: SerializingFunction,
-                 response_deserializer: DeserializingFunction) -> None:
+    _channel: cygrpc.AioChannel
+    _method: bytes
+    _request_serializer: SerializingFunction
+    _response_deserializer: DeserializingFunction
+    _interceptors: Optional[List[UnaryUnaryClientInterceptor]]
+    _loop: asyncio.AbstractEventLoop
+
+    def __init__(
+            self,
+            channel: cygrpc.AioChannel,
+            method: bytes,
+            request_serializer: SerializingFunction,
+            response_deserializer: DeserializingFunction,
+            interceptors: Optional[List[UnaryUnaryClientInterceptor]] = None
+    ) -> None:
         self._channel = channel
         self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
+        self._interceptors = interceptors
         self._loop = asyncio.get_event_loop()
 
     def _timeout_to_deadline(self, timeout: int) -> Optional[int]:
@@ -44,11 +62,11 @@ class UnaryUnaryMultiCallable:
     def __call__(self,
                  request,
                  *,
-                 timeout=None,
-                 metadata=None,
+                 timeout: Optional[float] = None,
+                 metadata: Optional[Dict] = None,
                  credentials=None,
-                 wait_for_ready=None,
-                 compression=None) -> Call:
+                 wait_for_ready: Optional[bool] = None,
+                 compression: Optional[bool] = None) -> Call:
         """Asynchronously invokes the underlying RPC.
 
         Args:
@@ -66,11 +84,6 @@ class UnaryUnaryMultiCallable:
 
         Returns:
           A Call object instance which is an awaitable object.
-
-        Raises:
-          RpcError: Indicating that the RPC terminated with non-OK status. The
-            raised RpcError will also be a Call for the RPC affording the RPC's
-            metadata, status code, and details.
         """
 
         if metadata:
@@ -88,13 +101,63 @@ class UnaryUnaryMultiCallable:
 
         serialized_request = _common.serialize(request,
                                                self._request_serializer)
-        timeout = self._timeout_to_deadline(timeout)
         aio_cancel_status = cygrpc.AioCancelStatus()
-        aio_call = asyncio.ensure_future(
-            self._channel.unary_unary(self._method, serialized_request, timeout,
-                                      aio_cancel_status),
-            loop=self._loop)
+
+        if self._interceptors:
+            client_call_details = _ClientCallDetails(
+                self._method, timeout, metadata, credentials, wait_for_ready,
+                compression)
+            aio_call = asyncio.ensure_future(
+                self._wrap_call_in_interceptors(
+                    client_call_details, serialized_request, aio_cancel_status),
+                loop=self._loop)
+        else:
+            aio_call = asyncio.ensure_future(
+                self._call(self._method, serialized_request, timeout,
+                           aio_cancel_status),
+                loop=self._loop)
+
         return Call(aio_call, self._response_deserializer, aio_cancel_status)
+
+    async def _wrap_call_in_interceptors(
+            self, client_call_details: ClientCallDetails, request: bytes,
+            aio_cancel_status: cygrpc.AioCancelStatus):
+        """Run the RPC call wraped in interceptors"""
+
+        async def _run_interceptor(
+                interceptors: Iterable[UnaryUnaryClientInterceptor],
+                client_call_details: ClientCallDetails, request: bytes):
+            try:
+                interceptor = next(interceptors)
+            except StopIteration:
+                interceptor = None
+
+            if interceptor:
+                continuation = functools.partial(_run_interceptor, interceptors)
+                return await interceptor.intercept_unary_unary(
+                    continuation, client_call_details, request)
+            else:
+                return await self._call(client_call_details.method, request,
+                                        client_call_details.timeout,
+                                        aio_cancel_status)
+
+        return await _run_interceptor(
+            iter(self._interceptors), client_call_details, request)
+
+    async def _call(self, method: bytes, request: bytes,
+                    timeout: Optional[float],
+                    aio_cancel_status: cygrpc.AioCancelStatus):
+
+        deadline = self._timeout_to_deadline(timeout)
+
+        try:
+            return await self._channel.unary_unary(method, request, deadline,
+                                                   aio_cancel_status)
+        except cygrpc.AioRpcError as aio_rpc_error:
+            raise AioRpcError(
+                _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[aio_rpc_error.code()],
+                aio_rpc_error.details(), aio_rpc_error.initial_metadata(),
+                aio_rpc_error.trailing_metadata()) from aio_rpc_error
 
 
 class Channel:
@@ -103,7 +166,12 @@ class Channel:
     A cygrpc.AioChannel-backed implementation.
     """
 
-    def __init__(self, target, options, credentials, compression):
+    def __init__(self,
+                 target,
+                 options,
+                 credentials,
+                 compression,
+                 interceptors=None):
         """Constructor.
 
         Args:
@@ -122,6 +190,14 @@ class Channel:
 
         if compression:
             raise NotImplementedError("TODO: compression not implemented yet")
+
+        if interceptors is None:
+            self._unary_unary_interceptors = None
+        else:
+            self._unary_unary_interceptors = list(
+                filter(
+                    lambda interceptor: isinstance(interceptor, UnaryUnaryClientInterceptor),
+                    interceptors)) or None
 
         self._channel = cygrpc.AioChannel(_common.encode(target))
 
@@ -142,9 +218,12 @@ class Channel:
         Returns:
           A UnaryUnaryMultiCallable value for the named unary-unary method.
         """
-        return UnaryUnaryMultiCallable(self._channel, _common.encode(method),
-                                       request_serializer,
-                                       response_deserializer)
+        return UnaryUnaryMultiCallable(
+            self._channel,
+            _common.encode(method),
+            request_serializer,
+            response_deserializer,
+            interceptors=self._unary_unary_interceptors)
 
     async def _close(self):
         # TODO: Send cancellation status

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -202,7 +202,8 @@ class Channel:
                     lambda interceptor: isinstance(interceptor, UnaryUnaryClientInterceptor),
                     interceptors)) or None
 
-            invalid_interceptors = set(interceptors) - set(self._unary_unary_interceptors or [])
+            invalid_interceptors = set(interceptors) - set(
+                self._unary_unary_interceptors or [])
             if invalid_interceptors:
                 raise ValueError(
                     "Interceptor must be "+\

--- a/src/python/grpcio/grpc/experimental/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/experimental/aio/_interceptor.py
@@ -34,10 +34,8 @@ class UnaryUnaryClientInterceptor:
     """Affords intercepting unary-unary invocations."""
 
     async def intercept_unary_unary(
-            self,
-            continuation: Callable[[ClientCallDetails, Any], Any],
-            client_call_details: ClientCallDetails,
-            request: Any) -> Any:
+            self, continuation: Callable[[ClientCallDetails, Any], Any],
+            client_call_details: ClientCallDetails, request: Any) -> Any:
         """Intercepts a unary-unary invocation asynchronously.
         Args:
           continuation: A coroutine that proceeds with the invocation by

--- a/src/python/grpcio/grpc/experimental/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/experimental/aio/_interceptor.py
@@ -1,0 +1,46 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interceptors implementation of gRPC Asyncio Python."""
+from typing import Callable
+
+import grpc
+
+
+class UnaryUnaryClientInterceptor:
+    """Affords intercepting unary-unary invocations."""
+
+    async def intercept_unary_unary(
+            self,
+            continuation: Callable[[grpc.ClientCallDetails, bytes], bytes],
+            client_call_details: grpc.ClientCallDetails,
+            request: bytes) -> bytes:
+        """Intercepts a unary-unary invocation asynchronously.
+        Args:
+          continuation: A coroutine that proceeds with the invocation by
+            executing the next interceptor in chain or invoking the
+            actual RPC on the underlying Channel. It is the interceptor's
+            responsibility to call it if it decides to move the RPC forward.
+            The interceptor can use
+            `response_future = await continuation(client_call_details, request)`
+            to continue with the RPC. `continuation` returns the response of the
+            RPC.
+          client_call_details: A ClientCallDetails object describing the
+            outgoing RPC.
+          request: The request value for the RPC.
+        Returns:
+            An object with the RPC response.
+        Raises:
+          AioRpcError: Indicating that the RPC terminated with non-OK status.
+          asyncio.CancelledError: Indicating that the RPC was canceled.
+        """

--- a/src/python/grpcio/grpc/experimental/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/experimental/aio/_interceptor.py
@@ -12,9 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Interceptors implementation of gRPC Asyncio Python."""
-from typing import Callable
+import collections
+from typing import Any, Dict, Callable, Optional
 
 import grpc
+
+
+class ClientCallDetails(
+        collections.namedtuple(
+            'ClientCallDetails',
+            ('method', 'timeout', 'metadata', 'credentials')),
+        grpc.ClientCallDetails):
+
+    method: int
+    timeout: Optional[float]
+    metadata: Optional[Dict]
+    credentials: Optional[Any]
 
 
 class UnaryUnaryClientInterceptor:
@@ -22,9 +35,9 @@ class UnaryUnaryClientInterceptor:
 
     async def intercept_unary_unary(
             self,
-            continuation: Callable[[grpc.ClientCallDetails, bytes], bytes],
-            client_call_details: grpc.ClientCallDetails,
-            request: bytes) -> bytes:
+            continuation: Callable[[ClientCallDetails, Any], Any],
+            client_call_details: ClientCallDetails,
+            request: Any) -> Any:
         """Intercepts a unary-unary invocation asynchronously.
         Args:
           continuation: A coroutine that proceeds with the invocation by

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -4,5 +4,6 @@
   "unit.call_test.TestCall",
   "unit.channel_test.TestChannel",
   "unit.init_test.TestInsecureChannel",
+  "unit.interceptor_test.TestUnaryUnaryClientInterceptor",
   "unit.server_test.TestServer"
 ]

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -15,9 +15,9 @@
 from time import sleep
 
 from grpc.experimental import aio
+from tests.unit.framework.common import test_constants
 from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2_grpc
-from tests.unit.framework.common import test_constants
 
 
 class _TestServiceServicer(test_pb2_grpc.TestServiceServicer):

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -18,10 +18,10 @@ import unittest
 import grpc
 
 from grpc.experimental import aio
-from src.proto.grpc.testing import messages_pb2
 from tests.unit.framework.common import test_constants
 from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
+from src.proto.grpc.testing import messages_pb2
 
 
 class TestAioRpcError(unittest.TestCase):

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -17,10 +17,10 @@ import unittest
 import grpc
 
 from grpc.experimental import aio
-from src.proto.grpc.testing import messages_pb2
 from tests.unit.framework.common import test_constants
 from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
+from src.proto.grpc.testing import messages_pb2
 
 _UNARY_CALL_METHOD = '/grpc.testing.TestService/UnaryCall'
 _EMPTY_CALL_METHOD = '/grpc.testing.TestService/EmptyCall'

--- a/src/python/grpcio_tests/tests_aio/unit/interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/interceptor_test.py
@@ -63,9 +63,9 @@ class TestUnaryUnaryClientInterceptor(AioTestBase):
                     response_deserializer=messages_pb2.SimpleResponse.FromString
                 )
                 response = await multicallable(messages_pb2.SimpleRequest())
+
                 self.assertTrue(
                     all([interceptor.executed for interceptor in interceptors]))
-
                 self.assertEqual(type(response), messages_pb2.SimpleResponse)
 
         self.loop.run_until_complete(coro())

--- a/src/python/grpcio_tests/tests_aio/unit/interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/interceptor_test.py
@@ -1,0 +1,216 @@
+# Copyright 2019 The gRPC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import collections
+import logging
+import unittest
+
+import grpc
+
+from grpc.experimental import aio
+from tests_aio.unit._test_server import start_test_server
+from tests_aio.unit._test_base import AioTestBase
+from src.proto.grpc.testing import messages_pb2
+
+
+class _ClientCallDetails(
+        collections.namedtuple(
+            '_ClientCallDetails',
+            ('method', 'timeout', 'metadata', 'credentials')),
+        grpc.ClientCallDetails):
+    pass
+
+
+class TestUnaryUnaryClientInterceptor(AioTestBase):
+
+    def test_many_interceptors(self):
+
+        class Interceptor(aio.UnaryUnaryClientInterceptor):
+            """Interceptor used for testing if the interceptor is being called"""
+
+            def __init__(self):
+                self.executed = False
+
+            async def intercept_unary_unary(self, continuation, client_call_details,
+                                            request):
+                self.executed = True
+                return await continuation(client_call_details, request)
+
+        async def coro():
+            interceptors = [Interceptor() for i in range(2)]
+            self.assertTrue(
+                all([not interceptor.executed for interceptor in interceptors]))
+
+            server_target, _ = await start_test_server()  # pylint: disable=unused-variable
+
+            async with aio.insecure_channel(
+                    server_target, interceptors=interceptors) as channel:
+                multicallable = channel.unary_unary(
+                    '/grpc.testing.TestService/UnaryCall',
+                    request_serializer=messages_pb2.SimpleRequest.
+                    SerializeToString,
+                    response_deserializer=messages_pb2.SimpleResponse.FromString
+                )
+                response = await multicallable(messages_pb2.SimpleRequest())
+                self.assertTrue(
+                    all([interceptor.executed for interceptor in interceptors]))
+
+                self.assertEqual(type(response), messages_pb2.SimpleResponse)
+
+        self.loop.run_until_complete(coro())
+
+    @unittest.expectedFailure
+    # TODO(https://github.com/grpc/grpc/issues/20144) Once metadata support is
+    # implemented in the client-side, this test must be implemented.
+    def test_modify_metadata(self):
+        raise NotImplementedError()
+
+    def test_status_code_observability(self):
+
+        class StatusCodeObservabilityInterceptor(
+                aio.UnaryUnaryClientInterceptor):
+            """Interceptor used for observe the status code returned by the RPC"""
+
+            def __init__(self):
+                self.status_codes_observed = {
+                    grpc.StatusCode.OK: 0,
+                    grpc.StatusCode.CANCELLED: 0,
+                    grpc.StatusCode.DEADLINE_EXCEEDED: 0
+                }
+
+            async def intercept_unary_unary(self, continuation, client_call_details,
+                                            request):
+                status_code = grpc.StatusCode.OK
+                try:
+                    return await continuation(client_call_details, request)
+                except aio.AioRpcError as aio_rpc_error:
+                    status_code = aio_rpc_error.code()
+                    raise
+                except asyncio.CancelledError:
+                    status_code = grpc.StatusCode.CANCELLED
+                    raise
+                finally:
+                    self.status_codes_observed[status_code] += 1
+
+        async def coro():
+            interceptor = StatusCodeObservabilityInterceptor()
+            server_target, server = await start_test_server()
+
+            async with aio.insecure_channel(
+                    server_target, interceptors=[interceptor]) as channel:
+
+                # when no error StatusCode.OK is observed
+                multicallable = channel.unary_unary(
+                    '/grpc.testing.TestService/UnaryCall',
+                    request_serializer=messages_pb2.SimpleRequest.
+                    SerializeToString,
+                    response_deserializer=messages_pb2.SimpleResponse.FromString
+                )
+
+                await multicallable(messages_pb2.SimpleRequest())
+
+                self.assertEqual(
+                    interceptor.status_codes_observed[grpc.StatusCode.OK], 1)
+                self.assertEqual(interceptor.status_codes_observed[
+                    grpc.StatusCode.CANCELLED], 0)
+                self.assertEqual(interceptor.status_codes_observed[
+                    grpc.StatusCode.DEADLINE_EXCEEDED], 0)
+
+                # when cancellation StatusCode.CANCELLED is observed
+                call = multicallable(messages_pb2.SimpleRequest())
+
+                await asyncio.sleep(0)
+
+                call.cancel()
+
+                try:
+                    await call
+                except asyncio.CancelledError:
+                    pass
+
+                self.assertEqual(
+                    interceptor.status_codes_observed[grpc.StatusCode.OK], 1)
+                self.assertEqual(interceptor.status_codes_observed[
+                    grpc.StatusCode.CANCELLED], 1)
+                self.assertEqual(interceptor.status_codes_observed[
+                    grpc.StatusCode.DEADLINE_EXCEEDED], 0)
+
+                # when deadline happens StatusCode.DEADLINE_EXCEEDED is observed
+                await server.stop(None)
+
+                empty_call_with_sleep = channel.unary_unary(
+                    "/grpc.testing.TestService/EmptyCall",
+                    request_serializer=messages_pb2.SimpleRequest.
+                    SerializeToString,
+                    response_deserializer=messages_pb2.SimpleResponse.
+                    FromString,
+                )
+
+                try:
+                    await empty_call_with_sleep(
+                        messages_pb2.SimpleRequest(), timeout=0.1)
+                except grpc.RpcError:
+                    pass
+
+                self.assertEqual(
+                    interceptor.status_codes_observed[grpc.StatusCode.OK], 1)
+                self.assertEqual(interceptor.status_codes_observed[
+                    grpc.StatusCode.CANCELLED], 1)
+                self.assertEqual(interceptor.status_codes_observed[
+                    grpc.StatusCode.DEADLINE_EXCEEDED], 1)
+
+        self.loop.run_until_complete(coro())
+
+    def test_add_timeout(self):
+
+        class TimeoutInterceptor(aio.UnaryUnaryClientInterceptor):
+            """Interceptor used for adding a timeout to the RPC"""
+
+            async def intercept_unary_unary(self, continuation, client_call_details,
+                                            request):
+                new_client_call_details = _ClientCallDetails(
+                    method=client_call_details.method,
+                    timeout=0.1,
+                    metadata=client_call_details.metadata,
+                    credentials=client_call_details.credentials)
+                return await continuation(new_client_call_details, request)
+
+        async def coro():
+            interceptor = TimeoutInterceptor()
+            server_target, server = await start_test_server()
+
+            async with aio.insecure_channel(
+                    server_target, interceptors=[interceptor]) as channel:
+
+                multicallable = channel.unary_unary(
+                    '/grpc.testing.TestService/UnaryCall',
+                    request_serializer=messages_pb2.SimpleRequest.
+                    SerializeToString,
+                    response_deserializer=messages_pb2.SimpleResponse.FromString
+                )
+
+                await server.stop(None)
+
+                with self.assertRaises(grpc.RpcError) as exception_context:
+                    await multicallable(messages_pb2.SimpleRequest())
+
+                self.assertEqual(exception_context.exception.code(),
+                                 grpc.StatusCode.DEADLINE_EXCEEDED)
+
+        self.loop.run_until_complete(coro())
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/interceptor_test.py
@@ -40,8 +40,9 @@ class TestUnaryUnaryClientInterceptor(AioTestBase):
 
         class Interceptor(aio.UnaryUnaryClientInterceptor):
             """Interceptor used for testing if the interceptor is being called"""
-            async def intercept_unary_unary(self, continuation, client_call_details,
-                                            request):
+
+            async def intercept_unary_unary(self, continuation,
+                                            client_call_details, request):
                 interceptors_executed.append(self)
                 return await continuation(client_call_details, request)
 
@@ -93,8 +94,8 @@ class TestUnaryUnaryClientInterceptor(AioTestBase):
                     grpc.StatusCode.DEADLINE_EXCEEDED: 0
                 }
 
-            async def intercept_unary_unary(self, continuation, client_call_details,
-                                            request):
+            async def intercept_unary_unary(self, continuation,
+                                            client_call_details, request):
                 status_code = grpc.StatusCode.OK
                 try:
                     return await continuation(client_call_details, request)
@@ -181,8 +182,8 @@ class TestUnaryUnaryClientInterceptor(AioTestBase):
         class TimeoutInterceptor(aio.UnaryUnaryClientInterceptor):
             """Interceptor used for adding a timeout to the RPC"""
 
-            async def intercept_unary_unary(self, continuation, client_call_details,
-                                            request):
+            async def intercept_unary_unary(self, continuation,
+                                            client_call_details, request):
                 new_client_call_details = aio.ClientCallDetails(
                     method=client_call_details.method,
                     timeout=0.1,


### PR DESCRIPTION
Implement the unary interceptor for the client-side. Interceptors
can be now installed by passing them as a new parameter of the `Channel` constructor or
by giving them as part of the `insecure_channel` function.

Interceptors are executed within the RPC Asyncio task, receiving as a
response the response body sent by the downstream layer implemented in
Cython.

## Main differences with the synchronous implementation.

### How interceptors are added

There is a significative difference in how interceptors are being added in the `Aio` package and the interface provided by the synchronous package, while the last one allows composition the `Aio` package publishes a very naive implementation which only accepts the interceptors as a new constructor keyword, which can be implicitly given by using the `insecure_channel` primitive. 

For example, the following snippet shows how interceptors would need to be installed from now on when `Aio` module is used.
 
```python
channel = insecure_channel(..., interceptors=[MyInterceptor()])
```

### Object returned by a continuation

In `Aio` the object returned by the continuation is the result of the unary call made by using the Cython interfaces. Right now only bytes but in the future most likely a more complex object with more attributes - for example for returning the metadata related to an object.

Following code shows how the interceptor handle takes this into consideration and also uses the proper except statements for catch any known exception

```python
async def intercept_unary_unary(self, continuation, client_call_details,
                                request):
    status_code = grpc.StatusCode.OK
    try:
        return await continuation(client_call_details, request)
    except aio.AioRpcError as aio_rpc_error:
        status_code = aio_rpc_error.code()
        raise
    except asyncio.CancelledError:
        status_code = grpc.StatusCode.CANCELLED
        raise
    finally:
        self.status_codes_observed[status_code] += 1
```

Note: these differences - if are accepted - would need to be added in the gRFC [1]

[1] https://github.com/grpc/proposal/pull/155