### PR TITLE
Use dedicated threads for synchronous runners

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -95,7 +95,7 @@ class TestLite(setuptools.Command):
         import tests
         loader = tests.Loader()
         loader.loadTestsFromNames(['tests'])
-        runner = tests.Runner()
+        runner = tests.Runner(dedicated_threads=True)
         result = runner.run(loader.suite)
         if not result.wasSuccessful():
             sys.exit('Test failure')


### PR DESCRIPTION
This unfortunate rollback should fix the flake in `coverage` package. Further investigation may be needed.

https://fusion.corp.google.com/runanalysis/test/prod%3Agrpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_basictests_python/prod%3Agrpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_basictests_python/KOKORO/a098439c-8721-4e12-baa7-0e1ed8461b61/1574061312254/build%20%233237/Targets?target=github%2Fgrpc%2Frun_tests%2Fpython_linux_opt_native%2Fpy36_native.test.interop._insecure_intraop_test.InsecureIntraopTest&drilldownTab=tests

Context: b/144706215