### PR TITLE
Remove namespace experimental from namespace grpc_impl for callback API functions/structs

### DIFF
--- a/include/grpcpp/generic/generic_stub_impl.h
+++ b/include/grpcpp/generic/generic_stub_impl.h
@@ -28,8 +28,6 @@
 #include <grpcpp/support/client_callback_impl.h>
 #include <grpcpp/support/status.h>
 
-#include <functional>
-
 namespace grpc {
 
 typedef ::grpc_impl::ClientAsyncReaderWriter<ByteBuffer, ByteBuffer>
@@ -92,15 +90,15 @@ class GenericStub final {
     void UnaryCall(grpc_impl::ClientContext* context,
                    const grpc::string& method, const grpc::ByteBuffer* request,
                    grpc::ByteBuffer* response,
-                   grpc_impl::experimental::ClientUnaryReactor* reactor);
+                   grpc_impl::ClientUnaryReactor* reactor);
 
     /// Setup a call to a named method \a method using \a context and tied to
     /// \a reactor . Like any other bidi streaming RPC, it will not be activated
     /// until StartCall is invoked on its reactor.
     void PrepareBidiStreamingCall(
         grpc_impl::ClientContext* context, const grpc::string& method,
-        grpc_impl::experimental::ClientBidiReactor<grpc::ByteBuffer,
-                                                   grpc::ByteBuffer>* reactor);
+        grpc_impl::ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>*
+            reactor);
 
    private:
     GenericStub* stub_;

