### PR TITLE
[Aio] Support channel argument for both client and server

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 cdef class AioChannel:
-    def __cinit__(self, bytes target):
-        self.channel = grpc_insecure_channel_create(<char *>target, NULL, NULL)
+    def __cinit__(self, bytes target, tuple options):
+        if options is None:
+            options = ()
+        cdef _ChannelArgs channel_args = _ChannelArgs(options)
+        self.channel = grpc_insecure_channel_create(<char *>target, channel_args.c_args(), NULL)
         self.cq = CallbackCompletionQueue()
         self._target = target
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -122,11 +122,11 @@ cdef grpc_error* asyncio_socket_listen(grpc_custom_socket* grpc_socket) with gil
     return grpc_error_none()
 
 
-def _asyncio_apply_socket_options(object s):
+def _asyncio_apply_socket_options(object socket):
     # TODO(https://github.com/grpc/grpc/issues/20667)
     # Connects the so_reuse_port option to channel arguments
-    s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, 1)
-    s.setsockopt(native_socket.IPPROTO_TCP, native_socket.TCP_NODELAY, True)
+    socket.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, 1)
+    socket.setsockopt(native_socket.IPPROTO_TCP, native_socket.TCP_NODELAY, True)
 
 
 cdef grpc_error* asyncio_socket_bind(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -122,22 +122,8 @@ cdef grpc_error* asyncio_socket_listen(grpc_custom_socket* grpc_socket) with gil
     return grpc_error_none()
 
 
-cdef list _socket_options_list = []
-cdef str _SOCKET_OPT_SO_REUSEPORT = 'grpc.so_reuseport'
-
-cdef _apply_socket_options(tuple options):
-    if options is None:
-        options = ()
-    
-    for key, value in options:
-        if key == _SOCKET_OPT_SO_REUSEPORT:
-            _socket_options_list.append(value)
-
-
 def _asyncio_apply_socket_options(object s):
     s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, 1)
-    if _socket_options_list.pop(0):
-        s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEPORT, 1)
     s.setsockopt(native_socket.IPPROTO_TCP, native_socket.TCP_NODELAY, True)
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -123,7 +123,7 @@ cdef grpc_error* asyncio_socket_listen(grpc_custom_socket* grpc_socket) with gil
 
 
 def _asyncio_apply_socket_options(object s):
-    # TODO(https://github.com/grpc/grpc/issues/20667)	
+    # TODO(https://github.com/grpc/grpc/issues/20667)
     # Connects the so_reuse_port option to channel arguments
     s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, 1)
     s.setsockopt(native_socket.IPPROTO_TCP, native_socket.TCP_NODELAY, True)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -123,6 +123,8 @@ cdef grpc_error* asyncio_socket_listen(grpc_custom_socket* grpc_socket) with gil
 
 
 def _asyncio_apply_socket_options(object s):
+    # TODO(https://github.com/grpc/grpc/issues/20667)	
+    # Connects the so_reuse_port option to channel arguments
     s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, 1)
     s.setsockopt(native_socket.IPPROTO_TCP, native_socket.TCP_NODELAY, True)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -26,6 +26,7 @@ cdef grpc_socket_vtable asyncio_socket_vtable
 cdef grpc_custom_resolver_vtable asyncio_resolver_vtable
 cdef grpc_custom_timer_vtable asyncio_timer_vtable
 cdef grpc_custom_poller_vtable asyncio_pollset_vtable
+cdef bint so_reuse_port
 
 
 cdef grpc_error* asyncio_socket_init(
@@ -121,10 +122,22 @@ cdef grpc_error* asyncio_socket_listen(grpc_custom_socket* grpc_socket) with gil
     return grpc_error_none()
 
 
-def _asyncio_apply_socket_options(object s, so_reuse_port=False):
-    # TODO(https://github.com/grpc/grpc/issues/20667)
-    # Connects the so_reuse_port option to channel arguments
+cdef list _socket_options_list = []
+cdef str _SOCKET_OPT_SO_REUSEPORT = 'grpc.so_reuseport'
+
+cdef _apply_socket_options(tuple options):
+    if options is None:
+        options = ()
+    
+    for key, value in options:
+        if key == _SOCKET_OPT_SO_REUSEPORT:
+            _socket_options_list.append(value)
+
+
+def _asyncio_apply_socket_options(object s):
     s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEADDR, 1)
