### PR TITLE
Fix compression filter crash on empty payload

### DIFF
--- a/src/core/ext/filters/http/message_compress/message_compress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.cc
@@ -321,6 +321,11 @@ static grpc_error* pull_slice_from_send_message(call_data* calld) {
 // eventually result in calling on_send_message_next_done().
 static void continue_reading_send_message(grpc_call_element* elem) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
+  if (calld->slices.length == calld->send_message_batch->payload->send_message
+                                    .send_message->length()) {
+    finish_send_message(elem);
+    return;
+  }
   while (calld->send_message_batch->payload->send_message.send_message->Next(
       ~static_cast<size_t>(0), &calld->on_send_message_next_done)) {
     grpc_error* error = pull_slice_from_send_message(calld);

--- a/src/core/ext/filters/http/message_compress/message_compress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.cc
@@ -321,8 +321,8 @@ static grpc_error* pull_slice_from_send_message(call_data* calld) {
 // eventually result in calling on_send_message_next_done().
 static void continue_reading_send_message(grpc_call_element* elem) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
-  if (calld->slices.length == calld->send_message_batch->payload->send_message
-                                    .send_message->length()) {
+  if (calld->slices.length ==
+      calld->send_message_batch->payload->send_message.send_message->length()) {
     finish_send_message(elem);
     return;
   }

--- a/src/core/lib/transport/byte_stream.h
+++ b/src/core/lib/transport/byte_stream.h
@@ -40,7 +40,8 @@ class ByteStream : public Orphanable {
   // Returns true if the bytes are available immediately (in which case
   // on_complete will not be called), or false if the bytes will be available
   // asynchronously (in which case on_complete will be called when they
-  // are available).
+  // are available). Should not be called if there is no data left on the
+  // stream.
   //
   // max_size_hint can be set as a hint as to the maximum number
   // of bytes that would be acceptable to read.

--- a/src/csharp/Grpc.Core.Tests/CompressionTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CompressionTest.cs
@@ -149,25 +149,5 @@ namespace Grpc.Core.Tests
 
             Assert.AreEqual(request, response);
         }
-
-        [Test]
-        public void CanReadCompressedMessages_EmptyPayload()
-        {
-            var compressionMetadata = new Metadata
-            {
-                { new Metadata.Entry(Metadata.CompressionRequestAlgorithmMetadataKey, "gzip") }
-            };
-
-            helper.UnaryHandler = new UnaryServerMethod<string, string>(async (req, context) =>
-            {
-                await context.WriteResponseHeadersAsync(compressionMetadata);
-                return req;
-            });
-
-            var request = "";
-            var response = Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(compressionMetadata)), request);
-
-            Assert.AreEqual(request, response);
-        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/CompressionTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CompressionTest.cs
@@ -149,5 +149,25 @@ namespace Grpc.Core.Tests
 
             Assert.AreEqual(request, response);
         }
+
+        [Test]
+        public void CanReadCompressedMessages_EmptyPayload()
+        {
+            var compressionMetadata = new Metadata
+            {
+                { new Metadata.Entry(Metadata.CompressionRequestAlgorithmMetadataKey, "gzip") }
+            };
+
+            helper.UnaryHandler = new UnaryServerMethod<string, string>(async (req, context) =>
+            {
+                await context.WriteResponseHeadersAsync(compressionMetadata);
+                return req;
+            });
+
+            var request = "";
+            var response = Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(compressionMetadata)), request);
+
+            Assert.AreEqual(request, response);
+        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/Internal/SliceBufferSafeHandleTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/SliceBufferSafeHandleTest.cs
@@ -33,21 +33,6 @@ namespace Grpc.Core.Internal.Tests
             {
                 sliceBuffer.Complete();
                 CollectionAssert.AreEqual(new byte[0], sliceBuffer.ToByteArray());
-                Assert.AreEqual(1, sliceBuffer.TestOnly_GetSliceCount());
-            }
-        }
-
-        [TestCase]
-        public void SliceBuffer_CompleteWithEmptyPayload()
-        {
-            using (var sliceBuffer = SliceBufferSafeHandle.Create())
-            {
-                var destSpan = sliceBuffer.GetSpan(0);
-                Assert.IsTrue(destSpan.Length > 0);  // some non-zero size memory is made available
-                sliceBuffer.Advance(0);
-                sliceBuffer.Complete();
-                CollectionAssert.AreEqual(new byte[0], sliceBuffer.ToByteArray());
-                Assert.AreEqual(1, sliceBuffer.TestOnly_GetSliceCount());
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/SliceBufferSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/SliceBufferSafeHandle.cs
@@ -130,12 +130,6 @@ namespace Grpc.Core.Internal
             return result;
         }
 
-        // for testing only
-        public int TestOnly_GetSliceCount()
-        {
-            return (int) Native.grpcsharp_slice_buffer_slice_count(this).ToUInt64();
-        }
-
         private void EnsureBufferSpace(int sizeHint)
         {
             GrpcPreconditions.CheckArgument(sizeHint >= 0);

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -1244,11 +1244,7 @@ GPR_EXPORT void* GPR_CALLTYPE grpcsharp_slice_buffer_adjust_tail_space(
   }
 
   if (buffer->count == 0) {
-    // when sending messages, C-core requires that there
-    // is at least one slice, even for empty payload.
-    // TODO(jtattermusch): this fix can be removed once
-    // https://github.com/grpc/grpc/issues/21299 is fixed.
-    grpc_slice_buffer_add_indexed(buffer, grpc_empty_slice());
+    return NULL;
   }
   grpc_slice* last_slice = &(buffer->slices[buffer->count - 1]);
   return GRPC_SLICE_END_PTR(*last_slice) - requested_tail_space;


### PR DESCRIPTION
- Fix #21299, where empty payloads with gzip compression enabled crash the sender
- Revert the csharp workaround in #21266 (except one relevant test), since it's no longer needed with this fix in core