### PR TITLE
Upgrade third_party/protobuf to v3.11.2

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -141,9 +141,9 @@ def grpc_deps():
     if "com_google_protobuf" not in native.existing_rules():
         http_archive(
             name = "com_google_protobuf",
-            sha256 = "416212e14481cff8fd4849b1c1c1200a7f34808a54377e22d7447efdf54ad758",
-            strip_prefix = "protobuf-09745575a923640154bcf307fba8aedff47f240a",
-            url = "https://github.com/google/protobuf/archive/09745575a923640154bcf307fba8aedff47f240a.tar.gz",
+            sha256 = "7adbf4833bc56e201db3076e864f6f4fd3043b5895e5f7e6ab953d385b49a926",
+            strip_prefix = "protobuf-fe1790ca0df67173702f70d5646b82f48f412b99",
+            url = "https://github.com/google/protobuf/archive/fe1790ca0df67173702f70d5646b82f48f412b99.tar.gz",
         )
 
     if "com_github_google_googletest" not in native.existing_rules():

--- a/examples/csharp/Helloworld/Greeter/Greeter.csproj
+++ b/examples/csharp/Helloworld/Greeter/Greeter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.8.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
     <PackageReference Include="Grpc" Version="2.23.0" />
     <PackageReference Include="Grpc.Tools" Version="2.23.0" PrivateAssets="All" />
   </ItemGroup>

--- a/examples/csharp/HelloworldLegacyCsproj/Greeter/Greeter.csproj
+++ b/examples/csharp/HelloworldLegacyCsproj/Greeter/Greeter.csproj
@@ -33,8 +33,8 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.8.0\lib\net45\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Grpc.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
       <HintPath>..\packages\Grpc.Core.2.23.0\lib\net45\Grpc.Core.dll</HintPath>

--- a/examples/csharp/HelloworldLegacyCsproj/Greeter/packages.config
+++ b/examples/csharp/HelloworldLegacyCsproj/Greeter/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Protobuf" version="3.8.0" targetFramework="net45" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="net45" />
   <package id="Grpc" version="2.23.0" targetFramework="net45" />
   <package id="Grpc.Core" version="2.23.0" targetFramework="net45" />
   <package id="Grpc.Core.Api" version="2.23.0" targetFramework="net45" />

--- a/examples/csharp/HelloworldLegacyCsproj/GreeterClient/GreeterClient.csproj
+++ b/examples/csharp/HelloworldLegacyCsproj/GreeterClient/GreeterClient.csproj
@@ -32,8 +32,8 @@
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.8.0\lib\net45\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Grpc.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
       <HintPath>..\packages\Grpc.Core.2.23.0\lib\net45\Grpc.Core.dll</HintPath>

--- a/examples/csharp/HelloworldLegacyCsproj/GreeterClient/packages.config
+++ b/examples/csharp/HelloworldLegacyCsproj/GreeterClient/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Protobuf" version="3.8.0" targetFramework="net45" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="net45" />
   <package id="Grpc" version="2.23.0" targetFramework="net45" />
   <package id="Grpc.Core" version="2.23.0" targetFramework="net45" />
   <package id="Grpc.Core.Api" version="2.23.0" targetFramework="net45" />

--- a/examples/csharp/HelloworldLegacyCsproj/GreeterServer/GreeterServer.csproj
+++ b/examples/csharp/HelloworldLegacyCsproj/GreeterServer/GreeterServer.csproj
@@ -32,8 +32,8 @@
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.8.0\lib\net45\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Grpc.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
       <HintPath>..\packages\Grpc.Core.2.23.0\lib\net45\Grpc.Core.dll</HintPath>

--- a/examples/csharp/HelloworldLegacyCsproj/GreeterServer/packages.config
+++ b/examples/csharp/HelloworldLegacyCsproj/GreeterServer/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Protobuf" version="3.8.0" targetFramework="net45" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="net45" />
   <package id="Grpc" version="2.23.0" targetFramework="net45" />
   <package id="Grpc.Core" version="2.23.0" targetFramework="net45" />
   <package id="Grpc.Core.Api" version="2.23.0" targetFramework="net45" />

