### PR TITLE
Actually implement the generic reactor-based unary call

### DIFF
--- a/include/grpcpp/generic/generic_stub_impl.h
+++ b/include/grpcpp/generic/generic_stub_impl.h
@@ -85,12 +85,15 @@ class GenericStub final {
                    grpc::ByteBuffer* response,
                    std::function<void(grpc::Status)> on_completion);
 
-    /// Setup and start a unary call to a named method \a method using
+    /// Setup a unary call to a named method \a method using
     /// \a context and specifying the \a request and \a response buffers.
-    void UnaryCall(grpc_impl::ClientContext* context,
-                   const grpc::string& method, const grpc::ByteBuffer* request,
-                   grpc::ByteBuffer* response,
-                   grpc_impl::ClientUnaryReactor* reactor);
+    /// Like any other reactor-based RPC, it will not be activated until
+    /// StartCall is invoked on its reactor.
+    void PrepareUnaryCall(grpc_impl::ClientContext* context,
+                          const grpc::string& method,
+                          const grpc::ByteBuffer* request,
+                          grpc::ByteBuffer* response,
+                          grpc_impl::ClientUnaryReactor* reactor);
 
     /// Setup a call to a named method \a method using \a context and tied to
     /// \a reactor . Like any other bidi streaming RPC, it will not be activated

--- a/src/cpp/client/generic_stub.cc
+++ b/src/cpp/client/generic_stub.cc
@@ -90,4 +90,16 @@ void GenericStub::experimental_type::PrepareBidiStreamingCall(
                                 context, reactor);
 }
 
+void GenericStub::experimental_type::PrepareUnaryCall(
+    grpc::ClientContext* context, const grpc::string& method,
+    const grpc::ByteBuffer* request, grpc::ByteBuffer* response,
+    ClientUnaryReactor* reactor) {
+  internal::ClientCallbackUnaryFactory::Create<grpc::ByteBuffer,
+                                               grpc::ByteBuffer>(
+      stub_->channel_.get(),
+      grpc::internal::RpcMethod(method.c_str(),
+                                grpc::internal::RpcMethod::NORMAL_RPC),
+      context, request, response, reactor);
+}
+
 }  // namespace grpc_impl

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -838,6 +838,72 @@ TEST_P(ClientCallbackEnd2endTest, UnaryReactor) {
   }
 }
 
+TEST_P(ClientCallbackEnd2endTest, GenericUnaryReactor) {
+  MAYBE_SKIP_TEST;
+  ResetStub();
+  const grpc::string kMethodName("/grpc.testing.EchoTestService/Echo");
+  class UnaryClient : public grpc::experimental::ClientUnaryReactor {
+   public:
+    UnaryClient(grpc::GenericStub* stub, const grpc::string& method_name) {
+      cli_ctx_.AddMetadata("key1", "val1");
+      cli_ctx_.AddMetadata("key2", "val2");
+      request_.mutable_param()->set_echo_metadata_initially(true);
+      request_.set_message("Hello metadata");
+      send_buf_ = SerializeToByteBuffer(&request_);
+
+      stub->experimental().PrepareUnaryCall(&cli_ctx_, method_name,
+                                            send_buf_.get(), &recv_buf_, this);
+      StartCall();
+    }
+    void OnReadInitialMetadataDone(bool ok) override {
+      EXPECT_TRUE(ok);
+      EXPECT_EQ(1u, cli_ctx_.GetServerInitialMetadata().count("key1"));
+      EXPECT_EQ(
+          "val1",
+          ToString(cli_ctx_.GetServerInitialMetadata().find("key1")->second));
+      EXPECT_EQ(1u, cli_ctx_.GetServerInitialMetadata().count("key2"));
+      EXPECT_EQ(
+          "val2",
+          ToString(cli_ctx_.GetServerInitialMetadata().find("key2")->second));
+      initial_metadata_done_ = true;
+    }
+    void OnDone(const Status& s) override {
+      EXPECT_TRUE(initial_metadata_done_);
+      EXPECT_EQ(0u, cli_ctx_.GetServerTrailingMetadata().size());
+      EXPECT_TRUE(s.ok());
+      EchoResponse response;
+      EXPECT_TRUE(ParseFromByteBuffer(&recv_buf_, &response));
+      EXPECT_EQ(request_.message(), response.message());
+      std::unique_lock<std::mutex> l(mu_);
+      done_ = true;
+      cv_.notify_one();
+    }
+    void Await() {
+      std::unique_lock<std::mutex> l(mu_);
+      while (!done_) {
+        cv_.wait(l);
+      }
+    }
+
+   private:
+    EchoRequest request_;
+    std::unique_ptr<ByteBuffer> send_buf_;
+    ByteBuffer recv_buf_;
+    ClientContext cli_ctx_;
+    std::mutex mu_;
+    std::condition_variable cv_;
+    bool done_{false};
+    bool initial_metadata_done_{false};
+  };
+
+  UnaryClient test{generic_stub_.get(), kMethodName};
+  test.Await();
+  // Make sure that the server interceptors were not notified of a cancel
+  if (GetParam().use_interceptors) {
+    EXPECT_EQ(0, DummyInterceptor::GetNumTimesCancel());
+  }
+}
+
 class ReadClient : public grpc::experimental::ClientReadReactor<EchoResponse> {
  public:
   ReadClient(grpc::testing::EchoTestService::Stub* stub,


### PR DESCRIPTION
Previous work had implement client unary reactors for generated stubs, but I had forgotten to do this for generic stubs. This code fixes the name and comment and adds an implementation and test for this RPC mode.