### PR TITLE
Conditionally enable OPENSSL_NO_ASM for Visual Studio

### DIFF
--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -20,15 +20,26 @@ if(gRPC_SSL_PROVIDER STREQUAL "module")
   if(NOT BORINGSSL_ROOT_DIR)
     set(BORINGSSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/boringssl)
   endif()
+
   if(EXISTS "${BORINGSSL_ROOT_DIR}/CMakeLists.txt")
-    if (MSVC AND NOT CMAKE_GENERATOR STREQUAL "Ninja")
-      # Visual Studio build with assembly optimizations is broken,
-      # but it works with Ninja generator.
-      # This will get eventually fixed in cmake, but until then
-      # we need to disable assembly optimizations.
-      # See https://github.com/grpc/grpc/issues/16376
-      set(OPENSSL_NO_ASM ON)
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+      if(CMAKE_VERSION VERSION_LESS 3.13)
+        # Visual Studio build with assembly optimizations is broken for older
+        # version of CMake (< 3.13).
+        message(WARNING "Disabling SSL assembly support because CMake version ${CMAKE_VERSION} is too old (less than 3.13)")
+        set(OPENSSL_NO_ASM ON)
+      else()
+        # If we're using a new enough version of CMake, make sure that the
+        # NASM assembler can be found.
+        include(CheckLanguage)
+        check_language(ASM_NASM)
+        if(NOT CMAKE_ASM_NASM_COMPILER)
+          message(WARNING "Disabling SSL assembly support because NASM could not be found")
+          set(OPENSSL_NO_ASM ON)
+        endif()
+      endif()
     endif()
+
     add_subdirectory(${BORINGSSL_ROOT_DIR} third_party/boringssl)
     if(TARGET ssl)
       set(_gRPC_SSL_LIBRARIES ssl)


### PR DESCRIPTION
This configuration variable was originally disabled due to a bug
in CMake. If we are using a "new enough" version of CMake (3.13+)
we can now enable this flag for Visual Studio builds.

@karthikravis
@jtattermusch 

see https://github.com/grpc/grpc/issues/16376