### PR TITLE
Raise UNAVAILABLE instead of INTERNAL for RST_STREAM with code 0

### DIFF
--- a/src/core/lib/transport/status_conversion.cc
+++ b/src/core/lib/transport/status_conversion.cc
@@ -44,7 +44,9 @@ grpc_status_code grpc_http2_error_to_grpc_status(grpc_http2_error_code error,
   switch (error) {
     case GRPC_HTTP2_NO_ERROR:
       /* should never be received */
-      return GRPC_STATUS_INTERNAL;
+      /* if received, we should blame upstream and mark as UNAVALABLE to help
+       * application retry automatically */
+      return GRPC_STATUS_UNAVAILABLE;
     case GRPC_HTTP2_CANCEL:
       /* http2 cancel translates to STATUS_CANCELLED iff deadline hasn't been
        * exceeded */


### PR DESCRIPTION
Magic context:
* b/130522486
* b/144734355
* b/143580700

It is unclear to me that if the RST_STREAM frame with error code 0 (no error) is sent by proxy or firestore backends. But as an API client library, we should treat this error less verbosely. Here, as discussed with @yashykt, we could change the error code to UNAVAILABLE which helps client library to retry automatically.

Let's see if tests are happy.