### PR TITLE
Adding mixin classes to make client-side implementation cleaner

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,6 +20,7 @@ dummy-variables-rgx=^ignored_|^unused_
 # be what works for us at the moment (excepting the dead-code-walking Beta
 # API).
 max-args=7
+max-parents=8
 
 [MISCELLANEOUS]
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -32,6 +32,7 @@ cdef class RPCState(GrpcCallWrapper):
 
     cdef bytes method(self)
     cdef tuple invocation_metadata(self)
+    cdef void raise_for_termination(self) except *
 
 
 cdef enum AioServerStatus:

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -520,7 +520,16 @@ _STREAM_OUTPUT_REQUEST_ONE_RESPONSE.response_parameters.append(
     messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
 
 
-class TestStreamStreamCall(_MulticallableTestMixin, AioTestBase):
+class TestStreamStreamCall(AioTestBase):
+
+    async def setUp(self):
+        address, self._server = await start_test_server()
+        self._channel = aio.insecure_channel(address)
+        self._stub = test_pb2_grpc.TestServiceStub(self._channel)
+
+    async def tearDown(self):
+        await self._channel.close()
+        await self._server.stop(None)
 
     async def test_cancel(self):
         # Invokes the actual RPC
@@ -694,5 +703,5 @@ class TestStreamStreamCall(_MulticallableTestMixin, AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)


### PR DESCRIPTION
This is a children PR of https://github.com/grpc/grpc/pull/21681

The logic in `_call.py` has two copies because of the combination. After major semantics are implemented and https://github.com/grpc/grpc/pull/21681, there should not be any additional friction to prevent me merging the logic (or having another major refactor).

The idea is lifting duplicated methods into mixin classes which is self-contained, and managing its own variables.

Also, I have found another segfault point in `server.pyx.pxi` due to a race between the finish of the async iterator and server shutdown.