### PR TITLE
Stop using core server shutdown in microbenchmarks

### DIFF
--- a/test/cpp/microbenchmarks/fullstack_fixtures.h
+++ b/test/cpp/microbenchmarks/fullstack_fixtures.h
@@ -62,15 +62,6 @@ class FixtureConfiguration {
 
 class BaseFixture : public TrackCounters {};
 
-// Special tag to be used in Server shutdown. This tag is *NEVER* returned when
-// Cq->Next() API is called (This is because FinalizeResult() function in this
-// class always returns 'false'). This is intentional and makes writing shutdown
-// code easier.
-class ShutdownTag : public internal::CompletionQueueTag {
- public:
-  bool FinalizeResult(void** /*tag*/, bool* /*status*/) { return false; }
-};
-
 class FullstackFixture : public BaseFixture {
  public:
   FullstackFixture(Service* service, const FixtureConfiguration& config,
@@ -94,11 +85,7 @@ class FullstackFixture : public BaseFixture {
   }
 
   virtual ~FullstackFixture() {
-    // Dummy shutdown tag (this tag is swallowed by cq->Next() and is not
-    // returned to the user) see ShutdownTag definition for more details
-    ShutdownTag shutdown_tag;
-    grpc_server_shutdown_and_notify(server_->c_server(), cq_->cq(),
-                                    &shutdown_tag);
+    server_->Shutdown();
     cq_->Shutdown();
     void* tag;
     bool ok;
@@ -226,11 +213,7 @@ class EndpointPairFixture : public BaseFixture {
   }
 
   virtual ~EndpointPairFixture() {
-    // Dummy shutdown tag (this tag is swallowed by cq->Next() and is not
-    // returned to the user) see ShutdownTag definition for more details
-    ShutdownTag shutdown_tag;
-    grpc_server_shutdown_and_notify(server_->c_server(), cq_->cq(),
-                                    &shutdown_tag);
+    server_->Shutdown();
     cq_->Shutdown();
     void* tag;
     bool ok;


### PR DESCRIPTION
#21724 was exposed by a weirdness in the C++ microbenchmarks: they directly shutdown the C core server rather than using the C++ server. I don't see any reason for this, and it makes no sense overall (and conflicts with our debugging efforts in #21680). So, fixing this.
