### PR TITLE
Ship grpcio-status with the actual proto file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ py3[0-9]_gevent/
 py3[0-9]_native/
 a.out
 src/python/grpcio_*/LICENSE
+src/python/grpcio_status/grpc_status/google/rpc/status.proto
 
 # Node installation output
 node_modules

--- a/src/python/grpcio_status/MANIFEST.in
+++ b/src/python/grpcio_status/MANIFEST.in
@@ -1,4 +1,5 @@
 include grpc_version.py
+include grpc_status/google/rpc/status.proto
 recursive-include grpc_status *.py
 global-exclude *.pyc
 include LICENSE

--- a/src/python/grpcio_status/status_commands.py
+++ b/src/python/grpcio_status/status_commands.py
@@ -19,6 +19,9 @@ import shutil
 import setuptools
 
 ROOT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+STATUS_PROTO = os.path.join(
+    ROOT_DIR, '../../../third_party/googleapis/google/rpc/status.proto')
+PACKAGE_STATUS_PROTO_PATH = 'grpc_status/google/rpc'
 LICENSE = os.path.join(ROOT_DIR, '../../../LICENSE')
 
 
@@ -35,5 +38,11 @@ class Preprocess(setuptools.Command):
         pass
 
     def run(self):
+        if os.path.isfile(STATUS_PROTO):
+            if not os.path.isdir(PACKAGE_STATUS_PROTO_PATH):
+                os.makedirs(PACKAGE_STATUS_PROTO_PATH)
+            shutil.copyfile(STATUS_PROTO,
+                            os.path.join(ROOT_DIR, PACKAGE_STATUS_PROTO_PATH,
+                                         'status.proto'))
         if os.path.isfile(LICENSE):
             shutil.copyfile(LICENSE, os.path.join(ROOT_DIR, 'LICENSE'))


### PR DESCRIPTION
Related issue: b/145195649

To compile proto, one needs the depending proto files. It becomes more complicate, if the proto dependents are not in your control. The `status.proto` ground truth lays in `googleapis-common-proto` repo, but it requires creating a submodule or other hacky scripts to make the compilation process work.

There is a need for us to ship the actual protos file with the Python package, so users can directly depend on the `status.proto` without cloning entire common proto repo.