### PR TITLE
Do not mutate the input signal strings

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -392,7 +392,7 @@ module GRPC
       signals.each do |sig|
         # input validation
         if sig.class == String
-          sig.upcase!
+          sig = sig.upcase
           if sig.start_with?('SIG')
             # cut out the SIG prefix to see if valid signal
             sig = sig[3..-1]


### PR DESCRIPTION
When specifying the signals to use to the `run_till_terminated_or_interrupted` method as an array of frozen string literals, the `run_till_terminated_or_interrupted` method attempts to mutate those strings which is unexpected behavior for a library.

e.g.

```
# frozen_string_literal: true

server.run_till_terminated_or_interrupted(%w[SIGTERM SIGINT SIGQUIT])
```

This PR changes this behavior to instead make a copy of the modified string to prevent issues with passing in a frozen string.