### PR TITLE
Create a standalone target for insecure channel credential library (DO NOT SUBMIT)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1958,6 +1958,38 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "local_credentials",
+    srcs = [
+        "src/core/lib/security/credentials/local/local_credentials.cc",
+        "src/core/lib/security/security_connector/local/local_security_connector.cc",
+        "src/core/lib/security/credentials/credentials.cc",
+        "src/core/lib/security/security_connector/security_connector.cc",
+        "src/core/lib/security/context/security_context.cc",
+        "src/core/lib/security/transport/secure_endpoint.cc",
+        "src/core/lib/security/transport/security_handshaker.cc",
+        "src/core/lib/security/transport/tsi_error.cc",
+        "src/core/lib/security/security_connector/load_system_roots_fallback.cc",
+        "src/core/lib/security/security_connector/load_system_roots_linux.cc",
+    ],
+    hdrs = [
+        "src/core/lib/security/credentials/local/local_credentials.h",
+        "src/core/lib/security/security_connector/local/local_security_connector.h",
+        "src/core/lib/security/credentials/credentials.h",
+        "src/core/lib/security/security_connector/security_connector.h",
+        "src/core/lib/security/context/security_context.h",
+        "src/core/lib/security/transport/secure_endpoint.h",
+        "src/core/lib/security/transport/security_handshaker.h",
+        "src/core/lib/security/transport/tsi_error.h",
+        "src/core/lib/security/security_connector/load_system_roots.h",
+        "src/core/lib/security/security_connector/load_system_roots_linux.h",
+    ],
+    language = "c++",
+    deps = [
+        "tsi",
+    ],
+)
+
+grpc_cc_library(
     name = "alts_frame_protector",
     srcs = [
         "src/core/tsi/alts/crypt/aes_gcm.cc",

--- a/build.yaml
+++ b/build.yaml
@@ -1622,6 +1622,31 @@ filegroups:
 - name: grpcpp_channelz_proto
   src:
   - src/proto/grpc/channelz/channelz.proto
+- name: local_credentials
+  headers:
+  - src/core/lib/security/context/security_context.h
+  - src/core/lib/security/credentials/credentials.h
+  - src/core/lib/security/credentials/local/local_credentials.h
+  - src/core/lib/security/security_connector/load_system_roots.h
+  - src/core/lib/security/security_connector/load_system_roots_linux.h
+  - src/core/lib/security/security_connector/local/local_security_connector.h
+  - src/core/lib/security/security_connector/security_connector.h
+  - src/core/lib/security/transport/secure_endpoint.h
+  - src/core/lib/security/transport/security_handshaker.h
+  - src/core/lib/security/transport/tsi_error.h
+  src:
+  - src/core/lib/security/context/security_context.cc
+  - src/core/lib/security/credentials/credentials.cc
+  - src/core/lib/security/credentials/local/local_credentials.cc
+  - src/core/lib/security/security_connector/load_system_roots_fallback.cc
+  - src/core/lib/security/security_connector/load_system_roots_linux.cc
+  - src/core/lib/security/security_connector/local/local_security_connector.cc
+  - src/core/lib/security/security_connector/security_connector.cc
+  - src/core/lib/security/transport/secure_endpoint.cc
+  - src/core/lib/security/transport/security_handshaker.cc
+  - src/core/lib/security/transport/tsi_error.cc
+  uses:
+  - tsi
 - name: proto_gen_validate_upb
   headers:
   - src/core/ext/upb-generated/gogoproto/gogo.upb.h


### PR DESCRIPTION
New version of insecure credentials will be very much similar to the current local credentials.