### PR TITLE
Clean-up loggers and imports in Cython

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-import grpc
-
 
 _EMPTY_FLAGS = 0
 _EMPTY_MASK = 0

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
 
 cdef class CallbackFailureHandler:
     cdef str _core_function_name

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -17,8 +17,6 @@ import inspect
 import traceback
 
 
-# TODO(https://github.com/grpc/grpc/issues/20850) refactor this.
-_LOGGER = logging.getLogger(__name__)
 cdef int _EMPTY_FLAG = 0
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pyx.pxi
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
 
 cdef class _GrpcArgWrapper:
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
 
 cdef class Call:
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
-import threading
-import time
 
 _INTERNAL_CALL_ERROR_MESSAGE_FORMAT = (
     'Internal gRPC call error %d. ' +

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
-import threading
-import time
 
 cdef int _INTERRUPT_CHECK_PERIOD_MS = 200
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
-import grpc
-import threading
-
 
 def _spawn_callback_in_thread(cb_func, args):
   ForkManagedThread(target=cb_func, args=args).start()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import os
-import threading
-
-_LOGGER = logging.getLogger(__name__)
 
 _AWAIT_THREADS_TIMEOUT_SECONDS = 5
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-import threading
-
 # No-op implementations for Windows.
 
 def fork_handlers_and_grpc_init():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
@@ -13,7 +13,6 @@
 # limitations under the License.
 # distutils: language=c++
 
-cimport cpython
 from libc cimport string
 import errno
 gevent_g = None

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
-_LOGGER = logging.getLogger(__name__)
 
 # This function will ascii encode unicode string inputs if necessary.
 # In Python3, unicode strings are the default str type.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cimport cpython
-
-import logging
-import time
-import grpc
-
-_LOGGER = logging.getLogger(__name__)
-
 
 cdef class Server:
 

--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
@@ -13,6 +13,8 @@
 # limitations under the License.
 # distutils: language=c++
 
+cimport cpython
+
 include "_cygrpc/grpc.pxi"
 
 include "_cygrpc/arguments.pxd.pxi"

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -15,8 +15,14 @@
 
 cimport cpython
 
-import os.path
+import logging
+import os
 import sys
+import threading
+import time
+
+import grpc
+
 try:
     import asyncio
 except ImportError:
@@ -24,6 +30,9 @@ except ImportError:
     # distributed without breaking none compatible Python versions. For now, if
     # Asyncio package is not available we just skip it.
     pass
+
+# The only copy of Python logger for the Cython extension
+_LOGGER = logging.getLogger(__name__)
 
 # TODO(atash): figure out why the coverage tool gets confused about the Cython
 # coverage plugin when the following files don't have a '.pxi' suffix.


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/20850

This PR unified the creation of Python loggers in Cython layer, and cleaned up duplicated imports.