### PR TITLE
Introduce ChannelBase.ShutdownAsync() in a backward-compatible manner.

### DIFF
--- a/src/csharp/Grpc.Core.Api/ChannelBase.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelBase.cs
@@ -68,9 +68,15 @@ namespace Grpc.Core
         }
 
         /// <summary>Provides implementation of a non-virtual public member.</summary>
-        protected virtual Task ShutdownAsyncCore()
+        #pragma warning disable 1998
+        protected virtual async Task ShutdownAsyncCore()
         {
-            throw new NotImplementedException();
+            // default implementation is no-op for backwards compatibility, but all implementations
+            // are expected to override this method.
+
+            // warning 1998 is disabled to avoid needing TaskUtils.CompletedTask, which is
+            // only available in Grpc.Core
         }
+        #pragma warning restore 1998
     }
 }

--- a/src/csharp/Grpc.Core.Api/ChannelBase.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelBase.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Threading.Tasks;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core
@@ -48,5 +49,28 @@ namespace Grpc.Core
         /// </summary>
         /// <returns>A new <see cref="CallInvoker"/>.</returns>
         public abstract CallInvoker CreateCallInvoker();
+
+        /// <summary>
+        /// Shuts down the channel cleanly. It is strongly recommended to shutdown
+        /// the channel once you stopped using it.
+        /// </summary>
+        /// <remarks>
+        /// Guidance for implementors:
+        /// This method doesn't wait for all calls on this channel to finish (nor does
+        /// it have to explicitly cancel all outstanding calls). It is user's responsibility to make sure
+        /// all the calls on this channel have finished (successfully or with an error)
+        /// before shutting down the channel to ensure channel shutdown won't impact
+        /// the outcome of those remote calls.
+        /// </remarks>
+        public Task ShutdownAsync()
+        {
+            return ShutdownAsyncCore();
+        }
+
+        /// <summary>Provides implementation of a non-virtual public member.</summary>
+        protected virtual Task ShutdownAsyncCore()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ChannelTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelTest.cs
@@ -113,5 +113,15 @@ namespace Grpc.Core.Tests
             Assert.Throws(typeof(ObjectDisposedException), () => { var x = channel.ResolvedTarget; });
             Assert.ThrowsAsync(typeof(TaskCanceledException), async () => await channel.ConnectAsync());
         }
+
+        [Test]
+        public async Task ChannelBaseShutdownAsyncInvokesShutdownAsync()
+        {
+            var channel = new Channel("localhost", ChannelCredentials.Insecure);
+            ChannelBase channelBase = channel;
+            await channelBase.ShutdownAsync();
+            // check that Channel.ShutdownAsync has run
+            Assert.AreEqual(ChannelState.Shutdown, channel.State);
+        }
     }
 }

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -210,18 +210,8 @@ namespace Grpc.Core
             }
         }
 
-        /// <summary>
-        /// Shuts down the channel cleanly. It is strongly recommended to shutdown
-        /// all previously created channels before exiting from the process.
-        /// </summary>
-        /// <remarks>
-        /// This method doesn't wait for all calls on this channel to finish (nor does
-        /// it explicitly cancel all outstanding calls). It is user's responsibility to make sure
-        /// all the calls on this channel have finished (successfully or with an error)
-        /// before shutting down the channel to ensure channel shutdown won't impact
-        /// the outcome of those remote calls.
-        /// </remarks>
-        public new async Task ShutdownAsync()
+        /// <summary>Provides implementation of a non-virtual public member.</summary>
+        protected override async Task ShutdownAsyncCore()
         {
             lock (myLock)
             {
@@ -244,13 +234,6 @@ namespace Grpc.Core
             }
 
             await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false);
-        }
-
-        /// <summary>Provides implementation of a non-virtual public member.</summary>
-        protected override Task ShutdownAsyncCore()
-        {
-            // use the same behavior for ChannelBase.ShutdownAsync as for Channel.Shutdown()
-            return ShutdownAsync();
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -221,7 +221,7 @@ namespace Grpc.Core
         /// before shutting down the channel to ensure channel shutdown won't impact
         /// the outcome of those remote calls.
         /// </remarks>
-        public async Task ShutdownAsync()
+        public new async Task ShutdownAsync()
         {
             lock (myLock)
             {
@@ -244,6 +244,13 @@ namespace Grpc.Core
             }
 
             await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>Provides implementation of a non-virtual public member.</summary>
+        protected override Task ShutdownAsyncCore()
+        {
+            // use the same behavior for ChannelBase.ShutdownAsync as for Channel.Shutdown()
+            return ShutdownAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21612