### PR TITLE
Treat an empty `http_proxy` mean "Don't use proxy" and skip parsing it

### DIFF
--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -47,6 +47,7 @@ namespace {
  */
 char* GetHttpProxyServer(char** user_cred) {
   GPR_ASSERT(user_cred != nullptr);
+  grpc_uri* uri = nullptr;
   char* proxy_name = nullptr;
   char** authority_strs = nullptr;
   size_t authority_nstrs;
@@ -58,7 +59,9 @@ char* GetHttpProxyServer(char** user_cred) {
   if (uri_str == nullptr) uri_str = gpr_getenv("https_proxy");
   if (uri_str == nullptr) uri_str = gpr_getenv("http_proxy");
   if (uri_str == nullptr) return nullptr;
-  grpc_uri* uri = grpc_uri_parse(uri_str, false /* suppress_errors */);
+  // an emtpy value means "don't use proxy"
+  if (uri_str[0] == '\0') goto done;
+  uri = grpc_uri_parse(uri_str, false /* suppress_errors */);
   if (uri == nullptr || uri->authority == nullptr) {
     gpr_log(GPR_ERROR, "cannot parse value of 'http_proxy' env var");
     goto done;


### PR DESCRIPTION
Replaces #21570 

An empty value for `http_proxy` results error messages like this, as described in #17631 :

```
E1230 02:42:28.834924400       1 uri_parser.cc:46]           bad uri.scheme: ''
E1230 02:42:28.835090500       1 uri_parser.cc:52]                            ^ here
E1230 02:42:28.835106400       1 http_proxy.cc:63]           cannot parse value of 'http_proxy' env var
```

You can see this by simply running
```
$ http_proxy= bins/opt/h2_local_ipv4_test no_logging
```

I want to suppress this error as:

* I pass empty `http_proxy` with following docker-compose.yaml to have it work on environments both with proxies and without proxies:
    ```
    environment:
        http_proxy: ${http_proxy}
        https_proxy: ${https_proxy}
    ```
    * I created a repository to demonstrate that situation: https://github.com/ikedam/grpcio-httpproxy-demo .
* Allowing empty `grpc_proxy` can be useful as a way to have grpc not to use `http_proxy`
    * Refer https://github.com/rubygems/rubygems/issues/1706
* It's useless to let users know that an empty string is invalid as a URL.

This change only suppress the error message and doesn't change the actual communication behavior.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
