### PR TITLE
[Aio] Client Streaming and Bi-di Streaming

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -96,7 +96,7 @@ cdef class AioChannel:
     def call(self,
              bytes method,
              object deadline,
-             CallCredentials credentials):
+             object python_call_credentials):
         """Assembles a Cython Call object.
 
         Returns:
@@ -105,5 +105,12 @@ cdef class AioChannel:
         if self._status == AIO_CHANNEL_STATUS_DESTROYED:
             # TODO(lidiz) switch to UsageError
             raise RuntimeError('Channel is closed.')
-        cdef _AioCall call = _AioCall(self, deadline, method, credentials)
+
+        cdef CallCredentials cython_call_credentials
+        if python_call_credentials is not None:
+            cython_call_credentials = python_call_credentials._credentials
+        else:
+            cython_call_credentials = None
+
+        cdef _AioCall call = _AioCall(self, deadline, method, cython_call_credentials)
         return call

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -33,3 +33,24 @@ cdef bytes serialize(object serializer, object message):
         return serializer(message)
     else:
         return message
+
+
+class _EOF:
+
+    def __bool__(self):
+        return False
+    
+    def __len__(self):
+        return 0
+
+    def _repr(self) -> str:
+        return '<grpc.aio.EOF>'
+
+    def __repr__(self) -> str:
+        return self._repr()
+
+    def __str__(self) -> str:
+        return self._repr()
+
+
+EOF = _EOF()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -21,6 +21,10 @@ cdef class RPCState(GrpcCallWrapper):
     cdef grpc_call_details details
     cdef grpc_metadata_array request_metadata
     cdef AioServer server
+    # NOTE(lidiz) Under certain corner case, receiving the client close
+    # operation won't immediately fail ongoing RECV_MESSAGE operations. Here I
+    # added a flag to workaround this unexpected behavior.
+    cdef bint client_closed
     cdef object abort_exception
     cdef bint metadata_sent
     cdef bint status_sent

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -22,7 +22,7 @@ from typing import Any, Optional, Sequence, Text, Tuple
 import six
 
 import grpc
-from grpc._cython.cygrpc import init_grpc_aio, AbortError
+from grpc._cython.cygrpc import EOF, AbortError, init_grpc_aio
 
 from ._base_call import Call, RpcContext, UnaryStreamCall, UnaryUnaryCall
 from ._call import AioRpcError
@@ -86,5 +86,5 @@ __all__ = ('AioRpcError', 'RpcContext', 'Call', 'UnaryUnaryCall',
            'UnaryStreamCall', 'init_grpc_aio', 'Channel',
            'UnaryUnaryMultiCallable', 'ClientCallDetails',
            'UnaryUnaryClientInterceptor', 'InterceptedUnaryUnaryCall',
-           'insecure_channel', 'secure_channel', 'server', 'Server',
+           'insecure_channel', 'server', 'Server', 'EOF', 'secure_channel',
            'AbortError')

--- a/src/python/grpcio/grpc/experimental/aio/_base_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_call.py
@@ -19,11 +19,12 @@ RPC, e.g. cancellation.
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, AsyncIterable, Awaitable, Callable, Generic, Text, Optional
+from typing import (Any, AsyncIterable, Awaitable, Callable, Generic, Optional,
+                    Text, Union)
 
 import grpc
 
-from ._typing import MetadataType, RequestType, ResponseType
+from ._typing import EOFType, MetadataType, RequestType, ResponseType
 
 __all__ = 'RpcContext', 'Call', 'UnaryUnaryCall', 'UnaryStreamCall'
 
@@ -146,14 +147,85 @@ class UnaryStreamCall(Generic[RequestType, ResponseType],
         """
 
     @abstractmethod
-    async def read(self) -> ResponseType:
-        """Reads one message from the RPC.
+    async def read(self) -> Union[EOFType, ResponseType]:
+        """Reads one message from the stream.
 
-        For each streaming RPC, concurrent reads in multiple coroutines are not
-        allowed. If you want to perform read in multiple coroutines, you needs
-        synchronization. So, you can start another read after current read is
-        finished.
+        Read operations must be serialized when called from multiple
+        coroutines.
 
         Returns:
-          A response message of the RPC.
+          A response message, or an `grpc.aio.EOF` to indicate the end of the
+          stream.
+        """
+
+
+class StreamUnaryCall(Generic[RequestType, ResponseType],
+                      Call,
+                      metaclass=ABCMeta):
+
+    @abstractmethod
+    async def write(self, request: RequestType) -> None:
+        """Writes one message to the stream.
+
+        Raises:
+          An RpcError exception if the write failed.
+        """
+
+    @abstractmethod
+    async def done_writing(self) -> None:
+        """Notifies server that the client is done sending messages.
+
+        After done_writing is called, any additional invocation to the write
+        function will fail. This function is idempotent.
+        """
+
+    @abstractmethod
+    def __await__(self) -> Awaitable[ResponseType]:
+        """Await the response message to be ready.
+
+        Returns:
+          The response message of the stream.
+        """
+
+
+class StreamStreamCall(Generic[RequestType, ResponseType],
+                       Call,
+                       metaclass=ABCMeta):
+
+    @abstractmethod
+    def __aiter__(self) -> AsyncIterable[ResponseType]:
+        """Returns the async iterable representation that yields messages.
+
+        Under the hood, it is calling the "read" method.
+
+        Returns:
+          An async iterable object that yields messages.
+        """
+
+    @abstractmethod
+    async def read(self) -> Union[EOFType, ResponseType]:
+        """Reads one message from the stream.
+
+        Read operations must be serialized when called from multiple
+        coroutines.
+
+        Returns:
+          A response message, or an `grpc.aio.EOF` to indicate the end of the
+          stream.
+        """
+
+    @abstractmethod
+    async def write(self, request: RequestType) -> None:
+        """Writes one message to the stream.
+
+        Raises:
+          An RpcError exception if the write failed.
+        """
+
+    @abstractmethod
+    async def done_writing(self) -> None:
+        """Notifies server that the client is done sending messages.
+
+        After done_writing is called, any additional invocation to the write
+        function will fail. This function is idempotent.
         """

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -29,6 +29,7 @@ __all__ = 'AioRpcError', 'Call', 'UnaryUnaryCall', 'UnaryStreamCall'
 _LOCAL_CANCELLATION_DETAILS = 'Locally cancelled by application!'
 _GC_CANCELLATION_DETAILS = 'Cancelled upon garbage collection!'
 _RPC_ALREADY_FINISHED_DETAILS = 'RPC already finished.'
+_RPC_HALF_CLOSED_DETAILS = 'RPC is half closed after calling "done_writing".'
 
 _OK_CALL_REPRESENTATION = ('<{} of RPC that terminated with:\n'
                            '\tstatus = {}\n'
@@ -146,30 +147,47 @@ def _create_rpc_error(initial_metadata: Optional[MetadataType],
 
 
 class Call(_base_call.Call):
+    """Base implementation of client RPC Call object.
+
+    Implements logic around final status, metadata and cancellation.
+    """
     _loop: asyncio.AbstractEventLoop
     _code: grpc.StatusCode
     _status: Awaitable[cygrpc.AioRpcStatus]
     _initial_metadata: Awaitable[MetadataType]
     _locally_cancelled: bool
+    _cython_call: cygrpc._AioCall
 
-    def __init__(self) -> None:
+    def __init__(self, cython_call: cygrpc._AioCall) -> None:
         self._loop = asyncio.get_event_loop()
         self._code = None
         self._status = self._loop.create_future()
         self._initial_metadata = self._loop.create_future()
         self._locally_cancelled = False
+        self._cython_call = cython_call
 
-    def cancel(self) -> bool:
-        """Placeholder cancellation method.
-
-        The implementation of this method needs to pass the cancellation reason
-        into self._cancellation, using `set_result` instead of
-        `set_exception`.
-        """
-        raise NotImplementedError()
+    def __del__(self) -> None:
+        if not self._status.done():
+            self._cancel(
+                cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
+                                    _GC_CANCELLATION_DETAILS, None, None))
 
     def cancelled(self) -> bool:
         return self._code == grpc.StatusCode.CANCELLED
+
+    def _cancel(self, status: cygrpc.AioRpcStatus) -> bool:
+        """Forwards the application cancellation reasoning."""
+        if not self._status.done():
+            self._set_status(status)
+            self._cython_call.cancel(status)
+            return True
+        else:
+            return False
+
+    def cancel(self) -> bool:
+        return self._cancel(
+            cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
+                                _LOCAL_CANCELLATION_DETAILS, None, None))
 
     def done(self) -> bool:
         return self._status.done()
@@ -247,6 +265,7 @@ class Call(_base_call.Call):
         return self._repr()
 
 
+# TODO(https://github.com/grpc/grpc/issues/21623) remove this suppression
 # pylint: disable=abstract-method
 class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
     """Object for managing unary-unary RPC calls.