--- a/examples/csharp/HelloworldXamarin/Droid/HelloworldXamarin.Droid.csproj
+++ b/examples/csharp/HelloworldXamarin/Droid/HelloworldXamarin.Droid.csproj
@@ -39,8 +39,8 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.8.0\lib\netstandard2.0\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\netstandard2.0\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Grpc.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
       <HintPath>..\packages\Grpc.Core.2.23.0\lib\netstandard2.0\Grpc.Core.dll</HintPath>

--- a/examples/csharp/HelloworldXamarin/Droid/packages.config
+++ b/examples/csharp/HelloworldXamarin/Droid/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Protobuf" version="3.8.0" targetFramework="monoandroid81" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="monoandroid81" />
   <package id="Grpc.Core" version="2.23.0" targetFramework="monoandroid81" />
   <package id="Grpc.Core.Api" version="2.23.0" targetFramework="monoandroid81" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="monoandroid81" />

--- a/examples/csharp/HelloworldXamarin/iOS/HelloworldXamarin.iOS.csproj
+++ b/examples/csharp/HelloworldXamarin/iOS/HelloworldXamarin.iOS.csproj
@@ -79,8 +79,8 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.8.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.8.0\lib\netstandard2.0\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\netstandard2.0\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="Grpc.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
       <HintPath>..\packages\Grpc.Core.2.23.0\lib\netstandard2.0\Grpc.Core.dll</HintPath>

--- a/examples/csharp/HelloworldXamarin/iOS/packages.config
+++ b/examples/csharp/HelloworldXamarin/iOS/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.Protobuf" version="3.8.0" targetFramework="xamarinios10" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="xamarinios10" />
   <package id="Grpc.Core" version="2.23.0" targetFramework="xamarinios10" />
   <package id="Grpc.Core.Api" version="2.23.0" targetFramework="xamarinios10" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />

--- a/examples/csharp/RouteGuide/RouteGuide/RouteGuide.csproj
+++ b/examples/csharp/RouteGuide/RouteGuide/RouteGuide.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.8.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
     <PackageReference Include="Grpc" Version="2.23.0" />
     <PackageReference Include="Grpc.Tools" Version="2.23.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/examples/php/echo/base.Dockerfile
+++ b/examples/php/echo/base.Dockerfile
@@ -23,8 +23,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/\
-protoc-3.8.0-linux-x86_64.zip -o /tmp/protoc.zip && \
+RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/\
+protoc-3.11.2-linux-x86_64.zip -o /tmp/protoc.zip && \
   unzip -qq protoc.zip && \
   cp /tmp/bin/protoc /usr/local/bin/protoc
 

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 3.8'
+  s.add_dependency 'google-protobuf', '~> 3.11'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
   s.add_development_dependency 'bundler',            '>= 1.9'

--- a/src/cpp/Protobuf-C++.podspec
+++ b/src/cpp/Protobuf-C++.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Protobuf-C++'
-  s.version  = '3.8.0'
+  s.version  = '3.11.2'
   s.summary  = 'Protocol Buffers v3 runtime library for C++.'
   s.homepage = 'https://github.com/google/protobuf'
   s.license  = '3-Clause BSD License'

--- a/src/csharp/build/dependencies.props
+++ b/src/csharp/build/dependencies.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <GrpcCsharpVersion>2.27.0-dev</GrpcCsharpVersion>
-    <GoogleProtobufVersion>3.8.0</GoogleProtobufVersion>
+    <GoogleProtobufVersion>3.11.2</GoogleProtobufVersion>
   </PropertyGroup>
 </Project>

--- a/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
@@ -100,7 +100,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = plugin
 
   # Restrict the protoc version to the one supported by this plugin.
-  s.dependency '!ProtoCompiler', '3.8.0'
+  s.dependency '!ProtoCompiler', '3.11.2'
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'

