### PR TITLE
Upgrade the Cython version whenever we can

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux1_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux1_x64/Dockerfile
@@ -22,10 +22,10 @@ RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-de
 
 ###################################
 # Install Python build requirements
-RUN /opt/python/cp27-cp27m/bin/pip install cython
-RUN /opt/python/cp27-cp27mu/bin/pip install cython
-RUN /opt/python/cp34-cp34m/bin/pip install cython
-RUN /opt/python/cp35-cp35m/bin/pip install cython
-RUN /opt/python/cp36-cp36m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp38-cp38/bin/pip install cython
+RUN /opt/python/cp27-cp27m/bin/pip install --upgrade cython
+RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
+RUN /opt/python/cp34-cp34m/bin/pip install --upgrade cython
+RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
+RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux1_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux1_x86/Dockerfile
@@ -22,11 +22,11 @@ RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-de
 
 ###################################
 # Install Python build requirements
-RUN /opt/python/cp27-cp27m/bin/pip install cython
-RUN /opt/python/cp27-cp27mu/bin/pip install cython
-RUN /opt/python/cp34-cp34m/bin/pip install cython
-RUN /opt/python/cp35-cp35m/bin/pip install cython
-RUN /opt/python/cp36-cp36m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp38-cp38/bin/pip install cython
+RUN /opt/python/cp27-cp27m/bin/pip install --upgrade cython
+RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
+RUN /opt/python/cp34-cp34m/bin/pip install --upgrade cython
+RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
+RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
@@ -22,11 +22,11 @@ RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-de
 
 ###################################
 # Install Python build requirements
-RUN /opt/python/cp27-cp27m/bin/pip install cython
-RUN /opt/python/cp27-cp27mu/bin/pip install cython
-RUN /opt/python/cp34-cp34m/bin/pip install cython
-RUN /opt/python/cp35-cp35m/bin/pip install cython
-RUN /opt/python/cp36-cp36m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp38-cp38/bin/pip install cython
+RUN /opt/python/cp27-cp27m/bin/pip install --upgrade cython
+RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
+RUN /opt/python/cp34-cp34m/bin/pip install --upgrade cython
+RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
+RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
@@ -22,11 +22,11 @@ RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-de
 
 ###################################
 # Install Python build requirements
-RUN /opt/python/cp27-cp27m/bin/pip install cython
-RUN /opt/python/cp27-cp27mu/bin/pip install cython
-RUN /opt/python/cp34-cp34m/bin/pip install cython
-RUN /opt/python/cp35-cp35m/bin/pip install cython
-RUN /opt/python/cp36-cp36m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp37-cp37m/bin/pip install cython
-RUN /opt/python/cp38-cp38/bin/pip install cython
+RUN /opt/python/cp27-cp27m/bin/pip install --upgrade cython
+RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
+RUN /opt/python/cp34-cp34m/bin/pip install --upgrade cython
+RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
+RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -21,11 +21,11 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # install cython for all python versions
-python2.7 -m pip install -U cython setuptools wheel
-python3.5 -m pip install -U cython setuptools wheel
-python3.6 -m pip install -U cython setuptools wheel
-python3.7 -m pip install -U cython setuptools wheel
-python3.8 -m pip install -U cython setuptools wheel
+python2.7 -m pip install -U cython setuptools wheel --user
+python3.5 -m pip install -U cython setuptools wheel --user
+python3.6 -m pip install -U cython setuptools wheel --user
+python3.7 -m pip install -U cython setuptools wheel --user
+python3.8 -m pip install -U cython setuptools wheel --user
 
 # needed to build ruby artifacts
 time bash tools/distrib/build_ruby_environment_macos.sh

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -21,11 +21,11 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # install cython for all python versions
-python2.7 -m pip install cython setuptools wheel
-python3.5 -m pip install cython setuptools wheel
-python3.6 -m pip install cython setuptools wheel
-python3.7 -m pip install cython setuptools wheel
-python3.8 -m pip install cython setuptools wheel
+python2.7 -m pip install -U cython setuptools wheel
+python3.5 -m pip install -U cython setuptools wheel
+python3.6 -m pip install -U cython setuptools wheel
+python3.7 -m pip install -U cython setuptools wheel
+python3.8 -m pip install -U cython setuptools wheel
 
 # needed to build ruby artifacts
 time bash tools/distrib/build_ruby_environment_macos.sh

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -19,7 +19,7 @@ python -m pip install --upgrade six
 @rem some artifacts are broken for setuptools 38.5.0. See https://github.com/grpc/grpc/issues/14317
 python -m pip install --upgrade setuptools==38.2.4
 python -m pip install --upgrade cython
