### PR TITLE
Change the linux for linux artifacts to CentOS 6

### DIFF
--- a/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Docker file for building gRPC artifacts.
+
+##################
+# Base
+
+FROM dockcross/manylinux2010-x64
+
+# Install essential packages.
+RUN yum -y install golang strace
+
+
+##################
+# Ruby dependencies
+
+# Install rvm
+RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN \curl -sSL https://get.rvm.io | bash -s stable
+
+# Install Ruby 2.6
+RUN /bin/bash -l -c "rvm install ruby-2.6"
+RUN /bin/bash -l -c "rvm use --default ruby-2.6"
+RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
+RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.6' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler"
+
+
+##################
+# PHP dependencies
+
+RUN yum -y install php5 php5-dev php-pear
+
+RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
+  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+# Clean yum
+RUN yum clean all
+
+# Create default work directory.
+RUN mkdir /var/local/jenkins
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
@@ -1,0 +1,58 @@
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Docker file for building gRPC artifacts.
+
+##################
+# Base
+
+FROM dockcross/manylinux2010-x86
+
+# Install essential packages.
+RUN yum -y install golang strace
+
+
+##################
+# Ruby dependencies
+
+# Install rvm
+RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN \curl -sSL https://get.rvm.io | bash -s stable
+
+# Install Ruby 2.6
+RUN /bin/bash -l -c "rvm install ruby-2.6"
+RUN /bin/bash -l -c "rvm use --default ruby-2.6"
+RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
+RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.6' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler"
+
+
+##################
+# PHP dependencies
+
+RUN yum -y install php5 php5-dev php-pear
+
+RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
+  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+# Clean yum
+RUN yum clean all
+
+# Create default work directory.
+RUN mkdir /var/local/jenkins
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -271,7 +271,7 @@ class CSharpExtArtifact:
                     cmake_arch_option = '-DOPENSSL_NO_ASM=ON'
                 return create_docker_jobspec(
                     self.name,
-                    'tools/dockerfile/grpc_artifact_linux_%s' % self.arch,
+                    'tools/dockerfile/grpc_artifact_centos6_%s' % self.arch,
                     'tools/run_tests/artifacts/build_artifact_csharp.sh',
                     environ={
                         'CMAKE_ARCH_OPTION': cmake_arch_option
@@ -304,7 +304,7 @@ class PHPArtifact:
 
     def build_jobspec(self):
         return create_docker_jobspec(
-            self.name, 'tools/dockerfile/grpc_artifact_linux_{}'.format(
+            self.name, 'tools/dockerfile/grpc_artifact_centos6_{}'.format(
                 self.arch), 'tools/run_tests/artifacts/build_artifact_php.sh')
 
 


### PR DESCRIPTION
We can get the same benefit from the way how Python distributes binary libraries using manylinux to avoid the hairy dependency problem across various Linux distributions. Since `manylinux2010` is based on CentOS 6 which is a pretty conservative Linux distribution, artifacts built on this can be expected to run on almost all active Linux distributions. This change affects artifacts for .NET and PHP. (Ruby and Node.js use the other docker file.)

Instead of using vanilla CentOS 6, `dockcross/manylinux2010-x64` was chosen because it has additional packages on top of CentOS 6 such as newer version of gcc, cmake, so on, which free us from maintaining our own docker image.

[grpc_build_artifacts_multiplatform](https://sponge.corp.google.com/invocation?id=b498e9c1-f889-4a97-8bcb-c6f8b5adfdd8&searchFor=): passed