--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -102,7 +102,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = plugin
 
   # Restrict the protoc version to the one supported by this plugin.
-  s.dependency '!ProtoCompiler', '3.8.0'
+  s.dependency '!ProtoCompiler', '3.11.2'
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   # exclamation mark ensures that other "regular" pods will be able to find it as it'll be installed
   # before them.
   s.name     = '!ProtoCompiler'
-  v = '3.8.0'
+  v = '3.11.2'
   s.version  = v
   s.summary  = 'The Protobuf Compiler (protoc) generates Objective-C files from .proto files'
   s.description = <<-DESC

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -210,7 +210,7 @@ $ [sudo] pecl install protobuf
 or specific version
 
 ``` sh
-$ [sudo] pecl install protobuf-3.8.0
+$ [sudo] pecl install protobuf-3.11.2
 ```
 
 And add this to your `php.ini` file:

--- a/templates/examples/php/echo/base.Dockerfile.template
+++ b/templates/examples/php/echo/base.Dockerfile.template
@@ -26,7 +26,7 @@
   WORKDIR /tmp
 
   RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/${'\\'}
-  protoc-3.8.0-linux-x86_64.zip -o /tmp/protoc.zip && ${'\\'}
+  protoc-3.11.2-linux-x86_64.zip -o /tmp/protoc.zip && ${'\\'}
     unzip -qq protoc.zip && ${'\\'}
     cp /tmp/bin/protoc /usr/local/bin/protoc
 

--- a/templates/src/csharp/build/dependencies.props.template
+++ b/templates/src/csharp/build/dependencies.props.template
@@ -4,6 +4,6 @@
   <Project>
     <PropertyGroup>
       <GrpcCsharpVersion>${settings.csharp_version}</GrpcCsharpVersion>
-      <GoogleProtobufVersion>3.8.0</GoogleProtobufVersion>
+      <GoogleProtobufVersion>3.11.2</GoogleProtobufVersion>
     </PropertyGroup>
   </Project>

--- a/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
@@ -102,7 +102,7 @@
     s.preserve_paths = plugin
 
     # Restrict the protoc version to the one supported by this plugin.
-    s.dependency '!ProtoCompiler', '3.8.0'
+    s.dependency '!ProtoCompiler', '3.11.2'
     # For the Protobuf dependency not to complain:
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.9'

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -104,7 +104,7 @@
     s.preserve_paths = plugin
 
     # Restrict the protoc version to the one supported by this plugin.
-    s.dependency '!ProtoCompiler', '3.8.0'
+    s.dependency '!ProtoCompiler', '3.11.2'
     # For the Protobuf dependency not to complain:
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.9'

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -36,7 +36,7 @@ cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  28f50e0fed19872e0fd50dd23ce2ee8cd759338e third_party/gflags (v2.2.0-5-g30dbc81)
  80ed4d0bbf65d57cc267dfc63bd2584557f11f9b third_party/googleapis (common-protos-1_3_1-915-g80ed4d0bb)
  c9ccac7cb7345901884aabf5d1a786cfa6e2f397 third_party/googletest (6e2f397)
- 09745575a923640154bcf307fba8aedff47f240a third_party/protobuf (v3.7.0-rc.2-247-g09745575)
+ fe1790ca0df67173702f70d5646b82f48f412b99 third_party/protobuf (v3.11.2-fe1790ca)
  e143189bf6f37b3957fb31743df6a1bcf4a8c685 third_party/protoc-gen-validate (v0.0.10)
  94324803a497c8f76dbc78df393ef629d3a9f3c3 third_party/udpa (heads/master)
  cacf7f1d4e3d44d871b605da3b647f07d718623f third_party/zlib (v1.2.11)


### PR DESCRIPTION
grpc-tools ships with protoc v3.8.0, which generates an error with
proto3 extensions: https://github.com/protocolbuffers/protobuf/issues/6209

Closes https://github.com/grpc/grpc/issues/21226
