### PR TITLE
Add timestamp to stdout for grpc-ios-cpp-cronet

### DIFF
--- a/test/cpp/ios/build_and_run_tests.sh
+++ b/test/cpp/ios/build_and_run_tests.sh
@@ -35,6 +35,6 @@ xcodebuild \
     -scheme CronetTests \
     -destination name="iPhone 8" \
     test \
-    | ./verbose_time.sh
+    | ./verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' -

--- a/test/cpp/ios/build_and_run_tests.sh
+++ b/test/cpp/ios/build_and_run_tests.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")"
 
 echo "TIME:  $(date)"
 
-./build_tests.sh
+./build_tests.sh | ./verbose_time.sh
 
 echo "TIME:  $(date)"
 
@@ -35,5 +35,6 @@ xcodebuild \
     -scheme CronetTests \
     -destination name="iPhone 8" \
     test \
+    | ./verbose_time.sh
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' -

--- a/test/cpp/ios/verbose_time.sh
+++ b/test/cpp/ios/verbose_time.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
 
 while IFS= read -r line; do
   echo "$(date) - $line"

--- a/test/cpp/ios/verbose_time.sh
+++ b/test/cpp/ios/verbose_time.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while IFS= read -r line; do
+  echo "$(date) - $line"
+done


### PR DESCRIPTION
The test is timing out in Kokoro without an explicit indication of which step the timeout happens. This change allows Kokoro to provide a bit more info on that when it the timeout occurs.