### PR TITLE
Backport #21487 to v1.26.x.

### DIFF
--- a/examples/ruby/grpc-demo.gemspec
+++ b/examples/ruby/grpc-demo.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'grpc', '~> 1.0'
   s.add_dependency 'multi_json', '~> 1.13.1'
-  s.add_development_dependency 'bundler', '~> 1.7'
+  s.add_development_dependency 'bundler', '>= 1.9'
 end

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'google-protobuf', '~> 3.8'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
-  s.add_development_dependency 'bundler',            '~> 1.9'
+  s.add_development_dependency 'bundler',            '>= 1.9'
   s.add_development_dependency 'facter',             '~> 2.4'
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -34,7 +34,7 @@
     s.add_dependency 'google-protobuf', '~> 3.8'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
-    s.add_development_dependency 'bundler',            '~> 1.9'
+    s.add_development_dependency 'bundler',            '>= 1.9'
     s.add_development_dependency 'facter',             '~> 2.4'
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'

--- a/test/distrib/ruby/distribtest.gemspec
+++ b/test/distrib/ruby/distribtest.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'public_suffix', '< 3.0'
   s.add_dependency 'jwt', '< 2.0'
 
-  s.add_development_dependency 'bundler', '~> 1.7'
+  s.add_development_dependency 'bundler', '>= 1.9'
 end

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -37,6 +37,12 @@ if [ "$SYSTEM" == "MINGW32" ] ; then
 fi
 
 set +ex
+
+# To workaround the problem with bundler 2.1.0 and rubygems-bundler 1.4.5
+# https://github.com/bundler/bundler/issues/7488
+rvm @global
+gem uninstall rubygems-bundler
+
 rvm use default
 gem install bundler -v 1.17.3
 


### PR DESCRIPTION
Reference: https://github.com/grpc/grpc/pull/21487

This fixes broken Ruby artifact builds on MacOS.

CC @veblush @apolcyn 