### PR TITLE
Improve ChannelCredentials.Create error messsage with non-SslCredentials

### DIFF
--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -104,7 +104,7 @@ namespace Grpc.Core
 
                 if (!channelCredentials.IsComposable)
                 {
-                    throw new ArgumentException(string.Format("{0} credentials can't be used with CallCredentials. Secure credentials like SslCredentials must be used.", channelCredentials.GetType().Name));
+                    throw new ArgumentException(string.Format("{0} can't be composed with supplied CallCredentials. Secure credentials like SslCredentials must be used.", channelCredentials.GetType().Name));
                 }
             }
 

--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -104,7 +104,7 @@ namespace Grpc.Core
 
                 if (!channelCredentials.IsComposable)
                 {
-                    throw new ArgumentException(string.Format("{0} can't be composed with supplied CallCredentials. Secure credentials like SslCredentials must be used.", channelCredentials.GetType().Name));
+                    throw new ArgumentException(string.Format("CallCredentials can't be composed with {0}. CallCredentials must be used with secure channel credentials like SslCredentials.", channelCredentials.GetType().Name));
                 }
             }
 

--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -30,7 +30,7 @@ namespace Grpc.Core
     /// </summary>
     public abstract class ChannelCredentials
     {
-        static readonly ChannelCredentials InsecureInstance = new InsecureCredentialsImpl();
+        static readonly ChannelCredentials InsecureInstance = new InsecureCredentials();
 
         /// <summary>
         /// Creates a new instance of channel credentials
@@ -74,7 +74,7 @@ namespace Grpc.Core
         /// </summary>
         internal virtual bool IsComposable => false;
 
-        private sealed class InsecureCredentialsImpl : ChannelCredentials
+        private sealed class InsecureCredentials : ChannelCredentials
         {
             public override void InternalPopulateConfiguration(ChannelCredentialsConfiguratorBase configurator, object state)
             {
@@ -101,7 +101,11 @@ namespace Grpc.Core
             {
                 this.channelCredentials = GrpcPreconditions.CheckNotNull(channelCredentials);
                 this.callCredentials = GrpcPreconditions.CheckNotNull(callCredentials);
-                GrpcPreconditions.CheckArgument(channelCredentials.IsComposable, "Supplied channel credentials do not allow composition.");
+
+                if (!channelCredentials.IsComposable)
+                {
+                    throw new ArgumentException(string.Format("{0} credentials can't be used with CallCredentials. Secure credentials like SslCredentials must be used.", channelCredentials.GetType().Name));
+                }
             }
 
             public override void InternalPopulateConfiguration(ChannelCredentialsConfiguratorBase configurator, object state)

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -41,7 +41,7 @@ namespace Grpc.Core.Tests
 
             // forbid composing non-composable
             var ex = Assert.Throws(typeof(ArgumentException), () => ChannelCredentials.Create(new FakeChannelCredentials(false), new FakeCallCredentials()));
-            Assert.AreEqual("FakeChannelCredentials can't be composed with supplied CallCredentials. Secure credentials like SslCredentials must be used.", ex.Message);
+            Assert.AreEqual("CallCredentials can't be composed with FakeChannelCredentials. CallCredentials must be used with secure channel credentials like SslCredentials.", ex.Message);
         }
 
         [Test]

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -41,7 +41,7 @@ namespace Grpc.Core.Tests
 
             // forbid composing non-composable
             var ex = Assert.Throws(typeof(ArgumentException), () => ChannelCredentials.Create(new FakeChannelCredentials(false), new FakeCallCredentials()));
-            Assert.AreEqual("FakeChannelCredentials credentials can't be used with CallCredentials. Secure credentials like SslCredentials must be used.", ex.Message);
+            Assert.AreEqual("FakeChannelCredentials can't be composed with supplied CallCredentials. Secure credentials like SslCredentials must be used.", ex.Message);
         }
 
         [Test]

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -40,7 +40,8 @@ namespace Grpc.Core.Tests
             Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(new FakeChannelCredentials(true), null));
 
             // forbid composing non-composable
-            Assert.Throws(typeof(ArgumentException), () => ChannelCredentials.Create(new FakeChannelCredentials(false), new FakeCallCredentials()));
+            var ex = Assert.Throws(typeof(ArgumentException), () => ChannelCredentials.Create(new FakeChannelCredentials(false), new FakeCallCredentials()));
+            Assert.AreEqual("FakeChannelCredentials credentials can't be used with CallCredentials. Secure credentials like SslCredentials must be used.", ex.Message);
         }
 
         [Test]


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/679

Users are not finding the current exception message useful

@jtattermusch 