### PR TITLE
Sync time before running time_jump_test

### DIFF
--- a/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
@@ -23,6 +23,10 @@ cd $(dirname $0)/../../..
 # run cfstream_test separately because it messes with the network
 tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=standalone --genrule_strategy=standalone --test_output=all //test/cpp/end2end:cfstream_test
 
+# Make sure time is in sync before running time_jump_test because the test does
+# NTP sync before exiting. Bazel gets confused if test end time < start time.
+sudo sntp -sS pool.ntp.org
+
 # run time_jump_test separately because it changes system time
 tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=standalone --genrule_strategy=standalone --test_output=all //test/cpp/common:time_jump_test
 


### PR DESCRIPTION
If the system clock is out of sync with NTP server at the beginning of `time_jump_test`, the test might complete in negative time because the test's `TearDown` does NTP sync.
Bazel's test runtime calculation errors out if the test runtime is negative. See https://source.cloud.google.com/results/invocations/ea323ec4-aceb-46bc-b726-b15998cabe8d/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_cfstream/log for an example.

The fix is to ensure that system clock is synced before running the test.