### PR TITLE
Update GRPCUnaryResponseHandler with generics

### DIFF
--- a/examples/objective-c/route_guide/ViewControllers.m
+++ b/examples/objective-c/route_guide/ViewControllers.m
@@ -106,6 +106,23 @@ static NSString * const kHostAddress = @"localhost:50051";
 }
 
 - (void)execRequest {
+  void (^handler)(RTGFeature *response, NSError *error) = ^(RTGFeature *response, NSError *error) {
+    // TODO(makdharma): Remove boilerplate by consolidating into one log function.
+    if (response.name.length) {
+      NSString *str =[NSString stringWithFormat:@"%@\nFound feature called %@ at %@.", self.outputLabel.text, response.location, response.name];
+      self.outputLabel.text = str;
+      NSLog(@"Found feature called %@ at %@.", response.name, response.location);
+    } else if (response) {
+      NSString *str =[NSString stringWithFormat:@"%@\nFound no features at %@",  self.outputLabel.text,response.location];
+      self.outputLabel.text = str;
+      NSLog(@"Found no features at %@", response.location);
+    } else {
+      NSString *str =[NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
+      self.outputLabel.text = str;
+      NSLog(@"RPC error: %@", error);
+    }
+  };
+
   RTGPoint *point = [RTGPoint message];
   point.latitude = 409146138;
   point.longitude = -746188906;
@@ -115,7 +132,7 @@ static NSString * const kHostAddress = @"localhost:50051";
                                                  callOptions:nil];
   [call start];
   call = [_service getFeatureWithMessage:[RTGPoint message]
-                         responseHandler:self
+                         responseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler responseDispatchQueue:nil]
                              callOptions:nil];
   [call start];
 

--- a/examples/objective-c/route_guide/ViewControllers.m
+++ b/examples/objective-c/route_guide/ViewControllers.m
@@ -25,7 +25,7 @@
 
 #import <GRPCClient/GRPCTransport.h>
 
-static NSString * const kHostAddress = @"localhost:50051";
+static NSString *const kHostAddress = @"localhost:50051";
 
 /** Category to override RTGPoint's description. */
 @interface RTGPoint (Description)
@@ -36,9 +36,9 @@ static NSString * const kHostAddress = @"localhost:50051";
 - (NSString *)description {
   NSString *verticalDirection = self.latitude >= 0 ? @"N" : @"S";
   NSString *horizontalDirection = self.longitude >= 0 ? @"E" : @"W";
-  return [NSString stringWithFormat:@"%.02f%@ %.02f%@",
-          abs(self.latitude) / 1E7f, verticalDirection,
-          abs(self.longitude) / 1E7f, horizontalDirection];
+  return
+      [NSString stringWithFormat:@"%.02f%@ %.02f%@", abs(self.latitude) / 1E7f, verticalDirection,
+                                 abs(self.longitude) / 1E7f, horizontalDirection];
 }
 @end
 
@@ -55,12 +55,11 @@ static NSString * const kHostAddress = @"localhost:50051";
                       longitude:(float)longitude {
   RTGRouteNote *note = [self message];
   note.message = message;
-  note.location.latitude = (int32_t) latitude * 1E7;
-  note.location.longitude = (int32_t) longitude * 1E7;
+  note.location.latitude = (int32_t)latitude * 1E7;
+  note.location.longitude = (int32_t)longitude * 1E7;
   return note;
 }
 @end
-
 
 #pragma mark Demo: Get Feature
 
@@ -70,7 +69,7 @@ static NSString * const kHostAddress = @"localhost:50051";
  */
 @interface GetFeatureViewController : UIViewController
 
-@property (weak, nonatomic) IBOutlet UILabel *outputLabel;
+@property(weak, nonatomic) IBOutlet UILabel *outputLabel;
 
 @end
 
