### PR TITLE
Make bazel test sharding work for poller-specific tests

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -193,6 +193,8 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
     copts = if_mac(["-DGRPC_CFSTREAM"])
     if language.upper() == "C":
         copts = copts + if_not_windows(["-std=c99"])
+    # NOTE: these attributes won't be used for the poller-specific versions of a test
+    # automatically, you need to set them explicitly (if applicable)
     args = {
         "srcs": srcs,
         "args": args,
@@ -235,6 +237,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
                 tags = (tags + ["no_windows", "no_mac"]),
                 exec_compatible_with = exec_compatible_with,
                 exec_properties = exec_properties,
+                shard_count = shard_count,
             )
     else:
         # the test behavior doesn't depend on polling, just generate the test


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/21274 that will actually fix https://github.com/grpc/grpc/issues/20695.

Without this, the xds_end2end_test won't actually be sharded (we're still getting the "unevaluated target" problem on master and there is only one shard: https://source.cloud.google.com/results/invocations/e7b604d6-74d2-4f6c-8768-733889379b9e/targets)


Can be verified manually with
`bazel --bazelrc=tools/remote_build/manual.bazelrc test --config=ubsan //test/cpp/end2end:xds_end2end_test@poller=epollex`








