### PR TITLE
Support CentOS 7 for gRPC.NET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5853,6 +5853,7 @@ if(gRPC_BUILD_CSHARP_EXT)
 
 add_library(grpc_csharp_ext SHARED
   src/csharp/ext/grpc_csharp_ext.c
+  src/csharp/ext/std++compat.cc
 )
 
 set_target_properties(grpc_csharp_ext PROPERTIES

--- a/Makefile
+++ b/Makefile
@@ -8143,6 +8143,7 @@ $(OBJDIR)/$(CONFIG)/test/cpp/qps/usage_timer.o: $(GENDIR)/src/proto/grpc/testing
 
 LIBGRPC_CSHARP_EXT_SRC = \
     src/csharp/ext/grpc_csharp_ext.c \
+    src/csharp/ext/std++compat.cc \
 
 PUBLIC_HEADERS_C += \
 
@@ -23364,6 +23365,7 @@ src/cpp/server/secure_server_credentials.cc: $(OPENSSL_DEP)
 src/cpp/util/core_stats.cc: $(OPENSSL_DEP)
 src/cpp/util/error_details.cc: $(OPENSSL_DEP)
 src/csharp/ext/grpc_csharp_ext.c: $(OPENSSL_DEP)
+src/csharp/ext/std++compat.cc: $(OPENSSL_DEP)
 test/core/bad_client/bad_client.cc: $(OPENSSL_DEP)
 test/core/bad_ssl/server_common.cc: $(OPENSSL_DEP)
 test/core/end2end/data/client_certs.cc: $(OPENSSL_DEP)

--- a/build.yaml
+++ b/build.yaml
@@ -2256,6 +2256,7 @@ libs:
   language: csharp
   src:
   - src/csharp/ext/grpc_csharp_ext.c
+  - src/csharp/ext/std++compat.cc
   deps:
   - grpc
   - gpr

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -2308,6 +2308,7 @@
       ],
       'sources': [
         'src/csharp/ext/grpc_csharp_ext.c',
+        'src/csharp/ext/std++compat.cc',
       ],
     },
     {

--- a/src/csharp/ext/std++compat.cc
+++ b/src/csharp/ext/std++compat.cc
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <cstdarg>
+#include <cstdio>
+#include <vector>
+
+#if defined(__GNUC__)
+
+namespace std {
+
+// CentOS 7 (GLIBC_2.17 / GLIBCXX_3.4.19) doesn't have a following symbol
+// which was added to GLIBCXX_3.4.20. gRPC uses Debian 8 which has
+// GLIBCXX_3.4.20 when buliding .net artifacts so artifacts can have symbols
+// which are not available on CentOS 7.
+// To support CentOS 7, missing symbols are provided as weak symbols.
+void __attribute__((weak)) __throw_out_of_range_fmt(char const* fmt, ...) {
+  va_list ap;
+  char buf[1024];  // That should be big enough.
+
+  va_start(ap, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, ap);
+  buf[sizeof(buf) - 1] = 0;
+  va_end(ap);
+
+  __throw_range_error(buf);
+}
+
+}  // namespace std
+
+#endif  // defined(__GNUC__)

--- a/src/csharp/ext/std++compat.cc
+++ b/src/csharp/ext/std++compat.cc
@@ -26,7 +26,7 @@ namespace std {
 
 // CentOS 7 (GLIBC_2.17 / GLIBCXX_3.4.19) doesn't have a following symbol
 // which was added to GLIBCXX_3.4.20. gRPC uses Debian 8 which has
-// GLIBCXX_3.4.20 when buliding .net artifacts so artifacts can have symbols
+// GLIBCXX_3.4.20 when building .net artifacts so artifacts can have symbols
 // which are not available on CentOS 7.
 // To support CentOS 7, missing symbols are provided as weak symbols.
 void __attribute__((weak)) __throw_out_of_range_fmt(char const* fmt, ...) {


### PR DESCRIPTION
Added missing symbols for CentOS 7 which lacks symbols from `GLIBCXX_3.4.20`. These symbols can be used by C++ libraries and adding Abseil makes gRPC use these symbols.

This is a prerequisite to #20184.