### PR TITLE
Downgrade abseil to Jan 7, 2020

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9051,7 +9051,6 @@ LIBGRPC_ABSEIL_SRC = \
     third_party/abseil-cpp/absl/strings/escaping.cc \
     third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc \
     third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc \
-    third_party/abseil-cpp/absl/strings/internal/escaping.cc \
     third_party/abseil-cpp/absl/strings/internal/memutil.cc \
     third_party/abseil-cpp/absl/strings/internal/ostringstream.cc \
     third_party/abseil-cpp/absl/strings/internal/utf8.cc \
@@ -23461,7 +23460,6 @@ third_party/abseil-cpp/absl/strings/charconv.cc: $(OPENSSL_DEP)
 third_party/abseil-cpp/absl/strings/escaping.cc: $(OPENSSL_DEP)
 third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc: $(OPENSSL_DEP)
 third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc: $(OPENSSL_DEP)
-third_party/abseil-cpp/absl/strings/internal/escaping.cc: $(OPENSSL_DEP)
 third_party/abseil-cpp/absl/strings/internal/memutil.cc: $(OPENSSL_DEP)
 third_party/abseil-cpp/absl/strings/internal/ostringstream.cc: $(OPENSSL_DEP)
 third_party/abseil-cpp/absl/strings/internal/utf8.cc: $(OPENSSL_DEP)

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -195,9 +195,9 @@ def grpc_deps():
     if "com_google_absl" not in native.existing_rules():
         http_archive(
             name = "com_google_absl",
-            sha256 = "939e50c2fbcbd6f1124023350ef9bd5310d413227faf0e11de2a366dcc4e1e48",
-            strip_prefix = "abseil-cpp-a2e6adecc294dc4cd98cc285a9134ce58e0f2ad0",
-            url = "https://github.com/abseil/abseil-cpp/archive/a2e6adecc294dc4cd98cc285a9134ce58e0f2ad0.tar.gz",
+            sha256 = "bc654b90acb782d55b2e2f0779798b1f9a0b06cc7fb3ddc9d30560d898f6d05b",
+            strip_prefix = "abseil-cpp-a048203a881f11f4b7b8df5fb563aec85522f8db",
+            url = "https://github.com/abseil/abseil-cpp/archive/a048203a881f11f4b7b8df5fb563aec85522f8db.tar.gz",
         )
 
     if "bazel_toolchains" not in native.existing_rules():

--- a/config.m4
+++ b/config.m4
@@ -477,7 +477,6 @@ if test "$PHP_GRPC" != "no"; then
     third_party/abseil-cpp/absl/strings/escaping.cc \
     third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc \
     third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc \
-    third_party/abseil-cpp/absl/strings/internal/escaping.cc \
     third_party/abseil-cpp/absl/strings/internal/memutil.cc \
     third_party/abseil-cpp/absl/strings/internal/ostringstream.cc \
     third_party/abseil-cpp/absl/strings/internal/utf8.cc \