-python -m pip install -rrequirements.txt
+python -m pip install -rrequirements.txt --user
 
 set GRPC_PYTHON_BUILD_WITH_CYTHON=1
 

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -23,7 +23,7 @@ export PIP=${PIP:-pip}
 export AUDITWHEEL=${AUDITWHEEL:-auditwheel}
 
 # Install mandatory Python dependencies to avoid source wheel build failure.
-"${PIP}" install -rrequirements.txt
+"${PIP}" install -rrequirements.txt --user
 
 # Allow build_ext to build C/C++ files in parallel
 # by enabling a monkeypatch. It speeds up the build a lot.

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -22,6 +22,9 @@ export PYTHON=${PYTHON:-python}
 export PIP=${PIP:-pip}
 export AUDITWHEEL=${AUDITWHEEL:-auditwheel}
 
+# Install mandatory Python dependencies to avoid source wheel build failure.
+"${PIP}" install -rrequirements.txt
+
 # Allow build_ext to build C/C++ files in parallel
 # by enabling a monkeypatch. It speeds up the build a lot.
 # Use externally provided GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS value if set.
@@ -96,8 +99,6 @@ fi
 # are in a docker image or in a virtualenv.
 if [ "$GRPC_BUILD_GRPCIO_TOOLS_DEPENDENTS" != "" ]
 then
-  "${PIP}" install -rrequirements.txt
-
   if [ "$("$PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
   then
     "${PIP}" install futures>=2.2.0

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -22,8 +22,8 @@ export PYTHON=${PYTHON:-python}
 export PIP=${PIP:-pip}
 export AUDITWHEEL=${AUDITWHEEL:-auditwheel}
 
-# Install mandatory Python dependencies to avoid source wheel build failure.
-"${PIP}" install -rrequirements.txt --user
+# Install Cython to avoid source wheel build failure.
+"${PIP}" install --upgrade cython
 
 # Allow build_ext to build C/C++ files in parallel
 # by enabling a monkeypatch. It speeds up the build a lot.
@@ -99,6 +99,8 @@ fi
 # are in a docker image or in a virtualenv.
 if [ "$GRPC_BUILD_GRPCIO_TOOLS_DEPENDENTS" != "" ]
 then
+  "${PIP}" install -rrequirements.txt
+
   if [ "$("$PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
   then
     "${PIP}" install futures>=2.2.0

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -175,10 +175,10 @@ case "$VENV" in
   ;;
 esac
 
-$VENV_PYTHON -m pip install --upgrade pip==10.0.1
-$VENV_PYTHON -m pip install setuptools
-$VENV_PYTHON -m pip install cython
-$VENV_PYTHON -m pip install six enum34 protobuf
+$VENV_PYTHON -m pip install --upgrade pip
+$VENV_PYTHON -m pip install --upgrade setuptools
+$VENV_PYTHON -m pip install --upgrade cython
+$VENV_PYTHON -m pip install --upgrade six enum34 protobuf
 
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21450, which is a breakage introduced by #21232.

This is a straight forward error that the Cython version is too old to understand new Python syntax. Once we upgrade Cython package, the problem should go away.