### PR TITLE
Fix submodule_at_head script

### DIFF
--- a/tools/distrib/python/bazel_deps.sh
+++ b/tools/distrib/python/bazel_deps.sh
@@ -16,17 +16,6 @@
 
 cd $(dirname $0)/../../../
 
-# First check if bazel is installed on the machine. If it is, then we don't need
-# to invoke the docker bazel.
-if [ -x "$(command -v bazel)" ]
-then
-  cd third_party/protobuf
-  bazel query 'deps('$1')'
-else
-  docker build -t bazel_local_img tools/dockerfile/test/sanity
-  docker run -v "$(realpath .):/src/grpc/:ro" \
-    -w /src/grpc/third_party/protobuf         \
-    --rm=true                                 \
-    bazel_local_img                           \
-    bazel query 'deps('$1')'
-fi
+cd third_party/protobuf
+# use tools/bazel wrapper to make sure we use the right version of bazel
+../../tools/bazel query 'deps('$1')'

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -22,20 +22,24 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
+# Submodule name is passed as the RUN_TESTS_FLAGS variable
+SUBMODULE_NAME="${RUN_TESTS_FLAGS}"
+
 # Update submodule to be tested at HEAD
-(cd third_party/$RUN_TESTS_FLAGS && git fetch --all && git checkout origin/master)
+(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout origin/master)
+
+echo "This suite tests whether gRPC HEAD builds with HEAD of submodule '${SUBMODULE_NAME}'"
+echo "If a test breaks, either"
+echo "1) some change in the grpc repository has caused the failure"
+echo "2) some change that was just merged in the submodule head has caused the failure."
+
+echo ""
+echo "submodule '${SUBMODULE_NAME}' is at commit: $(cd third_party/${SUBMODULE_NAME}; git rev-parse --verify HEAD)"
+
 tools/buildgen/generate_projects.sh
 
-if [ "$RUN_TESTS_FLAGS" == "protobuf" ]
+if [ "${SUBMODULE_NAME}" == "protobuf" ]
 then
-  # Upgrade bazel.
-  # make_grpcio_tools.py requires bazel >=0.13.1 to run (Kokoro workers only have bazel 0.9)
-  curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.13.1/bazel-0.13.1-installer-linux-x86_64.sh
-  chmod +x ./bazel-0.13.1-installer-linux-x86_64.sh
-  ./bazel-0.13.1-installer-linux-x86_64.sh --user
-  rm -f ./bazel-0.13.1-installer-linux-x86_64.sh
-  export PATH="$PATH:$HOME/bin"
-
   tools/distrib/python/make_grpcio_tools.py
 fi
 


### PR DESCRIPTION
This should fix the recent protobuf_at_head breakage (b/144454974)

Analysis what happened:
- protobuf has updated mathlimits.cc at head
- the grpc_build_submodule_at_head.sh updated third_party/protobuf submodule and ran make_grpcio_tools.py script (which normally would regenerate the source file list and thus remove the mathlimits.cc file)
- make_grpcio_tools.py runs bazel query internally, but unfortunately uses a bazel version that's way out of date.  Therefore, make_grpcio_tools.py has failed and didn't update the source list
- our build still thought that mathlimits.cc exists and tried to build it
- that resulted in an error.

This PR refactors the grpc_build_submodule_at_head.sh for better readability and also uses tools/bazel wrapper instead of trying to download bazel itself.