### PR TITLE
Fix build in c++2a mode

### DIFF
--- a/src/core/lib/gprpp/atomic.h
+++ b/src/core/lib/gprpp/atomic.h
@@ -28,12 +28,12 @@
 namespace grpc_core {
 
 enum class MemoryOrder {
-  RELAXED = (int)std::memory_order_relaxed,
-  CONSUME = (int)std::memory_order_consume,
-  ACQUIRE = (int)std::memory_order_acquire,
-  RELEASE = (int)std::memory_order_release,
-  ACQ_REL = (int)std::memory_order_acq_rel,
-  SEQ_CST = (int)std::memory_order_seq_cst
+  RELAXED = static_cast<int>(std::memory_order_relaxed),
+  CONSUME = static_cast<int>(std::memory_order_consume),
+  ACQUIRE = static_cast<int>(std::memory_order_acquire),
+  RELEASE = static_cast<int>(std::memory_order_release),
+  ACQ_REL = static_cast<int>(std::memory_order_acq_rel),
+  SEQ_CST = static_cast<int>(std::memory_order_seq_cst)
 };
 
 template <typename T>

--- a/src/core/lib/gprpp/atomic.h
+++ b/src/core/lib/gprpp/atomic.h
@@ -28,12 +28,12 @@
 namespace grpc_core {
 
 enum class MemoryOrder {
-  RELAXED = std::memory_order_relaxed,
-  CONSUME = std::memory_order_consume,
-  ACQUIRE = std::memory_order_acquire,
-  RELEASE = std::memory_order_release,
-  ACQ_REL = std::memory_order_acq_rel,
-  SEQ_CST = std::memory_order_seq_cst
+  RELAXED = (int)std::memory_order_relaxed,
+  CONSUME = (int)std::memory_order_consume,
+  ACQUIRE = (int)std::memory_order_acquire,
+  RELEASE = (int)std::memory_order_release,
+  ACQ_REL = (int)std::memory_order_acq_rel,
+  SEQ_CST = (int)std::memory_order_seq_cst
 };
 
 template <typename T>


### PR DESCRIPTION
std::memory_order (is planned to) change to a scoped enum in c++20,
breaking the MemoryOrder decl. Casting the members to an int fixes
the build in c++20, and keeps the same behaviour in earlier versions.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
