### PR TITLE
[Aio] Implement connectivity state related APIs

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -33,9 +33,12 @@ cdef struct CallbackContext:
     #       invoked by Core.
     #     failure_handler: A CallbackFailureHandler object that called when Core
     #       returns 'success == 0' state.
+    #     wrapper: A self-reference to the CallbackWrapper to help life cycle
+    #       management.
     grpc_experimental_completion_queue_functor functor
     cpython.PyObject *waiter
     cpython.PyObject *failure_handler
+    cpython.PyObject *callback_wrapper
 
 
 cdef class CallbackWrapper:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -36,10 +36,12 @@ cdef class CallbackWrapper:
         self.context.functor.functor_run = self.functor_run
         self.context.waiter = <cpython.PyObject*>future
         self.context.failure_handler = <cpython.PyObject*>failure_handler
+        self.context.callback_wrapper = <cpython.PyObject*>self
         # NOTE(lidiz) Not using a list here, because this class is critical in
         # data path. We should make it as efficient as possible.
         self._reference_of_future = future
         self._reference_of_failure_handler = failure_handler
+        cpython.Py_INCREF(self)
 
     @staticmethod
     cdef void functor_run(
@@ -47,12 +49,12 @@ cdef class CallbackWrapper:
             int success):
         cdef CallbackContext *context = <CallbackContext *>functor
         cdef object waiter = <object>context.waiter
-        if waiter.cancelled():
-            return
-        if success == 0:
-            (<CallbackFailureHandler>context.failure_handler).handle(waiter)
-        else:
-            waiter.set_result(None)
+        if not waiter.cancelled():
+            if success == 0:
+                (<CallbackFailureHandler>context.failure_handler).handle(waiter)
+            else:
+                waiter.set_result(None)
+        cpython.Py_DECREF(<object>context.callback_wrapper)
 
     cdef grpc_experimental_completion_queue_functor *c_functor(self):
         return &self.context.functor
@@ -99,9 +101,6 @@ async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
     cdef CallbackWrapper wrapper = CallbackWrapper(
         future,
         CallbackFailureHandler('execute_batch', operations, ExecuteBatchError))
