### PR TITLE
Remove unused (and defective) constructor

### DIFF
--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -150,11 +150,6 @@ class CallbackWithSuccessTag
 
   CallbackWithSuccessTag() : call_(nullptr) {}
 
-  CallbackWithSuccessTag(grpc_call* call, std::function<void(bool)> f,
-                         CompletionQueueTag* ops, bool can_inline) {
-    Set(call, f, ops, can_inline);
-  }
-
   CallbackWithSuccessTag(const CallbackWithSuccessTag&) = delete;
   CallbackWithSuccessTag& operator=(const CallbackWithSuccessTag&) = delete;
 


### PR DESCRIPTION
This constructor is currently unused, but if it were ever used, it would fire an assertion in the function that it calls.
