### PR TITLE
Fix cancellation callback data race

### DIFF
--- a/include/grpcpp/impl/codegen/server_callback_impl.h
+++ b/include/grpcpp/impl/codegen/server_callback_impl.h
@@ -118,8 +118,9 @@ class ServerCallbackCall {
   // should be called, false otherwise.
   bool UnblockCancellation() {
     return on_cancel_conditions_remaining_.fetch_sub(
-						     1, std::memory_order_acq_rel) == 1; }
-  
+               1, std::memory_order_acq_rel) == 1;
+  }
+
   std::atomic_int on_cancel_conditions_remaining_{2};
   std::atomic_int callbacks_outstanding_{
       3};  // reserve for start, Finish, and CompletionOp


### PR DESCRIPTION
Fixes a bug seen internally. The important thing here was to not call the `reactor()` virtual function until we are sure that we need to do a cancellation, since premature calling of `reactor()` could lead to an attempt to check the reactor before it was actually setup.

Asking for a review from @yang-g who identified the bug and from @soheilhy to see if my use of atomics is broken. Thanks!
