### PR TITLE
Prevent use of pthread header

### DIFF
--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -21,7 +21,6 @@
 #include <fcntl.h>
 #include <gmock/gmock.h>
 #include <netinet/in.h>
-#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -34,7 +34,6 @@
 #include "test/cpp/util/subprocess.h"
 
 #include <gtest/gtest.h>
-#include <pthread.h>
 #include <sys/time.h>
 #include <thread>
 

--- a/tools/run_tests/sanity/cpp_banned_constructs.sh
+++ b/tools/run_tests/sanity/cpp_banned_constructs.sh
@@ -38,3 +38,12 @@ egrep -Irn \
     include/grpc include/grpcpp src/core src/cpp | \
     egrep -v include/grpcpp/impl/codegen/sync.h | \
     diff - /dev/null
+
+#
+# Prevent the include of headers that shouldn't be used in tests.
+#
+
+egrep -Irn \
+    '^#include (<pthread.h>)' \
+    test | \
+    diff - /dev/null


### PR DESCRIPTION
Just like we've cleaned up banned/unwanted headers from the sources, we should do so for the tests as well. Starting with a simple one.
