### PR TITLE
[Aio] Improve cancellation mechanism on client side

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pxd.pxi
@@ -22,13 +22,12 @@ cdef class _AioCall:
         # time we need access to the event loop.
         object _loop
 
-        # Streaming call only attributes:
-        # 
-        # A asyncio.Event that indicates if the status is received on the client side.
-        object _status_received
-        # A tuple of key value pairs representing the initial metadata sent by peer.
-        tuple _initial_metadata
+        # Flag indicates whether cancel being called or not. Cancellation from
+        # Core or peer works perfectly fine with normal procedure. However, we
+        # need this flag to clean up resources for cancellation from the
+        # application layer. Directly cancelling tasks might cause segfault
+        # because Core is holding a pointer for the callback handler.
+        bint _is_locally_cancelled
 
     cdef grpc_call* _create_grpc_call(self, object timeout, bytes method) except *
     cdef void _destroy_grpc_call(self)
-    cdef AioRpcStatus _cancel_and_create_status(self, object cancellation_future)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -77,11 +77,6 @@ cdef class _AioCall:
         """Destroys the corresponding Core object for this RPC."""
         grpc_call_unref(self._grpc_call_wrapper.call)
 
-    @property
-    def locally_cancelled(self):
-        """Grant Python layer access of the cancelled flag."""
-        return self._is_locally_cancelled
-
     def cancel(self, AioRpcStatus status):
         """Cancels the RPC in Core with given RPC status.
         
@@ -112,12 +107,6 @@ cdef class _AioCall:
             # By implementation, grpc_call_cancel always return OK
             error = grpc_call_cancel(self._grpc_call_wrapper.call, NULL)
             assert error == GRPC_CALL_OK
-            status = AioRpcStatus(
-                StatusCode.cancelled,
-                _UNKNOWN_CANCELLATION_DETAILS,
-                None,
-                None,
-            )
 
     async def unary_unary(self,
                           bytes request,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -77,6 +77,11 @@ cdef class _AioCall:
         """Destroys the corresponding Core object for this RPC."""
         grpc_call_unref(self._grpc_call_wrapper.call)
 
+    @property
+    def locally_cancelled(self):
+        """Grant Python layer access of the cancelled flag."""
+        return self._is_locally_cancelled
+
     def cancel(self, AioRpcStatus status):
         """Cancels the RPC in Core with given RPC status.
         
@@ -145,6 +150,7 @@ cdef class _AioCall:
                receive_status_on_client_op)
 
         # Executes all operations in one batch.
+        # Might raise CancelledError, handling it in Python UnaryUnaryCall.
         await execute_batch(self._grpc_call_wrapper,
                             ops,
                             self._loop)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -26,38 +26,13 @@ cdef class AioChannel:
     def close(self):
         grpc_channel_destroy(self.channel)
 
-    async def unary_unary(self,
-                          bytes method,
-                          bytes request,
-                          object deadline,
-                          object cancellation_future,
-                          object initial_metadata_observer,
-                          object status_observer):
-        """Assembles a unary-unary RPC.
+    def call(self,
+             bytes method,
+             object deadline):
+        """Assembles a Cython Call object.
 
         Returns:
-          The response message in bytes.
+          The _AioCall object.
         """
         cdef _AioCall call = _AioCall(self, deadline, method)
-        return await call.unary_unary(request,
-                                      cancellation_future,
-                                      initial_metadata_observer,
-                                      status_observer)
-
-    def unary_stream(self,
-                     bytes method,
-                     bytes request,
-                     object deadline,
-                     object cancellation_future,
-                     object initial_metadata_observer,
-                     object status_observer):
-        """Assembles a unary-stream RPC.
-
-        Returns:
-          An async generator that yields raw responses.
-        """
-        cdef _AioCall call = _AioCall(self, deadline, method)
-        return call.unary_stream(request,
-                                 cancellation_future,
-                                 initial_metadata_observer,
-                                 status_observer)
+        return call

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -297,6 +297,7 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
         """Forwards the application cancellation reasoning."""
         if not self._status.done():
             self._set_status(status)
+            self._cython_call.cancel(status)
             self._call.cancel()
             return True
         else:

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -417,7 +417,7 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
         if response_message is None:
             # If the read operation failed, Core should explain why.
             await self._raise_rpc_error_if_not_ok()
-            # If everything is okay, there is something wrong internally.
+            # If no exception raised, there is something wrong internally.
             assert False, 'Read operation failed with StatusCode.OK'
         else:
             return response_message

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -321,7 +321,7 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
         try:
             response = yield from self._call
         except asyncio.CancelledError:
-            # Even if we converted all other CancelledError, there is still
+            # Even if we caught all other CancelledError, there is still
             # this corner case. If the application cancels immediately after
             # the Call object is created, we will observe this
             # `CancelledError`.

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -15,6 +15,7 @@
 
 import asyncio
 from typing import AsyncIterable, Awaitable, Dict, Optional
+import logging
 
 import grpc
 from grpc import _common
@@ -167,8 +168,7 @@ class Call(_base_call.Call):
         raise NotImplementedError()
 
     def cancelled(self) -> bool:
-        return self._cancellation.done(
-        ) or self._code == grpc.StatusCode.CANCELLED
+        return self._code == grpc.StatusCode.CANCELLED
 
     def done(self) -> bool:
         return self._status.done()
@@ -205,14 +205,17 @@ class Call(_base_call.Call):
         cancellation (by application) and Core receiving status from peer. We
         make no promise here which one will win.
         """
