### PR TITLE
De-experimentalize generated callback code

### DIFF
--- a/include/grpcpp/impl/codegen/service_type.h
+++ b/include/grpcpp/impl/codegen/service_type.h
@@ -109,34 +109,15 @@ class Service {
     explicit experimental_type(Service* service) : service_(service) {}
 
     void MarkMethodCallback(int index, internal::MethodHandler* handler) {
-      // This does not have to be a hard error, however no one has approached us
-      // with a use case yet. Please file an issue if you believe you have one.
-      size_t idx = static_cast<size_t>(index);
-      GPR_CODEGEN_ASSERT(
-          service_->methods_[idx].get() != nullptr &&
-          "Cannot mark the method as 'callback' because it has already been "
-          "marked as 'generic'.");
-      service_->methods_[idx]->SetHandler(handler);
-      service_->methods_[idx]->SetServerApiType(
-          internal::RpcServiceMethod::ApiType::CALL_BACK);
+      service_->MarkMethodCallbackInternal(index, handler);
     }
 
     void MarkMethodRawCallback(int index, internal::MethodHandler* handler) {
-      // This does not have to be a hard error, however no one has approached us
-      // with a use case yet. Please file an issue if you believe you have one.
-      size_t idx = static_cast<size_t>(index);
-      GPR_CODEGEN_ASSERT(
-          service_->methods_[idx].get() != nullptr &&
-          "Cannot mark the method as 'raw callback' because it has already "
-          "been marked as 'generic'.");
-      service_->methods_[idx]->SetHandler(handler);
-      service_->methods_[idx]->SetServerApiType(
-          internal::RpcServiceMethod::ApiType::RAW_CALL_BACK);
+      service_->MarkMethodRawCallbackInternal(index, handler);
     }
 
     internal::MethodHandler* GetHandler(int index) {
-      size_t idx = static_cast<size_t>(index);
-      return service_->methods_[idx]->handler();
+      return service_->GetHandlerInternal(index);
     }
 
    private:
@@ -239,7 +220,54 @@ class Service {
     methods_[idx]->SetMethodType(internal::RpcMethod::BIDI_STREAMING);
   }
 
+#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+  void MarkMethodCallback(int index, internal::MethodHandler* handler) {
+    MarkMethodCallbackInternal(index, handler);
+  }
+
+  void MarkMethodRawCallback(int index, internal::MethodHandler* handler) {
+    MarkMethodRawCallbackInternal(index, handler);
+  }
+
+  internal::MethodHandler* GetHandler(int index) {
+    return GetHandlerInternal(index);
+  }
+#endif
  private:
+  // TODO(vjpai): migrate the Internal functions to mainline functions once
+  //              callback API is fully de-experimental
+  void MarkMethodCallbackInternal(int index, internal::MethodHandler* handler) {
+    // This does not have to be a hard error, however no one has approached us
+    // with a use case yet. Please file an issue if you believe you have one.
+    size_t idx = static_cast<size_t>(index);
+    GPR_CODEGEN_ASSERT(
+        methods_[idx].get() != nullptr &&
+        "Cannot mark the method as 'callback' because it has already been "
+        "marked as 'generic'.");
+    methods_[idx]->SetHandler(handler);
+    methods_[idx]->SetServerApiType(
+        internal::RpcServiceMethod::ApiType::CALL_BACK);
+  }
+
+  void MarkMethodRawCallbackInternal(int index,
+                                     internal::MethodHandler* handler) {
+    // This does not have to be a hard error, however no one has approached us
+    // with a use case yet. Please file an issue if you believe you have one.
+    size_t idx = static_cast<size_t>(index);
+    GPR_CODEGEN_ASSERT(
+        methods_[idx].get() != nullptr &&
+        "Cannot mark the method as 'raw callback' because it has already "
+        "been marked as 'generic'.");
+    methods_[idx]->SetHandler(handler);
+    methods_[idx]->SetServerApiType(
+        internal::RpcServiceMethod::ApiType::RAW_CALL_BACK);
+  }
+
+  internal::MethodHandler* GetHandlerInternal(int index) {
+    size_t idx = static_cast<size_t>(index);
+    return methods_[idx]->handler();
+  }
+
   friend class grpc_impl::Server;
   friend class ServerInterface;
   ServerInterface* server_;

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -136,8 +136,12 @@ grpc::string GetHeaderIncludes(grpc_generator::File* file,
       PrintIncludes(printer.get(), params.additional_header_includes, false,
                     "");
     }
