### PR TITLE
Fix the version of twine <= 2.0

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -47,7 +47,7 @@ python setup.py bdist_wheel || goto :error
 popd
 
 @rem Ensure the generate artifacts are valid.
-python -m pip install twine
+python -m pip install "twine<=2.0"
 python -m twine check dist\* tools\distrib\python\grpcio_tools\dist\* || goto :error
 
 xcopy /Y /I /S dist\* %ARTIFACT_DIR% || goto :error

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -134,7 +134,7 @@ fi
 
 # Ensure the generated artifacts are valid.
 "${PYTHON}" -m virtualenv venv || { "${PYTHON}" -m pip install virtualenv && "${PYTHON}" -m virtualenv venv; }
-venv/bin/python -m pip install twine
+venv/bin/python -m pip install "twine<=2.0"
 venv/bin/python -m twine check dist/* tools/distrib/python/grpcio_tools/dist/*
 rm -rf venv/
 


### PR DESCRIPTION
Fix #21250. Twine 3.0 introduces new dependency against `cryptography` which is not available on manylinux1 x86. So the version of twine should be fixed <= 2.0.