@@ -254,37 +273,29 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
     Returned when an instance of `UnaryUnaryMultiCallable` object is called.
     """
     _request: RequestType
-    _channel: cygrpc.AioChannel
     _request_serializer: SerializingFunction
     _response_deserializer: DeserializingFunction
     _call: asyncio.Task
-    _cython_call: cygrpc._AioCall
 
-    def __init__(  # pylint: disable=R0913
-            self, request: RequestType, deadline: Optional[float],
-            credentials: Optional[grpc.CallCredentials],
-            channel: cygrpc.AioChannel, method: bytes,
-            request_serializer: SerializingFunction,
-            response_deserializer: DeserializingFunction) -> None:
-        super().__init__()
+    # pylint: disable=too-many-arguments
+    def __init__(self, request: RequestType, deadline: Optional[float],
+                 credentials: Optional[grpc.CallCredentials],
+                 channel: cygrpc.AioChannel, method: bytes,
+                 request_serializer: SerializingFunction,
+                 response_deserializer: DeserializingFunction) -> None:
+        channel.call(method, deadline, credentials)
+        super().__init__(channel.call(method, deadline, credentials))
         self._request = request
-        self._channel = channel
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
-
-        if credentials is not None:
-            grpc_credentials = credentials._credentials
-        else:
-            grpc_credentials = None
-        self._cython_call = self._channel.call(method, deadline,
-                                               grpc_credentials)
         self._call = self._loop.create_task(self._invoke())
 
-    def __del__(self) -> None:
-        if not self._call.done():
-            self._cancel(
-                cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
-                                    _GC_CANCELLATION_DETAILS, None, None))
+    def cancel(self) -> bool:
+        if super().cancel():
+            self._call.cancel()
+            return True
+        else:
+            return False
 
     async def _invoke(self) -> ResponseType:
         serialized_request = _common.serialize(self._request,
@@ -300,7 +311,7 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
                 self._set_status,
             )
         except asyncio.CancelledError:
-            if self._code != grpc.StatusCode.CANCELLED:
+            if not self.cancelled():
                 self.cancel()
 
         # Raises here if RPC failed or cancelled
@@ -308,21 +319,6 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
 
         return _common.deserialize(serialized_response,
                                    self._response_deserializer)
-
-    def _cancel(self, status: cygrpc.AioRpcStatus) -> bool:
-        """Forwards the application cancellation reasoning."""
-        if not self._status.done():
-            self._set_status(status)
-            self._cython_call.cancel(status)
-            self._call.cancel()
-            return True
-        else:
-            return False
-
-    def cancel(self) -> bool:
-        return self._cancel(
-            cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
-                                _LOCAL_CANCELLATION_DETAILS, None, None))
 
     def __await__(self) -> ResponseType:
         """Wait till the ongoing RPC request finishes."""
@@ -339,6 +335,7 @@ class UnaryUnaryCall(Call, _base_call.UnaryUnaryCall):
         return response
 
 
+# TODO(https://github.com/grpc/grpc/issues/21623) remove this suppression
 # pylint: disable=abstract-method
 class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
     """Object for managing unary-stream RPC calls.