+    // TODO(vjpai): Remove port_platform.h from header list when callback API is
+    //              fully de-experimentalized since we will no longer be using
+    //              macros from it.
     static const char* headers_strs[] = {
         "functional",
+        "grpc/impl/codegen/port_platform.h",
         "grpcpp/impl/codegen/async_generic_service.h",
         "grpcpp/impl/codegen/async_stream.h",
         "grpcpp/impl/codegen/async_unary_call.h",
@@ -604,31 +608,65 @@ void PrintHeaderClientMethodCallbackInterfaces(
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const ::grpc::ByteBuffer* request, $Response$* response, "
                    "std::function<void(::grpc::Status)>) = 0;\n");
+    // TODO(vjpai): Remove experimental versions and macros when callback API is
+    //              fully de-experimentalized.
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
-                   "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n");
+                   "::grpc::ClientUnaryReactor* reactor) = 0;\n"
+                   "#else\n"
+                   "virtual void $Method$(::grpc::ClientContext* context, "
+                   "const $Request$* request, $Response$* response, "
+                   "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n"
+                   "#endif\n");
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const ::grpc::ByteBuffer* request, $Response$* response, "
-                   "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n");
+                   "::grpc::ClientUnaryReactor* reactor) = 0;\n"
+                   "#else\n"
+                   "virtual void $Method$(::grpc::ClientContext* context, "
+                   "const ::grpc::ByteBuffer* request, $Response$* response, "
+                   "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n"
+                   "#endif\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "virtual void $Method$(::grpc::ClientContext* context, "
+                   "$Response$* response, "
+                   "::grpc::ClientWriteReactor< $Request$>* "
+                   "reactor) = 0;\n"
+                   "#else\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "$Response$* response, "
                    "::grpc::experimental::ClientWriteReactor< $Request$>* "
-                   "reactor) = 0;\n");
+                   "reactor) = 0;\n"
+                   "#endif\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "virtual void $Method$(::grpc::ClientContext* context, "
+                   "$Request$* request, "
+                   "::grpc::ClientReadReactor< $Response$>* "
+                   "reactor) = 0;\n"
+                   "#else\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "$Request$* request, "
                    "::grpc::experimental::ClientReadReactor< $Response$>* "
-                   "reactor) = 0;\n");
+                   "reactor) = 0;\n"
+                   "#endif\n");
   } else if (method->BidiStreaming()) {
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "virtual void $Method$(::grpc::ClientContext* context, "
+                   "::grpc::ClientBidiReactor< "
+                   "$Request$,$Response$>* reactor) = 0;\n"
+                   "#else\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "::grpc::experimental::ClientBidiReactor< "
-                   "$Request$,$Response$>* reactor) = 0;\n");
+                   "$Request$,$Response$>* reactor) = 0;\n"
+                   "#endif\n");
   }
 }
 
