### PR TITLE
Make CancelDelayedRpc anc ClientCancelsRpc tests not use sleeps for client-server synchronization

### DIFF
--- a/src/proto/grpc/testing/echo_messages.proto
+++ b/src/proto/grpc/testing/echo_messages.proto
@@ -47,9 +47,11 @@ message RequestParams {
   bool server_die = 12; // Server should not see a request with this set.
   string binary_error_details = 13;
   ErrorStatus expected_error = 14;
-  int32 server_sleep_us = 15; // Amount to sleep when invoking server
+  int32 server_sleep_us = 15; // sleep when invoking server for deadline tests
   int32 backend_channel_idx = 16; // which backend to send request to
   bool echo_metadata_initially = 17;
+  bool server_notify_started = 18;
+  bool client_will_cancel_after_notified = 19;
 }
 
 message EchoRequest {

--- a/test/cpp/end2end/test_service_impl.h
+++ b/test/cpp/end2end/test_service_impl.h
@@ -46,11 +46,52 @@ typedef enum {
   CANCEL_AFTER_PROCESSING
 } ServerTryCancelRequestPhase;
 
+class TestServiceSignaller {
+ public:
+  void ClientWaitToCancelSelf() {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_client_cancel_self_.wait(lock,
+                                [this] { return client_should_cancel_self_; });
+  }
+  void ClientWaitRpcStarted() {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_rpc_started_.wait(lock, [this] { return rpc_started_; });
+  }
+  void ServerWaitToContinue() {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_server_continue_.wait(lock, [this] { return server_should_continue_; });
+  }
+  void SignalClientToCancelSelf() {
+    std::unique_lock<std::mutex> lock(mu_);
+    client_should_cancel_self_ = true;
+    cv_client_cancel_self_.notify_one();
+  }
+  void SignalClientRpcStarted() {
+    std::unique_lock<std::mutex> lock(mu_);
+    rpc_started_ = true;
+    cv_rpc_started_.notify_one();
+  }
+  void SignalServerToContinue() {
+    std::unique_lock<std::mutex> lock(mu_);
+    server_should_continue_ = true;
+    cv_server_continue_.notify_one();
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_client_cancel_self_;
+  bool client_should_cancel_self_ /* GUARDED_BY(mu_) */ = false;
+  std::condition_variable cv_rpc_started_;
+  bool rpc_started_ /* GUARDED_BY(mu_) */ = false;
+  std::condition_variable cv_server_continue_;
+  bool server_should_continue_ /* GUARDED_BY(mu_) */ = false;
+};
+
 class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
  public:
-  TestServiceImpl() : signal_client_(false), host_() {}
+  TestServiceImpl() : host_() {}
   explicit TestServiceImpl(const grpc::string& host)
-      : signal_client_(false), host_(new grpc::string(host)) {}
+      : host_(new grpc::string(host)) {}
 
   Status Echo(ServerContext* context, const EchoRequest* request,
               EchoResponse* response) override;
@@ -72,23 +113,21 @@ class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
       ServerContext* context,
       ServerReaderWriter<EchoResponse, EchoRequest>* stream) override;
 
-  bool signal_client() {
-    std::unique_lock<std::mutex> lock(mu_);
-    return signal_client_;
-  }
+  void ClientWaitToCancelSelf() { signaller_.ClientWaitToCancelSelf(); }
+  void ClientWaitRpcStarted() { signaller_.ClientWaitRpcStarted(); }
+  void SignalServerToContinue() { signaller_.SignalServerToContinue(); }
 
  private:
-  bool signal_client_;
-  std::mutex mu_;
+  TestServiceSignaller signaller_;
   std::unique_ptr<grpc::string> host_;
 };
 
 class CallbackTestServiceImpl
     : public ::grpc::testing::EchoTestService::ExperimentalCallbackService {
  public:
-  CallbackTestServiceImpl() : signal_client_(false), host_() {}
+  CallbackTestServiceImpl() = default;
   explicit CallbackTestServiceImpl(const grpc::string& host)
-      : signal_client_(false), host_(new grpc::string(host)) {}
+      : host_(new grpc::string(host)) {}
 
   experimental::ServerUnaryReactor* Echo(
       experimental::CallbackServerContext* context, const EchoRequest* request,
@@ -109,15 +148,12 @@ class CallbackTestServiceImpl
   experimental::ServerBidiReactor<EchoRequest, EchoResponse>* BidiStream(
       experimental::CallbackServerContext* context) override;
 
-  // Unimplemented is left unimplemented to test the returned error.
-  bool signal_client() {
-    std::unique_lock<std::mutex> lock(mu_);
-    return signal_client_;
-  }
+  void ClientWaitToCancelSelf() { signaller_.ClientWaitToCancelSelf(); }
+  void ClientWaitRpcStarted() { signaller_.ClientWaitRpcStarted(); }
+  void SignalServerToContinue() { signaller_.SignalServerToContinue(); }
 
  private:
-  bool signal_client_;
-  std::mutex mu_;
+  TestServiceSignaller signaller_;
   std::unique_ptr<grpc::string> host_;
 };
 


### PR DESCRIPTION
Fixes #21263 
