### PR TITLE
Make transitive_deps as a topologically sorted list

### DIFF
--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -35,7 +35,7 @@
     return "abseil/" + label[5:].replace(":", "/")
 
   def lib_and_transitive_deps(lib):
-    return list(sorted(set({lib} | lib_maps[lib].transitive_deps)))
+    return list(sorted(set({lib} | set(lib_maps[lib].transitive_deps))))
 
   def non_abseil_lib_and_transitive_deps(lib):
     return [l for l in lib_and_transitive_deps(lib) if not is_absl_lib(l)]

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -34,7 +34,7 @@
     return "abseil/" + label[5:].replace(":", "/")
 
   def lib_and_transitive_deps(lib):
-    return list(sorted(set({lib} | lib_maps[lib].transitive_deps)))
+    return list(sorted(set({lib} | set(lib_maps[lib].transitive_deps))))
 
   def non_abseil_lib_and_transitive_deps(lib):
     return [l for l in lib_and_transitive_deps(lib) if not is_absl_lib(l)]


### PR DESCRIPTION
Changed `transitive_deps` from `set` to `list` especially in a [topological ordering](https://en.wikipedia.org/wiki/Topological_sorting) so that this can be used as a linking parameter directly.

This is a prerequisite to #20184.