### PR TITLE
Make buildifier sanity test fail-able

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -873,7 +873,7 @@ grpc_cc_library(
         "src/core/lib/iomgr/is_epollexclusive_available.h",
         "src/core/lib/iomgr/load_file.h",
         "src/core/lib/iomgr/lockfree_event.h",
-        "src/core/lib/iomgr/logical_thread.h",  
+        "src/core/lib/iomgr/logical_thread.h",
         "src/core/lib/iomgr/nameser.h",
         "src/core/lib/iomgr/polling_entity.h",
         "src/core/lib/iomgr/pollset.h",

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -193,6 +193,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
     copts = if_mac(["-DGRPC_CFSTREAM"])
     if language.upper() == "C":
         copts = copts + if_not_windows(["-std=c99"])
+
     # NOTE: these attributes won't be used for the poller-specific versions of a test
     # automatically, you need to set them explicitly (if applicable)
     args = {

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -138,15 +138,15 @@ grpc_cc_test(
     name = "logical_thread_test",
     srcs = ["logical_thread_test.cc"],
     exec_properties = LARGE_MACHINE,
+    external_deps = [
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],  # LARGE_MACHINE is not configured for windows RBE
     deps = [
         "//:gpr",
         "//:grpc",
         "//test/core/util:grpc_test_util",
-    ],
-    external_deps = [
-      "gtest",
     ],
 )
 
@@ -271,8 +271,8 @@ grpc_cc_test(
     srcs = ["tcp_posix_test.cc"],
     language = "C++",
     tags = [
-        "no_windows",
         "no_mac",  # TODO(jtattermusch): Reenable once https://github.com/grpc/grpc/issues/21282 is fixed.
+        "no_windows",
     ],
     deps = [
         ":endpoint_tests",

--- a/test/core/iomgr/poller/BUILD
+++ b/test/core/iomgr/poller/BUILD
@@ -1,4 +1,3 @@
-
 # Copyright 2019 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -501,6 +501,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    shard_count = 10,
     tags = [
         "no_test_ios",
         "no_windows",
@@ -520,7 +521,6 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    shard_count = 10,
 )
 
 grpc_cc_test(
@@ -713,6 +713,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    shard_count = 5,
     tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
     deps = [
         "//:gpr",
@@ -724,7 +725,6 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    shard_count = 5,
 )
 
 grpc_cc_test(

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -137,8 +137,8 @@ grpc_cc_binary(
         "bm_fullstack_streaming_ping_pong.cc",
     ],
     tags = [
-        "no_windows",
         "no_mac",  # to emulate "excluded_poll_engines: poll"
+        "no_windows",
     ],
     deps = [":fullstack_streaming_ping_pong_h"],
 )
@@ -159,8 +159,8 @@ grpc_cc_binary(
         "bm_fullstack_streaming_pump.cc",
     ],
     tags = [
-        "no_windows",
         "no_mac",  # to emulate "excluded_poll_engines: poll"
+        "no_windows",
     ],
     deps = [":fullstack_streaming_pump_h"],
 )
@@ -170,8 +170,8 @@ grpc_cc_binary(
     testonly = 1,
     srcs = ["bm_fullstack_trickle.cc"],
     tags = [
-        "no_windows",
         "no_mac",  # to emulate "excluded_poll_engines: poll"
+        "no_windows",
     ],
     deps = [":helpers"],
 )
@@ -192,8 +192,8 @@ grpc_cc_binary(
         "bm_fullstack_unary_ping_pong.cc",
     ],
     tags = [
-        "no_windows",
         "no_mac",  # to emulate "excluded_poll_engines: poll"
+        "no_windows",
     ],
     deps = [":fullstack_unary_ping_pong_h"],
 )

--- a/tools/distrib/buildifier_format_code.sh
+++ b/tools/distrib/buildifier_format_code.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -e
+#! /bin/bash
 # Copyright 2019 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -e
 
 BUILDIFIER_VERSION="0.29.0"
 TEMP_BUILDIFIER_PATH="/tmp/buildifier"

--- a/tools/distrib/buildifier_format_code.sh
+++ b/tools/distrib/buildifier_format_code.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -ex
+#! /bin/bash -e
 # Copyright 2019 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The script to check if Bazel files needs to be formatted.
+# The script to check if Bazel files need to be formatted.
 
 GIT_ROOT="$(dirname "$0")/../../.."
 "$GIT_ROOT/tools/distrib/buildifier_format_code.sh" -mode=diff

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -28,6 +28,7 @@ if [[ ${result} != 0 ]]; then
     echo ""
     echo "    tools/distrib/buildifier_format_code.sh"
     echo ""
+    exit 1
 else
     echo "==========BUILDIFIER CHECK PASSED=========="
 fi

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -x
+#! /bin/bash
 # Copyright 2019 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# The script to sanitize Bazel files
+# The script to check if Bazel files needs to be formatted.
 
 GIT_ROOT="$(dirname "$0")/../../.."
-TMP_ROOT="/tmp/buildifier_grpc"
-rm -rf "${TMP_ROOT}"
-git clone -- "$GIT_ROOT" "$TMP_ROOT"
-buildifier -r -v -mode=diff $TMP_ROOT
+"$GIT_ROOT/tools/distrib/buildifier_format_code.sh" -mode=diff
 result=$?
 
 if [[ ${result} != 0 ]]; then


### PR DESCRIPTION
I introduced sanity test for Bazel files months ago, but it is actually not a fail-able test. This PR fixes the script, and format all the Bazel files.