--- a/include/grpcpp/impl/codegen/async_generic_service.h
+++ b/include/grpcpp/impl/codegen/async_generic_service.h
@@ -93,10 +93,10 @@ namespace experimental {
 /// invoked on a CallbackGenericService. It is just a ServerBidi reactor with
 /// ByteBuffer arguments.
 using ServerGenericBidiReactor =
-    ::grpc_impl::experimental::ServerBidiReactor<ByteBuffer, ByteBuffer>;
+    ::grpc_impl::ServerBidiReactor<ByteBuffer, ByteBuffer>;
 
 class GenericCallbackServerContext final
-    : public ::grpc_impl::experimental::CallbackServerContext {
+    : public ::grpc_impl::CallbackServerContext {
  public:
   const grpc::string& method() const { return method_; }
   const grpc::string& host() const { return host_; }
@@ -108,7 +108,7 @@ class GenericCallbackServerContext final
   void Clear() {
     method_.clear();
     host_.clear();
-    ::grpc_impl::experimental::CallbackServerContext::Clear();
+    ::grpc_impl::CallbackServerContext::Clear();
   }
 
   grpc::string method_;
@@ -143,7 +143,7 @@ class CallbackGenericService {
   Handler() {
     return new ::grpc_impl::internal::CallbackBidiHandler<ByteBuffer,
                                                           ByteBuffer>(
-        [this](::grpc_impl::experimental::CallbackServerContext* ctx) {
+        [this](::grpc_impl::CallbackServerContext* ctx) {
           return CreateReactor(static_cast<GenericCallbackServerContext*>(ctx));
         });
   }

--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -25,30 +25,25 @@ namespace grpc {
 namespace experimental {
 
 template <class Response>
-using ClientCallbackReader =
-    ::grpc_impl::experimental::ClientCallbackReader<Response>;
+using ClientCallbackReader = ::grpc_impl::ClientCallbackReader<Response>;
 
 template <class Request>
-using ClientCallbackWriter =
-    ::grpc_impl::experimental::ClientCallbackWriter<Request>;
+using ClientCallbackWriter = ::grpc_impl::ClientCallbackWriter<Request>;
 
 template <class Request, class Response>
 using ClientCallbackReaderWriter =
-    ::grpc_impl::experimental::ClientCallbackReaderWriter<Request, Response>;
+    ::grpc_impl::ClientCallbackReaderWriter<Request, Response>;
 
 template <class Response>
-using ClientReadReactor =
-    ::grpc_impl::experimental::ClientReadReactor<Response>;
+using ClientReadReactor = ::grpc_impl::ClientReadReactor<Response>;
 
 template <class Request>
-using ClientWriteReactor =
-    ::grpc_impl::experimental::ClientWriteReactor<Request>;
+using ClientWriteReactor = ::grpc_impl::ClientWriteReactor<Request>;
 
 template <class Request, class Response>
-using ClientBidiReactor =
-    ::grpc_impl::experimental::ClientBidiReactor<Request, Response>;
+using ClientBidiReactor = ::grpc_impl::ClientBidiReactor<Request, Response>;
 
-typedef ::grpc_impl::experimental::ClientUnaryReactor ClientUnaryReactor;
+typedef ::grpc_impl::ClientUnaryReactor ClientUnaryReactor;
 }  // namespace experimental
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/client_callback_impl.h
+++ b/include/grpcpp/impl/codegen/client_callback_impl.h
@@ -103,8 +103,6 @@ class CallbackUnaryCallImpl {
 };
 }  // namespace internal
 
-namespace experimental {
-
 // Forward declarations
 template <class Request, class Response>
 class ClientBidiReactor;
@@ -404,8 +402,6 @@ inline void ClientCallbackUnary::BindReactor(ClientUnaryReactor* reactor) {
   reactor->BindCall(this);
 }
 
-}  // namespace experimental
-
 namespace internal {
 
 // Forward declare factory classes for friendship
@@ -418,7 +414,7 @@ class ClientCallbackWriterFactory;
 
 template <class Request, class Response>
 class ClientCallbackReaderWriterImpl
-    : public experimental::ClientCallbackReaderWriter<Request, Response> {
+    : public ClientCallbackReaderWriter<Request, Response> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
@@ -562,9 +558,9 @@ class ClientCallbackReaderWriterImpl
  private:
   friend class ClientCallbackReaderWriterFactory<Request, Response>;
 
-  ClientCallbackReaderWriterImpl(
-      grpc::internal::Call call, ::grpc_impl::ClientContext* context,
-      experimental::ClientBidiReactor<Request, Response>* reactor)
+  ClientCallbackReaderWriterImpl(grpc::internal::Call call,
+                                 ::grpc_impl::ClientContext* context,
+                                 ClientBidiReactor<Request, Response>* reactor)
       : context_(context),
         call_(call),
         reactor_(reactor),
@@ -574,7 +570,7 @@ class ClientCallbackReaderWriterImpl
 
   ::grpc_impl::ClientContext* const context_;
   grpc::internal::Call call_;
-  experimental::ClientBidiReactor<Request, Response>* const reactor_;
+  ClientBidiReactor<Request, Response>* const reactor_;
 
   grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpRecvInitialMetadata>
@@ -612,11 +608,10 @@ class ClientCallbackReaderWriterImpl
 template <class Request, class Response>
 class ClientCallbackReaderWriterFactory {
  public:
-  static void Create(
-      ::grpc::ChannelInterface* channel,
-      const ::grpc::internal::RpcMethod& method,
-      ::grpc_impl::ClientContext* context,
-      experimental::ClientBidiReactor<Request, Response>* reactor) {
+  static void Create(::grpc::ChannelInterface* channel,
+                     const ::grpc::internal::RpcMethod& method,
+                     ::grpc_impl::ClientContext* context,
+                     ClientBidiReactor<Request, Response>* reactor) {
     grpc::internal::Call call =
         channel->CreateCall(method, context, channel->CallbackCQ());
 
@@ -629,8 +624,7 @@ class ClientCallbackReaderWriterFactory {
 };
 
 template <class Response>
-class ClientCallbackReaderImpl
-    : public experimental::ClientCallbackReader<Response> {
+class ClientCallbackReaderImpl : public ClientCallbackReader<Response> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
@@ -716,7 +710,7 @@ class ClientCallbackReaderImpl
   ClientCallbackReaderImpl(::grpc::internal::Call call,
                            ::grpc_impl::ClientContext* context,
                            Request* request,
-                           experimental::ClientReadReactor<Response>* reactor)
+                           ClientReadReactor<Response>* reactor)
       : context_(context), call_(call), reactor_(reactor) {
     this->BindReactor(reactor);
     // TODO(vjpai): don't assert
@@ -726,7 +720,7 @@ class ClientCallbackReaderImpl
 
   ::grpc_impl::ClientContext* const context_;
   grpc::internal::Call call_;
-  experimental::ClientReadReactor<Response>* const reactor_;
+  ClientReadReactor<Response>* const reactor_;
 
   grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
@@ -757,7 +751,7 @@ class ClientCallbackReaderFactory {
                      const ::grpc::internal::RpcMethod& method,
                      ::grpc_impl::ClientContext* context,
                      const Request* request,
-                     experimental::ClientReadReactor<Response>* reactor) {
+                     ClientReadReactor<Response>* reactor) {
     grpc::internal::Call call =
         channel->CreateCall(method, context, channel->CallbackCQ());
 
@@ -769,8 +763,7 @@ class ClientCallbackReaderFactory {
 };
 
 template <class Request>
-class ClientCallbackWriterImpl
-    : public experimental::ClientCallbackWriter<Request> {
+class ClientCallbackWriterImpl : public ClientCallbackWriter<Request> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
@@ -896,7 +889,7 @@ class ClientCallbackWriterImpl
   ClientCallbackWriterImpl(::grpc::internal::Call call,
                            ::grpc_impl::ClientContext* context,
                            Response* response,
-                           experimental::ClientWriteReactor<Request>* reactor)
+                           ClientWriteReactor<Request>* reactor)
       : context_(context),
         call_(call),
         reactor_(reactor),
@@ -908,7 +901,7 @@ class ClientCallbackWriterImpl
 
   ::grpc_impl::ClientContext* const context_;
   grpc::internal::Call call_;
-  experimental::ClientWriteReactor<Request>* const reactor_;
+  ClientWriteReactor<Request>* const reactor_;
 
   grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpRecvInitialMetadata>
@@ -947,7 +940,7 @@ class ClientCallbackWriterFactory {
   static void Create(::grpc::ChannelInterface* channel,
                      const ::grpc::internal::RpcMethod& method,
                      ::grpc_impl::ClientContext* context, Response* response,
-                     experimental::ClientWriteReactor<Request>* reactor) {
+                     ClientWriteReactor<Request>* reactor) {
     grpc::internal::Call call =
         channel->CreateCall(method, context, channel->CallbackCQ());
 
@@ -958,7 +951,7 @@ class ClientCallbackWriterFactory {
   }
 };
 
-class ClientCallbackUnaryImpl final : public experimental::ClientCallbackUnary {
+class ClientCallbackUnaryImpl final : public ClientCallbackUnary {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
@@ -1015,8 +1008,7 @@ class ClientCallbackUnaryImpl final : public experimental::ClientCallbackUnary {
   template <class Request, class Response>
   ClientCallbackUnaryImpl(::grpc::internal::Call call,
                           ::grpc_impl::ClientContext* context, Request* request,
-                          Response* response,
-                          experimental::ClientUnaryReactor* reactor)
+                          Response* response, ClientUnaryReactor* reactor)
       : context_(context), call_(call), reactor_(reactor) {
     this->BindReactor(reactor);
     // TODO(vjpai): don't assert
@@ -1028,7 +1020,7 @@ class ClientCallbackUnaryImpl final : public experimental::ClientCallbackUnary {
 
   ::grpc_impl::ClientContext* const context_;
   grpc::internal::Call call_;
-  experimental::ClientUnaryReactor* const reactor_;
+  ClientUnaryReactor* const reactor_;
 
   grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
@@ -1055,7 +1047,7 @@ class ClientCallbackUnaryFactory {
                      const ::grpc::internal::RpcMethod& method,
                      ::grpc_impl::ClientContext* context,
                      const Request* request, Response* response,
-                     experimental::ClientUnaryReactor* reactor) {
+                     ClientUnaryReactor* reactor) {
     grpc::internal::Call call =
         channel->CreateCall(method, context, channel->CallbackCQ());
 

--- a/include/grpcpp/impl/codegen/client_context_impl.h
+++ b/include/grpcpp/impl/codegen/client_context_impl.h
@@ -107,10 +107,8 @@ class ClientAsyncReaderWriter;
 template <class R>
 class ClientAsyncResponseReader;
 
-namespace experimental {
 class ServerContextBase;
 class CallbackServerContext;
-}  // namespace experimental
 
 /// Options for \a ClientContext::FromServerContext specifying which traits from
 /// the \a ServerContext to propagate (copy) from it into a new \a
@@ -202,7 +200,7 @@ class ClientContext {
       const grpc_impl::ServerContext& server_context,
       PropagationOptions options = PropagationOptions());
   static std::unique_ptr<ClientContext> FromCallbackServerContext(
-      const grpc_impl::experimental::CallbackServerContext& server_context,
+      const grpc_impl::CallbackServerContext& server_context,
       PropagationOptions options = PropagationOptions());
 
   /// Add the (\a meta_key, \a meta_value) pair to the metadata associated with
@@ -484,7 +482,7 @@ class ClientContext {
   void SendCancelToInterceptors();
 
   static std::unique_ptr<ClientContext> FromInternalServerContext(
-      const grpc_impl::experimental::ServerContextBase& server_context,
+      const grpc_impl::ServerContextBase& server_context,
       PropagationOptions options);
 
   bool initial_metadata_received_;

--- a/include/grpcpp/impl/codegen/completion_queue_impl.h
+++ b/include/grpcpp/impl/codegen/completion_queue_impl.h
@@ -56,9 +56,7 @@ template <class R>
 class ServerReader;
 template <class W>
 class ServerWriter;
-namespace experimental {
 class ServerContextBase;
-}  // namespace experimental
 namespace internal {
 template <class W, class R>
 class ServerReaderWriterBody;
@@ -277,7 +275,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   template <::grpc::StatusCode code>
   friend class ::grpc_impl::internal::ErrorMethodHandler;
   friend class ::grpc_impl::Server;
-  friend class ::grpc_impl::experimental::ServerContextBase;
+  friend class ::grpc_impl::ServerContextBase;
   friend class ::grpc::ServerInterface;
   template <class InputMessage, class OutputMessage>
   friend class ::grpc::internal::BlockingUnaryCallImpl;

--- a/include/grpcpp/impl/codegen/method_handler_impl.h
+++ b/include/grpcpp/impl/codegen/method_handler_impl.h
@@ -345,8 +345,7 @@ template <::grpc::StatusCode code>
 class ErrorMethodHandler : public ::grpc::internal::MethodHandler {
  public:
   template <class T>
-  static void FillOps(::grpc_impl::experimental::ServerContextBase* context,
-                      T* ops) {
+  static void FillOps(::grpc_impl::ServerContextBase* context, T* ops) {
     ::grpc::Status status(code, "");
     if (!context->sent_initial_metadata_) {
       ops->SendInitialMetadata(&context->initial_metadata_,

--- a/include/grpcpp/impl/codegen/rpc_service_method.h
+++ b/include/grpcpp/impl/codegen/rpc_service_method.h
@@ -32,9 +32,7 @@
 #include <grpcpp/impl/codegen/status.h>
 
 namespace grpc_impl {
-namespace experimental {
 class ServerContextBase;
-}
 }  // namespace grpc_impl
 
 namespace grpc {
@@ -54,8 +52,7 @@ class MethodHandler {
     /// \param requester : used only by the callback API. It is a function
     ///        called by the RPC Controller to request another RPC (and also
     ///        to set up the state required to make that request possible)
-    HandlerParameter(Call* c,
-                     ::grpc_impl::experimental::ServerContextBase* context,
+    HandlerParameter(Call* c, ::grpc_impl::ServerContextBase* context,
                      void* req, Status req_status, void* handler_data,
                      std::function<void()> requester)
         : call(c),
@@ -66,7 +63,7 @@ class MethodHandler {
           call_requester(std::move(requester)) {}
     ~HandlerParameter() {}
     Call* const call;
-    ::grpc_impl::experimental::ServerContextBase* const server_context;
+    ::grpc_impl::ServerContextBase* const server_context;
     void* const request;
     const Status status;
     void* const internal_data;

--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -24,17 +24,15 @@
 namespace grpc {
 namespace experimental {
 template <class Request>
-using ServerReadReactor = ::grpc_impl::experimental::ServerReadReactor<Request>;
+using ServerReadReactor = ::grpc_impl::ServerReadReactor<Request>;
 
 template <class Response>
-using ServerWriteReactor =
-    ::grpc_impl::experimental::ServerWriteReactor<Response>;
+using ServerWriteReactor = ::grpc_impl::ServerWriteReactor<Response>;
 
 template <class Request, class Response>
-using ServerBidiReactor =
-    ::grpc_impl::experimental::ServerBidiReactor<Request, Response>;
+using ServerBidiReactor = ::grpc_impl::ServerBidiReactor<Request, Response>;
 
-using ServerUnaryReactor = ::grpc_impl::experimental::ServerUnaryReactor;
+using ServerUnaryReactor = ::grpc_impl::ServerUnaryReactor;
 
 }  // namespace experimental
 }  // namespace grpc

--- a/include/grpcpp/impl/codegen/server_callback_impl.h
+++ b/include/grpcpp/impl/codegen/server_callback_impl.h
@@ -136,8 +136,6 @@ class DefaultMessageHolder
 
 }  // namespace internal
 
-namespace experimental {
-
 // Forward declarations
 class ServerUnaryReactor;
 template <class Request>
@@ -723,8 +721,6 @@ class ServerUnaryReactor : public internal::ServerReactor {
   ::grpc::Status status_wanted_ /* GUARDED_BY(writer_mu_) */;
 };
 
-}  // namespace experimental
-
 namespace internal {
 
 template <class Base>
@@ -734,17 +730,15 @@ class FinishOnlyReactor : public Base {
   void OnDone() override { this->~FinishOnlyReactor(); }
 };
 
-using UnimplementedUnaryReactor =
-    FinishOnlyReactor<experimental::ServerUnaryReactor>;
+using UnimplementedUnaryReactor = FinishOnlyReactor<ServerUnaryReactor>;
 template <class Request>
-using UnimplementedReadReactor =
-    FinishOnlyReactor<experimental::ServerReadReactor<Request>>;
+using UnimplementedReadReactor = FinishOnlyReactor<ServerReadReactor<Request>>;
 template <class Response>
 using UnimplementedWriteReactor =
-    FinishOnlyReactor<experimental::ServerWriteReactor<Response>>;
+    FinishOnlyReactor<ServerWriteReactor<Response>>;
 template <class Request, class Response>
 using UnimplementedBidiReactor =
-    FinishOnlyReactor<experimental::ServerBidiReactor<Request, Response>>;
+    FinishOnlyReactor<ServerBidiReactor<Request, Response>>;
 
 }  // namespace internal
 }  // namespace grpc_impl

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -27,8 +27,8 @@ typedef ::grpc_impl::ServerContext ServerContext;
 
 namespace experimental {
 
-typedef ::grpc_impl::experimental::ServerContextBase ServerContextBase;
-typedef ::grpc_impl::experimental::CallbackServerContext CallbackServerContext;
+typedef ::grpc_impl::ServerContextBase ServerContextBase;
+typedef ::grpc_impl::CallbackServerContext CallbackServerContext;
 
 }  // namespace experimental
 }  // namespace grpc

--- a/include/grpcpp/impl/codegen/server_context_impl.h
+++ b/include/grpcpp/impl/codegen/server_context_impl.h
@@ -112,7 +112,6 @@ class DefaultReactorTestPeer;
 }  // namespace grpc
 
 namespace grpc_impl {
-namespace experimental {
 
 /// Base class of ServerContext. Experimental until callback API is final.
 class ServerContextBase {
@@ -297,7 +296,7 @@ class ServerContextBase {
   /// from the method handler.
   ///
   /// WARNING: This is experimental API and could be changed or removed.
-  ::grpc_impl::experimental::ServerUnaryReactor* DefaultReactor() {
+  ::grpc_impl::ServerUnaryReactor* DefaultReactor() {
     auto reactor = &default_reactor_;
     default_reactor_used_.store(true, std::memory_order_relaxed);
     return reactor;
@@ -415,7 +414,7 @@ class ServerContextBase {
   ::grpc::experimental::ServerRpcInfo* rpc_info_;
   ::grpc::experimental::RpcAllocatorState* message_allocator_state_ = nullptr;
 
-  class Reactor : public experimental::ServerUnaryReactor {
+  class Reactor : public ServerUnaryReactor {
    public:
     void OnCancel() override {}
     void OnDone() override {}
@@ -434,8 +433,7 @@ class ServerContextBase {
   }
   ::grpc::Status test_status() const { return test_unary_->status(); }
 
-  class TestServerCallbackUnary
-      : public ::grpc_impl::experimental::ServerCallbackUnary {
+  class TestServerCallbackUnary : public ::grpc_impl::ServerCallbackUnary {
    public:
     TestServerCallbackUnary(ServerContextBase* ctx,
                             std::function<void(::grpc::Status)> func)
@@ -460,7 +458,7 @@ class ServerContextBase {
       return reactor_;
     }
 
-    ::grpc_impl::experimental::ServerUnaryReactor* const reactor_;
+    ::grpc_impl::ServerUnaryReactor* const reactor_;
     std::atomic_bool status_set_{false};
     ::grpc::Status status_;
     const std::function<void(::grpc::Status s)> func_;
@@ -470,8 +468,6 @@ class ServerContextBase {
   std::atomic_bool default_reactor_used_{false};
   std::unique_ptr<TestServerCallbackUnary> test_unary_;
 };
-
-}  // namespace experimental
 
 /// A ServerContext or CallbackServerContext allows the code implementing a
 /// service handler to:
@@ -489,47 +485,45 @@ class ServerContextBase {
 /// to a \a grpc::ServerBuilder, via \a ServerBuilder::AddChannelArgument.
 ///
 /// \warning ServerContext instances should \em not be reused across rpcs.
-class ServerContext : public experimental::ServerContextBase {
+class ServerContext : public ServerContextBase {
  public:
   ServerContext() {}  // for async calls
 
-  using experimental::ServerContextBase::AddInitialMetadata;
-  using experimental::ServerContextBase::AddTrailingMetadata;
-  using experimental::ServerContextBase::IsCancelled;
-  using experimental::ServerContextBase::SetLoadReportingCosts;
-  using experimental::ServerContextBase::TryCancel;
-  using experimental::ServerContextBase::auth_context;
-  using experimental::ServerContextBase::c_call;
-  using experimental::ServerContextBase::census_context;
-  using experimental::ServerContextBase::client_metadata;
-  using experimental::ServerContextBase::compression_algorithm;
-  using experimental::ServerContextBase::compression_level;
-  using experimental::ServerContextBase::compression_level_set;
-  using experimental::ServerContextBase::deadline;
-  using experimental::ServerContextBase::peer;
-  using experimental::ServerContextBase::raw_deadline;
-  using experimental::ServerContextBase::set_compression_algorithm;
-  using experimental::ServerContextBase::set_compression_level;
+  using ServerContextBase::AddInitialMetadata;
+  using ServerContextBase::AddTrailingMetadata;
+  using ServerContextBase::IsCancelled;
+  using ServerContextBase::SetLoadReportingCosts;
+  using ServerContextBase::TryCancel;
+  using ServerContextBase::auth_context;
+  using ServerContextBase::c_call;
+  using ServerContextBase::census_context;
+  using ServerContextBase::client_metadata;
+  using ServerContextBase::compression_algorithm;
+  using ServerContextBase::compression_level;
+  using ServerContextBase::compression_level_set;
+  using ServerContextBase::deadline;
+  using ServerContextBase::peer;
+  using ServerContextBase::raw_deadline;
+  using ServerContextBase::set_compression_algorithm;
+  using ServerContextBase::set_compression_level;
 
   // Sync/CQ-based Async ServerContext only
-  using experimental::ServerContextBase::AsyncNotifyWhenDone;
+  using ServerContextBase::AsyncNotifyWhenDone;
 
  private:
   // Constructor for internal use by server only
   friend class ::grpc_impl::Server;
   ServerContext(gpr_timespec deadline, grpc_metadata_array* arr)
-      : experimental::ServerContextBase(deadline, arr) {}
+      : ServerContextBase(deadline, arr) {}
 
   // CallbackServerContext only
-  using experimental::ServerContextBase::DefaultReactor;
-  using experimental::ServerContextBase::GetRpcAllocatorState;
+  using ServerContextBase::DefaultReactor;
+  using ServerContextBase::GetRpcAllocatorState;
 
   /// Prevent copying.
   ServerContext(const ServerContext&) = delete;
   ServerContext& operator=(const ServerContext&) = delete;
 };
-
-namespace experimental {
 
 class CallbackServerContext : public ServerContextBase {
  public:
@@ -568,21 +562,19 @@ class CallbackServerContext : public ServerContextBase {
   CallbackServerContext& operator=(const CallbackServerContext&) = delete;
 };
 
-}  // namespace experimental
 }  // namespace grpc_impl
 
-static_assert(std::is_base_of<::grpc_impl::experimental::ServerContextBase,
+static_assert(std::is_base_of<::grpc_impl::ServerContextBase,
                               ::grpc_impl::ServerContext>::value,
               "improper base class");
-static_assert(
-    std::is_base_of<::grpc_impl::experimental::ServerContextBase,
-                    ::grpc_impl::experimental::CallbackServerContext>::value,
-    "improper base class");
-static_assert(sizeof(::grpc_impl::experimental::ServerContextBase) ==
+static_assert(std::is_base_of<::grpc_impl::ServerContextBase,
+                              ::grpc_impl::CallbackServerContext>::value,
+              "improper base class");
+static_assert(sizeof(::grpc_impl::ServerContextBase) ==
                   sizeof(::grpc_impl::ServerContext),
               "wrong size");
-static_assert(sizeof(::grpc_impl::experimental::ServerContextBase) ==
-                  sizeof(::grpc_impl::experimental::CallbackServerContext),
+static_assert(sizeof(::grpc_impl::ServerContextBase) ==
+                  sizeof(::grpc_impl::CallbackServerContext),
               "wrong size");
 
 #endif  // GRPCPP_IMPL_CODEGEN_SERVER_CONTEXT_IMPL_H

--- a/include/grpcpp/impl/codegen/server_interceptor.h
+++ b/include/grpcpp/impl/codegen/server_interceptor.h
@@ -27,9 +27,7 @@
 #include <grpcpp/impl/codegen/string_ref.h>
 
 namespace grpc_impl {
-namespace experimental {
 class ServerContextBase;
-}
 }  // namespace grpc_impl
 
 namespace grpc {
@@ -82,7 +80,7 @@ class ServerRpcInfo {
 
   /// Return a pointer to the underlying ServerContext structure associated
   /// with the RPC to support features that apply to it
-  grpc_impl::experimental::ServerContextBase* server_context() { return ctx_; }
+  grpc_impl::ServerContextBase* server_context() { return ctx_; }
 
  private:
   static_assert(Type::UNARY ==
@@ -98,8 +96,8 @@ class ServerRpcInfo {
                     static_cast<Type>(internal::RpcMethod::BIDI_STREAMING),
                 "violated expectation about Type enum");
 
-  ServerRpcInfo(grpc_impl::experimental::ServerContextBase* ctx,
-                const char* method, internal::RpcMethod::RpcType type)
+  ServerRpcInfo(grpc_impl::ServerContextBase* ctx, const char* method,
+                internal::RpcMethod::RpcType type)
       : ctx_(ctx), method_(method), type_(static_cast<Type>(type)) {}
 
   // Runs interceptor at pos \a pos.
@@ -129,14 +127,14 @@ class ServerRpcInfo {
     }
   }
 
-  grpc_impl::experimental::ServerContextBase* ctx_ = nullptr;
+  grpc_impl::ServerContextBase* ctx_ = nullptr;
   const char* method_ = nullptr;
   const Type type_;
   std::atomic<intptr_t> ref_{1};
   std::vector<std::unique_ptr<experimental::Interceptor>> interceptors_;
 
   friend class internal::InterceptorBatchMethodsImpl;
-  friend class grpc_impl::experimental::ServerContextBase;
+  friend class grpc_impl::ServerContextBase;
 };
 
 }  // namespace experimental

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -89,8 +89,7 @@ void ClientContext::set_credentials(
 }
 
 std::unique_ptr<ClientContext> ClientContext::FromInternalServerContext(
-    const grpc_impl::experimental::ServerContextBase& context,
-    PropagationOptions options) {
+    const grpc_impl::ServerContextBase& context, PropagationOptions options) {
   std::unique_ptr<ClientContext> ctx(new ClientContext);
   ctx->propagate_from_call_ = context.call_;
   ctx->propagation_options_ = options;
@@ -104,7 +103,7 @@ std::unique_ptr<ClientContext> ClientContext::FromServerContext(
 }
 
 std::unique_ptr<ClientContext> ClientContext::FromCallbackServerContext(
-    const grpc_impl::experimental::CallbackServerContext& server_context,
+    const grpc_impl::CallbackServerContext& server_context,
     PropagationOptions options) {
   return FromInternalServerContext(server_context, options);
 }

--- a/src/cpp/client/generic_stub.cc
+++ b/src/cpp/client/generic_stub.cc
@@ -80,8 +80,7 @@ void GenericStub::experimental_type::UnaryCall(
 
 void GenericStub::experimental_type::PrepareBidiStreamingCall(
     grpc::ClientContext* context, const grpc::string& method,
-    experimental::ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>*
-        reactor) {
+    ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>* reactor) {
   internal::ClientCallbackReaderWriterFactory<
       grpc::ByteBuffer,
       grpc::ByteBuffer>::Create(stub_->channel_.get(),

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -36,7 +36,6 @@
 #include "src/core/lib/surface/call.h"
 
 namespace grpc_impl {
-namespace experimental {
 
 // CompletionOp
 
@@ -379,5 +378,4 @@ void ServerContextBase::SetLoadReportingCosts(
   }
 }
 
-}  // namespace experimental
 }  // namespace grpc_impl


### PR DESCRIPTION
This is a step toward de-experimentalizing the gRPC C++ callback API, but this is _not_ an API change because grpc_impl is not considered API.