@@ -637,12 +675,20 @@ void PrintHeaderClientMethodCallbackInterfacesEnd(
     std::map<grpc::string, grpc::string>* /*vars*/) {
   printer->Outdent();
   printer->Print("};\n");
+  printer->Print(
+      "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+      "typedef class experimental_async_interface async_interface;\n"
+      "#endif\n");
 
   // Declare a function to give the async stub contents. It can't be pure
   // since this is a new API in StubInterface, but it is meaningless by default
   // (since any stub that wants to use it must have its own implementation of
   // the callback functions therein), so make the default return value nullptr.
   // Intentionally include the word "class" to avoid possible shadowing.
+  printer->Print(
+      "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+      "async_interface* async() { return experimental_async(); }\n"
+      "#endif\n");
   printer->Print(
       "virtual class experimental_async_interface* experimental_async() { "
       "return nullptr; }\n");
@@ -676,32 +722,64 @@ void PrintHeaderClientMethodCallback(
                    "std::function<void(::grpc::Status)>) override;\n");
     printer->Print(
         *vars,
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
         "void $Method$(::grpc::ClientContext* context, "
         "const $Request$* request, $Response$* response, "
-        "::grpc::experimental::ClientUnaryReactor* reactor) override;\n");
+        "::grpc::ClientUnaryReactor* reactor) override;\n"
+        "#else\n"
+        "void $Method$(::grpc::ClientContext* context, "
+        "const $Request$* request, $Response$* response, "
+        "::grpc::experimental::ClientUnaryReactor* reactor) override;\n"
+        "#endif\n");
     printer->Print(
         *vars,
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
         "void $Method$(::grpc::ClientContext* context, "
         "const ::grpc::ByteBuffer* request, $Response$* response, "
-        "::grpc::experimental::ClientUnaryReactor* reactor) override;\n");
+        "::grpc::ClientUnaryReactor* reactor) override;\n"
+        "#else\n"
+        "void $Method$(::grpc::ClientContext* context, "
+        "const ::grpc::ByteBuffer* request, $Response$* response, "
+        "::grpc::experimental::ClientUnaryReactor* reactor) override;\n"
+        "#endif\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "void $Method$(::grpc::ClientContext* context, "
+                   "$Response$* response, "
+                   "::grpc::ClientWriteReactor< $Request$>* "
+                   "reactor) override;\n"
+                   "#else\n"
                    "void $Method$(::grpc::ClientContext* context, "
                    "$Response$* response, "
                    "::grpc::experimental::ClientWriteReactor< $Request$>* "
-                   "reactor) override;\n");
+                   "reactor) override;\n"
+                   "#endif\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "void $Method$(::grpc::ClientContext* context, "
+                   "$Request$* request, "
+                   "::grpc::ClientReadReactor< $Response$>* "
+                   "reactor) override;\n"
+                   "#else\n"
                    "void $Method$(::grpc::ClientContext* context, "
                    "$Request$* request, "
                    "::grpc::experimental::ClientReadReactor< $Response$>* "
-                   "reactor) override;\n");
+                   "reactor) override;\n"
+                   "#endif\n");
 
   } else if (method->BidiStreaming()) {
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "void $Method$(::grpc::ClientContext* context, "
+                   "::grpc::ClientBidiReactor< "
+                   "$Request$,$Response$>* reactor) override;\n"
+                   "#else\n"
                    "void $Method$(::grpc::ClientContext* context, "
                    "::grpc::experimental::ClientBidiReactor< "
-                   "$Request$,$Response$>* reactor) override;\n");
+                   "$Request$,$Response$>* reactor) override;\n"
+                   "#endif\n");
   }
 }
 
@@ -914,11 +992,19 @@ void PrintHeaderServerCallbackMethodsHelper(
         "  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, \"\");\n"
         "}\n");
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "virtual ::grpc::ServerUnaryReactor* $Method$(\n"
+                   "  ::grpc::CallbackServerContext* /*context*/, "
+                   "const $RealRequest$* /*request*/, "
+                   "$RealResponse$* /*response*/)\n"
+                   "#else\n"
                    "virtual ::grpc::experimental::ServerUnaryReactor* "
-                   "$Method$(::grpc::experimental::CallbackServerContext* "
-                   "/*context*/, const $RealRequest$* "
-                   "/*request*/, $RealResponse$* /*response*/) { "
-                   "return nullptr; }\n");
+                   "$Method$(\n"
+                   "  ::grpc::experimental::CallbackServerContext* "
+                   "/*context*/, const $RealRequest$* /*request*/, "
+                   "$RealResponse$* /*response*/)\n"
+                   "#endif\n"
+                   "  { return nullptr; }\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(
         *vars,
