### PR TITLE
Skip building Android-dependent parts for Java interop test

### DIFF
--- a/templates/tools/dockerfile/java_build_interop.sh.include
+++ b/templates/tools/dockerfile/java_build_interop.sh.include
@@ -22,7 +22,7 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 cp -r /var/local/jenkins/service_account $HOME || true
 
 pushd /tmp/grpc-java
-./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true
+./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true
 
 mkdir -p /var/local/git/grpc-java/
 cp -r --parents -t /var/local/git/grpc-java/ ${'\\'}

--- a/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
@@ -22,7 +22,7 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 cp -r /var/local/jenkins/service_account $HOME || true
 
 pushd /tmp/grpc-java
-./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true
+./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true
 
 mkdir -p /var/local/git/grpc-java/
 cp -r --parents -t /var/local/git/grpc-java/ \


### PR DESCRIPTION
gRPC-Java's build requires Android SDK by default, add `-PskipAndroid=true` option to skip building Android-dependent parts.


Request for review: @nicolasnoble @ejona86 