### PR TITLE
[v1.27.x Patch] Double the time limit for linux extra artifacts build

### DIFF
--- a/tools/internal_ci/linux/grpc_build_artifacts_extra.cfg
+++ b/tools/internal_ci/linux/grpc_build_artifacts_extra.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_artifacts_extra.sh"
-timeout_mins: 240
+timeout_mins: 480
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_build_artifacts_extra_release.cfg
+++ b/tools/internal_ci/linux/grpc_build_artifacts_extra_release.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_artifacts_extra.sh"
-timeout_mins: 240
+timeout_mins: 480
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21753

This PR patches the time out into `v1.27.x` branch.