--- a/config.w32
+++ b/config.w32
@@ -446,7 +446,6 @@ if (PHP_GRPC != "no") {
     "third_party\\abseil-cpp\\absl\\strings\\escaping.cc " +
     "third_party\\abseil-cpp\\absl\\strings\\internal\\charconv_bigint.cc " +
     "third_party\\abseil-cpp\\absl\\strings\\internal\\charconv_parse.cc " +
-    "third_party\\abseil-cpp\\absl\\strings\\internal\\escaping.cc " +
     "third_party\\abseil-cpp\\absl\\strings\\internal\\memutil.cc " +
     "third_party\\abseil-cpp\\absl\\strings\\internal\\ostringstream.cc " +
     "third_party\\abseil-cpp\\absl\\strings\\internal\\utf8.cc " +

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -936,8 +936,6 @@ Gem::Specification.new do |s|
   s.files += %w( third_party/abseil-cpp/absl/strings/internal/charconv_bigint.h )
   s.files += %w( third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc )
   s.files += %w( third_party/abseil-cpp/absl/strings/internal/charconv_parse.h )
-  s.files += %w( third_party/abseil-cpp/absl/strings/internal/escaping.cc )
-  s.files += %w( third_party/abseil-cpp/absl/strings/internal/escaping.h )
   s.files += %w( third_party/abseil-cpp/absl/strings/internal/memutil.cc )
   s.files += %w( third_party/abseil-cpp/absl/strings/internal/memutil.h )
   s.files += %w( third_party/abseil-cpp/absl/strings/internal/ostringstream.cc )

--- a/package.xml
+++ b/package.xml
@@ -941,8 +941,6 @@
     <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/charconv_bigint.h" role="src" />
     <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc" role="src" />
     <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/charconv_parse.h" role="src" />
-    <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/escaping.cc" role="src" />
-    <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/escaping.h" role="src" />
     <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/memutil.cc" role="src" />
     <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/memutil.h" role="src" />
     <file baseinstalldir="/" name="third_party/abseil-cpp/absl/strings/internal/ostringstream.cc" role="src" />

--- a/src/abseil-cpp/preprocessed_builds.yaml
+++ b/src/abseil-cpp/preprocessed_builds.yaml
@@ -516,7 +516,6 @@
   - third_party/abseil-cpp/absl/debugging/symbolize.cc
 - cmake_target: absl::flags_config
   deps:
-  - absl/base:config
   - absl/base:core_headers
   - absl/flags:path_util
   - absl/flags:program_name
@@ -531,13 +530,12 @@
 - cmake_target: absl::flags
   deps:
   - absl/base:base
-  - absl/base:config
   - absl/base:core_headers
   - absl/flags:config
   - absl/flags:flag_internal
   - absl/flags:handle
   - absl/flags:marshalling
-  - absl/flags:registry
+  - absl/memory:memory
   - absl/strings:strings
   headers:
   - third_party/abseil-cpp/absl/flags/declare.h
@@ -547,7 +545,6 @@
   - third_party/abseil-cpp/absl/flags/flag.cc
 - cmake_target: absl::flags_internal
   deps:
-  - absl/base:config
   - absl/base:core_headers
   - absl/flags:config
   - absl/flags:handle
@@ -562,10 +559,9 @@
   - third_party/abseil-cpp/absl/flags/internal/flag.cc
 - cmake_target: absl::flags_handle
   deps:
-  - absl/base:config
   - absl/base:core_headers
+  - absl/flags:config
   - absl/flags:marshalling
-  - absl/strings:strings
   - absl/types:optional
   headers:
   - third_party/abseil-cpp/absl/flags/internal/commandlineflag.h
@@ -573,9 +569,7 @@
   src: []
 - cmake_target: absl::flags_marshalling
   deps:
-  - absl/base:config
   - absl/base:core_headers
-  - absl/base:log_severity
   - absl/strings:str_format
   - absl/strings:strings
   headers:
@@ -585,12 +579,8 @@
   - third_party/abseil-cpp/absl/flags/marshalling.cc
 - cmake_target: absl::flags_parse
   deps:
-  - absl/base:config
-  - absl/base:core_headers
   - absl/flags:config
   - absl/flags:flag
-  - absl/flags:flag_internal
-  - absl/flags:handle
   - absl/flags:program_name
   - absl/flags:registry
   - absl/flags:usage
@@ -605,7 +595,6 @@
   - third_party/abseil-cpp/absl/flags/parse.cc
 - cmake_target: absl::flags_path_util
   deps:
-  - absl/base:config
   - absl/strings:strings
   headers:
   - third_party/abseil-cpp/absl/flags/internal/path_util.h
@@ -613,8 +602,6 @@
   src: []
 - cmake_target: absl::flags_program_name
   deps:
-  - absl/base:config
-  - absl/base:core_headers
   - absl/flags:path_util
   - absl/strings:strings
   - absl/synchronization:synchronization
@@ -625,8 +612,8 @@
   - third_party/abseil-cpp/absl/flags/internal/program_name.cc
 - cmake_target: absl::flags_registry
   deps:
-  - absl/base:config
   - absl/base:core_headers
+  - absl/base:dynamic_annotations
   - absl/base:raw_logging_internal
   - absl/flags:config
   - absl/flags:handle
@@ -641,8 +628,6 @@
   - third_party/abseil-cpp/absl/flags/internal/type_erased.cc
 - cmake_target: absl::flags_usage
   deps:
-  - absl/base:config
-  - absl/base:core_headers
   - absl/flags:usage_internal
   - absl/strings:strings
   - absl/synchronization:synchronization
@@ -653,16 +638,13 @@
   - third_party/abseil-cpp/absl/flags/usage.cc
 - cmake_target: absl::flags_usage_internal
   deps:
-  - absl/base:config
-  - absl/base:core_headers
   - absl/flags:config
   - absl/flags:flag
-  - absl/flags:flag_internal
   - absl/flags:handle
   - absl/flags:path_util
   - absl/flags:program_name
-  - absl/flags:registry
   - absl/strings:strings
+  - absl/synchronization:synchronization
   headers:
   - third_party/abseil-cpp/absl/flags/internal/usage.h
   name: absl/flags:usage_internal
@@ -796,7 +778,6 @@
 - cmake_target: absl::random_internal_mocking_bit_gen_base
   deps:
   - absl/random:random
-  - absl/strings:strings
   headers:
   - third_party/abseil-cpp/absl/random/internal/mocking_bit_gen_base.h
   name: absl/random/internal:mocking_bit_gen_base
@@ -992,7 +973,6 @@
   - third_party/abseil-cpp/absl/random/bernoulli_distribution.h
   - third_party/abseil-cpp/absl/random/beta_distribution.h
   - third_party/abseil-cpp/absl/random/discrete_distribution.h
-  - third_party/abseil-cpp/absl/random/distribution_format_traits.h
   - third_party/abseil-cpp/absl/random/distributions.h
   - third_party/abseil-cpp/absl/random/exponential_distribution.h
   - third_party/abseil-cpp/absl/random/gaussian_distribution.h
@@ -1104,7 +1084,6 @@
   - third_party/abseil-cpp/absl/strings/escaping.h
   - third_party/abseil-cpp/absl/strings/internal/charconv_bigint.h
   - third_party/abseil-cpp/absl/strings/internal/charconv_parse.h
-  - third_party/abseil-cpp/absl/strings/internal/escaping.h
   - third_party/abseil-cpp/absl/strings/internal/memutil.h
   - third_party/abseil-cpp/absl/strings/internal/stl_type_traits.h
   - third_party/abseil-cpp/absl/strings/internal/str_join_internal.h
@@ -1125,7 +1104,6 @@
   - third_party/abseil-cpp/absl/strings/escaping.cc
   - third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc
   - third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc
-  - third_party/abseil-cpp/absl/strings/internal/escaping.cc
   - third_party/abseil-cpp/absl/strings/internal/memutil.cc
   - third_party/abseil-cpp/absl/strings/match.cc
   - third_party/abseil-cpp/absl/strings/numbers.cc

--- a/src/python/grpcio/grpc_core_dependencies.py
+++ b/src/python/grpcio/grpc_core_dependencies.py
@@ -445,7 +445,6 @@ CORE_SOURCE_FILES = [
     'third_party/abseil-cpp/absl/strings/escaping.cc',
     'third_party/abseil-cpp/absl/strings/internal/charconv_bigint.cc',
     'third_party/abseil-cpp/absl/strings/internal/charconv_parse.cc',
-    'third_party/abseil-cpp/absl/strings/internal/escaping.cc',
     'third_party/abseil-cpp/absl/strings/internal/memutil.cc',
     'third_party/abseil-cpp/absl/strings/internal/ostringstream.cc',
     'third_party/abseil-cpp/absl/strings/internal/utf8.cc',

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -26,7 +26,7 @@ want_submodules=$(mktemp /tmp/submXXXXXX)
 
 git submodule | awk '{ print $1 }' | sort > "$submodules"
 cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
- a2e6adecc294dc4cd98cc285a9134ce58e0f2ad0 third_party/abseil-cpp (heads/master)
+ a048203a881f11f4b7b8df5fb563aec85522f8db third_party/abseil-cpp (heads/master)
  090faecb454fbd6e6e17a75ef8146acb037118d4 third_party/benchmark (v1.5.0)
  73594cde8c9a52a102c4341c244c833aa61b9c06 third_party/bloaty (remotes/origin/wide-14-g73594cd)
  7f02881e96e51f1873afcf384d02f782b48967ca third_party/boringssl (remotes/origin/HEAD)


### PR DESCRIPTION
Downgrade abseil to `Jan 7, 2020` to avoid the issue for having two `escape.cc` in two different directories. Having the multiple files with the same basename may cause a problem with gyp for node.js.

Related to #21702