### PR TITLE
Make build template more robust

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -6224,10 +6224,8 @@ openssl_fallback:
 php_config_m4:
   deps:
   - grpc
-  - gpr
   - address_sorting
   - boringssl
-  - upb
   - z
   headers:
   - src/php/ext/grpc/byte_buffer.h
@@ -6256,18 +6254,14 @@ php_config_m4:
 python_dependencies:
   deps:
   - grpc
-  - gpr
   - address_sorting
   - ares
   - boringssl
-  - upb
   - z
 ruby_gem:
   deps:
   - grpc
-  - gpr
   - address_sorting
   - ares
   - boringssl
-  - upb
   - z

--- a/config.m4
+++ b/config.m4
@@ -735,8 +735,6 @@ if test "$PHP_GRPC" != "no"; then
     -D_HAS_EXCEPTIONS=0 -DNOMINMAX -DGRPC_ARES=0 \
     -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1)
 
-  PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)
-
   PHP_ADD_BUILD_DIR($ext_builddir/src/boringssl)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/census)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel)
@@ -831,6 +829,7 @@ if test "$PHP_GRPC" != "no"; then
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/tsi/alts/handshaker)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/tsi/alts/zero_copy_frame_protector)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/tsi/ssl/session_cache)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/address_sorting)
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto)
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/asn1)