-        if self._status.done():
-            return
-        else:
-            self._status.set_result(status)
-            self._code = _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[
-                status.code()]
+        logging.debug('Call._set_status, %s, %s', self._status.done(), status)
+        # In case of the RPC finished without receiving metadata.
+        if not self._initial_metadata.done():
+            self._initial_metadata.set_result(None)
+
+        # Sets final status
+        self._status.set_result(status)
+        self._code = _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[status.code()]
 
     async def _raise_rpc_error_if_not_ok(self) -> None:
+        await self._status
         if self._code != grpc.StatusCode.OK:
             raise _create_rpc_error(await self.initial_metadata(),
                                     self._status.result())
@@ -245,12 +248,11 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
     Returned when an instance of `UnaryUnaryMultiCallable` object is called.
     """
     _request: RequestType
-    _deadline: Optional[float]
     _channel: cygrpc.AioChannel
-    _method: bytes
     _request_serializer: SerializingFunction
     _response_deserializer: DeserializingFunction
     _call: asyncio.Task
+    _cython_call: cygrpc._AioCall
 
     def __init__(self, request: RequestType, deadline: Optional[float],
                  channel: cygrpc.AioChannel, method: bytes,
@@ -258,11 +260,10 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
                  response_deserializer: DeserializingFunction) -> None:
         super().__init__()
         self._request = request
-        self._deadline = deadline
         self._channel = channel
-        self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
+        self._cython_call = self._channel.call(method, deadline)
         self._call = self._loop.create_task(self._invoke())
 
     def __del__(self) -> None:
@@ -275,19 +276,20 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
         serialized_request = _common.serialize(self._request,
                                                self._request_serializer)
 
-        # NOTE(lidiz) asyncio.CancelledError is not a good transport for
-        # status, since the Task class do not cache the exact
-        # asyncio.CancelledError object. So, the solution is catching the error
-        # in Cython layer, then cancel the RPC and update the status, finally
-        # re-raise the CancelledError.
-        serialized_response = await self._channel.unary_unary(
-            self._method,
-            serialized_request,
-            self._deadline,
-            self._cancellation,
-            self._set_initial_metadata,
-            self._set_status,
-        )
+        # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
+        # because the asyncio.Task class do not cache the exception object.
+        # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
+        try:
+            serialized_response = await self._cython_call.unary_unary(
+                serialized_request,
+                self._set_initial_metadata,
+                self._set_status,
+            )
+        except asyncio.CancelledError:
+            # Only this class can inject the CancelledError into the RPC
+            # coroutine, so we are certain that this exception is due to local
+            # cancellation.
+            assert self._code == grpc.StatusCode.CANCELLED
         await self._raise_rpc_error_if_not_ok()
 
         return _common.deserialize(serialized_response,
@@ -295,8 +297,8 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
 
     def _cancel(self, status: cygrpc.AioRpcStatus) -> bool:
         """Forwards the application cancellation reasoning."""
-        if not self._status.done() and not self._cancellation.done():
-            self._cancellation.set_result(status)
+        if not self._status.done():
+            self._set_status(status)
             self._call.cancel()
             return True
         else:
@@ -328,13 +330,11 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
     Returned when an instance of `UnaryStreamMultiCallable` object is called.
     """
     _request: RequestType
-    _deadline: Optional[float]
     _channel: cygrpc.AioChannel
-    _method: bytes
     _request_serializer: SerializingFunction
     _response_deserializer: DeserializingFunction
-    _call: asyncio.Task
-    _bytes_aiter: AsyncIterable[bytes]
+    _cython_call: cygrpc._AioCall
+    _send_unary_request_task: asyncio.Task
     _message_aiter: AsyncIterable[ResponseType]
 
     def __init__(self, request: RequestType, deadline: Optional[float],
@@ -343,13 +343,13 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
                  response_deserializer: DeserializingFunction) -> None:
         super().__init__()
         self._request = request