@@ -82,15 +81,19 @@ static NSString * const kHostAddress = @"localhost:50051";
   void (^handler)(RTGFeature *response, NSError *error) = ^(RTGFeature *response, NSError *error) {
     // TODO(makdharma): Remove boilerplate by consolidating into one log function.
     if (response.name.length) {
-      NSString *str =[NSString stringWithFormat:@"%@\nFound feature called %@ at %@.", self.outputLabel.text, response.location, response.name];
+      NSString *str =
+          [NSString stringWithFormat:@"%@\nFound feature called %@ at %@.", self.outputLabel.text,
+                                     response.location, response.name];
       self.outputLabel.text = str;
       NSLog(@"Found feature called %@ at %@.", response.name, response.location);
     } else if (response) {
-      NSString *str =[NSString stringWithFormat:@"%@\nFound no features at %@",  self.outputLabel.text,response.location];
+      NSString *str = [NSString stringWithFormat:@"%@\nFound no features at %@",
+                                                 self.outputLabel.text, response.location];
       self.outputLabel.text = str;
       NSLog(@"Found no features at %@", response.location);
     } else {
-      NSString *str =[NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
+      NSString *str =
+          [NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
       self.outputLabel.text = str;
       NSLog(@"RPC error: %@", error);
     }
@@ -100,15 +103,18 @@ static NSString * const kHostAddress = @"localhost:50051";
   point.latitude = 409146138;
   point.longitude = -746188906;
 
-  GRPCUnaryProtoCall *call = [_service getFeatureWithMessage:point
-                                             responseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler responseDispatchQueue:nil]
-                                                 callOptions:nil];
+  GRPCUnaryProtoCall *call = [_service
+      getFeatureWithMessage:point
+            responseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler
+                                                                responseDispatchQueue:nil]
+                callOptions:nil];
   [call start];
-  call = [_service getFeatureWithMessage:[RTGPoint message]
-                         responseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler responseDispatchQueue:nil]
-                             callOptions:nil];
+  call = [_service
+      getFeatureWithMessage:[RTGPoint message]
+            responseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler
+                                                                responseDispatchQueue:nil]
+                callOptions:nil];
   [call start];
