### PR TITLE
Allow empty values for `http_proxy`

### DIFF
--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -55,9 +55,9 @@ char* GetHttpProxyServer(char** user_cred) {
    * fallback behavior can be removed if there's a demand for it.
    */
   char* uri_str = gpr_getenv("grpc_proxy");
-  if (uri_str == nullptr) uri_str = gpr_getenv("https_proxy");
-  if (uri_str == nullptr) uri_str = gpr_getenv("http_proxy");
-  if (uri_str == nullptr) return nullptr;
+  if (uri_str == nullptr || uri_str[0] == '\0') uri_str = gpr_getenv("https_proxy");
+  if (uri_str == nullptr || uri_str[0] == '\0') uri_str = gpr_getenv("http_proxy");
+  if (uri_str == nullptr || uri_str[0] == '\0') return nullptr;
   grpc_uri* uri = grpc_uri_parse(uri_str, false /* suppress_errors */);
   if (uri == nullptr || uri->authority == nullptr) {
     gpr_log(GPR_ERROR, "cannot parse value of 'http_proxy' env var");


### PR DESCRIPTION
An empty value for `http_proxy` results error messages like this, as described in #17631 :

```
E1230 02:42:28.834924400       1 uri_parser.cc:46]           bad uri.scheme: ''
E1230 02:42:28.835090500       1 uri_parser.cc:52]                            ^ here
E1230 02:42:28.835106400       1 http_proxy.cc:63]           cannot parse value of 'http_proxy' env var
```

You can see this by simply running
```
$ http_proxy= bins/opt/h2_local_ipv4_test no_logging
```

I often see those error messages as I work on the environment where some computers requires HTTP proxies and other computers don't. I created a repository to demonstrate that situation: https://github.com/ikedam/grpcio-httpproxy-demo .

I want grpc allow empty values for `http_proxy` and behave in the same way as `http_proxy` isn't set.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
