### PR TITLE
cython_library supports extra cc_binary args

### DIFF
--- a/bazel/cython_library.bzl
+++ b/bazel/cython_library.bzl
@@ -6,18 +6,20 @@
 # been written at cython/cython and tensorflow/tensorflow. We branch from
 # Tensorflow's version as it is more actively maintained and works for gRPC
 # Python's needs.
-def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
+def pyx_library(name, deps=[], copts=[], cc_kwargs={}, py_deps=[], srcs=[], **kwargs):
     """Compiles a group of .pyx / .pxd / .py files.
 
     First runs Cython to create .cpp files for each input .pyx or .py + .pxd
-    pair. Then builds a shared object for each, passing "deps" to each cc_binary
-    rule (includes Python headers by default). Finally, creates a py_library rule
-    with the shared objects and any pure Python "srcs", with py_deps as its
-    dependencies; the shared objects can be imported like normal Python files.
+    pair. Then builds a shared object for each, passing "deps" and `**cc_kwargs`
+    to each cc_binary rule (includes Python headers by default). Finally, creates
+    a py_library rule with the shared objects and any pure Python "srcs", with py_deps
+    as its dependencies; the shared objects can be imported like normal Python files.
 
     Args:
         name: Name for the rule.
         deps: C/C++ dependencies of the Cython (e.g. Numpy headers).
+        copts: C/C++ compiler options for Cython
+        cc_kwargs: cc_binary extra arguments such as linkstatic, linkopts, features
         py_deps: Pure Python dependencies of the final library.
         srcs: .py, .pyx, or .pxd files to either compile or pass through.
         **kwargs: Extra keyword arguments passed to the py_library.
@@ -56,10 +58,12 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
         stem = src.split(".")[0]
         shared_object_name = stem + ".so"
         native.cc_binary(
-            name = shared_object_name,
-            srcs = [stem + ".cpp"],
-            deps = deps + ["@local_config_python//:python_headers"],
-            linkshared = 1,
+            name=shared_object_name,
+            srcs=[stem + ".cpp"] + cc_kwargs.pop("srcs", []),
+            copts=copts,
+            deps=deps + ["@local_config_python//:python_headers"],
+            linkshared=1,
+            **cc_kwargs
         )
         shared_objects.append(shared_object_name)
 


### PR DESCRIPTION
Make pyx_library to support extra cc_binary args, which is needed in some complicated cases such as `linkstatic`, `linkopts` and so on.
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
