### PR TITLE
Make unit test have init-shutdown pair.

### DIFF
--- a/test/core/backoff/backoff_test.cc
+++ b/test/core/backoff/backoff_test.cc
@@ -172,9 +172,10 @@ TEST(BackOffTest, JitterBackOff) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  grpc_init();
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  grpc_init();
+  int ret = RUN_ALL_TESTS();
   grpc_shutdown();
+  return ret;
 }

--- a/test/core/transport/chttp2/context_list_test.cc
+++ b/test/core/transport/chttp2/context_list_test.cc
@@ -165,7 +165,9 @@ TEST_F(ContextListTest, NonEmptyListEmptyTimestamp) {
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
-  grpc_init();
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  grpc_init();
+  int ret = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return ret;
 }

--- a/test/cpp/performance/writes_per_rpc_test.cc
+++ b/test/cpp/performance/writes_per_rpc_test.cc
@@ -57,22 +57,6 @@ static void ApplyCommonChannelArguments(ChannelArguments* c) {
   c->SetInt(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, INT_MAX);
 }
 
-static class InitializeStuff {
- public:
-  InitializeStuff() {
-    init_lib_.init();
-    rq_ = grpc_resource_quota_create("bm");
-  }
-
-  ~InitializeStuff() { init_lib_.shutdown(); }
-
-  grpc_resource_quota* rq() { return rq_; }
-
- private:
-  internal::GrpcLibrary init_lib_;
-  grpc_resource_quota* rq_;
-} initialize_stuff;
-
 class EndpointPairFixture {
  public:
   EndpointPairFixture(Service* service, grpc_endpoint_pair endpoints) {
@@ -160,9 +144,9 @@ class InProcessCHTTP2 : public EndpointPairFixture {
   grpc_passthru_endpoint_stats* stats_;
 
   static grpc_endpoint_pair MakeEndpoints(grpc_passthru_endpoint_stats* stats) {
+    static grpc_resource_quota* rq = grpc_resource_quota_create("bm");
     grpc_endpoint_pair p;
-    grpc_passthru_endpoint_create(&p.client, &p.server, initialize_stuff.rq(),
-                                  stats);
+    grpc_passthru_endpoint_create(&p.client, &p.server, rq, stats);
     return p;
   }
 };
@@ -257,5 +241,8 @@ TEST(WritesPerRpcTest, UnaryPingPong) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  grpc_init();
+  int ret = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return ret;
 }


### PR DESCRIPTION
Follow-up PR of #21620.

- Added `grpc_shutdown` to tests which don't have it corresponding to `grpc_init`.
- When the destructor of TestEnvironment is called, it waits until gRPC shutdown actually happens for up to 10 seconds to give it a chance to clean up gRPC resources so that various sanitizers are satisfied with the result.

Related to #21606.