### PR TITLE
Add a minimal proxy package to route grpc to grpcio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ a.out
 src/python/grpcio_*/LICENSE
 src/python/grpcio_status/grpc_status/google/rpc/status.proto
 .pytype
+*.egg-info
+tools/distrib/python/*/LICENSE
 
 # Node installation output
 node_modules

--- a/templates/tools/distrib/python/grpc/grpc_version.py.template
+++ b/templates/tools/distrib/python/grpc/grpc_version.py.template
@@ -1,0 +1,19 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 The gRPC Authors
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  # AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpc/grpc_version.py.template`!!!
+
+  VERSION = '${settings.python_version.pep440()}'

--- a/tools/distrib/python/grpc/MANIFEST.in
+++ b/tools/distrib/python/grpc/MANIFEST.in
@@ -1,0 +1,3 @@
+global-exclude *.pyc
+include LICENSE
+include grpc_version.py

--- a/tools/distrib/python/grpc/README.rst
+++ b/tools/distrib/python/grpc/README.rst
@@ -1,0 +1,4 @@
+gRPC Python
+===========
+
+The official package of gRPC Python is `grpcio <https://pypi.org/project/grpcio/>`_.

--- a/tools/distrib/python/grpc/grpc_version.py
+++ b/tools/distrib/python/grpc/grpc_version.py
@@ -1,0 +1,17 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpc/grpc_version.py.template`!!!
+
+VERSION = '1.27.0.dev0'

--- a/tools/distrib/python/grpc/setup.py
+++ b/tools/distrib/python/grpc/setup.py
@@ -1,0 +1,110 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Setup module for the `grpc` package."""
+
+import os
+import shutil
+
+import setuptools
+
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+_LICENSE = os.path.join(_PACKAGE_PATH, '../../../../LICENSE')
+
+# Ensure we're in the proper directory whether or not we're being used by pip.
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+# Break import-style to ensure we can actually find our local modules.
+import grpc_version
+
+
+class _Preprocess(setuptools.Command):
+    """Command to copy LICENSE from root directory."""
+
+    description = ''
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        if os.path.isfile(_LICENSE):
+            shutil.copyfile(_LICENSE, os.path.join(_PACKAGE_PATH, 'LICENSE'))
+
+
+class _NoOpCommand(setuptools.Command):
+    """No-op command."""
+
+    description = ''
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        pass
+
+
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'License :: OSI Approved :: Apache Software License',
+]
+
+PACKAGE_DIRECTORIES = {
+    '': '.',
+}
+
+INSTALL_REQUIRES = ('grpcio=={version}'.format(version=grpc_version.VERSION),)
+
+try:
+    # we are in the build environment, otherwise the above import fails
+    COMMAND_CLASS = {
+        # Run preprocess from the repository *before* doing any packaging!
+        'preprocess': _Preprocess,
+        'build_package_protos': _NoOpCommand,
+    }
+except ImportError:
+    COMMAND_CLASS = {
+        # wire up commands to no-op not to break the external dependencies
+        'preprocess': _NoOpCommand,
+        'build_package_protos': _NoOpCommand,
+    }
+
+setuptools.setup(
+    name='grpc',
+    version=grpc_version.VERSION,
+    description='A proxy to install the official gRPC Python package.',
+    long_description=open(_README_PATH, 'r').read(),
+    author='The gRPC Authors',
+    author_email='grpc-io@googlegroups.com',
+    url='https://grpc.io',
+    license='Apache License 2.0',
+    classifiers=CLASSIFIERS,
+    package_dir=PACKAGE_DIRECTORIES,
+    packages=setuptools.find_packages('.'),
+    install_requires=INSTALL_REQUIRES,
+    cmdclass=COMMAND_CLASS)

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -70,6 +70,9 @@ tar xzf "${GRPCIO_TAR_GZ}" -C "${GRPCIO_STRIP_TEMPDIR}"
 )
 mv "${GRPCIO_STRIPPED_TAR_GZ}" "${GRPCIO_TAR_GZ}"
 
+# Build proxy package
+${SETARCH_CMD} "${PYTHON}" tools/distrib/python/grpc/setup.py preprocess sdist
+
 # Build gRPC tools package distribution
 "${PYTHON}" tools/distrib/python/make_grpcio_tools.py
 
@@ -138,8 +141,9 @@ fi
 # Ensure the generated artifacts are valid.
 "${PYTHON}" -m virtualenv venv || { "${PYTHON}" -m pip install virtualenv && "${PYTHON}" -m virtualenv venv; }
 venv/bin/python -m pip install "twine<=2.0"
-venv/bin/python -m twine check dist/* tools/distrib/python/grpcio_tools/dist/*
+venv/bin/python -m twine check dist/* tools/distrib/python/grpc/dist/* tools/distrib/python/grpcio_tools/dist/*
 rm -rf venv/
 
 cp -r dist/* "$ARTIFACT_DIR"
+cp -r tools/distrib/python/grpc/dist/* "$ARTIFACT_DIR"
 cp -r tools/distrib/python/grpcio_tools/dist/* "$ARTIFACT_DIR"


### PR DESCRIPTION
Adding a package that takes the same version of `grpcio` as dependency. It works as a proxy to install our official gRPC Python package. So, for people who typed `grpc` accidentally, now they should get `grpcio` installed properly.

Let's see if our infra are happy first...