### PR TITLE
Fix C# sending empty payloads with gzip compression

### DIFF
--- a/src/csharp/Grpc.Core.Tests/CompressionTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CompressionTest.cs
@@ -129,5 +129,25 @@ namespace Grpc.Core.Tests
 
             Assert.AreEqual(request, response);
         }
+
+        [Test]
+        public void CanReadCompressedMessages_EmptyPayload()
+        {
+            var compressionMetadata = new Metadata
+            {
+                { new Metadata.Entry(Metadata.CompressionRequestAlgorithmMetadataKey, "gzip") }
+            };
+
+            helper.UnaryHandler = new UnaryServerMethod<string, string>(async (req, context) =>
+            {
+                await context.WriteResponseHeadersAsync(compressionMetadata);
+                return req;
+            });
+
+            var request = "";
+            var response = Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(compressionMetadata)), request);
+
+            Assert.AreEqual(request, response);
+        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/Internal/SliceBufferSafeHandleTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/SliceBufferSafeHandleTest.cs
@@ -33,6 +33,21 @@ namespace Grpc.Core.Internal.Tests
             {
                 sliceBuffer.Complete();
                 CollectionAssert.AreEqual(new byte[0], sliceBuffer.ToByteArray());
+                Assert.AreEqual(1, sliceBuffer.TestOnly_GetSliceCount());
+            }
+        }
+
+        [TestCase]
+        public void SliceBuffer_CompleteWithEmptyPayload()
+        {
+            using (var sliceBuffer = SliceBufferSafeHandle.Create())
+            {
+                var destSpan = sliceBuffer.GetSpan(0);
+                Assert.IsTrue(destSpan.Length > 0);  // some non-zero size memory is made available
+                sliceBuffer.Advance(0);
+                sliceBuffer.Complete();
+                CollectionAssert.AreEqual(new byte[0], sliceBuffer.ToByteArray());
+                Assert.AreEqual(1, sliceBuffer.TestOnly_GetSliceCount());
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/SliceBufferSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/SliceBufferSafeHandle.cs
@@ -130,6 +130,12 @@ namespace Grpc.Core.Internal
             return result;
         }
 
+        // for testing only
+        public int TestOnly_GetSliceCount()
+        {
+            return (int) Native.grpcsharp_slice_buffer_slice_count(this).ToUInt64();
+        }
+
         private void EnsureBufferSpace(int sizeHint)
         {
             GrpcPreconditions.CheckArgument(sizeHint >= 0);

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -1245,7 +1245,9 @@ GPR_EXPORT void* GPR_CALLTYPE grpcsharp_slice_buffer_adjust_tail_space(
 
   if (buffer->count == 0) {
     // when sending messages, C-core requires that there
-    // is at least on slice, even for empty payload.
+    // is at least one slice, even for empty payload.
+    // TODO(jtattermusch): this fix can be removed once
+    // https://github.com/grpc/grpc/issues/21299 is fixed.
     grpc_slice_buffer_add_indexed(buffer, grpc_empty_slice());
   }
   grpc_slice* last_slice = &(buffer->slices[buffer->count - 1]);

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -1244,7 +1244,9 @@ GPR_EXPORT void* GPR_CALLTYPE grpcsharp_slice_buffer_adjust_tail_space(
   }
 
   if (buffer->count == 0) {
-    return NULL;
+    // when sending messages, C-core requires that there
+    // is at least on slice, even for empty payload.
+    grpc_slice_buffer_add_indexed(buffer, grpc_empty_slice());
   }
   grpc_slice* last_slice = &(buffer->slices[buffer->count - 1]);
   return GRPC_SLICE_END_PTR(*last_slice) - requested_tail_space;


### PR DESCRIPTION
Fixes #18753 

The problem is that C-core's "send_message" operation expects that the send buffer is not empty (= contains at least on slice, even if it's an empty slice) when compression is on.

Fix is to make sure that C# always provides a send buffer that has at least one slice (only a consideration in the case where the buffer is empty obviously).
Also adding extra tests to cover this case (I was able to reproduce reliably without the fix).

See https://github.com/grpc/grpc/pull/21118#issuecomment-557068042 for additional details.