### PR TITLE
Move ChannelOption and ChannelOptions classes to a managed part

### DIFF
--- a/src/csharp/Grpc.Core.Api/ChannelOptions.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelOptions.cs
@@ -211,48 +211,5 @@ namespace Grpc.Core
 
         /// <summary>If non-zero, allow the use of SO_REUSEPORT for server if it's available (default 1)</summary>
         public const string SoReuseport = "grpc.so_reuseport";
-
-        /// <summary>
-        /// Creates native object for a collection of channel options.
-        /// </summary>
-        /// <returns>The native channel arguments.</returns>
-        internal static ChannelArgsSafeHandle CreateChannelArgs(ICollection<ChannelOption> options)
-        {
-            if (options == null || options.Count == 0)
-            {
-                return ChannelArgsSafeHandle.CreateNull();
-            }
-            ChannelArgsSafeHandle nativeArgs = null;
-            try
-            {
-                nativeArgs = ChannelArgsSafeHandle.Create(options.Count);
-                int i = 0;
-                foreach (var option in options)
-                {
-                    if (option.Type == ChannelOption.OptionType.Integer)
-                    {
-                        nativeArgs.SetInteger(i, option.Name, option.IntValue);
-                    }
-                    else if (option.Type == ChannelOption.OptionType.String)
-                    {
-                        nativeArgs.SetString(i, option.Name, option.StringValue);
-                    }
-                    else 
-                    {
-                        throw new InvalidOperationException("Unknown option type");
-                    }
-                    i++;
-                }
-                return nativeArgs;
-            }
-            catch (Exception)
-            {
-                if (nativeArgs != null)
-                {
-                    nativeArgs.Dispose();
-                }
-                throw;
-            }
-        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ChannelOptionsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelOptionsTest.cs
@@ -60,7 +60,7 @@ namespace Grpc.Core.Tests
         [Test]
         public void CreateChannelArgsNull()
         {
-            var channelArgs = ChannelOptions.CreateChannelArgs(null);
+            var channelArgs = ChannelArgsSafeHandle.CreateFromOptions(null);
             Assert.IsTrue(channelArgs.IsInvalid);
         }
 
@@ -68,7 +68,7 @@ namespace Grpc.Core.Tests
         public void CreateChannelArgsEmpty()
         {
             var options = new List<ChannelOption>();
-            var channelArgs = ChannelOptions.CreateChannelArgs(options);
+            var channelArgs = ChannelArgsSafeHandle.CreateFromOptions(options);
             channelArgs.Dispose();
         }
 
@@ -83,7 +83,7 @@ namespace Grpc.Core.Tests
                 new ChannelOption("GHIJK", 12345),
             };
 
-            var channelArgs = ChannelOptions.CreateChannelArgs(options);
+            var channelArgs = ChannelArgsSafeHandle.CreateFromOptions(options);
             channelArgs.Dispose();
         }
     }

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -70,7 +70,7 @@ namespace Grpc.Core
             this.environment = GrpcEnvironment.AddRef();
 
             this.completionQueue = this.environment.PickCompletionQueue();
-            using (var nativeChannelArgs = ChannelOptions.CreateChannelArgs(this.options.Values))
+            using (var nativeChannelArgs = ChannelArgsSafeHandle.CreateFromOptions(this.options.Values))
             {
                 var nativeCredentials = credentials.ToNativeCredentials();
                 if (nativeCredentials != null)

--- a/src/csharp/Grpc.Core/ForwardedTypes.cs
+++ b/src/csharp/Grpc.Core/ForwardedTypes.cs
@@ -42,6 +42,8 @@ using Grpc.Core.Utils;
 [assembly:TypeForwardedToAttribute(typeof(ClientBase))]
 [assembly:TypeForwardedToAttribute(typeof(ClientBase<>))]
 [assembly:TypeForwardedToAttribute(typeof(ChannelCredentials))]
+[assembly:TypeForwardedToAttribute(typeof(ChannelOption))]
+[assembly:TypeForwardedToAttribute(typeof(ChannelOptions))]
 [assembly:TypeForwardedToAttribute(typeof(ClientInterceptorContext<,>))]
 [assembly:TypeForwardedToAttribute(typeof(ContextPropagationOptions))]
 [assembly:TypeForwardedToAttribute(typeof(ContextPropagationToken))]

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -71,7 +71,7 @@ namespace Grpc.Core
             this.ports = new ServerPortCollection(this);
             this.environment = GrpcEnvironment.AddRef();
             this.options = options != null ? new List<ChannelOption>(options) : new List<ChannelOption>();
-            using (var channelArgs = ChannelOptions.CreateChannelArgs(this.options))
+            using (var channelArgs = ChannelArgsSafeHandle.CreateFromOptions(this.options))
             {
                 this.handle = ServerSafeHandle.NewServer(channelArgs);
             }


### PR DESCRIPTION
Moving code around so it become a slightly easier to migrate to a managed Grpc.Core.Api / Grpc.Core.AspNetCore 

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
