### PR TITLE
De-experimentalize generic stub callback uses (under ifdef)

### DIFF
--- a/include/grpcpp/generic/generic_stub_impl.h
+++ b/include/grpcpp/generic/generic_stub_impl.h
@@ -71,6 +71,39 @@ class GenericStub final {
       grpc_impl::ClientContext* context, const grpc::string& method,
       CompletionQueue* cq, void* tag);
 
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+  /// Setup and start a unary call to a named method \a method using
+  /// \a context and specifying the \a request and \a response buffers.
+  void UnaryCall(grpc_impl::ClientContext* context, const grpc::string& method,
+                 const grpc::ByteBuffer* request, grpc::ByteBuffer* response,
+                 std::function<void(grpc::Status)> on_completion) {
+    UnaryCallInternal(context, method, request, response,
+                      std::move(on_completion));
+  };
+
+  /// Setup a unary call to a named method \a method using
+  /// \a context and specifying the \a request and \a response buffers.
+  /// Like any other reactor-based RPC, it will not be activated until
+  /// StartCall is invoked on its reactor.
+  void PrepareUnaryCall(grpc_impl::ClientContext* context,
+                        const grpc::string& method,
+                        const grpc::ByteBuffer* request,
+                        grpc::ByteBuffer* response,
+                        grpc_impl::ClientUnaryReactor* reactor) {
+    PrepareUnaryCallInternal(context, method, request, response, reactor);
+  }
+
+  /// Setup a call to a named method \a method using \a context and tied to
+  /// \a reactor . Like any other bidi streaming RPC, it will not be activated
+  /// until StartCall is invoked on its reactor.
+  void PrepareBidiStreamingCall(
+      grpc_impl::ClientContext* context, const grpc::string& method,
+      grpc_impl::ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>*
+          reactor) {
+    PrepareBidiStreamingCallInternal(context, method, reactor);
+  }
+#endif
+
   /// NOTE: class experimental_type is not part of the public API of this class
   /// TODO(vjpai): Move these contents to the public API of GenericStub when
   ///              they are no longer experimental
@@ -83,7 +116,10 @@ class GenericStub final {
     void UnaryCall(grpc_impl::ClientContext* context,
                    const grpc::string& method, const grpc::ByteBuffer* request,
                    grpc::ByteBuffer* response,
-                   std::function<void(grpc::Status)> on_completion);
+                   std::function<void(grpc::Status)> on_completion) {
+      stub_->UnaryCallInternal(context, method, request, response,
+                               std::move(on_completion));
+    };
 
     /// Setup a unary call to a named method \a method using
     /// \a context and specifying the \a request and \a response buffers.
@@ -93,7 +129,10 @@ class GenericStub final {
                           const grpc::string& method,
                           const grpc::ByteBuffer* request,
                           grpc::ByteBuffer* response,
-                          grpc_impl::ClientUnaryReactor* reactor);
+                          grpc_impl::ClientUnaryReactor* reactor) {
+      stub_->PrepareUnaryCallInternal(context, method, request, response,
+                                      reactor);
+    }
 
     /// Setup a call to a named method \a method using \a context and tied to
     /// \a reactor . Like any other bidi streaming RPC, it will not be activated
@@ -101,7 +140,9 @@ class GenericStub final {
     void PrepareBidiStreamingCall(
         grpc_impl::ClientContext* context, const grpc::string& method,
         grpc_impl::ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>*
-            reactor);
+            reactor) {
+      stub_->PrepareBidiStreamingCallInternal(context, method, reactor);
+    }
 
    private:
     GenericStub* stub_;
@@ -114,6 +155,23 @@ class GenericStub final {
 
  private:
   std::shared_ptr<grpc::ChannelInterface> channel_;
+
+  void UnaryCallInternal(grpc_impl::ClientContext* context,
+                         const grpc::string& method,
+                         const grpc::ByteBuffer* request,
+                         grpc::ByteBuffer* response,
+                         std::function<void(grpc::Status)> on_completion);
+
+  void PrepareUnaryCallInternal(grpc_impl::ClientContext* context,
+                                const grpc::string& method,
+                                const grpc::ByteBuffer* request,
+                                grpc::ByteBuffer* response,
+                                grpc_impl::ClientUnaryReactor* reactor);
+
+  void PrepareBidiStreamingCallInternal(
+      grpc_impl::ClientContext* context, const grpc::string& method,
+      grpc_impl::ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>*
+          reactor);
 };
 
 }  // namespace grpc_impl

--- a/src/cpp/client/generic_stub.cc
+++ b/src/cpp/client/generic_stub.cc
@@ -67,36 +67,37 @@ GenericStub::PrepareUnaryCall(grpc::ClientContext* context,
           context, request, false));
 }
 
-void GenericStub::experimental_type::UnaryCall(
+void GenericStub::UnaryCallInternal(
     grpc::ClientContext* context, const grpc::string& method,
     const grpc::ByteBuffer* request, grpc::ByteBuffer* response,
     std::function<void(grpc::Status)> on_completion) {
   internal::CallbackUnaryCall(
-      stub_->channel_.get(),
+      channel_.get(),
       grpc::internal::RpcMethod(method.c_str(),
                                 grpc::internal::RpcMethod::NORMAL_RPC),
       context, request, response, std::move(on_completion));
 }
 
-void GenericStub::experimental_type::PrepareBidiStreamingCall(
+void GenericStub::PrepareBidiStreamingCallInternal(
     grpc::ClientContext* context, const grpc::string& method,
     ClientBidiReactor<grpc::ByteBuffer, grpc::ByteBuffer>* reactor) {
   internal::ClientCallbackReaderWriterFactory<
       grpc::ByteBuffer,
-      grpc::ByteBuffer>::Create(stub_->channel_.get(),
+      grpc::ByteBuffer>::Create(channel_.get(),
                                 grpc::internal::RpcMethod(
                                     method.c_str(),
                                     grpc::internal::RpcMethod::BIDI_STREAMING),
                                 context, reactor);
 }
 
-void GenericStub::experimental_type::PrepareUnaryCall(
-    grpc::ClientContext* context, const grpc::string& method,
-    const grpc::ByteBuffer* request, grpc::ByteBuffer* response,
-    ClientUnaryReactor* reactor) {
+void GenericStub::PrepareUnaryCallInternal(grpc::ClientContext* context,
+                                           const grpc::string& method,
+                                           const grpc::ByteBuffer* request,
+                                           grpc::ByteBuffer* response,
+                                           ClientUnaryReactor* reactor) {
   internal::ClientCallbackUnaryFactory::Create<grpc::ByteBuffer,
                                                grpc::ByteBuffer>(
-      stub_->channel_.get(),
+      channel_.get(),
       grpc::internal::RpcMethod(method.c_str(),
                                 grpc::internal::RpcMethod::NORMAL_RPC),
       context, request, response, reactor);


### PR DESCRIPTION
As stated in title