### PR TITLE
Fix typo in recent BUILDING.md update

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -185,8 +185,8 @@ If you are running CMake v3.13 or newer you can build gRPC's dependencies
 in "module" mode and install them alongside gRPC in a single step.
 [Example](test/distrib/cpp/run_distrib_test_cmake_module_install.sh)
 
-If you are using an older version of gRPC, you will need to select "package"
-mode (rather than "module" mode) for the dependencies.
+If you are building gRPC < 1.27 or if you are using CMake < 3.13 you will need
+to select "package" mode (rather than "module" mode) for the dependencies.
 This means you will need to have external copies of these libraries available
 on your system.
 ```


### PR DESCRIPTION
It's an older version of CMake that will prevent you from installing
module-provided dependencies.

@jtattermusch 