@@ -931,11 +1017,18 @@ void PrintHeaderServerCallbackMethodsHelper(
         "  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, \"\");\n"
         "}\n");
     printer->Print(*vars,
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "virtual ::grpc::ServerReadReactor< "
+                   "$RealRequest$>* $Method$(\n"
+                   "  ::grpc::CallbackServerContext* "
+                   "/*context*/, $RealResponse$* /*response*/)\n"
+                   "#else\n"
                    "virtual ::grpc::experimental::ServerReadReactor< "
-                   "$RealRequest$>* $Method$("
-                   "::grpc::experimental::CallbackServerContext* /*context*/, "
-                   "$RealResponse$* /*response*/) { "
-                   "return nullptr; }\n");
+                   "$RealRequest$>* $Method$(\n"
+                   "  ::grpc::experimental::CallbackServerContext* "
+                   "/*context*/, $RealResponse$* /*response*/)\n"
+                   "#endif\n"
+                   "  { return nullptr; }\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(
         *vars,
@@ -949,11 +1042,17 @@ void PrintHeaderServerCallbackMethodsHelper(
         "}\n");
     printer->Print(
         *vars,
-        "virtual ::grpc::experimental::ServerWriteReactor< "
-        "$RealResponse$>* "
-        "$Method$(::grpc::experimental::CallbackServerContext* /*context*/, "
-        "const $RealRequest$* /*request*/) { "
-        "return nullptr; }\n");
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "virtual ::grpc::ServerWriteReactor< $RealResponse$>* $Method$(\n"
+        "  ::grpc::CallbackServerContext* "
+        "/*context*/, const $RealRequest$* /*request*/)\n"
+        "#else\n"
+        "virtual ::grpc::experimental::ServerWriteReactor< $RealResponse$>* "
+        "$Method$(\n"
+        "  ::grpc::experimental::CallbackServerContext* "
+        "/*context*/, const $RealRequest$* /*request*/)\n"
+        "#endif\n"
+        "  { return nullptr; }\n");
   } else if (method->BidiStreaming()) {
     printer->Print(
         *vars,
@@ -967,10 +1066,17 @@ void PrintHeaderServerCallbackMethodsHelper(
         "}\n");
     printer->Print(
         *vars,
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "virtual ::grpc::ServerBidiReactor< $RealRequest$, $RealResponse$>* "
+        "$Method$(\n"
+        "  ::grpc::CallbackServerContext* /*context*/)\n"
+        "#else\n"
         "virtual ::grpc::experimental::ServerBidiReactor< "
         "$RealRequest$, $RealResponse$>* "
-        "$Method$(::grpc::experimental::CallbackServerContext* /*context*/) { "
-        "return nullptr; }\n");
+        "$Method$(\n"
+        "  ::grpc::experimental::CallbackServerContext* /*context*/)\n"
+        "#endif\n"
+        "  { return nullptr; }\n");
   }
 }
 