-    # NOTE(lidiz) Without Py_INCREF, the wrapper object will be destructed
-    # when calling "await". This is an over-optimization by Cython.
-    cpython.Py_INCREF(wrapper)
     cdef grpc_call_error error = grpc_call_start_batch(
         grpc_call_wrapper.call,
         batch_operation_tag.c_ops,
@@ -111,10 +110,6 @@ async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
     if error != GRPC_CALL_OK:
         raise ExecuteBatchError("Failed grpc_call_start_batch: {}".format(error))
 
-    # NOTE(lidiz) Guard against CanceledError from future.
-    def dealloc_wrapper(_):
-        cpython.Py_DECREF(wrapper)
-    future.add_done_callback(dealloc_wrapper)
     await future
 
     cdef grpc_event c_event

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -41,6 +41,9 @@ cdef class CallbackWrapper:
         # data path. We should make it as efficient as possible.
         self._reference_of_future = future
         self._reference_of_failure_handler = failure_handler
+        # NOTE(lidiz) We need to ensure when Core invokes our callback, the
+        # callback function itself is not deallocated. Othersise, we will get
+        # a segfault. We can view this as Core holding a ref.
         cpython.Py_INCREF(self)
 
     @staticmethod

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pxd.pxi
@@ -17,3 +17,4 @@ cdef class AioChannel:
         grpc_channel * channel
         CallbackCompletionQueue cq
         bytes _target
+        object _loop

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pxd.pxi
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cdef enum AioChannelStatus:
+    AIO_CHANNEL_STATUS_UNKNOWN
+    AIO_CHANNEL_STATUS_READY
+    AIO_CHANNEL_STATUS_DESTROYED
+
 cdef class AioChannel:
     cdef:
         grpc_channel * channel
         CallbackCompletionQueue cq
         bytes _target
         object _loop
+        AioChannelStatus _status

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -13,14 +13,19 @@
 # limitations under the License.
 
 
+class _WatchConnectivityFailed(Exception): pass
+cdef CallbackFailureHandler _WATCH_CONNECTIVITY_FAILURE_HANDLER = CallbackFailureHandler(
+    'watch_connectivity_state',
+    'Maybe timed out.',
+    _WatchConnectivityFailed)
+
+
 cdef class AioChannel:
     def __cinit__(self, bytes target, tuple options, ChannelCredentials credentials):
         if options is None:
             options = ()
         cdef _ChannelArgs channel_args = _ChannelArgs(options)
         self._target = target
-        self.cq = CallbackCompletionQueue()
-
         if credentials is None:
             self.channel = grpc_insecure_channel_create(
                 <char *>target,
@@ -32,11 +37,41 @@ cdef class AioChannel:
                 <char *> target,
                 channel_args.c_args(),
                 NULL)
+        self._loop = asyncio.get_event_loop()
 
     def __repr__(self):
         class_name = self.__class__.__name__
         id_ = id(self)
         return f"<{class_name} {id_}>"
+
+    def check_connectivity_state(self, bint try_to_connect):
+        return grpc_channel_check_connectivity_state(
+            self.channel,
+            try_to_connect,
+        )
+
+    async def watch_connectivity_state(self,
+                                       grpc_connectivity_state last_observed_state,
+                                       object deadline):
+        cdef gpr_timespec c_deadline = _timespec_from_time(deadline)
+
+        cdef object future = self._loop.create_future()
+        cdef CallbackWrapper wrapper = CallbackWrapper(
+            future,
+            _WATCH_CONNECTIVITY_FAILURE_HANDLER)
+        grpc_channel_watch_connectivity_state(
+            self.channel,
+            last_observed_state,
+            c_deadline,
+            self.cq.c_ptr(),
+            wrapper.c_functor())
+
+        try:
+            await future
+        except _WatchConnectivityFailed:
+            return None
+        else:
+            return self.check_connectivity_state(False)
 
     def close(self):
         grpc_channel_destroy(self.channel)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -16,11 +16,11 @@
 class _WatchConnectivityFailed(Exception):
     """Dedicated exception class for watch connectivity failed.
 
-    It might be failed due to deadline exceeded, or the channel is closing.
+    It might be failed due to deadline exceeded.
     """
 cdef CallbackFailureHandler _WATCH_CONNECTIVITY_FAILURE_HANDLER = CallbackFailureHandler(
     'watch_connectivity_state',
-    'Timed out or channel closed.',
+    'Timed out',
     _WatchConnectivityFailed)
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -73,20 +73,12 @@ cdef class AioChannel:
         cdef CallbackWrapper wrapper = CallbackWrapper(
             future,
             _WATCH_CONNECTIVITY_FAILURE_HANDLER)
-        cpython.Py_INCREF(wrapper)
         grpc_channel_watch_connectivity_state(
             self.channel,
             last_observed_state,
             c_deadline,
             self.cq.c_ptr(),
             wrapper.c_functor())
-
-        # NOTE(lidiz) The callback will be invoked after the channel is closed
-        # with a failure state. We need to keep wrapper alive until then, or we
-        # will observe a segfault.
-        def dealloc_wrapper(_):
-            cpython.Py_DECREF(wrapper)
-        future.add_done_callback(dealloc_wrapper)
 
         try:
             await future

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -30,6 +30,10 @@ cdef class AioChannel:
             options = ()
         cdef _ChannelArgs channel_args = _ChannelArgs(options)
         self._target = target
+        self.cq = CallbackCompletionQueue()
+        self._loop = asyncio.get_event_loop()
+        self._status = AIO_CHANNEL_STATUS_READY
+
         if credentials is None:
             self.channel = grpc_insecure_channel_create(
                 <char *>target,
@@ -38,11 +42,9 @@ cdef class AioChannel:
         else:
             self.channel = grpc_secure_channel_create(
                 <grpc_channel_credentials *> credentials.c(),
-                <char *> target,
+                <char *>target,
                 channel_args.c_args(),
                 NULL)
-        self._loop = asyncio.get_event_loop()
-        self._status = AIO_CHANNEL_STATUS_READY
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -94,7 +94,6 @@ cdef class AioChannel:
             return False
         else:
             return True
-            
 
     def close(self):
         grpc_channel_destroy(self.channel)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -307,9 +307,6 @@ cdef class AioServer:
         cdef CallbackWrapper wrapper = CallbackWrapper(
             future,
             REQUEST_CALL_FAILURE_HANDLER)
-        # NOTE(lidiz) Without Py_INCREF, the wrapper object will be destructed
-        # when calling "await". This is an over-optimization by Cython.
-        cpython.Py_INCREF(wrapper)
         error = grpc_server_request_call(
             self._server.c_server, &rpc_state.call, &rpc_state.details,
             &rpc_state.request_metadata,
@@ -320,7 +317,6 @@ cdef class AioServer:
             raise RuntimeError("Error in grpc_server_request_call: %s" % error)
 
         await future
-        cpython.Py_DECREF(wrapper)
         return rpc_state
 
     async def _server_main_loop(self,

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -240,8 +240,7 @@ class Channel:
         Returns: A ChannelConnectivity object.
         """
         result = self._channel.check_connectivity_state(try_to_connect)
-        return _common.CYGRPC_CONNECTIVITY_STATE_TO_CHANNEL_CONNECTIVITY.get(
-            result)
+        return _common.CYGRPC_CONNECTIVITY_STATE_TO_CHANNEL_CONNECTIVITY[result]
 
     async def wait_for_state_change(
             self,

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Invocation-side implementation of gRPC Asyncio Python."""
 import asyncio
-from typing import Any, Optional, Sequence, Text, Tuple
+from typing import Any, Optional, Sequence, Text
 
 import grpc
 from grpc import _common

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -230,17 +230,14 @@ class Channel:
 
         This is an EXPERIMENTAL API.
 
-        It's the nature of connectivity states to change. The returned
-        connectivity state might become obsolete soon. Combining
-        "Channel.wait_for_state_change" we guarantee the convergence of
-        connectivity state between application and ground truth.
+        If the channel reaches a stable connectivity state, it is guaranteed
+        that the return value of this function will eventually converge to that
+        state.
 
-        Args:
-          try_to_connect: a bool indicate whether the Channel should try to
-            connect to peer or not.
+        Args: try_to_connect: a bool indicate whether the Channel should try to
+          connect to peer or not.
 
-        Returns:
-          A ChannelConnectivity object.
+        Returns: A ChannelConnectivity object.
         """
         result = self._channel.check_connectivity_state(try_to_connect)
         return _common.CYGRPC_CONNECTIVITY_STATE_TO_CHANNEL_CONNECTIVITY.get(
@@ -260,8 +257,8 @@ class Channel:
 
         There is an inherent race between the invocation of
         "Channel.wait_for_state_change" and "Channel.get_state". The state can
-        arbitrary times during the race, so there is no way to observe every
-        state transition.
+        change arbitrary times during the race, so there is no way to observe
+        every state transition.
 
         If there is a need to put a timeout for this function, please refer to
         "asyncio.wait_for".

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -5,6 +5,7 @@
   "unit.call_test.TestUnaryUnaryCall",
   "unit.channel_argument_test.TestChannelArgument",
   "unit.channel_test.TestChannel",
+  "unit.connectivity_test.TestConnectivityState",
   "unit.init_test.TestInsecureChannel",
   "unit.init_test.TestSecureChannel",
   "unit.interceptor_test.TestInterceptedUnaryUnaryCall",

--- a/src/python/grpcio_tests/tests_aio/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_aio/unit/BUILD.bazel
@@ -37,6 +37,12 @@ py_library(
     ],
 )
 
+py_library(
+    name = "_constants",
+    srcs = ["_constants.py"],
+    srcs_version = "PY3",
+)
+
 [
     py_test(
         name = test_file_name[:-3],
@@ -49,6 +55,7 @@ py_library(
         main = test_file_name,
         python_version = "PY3",
         deps = [
+            ":_constants",
             ":_test_base",
             ":_test_server",
             "//external:six",

--- a/src/python/grpcio_tests/tests_aio/unit/_constants.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_constants.py
@@ -1,0 +1,16 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+UNREACHABLE_TARGET = '0.0.0.1:1111'
+UNARY_CALL_WITH_SLEEP_VALUE = 0.2

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 import asyncio
-import logging
 import datetime
+import logging
 
 import grpc
 
 from grpc.experimental import aio
-from tests.unit.framework.common import test_constants
-from src.proto.grpc.testing import messages_pb2
-from src.proto.grpc.testing import test_pb2_grpc
 
-UNARY_CALL_WITH_SLEEP_VALUE = 0.2
+from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+from tests_aio.unit._constants import UNARY_CALL_WITH_SLEEP_VALUE
 
 
 class _TestServiceServicer(test_pb2_grpc.TestServiceServicer):

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -19,21 +19,20 @@ import threading
 import unittest
 
 import grpc
-
 from grpc.experimental import aio
-from src.proto.grpc.testing import messages_pb2
-from src.proto.grpc.testing import test_pb2_grpc
+
+from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
 from tests.unit.framework.common import test_constants
-from tests_aio.unit._test_server import start_test_server, UNARY_CALL_WITH_SLEEP_VALUE
+from tests_aio.unit._constants import (UNARY_CALL_WITH_SLEEP_VALUE,
+                                       UNREACHABLE_TARGET)
 from tests_aio.unit._test_base import AioTestBase
-from src.proto.grpc.testing import messages_pb2
+from tests_aio.unit._test_server import start_test_server
 
 _UNARY_CALL_METHOD = '/grpc.testing.TestService/UnaryCall'
 _UNARY_CALL_METHOD_WITH_SLEEP = '/grpc.testing.TestService/UnaryCallWithSleep'
 _STREAMING_OUTPUT_CALL_METHOD = '/grpc.testing.TestService/StreamingOutputCall'
 _NUM_STREAM_RESPONSES = 5
 _RESPONSE_PAYLOAD_SIZE = 42
-_UNREACHABLE_TARGET = '0.1:1111'
 
 
 class TestChannel(AioTestBase):

--- a/src/python/grpcio_tests/tests_aio/unit/connectivity_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/connectivity_test.py
@@ -100,9 +100,9 @@ class TestConnectivityState(AioTestBase):
         self.assertEqual(grpc.ChannelConnectivity.SHUTDOWN,
                          channel.get_state(False))
 
-        # It can raise Exception since it is an usage error, but it should not
+        # It can raise exceptions since it is an usage error, but it should not
         # segfault or abort.
-        with self.assertRaises(Exception):
+        with self.assertRaises(RuntimeError):
             await channel.wait_for_state_change(
                 grpc.ChannelConnectivity.SHUTDOWN)
 

--- a/src/python/grpcio_tests/tests_aio/unit/connectivity_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/connectivity_test.py
@@ -1,0 +1,98 @@
+# Copyright 2019 The gRPC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests behavior of the connectivity state."""
+
+import logging
+import threading
+import unittest
+import time
+import grpc
+
+from grpc.experimental import aio
+from src.proto.grpc.testing import messages_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from tests.unit.framework.common import test_constants
+from tests_aio.unit._test_server import start_test_server
+from tests_aio.unit._test_base import AioTestBase
+
+_INVALID_BACKEND_ADDRESS = '0.0.0.1:2'
+
+
+class TestChannel(AioTestBase):
+
+    async def setUp(self):
+        self._server_address, self._server = await start_test_server()
+
+    async def tearDown(self):
+        await self._server.stop(None)
+
+    async def test_unavailable_backend(self):
+        channel = aio.insecure_channel(_INVALID_BACKEND_ADDRESS)
+
+        self.assertEqual(grpc.ChannelConnectivity.IDLE,
+                         channel.check_connectivity_state(False))
+        self.assertEqual(grpc.ChannelConnectivity.IDLE,
+                         channel.check_connectivity_state(True))
+        self.assertEqual(
+            grpc.ChannelConnectivity.CONNECTING, await
+            channel.watch_connectivity_state(grpc.ChannelConnectivity.IDLE))
+        self.assertEqual(
+            grpc.ChannelConnectivity.TRANSIENT_FAILURE, await
+            channel.watch_connectivity_state(grpc.ChannelConnectivity.CONNECTING
+                                            ))
+
+        await channel.close()
+
+    async def test_normal_backend(self):
+        channel = aio.insecure_channel(self._server_address)
+
+        current_state = channel.check_connectivity_state(True)
+        self.assertEqual(grpc.ChannelConnectivity.IDLE, current_state)
+
+        deadline = time.time() + test_constants.SHORT_TIMEOUT
+
+        while current_state != grpc.ChannelConnectivity.READY:
+            current_state = await channel.watch_connectivity_state(
+                current_state, deadline - time.time())
+            self.assertIsNotNone(current_state)
+
+        await channel.close()
+
+    async def test_timeout(self):
+        channel = aio.insecure_channel(self._server_address)
+
+        self.assertEqual(grpc.ChannelConnectivity.IDLE,
+                         channel.check_connectivity_state(False))
+
+        # If timed out, the function should return None.
+        self.assertIsNone(await channel.watch_connectivity_state(
+            grpc.ChannelConnectivity.IDLE, test_constants.SHORT_TIMEOUT))
+
+        await channel.close()
+
+    async def test_shutdown(self):
+        channel = aio.insecure_channel(self._server_address)
+
+        self.assertEqual(grpc.ChannelConnectivity.IDLE,
+                         channel.check_connectivity_state(False))
+
+        await channel.close()
+
+        self.assertEqual(grpc.ChannelConnectivity.SHUTDOWN,
+                         channel.check_connectivity_state(False))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/connectivity_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/connectivity_test.py
@@ -29,7 +29,7 @@ from tests_aio.unit._test_base import AioTestBase
 _INVALID_BACKEND_ADDRESS = '0.0.0.1:2'
 
 
-class TestChannel(AioTestBase):
+class TestConnectivityState(AioTestBase):
 
     async def setUp(self):
         self._server_address, self._server = await start_test_server()


### PR DESCRIPTION
This PR implements connectivity state related APIs. It consists a check method and a watch method, which are mirroring what underlying Core provides. It should provide much more freedom to our users, and be less error-prone (comparing to the designated polling thread).

```Python
    def check_connectivity_state(self, try_to_connect: bool=False) -> grpc.ChannelConnectivity:
        """Check the connectivity state of a channel.

        This is an EXPERIMENTAL API.

        Args:
          try_to_connect: a bool indicate whether the Channel should try to connect to peer or not.
        
        Returns:
          A ChannelConnectivity object.
        """

    async def watch_connectivity_state(self,
                                       last_observed_state: grpc.ChannelConnectivity,
                                       timeout_seconds: float) -> Optional[grpc.ChannelConnectivity]:
        """Watch for a change in connectivity state.

        This is an EXPERIMENTAL API.
        
        Once the channel connectivity state is different from
        last_observed_state, the function will return the new connectivity
        state. If deadline expires BEFORE the state is changed, None will be
        returned.

        Args:
          try_to_connect: a bool indicate whether the Channel should try to connect to peer or not.
        
        Returns:
          A ChannelConnectivity object or None.
        """
```
