### PR TITLE
[csharp] Grpc.Auth supports Google.Apis.Auth.ITokenAccessWithHeaders

### DIFF
--- a/src/csharp/Grpc.Auth/GoogleAuthInterceptors.cs
+++ b/src/csharp/Grpc.Auth/GoogleAuthInterceptors.cs
@@ -16,7 +16,6 @@
 
 #endregion
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,10 +42,37 @@ namespace Grpc.Auth
         /// <returns>The interceptor.</returns>
         public static AsyncAuthInterceptor FromCredential(ITokenAccess credential)
         {
+            if (credential is ITokenAccessWithHeaders credentialWithHeaders)
+            {
+                return FromCredential(credentialWithHeaders);
+            }
+
             return new AsyncAuthInterceptor(async (context, metadata) =>
             {
                 var accessToken = await credential.GetAccessTokenForRequestAsync(context.ServiceUrl, CancellationToken.None).ConfigureAwait(false);
                 metadata.Add(CreateBearerTokenHeader(accessToken));
+            });
+        }
+
+        /// <summary>
+        /// Creates an <see cref="AsyncAuthInterceptor"/> that will obtain access token and associated information
+        /// from any credential type that implements <see cref="ITokenAccessWithHeaders"/>
+        /// </summary>
+        /// <param name="credential">The credential to use to obtain access tokens.</param>
+        /// <returns>The interceptor.</returns>
+        public static AsyncAuthInterceptor FromCredential(ITokenAccessWithHeaders credential)
+        {
+            return new AsyncAuthInterceptor(async (context, metadata) => 
+            {
+                AccessTokenWithHeaders tokenAndHeaders = await credential.GetAccessTokenWithHeadersForRequestAsync(context.ServiceUrl, CancellationToken.None).ConfigureAwait(false);
+                metadata.Add(CreateBearerTokenHeader(tokenAndHeaders.AccessToken));
+                foreach (var header in tokenAndHeaders.Headers)
+                {
+                    foreach (var headerValue in header.Value)
+                    {
+                        metadata.Add(new Metadata.Entry(header.Key, headerValue));
+                    }
+                }
             });
         }
 

--- a/src/csharp/Grpc.Auth/Grpc.Auth.csproj
+++ b/src/csharp/Grpc.Auth/Grpc.Auth.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Auth" Version="1.21.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.46.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
As agreed offline with @jtattermusch, adding support for an access token to be acompanied by extra information in the form of headers. See googleapis/google-api-dotnet-client#1484.