### PR TITLE
Fix ordering of load and licenses in BUILD

### DIFF
--- a/src/proto/grpc/http_over_grpc/BUILD
+++ b/src/proto/grpc/http_over_grpc/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache v2
-
 load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+
+licenses(["notice"])  # Apache v2
 
 grpc_package(
     name = "http_over_grpc",


### PR DESCRIPTION
Bazel requires load come above licenses in BUILD file.