### PR TITLE
[Aio] Support credentials for unary calls

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pxd.pxi
@@ -28,4 +28,4 @@ cdef class _AioCall(GrpcCallWrapper):
         # because Core is holding a pointer for the callback handler.
         bint _is_locally_cancelled
 
-    cdef grpc_call* _create_grpc_call(self, object timeout, bytes method) except *
+    cdef void _create_grpc_call(self, object timeout, bytes method, CallCredentials credentials) except *

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -14,7 +14,7 @@
 
 
 cdef class CallbackFailureHandler:
-    
+
     def __cinit__(self,
                   str core_function_name,
                   object error_details,
@@ -78,7 +78,7 @@ cdef class CallbackCompletionQueue:
 
     cdef grpc_completion_queue* c_ptr(self):
         return self._cq
-    
+
     async def shutdown(self):
         grpc_completion_queue_shutdown(self._cq)
         await self._shutdown_completed

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -52,10 +52,33 @@ def insecure_channel(
     Returns:
       A Channel.
     """
+    return Channel(target, () if options is None else options, None,
+                   compression, interceptors)
+
+
+def secure_channel(
+        target: Text,
+        credentials: grpc.ChannelCredentials,
+        options: Optional[list] = None,
+        compression: Optional[grpc.Compression] = None,
+        interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]] = None):
+    """Creates a secure asynchronous Channel to a server.
+
+    Args:
+      target: The server address.
+      credentials: A ChannelCredentials instance.
+      options: An optional list of key-value pairs (channel args
+        in gRPC Core runtime) to configure the channel.
+      compression: An optional value indicating the compression method to be
+        used over the lifetime of the channel. This is an EXPERIMENTAL option.
+      interceptors: An optional sequence of interceptors that will be executed for
+        any call executed with this channel.
+
+    Returns:
+      An aio.Channel.
+    """
     return Channel(target, () if options is None else options,
-                   None,
-                   compression,
-                   interceptors=interceptors)
+                   credentials._credentials, compression, interceptors)
 
 
 ###################################  __all__  #################################
@@ -64,4 +87,4 @@ __all__ = ('AioRpcError', 'RpcContext', 'Call', 'UnaryUnaryCall',
            'UnaryStreamCall', 'init_grpc_aio', 'Channel',
            'UnaryUnaryMultiCallable', 'ClientCallDetails',
            'UnaryUnaryClientInterceptor', 'InterceptedUnaryUnaryCall',
-           'insecure_channel', 'server', 'Server')
+           'insecure_channel', 'secure_channel', 'server')

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -85,13 +85,9 @@ class UnaryUnaryMultiCallable:
         if metadata:
             raise NotImplementedError("TODO: metadata not implemented yet")
 
-        if credentials:
-            raise NotImplementedError("TODO: credentials not implemented yet")
-
         if wait_for_ready:
             raise NotImplementedError(
                 "TODO: wait_for_ready not implemented yet")
-
         if compression:
             raise NotImplementedError("TODO: compression not implemented yet")
 
@@ -99,6 +95,7 @@ class UnaryUnaryMultiCallable:
             return UnaryUnaryCall(
                 request,
                 _timeout_to_deadline(timeout),
+                credentials,
                 self._channel,
                 self._method,
                 self._request_serializer,
@@ -109,6 +106,7 @@ class UnaryUnaryMultiCallable:
                 self._interceptors,
                 request,
                 timeout,
+                credentials,
                 self._channel,
                 self._method,
                 self._request_serializer,
@@ -158,9 +156,6 @@ class UnaryStreamMultiCallable:
         if metadata:
             raise NotImplementedError("TODO: metadata not implemented yet")
 
-        if credentials:
-            raise NotImplementedError("TODO: credentials not implemented yet")
-
         if wait_for_ready:
             raise NotImplementedError(
                 "TODO: wait_for_ready not implemented yet")
@@ -173,6 +168,7 @@ class UnaryStreamMultiCallable:
         return UnaryStreamCall(
             request,
             deadline,
+            credentials,
             self._channel,
             self._method,
             self._request_serializer,
@@ -204,9 +200,6 @@ class Channel:
             intercepting any RPC executed with that channel.
         """
 
-        if credentials:
-            raise NotImplementedError("TODO: credentials not implemented yet")
-
         if compression:
             raise NotImplementedError("TODO: compression not implemented yet")
 
@@ -228,7 +221,8 @@ class Channel:
                     "UnaryUnaryClientInterceptors, the following are invalid: {}"\
                     .format(invalid_interceptors))
 
-        self._channel = cygrpc.AioChannel(_common.encode(target), options)
+        self._channel = cygrpc.AioChannel(_common.encode(target), options,
+                                          credentials)
 
     def unary_unary(
             self,

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -6,6 +6,7 @@
   "unit.channel_argument_test.TestChannelArgument",
   "unit.channel_test.TestChannel",
   "unit.init_test.TestInsecureChannel",
+  "unit.init_test.TestSecureChannel",
   "unit.interceptor_test.TestInterceptedUnaryUnaryCall",
   "unit.interceptor_test.TestUnaryUnaryClientInterceptor",
   "unit.server_test.TestServer"

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -14,6 +14,7 @@
 """Tests behavior of the grpc.aio.Channel class."""
 
 import logging
+import os
 import threading
 import unittest
 
@@ -82,6 +83,8 @@ class TestChannel(AioTestBase):
             self.assertIsNotNone(
                 exception_context.exception.trailing_metadata())
 
+    @unittest.skipIf(os.name == 'nt',
+            'TODO: https://github.com/grpc/grpc/issues/21658')
     async def test_unary_call_does_not_times_out(self):
         async with aio.insecure_channel(self._server_target) as channel:
             hi = channel.unary_unary(

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -84,7 +84,7 @@ class TestChannel(AioTestBase):
                 exception_context.exception.trailing_metadata())
 
     @unittest.skipIf(os.name == 'nt',
-            'TODO: https://github.com/grpc/grpc/issues/21658')
+                     'TODO: https://github.com/grpc/grpc/issues/21658')
     async def test_unary_call_does_not_times_out(self):
         async with aio.insecure_channel(self._server_target) as channel:
             hi = channel.unary_unary(

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -14,6 +14,8 @@
 import logging
 import unittest
 
+import grpc
+
 from grpc.experimental import aio
 from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
@@ -26,6 +28,22 @@ class TestInsecureChannel(AioTestBase):
 
         channel = aio.insecure_channel(server_target)
         self.assertIsInstance(channel, aio.Channel)
+
+
+class TestSecureChannel(AioTestBase):
+    """Test a secure channel connected to a secure server"""
+
+    def test_secure_channel(self):
+
+        async def coro():
+            server_target, _ = await start_test_server(secure=True)  # pylint: disable=unused-variable
+            credentials = grpc.local_channel_credentials(
+                grpc.LocalConnectionType.LOCAL_TCP)
+            secure_channel = aio.secure_channel(server_target, credentials)
+
+            self.assertIsInstance(secure_channel, aio.Channel)
+
+        self.loop.run_until_complete(coro())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add support for the ``credentials`` parameter in the asynchronous unary_unary call.
Fixes partially the https://github.com/grpc/grpc/issues/20532

Results of the aio Python tests
```
Testing gRPC Python...
SUCCESS       _sanity._sanity_test.AioSanityTest.testTestsJsonUpToDate
SUCCESS       unit.call_test.TestAioRpcError.test_attributes
SUCCESS       unit.call_test.TestCall.test_call_code_awaitable
SUCCESS       unit.call_test.TestCall.test_call_details_awaitable
SUCCESS       unit.call_test.TestCall.test_call_ok
SUCCESS       unit.call_test.TestCall.test_call_rpc_error
SUCCESS       unit.call_test.TestCall.test_cancel
SUCCESS       unit.call_test.TestCall.test_credentials
SUCCESS       unit.channel_test.TestChannel.test_async_context
SKIP          unit.channel_test.TestChannel.test_call_to_the_void
SUCCESS       unit.channel_test.TestChannel.test_unary_call_times_out
SUCCESS       unit.channel_test.TestChannel.test_unary_unary
SUCCESS       unit.init_test.TestInsecureChannel.test_insecure_channel
SUCCESS       unit.init_test.TestSecureChannel.test_secure_channel
SUCCESS       unit.server_test.TestServer.test_concurrent_graceful_shutdown
SUCCESS       unit.server_test.TestServer.test_concurrent_graceful_shutdown_immediate
SUCCESS       unit.server_test.TestServer.test_graceful_shutdown_failed
SUCCESS       unit.server_test.TestServer.test_graceful_shutdown_success
SUCCESS       unit.server_test.TestServer.test_shutdown
SUCCESS       unit.server_test.TestServer.test_shutdown_after_call
SKIP          unit.server_test.TestServer.test_shutdown_before_call
SUCCESS       unit.server_test.TestServer.test_unary_unary
20 tests finished:
	20 successful
	0 unsuccessful
	2 skipped
	0 expected failures
	0 unexpected successes
Interrupted Tests:
	[]

Errors/Failures:

Unexpected successes: []
```
@lidizheng @gnossen 
