### PR TITLE
Clarify the set_trailing_metadata docstring

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1162,7 +1162,13 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
 
     @abc.abstractmethod
     def set_trailing_metadata(self, trailing_metadata):
-        """Sends the trailing metadata for the RPC.
+        """Sets the trailing metadata for the RPC.
+
+        Sets the trailing metadata to be sent upon completion of the RPC.
+
+        If this method is invoked multiple times throughout the lifetime of an
+        RPC, the value supplied in the final invocation will be the value sent
+        over the wire.
 
         This method need not be called by implementations if they have no
         metadata to add to what the gRPC runtime will transmit.


### PR DESCRIPTION
While reviewing https://github.com/grpc/grpc/pull/21577, I realized that the docstring for `grpc.Server.set_trailing_metadata` was blatantly wrong. The implementation does not immediately send the trailing metadata. In fact, this makes no sense, as doing so would bring a premature end to the RPC.