### PR TITLE
Add cmake_pkgconfig_simple

### DIFF
--- a/test/distrib/cpp/run_distrib_test_cmake_module_install_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install_pkgconfig.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+cd "$(dirname "$0")/../../.."
+
+echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
+sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+apt-get update
+apt-get install -t jessie-backports -y libssl-dev pkg-config wget
+
+# Install CMake 3.16
+wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.16.1/cmake-3.16.1-Linux-x86_64.sh
+sh cmake-linux.sh -- --skip-license --prefix=/usr
+rm cmake-linux.sh
+
+# Install gRPC and its dependencies
+mkdir -p "cmake/build"
+pushd "cmake/build"
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DgRPC_INSTALL=ON \
+  -DgRPC_BUILD_TESTS=OFF \
+  -DgRPC_SSL_PROVIDER=package \
+  ../..
+make -j4 install
+popd
+
+# Build helloworld example using make & pkg-config
+cd examples/cpp/helloworld
+export PKG_CONFIG_PATH=/usr/local/grpc/lib/pkgconfig
+export PATH=$PATH:/usr/local/grpc/bin
+make

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -302,6 +302,8 @@ def targets():
         CppDistribTest('linux', 'x64', 'jessie', 'cmake_as_submodule'),
         CppDistribTest('linux', 'x64', 'jessie', 'cmake_fetchcontent'),
         CppDistribTest('linux', 'x64', 'jessie', 'cmake_module_install'),
+        CppDistribTest('linux', 'x64', 'jessie',
+                       'cmake_module_install_pkgconfig'),
         CppDistribTest('linux', 'x64', 'jessie', 'cmake_pkgconfig'),
         CppDistribTest('linux', 'x64', 'jessie', 'raspberry_pi'),
         CppDistribTest('windows', 'x86', testcase='cmake'),


### PR DESCRIPTION
Added the new test to verify if gRPC can be installed without any advanced installation for dependencies and helloworld example can be built with makefile using pkg-config. This is not passing the test without corresponding abseil changes.

Related to the internal b/147766943.