--- a/config.w32
+++ b/config.w32
@@ -5,20 +5,170 @@ ARG_WITH("grpc", "grpc support", "no");
 
 if (PHP_GRPC != "no") {
 
-  grpc_source =
-    "src\\php\\ext\\grpc\\byte_buffer.c " +
-    "src\\php\\ext\\grpc\\call.c " +
-    "src\\php\\ext\\grpc\\call_credentials.c " +
-    "src\\php\\ext\\grpc\\channel.c " +
-    "src\\php\\ext\\grpc\\channel_credentials.c " +
-    "src\\php\\ext\\grpc\\completion_queue.c " +
-    "src\\php\\ext\\grpc\\php_grpc.c " +
-    "src\\php\\ext\\grpc\\server.c " +
-    "src\\php\\ext\\grpc\\server_credentials.c " +
-    "src\\php\\ext\\grpc\\timeval.c " +
-    "third_party\\address_sorting\\address_sorting.c " +
-    "third_party\\address_sorting\\address_sorting_posix.c " +
-    "third_party\\address_sorting\\address_sorting_windows.c " +
+  EXTENSION("grpc",
+    "src\\boringssl\\err_data.c " +
+    "src\\core\\ext\\filters\\census\\grpc_context.cc " +
+    "src\\core\\ext\\filters\\client_channel\\backend_metric.cc " +
+    "src\\core\\ext\\filters\\client_channel\\backup_poller.cc " +
+    "src\\core\\ext\\filters\\client_channel\\channel_connectivity.cc " +
+    "src\\core\\ext\\filters\\client_channel\\client_channel.cc " +
+    "src\\core\\ext\\filters\\client_channel\\client_channel_channelz.cc " +
+    "src\\core\\ext\\filters\\client_channel\\client_channel_factory.cc " +
+    "src\\core\\ext\\filters\\client_channel\\client_channel_plugin.cc " +
+    "src\\core\\ext\\filters\\client_channel\\global_subchannel_pool.cc " +
+    "src\\core\\ext\\filters\\client_channel\\health\\health_check_client.cc " +
+    "src\\core\\ext\\filters\\client_channel\\http_connect_handshaker.cc " +
+    "src\\core\\ext\\filters\\client_channel\\http_proxy.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\client_load_reporting_filter.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\grpclb.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\grpclb_channel_secure.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\grpclb_client_stats.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\load_balancer_api.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\pick_first\\pick_first.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\round_robin\\round_robin.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\xds\\cds.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy\\xds\\xds.cc " +
+    "src\\core\\ext\\filters\\client_channel\\lb_policy_registry.cc " +
+    "src\\core\\ext\\filters\\client_channel\\local_subchannel_pool.cc " +
+    "src\\core\\ext\\filters\\client_channel\\parse_address.cc " +
+    "src\\core\\ext\\filters\\client_channel\\proxy_mapper_registry.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\dns_resolver_ares.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver_libuv.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver_posix.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver_windows.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_fallback.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_libuv.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_posix.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_windows.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\dns_resolver_selection.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\native\\dns_resolver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\fake\\fake_resolver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\sockaddr\\sockaddr_resolver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\xds\\xds_resolver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver_registry.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver_result_parsing.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolving_lb_policy.cc " +
+    "src\\core\\ext\\filters\\client_channel\\retry_throttle.cc " +
+    "src\\core\\ext\\filters\\client_channel\\server_address.cc " +
+    "src\\core\\ext\\filters\\client_channel\\service_config.cc " +
+    "src\\core\\ext\\filters\\client_channel\\subchannel.cc " +
+    "src\\core\\ext\\filters\\client_channel\\subchannel_pool_interface.cc " +
+    "src\\core\\ext\\filters\\client_channel\\xds\\xds_api.cc " +
+    "src\\core\\ext\\filters\\client_channel\\xds\\xds_bootstrap.cc " +
+    "src\\core\\ext\\filters\\client_channel\\xds\\xds_channel_secure.cc " +
+    "src\\core\\ext\\filters\\client_channel\\xds\\xds_client.cc " +
+    "src\\core\\ext\\filters\\client_channel\\xds\\xds_client_stats.cc " +
+    "src\\core\\ext\\filters\\client_idle\\client_idle_filter.cc " +
+    "src\\core\\ext\\filters\\deadline\\deadline_filter.cc " +
+    "src\\core\\ext\\filters\\http\\client\\http_client_filter.cc " +
+    "src\\core\\ext\\filters\\http\\client_authority_filter.cc " +
+    "src\\core\\ext\\filters\\http\\http_filters_plugin.cc " +
+    "src\\core\\ext\\filters\\http\\message_compress\\message_compress_filter.cc " +
+    "src\\core\\ext\\filters\\http\\server\\http_server_filter.cc " +
+    "src\\core\\ext\\filters\\max_age\\max_age_filter.cc " +
+    "src\\core\\ext\\filters\\message_size\\message_size_filter.cc " +
+    "src\\core\\ext\\filters\\workarounds\\workaround_cronet_compression_filter.cc " +
+    "src\\core\\ext\\filters\\workarounds\\workaround_utils.cc " +
+    "src\\core\\ext\\transport\\chttp2\\alpn\\alpn.cc " +
+    "src\\core\\ext\\transport\\chttp2\\client\\authority.cc " +
+    "src\\core\\ext\\transport\\chttp2\\client\\chttp2_connector.cc " +
+    "src\\core\\ext\\transport\\chttp2\\client\\insecure\\channel_create.cc " +
+    "src\\core\\ext\\transport\\chttp2\\client\\insecure\\channel_create_posix.cc " +
+    "src\\core\\ext\\transport\\chttp2\\client\\secure\\secure_channel_create.cc " +
+    "src\\core\\ext\\transport\\chttp2\\server\\chttp2_server.cc " +
+    "src\\core\\ext\\transport\\chttp2\\server\\insecure\\server_chttp2.cc " +
+    "src\\core\\ext\\transport\\chttp2\\server\\insecure\\server_chttp2_posix.cc " +
+    "src\\core\\ext\\transport\\chttp2\\server\\secure\\server_secure_chttp2.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\bin_decoder.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\bin_encoder.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\chttp2_plugin.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\chttp2_transport.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\context_list.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\flow_control.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\frame_data.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\frame_goaway.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\frame_ping.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\frame_rst_stream.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\frame_settings.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\frame_window_update.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\hpack_encoder.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\hpack_parser.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\hpack_table.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\http2_settings.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\huffsyms.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\incoming_metadata.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\parsing.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\stream_lists.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\stream_map.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\varint.cc " +
+    "src\\core\\ext\\transport\\chttp2\\transport\\writing.cc " +
+    "src\\core\\ext\\transport\\inproc\\inproc_plugin.cc " +
+    "src\\core\\ext\\transport\\inproc\\inproc_transport.cc " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\auth\\cert.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cds.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cluster\\circuit_breaker.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cluster\\filter.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cluster\\outlier_detection.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\address.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\base.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\config_source.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\grpc_service.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\health_check.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\http_uri.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\protocol.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\discovery.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\eds.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\endpoint\\endpoint.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\endpoint\\load_report.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\service\\discovery\\v2\\ads.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\service\\load_stats\\v2\\lrs.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\type\\http.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\type\\percent.upb.c " +
+    "src\\core\\ext\\upb-generated\\envoy\\type\\range.upb.c " +
+    "src\\core\\ext\\upb-generated\\gogoproto\\gogo.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\api\\annotations.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\api\\http.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\any.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\descriptor.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\duration.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\empty.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\struct.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\timestamp.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\protobuf\\wrappers.upb.c " +
+    "src\\core\\ext\\upb-generated\\google\\rpc\\status.upb.c " +
+    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\gcp\\altscontext.upb.c " +
+    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\gcp\\handshaker.upb.c " +
+    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\gcp\\transport_security_common.upb.c " +
+    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\health\\v1\\health.upb.c " +
+    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\lb\\v1\\load_balancer.upb.c " +
+    "src\\core\\ext\\upb-generated\\udpa\\data\\orca\\v1\\orca_load_report.upb.c " +
+    "src\\core\\ext\\upb-generated\\validate\\validate.upb.c " +
+    "src\\core\\lib\\avl\\avl.cc " +
+    "src\\core\\lib\\backoff\\backoff.cc " +
+    "src\\core\\lib\\channel\\channel_args.cc " +
+    "src\\core\\lib\\channel\\channel_stack.cc " +
+    "src\\core\\lib\\channel\\channel_stack_builder.cc " +
+    "src\\core\\lib\\channel\\channel_trace.cc " +
+    "src\\core\\lib\\channel\\channelz.cc " +
+    "src\\core\\lib\\channel\\channelz_registry.cc " +
+    "src\\core\\lib\\channel\\connected_channel.cc " +
+    "src\\core\\lib\\channel\\handshaker.cc " +
+    "src\\core\\lib\\channel\\handshaker_registry.cc " +
+    "src\\core\\lib\\channel\\status_util.cc " +
+    "src\\core\\lib\\compression\\compression.cc " +
+    "src\\core\\lib\\compression\\compression_args.cc " +
+    "src\\core\\lib\\compression\\compression_internal.cc " +
+    "src\\core\\lib\\compression\\message_compress.cc " +
+    "src\\core\\lib\\compression\\stream_compression.cc " +
+    "src\\core\\lib\\compression\\stream_compression_gzip.cc " +
+    "src\\core\\lib\\compression\\stream_compression_identity.cc " +
+    "src\\core\\lib\\debug\\stats.cc " +
+    "src\\core\\lib\\debug\\stats_data.cc " +
+    "src\\core\\lib\\debug\\trace.cc " +
     "src\\core\\lib\\gpr\\alloc.cc " +
     "src\\core\\lib\\gpr\\atm.cc " +
     "src\\core\\lib\\gpr\\cpu_iphone.cc " +
@@ -57,32 +207,9 @@ if (PHP_GRPC != "no") {
     "src\\core\\lib\\gprpp\\mpscq.cc " +
     "src\\core\\lib\\gprpp\\thd_posix.cc " +
     "src\\core\\lib\\gprpp\\thd_windows.cc " +
-    "src\\core\\lib\\profiling\\basic_timers.cc " +
-    "src\\core\\lib\\profiling\\stap_timers.cc " +
-    "src\\core\\lib\\surface\\init.cc " +
-    "src\\core\\lib\\avl\\avl.cc " +
-    "src\\core\\lib\\backoff\\backoff.cc " +
-    "src\\core\\lib\\channel\\channel_args.cc " +
-    "src\\core\\lib\\channel\\channel_stack.cc " +
-    "src\\core\\lib\\channel\\channel_stack_builder.cc " +
-    "src\\core\\lib\\channel\\channel_trace.cc " +
-    "src\\core\\lib\\channel\\channelz.cc " +
-    "src\\core\\lib\\channel\\channelz_registry.cc " +
-    "src\\core\\lib\\channel\\connected_channel.cc " +
-    "src\\core\\lib\\channel\\handshaker.cc " +
-    "src\\core\\lib\\channel\\handshaker_registry.cc " +
-    "src\\core\\lib\\channel\\status_util.cc " +
-    "src\\core\\lib\\compression\\compression.cc " +
-    "src\\core\\lib\\compression\\compression_args.cc " +
-    "src\\core\\lib\\compression\\compression_internal.cc " +
-    "src\\core\\lib\\compression\\message_compress.cc " +
-    "src\\core\\lib\\compression\\stream_compression.cc " +
-    "src\\core\\lib\\compression\\stream_compression_gzip.cc " +
-    "src\\core\\lib\\compression\\stream_compression_identity.cc " +
-    "src\\core\\lib\\debug\\stats.cc " +
-    "src\\core\\lib\\debug\\stats_data.cc " +
     "src\\core\\lib\\http\\format_request.cc " +
     "src\\core\\lib\\http\\httpcli.cc " +
+    "src\\core\\lib\\http\\httpcli_security_connector.cc " +
     "src\\core\\lib\\http\\parser.cc " +
     "src\\core\\lib\\iomgr\\buffer_list.cc " +
     "src\\core\\lib\\iomgr\\call_combiner.cc " +
@@ -179,77 +306,17 @@ if (PHP_GRPC != "no") {
     "src\\core\\lib\\json\\json.cc " +
     "src\\core\\lib\\json\\json_reader.cc " +
     "src\\core\\lib\\json\\json_writer.cc " +
-    "src\\core\\lib\\slice\\b64.cc " +
-    "src\\core\\lib\\slice\\percent_encoding.cc " +
-    "src\\core\\lib\\slice\\slice.cc " +
-    "src\\core\\lib\\slice\\slice_buffer.cc " +
-    "src\\core\\lib\\slice\\slice_intern.cc " +
-    "src\\core\\lib\\slice\\slice_string_helpers.cc " +
-    "src\\core\\lib\\surface\\api_trace.cc " +
-    "src\\core\\lib\\surface\\byte_buffer.cc " +
-    "src\\core\\lib\\surface\\byte_buffer_reader.cc " +
-    "src\\core\\lib\\surface\\call.cc " +
-    "src\\core\\lib\\surface\\call_details.cc " +
-    "src\\core\\lib\\surface\\call_log_batch.cc " +
-    "src\\core\\lib\\surface\\channel.cc " +
-    "src\\core\\lib\\surface\\channel_init.cc " +
-    "src\\core\\lib\\surface\\channel_ping.cc " +
-    "src\\core\\lib\\surface\\channel_stack_type.cc " +
-    "src\\core\\lib\\surface\\completion_queue.cc " +
-    "src\\core\\lib\\surface\\completion_queue_factory.cc " +
-    "src\\core\\lib\\surface\\event_string.cc " +
-    "src\\core\\lib\\surface\\lame_client.cc " +
-    "src\\core\\lib\\surface\\metadata_array.cc " +
-    "src\\core\\lib\\surface\\server.cc " +
-    "src\\core\\lib\\surface\\validate_metadata.cc " +
-    "src\\core\\lib\\surface\\version.cc " +
-    "src\\core\\lib\\transport\\bdp_estimator.cc " +
-    "src\\core\\lib\\transport\\byte_stream.cc " +
-    "src\\core\\lib\\transport\\connectivity_state.cc " +
-    "src\\core\\lib\\transport\\error_utils.cc " +
-    "src\\core\\lib\\transport\\metadata.cc " +
-    "src\\core\\lib\\transport\\metadata_batch.cc " +
-    "src\\core\\lib\\transport\\pid_controller.cc " +
-    "src\\core\\lib\\transport\\static_metadata.cc " +
-    "src\\core\\lib\\transport\\status_conversion.cc " +
-    "src\\core\\lib\\transport\\status_metadata.cc " +
-    "src\\core\\lib\\transport\\timeout_encoding.cc " +
-    "src\\core\\lib\\transport\\transport.cc " +
-    "src\\core\\lib\\transport\\transport_op_string.cc " +
-    "src\\core\\lib\\uri\\uri_parser.cc " +
-    "src\\core\\lib\\debug\\trace.cc " +
-    "src\\core\\ext\\transport\\chttp2\\server\\secure\\server_secure_chttp2.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\bin_decoder.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\bin_encoder.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\chttp2_plugin.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\chttp2_transport.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\context_list.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\flow_control.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\frame_data.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\frame_goaway.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\frame_ping.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\frame_rst_stream.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\frame_settings.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\frame_window_update.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\hpack_encoder.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\hpack_parser.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\hpack_table.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\http2_settings.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\huffsyms.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\incoming_metadata.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\parsing.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\stream_lists.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\stream_map.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\varint.cc " +
-    "src\\core\\ext\\transport\\chttp2\\transport\\writing.cc " +
-    "src\\core\\ext\\transport\\chttp2\\alpn\\alpn.cc " +
-    "src\\core\\ext\\filters\\http\\client\\http_client_filter.cc " +
-    "src\\core\\ext\\filters\\http\\http_filters_plugin.cc " +
-    "src\\core\\ext\\filters\\http\\message_compress\\message_compress_filter.cc " +
-    "src\\core\\ext\\filters\\http\\server\\http_server_filter.cc " +
-    "src\\core\\lib\\http\\httpcli_security_connector.cc " +
+    "src\\core\\lib\\profiling\\basic_timers.cc " +
+    "src\\core\\lib\\profiling\\stap_timers.cc " +
     "src\\core\\lib\\security\\context\\security_context.cc " +
     "src\\core\\lib\\security\\credentials\\alts\\alts_credentials.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment_linux.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment_no_op.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment_windows.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\grpc_alts_credentials_client_options.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\grpc_alts_credentials_options.cc " +
+    "src\\core\\lib\\security\\credentials\\alts\\grpc_alts_credentials_server_options.cc " +
     "src\\core\\lib\\security\\credentials\\composite\\composite_credentials.cc " +
     "src\\core\\lib\\security\\credentials\\credentials.cc " +
     "src\\core\\lib\\security\\credentials\\credentials_metadata.cc " +
@@ -283,7 +350,47 @@ if (PHP_GRPC != "no") {
     "src\\core\\lib\\security\\transport\\target_authority_table.cc " +
     "src\\core\\lib\\security\\transport\\tsi_error.cc " +
     "src\\core\\lib\\security\\util\\json_util.cc " +
+    "src\\core\\lib\\slice\\b64.cc " +
+    "src\\core\\lib\\slice\\percent_encoding.cc " +
+    "src\\core\\lib\\slice\\slice.cc " +
+    "src\\core\\lib\\slice\\slice_buffer.cc " +
+    "src\\core\\lib\\slice\\slice_intern.cc " +
+    "src\\core\\lib\\slice\\slice_string_helpers.cc " +
+    "src\\core\\lib\\surface\\api_trace.cc " +
+    "src\\core\\lib\\surface\\byte_buffer.cc " +
+    "src\\core\\lib\\surface\\byte_buffer_reader.cc " +
+    "src\\core\\lib\\surface\\call.cc " +
+    "src\\core\\lib\\surface\\call_details.cc " +
+    "src\\core\\lib\\surface\\call_log_batch.cc " +
+    "src\\core\\lib\\surface\\channel.cc " +
+    "src\\core\\lib\\surface\\channel_init.cc " +
+    "src\\core\\lib\\surface\\channel_ping.cc " +
+    "src\\core\\lib\\surface\\channel_stack_type.cc " +
+    "src\\core\\lib\\surface\\completion_queue.cc " +
+    "src\\core\\lib\\surface\\completion_queue_factory.cc " +
+    "src\\core\\lib\\surface\\event_string.cc " +
+    "src\\core\\lib\\surface\\init.cc " +
     "src\\core\\lib\\surface\\init_secure.cc " +
+    "src\\core\\lib\\surface\\lame_client.cc " +
+    "src\\core\\lib\\surface\\metadata_array.cc " +
+    "src\\core\\lib\\surface\\server.cc " +
+    "src\\core\\lib\\surface\\validate_metadata.cc " +
+    "src\\core\\lib\\surface\\version.cc " +
+    "src\\core\\lib\\transport\\bdp_estimator.cc " +
+    "src\\core\\lib\\transport\\byte_stream.cc " +
+    "src\\core\\lib\\transport\\connectivity_state.cc " +
+    "src\\core\\lib\\transport\\error_utils.cc " +
+    "src\\core\\lib\\transport\\metadata.cc " +
+    "src\\core\\lib\\transport\\metadata_batch.cc " +
+    "src\\core\\lib\\transport\\pid_controller.cc " +
+    "src\\core\\lib\\transport\\static_metadata.cc " +
+    "src\\core\\lib\\transport\\status_conversion.cc " +
+    "src\\core\\lib\\transport\\status_metadata.cc " +
+    "src\\core\\lib\\transport\\timeout_encoding.cc " +
+    "src\\core\\lib\\transport\\transport.cc " +
+    "src\\core\\lib\\transport\\transport_op_string.cc " +
+    "src\\core\\lib\\uri\\uri_parser.cc " +
+    "src\\core\\plugin_registry\\grpc_plugin_registry.cc " +
     "src\\core\\tsi\\alts\\crypt\\aes_gcm.cc " +
     "src\\core\\tsi\\alts\\crypt\\gsec.cc " +
     "src\\core\\tsi\\alts\\frame_protector\\alts_counter.cc " +
@@ -296,141 +403,34 @@ if (PHP_GRPC != "no") {
     "src\\core\\tsi\\alts\\handshaker\\alts_handshaker_client.cc " +
     "src\\core\\tsi\\alts\\handshaker\\alts_shared_resource.cc " +
     "src\\core\\tsi\\alts\\handshaker\\alts_tsi_handshaker.cc " +
+    "src\\core\\tsi\\alts\\handshaker\\alts_tsi_utils.cc " +
+    "src\\core\\tsi\\alts\\handshaker\\transport_security_common_api.cc " +
     "src\\core\\tsi\\alts\\zero_copy_frame_protector\\alts_grpc_integrity_only_record_protocol.cc " +
     "src\\core\\tsi\\alts\\zero_copy_frame_protector\\alts_grpc_privacy_integrity_record_protocol.cc " +
     "src\\core\\tsi\\alts\\zero_copy_frame_protector\\alts_grpc_record_protocol_common.cc " +
     "src\\core\\tsi\\alts\\zero_copy_frame_protector\\alts_iovec_record_protocol.cc " +
     "src\\core\\tsi\\alts\\zero_copy_frame_protector\\alts_zero_copy_grpc_protector.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment_linux.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment_no_op.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\check_gcp_environment_windows.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\grpc_alts_credentials_client_options.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\grpc_alts_credentials_options.cc " +
-    "src\\core\\lib\\security\\credentials\\alts\\grpc_alts_credentials_server_options.cc " +
-    "src\\core\\tsi\\alts\\handshaker\\alts_tsi_utils.cc " +
-    "src\\core\\tsi\\alts\\handshaker\\transport_security_common_api.cc " +
-    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\gcp\\altscontext.upb.c " +
-    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\gcp\\handshaker.upb.c " +
-    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\gcp\\transport_security_common.upb.c " +
-    "src\\core\\tsi\\transport_security.cc " +
-    "src\\core\\ext\\transport\\chttp2\\client\\insecure\\channel_create.cc " +
-    "src\\core\\ext\\transport\\chttp2\\client\\insecure\\channel_create_posix.cc " +
-    "src\\core\\ext\\transport\\chttp2\\client\\authority.cc " +
-    "src\\core\\ext\\transport\\chttp2\\client\\chttp2_connector.cc " +
-    "src\\core\\ext\\filters\\client_channel\\backend_metric.cc " +
-    "src\\core\\ext\\filters\\client_channel\\backup_poller.cc " +
-    "src\\core\\ext\\filters\\client_channel\\channel_connectivity.cc " +
-    "src\\core\\ext\\filters\\client_channel\\client_channel.cc " +
-    "src\\core\\ext\\filters\\client_channel\\client_channel_channelz.cc " +
-    "src\\core\\ext\\filters\\client_channel\\client_channel_factory.cc " +
-    "src\\core\\ext\\filters\\client_channel\\client_channel_plugin.cc " +
-    "src\\core\\ext\\filters\\client_channel\\global_subchannel_pool.cc " +
-    "src\\core\\ext\\filters\\client_channel\\health\\health_check_client.cc " +
-    "src\\core\\ext\\filters\\client_channel\\http_connect_handshaker.cc " +
-    "src\\core\\ext\\filters\\client_channel\\http_proxy.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy_registry.cc " +
-    "src\\core\\ext\\filters\\client_channel\\local_subchannel_pool.cc " +
-    "src\\core\\ext\\filters\\client_channel\\parse_address.cc " +
-    "src\\core\\ext\\filters\\client_channel\\proxy_mapper_registry.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver_registry.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver_result_parsing.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolving_lb_policy.cc " +
-    "src\\core\\ext\\filters\\client_channel\\retry_throttle.cc " +
-    "src\\core\\ext\\filters\\client_channel\\server_address.cc " +
-    "src\\core\\ext\\filters\\client_channel\\service_config.cc " +
-    "src\\core\\ext\\filters\\client_channel\\subchannel.cc " +
-    "src\\core\\ext\\filters\\client_channel\\subchannel_pool_interface.cc " +
-    "src\\core\\ext\\filters\\deadline\\deadline_filter.cc " +
-    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\health\\v1\\health.upb.c " +
-    "src\\core\\ext\\upb-generated\\udpa\\data\\orca\\v1\\orca_load_report.upb.c " +
-    "src\\core\\ext\\upb-generated\\gogoproto\\gogo.upb.c " +
-    "src\\core\\ext\\upb-generated\\validate\\validate.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\api\\annotations.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\api\\http.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\any.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\descriptor.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\duration.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\empty.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\struct.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\timestamp.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\protobuf\\wrappers.upb.c " +
-    "src\\core\\ext\\upb-generated\\google\\rpc\\status.upb.c " +
     "src\\core\\tsi\\fake_transport_security.cc " +
     "src\\core\\tsi\\local_transport_security.cc " +
     "src\\core\\tsi\\ssl\\session_cache\\ssl_session_boringssl.cc " +
     "src\\core\\tsi\\ssl\\session_cache\\ssl_session_cache.cc " +
     "src\\core\\tsi\\ssl\\session_cache\\ssl_session_openssl.cc " +
     "src\\core\\tsi\\ssl_transport_security.cc " +
+    "src\\core\\tsi\\transport_security.cc " +
     "src\\core\\tsi\\transport_security_grpc.cc " +
-    "src\\core\\ext\\transport\\chttp2\\server\\chttp2_server.cc " +
-    "src\\core\\ext\\transport\\chttp2\\client\\secure\\secure_channel_create.cc " +
-    "src\\core\\ext\\transport\\chttp2\\server\\insecure\\server_chttp2.cc " +
-    "src\\core\\ext\\transport\\chttp2\\server\\insecure\\server_chttp2_posix.cc " +
-    "src\\core\\ext\\transport\\inproc\\inproc_plugin.cc " +
-    "src\\core\\ext\\transport\\inproc\\inproc_transport.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\client_load_reporting_filter.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\grpclb.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\grpclb_channel_secure.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\grpclb_client_stats.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\grpclb\\load_balancer_api.cc " +
-    "src\\core\\ext\\upb-generated\\src\\proto\\grpc\\lb\\v1\\load_balancer.upb.c " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\fake\\fake_resolver.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\xds\\cds.cc " +
-    "src\\core\\ext\\filters\\client_channel\\xds\\xds_api.cc " +
-    "src\\core\\ext\\filters\\client_channel\\xds\\xds_bootstrap.cc " +
-    "src\\core\\ext\\filters\\client_channel\\xds\\xds_channel_secure.cc " +
-    "src\\core\\ext\\filters\\client_channel\\xds\\xds_client.cc " +
-    "src\\core\\ext\\filters\\client_channel\\xds\\xds_client_stats.cc " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\auth\\cert.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cds.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cluster\\circuit_breaker.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cluster\\filter.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\cluster\\outlier_detection.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\discovery.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\eds.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\endpoint\\endpoint.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\endpoint\\load_report.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\service\\discovery\\v2\\ads.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\service\\load_stats\\v2\\lrs.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\address.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\base.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\config_source.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\grpc_service.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\health_check.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\http_uri.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\api\\v2\\core\\protocol.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\type\\http.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\type\\percent.upb.c " +
-    "src\\core\\ext\\upb-generated\\envoy\\type\\range.upb.c " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\xds\\xds.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\pick_first\\pick_first.cc " +
-    "src\\core\\ext\\filters\\client_channel\\lb_policy\\round_robin\\round_robin.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\dns_resolver_ares.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver_libuv.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver_posix.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_ev_driver_windows.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_fallback.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_libuv.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_posix.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares\\grpc_ares_wrapper_windows.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\dns_resolver_selection.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\native\\dns_resolver.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\sockaddr\\sockaddr_resolver.cc " +
-    "src\\core\\ext\\filters\\client_channel\\resolver\\xds\\xds_resolver.cc " +
-    "src\\core\\ext\\filters\\census\\grpc_context.cc " +
-    "src\\core\\ext\\filters\\client_idle\\client_idle_filter.cc " +
-    "src\\core\\ext\\filters\\max_age\\max_age_filter.cc " +
-    "src\\core\\ext\\filters\\message_size\\message_size_filter.cc " +
-    "src\\core\\ext\\filters\\http\\client_authority_filter.cc " +
-    "src\\core\\ext\\filters\\workarounds\\workaround_cronet_compression_filter.cc " +
-    "src\\core\\ext\\filters\\workarounds\\workaround_utils.cc " +
-    "src\\core\\plugin_registry\\grpc_plugin_registry.cc " +
-    "src\\boringssl\\err_data.c " +
+    "src\\php\\ext\\grpc\\byte_buffer.c " +
+    "src\\php\\ext\\grpc\\call.c " +
+    "src\\php\\ext\\grpc\\call_credentials.c " +
+    "src\\php\\ext\\grpc\\channel.c " +
+    "src\\php\\ext\\grpc\\channel_credentials.c " +
+    "src\\php\\ext\\grpc\\completion_queue.c " +
+    "src\\php\\ext\\grpc\\php_grpc.c " +
+    "src\\php\\ext\\grpc\\server.c " +
+    "src\\php\\ext\\grpc\\server_credentials.c " +
+    "src\\php\\ext\\grpc\\timeval.c " +
+    "third_party\\address_sorting\\address_sorting.c " +
+    "third_party\\address_sorting\\address_sorting_posix.c " +
+    "third_party\\address_sorting\\address_sorting_windows.c " +
     "third_party\\boringssl\\crypto\\asn1\\a_bitstr.c " +
     "third_party\\boringssl\\crypto\\asn1\\a_bool.c " +
     "third_party\\boringssl\\crypto\\asn1\\a_d2i_fp.c " +
@@ -715,9 +715,8 @@ if (PHP_GRPC != "no") {
     "third_party\\zlib\\trees.c " +
     "third_party\\zlib\\uncompr.c " +
     "third_party\\zlib\\zutil.c " +
-    "";
-
-  EXTENSION("grpc", grpc_source, null,
+    ""
+    , null,
     "/DOPENSSL_NO_ASM /D_GNU_SOURCE /DWIN32_LEAN_AND_MEAN "+
     "/D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 "+
     "/I"+configure_module_dirname+" "+
@@ -910,5 +909,4 @@ if (PHP_GRPC != "no") {
     }
   }
   build_dirs = _build_dirs;
-
 }

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -39,11 +39,13 @@
   <%
     srcs = []
     srcs.extend(php_config_m4.src)
-    php_deps = php_config_m4.get('deps', [])
     lib_maps = {lib.name: lib for lib in libs}
-    for dep in php_deps[:]:
-      php_deps.extend(lib_maps[dep].transitive_deps)
-    for dep in list(set(php_deps) - set(('z',))):
+    php_deps = php_config_m4.get('deps', [])
+    php_full_deps = []
+    for dep in php_deps:
+      php_full_deps.append(dep)
+      php_full_deps.extend(lib_maps[dep].transitive_deps)
+    for dep in set(php_full_deps) - set({'z'}):
       srcs.extend(lib_maps[dep].src)
     srcs = sorted(set(srcs))
   %>
@@ -56,11 +58,7 @@
       -D_HAS_EXCEPTIONS=0 -DNOMINMAX -DGRPC_ARES=0 ${"\\"}
       -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1)
   <%
-    dirs = {}
-    for src in srcs:
-      dirs[src[:src.rfind('/')]] = 1
-    dirs = dirs.keys()
-    dirs.sort()
+    dirs = sorted(set(src[:src.rfind('/')] for src in srcs))
   %>
     % for dir in dirs:
     PHP_ADD_BUILD_DIR($ext_builddir/${dir})

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -38,13 +38,14 @@
     PHP_SUBST(GRPC_SHARED_LIBADD)
   <%
     srcs = []
-    for src in php_config_m4.src:
-      srcs.append(src)
-    for lib in libs:
-      if lib.name in php_config_m4.get('deps', []) and lib.name != 'z':
-        for src in lib.src:
-          srcs.append(src)
-    srcs = sorted(srcs)
+    srcs.extend(php_config_m4.src)
+    php_deps = php_config_m4.get('deps', [])
+    lib_maps = {lib.name: lib for lib in libs}
+    for dep in php_deps[:]:
+      php_deps.extend(lib_maps[dep].transitive_deps)
+    for dep in list(set(php_deps) - set(('z',))):
+      srcs.extend(lib_maps[dep].src)
+    srcs = sorted(set(srcs))
   %>
     PHP_NEW_EXTENSION(grpc,
       % for src in srcs:
@@ -54,14 +55,10 @@
       -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN ${"\\"}
       -D_HAS_EXCEPTIONS=0 -DNOMINMAX -DGRPC_ARES=0 ${"\\"}
       -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1)
-
-    PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)
   <%
     dirs = {}
-    for lib in libs:
-      if lib.name in php_config_m4.get('deps', []) and lib.name != 'z':
-        for source in lib.src:
-          dirs[source[:source.rfind('/')]] = 1
+    for src in srcs:
+      dirs[src[:src.rfind('/')]] = 1
     dirs = dirs.keys()
     dirs.sort()
   %>

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -6,21 +6,23 @@
   ARG_WITH("grpc", "grpc support", "no");
 
   if (PHP_GRPC != "no") {
-
-    grpc_source =
-      % for source in php_config_m4.src:
-      "${source.replace('/','\\\\')} " +
+  <%
+    srcs = []
+    srcs.extend(php_config_m4.src)
+    php_deps = php_config_m4.get('deps', [])
+    lib_maps = {lib.name: lib for lib in libs}
+    for dep in php_deps[:]:
+      php_deps.extend(lib_maps[dep].transitive_deps)
+    for dep in php_deps:
+      srcs.extend(lib_maps[dep].src)
+    srcs = sorted(set(srcs))
+  %>
+    EXTENSION("grpc",
+      % for src in srcs:
+      "${src.replace('/','\\\\')} " +
       % endfor
-      % for lib in libs:
-      % if lib.name in php_config_m4.get('deps', []) and lib.name != 'ares':
-      % for source in lib.src:
-      "${source.replace('/','\\\\')} " +
-      % endfor
-      % endif
-      % endfor
-      "";
-
-    EXTENSION("grpc", grpc_source, null,
+      ""
+      , null,
       "/DOPENSSL_NO_ASM /D_GNU_SOURCE /DWIN32_LEAN_AND_MEAN "+
       "/D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 "+
       "/I"+configure_module_dirname+" "+
@@ -32,32 +34,20 @@
       "/I"+configure_module_dirname+"\\third_party\\upb "+
       "/I"+configure_module_dirname+"\\third_party\\zlib ");
   <%
-    dirs = {}
-    for lib in libs:
-      if lib.name in php_config_m4.get('deps', []) and lib.name != 'ares':
-        for source in lib.src:
-          tmp = source
-          prev = ''
-          while (True):
-            idx = tmp.find('/');
-            if (idx == -1):
-              break
-            dirs[prev + '\\\\' + tmp[:idx]] = 1
-            prev += ('\\\\' + tmp[:idx]);
-            tmp = tmp[idx+1:]
-            
-    dirs['\\\\src'] = 1;
-    dirs['\\\\src\\\\php'] = 1;
-    dirs['\\\\src\\\\php\\\\ext'] = 1;
-    dirs['\\\\src\\\\php\\\\ext\\\\grpc'] = 1;
-    dirs = dirs.keys()
-    dirs.sort()
+    dirset = set()
+    for src in srcs:
+      dirset.add(src[:src.rfind('/')])
+    for dir in list(dirset):
+      frags = dir.split('/')
+      for i in range(1, len(frags)):
+        dirset.add('/'.join(frags[:i]))
+    dirs = [d.replace('/', '\\\\') for d in sorted(list(dirset))]
   %>
     base_dir = get_define('BUILD_DIR');
     FSO.CreateFolder(base_dir+"\\ext");
     FSO.CreateFolder(base_dir+"\\ext\\grpc");
     % for dir in dirs:
-    FSO.CreateFolder(base_dir+"\\ext\\grpc${dir}");
+    FSO.CreateFolder(base_dir+"\\ext\\grpc\\${dir}");
     % endfor
     _build_dirs = new Array();
     for (i = 0; i < build_dirs.length; i++) {
@@ -66,5 +56,4 @@
       }
     }
     build_dirs = _build_dirs;
-
   }

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -9,11 +9,13 @@
   <%
     srcs = []
     srcs.extend(php_config_m4.src)
-    php_deps = php_config_m4.get('deps', [])
     lib_maps = {lib.name: lib for lib in libs}
-    for dep in php_deps[:]:
-      php_deps.extend(lib_maps[dep].transitive_deps)
+    php_deps = php_config_m4.get('deps', [])
+    php_full_deps = []
     for dep in php_deps:
+      php_full_deps.append(dep)
+      php_full_deps.extend(lib_maps[dep].transitive_deps)
+    for dep in php_full_deps:
       srcs.extend(lib_maps[dep].src)
     srcs = sorted(set(srcs))
   %>
@@ -34,14 +36,13 @@
       "/I"+configure_module_dirname+"\\third_party\\upb "+
       "/I"+configure_module_dirname+"\\third_party\\zlib ");
   <%
-    dirset = set()
-    for src in srcs:
-      dirset.add(src[:src.rfind('/')])
-    for dir in list(dirset):
+    dirs = sorted(set(src[:src.rfind('/')] for src in srcs))
+    dirset = set(dirs)
+    for dir in dirs:
       frags = dir.split('/')
       for i in range(1, len(frags)):
         dirset.add('/'.join(frags[:i]))
-    dirs = [d.replace('/', '\\\\') for d in sorted(list(dirset))]
+    dirs = [d.replace('/', '\\\\') for d in sorted(dirset)]
   %>
     base_dir = get_define('BUILD_DIR');
     FSO.CreateFolder(base_dir+"\\ext");

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -49,10 +49,13 @@
     s.extensions = %w(src/ruby/ext/grpc/extconf.rb)
   <%
     files = []
-    for lib in libs:
-      if lib.name in ruby_gem.get('deps', []):
-        for file in (lib.get('public_headers', []) + lib.headers + lib.src):
-          files.append(file)
+    ruby_deps = ruby_gem.get('deps', [])
+    lib_maps = {lib.name: lib for lib in libs}
+    for dep in ruby_deps[:]:
+      ruby_deps.extend(lib_maps[dep].transitive_deps)
+    for dep in ruby_deps:
+      lib = lib_maps[dep]
+      files.extend(lib.get('public_headers', []) + lib.headers + lib.src)
     files = sorted(set(files))
   %>
     % for file in files:

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -33,12 +33,14 @@
       <file baseinstalldir="/" name="src/php/README.md" role="src" />\
   <%
     srcs = []
-    for src in (php_config_m4.src + php_config_m4.headers):
-      srcs.append(src)
-    for lib in libs:
-      if lib.name in php_config_m4.get('deps', []):
-        for src in (lib.get('public_headers', []) + lib.headers + lib.src):
-          srcs.append(src)
+    srcs.extend(php_config_m4.src + php_config_m4.headers)
+    php_deps = php_config_m4.get('deps', [])
+    lib_maps = {lib.name: lib for lib in libs}
+    for dep in php_deps[:]:
+      php_deps.extend(lib_maps[dep].transitive_deps)
+    for dep in php_deps:
+      lib = lib_maps[dep]
+      srcs.extend(lib.get('public_headers', []) + lib.headers + lib.src)
     srcs = sorted(set(srcs))
   %>
       % for src in srcs:


### PR DESCRIPTION
Update following build templates to handle transitive dependencies to be added properly.
- templates/config.m4.template
- templates/config.w32.template
- templates/grpc.gemspec.template
- templates/package.xml.template

This shouldn't introduce any change on generated corresponding build files from templates. This makes templates more flexible to support further new dependencies such as abseil. This is a prerequisite for #20184.

Changes on `config.w32` are made because it starts using sort and they should be equivalent with the previous.