### PR TITLE
Make verify_peer_callback more powerful

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -184,6 +184,8 @@ typedef struct {
      cleaned up. The userdata argument will be passed to it. The intent is
      to perform any cleanup associated with that userdata. */
   void (*verify_peer_destruct)(void* userdata);
+  /** True, if the default verification should be skipped, otherwise False */
+  bool skip_default_verification;
 } verify_peer_options;
 
 /** Object that holds additional peer-verification options on a secure
@@ -204,6 +206,8 @@ typedef struct {
      cleaned up. The userdata argument will be passed to it. The intent is
      to perform any cleanup associated with that userdata. */
   void (*verify_peer_destruct)(void* userdata);
+  /** True, if the default verification should be skipped, otherwise False */
+  bool skip_default_verification;
 } grpc_ssl_verify_peer_options;
 
 /** Deprecated in favor of grpc_ssl_server_credentials_create_ex. It will be

--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -185,7 +185,7 @@ typedef struct {
      to perform any cleanup associated with that userdata. */
   void (*verify_peer_destruct)(void* userdata);
   /** True, if the default verification should be skipped, otherwise False */
-  bool skip_default_verification;
+  char skip_default_verification;
 } verify_peer_options;
 
 /** Object that holds additional peer-verification options on a secure
@@ -207,7 +207,7 @@ typedef struct {
      to perform any cleanup associated with that userdata. */
   void (*verify_peer_destruct)(void* userdata);
   /** True, if the default verification should be skipped, otherwise False */
-  bool skip_default_verification;
+  char skip_default_verification;
 } grpc_ssl_verify_peer_options;
 
 /** Deprecated in favor of grpc_ssl_server_credentials_create_ex. It will be

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -136,7 +136,7 @@ class grpc_ssl_channel_security_connector final
     const char* target_name = overridden_target_name_ != nullptr
                                   ? overridden_target_name_.get()
                                   : target_name_.get();
-    grpc_error* error;
+    grpc_error* error = GRPC_ERROR_NONE;
     if (!verify_options_->skip_default_verification) {
       /* Check the peer name if specified. */
       if (target_name != nullptr && !grpc_ssl_host_matches_name(&peer, target_name)) {
@@ -146,7 +146,7 @@ class grpc_ssl_channel_security_connector final
         gpr_free(msg);
       }
     }
-    if (verify_options_->verify_peer_callback != nullptr) {
+    if ( error == GRPC_ERROR_NONE && verify_options_->verify_peer_callback != nullptr) {
       const tsi_peer_property* p =
           tsi_peer_get_property_by_name(&peer, TSI_X509_PEM_CERT_PROPERTY);
       if (p == nullptr) {

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -98,7 +98,7 @@ class grpc_ssl_channel_security_connector final
     }
     options.cipher_suites = grpc_get_ssl_cipher_suites();
     options.session_cache = ssl_session_cache;
-    options.skip_server_certificate_verification = verify_options.skip_default_verification;
+    options.skip_server_certificate_verification = verify_options_->skip_default_verification;
     const tsi_result result =
         tsi_create_ssl_client_handshaker_factory_with_options(
             &options, &client_handshaker_factory_);

--- a/src/csharp/Grpc.Core.Api/ChannelCredentialsConfiguratorBase.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentialsConfiguratorBase.cs
@@ -34,7 +34,7 @@ namespace Grpc.Core
         /// <summary>
         /// Configures the credentials to use <c>SslCredentials</c>.
         /// </summary>
-        public abstract void SetSslCredentials(object state, string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback);
+        public abstract void SetSslCredentials(object state, string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback, bool skipDefaultVerification);
 
         /// <summary>
         /// Configures the credentials to use composite channel credentials (a composite of channel credentials and call credentials).

--- a/src/csharp/Grpc.Core.Api/SslCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/SslCredentials.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+using System;
+
 namespace Grpc.Core
 {
     /// <summary>
@@ -41,6 +43,7 @@ namespace Grpc.Core
         readonly string rootCertificates;
         readonly KeyCertificatePair keyCertificatePair;
         readonly VerifyPeerCallback verifyPeerCallback;
+        readonly bool skipDefaultVerification;
 
         /// <summary>
         /// Creates client-side SSL credentials loaded from
@@ -76,11 +79,25 @@ namespace Grpc.Core
         /// <param name="keyCertificatePair">a key certificate pair.</param>
         /// <param name="verifyPeerCallback">a callback to verify peer's target name and certificate.</param>
         /// Note: experimental API that can change or be removed without any prior notice.
-        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback)
+        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback) :
+            this(rootCertificates, keyCertificatePair, verifyPeerCallback, false)
+        {
+        }
+
+        /// <summary>
+        /// Creates client-side SSL credentials.
+        /// </summary>
+        /// <param name="rootCertificates">string containing PEM encoded server root certificates.</param>
+        /// <param name="keyCertificatePair">a key certificate pair.</param>
+        /// <param name="verifyPeerCallback">a callback to verify peer's target name and certificate.</param>
+        /// <param name="skipDefaultVerification">true, if the default server verification is turned off, otherwise false</param>
+        /// Note: experimental API that can change or be removed without any prior notice.
+        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback, bool skipDefaultVerification)
         {
             this.rootCertificates = rootCertificates;
             this.keyCertificatePair = keyCertificatePair;
             this.verifyPeerCallback = verifyPeerCallback;
+            this.skipDefaultVerification = skipDefaultVerification;
         }
 
         /// <summary>
