### PR TITLE
Add ares_android.h to the BUILD file

### DIFF
--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -159,9 +159,15 @@ cc_library(
         "inet_net_pton.c",
         "inet_ntop.c",
         "windows_port.c",
-    ],
+    ] + select({
+        ":android": [
+            "ares_android.c",
+        ],
+        "//conditions:default": [],
+    }),
     hdrs = [
         "ares.h",
+        "ares_android.h",
         "ares_build.h",
         "ares_config.h",
         "ares_data.h",


### PR DESCRIPTION
This change adds `ares_android.h` and `ares_android.c` to `third_party/cares/cares.BUILD` in order to support builds in the Android Native Development Kit (NDK).

Fixes #21437