@@ -998,10 +1104,21 @@ void PrintHeaderServerMethodCallback(
   if (method->NoStreaming()) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackUnaryHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackUnaryHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context, "
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context, "
         "const $RealRequest$* "
         "request, "
         "$RealResponse$* response) { "
@@ -1010,38 +1127,77 @@ void PrintHeaderServerMethodCallback(
                    "void SetMessageAllocatorFor_$Method$(\n"
                    "    ::grpc::experimental::MessageAllocator< "
                    "$RealRequest$, $RealResponse$>* allocator) {\n"
+                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+                   "  ::grpc::internal::MethodHandler* const handler = "
+                   "::grpc::Service::GetHandler($Idx$);\n"
+                   "#else\n"
+                   "  ::grpc::internal::MethodHandler* const handler = "
+                   "::grpc::Service::experimental().GetHandler($Idx$);\n"
+                   "#endif\n"
                    "  static_cast<::grpc_impl::internal::CallbackUnaryHandler< "
-                   "$RealRequest$, $RealResponse$>*>(\n"
-                   "      ::grpc::Service::experimental().GetHandler($Idx$))\n"
+                   "$RealRequest$, $RealResponse$>*>(handler)\n"
                    "          ->SetMessageAllocator(allocator);\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackClientStreamingHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackClientStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context, "
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context, "
         "$RealResponse$* "
         "response) { "
         "return this->$Method$(context, response); }));\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackServerStreamingHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackServerStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context, "
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context, "
         "const $RealRequest$* "
         "request) { "
         "return this->$Method$(context, request); }));\n");
   } else if (method->BidiStreaming()) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackBidiHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackBidiHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context) { "
-        "return this->$Method$(context); }));\n");
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context) "
+        "{ return this->$Method$(context); }));\n");
   }
   printer->Print(*vars, "}\n");
   printer->Print(*vars,
@@ -1077,10 +1233,21 @@ void PrintHeaderServerMethodRawCallback(
   if (method->NoStreaming()) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodRawCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackUnaryHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodRawCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackUnaryHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context, "
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context, "
         "const $RealRequest$* "
         "request, "
         "$RealResponse$* response) { return "
@@ -1088,31 +1255,63 @@ void PrintHeaderServerMethodRawCallback(
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodRawCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackClientStreamingHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodRawCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackClientStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context, "
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context, "
         "$RealResponse$* response) "
         "{ return this->$Method$(context, response); }));\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodRawCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackServerStreamingHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodRawCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackServerStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context, "
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context, "
         "const"
         "$RealRequest$* request) { return "
         "this->$Method$(context, request); }));\n");
   } else if (method->BidiStreaming()) {
     printer->Print(
         *vars,
-        "  ::grpc::Service::experimental().MarkMethodRawCallback($Idx$,\n"
-        "    new ::grpc_impl::internal::CallbackBidiHandler< "
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "  ::grpc::Service::\n"
+        "#else\n"
+        "  ::grpc::Service::experimental().\n"
+        "#endif\n"
+        "    MarkMethodRawCallback($Idx$,\n"
+        "      new ::grpc_impl::internal::CallbackBidiHandler< "
         "$RealRequest$, $RealResponse$>(\n"
-        "      [this](::grpc::experimental::CallbackServerContext* context) { "
-        "return "
-        "this->$Method$(context); }));\n");
+        "        [this](\n"
+        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
+        "               ::grpc::CallbackServerContext*\n"
+        "#else\n"
+        "               ::grpc::experimental::CallbackServerContext*\n"
+        "#endif\n"
+        "                 context) "
+        "{ return this->$Method$(context); }));\n");
   }
   printer->Print(*vars, "}\n");
   printer->Print(*vars,
@@ -1447,6 +1646,20 @@ void PrintHeaderService(grpc_generator::Printer* printer,
     (*vars)["Idx"] = as_string(i);
     PrintHeaderServerMethodCallback(printer, service->method(i).get(), vars);
   }
+
+  printer->Print("#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n");
+  printer->Print("typedef ");
+
+  for (int i = 0; i < service->method_count(); ++i) {
+    (*vars)["method_name"] = service->method(i)->name();
+    printer->Print(*vars, "ExperimentalWithCallbackMethod_$method_name$<");
+  }
+  printer->Print("Service");
+  for (int i = 0; i < service->method_count(); ++i) {
+    printer->Print(" >");
+  }
+  printer->Print(" CallbackService;\n");
+  printer->Print("#endif\n\n");
 
   printer->Print("typedef ");
 

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -27,6 +27,7 @@
 #include "src/proto/grpc/testing/compiler_test.pb.h"
 
 #include <functional>
+#include <grpc/impl/codegen/port_platform.h>
 #include <grpcpp/impl/codegen/async_generic_service.h>
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
@@ -112,22 +113,48 @@ class ServiceA final {
       // MethodA1 leading comment 1
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
       // MethodA1 trailing comment 1
       // MethodA2 detached leading comment 1
       //
       // Method A2 leading comment 1
       // Method A2 leading comment 2
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::ClientWriteReactor< ::grpc::testing::Request>* reactor) = 0;
+      #else
       virtual void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::experimental::ClientWriteReactor< ::grpc::testing::Request>* reactor) = 0;
