### PR TITLE
Attempt to fix ruby macos tests: Relax bundler pin in gemspec file to allow >= 2.0

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'google-protobuf', '~> 3.8'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
-  s.add_development_dependency 'bundler',            '~> 1.9'
+  s.add_development_dependency 'bundler',            '>= 1.9'
   s.add_development_dependency 'facter',             '~> 2.4'
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -34,7 +34,7 @@
     s.add_dependency 'google-protobuf', '~> 3.8'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
-    s.add_development_dependency 'bundler',            '~> 1.9'
+    s.add_development_dependency 'bundler',            '>= 1.9'
     s.add_development_dependency 'facter',             '~> 2.4'
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -44,7 +44,10 @@ then
   set -e  # rvm commands are very verbose
   time rvm install 2.5.0
   rvm use 2.5.0 --default
-  time gem install bundler -v 1.17.3 --no-ri --no-doc
+  # Install bundler with workaround from
+  # https://discuss.bitrise.io/t/machine-unable-to-use-update-bundler-2-0/7862
+  time gem uninstall bundler --force
+  time gem install bundler --force --no-ri --no-doc
   time gem install cocoapods --version 1.3.1 --no-ri --no-doc
   time gem install rake-compiler --no-ri --no-doc
   rvm osx-ssl-certs status all


### PR DESCRIPTION
Attempts to fix https://source.cloud.google.com/results/invocations/7ddd916b-d287-4c95-8098-76e9914bf454/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_build_artifacts/log

This is a duplicate of https://github.com/grpc/grpc/pull/19272/files