### PR TITLE
[Aio] Fixing a segfault in the shutdown path

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -32,6 +32,7 @@ cdef class RPCState(GrpcCallWrapper):
 
     cdef bytes method(self)
     cdef tuple invocation_metadata(self)
+    cdef void raise_for_termination(self) except *
 
 
 cdef enum AioServerStatus:

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -434,6 +434,7 @@ class TestServer(AioTestBase):
         # Don't segfault here
         self.assertEqual(grpc.StatusCode.UNKNOWN, await call.code())
 
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -37,6 +37,7 @@ _STREAM_STREAM_ASYNC_GEN = '/test/StreamStreamAsyncGen'
 _STREAM_STREAM_READER_WRITER = '/test/StreamStreamReaderWriter'
 _STREAM_STREAM_EVILLY_MIXED = '/test/StreamStreamEvillyMixed'
 _UNIMPLEMENTED_METHOD = '/test/UnimplementedMethod'
+_ERROR_IN_STREAM_STREAM = '/test/ErrorInStreamStream'
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x01\x01\x01'
@@ -82,6 +83,9 @@ class _GenericHandler(grpc.GenericRpcHandler):
             _STREAM_STREAM_EVILLY_MIXED:
                 grpc.stream_stream_rpc_method_handler(
                     self._stream_stream_evilly_mixed),
+            _ERROR_IN_STREAM_STREAM:
+                grpc.stream_stream_rpc_method_handler(
+                    self._error_in_stream_stream),
         }
 
     @staticmethod
@@ -157,6 +161,12 @@ class _GenericHandler(grpc.GenericRpcHandler):
         yield _RESPONSE
         for _ in range(_NUM_STREAM_RESPONSES - 1):
             await context.write(_RESPONSE)
+
+    async def _error_in_stream_stream(self, request_iterator, unused_context):
+        async for request in request_iterator:
+            assert _REQUEST == request
+            raise RuntimeError('A testing RuntimeError!')
+        yield _RESPONSE
 
     def service(self, handler_details):
         self._called.set_result(None)
@@ -401,6 +411,28 @@ class TestServer(AioTestBase):
         rpc_error = exception_context.exception
         self.assertEqual(grpc.StatusCode.UNIMPLEMENTED, rpc_error.code())
 
+    async def test_shutdown_during_stream_stream(self):
+        stream_stream_call = self._channel.stream_stream(
+            _STREAM_STREAM_ASYNC_GEN)
+        call = stream_stream_call()
+
+        # Don't half close the RPC yet, keep it alive.
+        await call.write(_REQUEST)
+        await self._server.stop(None)
+
+        self.assertEqual(grpc.StatusCode.UNAVAILABLE, await call.code())
+        # No segfault
+
+    async def test_error_in_stream_stream(self):
+        stream_stream_call = self._channel.stream_stream(
+            _ERROR_IN_STREAM_STREAM)
+        call = stream_stream_call()
+
+        # Don't half close the RPC yet, keep it alive.
+        await call.write(_REQUEST)
+
+        # Don't segfault here
+        self.assertEqual(grpc.StatusCode.UNKNOWN, await call.code())
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
This PR fixes another segfault point in `server.pyx.pxi` due to a race between the finish of the async iterator and server shutdown. I originally wanted to include this in https://github.com/grpc/grpc/pull/21689. However, since the major refactor https://github.com/grpc/grpc/pull/21696 is going on, I'm splitting this fix out.