### PR TITLE
[Exposing ALTS Context 2/2] Utility Wrapper Class

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -429,6 +429,23 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpc++_alts",
+    srcs = [
+        "src/cpp/common/alts_context.cc",
+    ],
+    hdrs = [
+        "include/grpcpp/alts_context.h",
+    ],
+    language = "c++",
+    standalone = True,
+    deps = [
+        "alts_upb",
+        "alts_util",
+        "grpc++",
+    ],
+)
+
+grpc_cc_library(
     name = "grpc_csharp_ext",
     srcs = [
         "src/csharp/ext/grpc_csharp_ext.c",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,6 +627,7 @@ if(gRPC_BUILD_TESTS)
   if(_gRPC_PLATFORM_LINUX)
     add_dependencies(buildtests_cxx alts_concurrent_connectivity_test)
   endif()
+  add_dependencies(buildtests_cxx alts_context_test)
   add_dependencies(buildtests_cxx alts_counter_test)
   add_dependencies(buildtests_cxx alts_crypt_test)
   add_dependencies(buildtests_cxx alts_crypter_test)
@@ -3813,6 +3814,66 @@ endforeach()
 
 if(gRPC_INSTALL)
   install(TARGETS grpc++ EXPORT gRPCTargets
+    RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
+  )
+endif()
+
+
+add_library(grpc++_alts
+  src/cpp/common/alts_context.cc
+)
+
+set_target_properties(grpc++_alts PROPERTIES
+  VERSION ${gRPC_CPP_VERSION}
+  SOVERSION ${gRPC_CPP_SOVERSION}
+)
+
+if(WIN32 AND MSVC)
+  set_target_properties(grpc++_alts PROPERTIES COMPILE_PDB_NAME "grpc++_alts"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  if(gRPC_INSTALL)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_alts.pdb
+      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+    )
+  endif()
+endif()
+
+target_include_directories(grpc++_alts
+  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    ${_gRPC_PROTO_GENS_DIR}
+)
+target_link_libraries(grpc++_alts
+  ${_gRPC_BASELIB_LIBRARIES}
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++
+)
+
+foreach(_hdr
+  include/grpcpp/alts_context.h
+  include/grpcpp/impl/codegen/security/auth_context.h
+)
+  string(REPLACE "include/" "" _path ${_hdr})
+  get_filename_component(_path ${_path} PATH)
+  install(FILES ${_hdr}
+    DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
+  )
+endforeach()
+
+
+if(gRPC_INSTALL)
+  install(TARGETS grpc++_alts EXPORT gRPCTargets
     RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
     LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
@@ -9839,6 +9900,46 @@ if(_gRPC_PLATFORM_LINUX)
 
 
 endif()
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(alts_context_test
+  test/cpp/common/alts_context_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(alts_context_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(alts_context_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++_test_util
+  grpc_test_util
+  grpc++_alts
+  grpc++
+  grpc
+  gpr
+  grpc++_test_config
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+
 endif()
 if(gRPC_BUILD_TESTS)
 

--- a/Makefile
+++ b/Makefile
@@ -1151,6 +1151,7 @@ uri_fuzzer_test: $(BINDIR)/$(CONFIG)/uri_fuzzer_test
 uri_parser_test: $(BINDIR)/$(CONFIG)/uri_parser_test
 alarm_test: $(BINDIR)/$(CONFIG)/alarm_test
 alts_concurrent_connectivity_test: $(BINDIR)/$(CONFIG)/alts_concurrent_connectivity_test
+alts_context_test: $(BINDIR)/$(CONFIG)/alts_context_test
 alts_counter_test: $(BINDIR)/$(CONFIG)/alts_counter_test
 alts_crypt_test: $(BINDIR)/$(CONFIG)/alts_crypt_test
 alts_crypter_test: $(BINDIR)/$(CONFIG)/alts_crypter_test
@@ -1411,14 +1412,14 @@ static: static_c static_cxx
 
 static_c: pc_c pc_c_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_cronet.a $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.a $(LIBDIR)/$(CONFIG)/libupb.a
 
-static_cxx: pc_cxx pc_cxx_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
+static_cxx: pc_cxx pc_cxx_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
 
 static_csharp: static_c  $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a
 
 shared: shared_c shared_cxx
 
 shared_c: pc_c pc_c_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_cronet$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
-shared_cxx: pc_cxx pc_cxx_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
+shared_cxx: pc_cxx pc_cxx_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 
 shared_csharp: shared_c  $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CSHARP).$(SHARED_EXT_CSHARP)
 grpc_csharp_ext: shared_csharp
@@ -1630,6 +1631,7 @@ ifeq ($(EMBED_OPENSSL),true)
 buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/alarm_test \
   $(BINDIR)/$(CONFIG)/alts_concurrent_connectivity_test \
+  $(BINDIR)/$(CONFIG)/alts_context_test \
   $(BINDIR)/$(CONFIG)/alts_counter_test \
   $(BINDIR)/$(CONFIG)/alts_crypt_test \
   $(BINDIR)/$(CONFIG)/alts_crypter_test \
@@ -1804,6 +1806,7 @@ else
 buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/alarm_test \
   $(BINDIR)/$(CONFIG)/alts_concurrent_connectivity_test \
+  $(BINDIR)/$(CONFIG)/alts_context_test \
   $(BINDIR)/$(CONFIG)/alts_counter_test \
   $(BINDIR)/$(CONFIG)/alts_crypt_test \
   $(BINDIR)/$(CONFIG)/alts_crypter_test \
@@ -2240,6 +2243,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/alarm_test || ( echo test alarm_test failed ; exit 1 )
 	$(E) "[RUN]     Testing alts_concurrent_connectivity_test"
 	$(Q) $(BINDIR)/$(CONFIG)/alts_concurrent_connectivity_test || ( echo test alts_concurrent_connectivity_test failed ; exit 1 )
+	$(E) "[RUN]     Testing alts_context_test"
+	$(Q) $(BINDIR)/$(CONFIG)/alts_context_test || ( echo test alts_context_test failed ; exit 1 )
 	$(E) "[RUN]     Testing alts_counter_test"
 	$(Q) $(BINDIR)/$(CONFIG)/alts_counter_test || ( echo test alts_counter_test failed ; exit 1 )
 	$(E) "[RUN]     Testing alts_crypt_test"
@@ -2590,6 +2595,8 @@ strip-static_cxx: static_cxx
 ifeq ($(CONFIG),opt)
 	$(E) "[STRIP]   Stripping libgrpc++.a"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc++.a
+	$(E) "[STRIP]   Stripping libgrpc++_alts.a"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a
 	$(E) "[STRIP]   Stripping libgrpc++_error_details.a"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a
 	$(E) "[STRIP]   Stripping libgrpc++_reflection.a"
@@ -2620,6 +2627,8 @@ strip-shared_cxx: shared_cxx
 ifeq ($(CONFIG),opt)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
+	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
@@ -3195,6 +3204,9 @@ install-static_cxx: static_cxx strip-static_cxx install-pkg-config_cxx
 	$(E) "[INSTALL] Installing libgrpc++.a"
 	$(Q) $(INSTALL) -d $(prefix)/lib
 	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpc++.a $(prefix)/lib/libgrpc++.a
+	$(E) "[INSTALL] Installing libgrpc++_alts.a"
+	$(Q) $(INSTALL) -d $(prefix)/lib
+	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(prefix)/lib/libgrpc++_alts.a
 	$(E) "[INSTALL] Installing libgrpc++_error_details.a"
 	$(Q) $(INSTALL) -d $(prefix)/lib
 	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(prefix)/lib/libgrpc++_error_details.a
@@ -3281,6 +3293,15 @@ ifeq ($(SYSTEM),MINGW32)
 else ifneq ($(SYSTEM),Darwin)
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpc++.so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpc++.so
+endif
+	$(E) "[INSTALL] Installing $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
+	$(Q) $(INSTALL) -d $(prefix)/lib
+	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
+ifeq ($(SYSTEM),MINGW32)
+	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP)-dll.a $(prefix)/lib/libgrpc++_alts.a
+else ifneq ($(SYSTEM),Darwin)
+	$(Q) ln -sf $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpc++_alts.so.1
+	$(Q) ln -sf $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpc++_alts.so
 endif
 	$(E) "[INSTALL] Installing $(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
 	$(Q) $(INSTALL) -d $(prefix)/lib
@@ -6215,6 +6236,76 @@ endif
 ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
 -include $(LIBGRPC++_OBJS:.o=.dep)
+endif
+endif
+
+
+LIBGRPC++_ALTS_SRC = \
+    src/cpp/common/alts_context.cc \
+
+PUBLIC_HEADERS_CXX += \
+    include/grpcpp/alts_context.h \
+    include/grpcpp/impl/codegen/security/auth_context.h \
+
+LIBGRPC++_ALTS_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC++_ALTS_SRC))))
+
+
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure libraries if you don't have OpenSSL.
+
+$(LIBDIR)/$(CONFIG)/libgrpc++_alts.a: openssl_dep_error
+
+$(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): openssl_dep_error
+
+else
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build a C++ library if you don't have protobuf - a bit overreached, but still okay.
+
+$(LIBDIR)/$(CONFIG)/libgrpc++_alts.a: protobuf_dep_error
+
+$(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): protobuf_dep_error
+
+else
+
+$(LIBDIR)/$(CONFIG)/libgrpc++_alts.a: $(ZLIB_DEP) $(OPENSSL_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(UPB_DEP)  $(PROTOBUF_DEP) $(LIBGRPC++_ALTS_OBJS)  $(LIBGPR_OBJS)  $(ZLIB_MERGE_OBJS)  $(CARES_MERGE_OBJS)  $(ADDRESS_SORTING_MERGE_OBJS)  $(UPB_MERGE_OBJS) 
+	$(E) "[AR]      Creating $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a
+	$(Q) $(AR) $(AROPTS) $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(LIBGRPC++_ALTS_OBJS)  $(LIBGPR_OBJS)  $(ZLIB_MERGE_OBJS)  $(CARES_MERGE_OBJS)  $(ADDRESS_SORTING_MERGE_OBJS)  $(UPB_MERGE_OBJS) 
+ifeq ($(SYSTEM),Darwin)
+	$(Q) ranlib -no_warning_for_no_symbols $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a
+endif
+
+
+
+ifeq ($(SYSTEM),MINGW32)
+$(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ALTS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(UPB_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(OPENSSL_DEP)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(UPB_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll
+else
+$(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ALTS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(UPB_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(OPENSSL_DEP)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+ifeq ($(SYSTEM),Darwin)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(UPB_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++
+else
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_alts.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(UPB_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++
+	$(Q) ln -sf $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).so.1
+	$(Q) ln -sf $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).so
+endif
+endif
+
+endif
+
+endif
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(LIBGRPC++_ALTS_OBJS:.o=.dep)
 endif
 endif
 
@@ -13710,6 +13801,49 @@ endif
 endif
 $(OBJDIR)/$(CONFIG)/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.o: $(GENDIR)/test/core/tsi/alts/fake_handshaker/handshaker.pb.cc $(GENDIR)/test/core/tsi/alts/fake_handshaker/handshaker.grpc.pb.cc $(GENDIR)/test/core/tsi/alts/fake_handshaker/transport_security_common.pb.cc $(GENDIR)/test/core/tsi/alts/fake_handshaker/transport_security_common.grpc.pb.cc
 $(OBJDIR)/$(CONFIG)/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.o: $(GENDIR)/test/core/tsi/alts/fake_handshaker/handshaker.pb.cc $(GENDIR)/test/core/tsi/alts/fake_handshaker/handshaker.grpc.pb.cc $(GENDIR)/test/core/tsi/alts/fake_handshaker/transport_security_common.pb.cc $(GENDIR)/test/core/tsi/alts/fake_handshaker/transport_security_common.grpc.pb.cc
+
+
+ALTS_CONTEXT_TEST_SRC = \
+    test/cpp/common/alts_context_test.cc \
+
+ALTS_CONTEXT_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(ALTS_CONTEXT_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/alts_context_test: openssl_dep_error
+
+else
+
+
+
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.5.0+.
+
+$(BINDIR)/$(CONFIG)/alts_context_test: protobuf_dep_error
+
+else
+
+$(BINDIR)/$(CONFIG)/alts_context_test: $(PROTOBUF_DEP) $(ALTS_CONTEXT_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_config.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) $(ALTS_CONTEXT_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_config.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/alts_context_test
+
+endif
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/cpp/common/alts_context_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_config.a
+
+deps_alts_context_test: $(ALTS_CONTEXT_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(ALTS_CONTEXT_TEST_OBJS:.o=.dep)
+endif
+endif
 
 
 ALTS_COUNTER_TEST_SRC = \
@@ -23215,6 +23349,7 @@ src/core/tsi/ssl_transport_security.cc: $(OPENSSL_DEP)
 src/core/tsi/transport_security.cc: $(OPENSSL_DEP)
 src/core/tsi/transport_security_grpc.cc: $(OPENSSL_DEP)
 src/cpp/client/secure_credentials.cc: $(OPENSSL_DEP)
+src/cpp/common/alts_context.cc: $(OPENSSL_DEP)
 src/cpp/common/auth_property_iterator.cc: $(OPENSSL_DEP)
 src/cpp/common/secure_auth_context.cc: $(OPENSSL_DEP)
 src/cpp/common/secure_channel_arguments.cc: $(OPENSSL_DEP)

--- a/build.yaml
+++ b/build.yaml
@@ -1879,6 +1879,17 @@ libs:
   - grpc++_codegen_proto
   - grpc++_codegen_base_src
   secure: check
+- name: grpc++_alts
+  build: all
+  language: c++
+  public_headers:
+  - include/grpcpp/alts_context.h
+  - include/grpcpp/impl/codegen/security/auth_context.h
+  src:
+  - src/cpp/common/alts_context.cc
+  deps:
+  - grpc++
+  baselib: true
 - name: grpc++_core_stats
   build: private
   language: c++
@@ -3904,6 +3915,19 @@ targets:
   - grpc++_test_config
   platforms:
   - linux
+- name: alts_context_test
+  build: test
+  language: c++
+  src:
+  - test/cpp/common/alts_context_test.cc
+  deps:
+  - grpc++_test_util
+  - grpc_test_util
+  - grpc++_alts
+  - grpc++
+  - grpc
+  - gpr
+  - grpc++_test_config
 - name: alts_counter_test
   build: test
   language: c++

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -1750,6 +1750,16 @@
       ],
     },
     {
+      'target_name': 'grpc++_alts',
+      'type': 'static_library',
+      'dependencies': [
+        'grpc++',
+      ],
+      'sources': [
+        'src/cpp/common/alts_context.cc',
+      ],
+    },
+    {
       'target_name': 'grpc++_core_stats',
       'type': 'static_library',
       'dependencies': [

--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -105,6 +105,15 @@ typedef enum {
   GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
 } grpc_ssl_client_certificate_request_type;
 
+/* Security levels of grpc transport security */
+typedef enum {
+  GRPC_SECURITY_MIN,
+  GRPC_SECURITY_NONE = GRPC_SECURITY_MIN,
+  GRPC_INTEGRITY_ONLY,
+  GRPC_PRIVACY_AND_INTEGRITY,
+  GRPC_SECURITY_MAX = GRPC_PRIVACY_AND_INTEGRITY,
+} grpc_security_level;
+
 /**
  * Type of local connections for which local channel/server credentials will be
  * applied. It supports UDS and local TCP connections.

--- a/include/grpcpp/alts_context.h
+++ b/include/grpcpp/alts_context.h
@@ -19,6 +19,7 @@
 #ifndef GRPCPP_ALTS_CONTEXT_H
 #define GRPCPP_ALTS_CONTEXT_H
 
+#include <grpc/grpc_security_constants.h>
 #include <grpcpp/impl/codegen/security/auth_context.h>
 
 #include <memory>
@@ -27,12 +28,6 @@
 #include "src/proto/grpc/gcp/altscontext.upb.h"
 
 namespace grpc {
-
-enum SecurityLevel {
-  SECURITY_NONE = 0,
-  INTEGRITY_ONLY = 1,
-  INTEGRITY_AND_PRIVACY = 2
-};
 
 typedef struct Versions {
   int major_version;
@@ -57,7 +52,7 @@ class AltsContext {
   std::string record_protocol() const;
   std::string peer_service_account() const;
   std::string local_service_account() const;
-  SecurityLevel security_level() const;
+  grpc_security_level security_level() const;
   RpcProtocolVersions peer_rpc_versions() const;
 
  private:
@@ -66,7 +61,7 @@ class AltsContext {
   std::string record_protocol_;
   std::string peer_service_account_;
   std::string local_service_account_;
-  SecurityLevel security_level_ = SECURITY_NONE;
+  grpc_security_level security_level_ = GRPC_SECURITY_NONE;
   RpcProtocolVersions peer_rpc_versions_ = {{0, 0}, {0, 0}};
   explicit AltsContext(const grpc_gcp_AltsContext* ctx);
   friend std::unique_ptr<AltsContext> GetAltsContextFromAuthContext(

--- a/include/grpcpp/alts_context.h
+++ b/include/grpcpp/alts_context.h
@@ -39,28 +39,25 @@ typedef struct RpcProtocolVersions {
 } RpcProtocolVersions;
 
 // AltsContext is wrapper class for grpc_gcp_AltsContext.
-// It should only be instantiated by calling GetAltsContextFromAuthContext.
 class AltsContext {
  public:
   explicit AltsContext(const grpc_gcp_AltsContext* ctx);
   AltsContext& operator=(const AltsContext&) = default;
   AltsContext(const AltsContext&) = default;
-  AltsContext& operator=(AltsContext&&) = default;
-  AltsContext(AltsContext&&) = default;
 
-  std::string application_protocol() const;
-  std::string record_protocol() const;
-  std::string peer_service_account() const;
-  std::string local_service_account() const;
+  const grpc::string& application_protocol() const;
+  const grpc::string& record_protocol() const;
+  const grpc::string& peer_service_account() const;
+  const grpc::string& local_service_account() const;
   grpc_security_level security_level() const;
-  RpcProtocolVersions peer_rpc_versions() const;
+  const RpcProtocolVersions& peer_rpc_versions() const;
 
  private:
   // TODO(ZhenLian): Also plumb field peer_attributes when it is in use
-  std::string application_protocol_;
-  std::string record_protocol_;
-  std::string peer_service_account_;
-  std::string local_service_account_;
+  grpc::string application_protocol_;
+  grpc::string record_protocol_;
+  grpc::string peer_service_account_;
+  grpc::string local_service_account_;
   grpc_security_level security_level_ = GRPC_SECURITY_NONE;
   RpcProtocolVersions peer_rpc_versions_ = {{0, 0}, {0, 0}};
 };

--- a/include/grpcpp/alts_context.h
+++ b/include/grpcpp/alts_context.h
@@ -1,0 +1,75 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPCPP_ALTS_CONTEXT_H
+#define GRPCPP_ALTS_CONTEXT_H
+
+#include <grpcpp/impl/codegen/security/auth_context.h>
+
+#include <memory>
+// might need forward declaration
+#include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
+#include "src/proto/grpc/gcp/altscontext.upb.h"
+
+namespace grpc {
+
+enum SecurityLevel {
+  SECURITY_NONE = 0,
+  INTEGRITY_ONLY = 1,
+  INTEGRITY_AND_PRIVACY = 2
+};
+
+typedef struct Versions {
+  int major_version;
+  int minor_version;
+} Versions;
+
+typedef struct RpcProtocolVersions {
+  Versions max_rpc_versions;
+  Versions min_rpc_versions;
+} RpcProtocolVersions;
+
+class AltsContext {
+ public:
+  explicit AltsContext(const AuthContext& auth_context);
+
+  AltsContext& operator=(const AltsContext&) = default;
+  AltsContext(const AltsContext&) = default;
+  AltsContext& operator=(AltsContext&&) = default;
+  AltsContext(AltsContext&&) = default;
+
+  std::string application_protocol() const;
+  std::string record_protocol() const;
+  std::string peer_service_account() const;
+  std::string local_service_account() const;
+  SecurityLevel security_level() const;
+  RpcProtocolVersions peer_rpc_versions() const;
+
+ private:
+  // TODO(ZhenLian): Also plumb field peer_attributes when it is in use
+  std::string application_protocol_;
+  std::string record_protocol_;
+  std::string peer_service_account_;
+  std::string local_service_account_;
+  SecurityLevel security_level_ = SECURITY_NONE;
+  RpcProtocolVersions peer_rpc_versions_ = {{0, 0}, {0, 0}};
+};
+
+}  // namespace grpc
+
+#endif  // GRPCPP_ALTS_CONTEXT_H

--- a/include/grpcpp/alts_context.h
+++ b/include/grpcpp/alts_context.h
@@ -23,9 +23,8 @@
 #include <grpcpp/impl/codegen/security/auth_context.h>
 
 #include <memory>
-// might need forward declaration
-#include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
-#include "src/proto/grpc/gcp/altscontext.upb.h"
+
+struct grpc_gcp_AltsContext;
 
 namespace grpc {
 
@@ -43,6 +42,7 @@ typedef struct RpcProtocolVersions {
 // It should only be instantiated by calling GetAltsContextFromAuthContext.
 class AltsContext {
  public:
+  explicit AltsContext(const grpc_gcp_AltsContext* ctx);
   AltsContext& operator=(const AltsContext&) = default;
   AltsContext(const AltsContext&) = default;
   AltsContext& operator=(AltsContext&&) = default;
@@ -63,9 +63,6 @@ class AltsContext {
   std::string local_service_account_;
   grpc_security_level security_level_ = GRPC_SECURITY_NONE;
   RpcProtocolVersions peer_rpc_versions_ = {{0, 0}, {0, 0}};
-  explicit AltsContext(const grpc_gcp_AltsContext* ctx);
-  friend std::unique_ptr<AltsContext> GetAltsContextFromAuthContext(
-      const AuthContext& auth_context);
 };
 
 // GetAltsContextFromAuthContext helps to get the AltsContext from AuthContext.

--- a/include/grpcpp/alts_context.h
+++ b/include/grpcpp/alts_context.h
@@ -44,10 +44,10 @@ typedef struct RpcProtocolVersions {
   Versions min_rpc_versions;
 } RpcProtocolVersions;
 
+// AltsContext is wrapper class for grpc_gcp_AltsContext.
+// It should only be instantiated by calling GetAltsContextFromAuthContext.
 class AltsContext {
  public:
-  explicit AltsContext(const AuthContext& auth_context);
-
   AltsContext& operator=(const AltsContext&) = default;
   AltsContext(const AltsContext&) = default;
   AltsContext& operator=(AltsContext&&) = default;
@@ -68,7 +68,16 @@ class AltsContext {
   std::string local_service_account_;
   SecurityLevel security_level_ = SECURITY_NONE;
   RpcProtocolVersions peer_rpc_versions_ = {{0, 0}, {0, 0}};
+  explicit AltsContext(const grpc_gcp_AltsContext* ctx);
+  friend std::unique_ptr<AltsContext> GetAltsContextFromAuthContext(
+      const AuthContext& auth_context);
 };
+
+// GetAltsContextFromAuthContext helps to get the AltsContext from AuthContext.
+// Please make sure the underlying protocol is ALTS before calling this
+// function. Otherwise a nullptr will be returned.
+std::unique_ptr<AltsContext> GetAltsContextFromAuthContext(
+    const AuthContext& auth_context);
 
 }  // namespace grpc
 

--- a/src/cpp/common/alts_context.cc
+++ b/src/cpp/common/alts_context.cc
@@ -19,7 +19,10 @@
 #include <grpc/grpc_security.h>
 #include <grpcpp/alts_context.h>
 
+#include "src/core/lib/gprpp/memory.h"
+#include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
 #include "src/cpp/common/secure_auth_context.h"
+#include "src/proto/grpc/gcp/altscontext.upb.h"
 
 namespace grpc {
 
@@ -103,8 +106,7 @@ std::unique_ptr<AltsContext> GetAltsContextFromAuthContext(
     gpr_log(GPR_ERROR, "fails to parse ALTS context.");
     return nullptr;
   }
-  std::unique_ptr<AltsContext> uniq_ctx(new AltsContext(ctx));
-  return uniq_ctx;
+  return grpc_core::MakeUnique<AltsContext>(AltsContext(ctx));
 }
 
 }  // namespace grpc

--- a/src/cpp/common/alts_context.cc
+++ b/src/cpp/common/alts_context.cc
@@ -62,8 +62,8 @@ AltsContext::AltsContext(const grpc_gcp_AltsContext* ctx) {
       peer_rpc_versions_.min_rpc_versions.minor_version = min_version_minor;
     }
   }
-  security_level_ =
-      static_cast<SecurityLevel>((int)grpc_gcp_AltsContext_security_level(ctx));
+  security_level_ = static_cast<grpc_security_level>(
+      (int)grpc_gcp_AltsContext_security_level(ctx));
 }
 
 std::string AltsContext::application_protocol() const {
@@ -80,7 +80,9 @@ std::string AltsContext::local_service_account() const {
   return local_service_account_;
 }
 
-SecurityLevel AltsContext::security_level() const { return security_level_; }
+grpc_security_level AltsContext::security_level() const {
+  return security_level_;
+}
 
 RpcProtocolVersions AltsContext::peer_rpc_versions() const {
   return peer_rpc_versions_;

--- a/src/cpp/common/alts_context.cc
+++ b/src/cpp/common/alts_context.cc
@@ -1,0 +1,102 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/grpc_security.h>
+#include <grpcpp/alts_context.h>
+
+#include "src/cpp/common/secure_auth_context.h"
+
+namespace grpc {
+
+AltsContext::AltsContext(const AuthContext& auth_context) {
+  std::vector<string_ref> ctx_vector =
+      auth_context.FindPropertyValues(TSI_ALTS_CONTEXT);
+  if (ctx_vector.size() != 1) {
+    gpr_log(GPR_ERROR, "contains zero or more than one ALTS context.");
+    return;
+  }
+  upb::Arena context_arena;
+  grpc_gcp_AltsContext* ctx = grpc_gcp_AltsContext_parse(
+      ctx_vector[0].data(), ctx_vector[0].size(), context_arena.ptr());
+  if (ctx == nullptr) {
+    gpr_log(GPR_ERROR, "fails to parse ALTS context.");
+    return;
+  }
+  upb_strview application_protocol =
+      grpc_gcp_AltsContext_application_protocol(ctx);
+  application_protocol_ =
+      std::string(application_protocol.data, application_protocol.size);
+  upb_strview record_protocol = grpc_gcp_AltsContext_record_protocol(ctx);
+  record_protocol_ = std::string(record_protocol.data, record_protocol.size);
+  upb_strview peer_service_account =
+      grpc_gcp_AltsContext_peer_service_account(ctx);
+  peer_service_account_ =
+      std::string(peer_service_account.data, peer_service_account.size);
+  upb_strview local_service_account =
+      grpc_gcp_AltsContext_local_service_account(ctx);
+  local_service_account_ =
+      std::string(local_service_account.data, local_service_account.size);
+  const grpc_gcp_RpcProtocolVersions* versions =
+      grpc_gcp_AltsContext_peer_rpc_versions(ctx);
+  if (versions != nullptr) {
+    const grpc_gcp_RpcProtocolVersions_Version* max_versions =
+        grpc_gcp_RpcProtocolVersions_max_rpc_version(versions);
+    if (max_versions != nullptr) {
+      int max_version_major =
+          grpc_gcp_RpcProtocolVersions_Version_major(max_versions);
+      int max_version_minor =
+          grpc_gcp_RpcProtocolVersions_Version_minor(max_versions);
+      peer_rpc_versions_.max_rpc_versions.major_version = max_version_major;
+      peer_rpc_versions_.max_rpc_versions.minor_version = max_version_minor;
+    }
+    const grpc_gcp_RpcProtocolVersions_Version* min_versions =
+        grpc_gcp_RpcProtocolVersions_min_rpc_version(versions);
+    if (min_versions != nullptr) {
+      int min_version_major =
+          grpc_gcp_RpcProtocolVersions_Version_major(min_versions);
+      int min_version_minor =
+          grpc_gcp_RpcProtocolVersions_Version_minor(min_versions);
+      peer_rpc_versions_.min_rpc_versions.major_version = min_version_major;
+      peer_rpc_versions_.min_rpc_versions.minor_version = min_version_minor;
+    }
+  }
+  security_level_ =
+      static_cast<SecurityLevel>((int)grpc_gcp_AltsContext_security_level(ctx));
+}
+
+std::string AltsContext::application_protocol() const {
+  return application_protocol_;
+}
+
+std::string AltsContext::record_protocol() const { return record_protocol_; }
+
+std::string AltsContext::peer_service_account() const {
+  return peer_service_account_;
+}
+
+std::string AltsContext::local_service_account() const {
+  return local_service_account_;
+}
+
+SecurityLevel AltsContext::security_level() const { return security_level_; }
+
+RpcProtocolVersions AltsContext::peer_rpc_versions() const {
+  return peer_rpc_versions_;
+}
+
+}  // namespace grpc

--- a/src/proto/grpc/gcp/BUILD
+++ b/src/proto/grpc/gcp/BUILD
@@ -14,12 +14,9 @@
 
 licenses(["notice"])  # Apache v2
 
-proto_library(
-    name = "alts_handshaker_proto",
-    srcs = [
-        "altscontext.proto",
-        "handshaker.proto",
-        "transport_security_common.proto",
-    ],
-    visibility = ["//visibility:public"],
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+
+grpc_package(
+    name = "src/proto/grpc/gcp",
+    visibility = "public",
 )

--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -108,3 +108,16 @@ grpc_cc_test(
         "//test/cpp/util:test_util",
     ],
 )
+
+grpc_cc_test(
+    name = "alts_context_test",
+    srcs = ["alts_context_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    deps = [
+        "//:grpc++_alts",
+        "//test/core/util:grpc_test_util",
+        "//test/cpp/util:test_util",
+    ],
+)

--- a/test/cpp/common/alts_context_test.cc
+++ b/test/cpp/common/alts_context_test.cc
@@ -1,0 +1,154 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpcpp/alts_context.h>
+#include <grpcpp/security/auth_context.h>
+#include <gtest/gtest.h>
+
+#include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
+#include "src/cpp/common/secure_auth_context.h"
+#include "src/proto/grpc/gcp/altscontext.upb.h"
+#include "test/cpp/util/string_ref_helper.h"
+
+using grpc::testing::ToString;
+
+namespace grpc {
+namespace {
+
+void expect_null_context(const AltsContext& context) {
+  EXPECT_EQ(context.application_protocol(), "");
+  EXPECT_EQ(context.record_protocol(), "");
+  EXPECT_EQ(context.peer_service_account(), "");
+  EXPECT_EQ(context.local_service_account(), "");
+  EXPECT_EQ(context.security_level(), SecurityLevel::SECURITY_NONE);
+}
+
+TEST(AltsContextTest, EmptyAuthContext) {
+  SecureAuthContext auth_context(nullptr);
+  AltsContext alts_context(auth_context);
+  expect_null_context(alts_context);
+}
+
+TEST(AltsContextTest, AuthContextWithMoreThanOneAltsContext) {
+  grpc_core::RefCountedPtr<grpc_auth_context> ctx =
+      grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
+  SecureAuthContext auth_context(ctx.get());
+  ctx.reset();
+  auth_context.AddProperty(TSI_ALTS_CONTEXT, "context1");
+  auth_context.AddProperty(TSI_ALTS_CONTEXT, "context2");
+  AltsContext alts_context(auth_context);
+  expect_null_context(alts_context);
+}
+
+TEST(AltsContextTest, AuthContextWithBadAltsContext) {
+  grpc_core::RefCountedPtr<grpc_auth_context> ctx =
+      grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
+  SecureAuthContext auth_context(ctx.get());
+  ctx.reset();
+  auth_context.AddProperty(TSI_ALTS_CONTEXT,
+                           "bad context string serialization");
+  AltsContext alts_context(auth_context);
+  expect_null_context(alts_context);
+}
+
+TEST(AltsContextTest, AuthContextWithGoodAltsContextWithoutRpcVersions) {
+  grpc_core::RefCountedPtr<grpc_auth_context> ctx =
+      grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
+  SecureAuthContext auth_context(ctx.get());
+  ctx.reset();
+
+  std::string expected_ap("application protocol");
+  std::string expected_rp("record protocol");
+  std::string expected_peer("peer");
+  std::string expected_local("local");
+  SecurityLevel expected_sl = SecurityLevel::INTEGRITY_ONLY;
+  upb::Arena context_arena;
+  grpc_gcp_AltsContext* context = grpc_gcp_AltsContext_new(context_arena.ptr());
+  grpc_gcp_AltsContext_set_application_protocol(
+      context, upb_strview_make(expected_ap.data(), expected_ap.length()));
+  grpc_gcp_AltsContext_set_record_protocol(
+      context, upb_strview_make(expected_rp.data(), expected_rp.length()));
+  grpc_gcp_AltsContext_set_security_level(context, expected_sl);
+  grpc_gcp_AltsContext_set_peer_service_account(
+      context, upb_strview_make(expected_peer.data(), expected_peer.length()));
+  grpc_gcp_AltsContext_set_local_service_account(
+      context,
+      upb_strview_make(expected_local.data(), expected_local.length()));
+  size_t serialized_ctx_length;
+  char* serialized_ctx = grpc_gcp_AltsContext_serialize(
+      context, context_arena.ptr(), &serialized_ctx_length);
+  EXPECT_NE(serialized_ctx, nullptr);
+  auth_context.AddProperty(TSI_ALTS_CONTEXT,
+                           string(serialized_ctx, serialized_ctx_length));
+  AltsContext alts_context(auth_context);
+  EXPECT_EQ(expected_ap, alts_context.application_protocol());
+  EXPECT_EQ(expected_rp, alts_context.record_protocol());
+  EXPECT_EQ(expected_peer, alts_context.peer_service_account());
+  EXPECT_EQ(expected_local, alts_context.local_service_account());
+  EXPECT_EQ(expected_sl, alts_context.security_level());
+  // all rpc versions should be 0 if not set
+  RpcProtocolVersions rpc_protocol_versions = alts_context.peer_rpc_versions();
+  EXPECT_EQ(0, rpc_protocol_versions.max_rpc_versions.major_version);
+  EXPECT_EQ(0, rpc_protocol_versions.max_rpc_versions.minor_version);
+  EXPECT_EQ(0, rpc_protocol_versions.min_rpc_versions.major_version);
+  EXPECT_EQ(0, rpc_protocol_versions.min_rpc_versions.minor_version);
+}
+
+TEST(AltsContextTest, AuthContextWithGoodAltsContext) {
+  grpc_core::RefCountedPtr<grpc_auth_context> ctx =
+      grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
+  SecureAuthContext auth_context(ctx.get());
+  ctx.reset();
+
+  upb::Arena context_arena;
+  grpc_gcp_AltsContext* context = grpc_gcp_AltsContext_new(context_arena.ptr());
+  upb::Arena versions_arena;
+  grpc_gcp_RpcProtocolVersions* versions =
+      grpc_gcp_RpcProtocolVersions_new(versions_arena.ptr());
+  upb::Arena max_major_version_arena;
+  grpc_gcp_RpcProtocolVersions_Version* version =
+      grpc_gcp_RpcProtocolVersions_Version_new(max_major_version_arena.ptr());
+  grpc_gcp_RpcProtocolVersions_Version_set_major(version, 10);
+  grpc_gcp_RpcProtocolVersions_set_max_rpc_version(versions, version);
+  grpc_gcp_AltsContext_set_peer_rpc_versions(context, versions);
+  size_t serialized_ctx_length;
+  char* serialized_ctx = grpc_gcp_AltsContext_serialize(
+      context, context_arena.ptr(), &serialized_ctx_length);
+  EXPECT_NE(serialized_ctx, nullptr);
+  auth_context.AddProperty(TSI_ALTS_CONTEXT,
+                           string(serialized_ctx, serialized_ctx_length));
+  AltsContext alts_context(auth_context);
+  EXPECT_EQ("", alts_context.application_protocol());
+  EXPECT_EQ("", alts_context.record_protocol());
+  EXPECT_EQ("", alts_context.peer_service_account());
+  EXPECT_EQ("", alts_context.local_service_account());
+  EXPECT_EQ(SecurityLevel::SECURITY_NONE, alts_context.security_level());
+  RpcProtocolVersions rpc_protocol_versions = alts_context.peer_rpc_versions();
+  EXPECT_EQ(10, rpc_protocol_versions.max_rpc_versions.major_version);
+  EXPECT_EQ(0, rpc_protocol_versions.max_rpc_versions.minor_version);
+  EXPECT_EQ(0, rpc_protocol_versions.min_rpc_versions.major_version);
+  EXPECT_EQ(0, rpc_protocol_versions.min_rpc_versions.minor_version);
+}
+
+}  // namespace
+}  // namespace grpc
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/cpp/common/alts_context_test.cc
+++ b/test/cpp/common/alts_context_test.cc
@@ -71,7 +71,7 @@ TEST(AltsContextTest, AuthContextWithGoodAltsContextWithoutRpcVersions) {
   std::string expected_rp("record protocol");
   std::string expected_peer("peer");
   std::string expected_local("local");
-  SecurityLevel expected_sl = SecurityLevel::INTEGRITY_ONLY;
+  grpc_security_level expected_sl = GRPC_INTEGRITY_ONLY;
   upb::Arena context_arena;
   grpc_gcp_AltsContext* context = grpc_gcp_AltsContext_new(context_arena.ptr());
   grpc_gcp_AltsContext_set_application_protocol(
@@ -136,7 +136,7 @@ TEST(AltsContextTest, AuthContextWithGoodAltsContext) {
   EXPECT_EQ("", alts_context->record_protocol());
   EXPECT_EQ("", alts_context->peer_service_account());
   EXPECT_EQ("", alts_context->local_service_account());
-  EXPECT_EQ(SecurityLevel::SECURITY_NONE, alts_context->security_level());
+  EXPECT_EQ(GRPC_SECURITY_NONE, alts_context->security_level());
   RpcProtocolVersions rpc_protocol_versions = alts_context->peer_rpc_versions();
   EXPECT_EQ(10, rpc_protocol_versions.max_rpc_versions.major_version);
   EXPECT_EQ(0, rpc_protocol_versions.max_rpc_versions.minor_version);

--- a/test/cpp/common/alts_context_test.cc
+++ b/test/cpp/common/alts_context_test.cc
@@ -67,10 +67,10 @@ TEST(AltsContextTest, AuthContextWithGoodAltsContextWithoutRpcVersions) {
   SecureAuthContext auth_context(ctx.get());
   ctx.reset();
 
-  std::string expected_ap("application protocol");
-  std::string expected_rp("record protocol");
-  std::string expected_peer("peer");
-  std::string expected_local("local");
+  grpc::string expected_ap("application protocol");
+  grpc::string expected_rp("record protocol");
+  grpc::string expected_peer("peer");
+  grpc::string expected_local("local");
   grpc_security_level expected_sl = GRPC_INTEGRITY_ONLY;
   upb::Arena context_arena;
   grpc_gcp_AltsContext* context = grpc_gcp_AltsContext_new(context_arena.ptr());

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3046,6 +3046,30 @@
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 
+    "name": "alts_context_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
     "name": "alts_crypter_test", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
This PR serves as the same purpose as this reverted one:

https://github.com/grpc/grpc/pull/21196,

but we adopt another approach for providing utilities to get AltsContext.
In that PR, we use upb to serialize the AltsContext in TSI layer, pass it up to the C++ user-facing APIs, and use standard pb to de-serialize it. Here we use upb for serializing and de-serializing, and provide a utility wrapper class for  the class generated from upb.
This change is based on the assumption that upb generated class is not user-friendly enough and we'd better provide more straightforward ways for users to use ALTS context.