-
 }
 
 - (void)viewDidLoad {
@@ -129,16 +135,15 @@ static NSString * const kHostAddress = @"localhost:50051";
 
 @end
 
-
 #pragma mark Demo: List Features
 
 /**
  * Run the listFeatures demo. Calls listFeatures with a rectangle containing all of the features in
  * the pre-generated database. Prints each response as it comes in.
  */
-@interface ListFeaturesViewController : UIViewController<GRPCProtoResponseHandler>
+@interface ListFeaturesViewController : UIViewController <GRPCProtoResponseHandler>
 
-@property (weak, nonatomic) IBOutlet UILabel *outputLabel;
+@property(weak, nonatomic) IBOutlet UILabel *outputLabel;
 
 @end
 
@@ -167,7 +172,9 @@ static NSString * const kHostAddress = @"localhost:50051";
 - (void)didReceiveProtoMessage:(GPBMessage *)message {
   RTGFeature *response = (RTGFeature *)message;
   if (response) {
-    NSString *str =[NSString stringWithFormat:@"%@\nFound feature at %@ called %@.", self.outputLabel.text, response.location, response.name];
+    NSString *str =
+        [NSString stringWithFormat:@"%@\nFound feature at %@ called %@.", self.outputLabel.text,
+                                   response.location, response.name];
     self.outputLabel.text = str;
     NSLog(@"Found feature at %@ called %@.", response.location, response.name);
   }
@@ -175,7 +182,7 @@ static NSString * const kHostAddress = @"localhost:50051";
 
 - (void)didCloseWithTrailingMetadata:(NSDictionary *)trailingMetadata error:(NSError *)error {
   if (error) {
-    NSString *str =[NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
+    NSString *str = [NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
     self.outputLabel.text = str;
     NSLog(@"RPC error: %@", error);
   }
@@ -208,7 +215,7 @@ static NSString * const kHostAddress = @"localhost:50051";
  */
 @interface RecordRouteViewController : UIViewController
 
-@property (weak, nonatomic) IBOutlet UILabel *outputLabel;
+@property(weak, nonatomic) IBOutlet UILabel *outputLabel;
 
 @end
 
@@ -217,11 +224,12 @@ static NSString * const kHostAddress = @"localhost:50051";
 }
 
 - (void)execRequest {
-  NSString *dataBasePath = [NSBundle.mainBundle pathForResource:@"route_guide_db"
-                                                         ofType:@"json"];
+  NSString *dataBasePath = [NSBundle.mainBundle pathForResource:@"route_guide_db" ofType:@"json"];
   NSData *dataBaseContent = [NSData dataWithContentsOfFile:dataBasePath];
   NSError *error;
-  NSArray *features = [NSJSONSerialization JSONObjectWithData:dataBaseContent options:0 error:&error];
+  NSArray *features = [NSJSONSerialization JSONObjectWithData:dataBaseContent
+                                                      options:0
+                                                        error:&error];
 
   if (error) {
     NSLog(@"Error reading database.");
@@ -230,34 +238,39 @@ static NSString * const kHostAddress = @"localhost:50051";
     return;
   }
 
-  void (^handler)(RTGRouteSummary *response, NSError *error) = ^(RTGRouteSummary *response, NSError *error) {
-    if (response) {
-      NSString *str =[NSString stringWithFormat:
-                      @"%@\nFinished trip with %i points\nPassed %i features\n"
-                      "Travelled %i meters\nIt took %i seconds",
-                      self.outputLabel.text, response.pointCount, response.featureCount,
-                      response.distance, response.elapsedTime];
-      self.outputLabel.text = str;
-      NSLog(@"Finished trip with %i points", response.pointCount);
-      NSLog(@"Passed %i features", response.featureCount);
-      NSLog(@"Travelled %i meters", response.distance);
-      NSLog(@"It took %i seconds", response.elapsedTime);
-    } else {
-      NSString *str =[NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
-      self.outputLabel.text = str;
-      NSLog(@"RPC error: %@", error);
-    }
-  };
+  void (^handler)(RTGRouteSummary *response, NSError *error) =
+      ^(RTGRouteSummary *response, NSError *error) {
+        if (response) {
+          NSString *str = [NSString
+              stringWithFormat:@"%@\nFinished trip with %i points\nPassed %i features\n"
+                                "Travelled %i meters\nIt took %i seconds",
+                               self.outputLabel.text, response.pointCount, response.featureCount,
+                               response.distance, response.elapsedTime];
+          self.outputLabel.text = str;
+          NSLog(@"Finished trip with %i points", response.pointCount);
+          NSLog(@"Passed %i features", response.featureCount);
+          NSLog(@"Travelled %i meters", response.distance);
+          NSLog(@"It took %i seconds", response.elapsedTime);
+        } else {
+          NSString *str =
+              [NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
+          self.outputLabel.text = str;
+          NSLog(@"RPC error: %@", error);
+        }
+      };
 
-  GRPCStreamingProtoCall *call = [_service recordRouteWithResponseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler
-                                                                                                              responseDispatchQueue:nil]
-                                                              callOptions:nil];
+  GRPCStreamingProtoCall *call =
+      [_service recordRouteWithResponseHandler:[[GRPCUnaryResponseHandler alloc]
+                                                   initWithResponseHandler:handler
+                                                     responseDispatchQueue:nil]
+                                   callOptions:nil];
   [call start];
   for (id feature in features) {
     RTGPoint *location = [RTGPoint message];
-    location.longitude = [((NSNumber *) feature[@"location"][@"longitude"]) intValue];
-    location.latitude = [((NSNumber *) feature[@"location"][@"latitude"]) intValue];
-    NSString *str =[NSString stringWithFormat:@"%@\nVisiting point %@", self.outputLabel.text, location];
+    location.longitude = [((NSNumber *)feature[@"location"][@"longitude"]) intValue];
+    location.latitude = [((NSNumber *)feature[@"location"][@"latitude"]) intValue];
+    NSString *str =
+        [NSString stringWithFormat:@"%@\nVisiting point %@", self.outputLabel.text, location];
     self.outputLabel.text = str;
     NSLog(@"Visiting point %@", location);
     [call writeMessage:location];
@@ -283,16 +296,15 @@ static NSString * const kHostAddress = @"localhost:50051";
 
 @end
 
-
 #pragma mark Demo: Route Chat
 
 /**
  * Run the routeChat demo. Send some chat messages, and print any chat messages that are sent from
  * the server.
  */
-@interface RouteChatViewController : UIViewController<GRPCProtoResponseHandler>
+@interface RouteChatViewController : UIViewController <GRPCProtoResponseHandler>
 
-@property (weak, nonatomic) IBOutlet UILabel *outputLabel;
+@property(weak, nonatomic) IBOutlet UILabel *outputLabel;
 
 @end
 
@@ -305,13 +317,14 @@ static NSString * const kHostAddress = @"localhost:50051";
 }
 
 - (void)execRequest {
-  NSArray *notes = @[[RTGRouteNote noteWithMessage:@"First message" latitude:0 longitude:0],
-                     [RTGRouteNote noteWithMessage:@"Second message" latitude:0 longitude:1],
-                     [RTGRouteNote noteWithMessage:@"Third message" latitude:1 longitude:0],
-                     [RTGRouteNote noteWithMessage:@"Fourth message" latitude:0 longitude:0]];
+  NSArray *notes = @[
+    [RTGRouteNote noteWithMessage:@"First message" latitude:0 longitude:0],
+    [RTGRouteNote noteWithMessage:@"Second message" latitude:0 longitude:1],
+    [RTGRouteNote noteWithMessage:@"Third message" latitude:1 longitude:0],
+    [RTGRouteNote noteWithMessage:@"Fourth message" latitude:0 longitude:0]
+  ];
 
-  GRPCStreamingProtoCall *call = [_service routeChatWithResponseHandler:self
-                                                            callOptions:nil];
+  GRPCStreamingProtoCall *call = [_service routeChatWithResponseHandler:self callOptions:nil];
   [call start];
   for (RTGRouteNote *note in notes) {
     [call writeMessage:note];
@@ -322,8 +335,8 @@ static NSString * const kHostAddress = @"localhost:50051";
 - (void)didReceiveProtoMessage:(GPBMessage *)message {
   RTGRouteNote *note = (RTGRouteNote *)message;
   if (note) {
-    NSString *str =[NSString stringWithFormat:@"%@\nGot message %@ at %@",
-                    self.outputLabel.text, note.message, note.location];
+    NSString *str = [NSString stringWithFormat:@"%@\nGot message %@ at %@", self.outputLabel.text,
+                                               note.message, note.location];
     self.outputLabel.text = str;
     NSLog(@"Got message %@ at %@", note.message, note.location);
   }
@@ -333,7 +346,7 @@ static NSString * const kHostAddress = @"localhost:50051";
   if (!error) {
     NSLog(@"Chat ended.");
   } else {
-    NSString *str =[NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
+    NSString *str = [NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
     self.outputLabel.text = str;
     NSLog(@"RPC error: %@", error);
   }

--- a/examples/objective-c/route_guide/ViewControllers.m
+++ b/examples/objective-c/route_guide/ViewControllers.m
@@ -259,6 +259,8 @@ static NSString *const kHostAddress = @"localhost:50051";
         }
       };
 
+  // We can use unary response handler here because, despite the requests being a stream, the
+  // response of the RPC is unary.
   GRPCStreamingProtoCall *call =
       [_service recordRouteWithResponseHandler:[[GRPCUnaryResponseHandler alloc]
                                                    initWithResponseHandler:handler

--- a/examples/objective-c/route_guide/ViewControllers.m
+++ b/examples/objective-c/route_guide/ViewControllers.m
@@ -128,7 +128,7 @@ static NSString * const kHostAddress = @"localhost:50051";
   point.longitude = -746188906;
 
   GRPCUnaryProtoCall *call = [_service getFeatureWithMessage:point
-                                             responseHandler:self
+                                             responseHandler:[[GRPCUnaryResponseHandler alloc] initWithResponseHandler:handler responseDispatchQueue:nil]
                                                  callOptions:nil];
   [call start];
   call = [_service getFeatureWithMessage:[RTGPoint message]

--- a/examples/objective-c/route_guide/ViewControllers.m
+++ b/examples/objective-c/route_guide/ViewControllers.m
@@ -68,7 +68,7 @@ static NSString * const kHostAddress = @"localhost:50051";
  * Run the getFeature demo. Calls getFeature with a point known to have a feature and a point known
  * not to have a feature.
  */
-@interface GetFeatureViewController : UIViewController<GRPCProtoResponseHandler>
+@interface GetFeatureViewController : UIViewController
 
 @property (weak, nonatomic) IBOutlet UILabel *outputLabel;
 
@@ -76,33 +76,6 @@ static NSString * const kHostAddress = @"localhost:50051";
 
 @implementation GetFeatureViewController {
   RTGRouteGuide *_service;
-}
-
-- (dispatch_queue_t)dispatchQueue {
-  return dispatch_get_main_queue();
-}
-
-- (void)didReceiveProtoMessage:(GPBMessage *)message {
-  RTGFeature *response = (RTGFeature *)message;
-
-  // TODO(makdharma): Remove boilerplate by consolidating into one log function.
-  if (response.name.length != 0) {
-    NSString *str =[NSString stringWithFormat:@"%@\nFound feature called %@ at %@.", self.outputLabel.text, response.location, response.name];
-    self.outputLabel.text = str;
-    NSLog(@"Found feature called %@ at %@.", response.name, response.location);
-  } else if (response) {
-    NSString *str =[NSString stringWithFormat:@"%@\nFound no features at %@",  self.outputLabel.text,response.location];
-    self.outputLabel.text = str;
-    NSLog(@"Found no features at %@", response.location);
-  }
-}
-
-- (void)didCloseWithTrailingMetadata:(NSDictionary *)trailingMetadata error:(NSError *)error {
-  if (error) {
-    NSString *str =[NSString stringWithFormat:@"%@\nRPC error: %@", self.outputLabel.text, error];
-    self.outputLabel.text = str;
-    NSLog(@"RPC error: %@", error);
-  }
 }
 
 - (void)execRequest {

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  * A convenience class of objects that act as response handlers of calls. Issues
  * response to a single handler when the response is completed.
  */
-@interface GRPCUnaryResponseHandler : NSObject<GRPCProtoResponseHandler>
+@interface GRPCUnaryResponseHandler<ResponseType> : NSObject<GRPCProtoResponseHandler>
 
 /**
  * Creates a responsehandler object with a unary call handler.
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
  * responseDispatchQueue: the dispatch queue on which the response handler
  * should be issued. If it's nil, the handler will use the main queue.
  */
-- (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
+- (nullable instancetype)initWithResponseHandler:(void (^)(ResponseType, NSError *))handler
                            responseDispatchQueue:(nullable dispatch_queue_t)dispatchQueue;
 
 /** Response headers received during the call. */

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -73,6 +73,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A convenience class of objects that act as response handlers of calls. Issues
  * response to a single handler when the response is completed.
+ *
+ * The object is stateful and should not be reused for multiple calls. If multiple calls share the
+ * same response handling logic, create separate GRPCUnaryResponseHandler objects for each call.
  */
 @interface GRPCUnaryResponseHandler<ResponseType> : NSObject<GRPCProtoResponseHandler>
 

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -28,13 +28,13 @@
 #import <RxLibrary/GRXWriter+Transformations.h>
 
 @implementation GRPCUnaryResponseHandler {
-  void (^_responseHandler)(GPBMessage *, NSError *);
+  void (^_responseHandler)(id, NSError *);
   dispatch_queue_t _responseDispatchQueue;
 
   GPBMessage *_message;
 }
 
-- (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
+- (nullable instancetype)initWithResponseHandler:(void (^)(id, NSError *))handler
                            responseDispatchQueue:(dispatch_queue_t)dispatchQueue {
   if ((self = [super init])) {
     _responseHandler = handler;


### PR DESCRIPTION
`GRPCUnaryResponseHandler` used to accept a handler with parameter of type `GPBMessage *`:
```
- (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
...
```
However when user makes a unary call, they usually specify a response handler with the actually class name.
```
void (^handler)(RTGFeature *response, NSError *error) = ^(RTGFeature *response, NSError *error) {
...
```
 This causes compiler error because the two block types are not compatible with each other.

In this PR we solve this problem with ObjC generics. It allows compiler to accept a generic parameter type.

This PR also updates RouteGuide example to use the `GRPCUnaryResponseHandler` with this change.