+    if _socket_options_list.pop(0):
+        s.setsockopt(native_socket.SOL_SOCKET, native_socket.SO_REUSEPORT, 1)
     s.setsockopt(native_socket.IPPROTO_TCP, native_socket.TCP_NODELAY, True)
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -230,12 +230,12 @@ async def _handle_rpc(list generic_handlers, RPCState rpc_state, object loop):
     # TODO(lidiz) extend to all 4 types of RPC
     if not method_handler.request_streaming and method_handler.response_streaming:
         await _handle_unary_stream_rpc(method_handler,
-                                    rpc_state,
-                                    loop)
+                                       rpc_state,
+                                       loop)
     elif not method_handler.request_streaming and not method_handler.response_streaming:
         await _handle_unary_unary_rpc(method_handler,
-                                    rpc_state,
-                                    loop)
+                                      rpc_state,
+                                      loop)
     else:
         raise NotImplementedError()
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -227,21 +227,17 @@ async def _handle_rpc(list generic_handlers, RPCState rpc_state, object loop):
         # TODO(lidiz) return unimplemented error to client side
         raise NotImplementedError()
 
-    try:
-        # TODO(lidiz) extend to all 4 types of RPC
-        if not method_handler.request_streaming and method_handler.response_streaming:
-            await _handle_unary_stream_rpc(method_handler,
-                                        rpc_state,
-                                        loop)
-        elif not method_handler.request_streaming and not method_handler.response_streaming:
-            await _handle_unary_unary_rpc(method_handler,
-                                        rpc_state,
-                                        loop)
-        else:
-            raise NotImplementedError()
-    except Exception as e:
-        _LOGGER.exception(e)
-        raise
+    # TODO(lidiz) extend to all 4 types of RPC
+    if not method_handler.request_streaming and method_handler.response_streaming:
+        await _handle_unary_stream_rpc(method_handler,
+                                    rpc_state,
+                                    loop)
+    elif not method_handler.request_streaming and not method_handler.response_streaming:
+        await _handle_unary_unary_rpc(method_handler,
+                                    rpc_state,
+                                    loop)
+    else:
+        raise NotImplementedError()
 
 
 class _RequestCallError(Exception): pass
@@ -473,7 +469,7 @@ cdef class AioServer:
         If the Cython representation is deallocated without underlying objects
         freed, raise an RuntimeError.
         """
-        # NOTE(lidiz) if users create server, and then dealloc it immediately.
+        # TODO(lidiz) if users create server, and then dealloc it immediately.
         # There is a potential memory leak of created Core server.
         if self._status != AIO_SERVER_STATUS_STOPPED:
             _LOGGER.warn(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -260,8 +260,6 @@ cdef class AioServer:
 
     def __init__(self, loop, thread_pool, generic_handlers, interceptors,
                  options, maximum_concurrent_rpcs, compression):
-        # Notify IO manager about the socket options
-        _apply_socket_options(options)
         # NOTE(lidiz) Core objects won't be deallocated automatically.
         # If AioServer.shutdown is not called, those objects will leak.
         self._server = Server(options)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -472,7 +472,7 @@ cdef class AioServer:
         # TODO(lidiz) if users create server, and then dealloc it immediately.
         # There is a potential memory leak of created Core server.
         if self._status != AIO_SERVER_STATUS_STOPPED:
-            _LOGGER.warn(
+            _LOGGER.warning(
                 '__dealloc__ called on running server %s with status %d',
                 self,
                 self._status

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -30,7 +30,7 @@ from ._channel import Channel
 from ._channel import UnaryUnaryMultiCallable
 from ._interceptor import ClientCallDetails, UnaryUnaryClientInterceptor
 from ._interceptor import InterceptedUnaryUnaryCall
-from ._server import server
+from ._server import server, Server
 
 
 def insecure_channel(
@@ -64,4 +64,4 @@ __all__ = ('AioRpcError', 'RpcContext', 'Call', 'UnaryUnaryCall',
            'UnaryStreamCall', 'init_grpc_aio', 'Channel',
            'UnaryUnaryMultiCallable', 'ClientCallDetails',
            'UnaryUnaryClientInterceptor', 'InterceptedUnaryUnaryCall',
-           'insecure_channel', 'server')
+           'insecure_channel', 'server', 'Server')

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Invocation-side implementation of gRPC Asyncio Python."""
 import asyncio
