### PR TITLE
Improve & update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -128,7 +128,7 @@ $ make
 
 If you want to build shared libraries (`.so` files), run `cmake` with `-DBUILD_SHARED_LIBS=ON`.
 
-## Building with cmake: Windows, Using Visual Studio 2015 or 2017 (can only build with OPENSSL_NO_ASM).
+## Building with CMake: Windows, Using Visual Studio 2015 or 2017 (can only build with OPENSSL_NO_ASM).
 
 When using the "Visual Studio" generator,
 cmake will generate a solution (`grpc.sln`) that contains a VS project for 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -143,7 +143,7 @@ you will be able to browse and build the code.
 > cmake --build . --config Release
 ```
 
-## Building with cmake: Windows, Using Ninja (faster build, supports boringssl's assembly optimizations).
+## Building with CMake: Windows, Using Ninja (faster build, supports boringssl's assembly optimizations).
 
 Please note that when using Ninja, you will still need Visual C++ (part of Visual Studio)
 installed to be able to compile the C/C++ sources.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -158,8 +158,7 @@ installed to be able to compile the C/C++ sources.
 
 ## Building with make (on UNIX systems)
 
-NOTE: `make` used to be gRPC's default build system, but we're no longer recommending it. You should use `bazel` or `cmake` instead.
-While still supported, make should only be used inside the gRPC repository (to satisfy some project-internal needs)
+NOTE: `make` used to be gRPC's default build system, but we're no longer recommending it. You should use `bazel` or `cmake` instead. The `Makefile` is only intended for internal usage and is not meant for public consumption.
 
 From the grpc repository root
 ```sh

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -116,7 +116,7 @@ $ bazel test --config=dbg //test/...
 NOTE: If you are gRPC maintainer and you have access to our test cluster, you should use the our [gRPC's Remote Execution environment](tools/remote_build/README.md)
 to get significant improvement to the build and test speed (and a bunch of other very useful features).
 
-## cmake: Linux/Unix, Using Make
+## CMake: Linux/Unix, Using Make
 
 Run from grpc directory after cloning the repo with --recursive or updating submodules.
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,9 @@
 gRPC C++ - Building from source
 ===========================
 
+This document has detailed instructions on how to build gRPC C++ from source. Note that it only covers the build of gRPC itself and is mostly meant for gRPC C++ contributors and/or power users.
+Other should follow the user instructions. See the [How to use](https://github.com/grpc/grpc/tree/master/src/cpp#to-start-using-grpc-c) instructions for guidance on how to add gRPC as a dependency to a C++ application (there are several ways and system wide installation is often not the best choice).
+
 # Pre-requisites
 
 ## Linux
@@ -14,7 +17,6 @@ If you plan to build from source and run tests, install the following as well:
  $ [sudo] apt-get install libgflags-dev libgtest-dev
  $ [sudo] apt-get install clang-5.0 libc++-dev
 ```
-Lastly, see the Protoc section below if you do not yet have the protoc compiler installed.
 
 ## MacOS
 
@@ -47,7 +49,6 @@ installed by `brew` is being used:
 ```sh
  $ LIBTOOL=glibtool LIBTOOLIZE=glibtoolize make
 ```
-Lastly, see the Protoc section below if you do not yet have the protoc compiler.
 
 ## Windows
 
@@ -57,25 +58,8 @@ To prepare for cmake + Microsoft Visual C++ compiler build
 - Install [CMake](https://cmake.org/download/).
 - Install [Active State Perl](https://www.activestate.com/activeperl/) (`choco install activeperl`) - *required by boringssl*
 - Install [Go](https://golang.org/dl/) (`choco install golang`) - *required by boringssl*
-- Install [yasm](http://yasm.tortall.net/) and add it to `PATH` (`choco install yasm`) - *required by boringssl*
+- Install [nasm](https://www.nasm.us/) and add it to `PATH` (`choco install nasm`) - *required by boringssl*
 - (Optional) Install [Ninja](https://ninja-build.org/) (`choco install ninja`)
-
-## Protoc
-
-By default gRPC uses [protocol buffers](https://github.com/google/protobuf),
-you will need the `protoc` compiler to generate stub server and client code.
-
-If you compile gRPC from source, as described below, the Makefile will
-automatically try compiling the `protoc` in third_party if you cloned the
-repository recursively and it detects that you do not already have 'protoc' compiler
-installed.
-
-If 'protoc' compiler has not been installed, following commands can be used for installation.
-
-```sh
-$ cd grpc/third_party/protobuf
-$ sudo make install   # 'make' should have been run by core grpc
-```
 
 # Clone the repository (including submodules)
 
@@ -100,37 +84,51 @@ repository at the latest stable version.
 > @rem To update submodules at later time, run "git submodule update --init"
 ```
 
+NOTE: The `bazel` build tool uses a different model for dependencies. You only need to worry about downloading submodules if you're building
+with something else than `bazel` (e.g. `cmake`).
+
 # Build from source
 
 In the C++ world, there's no "standard" build system that would work for in all supported use cases and on all supported platforms.
 Therefore, gRPC supports several major build systems, which should satisfy most users.
 
-Note that this section only covers the build of gRPC itself, not the installation. See the [How to use](https://github.com/grpc/grpc/tree/master/src/cpp#to-start-using-grpc-c) instructions
-for guidance on how to add gRPC as a dependency to a C++ application (there are several ways and system wide installation is often not the best choice).
+## Building with bazel (recommended)
 
-## make (on UNIX systems)
+Bazel is the primary build system for gRPC C++ and if you're comfortable with using bazel, we can certainly recommend it.
+Using bazel will give you the best developer experience as well as faster and cleaner builds.
 
-From the grpc repository root
-```sh
- $ make
-```
-NOTE: if you get an error on linux such as 'aclocal-1.15: command not found', which can happen if you ran 'make' before installing the pre-reqs, try the following:
-```sh
-$ git clean -f -d -x && git submodule foreach --recursive git clean -f -d -x
-$ [sudo] apt-get install build-essential autoconf libtool pkg-config
-$ make
-```
-
-## bazel
-
+You'll need `bazel` version `1.0.0` or higher to build gRPC.
 See [Installing Bazel](https://docs.bazel.build/versions/master/install.html) for instructions how to install bazel on your system.
+We support building with `bazel` on Linux, MacOS and Windows.
 
 From the grpc repository root
 ```
+# Build gRPC C++
 $ bazel build :all
 ```
 
-## cmake: Windows, Using Visual Studio 2015 or 2017 (can only build with OPENSSL_NO_ASM).
+```
+# Run all the C/C++ tests
+$ bazel test --config=dbg //test/...
+```
+
+NOTE: If you are gRPC maintainer and you have access to our test cluster, you should use the our [gRPC's Remote Execution environment](tools/remote_build/README.md)
+to get significant improvement to the build and test speed (and a bunch of other very useful features).
+
+## cmake: Linux/Unix, Using Make
+
+Run from grpc directory after cloning the repo with --recursive or updating submodules.
+```
+$ mkdir -p cmake/build
+$ cd cmake/build
+$ cmake ../..
+$ make
+```
+
+If you want to build shared libraries (`.so` files), run `cmake` with `-DBUILD_SHARED_LIBS=ON`.
+
+## Building with cmake: Windows, Using Visual Studio 2015 or 2017 (can only build with OPENSSL_NO_ASM).
+
 When using the "Visual Studio" generator,
 cmake will generate a solution (`grpc.sln`) that contains a VS project for 
 every target defined in `CMakeLists.txt` (+ few extra convenience projects
@@ -144,7 +142,8 @@ you will be able to browse and build the code.
 > cmake --build . --config Release
 ```
 
-## cmake: Windows, Using Ninja (faster build, supports boringssl's assembly optimizations).
+## Building with cmake: Windows, Using Ninja (faster build, supports boringssl's assembly optimizations).
+
 Please note that when using Ninja, you will still need Visual C++ (part of Visual Studio)
 installed to be able to compile the C/C++ sources.
 ```
@@ -155,3 +154,29 @@ installed to be able to compile the C/C++ sources.
 > cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release
 > cmake --build .
 ```
+
+## Building with make (on UNIX systems)
+
+NOTE: `make` used to be gRPC's default build system, but we're no longer recommending it. Use should use `bazel` or `cmake` instead.
+
+From the grpc repository root
+```sh
+ $ make
+```
+
+NOTE: if you get an error on linux such as 'aclocal-1.15: command not found', which can happen if you ran 'make' before installing the pre-reqs, try the following:
+```sh
+$ git clean -f -d -x && git submodule foreach --recursive git clean -f -d -x
+$ [sudo] apt-get install build-essential autoconf libtool pkg-config
+$ make
+```
+
+### A note on `protoc`
+
+By default gRPC uses [protocol buffers](https://github.com/google/protobuf),
+you will need the `protoc` compiler to generate stub server and client code.
+
+If you compile gRPC from source, as described below, the Makefile will
+automatically try compiling the `protoc` in third_party if you cloned the
+repository recursively and it detects that you do not already have 'protoc' compiler
+installed.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -90,7 +90,8 @@ with something else than `bazel` (e.g. `cmake`).
 # Build from source
 
 In the C++ world, there's no "standard" build system that would work for in all supported use cases and on all supported platforms.
-Therefore, gRPC supports several major build systems, which should satisfy most users.
+Therefore, gRPC supports several major build systems, which should satisfy most users. Depending on your needs
+we recommend building using `bazel` or `cmake`.
 
 ## Building with bazel (recommended)
 
@@ -157,7 +158,8 @@ installed to be able to compile the C/C++ sources.
 
 ## Building with make (on UNIX systems)
 
-NOTE: `make` used to be gRPC's default build system, but we're no longer recommending it. Use should use `bazel` or `cmake` instead.
+NOTE: `make` used to be gRPC's default build system, but we're no longer recommending it. You should use `bazel` or `cmake` instead.
+While still supported, make should only be used inside the gRPC repository (to satisfy some project-internal needs)
 
 From the grpc repository root
 ```sh

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -40,7 +40,7 @@ If your project is using cmake, there are several ways to add gRPC dependency.
 - via cmake's `ExternalProject_Add` using a technique called "superbuild". [Example](../../examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt)
 - add gRPC source tree to your project (preferably as a git submodule) and add it to your cmake project with `add_subdirectory`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
 
-If your project is not using cmake (e.g. you're using `make` directly), you can first install gRPC C++ using cmake,
+If your project is not using CMake (e.g. you're using `make` directly), you can first install gRPC C++ using CMake,
 and have your non-CMake project rely on the `pkgconfig` files which are provided by gRPC installation. [Example](../../test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh)
 
 ## make

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -38,7 +38,7 @@ support for crosscompiling and can be used for targeting Android platform.
 If your project is using cmake, there are several ways to add gRPC dependency.
 - install gRPC via cmake first and then locate it with `find_package(gRPC CONFIG)`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
 - via cmake's `ExternalProject_Add` using a technique called "superbuild". [Example](../../examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt)
-- add gRPC source tree to your project (preferably as a git submodule) and add it to your cmake project with `add_subdirectory`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
+- add gRPC source tree to your project (preferably as a git submodule) and add it to your CMake project with `add_subdirectory`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
 
 If your project is not using CMake (e.g. you're using `make` directly), you can first install gRPC C++ using CMake,
 and have your non-CMake project rely on the `pkgconfig` files which are provided by gRPC installation. [Example](../../test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh)

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -41,7 +41,7 @@ If your project is using cmake, there are several ways to add gRPC dependency.
 - add gRPC source tree to your project (preferably as a git submodule) and add it to your cmake project with `add_subdirectory`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
 
 If your project is not using cmake (e.g. you're using `make` directly), you can first install gRPC C++ using cmake,
-and have your non-cmake project rely on the `pkgconfig` files which are provided by gRPC installation. [Example](../../test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh)
+and have your non-CMake project rely on the `pkgconfig` files which are provided by gRPC installation. [Example](../../test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh)
 
 ## make
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -30,11 +30,23 @@ To add gRPC as a dependency in bazel:
   grpc_deps()
   ```
 
-NOTE: currently bazel is only supported for building gRPC on Linux.
+## cmake
+
+`cmake` is your best option if you cannot use bazel. It supports building on Linux, MacOS and Windows (official support) but also has a good chance of working on other platforms (no promises!). `cmake` has good
+support for crosscompiling and can be used for targeting Android platform.
+
+If your project is using cmake, there are several ways to add gRPC dependency.
+- install gRPC via cmake first and then locate it with `find_package(gRPC CONFIG)`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
+- via cmake's `ExternalProject_Add` using a technique called "superbuild". [Example](../../examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt)
+- add gRPC source tree to your project (preferably as a git submodule) and add it to your cmake project with `add_subdirectory`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
+
+If your project is not using cmake (e.g. you're using `make` directly), you can first install gRPC C++ using cmake,
+and have your non-cmake project rely on the `pkgconfig` files which are provided by gRPC installation. [Example](../../test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh)
 
 ## make
 
-Currently the default choice for building on UNIX based systems is `make`.
+The default choice for building on UNIX based systems used to be `make`, but we are no longer recommending it.
+You should use `bazel` or `cmake` instead.
 
 To install gRPC for C++ on your system using `make`, follow the [Building gRPC C++](../../BUILDING.md)
 instructions to build from source and then install locally using `make install`.
@@ -43,16 +55,6 @@ and the C++ gRPC plugin for `protoc`.
 
 WARNING: After installing with `make install` there is no easy way to uninstall, which can cause issues
 if you later want to remove the grpc and/or protobuf installation or upgrade to a newer version.
-
-## cmake
-
-`cmake` is the default build option on Windows, but also works on Linux, MacOS. `cmake` has good
-support for crosscompiling and can be used for targeting Android platform.
-
-If your project is using cmake, there are several ways to add gRPC dependency.
-- install gRPC via cmake first and then locate it with `find_package(gRPC CONFIG)`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
-- via cmake's `ExternalProject_Add` using a technique called "superbuild". [Example](../../examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt)
-- add gRPC source tree to your project (preferably as a git submodule) and add it to your cmake project with `add_subdirectory`. [Example](../../examples/cpp/helloworld/CMakeLists.txt)
 
 ## Packaging systems
 


### PR DESCRIPTION
The documentation is slightly out of date.

Main changes:
- recommend bazel for all contributors (and link to bazel RBE instructions for maintainers).
- cmake is preferred over make
- make is now our legacy build system, we continue investments into bazel and cmake and standalone `make` support will eventually go away.


