### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/doc/connection-backoff-interop-test-description.md
+++ b/doc/connection-backoff-interop-test-description.md
@@ -3,7 +3,7 @@ Connection Backoff Interop Test Descriptions
 
 This test is to verify the client is reconnecting the server with correct
 backoffs as specified in
-[the spec](http://github.com/grpc/grpc/blob/master/doc/connection-backoff.md).
+[the spec](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md).
 The test server has a port (control_port) running a rpc service for controlling
 the server and another port (retry_port) to close any incoming tcp connections.
 The test has the following flow:


### PR DESCRIPTION
Currently, when we access github.com with HTTP, it is redirected to HTTPS automatically. So this commit aims to replace http://github.com by https://github.com for security.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
