### PR TITLE
Added a fallback boringssl rule in build.yaml

### DIFF
--- a/src/boringssl/gen_build_yaml.py
+++ b/src/boringssl/gen_build_yaml.py
@@ -29,7 +29,20 @@ sys.path.append(os.path.join(boring_ssl_root, 'util'))
 try:
   import generate_build_files
 except ImportError:
-  print(yaml.dump({}))
+  # This is a fallback target in case where boringssl is not available.
+  # Without this, targets depending on boringssl run into errors due to missing targets.
+  print(yaml.dump({
+      'libs': [{
+          'name': 'boringssl',
+          'build': 'private',
+          'language': 'c',
+          'src': [],
+          'headers': [],
+          'secure': False,
+          'boringssl': True,
+          'defaults': 'boringssl',
+      },]
+  }))
   sys.exit()
 
 def map_dir(filename):


### PR DESCRIPTION
Internal build environment doesn't have `boringssl` at the expected location so it fails to generate build files from templates. It's mostly benign not to have build files internally but it shows error when importing it, which is bad. This helps removing errors when generating build files while importing.