### PR TITLE
Disable the flaky _exit_test for Bazel

### DIFF
--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -17,7 +17,8 @@ GRPCIO_TESTS_UNIT = [
     "_dns_resolver_test.py",
     "_empty_message_test.py",
     "_error_message_encoding_test.py",
-    "_exit_test.py",
+    # TODO(https://github.com/grpc/grpc/issues/20385) enable this test
+    # "_exit_test.py",
     "_grpc_shutdown_test.py",
     "_interceptor_test.py",
     "_invalid_metadata_test.py",


### PR DESCRIPTION
The flake rate of this test is not among the top list, but recently, I have seen this flake on Kokoro several times in my PRs. It usually appear as `TIMEOUT`, here is an occurrence:

https://source.cloud.google.com/results/invocations/acf42987-cb3f-439f-b57b-41331256b988/targets

I propose to disable it until we have resources to debug it. It should be a benign ignore, since the `_exit_test` is still ran by the `setuptools` path.