@@ -112,7 +129,7 @@ namespace Grpc.Core
         /// </summary>
         public override void InternalPopulateConfiguration(ChannelCredentialsConfiguratorBase configurator, object state)
         {
-            configurator.SetSslCredentials(state, rootCertificates, keyCertificatePair, verifyPeerCallback);
+            configurator.SetSslCredentials(state, rootCertificates, keyCertificatePair, verifyPeerCallback, skipDefaultVerification);
         }
 
         internal override bool IsComposable => true;

--- a/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
@@ -38,15 +38,15 @@ namespace Grpc.Core.Internal
             return creds;
         }
 
-        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair, IntPtr verifyPeerCallbackTag)
+        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair, IntPtr verifyPeerCallbackTag, bool skipDefaultVerification)
         {
             if (keyCertPair != null)
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey, verifyPeerCallbackTag);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey, verifyPeerCallbackTag, skipDefaultVerification ? 1 : 0);
             }
             else
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null, verifyPeerCallbackTag);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null, verifyPeerCallbackTag, skipDefaultVerification ? 1 : 0);
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
@@ -510,7 +510,7 @@ namespace Grpc.Core.Internal
             public delegate void grpcsharp_channel_args_set_integer_delegate(ChannelArgsSafeHandle args, UIntPtr index, string key, int value);
             public delegate void grpcsharp_channel_args_destroy_delegate(IntPtr args);
             public delegate void grpcsharp_override_default_ssl_roots_delegate(string pemRootCerts);
-            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
+            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag, int skipDefaultVerification);
             public delegate ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create_delegate(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
             public delegate void grpcsharp_channel_credentials_release_delegate(IntPtr credentials);
             public delegate ChannelSafeHandle grpcsharp_insecure_channel_create_delegate(string target, ChannelArgsSafeHandle channelArgs);
@@ -711,7 +711,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag, int skipDefaultVerification);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
@@ -1028,7 +1028,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag, int skipDefaultVerification);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -1006,7 +1006,8 @@ GPR_EXPORT grpc_channel_credentials* GPR_CALLTYPE
 grpcsharp_ssl_credentials_create(const char* pem_root_certs,
                                  const char* key_cert_pair_cert_chain,
                                  const char* key_cert_pair_private_key,
-                                 void* verify_peer_callback_tag) {
+                                 void* verify_peer_callback_tag,
+                                 int32_t skip_default_verification) {
   grpc_ssl_pem_key_cert_pair key_cert_pair;
   verify_peer_options verify_options;
   grpc_ssl_pem_key_cert_pair* key_cert_pair_ptr = NULL;
@@ -1027,7 +1028,14 @@ grpcsharp_ssl_credentials_create(const char* pem_root_certs,
     verify_options.verify_peer_callback_userdata = verify_peer_callback_tag;
     verify_options.verify_peer_destruct = grpcsharp_verify_peer_destroy_handler;
     verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
+    if (skip_default_verification != 0) {
+      verify_options.skip_default_verification = true;
+    } else {
+      verify_options.skip_default_verification = false;
+    }
     verify_options_ptr = &verify_options;
+  } else {
+    GPR_ASSERT(!skip_default_verification)
   }
 
   return grpc_ssl_credentials_create(pem_root_certs, key_cert_pair_ptr,

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -1029,13 +1029,13 @@ grpcsharp_ssl_credentials_create(const char* pem_root_certs,
     verify_options.verify_peer_destruct = grpcsharp_verify_peer_destroy_handler;
     verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
     if (skip_default_verification != 0) {
-      verify_options.skip_default_verification = true;
+      verify_options.skip_default_verification = 1;
     } else {
-      verify_options.skip_default_verification = false;
+      verify_options.skip_default_verification = 0;
     }
     verify_options_ptr = &verify_options;
   } else {
-    GPR_ASSERT(!skip_default_verification)
+    GPR_ASSERT(!skip_default_verification);
   }
 
   return grpc_ssl_credentials_create(pem_root_certs, key_cert_pair_ptr,


### PR DESCRIPTION
This is to resolve #21474. Basically, the problem there boils down to the fact that a `verify_peer_callback` cannot override the default policies, i.e. the client still checks whether the certificate is valid and that the target name is contained in the certificate _before_ the callback is executed. To me, this does not make a lot of sense, because it limits the use cases of the verify_peer_callback to those where you would want to pose additional verification rules. However, those can normally be executed before and the system would not even attempt to connect to this server. 

The changes here introduce a new field in the verify options that decide whether the default server verification should be skipped. If that is the case, gRPC would skip the check whether the host name matches the common Name. Further, certificates are requested, but not verified.

@yihuazhang
