### PR TITLE
Implement metadata in __call__ for aio unaryunary call

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 cimport cpython
+
+from collections import namedtuple
+
 import grpc
 
 _EMPTY_FLAGS = 0
 _EMPTY_MASK = 0
+
+UnaryUnaryOpsResult = namedtuple('UnaryUnaryOpsResult',
+                                 ['initial_metadata', 'message', 'code', 'details', 'trailing_metadata'])
 
 
 cdef class _AioCall:
@@ -139,11 +145,12 @@ cdef class _AioCall:
             self._destroy_grpc_call()
 
         if receive_status_on_client_operation.code() == StatusCode.ok:
-            return receive_initial_metadata_operation.initial_metadata(), \
-                   receive_message_operation.message(), \
-                   receive_status_on_client_operation.code(), \
-                   receive_status_on_client_operation.details(), \
-                   receive_status_on_client_operation.trailing_metadata()
+            return UnaryUnaryOpsResult(
+                initial_metadata=receive_initial_metadata_operation.initial_metadata(),
+                message=receive_message_operation.message(),
+                code=receive_status_on_client_operation.code(),
+                details=receive_status_on_client_operation.details(),
+                trailing_metadata=receive_status_on_client_operation.trailing_metadata())
 
         raise AioRpcError(
             receive_initial_metadata_operation.initial_metadata(),

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -26,6 +26,6 @@ cdef class AioChannel:
     def close(self):
         grpc_channel_destroy(self.channel)
 
-    async def unary_unary(self, method, request, timeout, cancel_status):
+    async def unary_unary(self, method, request, timeout, metadata, cancel_status):
         call = _AioCall(self)
-        return await call.unary_unary(method, request, timeout, cancel_status)
+        return await call.unary_unary(method, request, timeout, metadata, cancel_status)

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -250,7 +250,6 @@ class Call:
 
         try:
             ops_result = yield from self._call.__await__()
-            initial_metadata, message, code, details, trailing_metadata = ops_result
         except cygrpc.AioRpcError as aio_rpc_error:
             self._state = _RpcState.ABORT
             self._code = _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[
@@ -269,10 +268,11 @@ class Call:
             self._exception = cancel_error
             raise
 
-        self._response = _common.deserialize(message,
+        self._response = _common.deserialize(ops_result.message,
                                              self._response_deserializer)
-        self._code = _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[code]
+        self._code = _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[ops_result.code]
+        self._details = ops_result.details
         self._state = _RpcState.FINISHED
-        self._initial_metadata = initial_metadata
-        self._trailing_metadata = trailing_metadata
+        self._initial_metadata = ops_result.initial_metadata
+        self._trailing_metadata = ops_result.trailing_metadata
         return self._response

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -73,9 +73,6 @@ class UnaryUnaryMultiCallable:
             metadata, status code, and details.
         """
 
-        if metadata:
-            raise NotImplementedError("TODO: metadata not implemented yet")
-
         if credentials:
             raise NotImplementedError("TODO: credentials not implemented yet")
 
@@ -92,7 +89,7 @@ class UnaryUnaryMultiCallable:
         aio_cancel_status = cygrpc.AioCancelStatus()
         aio_call = asyncio.ensure_future(
             self._channel.unary_unary(self._method, serialized_request, timeout,
-                                      aio_cancel_status),
+                                      metadata, aio_cancel_status),
             loop=self._loop)
         return Call(aio_call, self._response_deserializer, aio_cancel_status)
 

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -19,10 +19,27 @@ from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2_grpc
 from tests.unit.framework.common import test_constants
 
+_INITIAL_METADATA_KEY = "initial-md-key"
+_TRAILING_METADATA_KEY = "trailing-md-key-bin"
+
+
+def _maybe_echo_metadata(servicer_context):
+    """Copies metadata from request to response if it is present."""
+    invocation_metadata = dict(servicer_context.invocation_metadata())
+    if _INITIAL_METADATA_KEY in invocation_metadata:
+        initial_metadatum = (_INITIAL_METADATA_KEY,
+                             invocation_metadata[_INITIAL_METADATA_KEY])
+        servicer_context.send_initial_metadata((initial_metadatum,))
+    if _TRAILING_METADATA_KEY in invocation_metadata:
+        trailing_metadatum = (_TRAILING_METADATA_KEY,
+                              invocation_metadata[_TRAILING_METADATA_KEY])
+        servicer_context.set_trailing_metadata((trailing_metadatum,))
+
 
 class _TestServiceServicer(test_pb2_grpc.TestServiceServicer):
 
     async def UnaryCall(self, request, context):
+        # _maybe_echo_metadata(context)
         return messages_pb2.SimpleResponse()
 
     async def EmptyCall(self, request, context):

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -143,7 +143,7 @@ class TestCall(AioTestBase):
                     response_deserializer=messages_pb2.SimpleResponse.FromString
                 )
                 call = hi(messages_pb2.SimpleRequest())
-                self.assertEqual(await call.details(), None)
+                self.assertEqual(await call.details(), '')
 
         self.loop.run_until_complete(coro())
 


### PR DESCRIPTION
Implement `metadata` for  `Aio  UnaryUnary Call` .

Fix https://github.com/grpc/grpc/issues/20144