### PR TITLE
Generic API: assert when sending uninitialized byte buffer

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -63,13 +63,16 @@ class DeserializeFuncType;
 class GrpcByteBufferPeer;
 
 }  // namespace internal
-/// A sequence of bytes.
+/// A sequence of bytes. A ByteBuffer must be backed by at least one slice to be
+/// considered valid. You can consstruct an empty buffer through creating a
+/// ByteBuffer backed by one empty slice.
 class ByteBuffer final {
  public:
-  /// Constuct an empty buffer.
+  /// Construct an uninitialized buffer.
   ByteBuffer() : buffer_(nullptr) {}
 
-  /// Construct buffer from \a slices, of which there are \a nslices.
+  /// Construct buffer from \a slices, of which there are \a nslices. \a slices
+  /// must be a valid pointer.
   ByteBuffer(const Slice* slices, size_t nslices) {
     // The following assertions check that the representation of a grpc::Slice
     // is identical to that of a grpc_slice:  it has a grpc_slice field, and


### PR DESCRIPTION
Fix for https://github.com/grpc/grpc/issues/18347

Sending an uninitialized byte buffer is an API misuse. Add an assert so it's clearer to users that this is the case.

~~This may not be the right place to propagate the error (i.e., I don't know if our API allows for returning nullptr from PrepareUnaryCall). It's possible we want to return the error from cq->Next instead. Let's chat about it.~~