### PR TITLE
PHP: Fix logic setting roots pem

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -43,7 +43,8 @@ class BaseStub
      */
     public function __construct($hostname, $opts, $channel = null)
     {
-        if (!ChannelCredentials::isDefaultRootsPemSet()) {
+        if (!method_exists('ChannelCredentials', 'isDefaultRootsPemSet') ||
+            !ChannelCredentials::isDefaultRootsPemSet()) {
             $ssl_roots = file_get_contents(
                 dirname(__FILE__).'/../../../../etc/roots.pem'
             );


### PR DESCRIPTION
To make this piece of code more backwards compatible - users may not upgrade the PECL extension simultaneously with the composer package. 