### PR TITLE
Updates the Google.Protobuf version to the latest.

### DIFF
--- a/templates/src/csharp/build/dependencies.props.template
+++ b/templates/src/csharp/build/dependencies.props.template
@@ -4,6 +4,6 @@
   <Project>
     <PropertyGroup>
       <GrpcCsharpVersion>${settings.csharp_version}</GrpcCsharpVersion>
-      <GoogleProtobufVersion>3.8.0</GoogleProtobufVersion>
+      <GoogleProtobufVersion>3.11.2</GoogleProtobufVersion>
     </PropertyGroup>
   </Project>


### PR DESCRIPTION
[This PR](https://github.com/protocolbuffers/protobuf/pull/5350) (and maybe others) changed the API of the generated code so the packaged Google.Protobuf version is not compatible with code files generated with the latest code generation plugin.

Example error:

```
error CS1729: 'GeneratedClrTypeInfo' does not contain a constructor that takes 7 arguments
```

@yashykt