+      #endif
       // MethodA2 trailing comment 1
       // Method A3 leading comment 1
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodA3(::grpc::ClientContext* context, ::grpc::testing::Request* request, ::grpc::ClientReadReactor< ::grpc::testing::Response>* reactor) = 0;
+      #else
       virtual void MethodA3(::grpc::ClientContext* context, ::grpc::testing::Request* request, ::grpc::experimental::ClientReadReactor< ::grpc::testing::Response>* reactor) = 0;
+      #endif
       // Method A3 trailing comment 1
       // Method A4 leading comment 1
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodA4(::grpc::ClientContext* context, ::grpc::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) = 0;
+      #else
       virtual void MethodA4(::grpc::ClientContext* context, ::grpc::experimental::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) = 0;
+      #endif
       // Method A4 trailing comment 1
     };
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    typedef class experimental_async_interface async_interface;
+    #endif
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    async_interface* async() { return experimental_async(); }
+    #endif
     virtual class experimental_async_interface* experimental_async() { return nullptr; }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* AsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -184,11 +211,31 @@ class ServiceA final {
      public:
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
       void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
       void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::ClientWriteReactor< ::grpc::testing::Request>* reactor) override;
+      #else
       void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::experimental::ClientWriteReactor< ::grpc::testing::Request>* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodA3(::grpc::ClientContext* context, ::grpc::testing::Request* request, ::grpc::ClientReadReactor< ::grpc::testing::Response>* reactor) override;