-from typing import Any, Optional, Text
+from typing import Any, Optional, Sequence, Text
 
 import grpc
 from grpc import _common

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Invocation-side implementation of gRPC Asyncio Python."""
 import asyncio
-from typing import Any, Optional, Sequence, Text, Tuple
+from typing import Any, Optional, Text
 
 import grpc
 from grpc import _common
@@ -188,9 +188,7 @@ class Channel:
     _channel: cygrpc.AioChannel
     _unary_unary_interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]]
 
-    def __init__(self,
-                 target: Text,
-                 options: Optional[ChannelArgumentType],
+    def __init__(self, target: Text, options: Optional[ChannelArgumentType],
                  credentials: Optional[grpc.ChannelCredentials],
                  compression: Optional[grpc.Compression],
                  interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]]):

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -20,9 +20,11 @@ from grpc import _common
 from grpc._cython import cygrpc
 
 from . import _base_call
-from ._call import UnaryUnaryCall, UnaryStreamCall
-from ._interceptor import UnaryUnaryClientInterceptor, InterceptedUnaryUnaryCall
-from ._typing import (DeserializingFunction, MetadataType, SerializingFunction)
+from ._call import UnaryStreamCall, UnaryUnaryCall
+from ._interceptor import (InterceptedUnaryUnaryCall,
+                           UnaryUnaryClientInterceptor)
+from ._typing import (ChannelArgumentType, DeserializingFunction, MetadataType,
+                      SerializingFunction)
 from ._utils import _timeout_to_deadline
 
 
@@ -186,8 +188,9 @@ class Channel:
     _channel: cygrpc.AioChannel
     _unary_unary_interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]]
 
-    def __init__(self, target: Text,
-                 options: Optional[Sequence[Tuple[Text, Any]]],
+    def __init__(self,
+                 target: Text,
+                 options: Optional[ChannelArgumentType],
                  credentials: Optional[grpc.ChannelCredentials],
                  compression: Optional[grpc.Compression],
                  interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]]):
@@ -202,8 +205,6 @@ class Channel:
           interceptors: An optional list of interceptors that would be used for
             intercepting any RPC executed with that channel.
         """
-        if options:
-            raise NotImplementedError("TODO: options not implemented yet")
 
         if credentials:
             raise NotImplementedError("TODO: credentials not implemented yet")
@@ -229,7 +230,7 @@ class Channel:
                     "UnaryUnaryClientInterceptors, the following are invalid: {}"\
                     .format(invalid_interceptors))
 