-        self._deadline = deadline
         self._channel = channel
-        self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
-        self._call = self._loop.create_task(self._invoke())
-        self._message_aiter = self._process()
+        self._send_unary_request_task = self._loop.create_task(
+            self._send_unary_request())
+        self._message_aiter = self._fetch_stream_responses()
+        self._cython_call = self._channel.call(method, deadline)
 
     def __del__(self) -> None:
         if not self._status.done():
@@ -357,32 +357,18 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
                 cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
                                     _GC_CANCELLATION_DETAILS, None, None))
 
-    async def _invoke(self) -> ResponseType:
+    async def _send_unary_request(self) -> ResponseType:
         serialized_request = _common.serialize(self._request,
                                                self._request_serializer)
+        await self._cython_call.unary_stream(
+            serialized_request, self._set_initial_metadata, self._set_status)
 
-        self._bytes_aiter = await self._channel.unary_stream(
-            self._method,
-            serialized_request,
-            self._deadline,
-            self._cancellation,
-            self._set_initial_metadata,
-            self._set_status,
-        )
-
-    async def _process(self) -> ResponseType:
-        await self._call
-        async for serialized_response in self._bytes_aiter:
-            if self._cancellation.done():
-                await self._status
-            if self._status.done():
-                # Raises pre-maturely if final status received here. Generates
-                # more helpful stack trace for end users.
-                await self._raise_rpc_error_if_not_ok()
-            yield _common.deserialize(serialized_response,
-                                      self._response_deserializer)
-
-        await self._raise_rpc_error_if_not_ok()
+    async def _fetch_stream_responses(self) -> ResponseType:
+        await self._send_unary_request_task
+        message = await self._read()
+        while message:
+            yield message
+            message = await self._read()
 
     def _cancel(self, status: cygrpc.AioRpcStatus) -> bool:
         """Forwards the application cancellation reasoning.
@@ -395,8 +381,15 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
         and the client calling "cancel" at the same time, this method respects
         the winner in Core.
         """
-        if not self._status.done() and not self._cancellation.done():
-            self._cancellation.set_result(status)
+        if not self._status.done():
+            self._set_status(status)
+            self._cython_call.cancel(status)
+
+            if not self._send_unary_request_task.done():
+                # Injects CancelledError to the Task. The exception will
+                # propagate to _fetch_stream_responses as well, if the sending
+                # is not done.
+                self._send_unary_request_task.cancel()
             return True
         else:
             return False
@@ -409,8 +402,25 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
     def __aiter__(self) -> AsyncIterable[ResponseType]:
         return self._message_aiter
 
+    async def _read(self) -> ResponseType:
+        serialized_response = await self._cython_call.receive_serialized_message(
+        )
+        if serialized_response is None:
+            return None
+        else:
+            return _common.deserialize(serialized_response,
+                                       self._response_deserializer)
+
     async def read(self) -> ResponseType:
         if self._status.done():
             await self._raise_rpc_error_if_not_ok()
             raise asyncio.InvalidStateError(_RPC_ALREADY_FINISHED_DETAILS)
-        return await self._message_aiter.__anext__()
+
+        response_message = await self._read()
+        if response_message is None:
+            # If the read operation failed, Core should explain why.
+            await self._raise_rpc_error_if_not_ok()
+            # If everything is okay, there is something wrong internally.
+            assert False, 'Read operation failed with StatusCode.OK'
+        else:
+            return response_message

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -149,14 +149,12 @@ class Call(_base_call.Call):
     _code: grpc.StatusCode
     _status: Awaitable[cygrpc.AioRpcStatus]
     _initial_metadata: Awaitable[MetadataType]
-    _cancellation: asyncio.Future
 
     def __init__(self) -> None:
         self._loop = asyncio.get_event_loop()
         self._code = None
         self._status = self._loop.create_future()
         self._initial_metadata = self._loop.create_future()
-        self._cancellation = self._loop.create_future()
 
     def cancel(self) -> bool:
         """Placeholder cancellation method.
@@ -205,7 +203,6 @@ class Call(_base_call.Call):
         cancellation (by application) and Core receiving status from peer. We
         make no promise here which one will win.
         """
-        logging.debug('Call._set_status, %s, %s', self._status.done(), status)
         # In case of the RPC finished without receiving metadata.
         if not self._initial_metadata.done():
             self._initial_metadata.set_result(None)

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -359,11 +359,9 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
         serialized_request = _common.serialize(self._request,
                                                self._request_serializer)
         try:
