### PR TITLE
Add move assignment method to Optional<>

### DIFF
--- a/src/core/lib/gprpp/optional.h
+++ b/src/core/lib/gprpp/optional.h
@@ -19,6 +19,10 @@
 #ifndef GRPC_CORE_LIB_GPRPP_OPTIONAL_H
 #define GRPC_CORE_LIB_GPRPP_OPTIONAL_H
 
+#include <grpc/support/port_platform.h>
+
+#include <utility>
+
 namespace grpc_core {
 
 /* A make-shift alternative for absl::Optional. This can be removed in favor of
@@ -27,8 +31,14 @@ template <typename T>
 class Optional {
  public:
   Optional() : value_() {}
+
   void set(const T& val) {
     value_ = val;
+    set_ = true;
+  }
+
+  void set(T&& val) {
+    value_ = std::move(val);
     set_ = true;
   }
 


### PR DESCRIPTION
Needed in #20638.

BTW, actually, `absl::Optional<>` doesn't have any `set()` method.