### PR TITLE
Bump the version of gcc to 4.9

### DIFF
--- a/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
@@ -24,8 +24,8 @@
   <%include file="../../run_tests_addons.include"/>
   <%include file="../../libuv_install.include"/>
 
-  # Install gcc-4.8 and other relevant items
-  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+  # Install gcc-4.9 and other relevant items
+  RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
 
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_jessie_x86/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x86/Dockerfile.template
@@ -24,8 +24,8 @@
   <%include file="../../run_tests_addons.include"/>
   <%include file="../../cmake_jessie_backports.include"/>
 
-  # Install gcc-4.8 and other relevant items
-  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+  # Install gcc-4.9 and other relevant items
+  RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
 
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -89,8 +89,8 @@ RUN mkdir /var/local/jenkins
 # libuv
 RUN cd /tmp     && wget http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz     && tar -xf libuv-v1.9.1.tar.gz     && cd libuv-v1.9.1     && sh autogen.sh && ./configure --prefix=/usr && make && make install
 
-# Install gcc-4.8 and other relevant items
-RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+# Install gcc-4.9 and other relevant items
+RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
@@ -86,8 +86,8 @@ RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt
 RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
 
 
-# Install gcc-4.8 and other relevant items
-RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+# Install gcc-4.9 and other relevant items
+RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -512,8 +512,6 @@ class CLanguage(object):
 
         if compiler == 'gcc4.9' or compiler == 'default':
             return ('jessie', [])
-        elif compiler == 'gcc4.8':
-            return ('jessie', self._gcc_make_options(version_suffix='-4.8'))
         elif compiler == 'gcc5.3':
             return ('ubuntu1604', [])
         elif compiler == 'gcc7.4':
@@ -1455,12 +1453,11 @@ argp.add_argument(
 argp.add_argument(
     '--compiler',
     choices=[
-        'default', 'gcc4.4', 'gcc4.6', 'gcc4.8', 'gcc4.9', 'gcc5.3', 'gcc7.4',
-        'gcc8.3', 'gcc_musl', 'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7',
-        'clang7.0', 'python2.7', 'python3.5', 'python3.6', 'python3.7',
-        'python3.8', 'pypy', 'pypy3', 'python_alpine', 'all_the_cpythons',
-        'electron1.3', 'electron1.6', 'coreclr', 'cmake', 'cmake_vs2015',
-        'cmake_vs2017'
+        'default', 'gcc4.9', 'gcc5.3', 'gcc7.4', 'gcc8.3', 'gcc_musl',
+        'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7', 'clang7.0', 'python2.7',
+        'python3.5', 'python3.6', 'python3.7', 'python3.8', 'pypy', 'pypy3',
+        'python_alpine', 'all_the_cpythons', 'electron1.3', 'electron1.6',
+        'coreclr', 'cmake', 'cmake_vs2015', 'cmake_vs2017'
     ],
     default='default',
     help=

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -308,7 +308,7 @@ def _create_portability_test_jobs(extra_args=[],
 
     # portability C and C++ on x64
     for compiler in [
-            'gcc4.8', 'gcc5.3', 'gcc7.4', 'gcc8.3', 'gcc_musl', 'clang3.5',
+            'gcc4.9', 'gcc5.3', 'gcc7.4', 'gcc8.3', 'gcc_musl', 'clang3.5',
             'clang3.6', 'clang3.7', 'clang7.0'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],


### PR DESCRIPTION
Changed the version of gcc for test from 4.8 to 4.9 since 4.9 will be the minimum gcc version that gRPC supports. This is mainly because gRPC core starts to depend on abseil which supports gcc 4.9 or later ([ref](https://abseil.io/docs/cpp/platforms/platforms)) and grpc.io got this [update](https://github.com/grpc/grpc.io/pull/77) as well.

[grpc_portability_build_only](https://sponge.corp.google.com/invocation?id=6aab2070-e8df-45e5-875f-45fca2c5bacc&searchFor=): passed