@@ -346,91 +343,53 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
     Returned when an instance of `UnaryStreamMultiCallable` object is called.
     """
     _request: RequestType
-    _channel: cygrpc.AioChannel
     _request_serializer: SerializingFunction
     _response_deserializer: DeserializingFunction
-    _cython_call: cygrpc._AioCall
     _send_unary_request_task: asyncio.Task
     _message_aiter: AsyncIterable[ResponseType]
 
-    def __init__(  # pylint: disable=R0913
-            self, request: RequestType, deadline: Optional[float],
-            credentials: Optional[grpc.CallCredentials],
-            channel: cygrpc.AioChannel, method: bytes,
-            request_serializer: SerializingFunction,
-            response_deserializer: DeserializingFunction) -> None:
-        super().__init__()
+    # pylint: disable=too-many-arguments
+    def __init__(self, request: RequestType, deadline: Optional[float],
+                 credentials: Optional[grpc.CallCredentials],
+                 channel: cygrpc.AioChannel, method: bytes,
+                 request_serializer: SerializingFunction,
+                 response_deserializer: DeserializingFunction) -> None:
+        super().__init__(channel.call(method, deadline, credentials))
         self._request = request
-        self._channel = channel
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
         self._send_unary_request_task = self._loop.create_task(
             self._send_unary_request())
-        self._message_aiter = self._fetch_stream_responses()
+        self._message_aiter = None
 
-        if credentials is not None:
-            grpc_credentials = credentials._credentials
+    def cancel(self) -> bool:
+        if super().cancel():
+            self._send_unary_request_task.cancel()
+            return True
         else:
-            grpc_credentials = None
-
-        self._cython_call = self._channel.call(method, deadline,
-                                               grpc_credentials)
-
-    def __del__(self) -> None:
-        if not self._status.done():
-            self._cancel(
-                cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
-                                    _GC_CANCELLATION_DETAILS, None, None))
+            return False
 
     async def _send_unary_request(self) -> ResponseType:
         serialized_request = _common.serialize(self._request,
                                                self._request_serializer)
         try:
-            await self._cython_call.unary_stream(serialized_request,
-                                                 self._set_initial_metadata,
-                                                 self._set_status)
+            await self._cython_call.initiate_unary_stream(
+                serialized_request, self._set_initial_metadata,
+                self._set_status)
         except asyncio.CancelledError:
-            if self._code != grpc.StatusCode.CANCELLED:
+            if not self.cancelled():
                 self.cancel()
             raise
 
     async def _fetch_stream_responses(self) -> ResponseType:
-        await self._send_unary_request_task
         message = await self._read()
-        while message:
+        while message is not cygrpc.EOF:
             yield message
             message = await self._read()
 
-    def _cancel(self, status: cygrpc.AioRpcStatus) -> bool:
-        """Forwards the application cancellation reasoning.
-
-        Async generator will receive an exception. The cancellation will go
-        deep down into Core, and then propagates backup as the
-        `cygrpc.AioRpcStatus` exception.
-
-        So, under race condition, e.g. the server sent out final state headers
-        and the client calling "cancel" at the same time, this method respects
-        the winner in Core.
-        """
-        if not self._status.done():
-            self._set_status(status)
-            self._cython_call.cancel(status)
-
-            if not self._send_unary_request_task.done():
-                # Injects CancelledError to the Task. The exception will
-                # propagate to _fetch_stream_responses as well, if the sending
-                # is not done.
-                self._send_unary_request_task.cancel()
-            return True
-        else:
-            return False
-
-    def cancel(self) -> bool:
-        return self._cancel(
-            cygrpc.AioRpcStatus(cygrpc.StatusCode.cancelled,
-                                _LOCAL_CANCELLATION_DETAILS, None, None))
-
     def __aiter__(self) -> AsyncIterable[ResponseType]:
+        if self._message_aiter is None:
+            self._message_aiter = self._fetch_stream_responses()
         return self._message_aiter
 
     async def _read(self) -> ResponseType:
@@ -441,12 +400,12 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
         try:
             raw_response = await self._cython_call.receive_serialized_message()
         except asyncio.CancelledError:
-            if self._code != grpc.StatusCode.CANCELLED:
+            if not self.cancelled():
                 self.cancel()
-            raise
+            await self._raise_for_status()
 
-        if raw_response is None:
-            return None
+        if raw_response is cygrpc.EOF:
+            return cygrpc.EOF
         else:
             return _common.deserialize(raw_response,
                                        self._response_deserializer)
@@ -454,14 +413,288 @@ class UnaryStreamCall(Call, _base_call.UnaryStreamCall):
     async def read(self) -> ResponseType:
         if self._status.done():
             await self._raise_for_status()
-            raise asyncio.InvalidStateError(_RPC_ALREADY_FINISHED_DETAILS)
+            return cygrpc.EOF
 
         response_message = await self._read()
 
-        if response_message is None:
+        if response_message is cygrpc.EOF:
             # If the read operation failed, Core should explain why.
             await self._raise_for_status()
-            # If no exception raised, there is something wrong internally.
-            assert False, 'Read operation failed with StatusCode.OK'
+        return response_message
+
+
+# TODO(https://github.com/grpc/grpc/issues/21623) remove this suppression
+# pylint: disable=abstract-method
+class StreamUnaryCall(Call, _base_call.StreamUnaryCall):
+    """Object for managing stream-unary RPC calls.
+
+    Returned when an instance of `StreamUnaryMultiCallable` object is called.
+    """
+    _metadata: MetadataType
+    _request_serializer: SerializingFunction
+    _response_deserializer: DeserializingFunction
+
+    _metadata_sent: asyncio.Event
+    _done_writing: bool
+    _call_finisher: asyncio.Task
+    _async_request_poller: asyncio.Task
+
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 request_async_iterator: Optional[AsyncIterable[RequestType]],
+                 deadline: Optional[float],
+                 credentials: Optional[grpc.CallCredentials],
+                 channel: cygrpc.AioChannel, method: bytes,
+                 request_serializer: SerializingFunction,
+                 response_deserializer: DeserializingFunction) -> None:
+        super().__init__(channel.call(method, deadline, credentials))
+        self._metadata = _EMPTY_METADATA
+        self._request_serializer = request_serializer
+        self._response_deserializer = response_deserializer
+
+        self._metadata_sent = asyncio.Event(loop=self._loop)
+        self._done_writing = False
+
+        self._call_finisher = self._loop.create_task(self._conduct_rpc())
+
+        # If user passes in an async iterator, create a consumer Task.
+        if request_async_iterator is not None:
+            self._async_request_poller = self._loop.create_task(
+                self._consume_request_iterator(request_async_iterator))
         else:
-            return response_message
+            self._async_request_poller = None
+
+    def cancel(self) -> bool:
+        if super().cancel():
+            self._call_finisher.cancel()
+            if self._async_request_poller is not None:
+                self._async_request_poller.cancel()
+            return True
+        else:
+            return False
+
+    def _metadata_sent_observer(self):
+        self._metadata_sent.set()
+
+    async def _conduct_rpc(self) -> ResponseType:
+        try:
+            serialized_response = await self._cython_call.stream_unary(
+                self._metadata,
+                self._metadata_sent_observer,
+                self._set_initial_metadata,
+                self._set_status,
+            )
+        except asyncio.CancelledError:
+            if not self.cancelled():
+                self.cancel()
+
+        # Raises RpcError if the RPC failed or cancelled
+        await self._raise_for_status()
+
+        return _common.deserialize(serialized_response,
+                                   self._response_deserializer)
+
+    async def _consume_request_iterator(
+            self, request_async_iterator: AsyncIterable[RequestType]) -> None:
+        async for request in request_async_iterator:
+            await self.write(request)
+        await self.done_writing()
+
+    def __await__(self) -> ResponseType:
+        """Wait till the ongoing RPC request finishes."""
+        try:
+            response = yield from self._call_finisher
+        except asyncio.CancelledError:
+            if not self.cancelled():
+                self.cancel()
+            raise
+        return response
+
+    async def write(self, request: RequestType) -> None:
+        if self._status.done():
+            raise asyncio.InvalidStateError(_RPC_ALREADY_FINISHED_DETAILS)
+        if self._done_writing:
+            raise asyncio.InvalidStateError(_RPC_HALF_CLOSED_DETAILS)
+        if not self._metadata_sent.is_set():
+            await self._metadata_sent.wait()
+
+        serialized_request = _common.serialize(request,
+                                               self._request_serializer)
+
+        try:
+            await self._cython_call.send_serialized_message(serialized_request)
+        except asyncio.CancelledError:
+            if not self.cancelled():
+                self.cancel()
+            await self._raise_for_status()
+
+    async def done_writing(self) -> None:
+        """Implementation of done_writing is idempotent."""
+        if self._status.done():
+            # If the RPC is finished, do nothing.
+            return
+        if not self._done_writing:
+            # If the done writing is not sent before, try to send it.
+            self._done_writing = True
+            try:
+                await self._cython_call.send_receive_close()
+            except asyncio.CancelledError:
+                if not self.cancelled():
+                    self.cancel()
+                await self._raise_for_status()
+
+
+# TODO(https://github.com/grpc/grpc/issues/21623) remove this suppression
+# pylint: disable=abstract-method
+class StreamStreamCall(Call, _base_call.StreamStreamCall):
+    """Object for managing stream-stream RPC calls.
+
+    Returned when an instance of `StreamStreamMultiCallable` object is called.
+    """
+    _metadata: MetadataType
+    _request_serializer: SerializingFunction
+    _response_deserializer: DeserializingFunction
+
+    _metadata_sent: asyncio.Event
+    _done_writing: bool
+    _initializer: asyncio.Task
+    _async_request_poller: asyncio.Task
+    _message_aiter: AsyncIterable[ResponseType]
+
+    # pylint: disable=too-many-arguments
+    def __init__(self,
+                 request_async_iterator: Optional[AsyncIterable[RequestType]],
+                 deadline: Optional[float],
+                 credentials: Optional[grpc.CallCredentials],
+                 channel: cygrpc.AioChannel, method: bytes,
+                 request_serializer: SerializingFunction,
+                 response_deserializer: DeserializingFunction) -> None:
+        super().__init__(channel.call(method, deadline, credentials))
+        self._metadata = _EMPTY_METADATA
+        self._request_serializer = request_serializer
+        self._response_deserializer = response_deserializer
+
+        self._metadata_sent = asyncio.Event(loop=self._loop)
+        self._done_writing = False
+
+        self._initializer = self._loop.create_task(self._prepare_rpc())
+
+        # If user passes in an async iterator, create a consumer coroutine.
+        if request_async_iterator is not None:
+            self._async_request_poller = self._loop.create_task(
+                self._consume_request_iterator(request_async_iterator))
+        else:
+            self._async_request_poller = None
+        self._message_aiter = None
+
+    def cancel(self) -> bool:
+        if super().cancel():
+            self._initializer.cancel()
+            if self._async_request_poller is not None:
+                self._async_request_poller.cancel()
+            return True
+        else:
+            return False
+
+    def _metadata_sent_observer(self):
+        self._metadata_sent.set()
+
+    async def _prepare_rpc(self):
+        """This method prepares the RPC for receiving/sending messages.
+
+        All other operations around the stream should only happen after the
+        completion of this method.
+        """
+        try:
+            await self._cython_call.initiate_stream_stream(
+                self._metadata,
+                self._metadata_sent_observer,
+                self._set_initial_metadata,
+                self._set_status,
+            )
+        except asyncio.CancelledError:
+            if not self.cancelled():
+                self.cancel()
+            # No need to raise RpcError here, because no one will `await` this task.
+
+    async def _consume_request_iterator(
+            self, request_async_iterator: Optional[AsyncIterable[RequestType]]
+    ) -> None:
+        async for request in request_async_iterator:
+            await self.write(request)
+        await self.done_writing()
+
+    async def write(self, request: RequestType) -> None:
+        if self._status.done():
+            raise asyncio.InvalidStateError(_RPC_ALREADY_FINISHED_DETAILS)
+        if self._done_writing:
+            raise asyncio.InvalidStateError(_RPC_HALF_CLOSED_DETAILS)
+        if not self._metadata_sent.is_set():
+            await self._metadata_sent.wait()
+
+        serialized_request = _common.serialize(request,
+                                               self._request_serializer)
+
+        try:
+            await self._cython_call.send_serialized_message(serialized_request)
+        except asyncio.CancelledError:
+            if not self.cancelled():
+                self.cancel()
+            await self._raise_for_status()
+
+    async def done_writing(self) -> None:
+        """Implementation of done_writing is idempotent."""
+        if self._status.done():
+            # If the RPC is finished, do nothing.
+            return
+        if not self._done_writing:
+            # If the done writing is not sent before, try to send it.
+            self._done_writing = True
+            try:
+                await self._cython_call.send_receive_close()
+            except asyncio.CancelledError:
+                if not self.cancelled():
+                    self.cancel()
+                await self._raise_for_status()
+
+    async def _fetch_stream_responses(self) -> ResponseType:
+        """The async generator that yields responses from peer."""
+        message = await self._read()
+        while message is not cygrpc.EOF:
+            yield message
+            message = await self._read()
+
+    def __aiter__(self) -> AsyncIterable[ResponseType]:
+        if self._message_aiter is None:
+            self._message_aiter = self._fetch_stream_responses()
+        return self._message_aiter
+
+    async def _read(self) -> ResponseType:
+        # Wait for the setup
+        await self._initializer
+
+        # Reads response message from Core
+        try:
+            raw_response = await self._cython_call.receive_serialized_message()
+        except asyncio.CancelledError:
+            if not self.cancelled():
+                self.cancel()
+            await self._raise_for_status()
+
+        if raw_response is cygrpc.EOF:
+            return cygrpc.EOF
+        else:
+            return _common.deserialize(raw_response,
+                                       self._response_deserializer)
+
+    async def read(self) -> ResponseType:
+        if self._status.done():
+            await self._raise_for_status()
+            return cygrpc.EOF
+
+        response_message = await self._read()
+
+        if response_message is cygrpc.EOF:
+            # If the read operation failed, Core should explain why.
+            await self._raise_for_status()
+        return response_message

--- a/src/python/grpcio/grpc/experimental/aio/_typing.py
+++ b/src/python/grpcio/grpc/experimental/aio/_typing.py
@@ -14,6 +14,7 @@
 """Common types for gRPC Async API"""
 
 from typing import Any, AnyStr, Callable, Sequence, Text, Tuple, TypeVar
+from grpc._cython.cygrpc import EOF
 
 RequestType = TypeVar('RequestType')
 ResponseType = TypeVar('ResponseType')
@@ -21,3 +22,4 @@ SerializingFunction = Callable[[Any], bytes]
 DeserializingFunction = Callable[[bytes], Any]
 MetadataType = Sequence[Tuple[Text, AnyStr]]
 ChannelArgumentType = Sequence[Tuple[Text, Any]]
+EOFType = type(EOF)

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -2,6 +2,8 @@
   "_sanity._sanity_test.AioSanityTest",
   "unit.abort_test.TestAbort",
   "unit.aio_rpc_error_test.TestAioRpcError",
+  "unit.call_test.TestStreamStreamCall",
+  "unit.call_test.TestStreamUnaryCall",
   "unit.call_test.TestUnaryStreamCall",
   "unit.call_test.TestUnaryUnaryCall",
   "unit.channel_argument_test.TestChannelArgument",

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -30,10 +30,10 @@ from src.proto.grpc.testing import messages_pb2
 
 _NUM_STREAM_RESPONSES = 5
 _RESPONSE_PAYLOAD_SIZE = 42
+_REQUEST_PAYLOAD_SIZE = 7
 _LOCAL_CANCEL_DETAILS_EXPECTATION = 'Locally cancelled by application!'
 _RESPONSE_INTERVAL_US = test_constants.SHORT_TIMEOUT * 1000 * 1000
 _UNREACHABLE_TARGET = '0.1:1111'
-
 _INFINITE_INTERVAL_US = 2**31 - 1
 
 
@@ -286,7 +286,7 @@ class TestUnaryStreamCall(AioTestBase):
                           [grpc.StatusCode.OK, grpc.StatusCode.CANCELLED])
 
     async def test_too_many_reads_unary_stream(self):
-        """Test cancellation after received all messages."""
+        """Test calling read after received all messages fails."""
         async with aio.insecure_channel(self._server_target) as channel:
             stub = test_pb2_grpc.TestServiceStub(channel)
 
@@ -306,13 +306,14 @@ class TestUnaryStreamCall(AioTestBase):
                               messages_pb2.StreamingOutputCallResponse)
                 self.assertEqual(_RESPONSE_PAYLOAD_SIZE,
                                  len(response.payload.body))
+            self.assertIs(await call.read(), aio.EOF)
 
             # After the RPC is finished, further reads will lead to exception.
             self.assertEqual(await call.code(), grpc.StatusCode.OK)
-            with self.assertRaises(asyncio.InvalidStateError):
-                await call.read()
+            self.assertIs(await call.read(), aio.EOF)
 
     async def test_unary_stream_async_generator(self):
+        """Sunny day test case for unary_stream."""
         async with aio.insecure_channel(self._server_target) as channel:
             stub = test_pb2_grpc.TestServiceStub(channel)
 
@@ -424,6 +425,307 @@ class TestUnaryStreamCall(AioTestBase):
                 self.assertEqual(await call.code(), grpc.StatusCode.OK)
 
         self.loop.run_until_complete(coro())
+
+
+class TestStreamUnaryCall(AioTestBase):
+
+    async def setUp(self):
+        self._server_target, self._server = await start_test_server()
+        self._channel = aio.insecure_channel(self._server_target)
+        self._stub = test_pb2_grpc.TestServiceStub(self._channel)
+
+    async def tearDown(self):
+        await self._channel.close()
+        await self._server.stop(None)
+
+    async def test_cancel_stream_unary(self):
+        call = self._stub.StreamingInputCall()
+
+        # Prepares the request
+        payload = messages_pb2.Payload(body=b'\0' * _REQUEST_PAYLOAD_SIZE)
+        request = messages_pb2.StreamingInputCallRequest(payload=payload)
+
+        # Sends out requests
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await call.write(request)
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+
+        await call.done_writing()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await call
+
+    async def test_early_cancel_stream_unary(self):
+        call = self._stub.StreamingInputCall()
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+
+        with self.assertRaises(asyncio.InvalidStateError):
+            await call.write(messages_pb2.StreamingInputCallRequest())
+
+        # Should be no-op
+        await call.done_writing()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await call
+
+    async def test_write_after_done_writing(self):
+        call = self._stub.StreamingInputCall()
+
+        # Prepares the request
+        payload = messages_pb2.Payload(body=b'\0' * _REQUEST_PAYLOAD_SIZE)
+        request = messages_pb2.StreamingInputCallRequest(payload=payload)
+
+        # Sends out requests
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await call.write(request)
+
+        # Should be no-op
+        await call.done_writing()
+
+        with self.assertRaises(asyncio.InvalidStateError):
+            await call.write(messages_pb2.StreamingInputCallRequest())
+
+        response = await call
+        self.assertIsInstance(response, messages_pb2.StreamingInputCallResponse)
+        self.assertEqual(_NUM_STREAM_RESPONSES * _REQUEST_PAYLOAD_SIZE,
+                         response.aggregated_payload_size)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_error_in_async_generator(self):
+        # Server will pause between responses
+        request = messages_pb2.StreamingOutputCallRequest()
+        request.response_parameters.append(
+            messages_pb2.ResponseParameters(
+                size=_RESPONSE_PAYLOAD_SIZE,
+                interval_us=_RESPONSE_INTERVAL_US,
+            ))
+
+        # We expect the request iterator to receive the exception
+        request_iterator_received_the_exception = asyncio.Event()
+
+        async def request_iterator():
+            with self.assertRaises(asyncio.CancelledError):
+                for _ in range(_NUM_STREAM_RESPONSES):
+                    yield request
+                    await asyncio.sleep(test_constants.SHORT_TIMEOUT)
+            request_iterator_received_the_exception.set()
+
+        call = self._stub.StreamingInputCall(request_iterator())
+
+        # Cancel the RPC after at least one response
+        async def cancel_later():
+            await asyncio.sleep(test_constants.SHORT_TIMEOUT * 2)
+            call.cancel()
+
+        cancel_later_task = self.loop.create_task(cancel_later())
+
+        # No exceptions here
+        with self.assertRaises(asyncio.CancelledError):
+            await call
+
+        await request_iterator_received_the_exception.wait()
+
+        # No failures in the cancel later task!
+        await cancel_later_task
+
+
+# Prepares the request that stream in a ping-pong manner.
+_STREAM_OUTPUT_REQUEST_ONE_RESPONSE = messages_pb2.StreamingOutputCallRequest()
+_STREAM_OUTPUT_REQUEST_ONE_RESPONSE.response_parameters.append(
+    messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+
+class TestStreamStreamCall(AioTestBase):
+
+    async def setUp(self):
+        self._server_target, self._server = await start_test_server()
+        self._channel = aio.insecure_channel(self._server_target)
+        self._stub = test_pb2_grpc.TestServiceStub(self._channel)
+
+    async def tearDown(self):
+        await self._channel.close()
+        await self._server.stop(None)
+
+    async def test_cancel(self):
+        # Invokes the actual RPC
+        call = self._stub.FullDuplexCall()
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await call.write(_STREAM_OUTPUT_REQUEST_ONE_RESPONSE)
+            response = await call.read()
+            self.assertIsInstance(response,
+                                  messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+        self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+
+    async def test_cancel_with_pending_read(self):
+        call = self._stub.FullDuplexCall()
+
+        await call.write(_STREAM_OUTPUT_REQUEST_ONE_RESPONSE)
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+        self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+
+    async def test_cancel_with_ongoing_read(self):
+        call = self._stub.FullDuplexCall()
+        coro_started = asyncio.Event()
+
+        async def read_coro():
+            coro_started.set()
+            await call.read()
+
+        read_task = self.loop.create_task(read_coro())
+        await coro_started.wait()
+        self.assertFalse(read_task.done())
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+        self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+
+    async def test_early_cancel(self):
+        call = self._stub.FullDuplexCall()
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+        self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+
+    async def test_cancel_after_done_writing(self):
+        call = self._stub.FullDuplexCall()
+        await call.done_writing()
+
+        # Cancels the RPC
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertTrue(call.cancel())
+        self.assertTrue(call.cancelled())
+        self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+
+    async def test_late_cancel(self):
+        call = self._stub.FullDuplexCall()
+        await call.done_writing()
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+        # Cancels the RPC
+        self.assertTrue(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertFalse(call.cancel())
+        self.assertFalse(call.cancelled())
+
+        # Status is still OK
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_async_generator(self):
+
+        async def request_generator():
+            yield _STREAM_OUTPUT_REQUEST_ONE_RESPONSE
+            yield _STREAM_OUTPUT_REQUEST_ONE_RESPONSE
+
+        call = self._stub.FullDuplexCall(request_generator())
+        async for response in call:
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_too_many_reads(self):
+
+        async def request_generator():
+            for _ in range(_NUM_STREAM_RESPONSES):
+                yield _STREAM_OUTPUT_REQUEST_ONE_RESPONSE
+
+        call = self._stub.FullDuplexCall(request_generator())
+        for _ in range(_NUM_STREAM_RESPONSES):
+            response = await call.read()
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+        self.assertIs(await call.read(), aio.EOF)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+        # After the RPC finished, the read should also produce EOF
+        self.assertIs(await call.read(), aio.EOF)
+
+    async def test_read_write_after_done_writing(self):
+        call = self._stub.FullDuplexCall()
+
+        # Writes two requests, and pending two requests
+        await call.write(_STREAM_OUTPUT_REQUEST_ONE_RESPONSE)
+        await call.write(_STREAM_OUTPUT_REQUEST_ONE_RESPONSE)
+        await call.done_writing()
+
+        # Further write should fail
+        with self.assertRaises(asyncio.InvalidStateError):
+            await call.write(_STREAM_OUTPUT_REQUEST_ONE_RESPONSE)
+
+        # But read should be unaffected
+        response = await call.read()
+        self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+        response = await call.read()
+        self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_error_in_async_generator(self):
+        # Server will pause between responses
+        request = messages_pb2.StreamingOutputCallRequest()
+        request.response_parameters.append(
+            messages_pb2.ResponseParameters(
+                size=_RESPONSE_PAYLOAD_SIZE,
+                interval_us=_RESPONSE_INTERVAL_US,
+            ))
+
+        # We expect the request iterator to receive the exception
+        request_iterator_received_the_exception = asyncio.Event()
+
+        async def request_iterator():
+            with self.assertRaises(asyncio.CancelledError):
+                for _ in range(_NUM_STREAM_RESPONSES):
+                    yield request
+                    await asyncio.sleep(test_constants.SHORT_TIMEOUT)
+            request_iterator_received_the_exception.set()
+
+        call = self._stub.FullDuplexCall(request_iterator())
+
+        # Cancel the RPC after at least one response
+        async def cancel_later():
+            await asyncio.sleep(test_constants.SHORT_TIMEOUT * 2)
+            call.cancel()
+
+        cancel_later_task = self.loop.create_task(cancel_later())
+
+        # No exceptions here
+        async for response in call:
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        await request_iterator_received_the_exception.wait()
+
+        self.assertEqual(grpc.StatusCode.CANCELLED, await call.code())
+        # No failures in the cancel later task!
+        await cancel_later_task
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -32,6 +32,7 @@ _UNARY_CALL_METHOD = '/grpc.testing.TestService/UnaryCall'
 _UNARY_CALL_METHOD_WITH_SLEEP = '/grpc.testing.TestService/UnaryCallWithSleep'
 _STREAMING_OUTPUT_CALL_METHOD = '/grpc.testing.TestService/StreamingOutputCall'
 _NUM_STREAM_RESPONSES = 5
+_REQUEST_PAYLOAD_SIZE = 7
 _RESPONSE_PAYLOAD_SIZE = 42
 
 
@@ -121,7 +122,104 @@ class TestChannel(AioTestBase):
         self.assertEqual(await call.code(), grpc.StatusCode.OK)
         await channel.close()
 
+    async def test_stream_unary_using_write(self):
+        channel = aio.insecure_channel(self._server_target)
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        # Invokes the actual RPC
+        call = stub.StreamingInputCall()
+
+        # Prepares the request
+        payload = messages_pb2.Payload(body=b'\0' * _REQUEST_PAYLOAD_SIZE)
+        request = messages_pb2.StreamingInputCallRequest(payload=payload)
+
+        # Sends out requests
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await call.write(request)
+        await call.done_writing()
+
+        # Validates the responses
+        response = await call
+        self.assertIsInstance(response, messages_pb2.StreamingInputCallResponse)
+        self.assertEqual(_NUM_STREAM_RESPONSES * _REQUEST_PAYLOAD_SIZE,
+                         response.aggregated_payload_size)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+        await channel.close()
+
+    async def test_stream_unary_using_async_gen(self):
+        channel = aio.insecure_channel(self._server_target)
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        # Prepares the request
+        payload = messages_pb2.Payload(body=b'\0' * _REQUEST_PAYLOAD_SIZE)
+        request = messages_pb2.StreamingInputCallRequest(payload=payload)
+
+        async def gen():
+            for _ in range(_NUM_STREAM_RESPONSES):
+                yield request
+
+        # Invokes the actual RPC
+        call = stub.StreamingInputCall(gen())
+
+        # Validates the responses
+        response = await call
+        self.assertIsInstance(response, messages_pb2.StreamingInputCallResponse)
+        self.assertEqual(_NUM_STREAM_RESPONSES * _REQUEST_PAYLOAD_SIZE,
+                         response.aggregated_payload_size)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+        await channel.close()
+
+    async def test_stream_stream_using_read_write(self):
+        channel = aio.insecure_channel(self._server_target)
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        # Invokes the actual RPC
+        call = stub.FullDuplexCall()
+
+        # Prepares the request
+        request = messages_pb2.StreamingOutputCallRequest()
+        request.response_parameters.append(
+            messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await call.write(request)
+            response = await call.read()
+            self.assertIsInstance(response,
+                                  messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        await call.done_writing()
+
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+        await channel.close()
+
+    async def test_stream_stream_using_async_gen(self):
+        channel = aio.insecure_channel(self._server_target)
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        # Prepares the request
+        request = messages_pb2.StreamingOutputCallRequest()
+        request.response_parameters.append(
+            messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        async def gen():
+            for _ in range(_NUM_STREAM_RESPONSES):
+                yield request
+
+        # Invokes the actual RPC
+        call = stub.FullDuplexCall(gen())
+
+        async for response in call:
+            self.assertIsInstance(response,
+                                  messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+        await channel.close()
+
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.WARN)
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import asyncio
-import logging
-import unittest
-import time
 import gc
+import logging
+import time
+import unittest
 
 import grpc
 from grpc.experimental import aio
-from tests_aio.unit._test_base import AioTestBase
+
 from tests.unit.framework.common import test_constants
+from tests_aio.unit._test_base import AioTestBase
 
 _SIMPLE_UNARY_UNARY = '/test/SimpleUnaryUnary'
 _BLOCK_FOREVER = '/test/BlockForever'
@@ -29,9 +30,16 @@ _BLOCK_BRIEFLY = '/test/BlockBriefly'
 _UNARY_STREAM_ASYNC_GEN = '/test/UnaryStreamAsyncGen'
 _UNARY_STREAM_READER_WRITER = '/test/UnaryStreamReaderWriter'
 _UNARY_STREAM_EVILLY_MIXED = '/test/UnaryStreamEvillyMixed'
+_STREAM_UNARY_ASYNC_GEN = '/test/StreamUnaryAsyncGen'
+_STREAM_UNARY_READER_WRITER = '/test/StreamUnaryReaderWriter'
+_STREAM_UNARY_EVILLY_MIXED = '/test/StreamUnaryEvillyMixed'
+_STREAM_STREAM_ASYNC_GEN = '/test/StreamStreamAsyncGen'
+_STREAM_STREAM_READER_WRITER = '/test/StreamStreamReaderWriter'
+_STREAM_STREAM_EVILLY_MIXED = '/test/StreamStreamEvillyMixed'
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x01\x01\x01'
+_NUM_STREAM_REQUESTS = 3
 _NUM_STREAM_RESPONSES = 5
 
 
@@ -39,6 +47,41 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
     def __init__(self):
         self._called = asyncio.get_event_loop().create_future()
+        self._routing_table = {
+            _SIMPLE_UNARY_UNARY:
+                grpc.unary_unary_rpc_method_handler(self._unary_unary),
+            _BLOCK_FOREVER:
+                grpc.unary_unary_rpc_method_handler(self._block_forever),
+            _BLOCK_BRIEFLY:
+                grpc.unary_unary_rpc_method_handler(self._block_briefly),
+            _UNARY_STREAM_ASYNC_GEN:
+                grpc.unary_stream_rpc_method_handler(
+                    self._unary_stream_async_gen),
+            _UNARY_STREAM_READER_WRITER:
+                grpc.unary_stream_rpc_method_handler(
+                    self._unary_stream_reader_writer),
+            _UNARY_STREAM_EVILLY_MIXED:
+                grpc.unary_stream_rpc_method_handler(
+                    self._unary_stream_evilly_mixed),
+            _STREAM_UNARY_ASYNC_GEN:
+                grpc.stream_unary_rpc_method_handler(
+                    self._stream_unary_async_gen),
+            _STREAM_UNARY_READER_WRITER:
+                grpc.stream_unary_rpc_method_handler(
+                    self._stream_unary_reader_writer),
+            _STREAM_UNARY_EVILLY_MIXED:
+                grpc.stream_unary_rpc_method_handler(
+                    self._stream_unary_evilly_mixed),
+            _STREAM_STREAM_ASYNC_GEN:
+                grpc.stream_stream_rpc_method_handler(
+                    self._stream_stream_async_gen),
+            _STREAM_STREAM_READER_WRITER:
+                grpc.stream_stream_rpc_method_handler(
+                    self._stream_stream_reader_writer),
+            _STREAM_STREAM_EVILLY_MIXED:
+                grpc.stream_stream_rpc_method_handler(
+                    self._stream_stream_evilly_mixed),
+        }
 
     @staticmethod
     async def _unary_unary(unused_request, unused_context):
@@ -64,23 +107,59 @@ class _GenericHandler(grpc.GenericRpcHandler):
         for _ in range(_NUM_STREAM_RESPONSES - 1):
             await context.write(_RESPONSE)
 
+    async def _stream_unary_async_gen(self, request_iterator, unused_context):
+        request_count = 0
+        async for request in request_iterator:
+            assert _REQUEST == request
+            request_count += 1
+        assert _NUM_STREAM_REQUESTS == request_count
+        return _RESPONSE
+
+    async def _stream_unary_reader_writer(self, unused_request, context):
+        for _ in range(_NUM_STREAM_REQUESTS):
+            assert _REQUEST == await context.read()
+        return _RESPONSE
+
+    async def _stream_unary_evilly_mixed(self, request_iterator, context):
+        assert _REQUEST == await context.read()
+        request_count = 0
+        async for request in request_iterator:
+            assert _REQUEST == request
+            request_count += 1
+        assert _NUM_STREAM_REQUESTS - 1 == request_count
+        return _RESPONSE
+
+    async def _stream_stream_async_gen(self, request_iterator, unused_context):
+        request_count = 0
+        async for request in request_iterator:
+            assert _REQUEST == request
+            request_count += 1
+        assert _NUM_STREAM_REQUESTS == request_count
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            yield _RESPONSE
+
+    async def _stream_stream_reader_writer(self, unused_request, context):
+        for _ in range(_NUM_STREAM_REQUESTS):
+            assert _REQUEST == await context.read()
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await context.write(_RESPONSE)
+
+    async def _stream_stream_evilly_mixed(self, request_iterator, context):
+        assert _REQUEST == await context.read()
+        request_count = 0
+        async for request in request_iterator:
+            assert _REQUEST == request
+            request_count += 1
+        assert _NUM_STREAM_REQUESTS - 1 == request_count
+
+        yield _RESPONSE
+        for _ in range(_NUM_STREAM_RESPONSES - 1):
+            await context.write(_RESPONSE)
+
     def service(self, handler_details):
         self._called.set_result(None)
-        if handler_details.method == _SIMPLE_UNARY_UNARY:
-            return grpc.unary_unary_rpc_method_handler(self._unary_unary)
-        if handler_details.method == _BLOCK_FOREVER:
-            return grpc.unary_unary_rpc_method_handler(self._block_forever)
-        if handler_details.method == _BLOCK_BRIEFLY:
-            return grpc.unary_unary_rpc_method_handler(self._block_briefly)
-        if handler_details.method == _UNARY_STREAM_ASYNC_GEN:
-            return grpc.unary_stream_rpc_method_handler(
-                self._unary_stream_async_gen)
-        if handler_details.method == _UNARY_STREAM_READER_WRITER:
-            return grpc.unary_stream_rpc_method_handler(
-                self._unary_stream_reader_writer)
-        if handler_details.method == _UNARY_STREAM_EVILLY_MIXED:
-            return grpc.unary_stream_rpc_method_handler(
-                self._unary_stream_evilly_mixed)
+        return self._routing_table[handler_details.method]
 
     async def wait_for_call(self):
         await self._called
@@ -98,89 +177,152 @@ async def _start_test_server():
 class TestServer(AioTestBase):
 
     async def setUp(self):
-        self._server_target, self._server, self._generic_handler = await _start_test_server(
-        )
+        addr, self._server, self._generic_handler = await _start_test_server()
+        self._channel = aio.insecure_channel(addr)
 
     async def tearDown(self):
+        await self._channel.close()
         await self._server.stop(None)
 
     async def test_unary_unary(self):
-        async with aio.insecure_channel(self._server_target) as channel:
-            unary_unary_call = channel.unary_unary(_SIMPLE_UNARY_UNARY)
-            response = await unary_unary_call(_REQUEST)
-            self.assertEqual(response, _RESPONSE)
+        unary_unary_call = self._channel.unary_unary(_SIMPLE_UNARY_UNARY)
+        response = await unary_unary_call(_REQUEST)
+        self.assertEqual(response, _RESPONSE)
 
     async def test_unary_stream_async_generator(self):
-        async with aio.insecure_channel(self._server_target) as channel:
-            unary_stream_call = channel.unary_stream(_UNARY_STREAM_ASYNC_GEN)
-            call = unary_stream_call(_REQUEST)
+        unary_stream_call = self._channel.unary_stream(_UNARY_STREAM_ASYNC_GEN)
+        call = unary_stream_call(_REQUEST)
 
-            # Expecting the request message to reach server before retriving
-            # any responses.
-            await asyncio.wait_for(self._generic_handler.wait_for_call(),
-                                   test_constants.SHORT_TIMEOUT)
+        response_cnt = 0
+        async for response in call:
+            response_cnt += 1
+            self.assertEqual(_RESPONSE, response)
 
-            response_cnt = 0
-            async for response in call:
-                response_cnt += 1
-                self.assertEqual(_RESPONSE, response)
-
-            self.assertEqual(_NUM_STREAM_RESPONSES, response_cnt)
-            self.assertEqual(await call.code(), grpc.StatusCode.OK)
+        self.assertEqual(_NUM_STREAM_RESPONSES, response_cnt)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
 
     async def test_unary_stream_reader_writer(self):
-        async with aio.insecure_channel(self._server_target) as channel:
-            unary_stream_call = channel.unary_stream(
-                _UNARY_STREAM_READER_WRITER)
-            call = unary_stream_call(_REQUEST)
+        unary_stream_call = self._channel.unary_stream(
+            _UNARY_STREAM_READER_WRITER)
+        call = unary_stream_call(_REQUEST)
 
-            # Expecting the request message to reach server before retriving
-            # any responses.
-            await asyncio.wait_for(self._generic_handler.wait_for_call(),
-                                   test_constants.SHORT_TIMEOUT)
+        for _ in range(_NUM_STREAM_RESPONSES):
+            response = await call.read()
+            self.assertEqual(_RESPONSE, response)
 
-            for _ in range(_NUM_STREAM_RESPONSES):
-                response = await call.read()
-                self.assertEqual(_RESPONSE, response)
-
-            self.assertEqual(await call.code(), grpc.StatusCode.OK)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
 
     async def test_unary_stream_evilly_mixed(self):
-        async with aio.insecure_channel(self._server_target) as channel:
-            unary_stream_call = channel.unary_stream(_UNARY_STREAM_EVILLY_MIXED)
-            call = unary_stream_call(_REQUEST)
+        unary_stream_call = self._channel.unary_stream(
+            _UNARY_STREAM_EVILLY_MIXED)
+        call = unary_stream_call(_REQUEST)
 
-            # Expecting the request message to reach server before retriving
-            # any responses.
-            await asyncio.wait_for(self._generic_handler.wait_for_call(),
-                                   test_constants.SHORT_TIMEOUT)
+        # Uses reader API
+        self.assertEqual(_RESPONSE, await call.read())
 
-            # Uses reader API
-            self.assertEqual(_RESPONSE, await call.read())
+        # Uses async generator API
+        response_cnt = 0
+        async for response in call:
+            response_cnt += 1
+            self.assertEqual(_RESPONSE, response)
 
-            # Uses async generator API
-            response_cnt = 0
-            async for response in call:
-                response_cnt += 1
-                self.assertEqual(_RESPONSE, response)
+        self.assertEqual(_NUM_STREAM_RESPONSES - 1, response_cnt)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
 
-            self.assertEqual(_NUM_STREAM_RESPONSES - 1, response_cnt)
+    async def test_stream_unary_async_generator(self):
+        stream_unary_call = self._channel.stream_unary(_STREAM_UNARY_ASYNC_GEN)
+        call = stream_unary_call()
 
-            self.assertEqual(await call.code(), grpc.StatusCode.OK)
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        response = await call
+        self.assertEqual(_RESPONSE, response)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_stream_unary_reader_writer(self):
+        stream_unary_call = self._channel.stream_unary(
+            _STREAM_UNARY_READER_WRITER)
+        call = stream_unary_call()
+
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        response = await call
+        self.assertEqual(_RESPONSE, response)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_stream_unary_evilly_mixed(self):
+        stream_unary_call = self._channel.stream_unary(
+            _STREAM_UNARY_EVILLY_MIXED)
+        call = stream_unary_call()
+
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        response = await call
+        self.assertEqual(_RESPONSE, response)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_stream_stream_async_generator(self):
+        stream_stream_call = self._channel.stream_stream(
+            _STREAM_STREAM_ASYNC_GEN)
+        call = stream_stream_call()
+
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            response = await call.read()
+            self.assertEqual(_RESPONSE, response)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_stream_stream_reader_writer(self):
+        stream_stream_call = self._channel.stream_stream(
+            _STREAM_STREAM_READER_WRITER)
+        call = stream_stream_call()
+
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            response = await call.read()
+            self.assertEqual(_RESPONSE, response)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_stream_stream_evilly_mixed(self):
+        stream_stream_call = self._channel.stream_stream(
+            _STREAM_STREAM_EVILLY_MIXED)
+        call = stream_stream_call()
+
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            response = await call.read()
+            self.assertEqual(_RESPONSE, response)
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
 
     async def test_shutdown(self):
         await self._server.stop(None)
         # Ensures no SIGSEGV triggered, and ends within timeout.
 
     async def test_shutdown_after_call(self):
-        async with aio.insecure_channel(self._server_target) as channel:
-            await channel.unary_unary(_SIMPLE_UNARY_UNARY)(_REQUEST)
+        await self._channel.unary_unary(_SIMPLE_UNARY_UNARY)(_REQUEST)
 
         await self._server.stop(None)
 
     async def test_graceful_shutdown_success(self):
-        channel = aio.insecure_channel(self._server_target)
-        call = channel.unary_unary(_BLOCK_BRIEFLY)(_REQUEST)
+        call = self._channel.unary_unary(_BLOCK_BRIEFLY)(_REQUEST)
         await self._generic_handler.wait_for_call()
 
         shutdown_start_time = time.time()
@@ -190,13 +332,11 @@ class TestServer(AioTestBase):
                            test_constants.SHORT_TIMEOUT / 3)
 
         # Validates the states.
-        await channel.close()
         self.assertEqual(_RESPONSE, await call)
         self.assertTrue(call.done())
 
     async def test_graceful_shutdown_failed(self):
-        channel = aio.insecure_channel(self._server_target)
-        call = channel.unary_unary(_BLOCK_FOREVER)(_REQUEST)
+        call = self._channel.unary_unary(_BLOCK_FOREVER)(_REQUEST)
         await self._generic_handler.wait_for_call()
 
         await self._server.stop(test_constants.SHORT_TIMEOUT)
@@ -206,11 +346,9 @@ class TestServer(AioTestBase):
         self.assertEqual(grpc.StatusCode.UNAVAILABLE,
                          exception_context.exception.code())
         self.assertIn('GOAWAY', exception_context.exception.details())
-        await channel.close()
 
     async def test_concurrent_graceful_shutdown(self):
-        channel = aio.insecure_channel(self._server_target)
-        call = channel.unary_unary(_BLOCK_BRIEFLY)(_REQUEST)
+        call = self._channel.unary_unary(_BLOCK_BRIEFLY)(_REQUEST)
         await self._generic_handler.wait_for_call()
 
         # Expects the shortest grace period to be effective.
@@ -224,13 +362,11 @@ class TestServer(AioTestBase):
         self.assertGreater(grace_period_length,
                            test_constants.SHORT_TIMEOUT / 3)
 
-        await channel.close()
         self.assertEqual(_RESPONSE, await call)
         self.assertTrue(call.done())
 
     async def test_concurrent_graceful_shutdown_immediate(self):
-        channel = aio.insecure_channel(self._server_target)
-        call = channel.unary_unary(_BLOCK_FOREVER)(_REQUEST)
+        call = self._channel.unary_unary(_BLOCK_FOREVER)(_REQUEST)
         await self._generic_handler.wait_for_call()
 
         # Expects no grace period, due to the "server.stop(None)".
@@ -246,7 +382,6 @@ class TestServer(AioTestBase):
         self.assertEqual(grpc.StatusCode.UNAVAILABLE,
                          exception_context.exception.code())
         self.assertIn('GOAWAY', exception_context.exception.details())
-        await channel.close()
 
     @unittest.skip('https://github.com/grpc/grpc/issues/20818')
     async def test_shutdown_before_call(self):


### PR DESCRIPTION
This PR implements the client streaming RPC and bi-di streaming RPC on both the client-side and the server-side.

Many of the code are boilerplate, and there are similar functions in different call objects (e.g. `read()` in `UnaryStreamCall` and `StreamStreamCall`). However, I'm not sure about whether abstract all duplicate code into a third place is improving readability or introducing complexity. If needed, I can change the code into using mixing classes.

This PR adds 19 test cases (526+ 68-), majorly focus on cancellation and combinations of API.

Sorry for sending large PR again. Feel free to ask for info if anything is unclear.