### PR TITLE
Revert "Update security level of local TCP connection"

### DIFF
--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -120,10 +120,9 @@ void local_check_peer(grpc_security_connector* sc, tsi_peer peer,
   }
   if (peer.properties != nullptr) gpr_free(peer.properties);
   peer.properties = new_properties;
+  // TODO(yihuazhang): Set security level of local TCP to TSI_SECURITY_NONE.
   const char* security_level =
-      type == LOCAL_TCP
-          ? tsi_security_level_to_string(TSI_SECURITY_NONE)
-          : tsi_security_level_to_string(TSI_PRIVACY_AND_INTEGRITY);
+      tsi_security_level_to_string(TSI_PRIVACY_AND_INTEGRITY);
   tsi_result result = tsi_construct_string_peer_property_from_cstring(
       TSI_SECURITY_LEVEL_PEER_PROPERTY, security_level,
       &peer.properties[peer.property_count]);

--- a/test/core/end2end/fixtures/h2_local_ipv4.cc
+++ b/test/core/end2end/fixtures/h2_local_ipv4.cc
@@ -54,7 +54,7 @@ static grpc_end2end_test_config configs[] = {
      FEATURE_MASK_SUPPORTS_DELAYED_CONNECTION |
          FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
          FEATURE_MASK_SUPPORTS_AUTHORITY_HEADER |
-         FEATURE_MASK_DOES_NOT_SUPPORT_SEND_CALL_CREDENTIALS,
+         FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS,
      nullptr, chttp2_create_fixture_fullstack_ipv4,
      chttp2_init_client_fullstack_ipv4, chttp2_init_server_fullstack_ipv4,
      grpc_end2end_local_chttp2_tear_down_fullstack}};

--- a/test/core/end2end/fixtures/h2_local_ipv6.cc
+++ b/test/core/end2end/fixtures/h2_local_ipv6.cc
@@ -54,7 +54,7 @@ static grpc_end2end_test_config configs[] = {
      FEATURE_MASK_SUPPORTS_DELAYED_CONNECTION |
          FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
          FEATURE_MASK_SUPPORTS_AUTHORITY_HEADER |
-         FEATURE_MASK_DOES_NOT_SUPPORT_SEND_CALL_CREDENTIALS,
+         FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS,
      nullptr, chttp2_create_fixture_fullstack_ipv6,
      chttp2_init_client_fullstack_ipv6, chttp2_init_server_fullstack_ipv6,
      grpc_end2end_local_chttp2_tear_down_fullstack}};


### PR DESCRIPTION
Reverts grpc/grpc#21640

This PR unfortunately breaks an internal test. Reverting to continue the import process

CC @yashykt 