-        self._channel = cygrpc.AioChannel(_common.encode(target))
+        self._channel = cygrpc.AioChannel(_common.encode(target), options)
 
     def unary_unary(
             self,

--- a/src/python/grpcio/grpc/experimental/aio/_typing.py
+++ b/src/python/grpcio/grpc/experimental/aio/_typing.py
@@ -20,3 +20,4 @@ ResponseType = TypeVar('ResponseType')
 SerializingFunction = Callable[[Any], bytes]
 DeserializingFunction = Callable[[bytes], Any]
 MetadataType = Sequence[Tuple[Text, AnyStr]]
+ChannelArgumentType = Sequence[Tuple[Text, Any]]

--- a/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
@@ -17,14 +17,16 @@ import os
 import socket
 import errno
 
-_DEFAULT_SOCK_OPTION = socket.SO_REUSEADDR if os.name == 'nt' else socket.SO_REUSEPORT
-_UNRECOVERABLE_ERRNOS = (errno.EADDRINUSE,)
+_DEFAULT_SOCK_OPTIONS = (socket.SO_REUSEADDR,
+                         socket.SO_REUSEPORT) if os.name != 'nt' else (
+                             socket.SO_REUSEADDR,)
+_UNRECOVERABLE_ERRNOS = (errno.EADDRINUSE, errno.ENOSR)
 
 
 def get_socket(bind_address='localhost',
                port=0,
                listen=True,
-               sock_options=(_DEFAULT_SOCK_OPTION,)):
+               sock_options=_DEFAULT_SOCK_OPTIONS):
     """Opens a socket.
 
     Useful for reserving a port for a system-under-test.
@@ -69,7 +71,7 @@ def get_socket(bind_address='localhost',
 def bound_socket(bind_address='localhost',
                  port=0,
                  listen=True,
-                 sock_options=(_DEFAULT_SOCK_OPTION,)):
+                 sock_options=_DEFAULT_SOCK_OPTIONS):
     """Opens a socket bound to an arbitrary port.
 
     Useful for reserving a port for a system-under-test.

--- a/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
@@ -21,13 +21,6 @@ _DEFAULT_SOCK_OPTION = socket.SO_REUSEADDR if os.name == 'nt' else socket.SO_REU
 _UNRECOVERABLE_ERRNOS = (errno.EADDRINUSE, errno.ENOSR)
 
 
