### PR TITLE
Make yapf_code capable of making in-place changes

### DIFF
--- a/tools/distrib/yapf_code.sh
+++ b/tools/distrib/yapf_code.sh
@@ -15,6 +15,9 @@
 
 set -ex
 
+ACTION=${1:---in-place}
+[[ $ACTION == '--in-place' ]] || [[ $ACTION == '--diff' ]]
+
 # change to root directory
 cd "$(dirname "${0}")/../.."
 
@@ -33,4 +36,4 @@ PYTHON=${VIRTUALENV}/bin/python
 "$PYTHON" -m pip install --upgrade futures
 "$PYTHON" -m pip install yapf==0.28.0
 
-$PYTHON -m yapf --diff --recursive --style=setup.cfg "${DIRS[@]}"
+$PYTHON -m yapf $ACTION --recursive --style=setup.cfg "${DIRS[@]}"

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -25,7 +25,7 @@
 - script: tools/distrib/clang_tidy_code.sh
 - script: tools/distrib/pylint_code.sh
 - script: tools/distrib/python/check_grpcio_tools.py
-- script: tools/distrib/yapf_code.sh
+- script: tools/distrib/yapf_code.sh --diff
   cpu_cost: 1000
 - script: tools/distrib/check_protobuf_pod_version.sh
 - script: tools/distrib/check_shadow_boringssl_symbol_list.sh


### PR DESCRIPTION
I personally use `yapf_code.sh` to format my code before submission, so I hope we could keep its ability of making in-place changes. It should not affect existing checks.