### PR TITLE
Link to libatomic when necessary (e.g. on armv6l)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ else()
 endif()
 
 include(cmake/address_sorting.cmake)
+include(cmake/atomic.cmake)
 include(cmake/benchmark.cmake)
 include(cmake/cares.cmake)
 include(cmake/gflags.cmake)
@@ -1510,6 +1511,7 @@ target_link_libraries(grpc
   ${_gRPC_CARES_LIBRARIES}
   ${_gRPC_ADDRESS_SORTING_LIBRARIES}
   ${_gRPC_UPB_LIBRARIES}
+  ${_gRPC_ATOMIC_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr
   upb

--- a/cmake/atomic.cmake
+++ b/cmake/atomic.cmake
@@ -1,0 +1,39 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+set(ATOMIC_TEST_CXX_SOURCE "
+#include <atomic>
+#include <cstdint>
+std::atomic<std::int64_t> v;
+int main() {
+  return v;
+}")
+
+# Determine if libatomic is needed for C++ atomics.
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_FLAGS -std=c++11)
+check_cxx_source_compiles("${ATOMIC_TEST_CXX_SOURCE}" HAVE_ATOMICS_WITHOUT_LIBATOMIC)
+if(NOT HAVE_ATOMICS_WITHOUT_LIBATOMIC)
+    set(CMAKE_REQUIRED_LIBRARIES atomic)
+    check_cxx_source_compiles("${ATOMIC_TEST_CXX_SOURCE}" HAVE_ATOMICS_WITH_LIBATOMIC)
+    if(HAVE_ATOMICS_WITH_LIBATOMIC)
+        set(_gRPC_ATOMIC_LIBRARIES atomic)
+    else()
+        message(FATAL_ERROR "Could not determine support for atomic operations.")
+    endif()
+endif()
+cmake_pop_check_state()

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -48,6 +48,8 @@
       deps.append("${_gRPC_CARES_LIBRARIES}")
       deps.append("${_gRPC_ADDRESS_SORTING_LIBRARIES}")
       deps.append("${_gRPC_UPB_LIBRARIES}")
+    if target_dict['name'] == 'grpc':
+      deps.append("${_gRPC_ATOMIC_LIBRARIES}")
     deps.append("${_gRPC_ALLTARGETS_LIBRARIES}")
     for d in target_dict.get('deps', []):
       if d == 'benchmark':
@@ -240,6 +242,7 @@
   endif()
 
   include(cmake/address_sorting.cmake)
+  include(cmake/atomic.cmake)
   include(cmake/benchmark.cmake)
   include(cmake/cares.cmake)
   include(cmake/gflags.cmake)


### PR DESCRIPTION
Building grpc 1.25.0 on armv6l fails with the following error:
```
Scanning dependencies of target check_epollexclusive
[ 92%] Building C object CMakeFiles/check_epollexclusive.dir/test/build/check_epollexclusive.c.o
[ 92%] Linking C executable check_epollexclusive
/nix/store/scws8zwg1qnz313ra29y4jnxw95dl3vg-binutils-2.31.1/bin/ld: libgrpc.so: undefined reference to `__atomic_exchange_8'
/nix/store/scws8zwg1qnz313ra29y4jnxw95dl3vg-binutils-2.31.1/bin/ld: libgrpc.so: undefined reference to `__atomic_load_8'
/nix/store/scws8zwg1qnz313ra29y4jnxw95dl3vg-binutils-2.31.1/bin/ld: libgrpc.so: undefined reference to `__atomic_store_8'
/nix/store/scws8zwg1qnz313ra29y4jnxw95dl3vg-binutils-2.31.1/bin/ld: libgrpc.so: undefined reference to `__atomic_fetch_add_8'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/check_epollexclusive.dir/build.make:91: check_epollexclusive] Error 1
make[1]: *** [CMakeFiles/Makefile2:368: CMakeFiles/check_epollexclusive.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```

This is due to the fact that C++ atomics require linking to libatomic on armv6l. This PR adds a check to determine whether linking to libatomic is necessary. A similar fix was added to the gRPC Python library in #20414.
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
