### PR TITLE
Enclose pthread include with GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK

### DIFF
--- a/src/core/lib/iomgr/fork_posix.cc
+++ b/src/core/lib/iomgr/fork_posix.cc
@@ -22,6 +22,10 @@
 
 #ifdef GRPC_POSIX_FORK
 
+#ifdef GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
+#include <pthread.h>
+#endif
+
 #include <string.h>
 
 #include <grpc/fork.h>

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -33,6 +33,10 @@
 #include <ext/spl/spl_exceptions.h>
 #include <zend_exceptions.h>
 
+#ifdef GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
+#include <pthread.h>
+#endif
+
 ZEND_DECLARE_MODULE_GLOBALS(grpc)
 static PHP_GINIT_FUNCTION(grpc);
 HashTable grpc_persistent_list;


### PR DESCRIPTION
Added explicit include statement for `pthread.h` in source files which use pthread functions.

Related to #21606