### PR TITLE
Test this repo against grpc/grpc-node#1239

### DIFF
--- a/tools/run_tests/helper_scripts/run_grpc-node.sh
+++ b/tools/run_tests/helper_scripts/run_grpc-node.sh
@@ -27,4 +27,7 @@ rm -rf ./../grpc-node
 git clone --recursive https://github.com/grpc/grpc-node ./../grpc-node
 cd ./../grpc-node
 
+git fetch --tags --progress https://github.com/grpc/grpc-node.git +refs/pull/*:refs/remotes/origin/pr/*
+git checkout 58ecf72331a39ae1c928802ed4051154b92dedd8
+
 ./test-grpc-submodule.sh "$CURRENT_COMMIT"

--- a/tools/run_tests/helper_scripts/run_grpc-node.sh
+++ b/tools/run_tests/helper_scripts/run_grpc-node.sh
@@ -28,6 +28,6 @@ git clone --recursive https://github.com/grpc/grpc-node ./../grpc-node
 cd ./../grpc-node
 
 git fetch --tags --progress https://github.com/grpc/grpc-node.git +refs/pull/*:refs/remotes/origin/pr/*
-git checkout 58ecf72331a39ae1c928802ed4051154b92dedd8
+git checkout d03444234ce899f567e10bdb99d92e224234a816
 
 ./test-grpc-submodule.sh "$CURRENT_COMMIT"


### PR DESCRIPTION
Background: The Node test jobs in this repo's PRs run [this script](https://github.com/grpc/grpc-node/blob/master/test-grpc-submodule.sh) in the node repository, passing a commit reference for the commit in the PR. That script is missing a `set -e` line and recently the command to check out the submodule commit has been failing because of some changes made to the `third_party/upb`. As a result of that combination of problems, the script has been silently testing the current state of the grpc-node repository, instead of the state corresponding to updating the submodule with the contents of the PR.

This PR runs the Node test job against grpc/grpc-node#1239, which fixes those problems. There are other known integration problems, so the Node test job for this PR will fail initially.