### PR TITLE
Update PGP keys and keyserver for RVM install

### DIFF
--- a/tools/gce/linux_kokoro_performance_worker_init.sh
+++ b/tools/gce/linux_kokoro_performance_worker_init.sh
@@ -140,7 +140,7 @@ tar zxf dotnet_old.tar.gz -C dotnet_old
 sudo cp -r dotnet_old/shared/Microsoft.NETCore.App/1.1.10/ /usr/share/dotnet/shared/Microsoft.NETCore.App/
 
 # Ruby dependencies
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+gpg --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://get.rvm.io | bash -s stable --ruby
 # silence shellcheck as it cannot follow the following `source` path statically:
 # shellcheck disable=SC1090


### PR DESCRIPTION
The [tools/gce/linux_kokoro_performance_worker_init.sh](tools/gce/linux_kokoro_performance_worker_init.sh) executes a script that installs a ruby version manager, RVM.  For security reasons, this script relies on PGP keys from RVM maintainers.

It's execution failed at the installation of RVM, because the key for a new maintainer had not been received. This commit adds GPG key 7D2BAF1CF37B13E2069D6956105BD0E739499BDB for RVM's maintainer "pkuczynski". It results in the successful installation of rvm stable.

The current keyserver, hkp://keys.gnupg.net, is not one of the keyservers listed on https://rvm.io/rvm/security.  When navigating to https://keys.gnupg.net in a browser, the server does not provide a way to search for keys without authenticating and redirecting to a strange domain. This commit also moves the script to use hkp://pgp.mit.edu, a listed keyserver that is maintained by MIT.

