### PR TITLE
Added a test to keep grpc run without abseil

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -69,6 +69,11 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
+config_setting(
+    name = "grpc_disable_absl",
+    values = {"define": "GRPC_USE_ABSL=0"},
+)
+
 python_config_settings()
 
 # This should be updated along with build.yaml

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -100,6 +100,10 @@ def grpc_cc_library(
                       "//:grpc_allow_exceptions": ["GRPC_ALLOW_EXCEPTIONS=1"],
                       "//:grpc_disallow_exceptions": ["GRPC_ALLOW_EXCEPTIONS=0"],
                       "//conditions:default": [],
+                  }) +
+                  select({
+                      "//:grpc_disable_absl": ["GRPC_USE_ABSL=0"],
+                      "//conditions:default": [],
                   }),
         hdrs = hdrs + public_hdrs,
         deps = deps + _get_external_deps(external_deps),

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -25,3 +25,7 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 bazel build --spawn_strategy=standalone --genrule_strategy=standalone :all test/... examples/...
+
+# This is a temporary build test before absl is proven safe to work with gRPC.
+# TODO(veblush): Remove this after abseil integration is finally done.
+bazel build --spawn_strategy=standalone --genrule_strategy=standalone --define=GRPC_USE_ABSL=0 :grpc


### PR DESCRIPTION
Adding a temporary test to keep gRPC run without abseil. This enforce gRPC code not to use abseil directly. Until abseil is proven safe to use, gRPC code should be maintained so that it can be rolled back anytime. 

Related with #20184.