### PR TITLE
Add linux-headers to docker images for alpine linux

### DIFF
--- a/tools/dockerfile/distribtest/python_dev_alpine3.7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_alpine3.7_x64/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.7
 
-RUN apk add --update build-base python python-dev py-pip
+RUN apk add --update build-base linux-headers python python-dev py-pip
 
 RUN pip install --upgrade pip
 


### PR DESCRIPTION
Alpine Linux needs `linux-headers` package to have `futex.h` file.

This is a prerequisite for #20184.