### PR TITLE
Add watchOS target

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '6.0'
 
   s.requires_arc = false
 


### PR DESCRIPTION
Add watchOS target to support effort to have Firebase Firestore on watchOS. See https://github.com/grpc/grpc/issues/21566

@yashykt
