### PR TITLE
Use fast cpp protos for Bazel Python builds

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -6,6 +6,7 @@
 build --client_env=CC=clang
 build --copt=-DGRPC_BAZEL_BUILD
 build --action_env=GRPC_BAZEL_RUNTIME=1
+build --define=use_fast_cpp_protos=true
 
 build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21479

This flag enables the fast mode for ProtoBuf Python. It should speed up all our Python test cases.