### PR TITLE
Add job config for MacOS bazel C/C++ tests on PRs

### DIFF
--- a/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_dbg.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_dbg.cfg
@@ -1,0 +1,36 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
+timeout_mins: 90
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}
+
+env_vars {
+  # flags will be passed to bazel invocation
+  key: "BAZEL_FLAGS"
+  value: "--config=dbg"
+}

--- a/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_opt.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_opt.cfg
@@ -1,0 +1,37 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
+timeout_mins: 90
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}
+
+env_vars {
+  # flags will be passed to bazel invocation
+  key: "BAZEL_FLAGS"
+  value: "--config=opt"
+}
+


### PR DESCRIPTION
Prerequisite for creating the kokoro jobs (I will create them once tests pass reliably on master).