### PR TITLE
De-experimentalize callback alarm

### DIFF
--- a/include/grpcpp/alarm_impl.h
+++ b/include/grpcpp/alarm_impl.h
@@ -77,6 +77,17 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   /// has already fired has no effect.
   void Cancel();
 
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+  /// Set an alarm to invoke callback \a f. The argument to the callback
+  /// states whether the alarm expired at \a deadline (true) or was cancelled
+  /// (false)
+  template <typename T>
+  void Set(const T& deadline, std::function<void(bool)> f) {
+    alarm_->SetInternal(::grpc::TimePoint<T>(deadline).raw_time(),
+                        std::move(f));
+  }
+#endif
+
   /// NOTE: class experimental_type is not part of the public API of this class
   /// TODO(vjpai): Move these contents to the public API of Alarm when
   ///              they are no longer experimental


### PR DESCRIPTION
Note that even though this is not dependent on the EM, we still will keep this macro-protected so that we can properly prepare a gRFC when it's time to de-experimentalize it all.
