### PR TITLE
Update ruby docker image to use pthread for win32

### DIFF
--- a/third_party/rake-compiler-dock/Dockerfile
+++ b/third_party/rake-compiler-dock/Dockerfile
@@ -11,4 +11,12 @@ RUN apt-get install -y g++-multilib
 # generated ruby package can run on CentOS 6 with GLIBC 2.12
 RUN sed -i 's/__GLIBC_MINOR__\t23/__GLIBC_MINOR__\t12/' /usr/include/features.h
 
+# Use posix pthread for mingw so that C++ standard library for thread could be
+# available such as std::thread, std::mutex, so on.
+# https://sourceware.org/pthreads-win32/
+RUN printf "1\n" | update-alternatives --config x86_64-w64-mingw32-gcc && \
+    printf "1\n" | update-alternatives --config x86_64-w64-mingw32-g++ && \
+    printf "1\n" | update-alternatives --config i686-w64-mingw32-gcc && \
+    printf "1\n" | update-alternatives --config i686-w64-mingw32-g++
+
 CMD bash


### PR DESCRIPTION
By default, MinGW doesn't have support for std::thread because libstdc++ uses pthread which Windows lacks. To use std::thread, there are two solutions:

1. Using [pthread for Windows](https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-libraries/winpthreads).
1. Using [mingw-std-threads](https://github.com/meganz/mingw-std-threads)

This PR chose the first solution because it makes this transparent at the cost of adding new layer between gRPC and Windows thread. For the second solution, all #include statement for C++ thread library should be replaced with the corresponding ones. e.g. `#include <thread>` to `#include <mingw.thread.h>`.