### PR TITLE
Census client filter: use current span and tags

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2300,7 +2300,9 @@ grpc_cc_library(
         "absl-base",
         "absl-time",
         "opencensus-trace",
+        "opencensus-trace-context_util",
         "opencensus-stats",
+        "opencensus-context",
     ],
     language = "c++",
     deps = [

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -82,8 +82,18 @@ def grpc_deps():
     )
 
     native.bind(
+        name = "opencensus-context",
+        actual = "@io_opencensus_cpp//opencensus/context:context",
+    )
+
+    native.bind(
         name = "opencensus-trace",
         actual = "@io_opencensus_cpp//opencensus/trace:trace",
+    )
+
+    native.bind(
+        name = "opencensus-trace-context_util",
+        actual = "@io_opencensus_cpp//opencensus/trace:context_util",
     )
 
     native.bind(
@@ -94,6 +104,16 @@ def grpc_deps():
     native.bind(
         name = "opencensus-stats-test",
         actual = "@io_opencensus_cpp//opencensus/stats:test_utils",
+    )
+
+    native.bind(
+        name = "opencensus-with-tag-map",
+        actual = "@io_opencensus_cpp//opencensus/tags:with_tag_map",
+    )
+
+    native.bind(
+        name = "opencensus-tags",
+        actual = "@io_opencensus_cpp//opencensus/tags:tags",
     )
 
     if "boringssl" not in native.existing_rules():

--- a/src/cpp/ext/filters/census/context.cc
+++ b/src/cpp/ext/filters/census/context.cc
@@ -18,10 +18,13 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "opencensus/tags/context_util.h"
+#include "opencensus/trace/context_util.h"
 #include "src/cpp/ext/filters/census/context.h"
 
 namespace grpc {
 
+using ::opencensus::tags::TagMap;
 using ::opencensus::trace::Span;
 using ::opencensus::trace::SpanContext;
 
@@ -40,7 +43,7 @@ void GenerateServerContext(absl::string_view tracing, absl::string_view stats,
       return;
     }
   }
-  new (context) CensusContext(method);
+  new (context) CensusContext(method, TagMap{});
 }
 
 void GenerateClientContext(absl::string_view method, CensusContext* ctxt,
@@ -52,11 +55,19 @@ void GenerateClientContext(absl::string_view method, CensusContext* ctxt,
     SpanContext span_ctxt = parent_ctxt->Context();
     Span span = parent_ctxt->Span();
     if (span_ctxt.IsValid()) {
-      new (ctxt) CensusContext(method, &span);
+      new (ctxt) CensusContext(method, &span, TagMap{});
       return;
     }
   }
-  new (ctxt) CensusContext(method);
+  const Span& span = opencensus::trace::GetCurrentSpan();
+  const TagMap& tags = opencensus::tags::GetCurrentTagMap();
+  if (span.context().IsValid()) {
+    // Create span with parent.
+    new (ctxt) CensusContext(method, &span, tags);
+    return;
+  }
+  // Create span without parent.
+  new (ctxt) CensusContext(method, tags);
 }
 
 size_t TraceContextSerialize(const ::opencensus::trace::SpanContext& context,

--- a/test/cpp/ext/filters/census/BUILD
+++ b/test/cpp/ext/filters/census/BUILD
@@ -27,6 +27,8 @@ grpc_cc_test(
     external_deps = [
         "gtest",
         "opencensus-stats-test",
+        "opencensus-tags",
+        "opencensus-with-tag-map",
     ],
     language = "C++",
     tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -27,7 +27,10 @@
 #include "include/grpc++/grpc++.h"
 #include "include/grpcpp/opencensus.h"
 #include "opencensus/stats/stats.h"
+#include "opencensus/stats/tag_key.h"
 #include "opencensus/stats/testing/test_utils.h"
+#include "opencensus/tags/tag_map.h"
+#include "opencensus/tags/with_tag_map.h"
 #include "src/cpp/ext/filters/census/grpc_plugin.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/test_config.h"
@@ -41,6 +44,12 @@ using ::opencensus::stats::Distribution;
 using ::opencensus::stats::View;
 using ::opencensus::stats::ViewDescriptor;
 using ::opencensus::stats::testing::TestUtils;
+using ::opencensus::tags::TagKey;
+using ::opencensus::tags::TagMap;
+using ::opencensus::tags::WithTagMap;
+
+static const auto TEST_TAG_KEY = TagKey::Register("my_key");
+static const auto TEST_TAG_VALUE = "my_value";
 
 class EchoServer final : public EchoTestService::Service {
   ::grpc::Status Echo(::grpc::ServerContext* context,
@@ -104,7 +113,8 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_measure(kRpcClientRoundtripLatencyMeasureName)
           .set_name("client_method")
           .set_aggregation(Aggregation::Count())
-          .add_column(ClientMethodTagKey());
+          .add_column(ClientMethodTagKey())
+          .add_column(TEST_TAG_KEY);
   View client_method_view(client_method_descriptor);
   const auto server_method_descriptor =
       ViewDescriptor()
@@ -112,6 +122,7 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_name("server_method")
           .set_aggregation(Aggregation::Count())
           .add_column(ServerMethodTagKey());
+  //.add_column(TEST_TAG_KEY);
   View server_method_view(server_method_descriptor);
 
   const auto client_status_descriptor =
@@ -119,7 +130,8 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
           .set_measure(kRpcClientRoundtripLatencyMeasureName)
           .set_name("client_status")
           .set_aggregation(Aggregation::Count())
-          .add_column(ClientStatusTagKey());
+          .add_column(ClientStatusTagKey())
+          .add_column(TEST_TAG_KEY);
   View client_status_view(client_status_descriptor);
   const auto server_status_descriptor =
       ViewDescriptor()
@@ -136,19 +148,56 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
     request.mutable_param()->mutable_expected_error()->set_code(i);
     EchoResponse response;
     ::grpc::ClientContext context;
-    ::grpc::Status status = stub_->Echo(&context, request, &response);
+    {
+      WithTagMap tags({{TEST_TAG_KEY, TEST_TAG_VALUE}});
+      ::grpc::Status status = stub_->Echo(&context, request, &response);
+    }
   }
   absl::SleepFor(absl::Milliseconds(500));
   TestUtils::Flush();
 
-  EXPECT_THAT(client_method_view.GetData().int_data(),
-              ::testing::UnorderedElementsAre(::testing::Pair(
-                  ::testing::ElementsAre(client_method_name_), 17)));
+  // Client side views can be tagged with custom tags.
+  EXPECT_THAT(
+      client_method_view.GetData().int_data(),
+      ::testing::UnorderedElementsAre(::testing::Pair(
+          ::testing::ElementsAre(client_method_name_, TEST_TAG_VALUE), 17)));
+  // TODO: Implement server view tagging with custom tags.
   EXPECT_THAT(server_method_view.GetData().int_data(),
               ::testing::UnorderedElementsAre(::testing::Pair(
                   ::testing::ElementsAre(server_method_name_), 17)));
 
-  auto codes = {
+  // Client side views can be tagged with custom tags.
+  auto client_tags = {
+      ::testing::Pair(::testing::ElementsAre("OK", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("CANCELLED", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("UNKNOWN", TEST_TAG_VALUE), 1),
+      ::testing::Pair(
+          ::testing::ElementsAre("INVALID_ARGUMENT", TEST_TAG_VALUE), 1),
+      ::testing::Pair(
+          ::testing::ElementsAre("DEADLINE_EXCEEDED", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("NOT_FOUND", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("ALREADY_EXISTS", TEST_TAG_VALUE),
+                      1),
+      ::testing::Pair(
+          ::testing::ElementsAre("PERMISSION_DENIED", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("UNAUTHENTICATED", TEST_TAG_VALUE),
+                      1),
+      ::testing::Pair(
+          ::testing::ElementsAre("RESOURCE_EXHAUSTED", TEST_TAG_VALUE), 1),
+      ::testing::Pair(
+          ::testing::ElementsAre("FAILED_PRECONDITION", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("ABORTED", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("OUT_OF_RANGE", TEST_TAG_VALUE),
+                      1),
+      ::testing::Pair(::testing::ElementsAre("UNIMPLEMENTED", TEST_TAG_VALUE),
+                      1),
+      ::testing::Pair(::testing::ElementsAre("INTERNAL", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("UNAVAILABLE", TEST_TAG_VALUE), 1),
+      ::testing::Pair(::testing::ElementsAre("DATA_LOSS", TEST_TAG_VALUE), 1),
+  };
+
+  // TODO: Implement server view tagging with custom tags.
+  auto server_tags = {
       ::testing::Pair(::testing::ElementsAre("OK"), 1),
       ::testing::Pair(::testing::ElementsAre("CANCELLED"), 1),
       ::testing::Pair(::testing::ElementsAre("UNKNOWN"), 1),
@@ -169,9 +218,9 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
   };
 
   EXPECT_THAT(client_status_view.GetData().int_data(),
-              ::testing::UnorderedElementsAreArray(codes));
+              ::testing::UnorderedElementsAreArray(client_tags));
   EXPECT_THAT(server_status_view.GetData().int_data(),
-              ::testing::UnorderedElementsAreArray(codes));
+              ::testing::UnorderedElementsAreArray(server_tags));
 }
 
 TEST_F(StatsPluginEnd2EndTest, RequestReceivedBytesPerRpc) {


### PR DESCRIPTION
Census client filter: use current span and tags.

Add support to use current span and tags, to support census tagging.

original_author was @g-easy, who asked mt to produce a PR from this commit
https://github.com/g-easy/grpc/commit/ae02d171d52a1e082fff9b6a969e380aef3d4ada

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@sheenaqotj
