### PR TITLE
Add preprocessed_builds to abseil-cpp

### DIFF
--- a/src/abseil-cpp/gen_build_yaml.py
+++ b/src/abseil-cpp/gen_build_yaml.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python2.7
+
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import yaml
+
+BUILDS_YAML_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'preprocessed_builds.yaml')
+with open(BUILDS_YAML_PATH) as f:
+  builds = yaml.load(f)
+
+for build in builds:
+    build['build'] = 'private'
+    build['build_system'] = []
+    build['language'] = 'c'
+print(yaml.dump({'libs': builds}))

--- a/src/abseil-cpp/preprocessed_builds.yaml
+++ b/src/abseil-cpp/preprocessed_builds.yaml
@@ -1,0 +1,1179 @@
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/algorithm/algorithm.h
+  name: absl/algorithm:algorithm
+  src: []
+- deps:
+  - absl/algorithm:algorithm
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/algorithm/container.h
+  name: absl/algorithm:container
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/atomic_hook.h
+  name: absl/base:atomic_hook
+  src: []
+- deps:
+  - absl/base:atomic_hook
+  - absl/base:base_internal
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:log_severity
+  - absl/base:raw_logging_internal
+  - absl/base:spinlock_wait
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/base/call_once.h
+  - third_party/abseil-cpp/absl/base/casts.h
+  - third_party/abseil-cpp/absl/base/internal/cycleclock.h
+  - third_party/abseil-cpp/absl/base/internal/low_level_scheduling.h
+  - third_party/abseil-cpp/absl/base/internal/per_thread_tls.h
+  - third_party/abseil-cpp/absl/base/internal/spinlock.h
+  - third_party/abseil-cpp/absl/base/internal/sysinfo.h
+  - third_party/abseil-cpp/absl/base/internal/thread_identity.h
+  - third_party/abseil-cpp/absl/base/internal/tsan_mutex_interface.h
+  - third_party/abseil-cpp/absl/base/internal/unscaledcycleclock.h
+  name: absl/base:base
+  src:
+  - third_party/abseil-cpp/absl/base/internal/cycleclock.cc
+  - third_party/abseil-cpp/absl/base/internal/spinlock.cc
+  - third_party/abseil-cpp/absl/base/internal/sysinfo.cc
+  - third_party/abseil-cpp/absl/base/internal/thread_identity.cc
+  - third_party/abseil-cpp/absl/base/internal/unscaledcycleclock.cc
+- deps:
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/hide_ptr.h
+  - third_party/abseil-cpp/absl/base/internal/identity.h
+  - third_party/abseil-cpp/absl/base/internal/inline_variable.h
+  - third_party/abseil-cpp/absl/base/internal/invoke.h
+  - third_party/abseil-cpp/absl/base/internal/scheduling_mode.h
+  name: absl/base:base_internal
+  src: []
+- deps:
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/bits.h
+  name: absl/base:bits
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/base/config.h
+  - third_party/abseil-cpp/absl/base/options.h
+  - third_party/abseil-cpp/absl/base/policy_checks.h
+  name: absl/base:config
+  src: []
+- deps:
+  - absl/base:config
+  headers:
+  - third_party/abseil-cpp/absl/base/attributes.h
+  - third_party/abseil-cpp/absl/base/const_init.h
+  - third_party/abseil-cpp/absl/base/internal/thread_annotations.h
+  - third_party/abseil-cpp/absl/base/macros.h
+  - third_party/abseil-cpp/absl/base/optimization.h
+  - third_party/abseil-cpp/absl/base/port.h
+  - third_party/abseil-cpp/absl/base/thread_annotations.h
+  name: absl/base:core_headers
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/base/dynamic_annotations.h
+  name: absl/base:dynamic_annotations
+  src:
+  - third_party/abseil-cpp/absl/base/dynamic_annotations.cc
+- deps:
+  - absl/base:config
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/endian.h
+  - third_party/abseil-cpp/absl/base/internal/unaligned_access.h
+  name: absl/base:endian
+  src: []
+- deps:
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/exponential_biased.h
+  name: absl/base:exponential_biased
+  src:
+  - third_party/abseil-cpp/absl/base/internal/exponential_biased.cc
+- deps:
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/base/log_severity.h
+  name: absl/base:log_severity
+  src:
+  - third_party/abseil-cpp/absl/base/log_severity.cc
+- deps:
+  - absl/base:base
+  - absl/base:base_internal
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/direct_mmap.h
+  - third_party/abseil-cpp/absl/base/internal/low_level_alloc.h
+  name: absl/base:malloc_internal
+  src:
+  - third_party/abseil-cpp/absl/base/internal/low_level_alloc.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:exponential_biased
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/periodic_sampler.h
+  name: absl/base:periodic_sampler
+  src:
+  - third_party/abseil-cpp/absl/base/internal/periodic_sampler.cc
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/pretty_function.h
+  name: absl/base:pretty_function
+  src: []
+- deps:
+  - absl/base:atomic_hook
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:log_severity
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/raw_logging.h
+  name: absl/base:raw_logging_internal
+  src:
+  - third_party/abseil-cpp/absl/base/internal/raw_logging.cc
+- deps:
+  - absl/base:base_internal
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/spinlock_akaros.inc
+  - third_party/abseil-cpp/absl/base/internal/spinlock_linux.inc
+  - third_party/abseil-cpp/absl/base/internal/spinlock_posix.inc
+  - third_party/abseil-cpp/absl/base/internal/spinlock_wait.h
+  - third_party/abseil-cpp/absl/base/internal/spinlock_win32.inc
+  name: absl/base:spinlock_wait
+  src:
+  - third_party/abseil-cpp/absl/base/internal/spinlock_wait.cc
+- deps:
+  - absl/base:config
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/base/internal/throw_delegate.h
+  name: absl/base:throw_delegate
+  src:
+  - third_party/abseil-cpp/absl/base/internal/throw_delegate.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:throw_delegate
+  - absl/container:common
+  - absl/container:compressed_tuple
+  - absl/container:container_memory
+  - absl/container:layout
+  - absl/memory:memory
+  - absl/meta:type_traits
+  - absl/strings:strings
+  - absl/types:compare
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/container/btree_map.h
+  - third_party/abseil-cpp/absl/container/btree_set.h
+  - third_party/abseil-cpp/absl/container/internal/btree.h
+  - third_party/abseil-cpp/absl/container/internal/btree_container.h
+  name: absl/container:btree
+  src: []
+- deps:
+  - absl/meta:type_traits
+  - absl/types:optional
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/common.h
+  name: absl/container:common
+  src: []
+- deps:
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/compressed_tuple.h
+  name: absl/container:compressed_tuple
+  src: []
+- deps:
+  - absl/memory:memory
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/container_memory.h
+  name: absl/container:container_memory
+  src: []
+- deps:
+  - absl/algorithm:algorithm
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:throw_delegate
+  - absl/container:compressed_tuple
+  - absl/memory:memory
+  headers:
+  - third_party/abseil-cpp/absl/container/fixed_array.h
+  name: absl/container:fixed_array
+  src: []
+- deps:
+  - absl/algorithm:container
+  - absl/container:container_memory
+  - absl/container:hash_function_defaults
+  - absl/container:raw_hash_map
+  - absl/memory:memory
+  headers:
+  - third_party/abseil-cpp/absl/container/flat_hash_map.h
+  name: absl/container:flat_hash_map
+  src: []
+- deps:
+  - absl/algorithm:container
+  - absl/base:core_headers
+  - absl/container:container_memory
+  - absl/container:hash_function_defaults
+  - absl/container:raw_hash_set
+  - absl/memory:memory
+  headers:
+  - third_party/abseil-cpp/absl/container/flat_hash_set.h
+  name: absl/container:flat_hash_set
+  src: []
+- deps:
+  - absl/base:config
+  - absl/hash:hash
+  - absl/strings:strings
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/hash_function_defaults.h
+  name: absl/container:hash_function_defaults
+  src: []
+- deps:
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/hash_policy_traits.h
+  name: absl/container:hash_policy_traits
+  src: []
+- deps:
+  - absl/container:hashtable_debug_hooks
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/hashtable_debug.h
+  name: absl/container:hashtable_debug
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/hashtable_debug_hooks.h
+  name: absl/container:hashtable_debug_hooks
+  src: []
+- deps:
+  - absl/base:base
+  - absl/base:core_headers
+  - absl/base:exponential_biased
+  - absl/container:have_sse
+  - absl/debugging:stacktrace
+  - absl/memory:memory
+  - absl/synchronization:synchronization
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/hashtablez_sampler.h
+  name: absl/container:hashtablez_sampler
+  src:
+  - third_party/abseil-cpp/absl/container/internal/hashtablez_sampler.cc
+  - third_party/abseil-cpp/absl/container/internal/hashtablez_sampler_force_weak_definition.cc
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/have_sse.h
+  name: absl/container:have_sse
+  src: []
+- deps:
+  - absl/algorithm:algorithm
+  - absl/base:core_headers
+  - absl/base:throw_delegate
+  - absl/container:inlined_vector_internal
+  - absl/memory:memory
+  headers:
+  - third_party/abseil-cpp/absl/container/inlined_vector.h
+  name: absl/container:inlined_vector
+  src: []
+- deps:
+  - absl/base:core_headers
+  - absl/container:compressed_tuple
+  - absl/memory:memory
+  - absl/meta:type_traits
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/inlined_vector.h
+  name: absl/container:inlined_vector_internal
+  src: []
+- deps:
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/strings:strings
+  - absl/types:span
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/layout.h
+  name: absl/container:layout
+  src: []
+- deps:
+  - absl/algorithm:container
+  - absl/container:container_memory
+  - absl/container:hash_function_defaults
+  - absl/container:node_hash_policy
+  - absl/container:raw_hash_map
+  - absl/memory:memory
+  headers:
+  - third_party/abseil-cpp/absl/container/node_hash_map.h
+  name: absl/container:node_hash_map
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/node_hash_policy.h
+  name: absl/container:node_hash_policy
+  src: []
+- deps:
+  - absl/algorithm:container
+  - absl/container:hash_function_defaults
+  - absl/container:node_hash_policy
+  - absl/container:raw_hash_set
+  - absl/memory:memory
+  headers:
+  - third_party/abseil-cpp/absl/container/node_hash_set.h
+  name: absl/container:node_hash_set
+  src: []
+- deps:
+  - absl/base:throw_delegate
+  - absl/container:container_memory
+  - absl/container:raw_hash_set
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/raw_hash_map.h
+  name: absl/container:raw_hash_map
+  src: []
+- deps:
+  - absl/base:bits
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:endian
+  - absl/container:common
+  - absl/container:compressed_tuple
+  - absl/container:container_memory
+  - absl/container:hash_policy_traits
+  - absl/container:hashtable_debug_hooks
+  - absl/container:hashtablez_sampler
+  - absl/container:have_sse
+  - absl/container:layout
+  - absl/memory:memory
+  - absl/meta:type_traits
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/container/internal/raw_hash_set.h
+  name: absl/container:raw_hash_set
+  src:
+  - third_party/abseil-cpp/absl/container/internal/raw_hash_set.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/debugging/internal/address_is_readable.h
+  - third_party/abseil-cpp/absl/debugging/internal/elf_mem_image.h
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_aarch64-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_arm-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_config.h
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_generic-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_powerpc-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_unimplemented-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_win32-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/stacktrace_x86-inl.inc
+  - third_party/abseil-cpp/absl/debugging/internal/vdso_support.h
+  name: absl/debugging:debugging_internal
+  src:
+  - third_party/abseil-cpp/absl/debugging/internal/address_is_readable.cc
+  - third_party/abseil-cpp/absl/debugging/internal/elf_mem_image.cc
+  - third_party/abseil-cpp/absl/debugging/internal/vdso_support.cc
+- deps:
+  - absl/base:base
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/debugging/internal/demangle.h
+  name: absl/debugging:demangle_internal
+  src:
+  - third_party/abseil-cpp/absl/debugging/internal/demangle.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:raw_logging_internal
+  - absl/debugging:stacktrace
+  - absl/debugging:symbolize
+  headers:
+  - third_party/abseil-cpp/absl/debugging/internal/examine_stack.h
+  name: absl/debugging:examine_stack
+  src:
+  - third_party/abseil-cpp/absl/debugging/internal/examine_stack.cc
+- deps:
+  - absl/base:base
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:raw_logging_internal
+  - absl/debugging:examine_stack
+  - absl/debugging:stacktrace
+  headers:
+  - third_party/abseil-cpp/absl/debugging/failure_signal_handler.h
+  name: absl/debugging:failure_signal_handler
+  src:
+  - third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+- deps:
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/debugging/leak_check.h
+  name: absl/debugging:leak_check
+  src:
+  - third_party/abseil-cpp/absl/debugging/leak_check.cc
+- deps: []
+  headers: []
+  name: absl/debugging:leak_check_disable
+  src:
+  - third_party/abseil-cpp/absl/debugging/leak_check_disable.cc
+- deps:
+  - absl/base:core_headers
+  - absl/debugging:debugging_internal
+  headers:
+  - third_party/abseil-cpp/absl/debugging/stacktrace.h
+  name: absl/debugging:stacktrace
+  src:
+  - third_party/abseil-cpp/absl/debugging/stacktrace.cc
+- deps:
+  - absl/base:base
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:malloc_internal
+  - absl/base:raw_logging_internal
+  - absl/debugging:debugging_internal
+  - absl/debugging:demangle_internal
+  headers:
+  - third_party/abseil-cpp/absl/debugging/internal/symbolize.h
+  - third_party/abseil-cpp/absl/debugging/symbolize.h
+  - third_party/abseil-cpp/absl/debugging/symbolize_elf.inc
+  - third_party/abseil-cpp/absl/debugging/symbolize_unimplemented.inc
+  - third_party/abseil-cpp/absl/debugging/symbolize_win32.inc
+  name: absl/debugging:symbolize
+  src:
+  - third_party/abseil-cpp/absl/debugging/symbolize.cc
+- deps:
+  - absl/base:core_headers
+  - absl/flags:path_util
+  - absl/flags:program_name
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/config.h
+  - third_party/abseil-cpp/absl/flags/usage_config.h
+  name: absl/flags:config
+  src:
+  - third_party/abseil-cpp/absl/flags/usage_config.cc
+- deps:
+  - absl/base:base
+  - absl/base:core_headers
+  - absl/flags:config
+  - absl/flags:flag_internal
+  - absl/flags:handle
+  - absl/flags:marshalling
+  - absl/memory:memory
+  - absl/strings:strings
+  headers:
+  - third_party/abseil-cpp/absl/flags/declare.h
+  - third_party/abseil-cpp/absl/flags/flag.h
+  name: absl/flags:flag
+  src:
+  - third_party/abseil-cpp/absl/flags/flag.cc
+- deps:
+  - absl/base:core_headers
+  - absl/flags:handle
+  - absl/flags:registry
+  - absl/memory:memory
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/flag.h
+  name: absl/flags:flag_internal
+  src:
+  - third_party/abseil-cpp/absl/flags/internal/flag.cc
+- deps:
+  - absl/base:core_headers
+  - absl/flags:config
+  - absl/flags:marshalling
+  - absl/types:optional
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/commandlineflag.h
+  name: absl/flags:handle
+  src:
+  - third_party/abseil-cpp/absl/flags/internal/commandlineflag.cc
+- deps:
+  - absl/base:core_headers
+  - absl/strings:str_format
+  - absl/strings:strings
+  headers:
+  - third_party/abseil-cpp/absl/flags/marshalling.h
+  name: absl/flags:marshalling
+  src:
+  - third_party/abseil-cpp/absl/flags/marshalling.cc
+- deps:
+  - absl/flags:config
+  - absl/flags:flag
+  - absl/flags:program_name
+  - absl/flags:registry
+  - absl/flags:usage
+  - absl/flags:usage_internal
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/parse.h
+  - third_party/abseil-cpp/absl/flags/parse.h
+  name: absl/flags:parse
+  src:
+  - third_party/abseil-cpp/absl/flags/parse.cc
+- deps:
+  - absl/strings:strings
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/path_util.h
+  name: absl/flags:path_util
+  src: []
+- deps:
+  - absl/flags:path_util
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/program_name.h
+  name: absl/flags:program_name
+  src:
+  - third_party/abseil-cpp/absl/flags/internal/program_name.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:raw_logging_internal
+  - absl/flags:config
+  - absl/flags:handle
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/registry.h
+  - third_party/abseil-cpp/absl/flags/internal/type_erased.h
+  name: absl/flags:registry
+  src:
+  - third_party/abseil-cpp/absl/flags/internal/registry.cc
+  - third_party/abseil-cpp/absl/flags/internal/type_erased.cc
+- deps:
+  - absl/flags:usage_internal
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/usage.h
+  name: absl/flags:usage
+  src:
+  - third_party/abseil-cpp/absl/flags/usage.cc
+- deps:
+  - absl/flags:config
+  - absl/flags:flag
+  - absl/flags:handle
+  - absl/flags:path_util
+  - absl/flags:program_name
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  headers:
+  - third_party/abseil-cpp/absl/flags/internal/usage.h
+  name: absl/flags:usage_internal
+  src:
+  - third_party/abseil-cpp/absl/flags/internal/usage.cc
+- deps:
+  - absl/base:base_internal
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/functional/function_ref.h
+  - third_party/abseil-cpp/absl/functional/internal/function_ref.h
+  name: absl/functional:function_ref
+  src: []
+- deps:
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:endian
+  headers:
+  - third_party/abseil-cpp/absl/hash/internal/city.h
+  name: absl/hash:city
+  src:
+  - third_party/abseil-cpp/absl/hash/internal/city.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:endian
+  - absl/container:fixed_array
+  - absl/hash:city
+  - absl/meta:type_traits
+  - absl/numeric:int128
+  - absl/strings:strings
+  - absl/types:optional
+  - absl/types:variant
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/hash/hash.h
+  - third_party/abseil-cpp/absl/hash/internal/hash.h
+  name: absl/hash:hash
+  src:
+  - third_party/abseil-cpp/absl/hash/internal/hash.cc
+- deps:
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/memory/memory.h
+  name: absl/memory:memory
+  src: []
+- deps:
+  - absl/base:config
+  headers:
+  - third_party/abseil-cpp/absl/meta/type_traits.h
+  name: absl/meta:type_traits
+  src: []
+- deps:
+  - absl/base:config
+  - absl/base:core_headers
+  headers:
+  - third_party/abseil-cpp/absl/numeric/int128.h
+  - third_party/abseil-cpp/absl/numeric/int128_have_intrinsic.inc
+  - third_party/abseil-cpp/absl/numeric/int128_no_intrinsic.inc
+  name: absl/numeric:int128
+  src:
+  - third_party/abseil-cpp/absl/numeric/int128.cc
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/distribution_caller.h
+  name: absl/random/internal:distribution_caller
+  src: []
+- deps:
+  - absl/base:base
+  - absl/meta:type_traits
+  - absl/random/internal:distribution_caller
+  - absl/random/internal:traits
+  - absl/random/internal:uniform_helper
+  - absl/strings:strings
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/distributions.h
+  name: absl/random/internal:distributions
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/fast_uniform_bits.h
+  name: absl/random/internal:fast_uniform_bits
+  src: []
+- deps:
+  - absl/base:bits
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/fastmath.h
+  name: absl/random/internal:fastmath
+  src: []
+- deps:
+  - absl/base:bits
+  - absl/meta:type_traits
+  - absl/random/internal:fastmath
+  - absl/random/internal:traits
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/generate_real.h
+  name: absl/random/internal:generate_real
+  src: []
+- deps:
+  - absl/meta:type_traits
+  - absl/numeric:int128
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/iostream_state_saver.h
+  name: absl/random/internal:iostream_state_saver
+  src: []
+- deps:
+  - absl/random:random
+  - absl/strings:strings
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/mocking_bit_gen_base.h
+  name: absl/random/internal:mocking_bit_gen_base
+  src: []
+- deps:
+  - absl/base:raw_logging_internal
+  - absl/random/internal:platform
+  - absl/random/internal:randen_engine
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/nanobenchmark.h
+  name: absl/random/internal:nanobenchmark
+  src:
+  - third_party/abseil-cpp/absl/random/internal/nanobenchmark.cc
+- deps:
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/random/internal:pool_urbg
+  - absl/random/internal:salted_seed_seq
+  - absl/random/internal:seed_material
+  - absl/strings:strings
+  - absl/types:optional
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/nonsecure_base.h
+  name: absl/random/internal:nonsecure_base
+  src: []
+- deps:
+  - absl/base:config
+  - absl/meta:type_traits
+  - absl/numeric:int128
+  - absl/random/internal:fastmath
+  - absl/random/internal:iostream_state_saver
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/pcg_engine.h
+  name: absl/random/internal:pcg_engine
+  src: []
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/platform.h
+  - third_party/abseil-cpp/absl/random/internal/randen-keys.inc
+  - third_party/abseil-cpp/absl/random/internal/randen_traits.h
+  name: absl/random/internal:platform
+  src: []
+- deps:
+  - absl/base:base
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:endian
+  - absl/base:raw_logging_internal
+  - absl/random/internal:randen
+  - absl/random/internal:seed_material
+  - absl/random/internal:traits
+  - absl/random:seed_gen_exception
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/pool_urbg.h
+  name: absl/random/internal:pool_urbg
+  src:
+  - third_party/abseil-cpp/absl/random/internal/pool_urbg.cc
+- deps:
+  - absl/base:raw_logging_internal
+  - absl/random/internal:platform
+  - absl/random/internal:randen_hwaes
+  - absl/random/internal:randen_slow
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/randen.h
+  name: absl/random/internal:randen
+  src:
+  - third_party/abseil-cpp/absl/random/internal/randen.cc
+- deps:
+  - absl/meta:type_traits
+  - absl/random/internal:iostream_state_saver
+  - absl/random/internal:randen
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/randen_engine.h
+  name: absl/random/internal:randen_engine
+  src: []
+- deps:
+  - absl/random/internal:platform
+  - absl/random/internal:randen_hwaes_impl
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/randen_detect.h
+  - third_party/abseil-cpp/absl/random/internal/randen_hwaes.h
+  name: absl/random/internal:randen_hwaes
+  src:
+  - third_party/abseil-cpp/absl/random/internal/randen_detect.cc
+- deps:
+  - absl/base:core_headers
+  - absl/random/internal:platform
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/randen_hwaes.h
+  name: absl/random/internal:randen_hwaes_impl
+  src:
+  - third_party/abseil-cpp/absl/random/internal/randen_hwaes.cc
+- deps:
+  - absl/random/internal:platform
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/randen_slow.h
+  name: absl/random/internal:randen_slow
+  src:
+  - third_party/abseil-cpp/absl/random/internal/randen_slow.cc
+- deps:
+  - absl/container:inlined_vector
+  - absl/meta:type_traits
+  - absl/random/internal:seed_material
+  - absl/types:optional
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/salted_seed_seq.h
+  name: absl/random/internal:salted_seed_seq
+  src: []
+- deps:
+  - absl/base:core_headers
+  - absl/base:raw_logging_internal
+  - absl/random/internal:fast_uniform_bits
+  - absl/strings:strings
+  - absl/types:optional
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/seed_material.h
+  name: absl/random/internal:seed_material
+  src:
+  - third_party/abseil-cpp/absl/random/internal/seed_material.cc
+- deps:
+  - absl/base:config
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/traits.h
+  name: absl/random/internal:traits
+  src: []
+- deps:
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/uniform_helper.h
+  name: absl/random/internal:uniform_helper
+  src: []
+- deps:
+  - absl/base:bits
+  - absl/base:config
+  - absl/numeric:int128
+  - absl/random/internal:traits
+  headers:
+  - third_party/abseil-cpp/absl/random/internal/wide_multiply.h
+  name: absl/random/internal:wide_multiply
+  src: []
+- deps:
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/random/internal:distribution_caller
+  - absl/random/internal:fast_uniform_bits
+  - absl/random/internal:mocking_bit_gen_base
+  headers:
+  - third_party/abseil-cpp/absl/random/bit_gen_ref.h
+  name: absl/random:bit_gen_ref
+  src: []
+- deps:
+  - absl/base:base_internal
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/random/internal:distributions
+  - absl/random/internal:fast_uniform_bits
+  - absl/random/internal:fastmath
+  - absl/random/internal:generate_real
+  - absl/random/internal:iostream_state_saver
+  - absl/random/internal:traits
+  - absl/random/internal:uniform_helper
+  - absl/random/internal:wide_multiply
+  - absl/strings:strings
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/random/bernoulli_distribution.h
+  - third_party/abseil-cpp/absl/random/beta_distribution.h
+  - third_party/abseil-cpp/absl/random/discrete_distribution.h
+  - third_party/abseil-cpp/absl/random/distribution_format_traits.h
+  - third_party/abseil-cpp/absl/random/distributions.h
+  - third_party/abseil-cpp/absl/random/exponential_distribution.h
+  - third_party/abseil-cpp/absl/random/gaussian_distribution.h
+  - third_party/abseil-cpp/absl/random/log_uniform_int_distribution.h
+  - third_party/abseil-cpp/absl/random/poisson_distribution.h
+  - third_party/abseil-cpp/absl/random/uniform_int_distribution.h
+  - third_party/abseil-cpp/absl/random/uniform_real_distribution.h
+  - third_party/abseil-cpp/absl/random/zipf_distribution.h
+  name: absl/random:distributions
+  src:
+  - third_party/abseil-cpp/absl/random/discrete_distribution.cc
+  - third_party/abseil-cpp/absl/random/gaussian_distribution.cc
+- deps:
+  - absl/random/internal:nonsecure_base
+  - absl/random/internal:pcg_engine
+  - absl/random/internal:pool_urbg
+  - absl/random/internal:randen_engine
+  - absl/random:distributions
+  - absl/random:seed_sequences
+  headers:
+  - third_party/abseil-cpp/absl/random/random.h
+  name: absl/random:random
+  src: []
+- deps:
+  - absl/base:config
+  headers:
+  - third_party/abseil-cpp/absl/random/seed_gen_exception.h
+  name: absl/random:seed_gen_exception
+  src:
+  - third_party/abseil-cpp/absl/random/seed_gen_exception.cc
+- deps:
+  - absl/container:inlined_vector
+  - absl/random/internal:nonsecure_base
+  - absl/random/internal:pool_urbg
+  - absl/random/internal:salted_seed_seq
+  - absl/random/internal:seed_material
+  - absl/random:seed_gen_exception
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/random/seed_sequences.h
+  name: absl/random:seed_sequences
+  src:
+  - third_party/abseil-cpp/absl/random/seed_sequences.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:endian
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/strings/internal/char_map.h
+  - third_party/abseil-cpp/absl/strings/internal/ostringstream.h
+  - third_party/abseil-cpp/absl/strings/internal/resize_uninitialized.h
+  - third_party/abseil-cpp/absl/strings/internal/utf8.h
+  name: absl/strings:internal
+  src:
+  - third_party/abseil-cpp/absl/strings/internal/ostringstream.cc
+  - third_party/abseil-cpp/absl/strings/internal/utf8.cc
+- deps:
+  - absl/strings:str_format_internal
+  headers:
+  - third_party/abseil-cpp/absl/strings/str_format.h
+  name: absl/strings:str_format
+  src: []
+- deps:
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/numeric:int128
+  - absl/strings:strings
+  - absl/types:span
+  headers:
+  - third_party/abseil-cpp/absl/strings/internal/str_format/arg.h
+  - third_party/abseil-cpp/absl/strings/internal/str_format/bind.h
+  - third_party/abseil-cpp/absl/strings/internal/str_format/checker.h
+  - third_party/abseil-cpp/absl/strings/internal/str_format/extension.h
+  - third_party/abseil-cpp/absl/strings/internal/str_format/float_conversion.h
+  - third_party/abseil-cpp/absl/strings/internal/str_format/output.h
+  - third_party/abseil-cpp/absl/strings/internal/str_format/parser.h
+  name: absl/strings:str_format_internal
+  src:
+  - third_party/abseil-cpp/absl/strings/internal/str_format/arg.cc
+  - third_party/abseil-cpp/absl/strings/internal/str_format/bind.cc
+  - third_party/abseil-cpp/absl/strings/internal/str_format/extension.cc
+  - third_party/abseil-cpp/absl/strings/internal/str_format/float_conversion.cc
+  - third_party/abseil-cpp/absl/strings/internal/str_format/output.cc
+  - third_party/abseil-cpp/absl/strings/internal/str_format/parser.cc
+- deps:
+  - absl/base:base
+  - absl/base:bits
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:endian
+  - absl/base:raw_logging_internal
+  - absl/base:throw_delegate
+  - absl/memory:memory
+  - absl/meta:type_traits
+  - absl/numeric:int128
+  - absl/strings:internal
+  headers:
+  - third_party/abseil-cpp/absl/strings/ascii.h
+  - third_party/abseil-cpp/absl/strings/charconv.h
+  - third_party/abseil-cpp/absl/strings/escaping.h
+  - third_party/abseil-cpp/absl/strings/internal/charconv_bigint.h
+  - third_party/abseil-cpp/absl/strings/internal/charconv_parse.h
+  - third_party/abseil-cpp/absl/strings/internal/memutil.h
+  - third_party/abseil-cpp/absl/strings/internal/stl_type_traits.h
+  - third_party/abseil-cpp/absl/strings/internal/str_join_internal.h
+  - third_party/abseil-cpp/absl/strings/internal/str_split_internal.h
+  - third_party/abseil-cpp/absl/strings/match.h
+  - third_party/abseil-cpp/absl/strings/numbers.h
+  - third_party/abseil-cpp/absl/strings/str_cat.h
+  - third_party/abseil-cpp/absl/strings/str_join.h
+  - third_party/abseil-cpp/absl/strings/str_replace.h
+  - third_party/abseil-cpp/absl/strings/str_split.h
+  - third_party/abseil-cpp/absl/strings/string_view.h
+  - third_party/abseil-cpp/absl/strings/strip.h
+  - third_party/abseil-cpp/absl/strings/substitute.h
+  name: absl/strings:strings
+  src:
+  - third_party/abseil-cpp/absl/strings/ascii.cc
+  - third_party/abseil-cpp/absl/strings/charconv.cc
+  - third_party/abseil-cpp/absl/strings/escaping.cc
+  - third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc
+  - third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc
+  - third_party/abseil-cpp/absl/strings/internal/memutil.cc
+  - third_party/abseil-cpp/absl/strings/match.cc
+  - third_party/abseil-cpp/absl/strings/numbers.cc
+  - third_party/abseil-cpp/absl/strings/str_cat.cc
+  - third_party/abseil-cpp/absl/strings/str_replace.cc
+  - third_party/abseil-cpp/absl/strings/str_split.cc
+  - third_party/abseil-cpp/absl/strings/string_view.cc
+  - third_party/abseil-cpp/absl/strings/substitute.cc
+- deps:
+  - absl/base:base
+  - absl/base:base_internal
+  - absl/base:core_headers
+  - absl/base:malloc_internal
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/synchronization/internal/graphcycles.h
+  name: absl/synchronization:graphcycles_internal
+  src:
+  - third_party/abseil-cpp/absl/synchronization/internal/graphcycles.cc
+- deps:
+  - absl/base:core_headers
+  - absl/base:raw_logging_internal
+  - absl/time:time
+  headers:
+  - third_party/abseil-cpp/absl/synchronization/internal/kernel_timeout.h
+  name: absl/synchronization:kernel_timeout_internal
+  src: []
+- deps:
+  - absl/base:atomic_hook
+  - absl/base:base
+  - absl/base:base_internal
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/base:dynamic_annotations
+  - absl/base:malloc_internal
+  - absl/base:raw_logging_internal
+  - absl/debugging:stacktrace
+  - absl/debugging:symbolize
+  - absl/synchronization:graphcycles_internal
+  - absl/synchronization:kernel_timeout_internal
+  - absl/time:time
+  headers:
+  - third_party/abseil-cpp/absl/synchronization/barrier.h
+  - third_party/abseil-cpp/absl/synchronization/blocking_counter.h
+  - third_party/abseil-cpp/absl/synchronization/internal/create_thread_identity.h
+  - third_party/abseil-cpp/absl/synchronization/internal/mutex_nonprod.inc
+  - third_party/abseil-cpp/absl/synchronization/internal/per_thread_sem.h
+  - third_party/abseil-cpp/absl/synchronization/internal/waiter.h
+  - third_party/abseil-cpp/absl/synchronization/mutex.h
+  - third_party/abseil-cpp/absl/synchronization/notification.h
+  name: absl/synchronization:synchronization
+  src:
+  - third_party/abseil-cpp/absl/synchronization/barrier.cc
+  - third_party/abseil-cpp/absl/synchronization/blocking_counter.cc
+  - third_party/abseil-cpp/absl/synchronization/internal/create_thread_identity.cc
+  - third_party/abseil-cpp/absl/synchronization/internal/per_thread_sem.cc
+  - third_party/abseil-cpp/absl/synchronization/internal/waiter.cc
+  - third_party/abseil-cpp/absl/synchronization/mutex.cc
+  - third_party/abseil-cpp/absl/synchronization/notification.cc
+- deps: []
+  headers:
+  - third_party/abseil-cpp/absl/time/internal/cctz/include/cctz/civil_time.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/include/cctz/civil_time_detail.h
+  name: absl/time/internal/cctz:civil_time
+  src:
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/civil_time_detail.cc
+- deps:
+  - absl/time/internal/cctz:civil_time
+  headers:
+  - third_party/abseil-cpp/absl/time/internal/cctz/include/cctz/time_zone.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/include/cctz/zone_info_source.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_fixed.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_if.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_impl.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_posix.h
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/tzfile.h
+  name: absl/time/internal/cctz:time_zone
+  src:
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_fixed.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_format.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_if.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_impl.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_info.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_lookup.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/time_zone_posix.cc
+  - third_party/abseil-cpp/absl/time/internal/cctz/src/zone_info_source.cc
+- deps:
+  - absl/base:base
+  - absl/base:core_headers
+  - absl/base:raw_logging_internal
+  - absl/numeric:int128
+  - absl/strings:strings
+  - absl/time/internal/cctz:civil_time
+  - absl/time/internal/cctz:time_zone
+  headers:
+  - third_party/abseil-cpp/absl/time/civil_time.h
+  - third_party/abseil-cpp/absl/time/clock.h
+  - third_party/abseil-cpp/absl/time/internal/get_current_time_chrono.inc
+  - third_party/abseil-cpp/absl/time/internal/get_current_time_posix.inc
+  - third_party/abseil-cpp/absl/time/time.h
+  name: absl/time:time
+  src:
+  - third_party/abseil-cpp/absl/time/civil_time.cc
+  - third_party/abseil-cpp/absl/time/clock.cc
+  - third_party/abseil-cpp/absl/time/duration.cc
+  - third_party/abseil-cpp/absl/time/format.cc
+  - third_party/abseil-cpp/absl/time/time.cc
+- deps:
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/types:bad_any_cast
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/types/any.h
+  name: absl/types:any
+  src: []
+- deps:
+  - absl/base:config
+  - absl/types:bad_any_cast_impl
+  headers:
+  - third_party/abseil-cpp/absl/types/bad_any_cast.h
+  name: absl/types:bad_any_cast
+  src: []
+- deps:
+  - absl/base:config
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/types/bad_any_cast.h
+  name: absl/types:bad_any_cast_impl
+  src:
+  - third_party/abseil-cpp/absl/types/bad_any_cast.cc
+- deps:
+  - absl/base:config
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/types/bad_optional_access.h
+  name: absl/types:bad_optional_access
+  src:
+  - third_party/abseil-cpp/absl/types/bad_optional_access.cc
+- deps:
+  - absl/base:config
+  - absl/base:raw_logging_internal
+  headers:
+  - third_party/abseil-cpp/absl/types/bad_variant_access.h
+  name: absl/types:bad_variant_access
+  src:
+  - third_party/abseil-cpp/absl/types/bad_variant_access.cc
+- deps:
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/types/compare.h
+  name: absl/types:compare
+  src: []
+- deps:
+  - absl/base:base_internal
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/memory:memory
+  - absl/meta:type_traits
+  - absl/types:bad_optional_access
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/types/internal/optional.h
+  - third_party/abseil-cpp/absl/types/optional.h
+  name: absl/types:optional
+  src: []
+- deps:
+  - absl/algorithm:algorithm
+  - absl/base:core_headers
+  - absl/base:throw_delegate
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/types/internal/span.h
+  - third_party/abseil-cpp/absl/types/span.h
+  name: absl/types:span
+  src: []
+- deps:
+  - absl/base:base_internal
+  - absl/base:config
+  - absl/base:core_headers
+  - absl/meta:type_traits
+  - absl/types:bad_variant_access
+  - absl/utility:utility
+  headers:
+  - third_party/abseil-cpp/absl/types/internal/variant.h
+  - third_party/abseil-cpp/absl/types/variant.h
+  name: absl/types:variant
+  src: []
+- deps:
+  - absl/base:base_internal
+  - absl/base:config
+  - absl/meta:type_traits
+  headers:
+  - third_party/abseil-cpp/absl/utility/utility.h
+  name: absl/utility:utility
+  src: []

