### PR TITLE
Support Ruby 2.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -120,15 +120,15 @@ task 'gem:native' do
   if RUBY_PLATFORM =~ /darwin/
     FileUtils.touch 'grpc_c.32.ruby'
     FileUtils.touch 'grpc_c.64.ruby'
-    unless '2.5' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
+    unless '2.7' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
       fail "rake gem:native (the rake task to build the binary packages) is being " \
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
-        "build should be running on ruby 2.5."
+        "build should be running on ruby 2.7."
     end
-    system "rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    system "rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     Rake::Task['dlls'].execute
-    docker_for_windows "gem update --system --no-document && bundle && rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    docker_for_windows "gem update --system --no-document && bundle && rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   end
 end
 

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -19,13 +19,13 @@ rm -rf ~/.rake-compiler
 
 CROSS_RUBY=$(mktemp tmpfile.XXXXXXXX)
 
-curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.3/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
+curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.9/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
 
 # See https://github.com/grpc/grpc/issues/12161 for verconf.h patch details
 patch "$CROSS_RUBY" << EOF
 --- cross-ruby.rake	2018-04-10 11:32:16.000000000 -0700
 +++ patched	2018-04-10 11:40:25.000000000 -0700
-@@ -133,8 +133,10 @@
+@@ -141,8 +141,10 @@
      "--host=#{MINGW_HOST}",
      "--target=#{MINGW_TARGET}",
      "--build=#{RUBY_BUILD}",
@@ -36,10 +36,10 @@ patch "$CROSS_RUBY" << EOF
 +    '--without-gmp',
      '--with-ext='
    ]
- 
-@@ -151,6 +153,7 @@
+
+@@ -159,6 +161,7 @@
  # make
- file "#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/ruby.exe" => ["#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/Makefile"] do |t|
+ file "#{build_dir}/ruby.exe" => ["#{build_dir}/Makefile"] do |t|
    chdir File.dirname(t.prerequisites.first) do
 +    sh "test -s verconf.h || rm -f verconf.h"  # if verconf.h has size 0, make sure it gets re-built by make
      sh MAKE
@@ -49,7 +49,7 @@ EOF
 
 MAKE="make -j8"
 
-for v in 2.6.0 2.5.0 2.4.0 2.3.0 2.2.2 ; do
+for v in 2.7.0 2.6.0 2.5.0 2.4.0 2.3.0 2.2.2 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
 done

--- a/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_7/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_7/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 gRPC authors.
+# Copyright 2015 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,46 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Docker file for building gRPC artifacts.
+FROM debian:jessie
 
-##################
-# Base
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  curl \
+  gcc && apt-get clean
 
-FROM dockcross/manylinux2010-x86
-
-# Install essential packages.
-RUN yum -y install golang strace
-
-
-##################
+#==================
 # Ruby dependencies
 
 # Install rvm
-RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.7
-RUN /bin/bash -l -c "rvm install ruby-2.7"
-RUN /bin/bash -l -c "rvm use --default ruby-2.7"
+RUN /bin/bash -l -c "rvm install ruby-2.7.0"
+RUN /bin/bash -l -c "rvm use --default ruby-2.7.0"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.7' >> ~/.bashrc"
-RUN /bin/bash -l -c "gem install bundler"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.7.0' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler --no-document"
 
-
-##################
-# PHP dependencies
-
-RUN yum -y install php5 php5-dev php-pear
-
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
-  chmod +x /usr/local/bin/phpunit
-
-# Clean yum
-RUN yum clean all
-
-# Create default work directory.
 RUN mkdir /var/local/jenkins
 
 # Define the default command.

--- a/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
@@ -30,12 +30,12 @@ RUN yum -y install golang strace
 RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
-# Install Ruby 2.6
-RUN /bin/bash -l -c "rvm install ruby-2.6"
-RUN /bin/bash -l -c "rvm use --default ruby-2.6"
+# Install Ruby 2.7
+RUN /bin/bash -l -c "rvm install ruby-2.7"
+RUN /bin/bash -l -c "rvm use --default ruby-2.7"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.6' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.7' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler"
 
 

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
@@ -73,12 +73,12 @@ RUN apt-get update && apt-get install -y gnupg2
 RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
-# Install Ruby 2.5
-RUN /bin/bash -l -c "rvm install ruby-2.5"
-RUN /bin/bash -l -c "rvm use --default ruby-2.5"
+# Install Ruby 2.7
+RUN /bin/bash -l -c "rvm install ruby-2.7"
+RUN /bin/bash -l -c "rvm use --default ruby-2.7"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.7' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
@@ -27,7 +27,7 @@ ${name}')
 cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
-rvm --default use ruby-2.5
+rvm --default use ruby-2.7
 
 # build Ruby interop client and server
 (cd src/ruby && gem install bundler -v 1.17.3 && bundle && rake compile)

--- a/tools/dockerfile/test/ruby_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_jessie_x64/Dockerfile
@@ -77,12 +77,12 @@ RUN apt-get update && apt-get install -y gnupg2
 RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
-# Install Ruby 2.5
-RUN /bin/bash -l -c "rvm install ruby-2.5"
-RUN /bin/bash -l -c "rvm use --default ruby-2.5"
+# Install Ruby 2.7
+RUN /bin/bash -l -c "rvm install ruby-2.7"
+RUN /bin/bash -l -c "rvm use --default ruby-2.7"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.7' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -39,11 +39,11 @@ then
   set +ex  # rvm script is very verbose and exits with errorcode
   # Advice from https://github.com/Homebrew/homebrew-cask/issues/8629#issuecomment-68641176
   brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
-  rvm --debug requirements ruby-2.5.0
+  rvm --debug requirements ruby-2.7.0
   source $HOME/.rvm/scripts/rvm
   set -e  # rvm commands are very verbose
-  time rvm install 2.5.0
-  rvm use 2.5.0 --default
+  time rvm install 2.7.0
+  rvm use 2.7.0 --default
   time gem install bundler -v 1.17.3 --no-ri --no-doc
   time gem install cocoapods --version 1.3.1 --no-ri --no-doc
   time gem install rake-compiler --no-ri --no-doc

--- a/tools/interop_matrix/patches/ruby_v1.18.0/git_repo.patch
+++ b/tools/interop_matrix/patches/ruby_v1.18.0/git_repo.patch
@@ -3,7 +3,7 @@ index 67f66090ae..e71ad91499 100755
 --- a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
 +++ b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
 @@ -30,4 +30,4 @@ cd /var/local/git/grpc
- rvm --default use ruby-2.5
+ rvm --default use ruby-2.7
  
  # build Ruby interop client and server
 -(cd src/ruby && gem update bundler && bundle && rake compile)

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -339,6 +339,7 @@ def targets():
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_4'),
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_5'),
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_6'),
+        RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_7'),
         RubyDistribTest('linux', 'x64', 'centos6'),
         RubyDistribTest('linux', 'x64', 'centos7'),
         RubyDistribTest('linux', 'x64', 'fedora23'),


### PR DESCRIPTION
Similarly to https://github.com/protocolbuffers/protobuf/pull/7027, this PR modifies build configurations to ship prebuilt extensions for Ruby 2.7.

I thought it's also good to add Ruby 2.7 to the test matrix, but I can remove them if that is too much for this PR. The minimal required changes would be the following:

- Rakefile ... add Ruby 2.7 to build matrix
- tools/distrib/build_ruby_environment_macos.sh ... build Ruby 2.7 environment for building extensions
- tools/internal_ci/helper_scripts/prepare_build_macos_rc ... rake-compiler needs Ruby 2.7 to build Ruby 2.7 cross-toolchains.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
