### PR TITLE
Add v1.26.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -150,6 +150,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.23.1', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.24.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.25.0', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.26.0', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
     OrderedDict([


### PR DESCRIPTION
```
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.11 | grep v1.26
496b3e5bb3d4  v1.26.0  2019-12-18T12:40:30  CRITICAL=18,HIGH=112,LOW=81,MEDIUM=390                                           FINISHED_SUCCESS
```