--- a/src/abseil-cpp/preprocessed_builds.yaml.gen.py
+++ b/src/abseil-cpp/preprocessed_builds.yaml.gen.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+import yaml
+
+ABSEIL_PATH = "third_party/abseil-cpp"
+OUTPUT_PATH = "src/abseil-cpp/preprocessed_builds.yaml"
+
+# Rule object representing the rule of Bazel BUILD.
+Rule = collections.namedtuple(
+    "Rule", "type name package srcs hdrs textual_hdrs deps visibility testonly")
+
+
+def get_elem_value(elem, name):
+  """Returns the value of XML element with the given name."""
+  for child in elem:
+    if child.attrib.get("name") == name:
+      if child.tag == "string":
+        return child.attrib.get("value")
+      elif child.tag == "boolean":
+        return child.attrib.get("value") == "true"
+      elif child.tag == "list":
+        return [nested_child.attrib.get("value") for nested_child in child]
+      else:
+        raise "Cannot recognize tag: " + child.tag
+  return None
+
+
+def normalize_paths(paths):
+  """Returns the list of normalized path."""
+  # e.g. ["//absl/strings:dir/header.h"] -> ["absl/strings/dir/header.h"]
+  return [path.lstrip("/").replace(":", "/") for path in paths]
+
+
+def parse_rule(elem, package):
+  """Returns a rule from bazel XML rule."""
+  return Rule(
+      type=elem.attrib["class"],
+      name=get_elem_value(elem, "name"),
+      package=package,
+      srcs=normalize_paths(get_elem_value(elem, "srcs") or []),
+      hdrs=normalize_paths(get_elem_value(elem, "hdrs") or []),
+      textual_hdrs=normalize_paths(get_elem_value(elem, "textual_hdrs") or []),
+      deps=get_elem_value(elem, "deps") or [],
+      visibility=get_elem_value(elem, "visibility") or [],
+      testonly=get_elem_value(elem, "testonly") or False)
+
+
+def read_build(package):
+  """Runs bazel query on given package file and returns all cc rules."""
+  result = subprocess.check_output(
+      ["bazel", "query", package + ":all", "--output", "xml"])
+  root = ET.fromstring(result)
+  return [
+      parse_rule(elem, package)
+      for elem in root
+      if elem.tag == "rule" and elem.attrib["class"].startswith("cc_")
+  ]
+
+
+def collect_rules(root_path):
+  """Collects and returns all rules from root path recursively."""
+  rules = []
+  for cur, _, _ in os.walk(root_path):
+    build_path = os.path.join(cur, "BUILD.bazel")
+    if os.path.exists(build_path):
+      rules.extend(read_build("//" + cur))
+  return rules
+
+
+def resolve_hdrs(files):
+  return [
+      ABSEIL_PATH + "/" + f for f in files if f.endswith((".h", ".inc"))
+  ]
+
+
+def resolve_srcs(files):
+  return [
+      ABSEIL_PATH + "/" + f for f in files if f.endswith(".cc")
+  ]
+
+
+def resolve_deps(targets):
+  return [(t[2:] if t.startswith("//") else t) for t in targets]
+
+
+def generate_builds(root_path):
+  """Generates builds from all BUILD files under absl directory."""
+  rules = filter(lambda r: r.type == "cc_library" and not r.testonly,
+                 collect_rules(root_path))
+  builds = []
+  for rule in sorted(rules, key=lambda r: r.package[2:] + ":" + r.name):
+    p = {
+        "name": rule.package[2:] + ":" + rule.name,
+        "headers": sorted(resolve_hdrs(rule.srcs + rule.hdrs + rule.textual_hdrs)),
+        "src": sorted(resolve_srcs(rule.srcs + rule.hdrs + rule.textual_hdrs)),
+        "deps": sorted(resolve_deps(rule.deps)),
+    }
+    builds.append(p)
+  return builds
+
+
+def main():
+  previous_dir = os.getcwd()
+  os.chdir(ABSEIL_PATH)
+  builds = generate_builds("absl")
+  os.chdir(previous_dir)
+  with open(OUTPUT_PATH, 'w') as outfile:
+    outfile.write(yaml.dump(builds, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+  main()

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -33,6 +33,9 @@
         return filename
       return '${_gRPC_PROTO_GENS_DIR}/' + m.group(1) + ext
 
+  def is_absl_lib(target_name):
+      return target_name.startswith("absl/");
+
   def get_deps(target_dict):
     deps = []
     if target_dict.get('baselib', False) or target_dict['name'] == 'address_sorting':
@@ -387,11 +390,16 @@
     add_custom_target(buildtests
       DEPENDS buildtests_c buildtests_cxx)
   endif()
-
-  % for lib in libs:
-  % if lib.build in ["all", "protoc", "tool", "test", "private"] and not lib.boringssl:
-  % if not lib.get('build_system', []) or 'cmake' in lib.get('build_system', []):
-  % if not lib.name in ['ares', 'benchmark', 'z']:  # we build these using CMake instead
+  <%
+    cmake_libs = []
+    for lib in libs:
+      if lib.build not in ["all", "protoc", "tool", "test", "private"] or lib.boringssl: continue
+      if lib.get('build_system', []) and 'cmake' not in lib.get('build_system', []): continue
+      if lib.name in ['ares', 'benchmark', 'z']: continue  # we build these using CMake instead
+      if is_absl_lib(lib.name): continue  # we build these using CMake instead
+      cmake_libs.append(lib)
+  %>
+  % for lib in cmake_libs:
   % if lib.build in ["test", "private"]:
   if(gRPC_BUILD_TESTS)
   ${cc_library(lib)}
@@ -416,9 +424,6 @@
   ${cc_install(lib)}
   % if any(proto_re.match(src) for src in lib.src):
   endif()
-  % endif
-  % endif
-  % endif
   % endif
   % endif
   % endif

--- a/templates/grpc.gyp.template
+++ b/templates/grpc.gyp.template
@@ -20,7 +20,10 @@
   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   # See the License for the specific language governing permissions and
   # limitations under the License.
-
+  <%
+  def is_absl_lib(target_name):
+      return target_name.startswith("absl/");
+  %>
   {
     'variables': {
      # The openssl and zlib dependencies must be passed in as variables
@@ -136,7 +139,7 @@
     },
     'targets': [
       % for lib in libs:
-      %  if getattr(lib, 'platforms', None) is None and lib.name != 'ares':
+      %  if getattr(lib, 'platforms', None) is None and lib.name != 'ares' and not is_absl_lib(lib.name):
       {
         'target_name': '${lib.name}',
         'type': 'static_library',

--- a/tools/buildgen/generate_build_additions.sh
+++ b/tools/buildgen/generate_build_additions.sh
@@ -16,8 +16,9 @@
 set -e
 
 gen_build_yaml_dirs="  \
+  src/abseil-cpp       \
   src/boringssl        \
-  src/benchmark \
+  src/benchmark        \
   src/proto            \
   src/upb              \
   src/zlib             \
@@ -25,8 +26,8 @@ gen_build_yaml_dirs="  \
   test/core/bad_client \
   test/core/bad_ssl    \
   test/core/end2end    \
-  test/cpp/naming \
-  test/cpp/qps \
+  test/cpp/naming      \
+  test/cpp/qps         \
   tools/run_tests/lb_interop_tests"
 gen_build_files=""
 for gen_build_yaml in $gen_build_yaml_dirs


### PR DESCRIPTION
Added `preprocessed_builds.yaml` to be used as builds for abseil dependency.
Added `preprocessed_builds.yaml.gen.py` to generate `builds.yaml` files from BUILD files of abseil.
There is no change on generated build files yet. 

This is a prerequisite for #20184