### PR TITLE
Fix C# distribtests

### DIFF
--- a/test/distrib/csharp/DistribTest/DistribTest.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTest.csproj
@@ -100,8 +100,8 @@
     <Reference Include="Google.Apis.Auth.PlatformServices">
       <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Protobuf, Version=3.7.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.7.0\lib\net45\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Grpc" Version="__GRPC_NUGET_VERSION__" />
     <PackageReference Include="Grpc.Auth" Version="__GRPC_NUGET_VERSION__" />
     <PackageReference Include="Grpc.Tools" Version="__GRPC_NUGET_VERSION__" />
-    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
   </ItemGroup>
   
   <ItemGroup>
@@ -25,6 +25,6 @@
 
   <!-- Needed for the net45 build to work on Unix. See https://github.com/dotnet/designs/pull/33 -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/test/distrib/csharp/DistribTest/packages.config
+++ b/test/distrib/csharp/DistribTest/packages.config
@@ -8,7 +8,7 @@
   <package id="Grpc.Core" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
   <package id="Grpc.Core.Api" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
   <package id="Grpc.Tools" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
-  <package id="Google.Protobuf" version="3.7.0" targetFramework="net45" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net45" />
   <package id="System.Memory" version="4.5.3" targetFramework="net45" />


### PR DESCRIPTION
They started failing after merging https://github.com/grpc/grpc/pull/21590 (and not upgrading the Google.Protobuf version accordingly in C# distribtests).