### PR TITLE
Add more non-experimental content under an ifdef

### DIFF
--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -22,6 +22,31 @@
 #include <grpcpp/impl/codegen/client_callback_impl.h>
 
 namespace grpc {
+
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+template <class Response>
+using ClientCallbackReader = ::grpc_impl::ClientCallbackReader<Response>;
+
+template <class Request>
+using ClientCallbackWriter = ::grpc_impl::ClientCallbackWriter<Request>;
+
+template <class Request, class Response>
+using ClientCallbackReaderWriter =
+    ::grpc_impl::ClientCallbackReaderWriter<Request, Response>;
+
+template <class Response>
+using ClientReadReactor = ::grpc_impl::ClientReadReactor<Response>;
+
+template <class Request>
+using ClientWriteReactor = ::grpc_impl::ClientWriteReactor<Request>;
+
+template <class Request, class Response>
+using ClientBidiReactor = ::grpc_impl::ClientBidiReactor<Request, Response>;
+
+typedef ::grpc_impl::ClientUnaryReactor ClientUnaryReactor;
+#endif
+
+// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
 namespace experimental {
 
 template <class Response>
@@ -44,6 +69,7 @@ template <class Request, class Response>
 using ClientBidiReactor = ::grpc_impl::ClientBidiReactor<Request, Response>;
 
 typedef ::grpc_impl::ClientUnaryReactor ClientUnaryReactor;
+
 }  // namespace experimental
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/message_allocator.h
+++ b/include/grpcpp/impl/codegen/message_allocator.h
@@ -20,7 +20,9 @@
 #define GRPCPP_IMPL_CODEGEN_MESSAGE_ALLOCATOR_H
 
 namespace grpc {
+#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
 namespace experimental {
+#endif
 
 // NOTE: This is an API for advanced users who need custom allocators.
 // Per rpc struct for the allocator. This is the interface to return to user.
@@ -67,7 +69,25 @@ class MessageAllocator {
   virtual MessageHolder<RequestT, ResponseT>* AllocateMessages() = 0;
 };
 
+#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
 }  // namespace experimental
+#endif
+
+// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+namespace experimental {
+
+using ::grpc::RpcAllocatorState;
+
+template <typename RequestT, typename ResponseT>
+using MessageHolder = ::grpc::MessageHolder<RequestT, ResponseT>;
+
+template <typename RequestT, typename ResponseT>
+using MessageAllocator = ::grpc::MessageAllocator<RequestT, ResponseT>;
+
+}  // namespace experimental
+#endif
+
 }  // namespace grpc
 
 #endif  // GRPCPP_IMPL_CODEGEN_MESSAGE_ALLOCATOR_H

--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -22,7 +22,23 @@
 #include <grpcpp/impl/codegen/server_callback_impl.h>
 
 namespace grpc {
+
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+template <class Request>
+using ServerReadReactor = ::grpc_impl::ServerReadReactor<Request>;
+
+template <class Response>
+using ServerWriteReactor = ::grpc_impl::ServerWriteReactor<Response>;
+
+template <class Request, class Response>
+using ServerBidiReactor = ::grpc_impl::ServerBidiReactor<Request, Response>;
+
+using ServerUnaryReactor = ::grpc_impl::ServerUnaryReactor;
+#endif
+
+// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
 namespace experimental {
+
 template <class Request>
 using ServerReadReactor = ::grpc_impl::ServerReadReactor<Request>;
 

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -25,6 +25,12 @@ namespace grpc {
 
 typedef ::grpc_impl::ServerContext ServerContext;
 
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+typedef ::grpc_impl::ServerContextBase ServerContextBase;
+typedef ::grpc_impl::CallbackServerContext CallbackServerContext;
+#endif
+
+// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
 namespace experimental {
 
 typedef ::grpc_impl::ServerContextBase ServerContextBase;

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -111,6 +111,7 @@ class UnimplementedAsyncRequestContext {
 // de-experimentalized fully.
 #ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
 using ::grpc::experimental::CallbackGenericService;
+using ::grpc::experimental::CallbackServerContext;
 using ::grpc::experimental::GenericCallbackServerContext;
 #endif
 
@@ -551,9 +552,9 @@ class Server::CallbackRequestBase : public grpc::internal::CompletionQueueTag {
 template <class ServerContextType>
 class Server::CallbackRequest final : public Server::CallbackRequestBase {
  public:
-  static_assert(std::is_base_of<grpc::experimental::CallbackServerContext,
-                                ServerContextType>::value,
-                "ServerContextType must be derived from CallbackServerContext");
+  static_assert(
+      std::is_base_of<grpc::CallbackServerContext, ServerContextType>::value,
+      "ServerContextType must be derived from CallbackServerContext");
 
   // The constructor needs to know the server for this callback request and its
   // index in the server's request count array to allow for proper dynamic
@@ -807,8 +808,8 @@ class Server::CallbackRequest final : public Server::CallbackRequestBase {
 };
 
 template <>
-bool Server::CallbackRequest<grpc::experimental::CallbackServerContext>::
-    FinalizeResult(void** /*tag*/, bool* /*status*/) {
+bool Server::CallbackRequest<grpc::CallbackServerContext>::FinalizeResult(
+    void** /*tag*/, bool* /*status*/) {
   return false;
 }
 
@@ -827,8 +828,8 @@ bool Server::CallbackRequest<
 }
 
 template <>
-const char* Server::CallbackRequest<
-    grpc::experimental::CallbackServerContext>::method_name() const {
+const char* Server::CallbackRequest<grpc::CallbackServerContext>::method_name()
+    const {
   return method_->name();
 }
 
@@ -1140,7 +1141,7 @@ bool Server::RegisterService(const grpc::string* host, grpc::Service* service) {
       // TODO(vjpai): Register these dynamically based on need
       for (int i = 0; i < DEFAULT_CALLBACK_REQS_PER_METHOD; i++) {
         callback_reqs_to_start_.push_back(
-            new CallbackRequest<grpc::experimental::CallbackServerContext>(
+            new CallbackRequest<grpc::CallbackServerContext>(
                 this, method_index, method.get(), method_registration_tag));
       }
       // Enqueue it so that it will be Request'ed later after all request


### PR DESCRIPTION
Add non-experimental versions of all reactors, server context, and message allocators. Note that the old ones under experimental:: are not removed from any use cases for the time being; this is a purely-additive change for all users (even those that get the macro).