-def _is_unrecoverable_os_error(e):
-    for error in _UNRECOVERABLE_ERRNOS:
-        if error == e.errno:
-            return True
-    return False
-
-
 def get_socket(bind_address='localhost',
                port=0,
                listen=True,
@@ -38,7 +31,7 @@ def get_socket(bind_address='localhost',
 
     Args:
       bind_address: The host to which to bind.
-      port: The port to bind.
+      port: The port to which to bind.
       listen: A boolean value indicating whether or not to listen on the socket.
       sock_options: A sequence of socket options to apply to the socket.
 
@@ -64,7 +57,7 @@ def get_socket(bind_address='localhost',
             return bind_address, sock.getsockname()[1], sock
         except OSError as os_error:
             sock.close()
-            if _is_unrecoverable_os_error(os_error):
+            if os_error.errno in _UNRECOVERABLE_ERRNOS:
                 raise
             else:
                 continue
@@ -83,7 +76,7 @@ def bound_socket(bind_address='localhost',
 
     Args:
       bind_address: The host to which to bind.
-      port: The port to bind.
+      port: The port to which to bind.
       listen: A boolean value indicating whether or not to listen on the socket.
       sock_options: A sequence of socket options to apply to the socket.
 

--- a/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
@@ -63,6 +63,11 @@ def get_socket(bind_address='localhost',
                 raise
             else:
                 continue
+        # For PY2, socket.error is a child class of IOError; for PY3, it is
+        # pointing to OSError. We need this catch to make it 2/3 agnostic.
+        except socket.error:  # pylint: disable=duplicate-except
+            sock.close()
+            continue
     raise RuntimeError("Failed to bind to {} with sock_options {}".format(
         bind_address, sock_options))
 

--- a/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/__init__.py
@@ -18,7 +18,7 @@ import socket
 import errno
 
 _DEFAULT_SOCK_OPTION = socket.SO_REUSEADDR if os.name == 'nt' else socket.SO_REUSEPORT
-_UNRECOVERABLE_ERRNOS = (errno.EADDRINUSE, errno.ENOSR)
+_UNRECOVERABLE_ERRNOS = (errno.EADDRINUSE,)
 
 
 def get_socket(bind_address='localhost',

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -3,6 +3,7 @@
   "unit.aio_rpc_error_test.TestAioRpcError",
   "unit.call_test.TestUnaryStreamCall",
   "unit.call_test.TestUnaryUnaryCall",
+  "unit.channel_argument_test.TestChannelArgument",
   "unit.channel_test.TestChannel",
   "unit.init_test.TestInsecureChannel",
   "unit.interceptor_test.TestInterceptedUnaryUnaryCall",

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -93,6 +93,7 @@ class TestChannelArgument(AioTestBase):
         random.seed(_RANDOM_SEED)
 
     async def test_server_so_reuse_port_is_set_properly(self):
+
         async def test_body():
             fact, options = random.choice(_OPTIONS)
             server = aio.server(options=options)
@@ -110,9 +111,7 @@ class TestChannelArgument(AioTestBase):
                 await server.stop(None)
 
         # Creating a lot of servers concurrently
-        await asyncio.gather(
-            *(test_body() for _ in range(_NUM_SERVER_CREATED))
-        )
+        await asyncio.gather(*(test_body() for _ in range(_NUM_SERVER_CREATED)))
 
     async def test_client(self):
         aio.insecure_channel('[::]:0', options=_TEST_CHANNEL_ARGS)

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -93,7 +93,7 @@ class TestChannelArgument(AioTestBase):
         random.seed(_RANDOM_SEED)
 
     async def test_server_so_reuse_port_is_set_properly(self):
-        for _ in range(_NUM_SERVER_CREATED):
+        async def test_body():
             fact, options = random.choice(_OPTIONS)
             server = aio.server(options=options)
             try:
@@ -108,6 +108,11 @@ class TestChannelArgument(AioTestBase):
                     )
             finally:
                 await server.stop(None)
+
+        # Creating a lot of servers concurrently
+        await asyncio.gather(
+            *(test_body() for _ in range(_NUM_SERVER_CREATED))
+        )
 
     async def test_client(self):
         aio.insecure_channel('[::]:0', options=_TEST_CHANNEL_ARGS)

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -73,7 +73,7 @@ async def test_if_reuse_port_enabled(server: aio.Server):
     await server.start()
 
     try:
-        another_socket = socket.socket(family=socket.AF_INET6)
+        another_socket = socket.socket(family=socket.AF_INET)
         another_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         another_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         another_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
@@ -92,6 +92,7 @@ class TestChannelArgument(AioTestBase):
     async def setUp(self):
         random.seed(_RANDOM_SEED)
 
+    @unittest.skip('https://github.com/grpc/grpc/issues/20667')
     async def test_server_so_reuse_port_is_set_properly(self):
 
         async def test_body():

--- a/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_argument_test.py
@@ -1,0 +1,156 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests behavior around the Core channel arguments."""
+
+import asyncio
+import logging
+import unittest
+import socket
+
+import grpc
+import random
+
+from grpc.experimental import aio
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests.unit.framework.common import test_constants
+from tests_aio.unit._test_server import start_test_server
+from tests_aio.unit._test_base import AioTestBase
+# 100 servers in sequence
+
+_RANDOM_SEED = 42
+
+_ENABLE_REUSE_PORT = 'SO_REUSEPORT enabled'
+_DISABLE_REUSE_PORT = 'SO_REUSEPORT disabled'
+_SOCKET_OPT_SO_REUSEPORT = 'grpc.so_reuseport'
+_OPTIONS = (
+    (_ENABLE_REUSE_PORT, ((_SOCKET_OPT_SO_REUSEPORT, 1),)),
+    (_DISABLE_REUSE_PORT, ((_SOCKET_OPT_SO_REUSEPORT, 0),)),
+)
+
+_NUM_SERVER_CREATED = 100
+
+_GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH = 'grpc.max_receive_message_length'
+_MAX_MESSAGE_LENGTH = 1024
+
+class _TestPointerWrapper(object):
+
+    def __int__(self):
+        return 123456
+
+
+_TEST_CHANNEL_ARGS = (
+    ('arg1', b'bytes_val'),
+    ('arg2', 'str_val'),
+    ('arg3', 1),
+    (b'arg4', 'str_val'),
+    ('arg6', _TestPointerWrapper()),
+)
+
+
+_INVALID_TEST_CHANNEL_ARGS = [
+    {'foo': 'bar'},
+    (('key',),),
+    'str',
+]
+
+
+async def test_if_reuse_port_enabled(server: aio.Server):
+    port = server.add_insecure_port('127.0.0.1:0')
+    await server.start()
+
+    try:
+        another_socket = socket.socket(family=socket.AF_INET6)
+        another_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        another_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        another_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
+        another_socket.bind(('127.0.0.1', port))
+    except OSError as e:
+        assert 'Address already in use' in str(e)
+        return False
+    else:
+        return True
+    finally:
+        another_socket.close()
+
+
+class TestChannelArgument(AioTestBase):
+
+    async def setUp(self):
+        random.seed(_RANDOM_SEED)
+
+    async def test_server_so_reuse_port_is_set_properly(self):
+        for _ in range(_NUM_SERVER_CREATED):
+            fact, options = random.choice(_OPTIONS)
+            server = aio.server(options=options)
+            try:
+                result = await test_if_reuse_port_enabled(server)
+                if fact == _ENABLE_REUSE_PORT and not result:
+                    self.fail('Enabled reuse port in options, but not observed in socket')
+                elif fact == _DISABLE_REUSE_PORT and result:
+                    self.fail('Disabled reuse port in options, but observed in socket')
+            finally:
+                await server.stop(None)
+
+
+    async def test_client(self):
+        aio.insecure_channel('[::]:0', options=_TEST_CHANNEL_ARGS)
+
+    async def test_server(self):
+        aio.server(options=_TEST_CHANNEL_ARGS)
+
+    async def test_invalid_client_args(self):
+        for invalid_arg in _INVALID_TEST_CHANNEL_ARGS:
+            self.assertRaises((ValueError, TypeError),
+                              aio.insecure_channel,
+                              '[::]:0',
+                              options=invalid_arg)
+
+    async def test_max_message_length_applied(self):
+        address, server = await start_test_server()
+
+        async with aio.insecure_channel(address, options=(
+                (_GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, _MAX_MESSAGE_LENGTH),
+            )) as channel:
+            stub = test_pb2_grpc.TestServiceStub(channel)
+
+            request = messages_pb2.StreamingOutputCallRequest()
+            # First request will pass
+            request.response_parameters.append(
+                messages_pb2.ResponseParameters(size=_MAX_MESSAGE_LENGTH//2,)
+            )
+            # Second request should fail
+            request.response_parameters.append(
+                messages_pb2.ResponseParameters(size=_MAX_MESSAGE_LENGTH*2,)
+            )
+
+            call = stub.StreamingOutputCall(request)
+
+            response = await call.read()
+            self.assertEqual(_MAX_MESSAGE_LENGTH//2, len(response.payload.body))
+
+            with self.assertRaises(aio.AioRpcError) as exception_context:
+                await call.read()
+            rpc_error = exception_context.exception
+            self.assertEqual(grpc.StatusCode.RESOURCE_EXHAUSTED, rpc_error.code())
+            self.assertIn(str(_MAX_MESSAGE_LENGTH), rpc_error.details())
+
+            self.assertEqual(grpc.StatusCode.RESOURCE_EXHAUSTED, await call.code())
+
+        await server.stop(None)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Related https://github.com/grpc/grpc/issues/20667

This PR plumbs through channel arguments from application into Core channels and servers. Most design is identical to existing stack.

~~However, to support `SO_REUSEPORT`, we need another mechanism because the IO manager has no idea with socket mapped to which server. It is kind of hacky, but I wrote a test to ensure it is reliable.~~ `SO_REUSEPORT` is not supported in this PR due to lower level unaware of upper level information.

Also, I added more tests than existing stack to ensure the channel arguments are actually working, instead of simply expecting no exceptions.