+      #else
       void MethodA3(::grpc::ClientContext* context, ::grpc::testing::Request* request, ::grpc::experimental::ClientReadReactor< ::grpc::testing::Response>* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodA4(::grpc::ClientContext* context, ::grpc::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) override;
+      #else
       void MethodA4(::grpc::ClientContext* context, ::grpc::experimental::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) override;
+      #endif
      private:
       friend class Stub;
       explicit experimental_async(Stub* stub): stub_(stub) { }
@@ -325,13 +372,28 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_MethodA1() {
-      ::grpc::Service::experimental().MarkMethodCallback(0,
-        new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodA1(context, request, response); }));}
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(0,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodA1(context, request, response); }));}
     void SetMessageAllocatorFor_MethodA1(
         ::grpc::experimental::MessageAllocator< ::grpc::testing::Request, ::grpc::testing::Response>* allocator) {
-      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>*>(
-          ::grpc::Service::experimental().GetHandler(0))
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(0);
+    #endif
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>*>(handler)
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_MethodA1() override {
@@ -342,7 +404,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodA1(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* MethodA1(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* MethodA1(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_MethodA2 : public BaseClass {
@@ -350,9 +419,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_MethodA2() {
-      ::grpc::Service::experimental().MarkMethodCallback(1,
-        new ::grpc_impl::internal::CallbackClientStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
-          [this](::grpc::experimental::CallbackServerContext* context, ::grpc::testing::Response* response) { return this->MethodA2(context, response); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(1,
+          new ::grpc_impl::internal::CallbackClientStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, ::grpc::testing::Response* response) { return this->MethodA2(context, response); }));
     }
     ~ExperimentalWithCallbackMethod_MethodA2() override {
       BaseClassMustBeDerivedFromService(this);
@@ -362,7 +442,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerReadReactor< ::grpc::testing::Request>* MethodA2(::grpc::experimental::CallbackServerContext* /*context*/, ::grpc::testing::Response* /*response*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerReadReactor< ::grpc::testing::Request>* MethodA2(
+      ::grpc::CallbackServerContext* /*context*/, ::grpc::testing::Response* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerReadReactor< ::grpc::testing::Request>* MethodA2(
+      ::grpc::experimental::CallbackServerContext* /*context*/, ::grpc::testing::Response* /*response*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_MethodA3 : public BaseClass {
@@ -370,9 +457,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_MethodA3() {
-      ::grpc::Service::experimental().MarkMethodCallback(2,
-        new ::grpc_impl::internal::CallbackServerStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::testing::Request* request) { return this->MethodA3(context, request); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(2,
+          new ::grpc_impl::internal::CallbackServerStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::testing::Request* request) { return this->MethodA3(context, request); }));
     }
     ~ExperimentalWithCallbackMethod_MethodA3() override {
       BaseClassMustBeDerivedFromService(this);
@@ -382,7 +480,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::testing::Response>* MethodA3(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerWriteReactor< ::grpc::testing::Response>* MethodA3(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/)
+    #else
+    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::testing::Response>* MethodA3(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_MethodA4 : public BaseClass {
@@ -390,9 +495,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_MethodA4() {
-      ::grpc::Service::experimental().MarkMethodCallback(3,
-        new ::grpc_impl::internal::CallbackBidiHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
-          [this](::grpc::experimental::CallbackServerContext* context) { return this->MethodA4(context); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(3,
+          new ::grpc_impl::internal::CallbackBidiHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context) { return this->MethodA4(context); }));
     }
     ~ExperimentalWithCallbackMethod_MethodA4() override {
       BaseClassMustBeDerivedFromService(this);
@@ -402,8 +518,19 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerBidiReactor< ::grpc::testing::Request, ::grpc::testing::Response>* MethodA4(::grpc::experimental::CallbackServerContext* /*context*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerBidiReactor< ::grpc::testing::Request, ::grpc::testing::Response>* MethodA4(
+      ::grpc::CallbackServerContext* /*context*/)
+    #else
+    virtual ::grpc::experimental::ServerBidiReactor< ::grpc::testing::Request, ::grpc::testing::Response>* MethodA4(
+      ::grpc::experimental::CallbackServerContext* /*context*/)
+    #endif
+      { return nullptr; }
   };
+  #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+  typedef ExperimentalWithCallbackMethod_MethodA1<ExperimentalWithCallbackMethod_MethodA2<ExperimentalWithCallbackMethod_MethodA3<ExperimentalWithCallbackMethod_MethodA4<Service > > > > CallbackService;
+  #endif
+
   typedef ExperimentalWithCallbackMethod_MethodA1<ExperimentalWithCallbackMethod_MethodA2<ExperimentalWithCallbackMethod_MethodA3<ExperimentalWithCallbackMethod_MethodA4<Service > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_MethodA1 : public BaseClass {
@@ -559,9 +686,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_MethodA1() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(0,
-        new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodA1(context, request, response); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(0,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodA1(context, request, response); }));
     }
     ~ExperimentalWithRawCallbackMethod_MethodA1() override {
       BaseClassMustBeDerivedFromService(this);
@@ -571,7 +709,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodA1(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* MethodA1(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* MethodA1(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_MethodA2 : public BaseClass {
@@ -579,9 +724,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_MethodA2() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(1,
-        new ::grpc_impl::internal::CallbackClientStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-          [this](::grpc::experimental::CallbackServerContext* context, ::grpc::ByteBuffer* response) { return this->MethodA2(context, response); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(1,
+          new ::grpc_impl::internal::CallbackClientStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, ::grpc::ByteBuffer* response) { return this->MethodA2(context, response); }));
     }
     ~ExperimentalWithRawCallbackMethod_MethodA2() override {
       BaseClassMustBeDerivedFromService(this);
@@ -591,7 +747,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerReadReactor< ::grpc::ByteBuffer>* MethodA2(::grpc::experimental::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerReadReactor< ::grpc::ByteBuffer>* MethodA2(
+      ::grpc::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerReadReactor< ::grpc::ByteBuffer>* MethodA2(
+      ::grpc::experimental::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_MethodA3 : public BaseClass {
@@ -599,9 +762,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_MethodA3() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(2,
-        new ::grpc_impl::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-          [this](::grpc::experimental::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->MethodA3(context, request); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(2,
+          new ::grpc_impl::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const::grpc::ByteBuffer* request) { return this->MethodA3(context, request); }));
     }
     ~ExperimentalWithRawCallbackMethod_MethodA3() override {
       BaseClassMustBeDerivedFromService(this);
@@ -611,7 +785,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::ByteBuffer>* MethodA3(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* MethodA3(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)
+    #else
+    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::ByteBuffer>* MethodA3(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_MethodA4 : public BaseClass {
@@ -619,9 +800,20 @@ class ServiceA final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_MethodA4() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(3,
-        new ::grpc_impl::internal::CallbackBidiHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-          [this](::grpc::experimental::CallbackServerContext* context) { return this->MethodA4(context); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(3,
+          new ::grpc_impl::internal::CallbackBidiHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context) { return this->MethodA4(context); }));
     }
     ~ExperimentalWithRawCallbackMethod_MethodA4() override {
       BaseClassMustBeDerivedFromService(this);
@@ -631,7 +823,14 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerBidiReactor< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* MethodA4(::grpc::experimental::CallbackServerContext* /*context*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerBidiReactor< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* MethodA4(
+      ::grpc::CallbackServerContext* /*context*/)
+    #else
+    virtual ::grpc::experimental::ServerBidiReactor< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* MethodA4(
+      ::grpc::experimental::CallbackServerContext* /*context*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_MethodA1 : public BaseClass {
@@ -702,10 +901,24 @@ class ServiceB final {
       // MethodB1 leading comment 1
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
       // MethodB1 trailing comment 1
     };
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    typedef class experimental_async_interface async_interface;
+    #endif
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    async_interface* async() { return experimental_async(); }
+    #endif
     virtual class experimental_async_interface* experimental_async() { return nullptr; }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* AsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -726,8 +939,16 @@ class ServiceB final {
      public:
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
       void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
       void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
      private:
       friend class Stub;
       explicit experimental_async(Stub* stub): stub_(stub) { }
@@ -780,13 +1001,28 @@ class ServiceB final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithCallbackMethod_MethodB1() {
-      ::grpc::Service::experimental().MarkMethodCallback(0,
-        new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodB1(context, request, response); }));}
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(0,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodB1(context, request, response); }));}
     void SetMessageAllocatorFor_MethodB1(
         ::grpc::experimental::MessageAllocator< ::grpc::testing::Request, ::grpc::testing::Response>* allocator) {
-      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>*>(
-          ::grpc::Service::experimental().GetHandler(0))
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(0);
+    #endif
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>*>(handler)
               ->SetMessageAllocator(allocator);
     }
     ~ExperimentalWithCallbackMethod_MethodB1() override {
@@ -797,8 +1033,19 @@ class ServiceB final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodB1(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* MethodB1(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* MethodB1(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
+    #endif
+      { return nullptr; }
   };
+  #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+  typedef ExperimentalWithCallbackMethod_MethodB1<Service > CallbackService;
+  #endif
+
   typedef ExperimentalWithCallbackMethod_MethodB1<Service > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_MethodB1 : public BaseClass {
@@ -843,9 +1090,20 @@ class ServiceB final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     ExperimentalWithRawCallbackMethod_MethodB1() {
-      ::grpc::Service::experimental().MarkMethodRawCallback(0,
-        new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
-          [this](::grpc::experimental::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodB1(context, request, response); }));
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(0,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodB1(context, request, response); }));
     }
     ~ExperimentalWithRawCallbackMethod_MethodB1() override {
       BaseClassMustBeDerivedFromService(this);
@@ -855,7 +1113,14 @@ class ServiceB final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodB1(::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/) { return nullptr; }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* MethodB1(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* MethodB1(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_MethodB1 : public BaseClass {


### PR DESCRIPTION
This allows the code to no longer use "experimental_async()", "ExperimentalCallbackService", etc, and also changes the method signatures to use the non-experimental versions when possible (under the appropriate macro).

Is this the right approach to how the generated code should look? ~~Hard to tell.~~ I think so. Although having #ifdef's in the generated code may be confusing to users since they may think that they have to override both versions of the code in their service definitions, in practice, nobody is currently using the experimental version except for those that will get to migrate right now. Then we can remove the experimental for everybody else with the gRFC once the OSS EM is ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/21405)
<!-- Reviewable:end -->