-            await self._cython_call.unary_stream(
-                serialized_request,
-                self._set_initial_metadata,
-                self._set_status
-            )
+            await self._cython_call.unary_stream(serialized_request,
+                                                 self._set_initial_metadata,
+                                                 self._set_status)
         except asyncio.CancelledError:
             if self._code != grpc.StatusCode.CANCELLED:
                 self.cancel()

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -124,18 +124,10 @@ class TestUnaryUnaryCall(AioTestBase):
             self.assertTrue(call.cancel())
             self.assertFalse(call.cancel())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await call
 
             # The info in the RpcError should match the info in Call object.
-            rpc_error = exception_context.exception
-            self.assertEqual(rpc_error.code(), await call.code())
-            self.assertEqual(rpc_error.details(), await call.details())
-            self.assertEqual(rpc_error.trailing_metadata(), await
-                             call.trailing_metadata())
-            self.assertEqual(rpc_error.debug_error_string(), await
-                             call.debug_error_string())
-
             self.assertTrue(call.cancelled())
             self.assertEqual(await call.code(), grpc.StatusCode.CANCELLED)
             self.assertEqual(await call.details(),
@@ -159,10 +151,8 @@ class TestUnaryUnaryCall(AioTestBase):
 
             self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await task
-            self.assertEqual(grpc.StatusCode.CANCELLED,
-                             exception_context.exception.code())
 
 
 class TestUnaryStreamCall(AioTestBase):
@@ -201,7 +191,7 @@ class TestUnaryStreamCall(AioTestBase):
                              call.details())
             self.assertFalse(call.cancel())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await call.read()
             self.assertTrue(call.cancelled())
 
@@ -232,7 +222,7 @@ class TestUnaryStreamCall(AioTestBase):
             self.assertFalse(call.cancel())
             self.assertFalse(call.cancel())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await call.read()
 
     async def test_early_cancel_unary_stream(self):
@@ -256,15 +246,10 @@ class TestUnaryStreamCall(AioTestBase):
             self.assertTrue(call.cancel())
             self.assertFalse(call.cancel())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await call.read()
 
             self.assertTrue(call.cancelled())
-
-            self.assertEqual(grpc.StatusCode.CANCELLED,
-                             exception_context.exception.code())
-            self.assertEqual(_LOCAL_CANCEL_DETAILS_EXPECTATION,
-                             exception_context.exception.details())
 
             self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
             self.assertEqual(_LOCAL_CANCEL_DETAILS_EXPECTATION, await
@@ -377,10 +362,8 @@ class TestUnaryStreamCall(AioTestBase):
 
             self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await task
-            self.assertEqual(grpc.StatusCode.CANCELLED,
-                             exception_context.exception.code())
 
     async def test_cancel_unary_stream_in_task_using_async_for(self):
         async with aio.insecure_channel(self._server_target) as channel:
@@ -411,10 +394,8 @@ class TestUnaryStreamCall(AioTestBase):
 
             self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
 
-            with self.assertRaises(grpc.RpcError) as exception_context:
+            with self.assertRaises(asyncio.CancelledError):
                 await task
-            self.assertEqual(grpc.StatusCode.CANCELLED,
-                             exception_context.exception.code())
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -121,10 +121,6 @@ class TestUnaryUnaryCall(AioTestBase):
 
             self.assertFalse(call.cancelled())
 
-            # TODO(https://github.com/grpc/grpc/issues/20869) remove sleep.
-            # Force the loop to execute the RPC task.
-            await asyncio.sleep(0)
-
             self.assertTrue(call.cancel())
             self.assertFalse(call.cancel())
 

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -33,7 +33,7 @@ _LOCAL_CANCEL_DETAILS_EXPECTATION = 'Locally cancelled by application!'
 _RESPONSE_INTERVAL_US = test_constants.SHORT_TIMEOUT * 1000 * 1000
 _UNREACHABLE_TARGET = '0.1:1111'
 
-_INFINITE_INTERVAL_US = 2**31-1
+_INFINITE_INTERVAL_US = 2**31 - 1
 
 
 class TestUnaryUnaryCall(AioTestBase):


### PR DESCRIPTION
As discussed with @pfreixes in https://github.com/grpc/grpc/pull/21455 and Slack, my implementation of cancellation mechanism is not ideal.

Current implementation tries to preserve the native `asyncio.CancelledError`, which causing headaches about the error handling path. It requires an additional catch clause, and additional coordination between layers, as well as additional recognitive burden for our users.

Since I made the mistake in #21232, I implemented this PR to propose a fix for the bad design. This PR contains several items:

* Remove the weird cancellation_future;
* Convert all CancelledError into RpcError with CANCELLED;
* Move part of call logic from Cython to Python layer;
* Make unary-stream call based on reader API instead of async generator.

It should make the implementation less twisted. Also, it should be orthogonal to #21455, since these two PRs are changing different set of files.