### PR TITLE
Clean up grpc_core::MakeUnique

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1594,7 +1594,8 @@ void ChannelData::CreateResolvingLoadBalancingPolicyLocked() {
   // Instantiate resolving LB policy.
   LoadBalancingPolicy::Args lb_args;
   lb_args.combiner = combiner_;
-  lb_args.channel_control_helper = MakeUnique<ClientChannelControlHelper>(this);
+  lb_args.channel_control_helper =
+      grpc_core::MakeUnique<ClientChannelControlHelper>(this);
   lb_args.args = channel_args_;
   grpc_core::UniquePtr<char> target_uri(gpr_strdup(target_uri_.get()));
   resolving_lb_policy_.reset(new ResolvingLoadBalancingPolicy(
@@ -1870,7 +1871,7 @@ void ChannelData::StartTransportOpLocked(void* arg, grpc_error* /*ignored*/) {
                                      MemoryOrder::RELEASE);
       chand->UpdateStateAndPickerLocked(
           GRPC_CHANNEL_SHUTDOWN, "shutdown from API",
-          MakeUnique<LoadBalancingPolicy::TransientFailurePicker>(
+          grpc_core::MakeUnique<LoadBalancingPolicy::TransientFailurePicker>(
               GRPC_ERROR_REF(op->disconnect_with_error)));
     }
   }

--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -385,5 +385,5 @@ void grpc_http_connect_register_handshaker_factory() {
   using namespace grpc_core;
   HandshakerRegistry::RegisterHandshakerFactory(
       true /* at_start */, HANDSHAKER_CLIENT,
-      MakeUnique<HttpConnectHandshakerFactory>());
+      grpc_core::MakeUnique<HttpConnectHandshakerFactory>());
 }

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -715,8 +715,9 @@ void GrpcLb::Helper::UpdateState(grpc_connectivity_state state,
     client_stats = parent_->lb_calld_->client_stats()->Ref();
   }
   parent_->channel_control_helper()->UpdateState(
-      state, MakeUnique<Picker>(parent_.get(), parent_->serverlist_,
-                                std::move(picker), std::move(client_stats)));
+      state, grpc_core::MakeUnique<Picker>(parent_.get(), parent_->serverlist_,
+                                           std::move(picker),
+                                           std::move(client_stats)));
 }
 
 void GrpcLb::Helper::RequestReresolution() {

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -201,7 +201,7 @@ void PickFirst::AttemptToConnectUsingLatestUpdateArgsLocked() {
                            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
     channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE,
-        MakeUnique<TransientFailurePicker>(error));
+        grpc_core::MakeUnique<TransientFailurePicker>(error));
     return;
   }
   // If one of the subchannels in the new list is already in state
@@ -319,11 +319,11 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
             GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
         p->channel_control_helper()->UpdateState(
             GRPC_CHANNEL_TRANSIENT_FAILURE,
-            MakeUnique<TransientFailurePicker>(error));
+            grpc_core::MakeUnique<TransientFailurePicker>(error));
       } else {
         p->channel_control_helper()->UpdateState(
-            GRPC_CHANNEL_CONNECTING,
-            MakeUnique<QueuePicker>(p->Ref(DEBUG_LOCATION, "QueuePicker")));
+            GRPC_CHANNEL_CONNECTING, grpc_core::MakeUnique<QueuePicker>(p->Ref(
+                                         DEBUG_LOCATION, "QueuePicker")));
       }
     } else {
       if (connectivity_state == GRPC_CHANNEL_TRANSIENT_FAILURE) {
@@ -338,19 +338,20 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
         p->selected_ = nullptr;
         p->subchannel_list_.reset();
         p->channel_control_helper()->UpdateState(
-            GRPC_CHANNEL_IDLE,
-            MakeUnique<QueuePicker>(p->Ref(DEBUG_LOCATION, "QueuePicker")));
+            GRPC_CHANNEL_IDLE, grpc_core::MakeUnique<QueuePicker>(
+                                   p->Ref(DEBUG_LOCATION, "QueuePicker")));
       } else {
         // This is unlikely but can happen when a subchannel has been asked
         // to reconnect by a different channel and this channel has dropped
         // some connectivity state notifications.
         if (connectivity_state == GRPC_CHANNEL_READY) {
           p->channel_control_helper()->UpdateState(
-              GRPC_CHANNEL_READY, MakeUnique<Picker>(subchannel()->Ref()));
+              GRPC_CHANNEL_READY,
+              grpc_core::MakeUnique<Picker>(subchannel()->Ref()));
         } else {  // CONNECTING
           p->channel_control_helper()->UpdateState(
-              connectivity_state,
-              MakeUnique<QueuePicker>(p->Ref(DEBUG_LOCATION, "QueuePicker")));
+              connectivity_state, grpc_core::MakeUnique<QueuePicker>(
+                                      p->Ref(DEBUG_LOCATION, "QueuePicker")));
         }
       }
     }
@@ -394,7 +395,7 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
               GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
           p->channel_control_helper()->UpdateState(
               GRPC_CHANNEL_TRANSIENT_FAILURE,
-              MakeUnique<TransientFailurePicker>(error));
+              grpc_core::MakeUnique<TransientFailurePicker>(error));
         }
       }
       sd->CheckConnectivityStateAndStartWatchingLocked();
@@ -405,8 +406,8 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
       // Only update connectivity state in case 1.
       if (subchannel_list() == p->subchannel_list_.get()) {
         p->channel_control_helper()->UpdateState(
-            GRPC_CHANNEL_CONNECTING,
-            MakeUnique<QueuePicker>(p->Ref(DEBUG_LOCATION, "QueuePicker")));
+            GRPC_CHANNEL_CONNECTING, grpc_core::MakeUnique<QueuePicker>(p->Ref(
+                                         DEBUG_LOCATION, "QueuePicker")));
       }
       break;
     }
@@ -445,7 +446,7 @@ void PickFirst::PickFirstSubchannelData::ProcessUnselectedReadyLocked() {
   }
   p->selected_ = this;
   p->channel_control_helper()->UpdateState(
-      GRPC_CHANNEL_READY, MakeUnique<Picker>(subchannel()->Ref()));
+      GRPC_CHANNEL_READY, grpc_core::MakeUnique<Picker>(subchannel()->Ref()));
   for (size_t i = 0; i < subchannel_list()->num_subchannels(); ++i) {
     if (i != Index()) {
       subchannel_list()->subchannel(i)->ShutdownLocked();

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -321,13 +321,13 @@ void RoundRobin::RoundRobinSubchannelList::
    */
   if (num_ready_ > 0) {
     /* 1) READY */
-    p->channel_control_helper()->UpdateState(GRPC_CHANNEL_READY,
-                                             MakeUnique<Picker>(p, this));
+    p->channel_control_helper()->UpdateState(
+        GRPC_CHANNEL_READY, grpc_core::MakeUnique<Picker>(p, this));
   } else if (num_connecting_ > 0) {
     /* 2) CONNECTING */
     p->channel_control_helper()->UpdateState(
-        GRPC_CHANNEL_CONNECTING,
-        MakeUnique<QueuePicker>(p->Ref(DEBUG_LOCATION, "QueuePicker")));
+        GRPC_CHANNEL_CONNECTING, grpc_core::MakeUnique<QueuePicker>(
+                                     p->Ref(DEBUG_LOCATION, "QueuePicker")));
   } else if (num_transient_failure_ == num_subchannels()) {
     /* 3) TRANSIENT_FAILURE */
     grpc_error* error =
@@ -336,7 +336,7 @@ void RoundRobin::RoundRobinSubchannelList::
                            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
     p->channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE,
-        MakeUnique<TransientFailurePicker>(error));
+        grpc_core::MakeUnique<TransientFailurePicker>(error));
   }
 }
 
@@ -453,7 +453,7 @@ void RoundRobin::UpdateLocked(UpdateArgs args) {
                            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
     channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE,
-        MakeUnique<TransientFailurePicker>(error));
+        grpc_core::MakeUnique<TransientFailurePicker>(error));
     subchannel_list_ = std::move(latest_pending_subchannel_list_);
   } else if (subchannel_list_ == nullptr) {
     // If there is no current list, immediately promote the new list to

--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -162,7 +162,7 @@ void CdsLb::ClusterWatcher::OnClusterChanged(CdsUpdate cluster_data) {
     LoadBalancingPolicy::Args args;
     args.combiner = parent_->combiner();
     args.args = parent_->args_;
-    args.channel_control_helper = MakeUnique<Helper>(parent_->Ref());
+    args.channel_control_helper = grpc_core::MakeUnique<Helper>(parent_->Ref());
     parent_->child_policy_ =
         LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
             "xds_experimental", std::move(args));
@@ -186,7 +186,7 @@ void CdsLb::ClusterWatcher::OnError(grpc_error* error) {
   if (parent_->child_policy_ == nullptr) {
     parent_->channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE,
-        MakeUnique<TransientFailurePicker>(error));
+        grpc_core::MakeUnique<TransientFailurePicker>(error));
   } else {
     GRPC_ERROR_UNREF(error);
   }
@@ -287,7 +287,7 @@ void CdsLb::UpdateLocked(UpdateArgs args) {
       xds_client_->CancelClusterDataWatch(StringView(old_config->cluster()),
                                           cluster_watcher_);
     }
-    auto watcher = MakeUnique<ClusterWatcher>(Ref());
+    auto watcher = grpc_core::MakeUnique<ClusterWatcher>(Ref());
     cluster_watcher_ = watcher.get();
     xds_client_->WatchClusterData(StringView(config_->cluster()),
                                   std::move(watcher));

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -834,8 +834,8 @@ void XdsLb::UpdateLocked(UpdateArgs args) {
       xds_client()->CancelEndpointDataWatch(StringView(old_eds_service_name),
                                             endpoint_watcher_);
     }
-    auto watcher =
-        MakeUnique<EndpointWatcher>(Ref(DEBUG_LOCATION, "EndpointWatcher"));
+    auto watcher = grpc_core::MakeUnique<EndpointWatcher>(
+        Ref(DEBUG_LOCATION, "EndpointWatcher"));
     endpoint_watcher_ = watcher.get();
     xds_client()->WatchEndpointData(StringView(eds_service_name()),
                                     std::move(watcher));
@@ -1092,7 +1092,7 @@ void XdsLb::PriorityList::UpdateXdsPickerLocked() {
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
     xds_policy_->channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE,
-        MakeUnique<TransientFailurePicker>(error));
+        grpc_core::MakeUnique<TransientFailurePicker>(error));
     return;
   }
   priorities_[current_priority_]->UpdateXdsPickerLocked();
@@ -1183,8 +1183,9 @@ XdsLb::PriorityList::LocalityMap::LocalityMap(RefCountedPtr<XdsLb> xds_policy,
   // This is the first locality map ever created, report CONNECTING.
   if (priority_ == 0) {
     xds_policy_->channel_control_helper()->UpdateState(
-        GRPC_CHANNEL_CONNECTING, MakeUnique<QueuePicker>(xds_policy_->Ref(
-                                     DEBUG_LOCATION, "QueuePicker")));
+        GRPC_CHANNEL_CONNECTING,
+        grpc_core::MakeUnique<QueuePicker>(
+            xds_policy_->Ref(DEBUG_LOCATION, "QueuePicker")));
   }
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
@@ -173,7 +173,7 @@ class GrpcPolledFdFactoryLibuv : public GrpcPolledFdFactory {
 
 std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(
     Combiner* combiner) {
-  return MakeUnique<GrpcPolledFdFactoryLibuv>();
+  return grpc_core::MakeUnique<GrpcPolledFdFactoryLibuv>();
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -99,7 +99,7 @@ class GrpcPolledFdFactoryPosix : public GrpcPolledFdFactory {
 
 std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(
     Combiner* /*combiner*/) {
-  return MakeUnique<GrpcPolledFdFactoryPosix>();
+  return grpc_core::MakeUnique<GrpcPolledFdFactoryPosix>();
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -934,7 +934,7 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
 
 std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(
     Combiner* combiner) {
-  return MakeUnique<GrpcPolledFdFactoryWindows>(combiner);
+  return grpc_core::MakeUnique<GrpcPolledFdFactoryWindows>(combiner);
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -89,7 +89,7 @@ void XdsResolver::StartLocked() {
   grpc_error* error = GRPC_ERROR_NONE;
   xds_client_ = MakeOrphanable<XdsClient>(
       combiner(), interested_parties_, StringView(server_name_.get()),
-      MakeUnique<ServiceConfigWatcher>(Ref()), *args_, &error);
+      grpc_core::MakeUnique<ServiceConfigWatcher>(Ref()), *args_, &error);
   if (error != GRPC_ERROR_NONE) {
     gpr_log(GPR_ERROR,
             "Failed to create xds client -- channel will remain in "

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -54,7 +54,7 @@ size_t ClientChannelServiceConfigParser::ParserIndex() {
 
 void ClientChannelServiceConfigParser::Register() {
   g_client_channel_service_config_parser_index = ServiceConfig::RegisterParser(
-      MakeUnique<ClientChannelServiceConfigParser>());
+      grpc_core::MakeUnique<ClientChannelServiceConfigParser>());
 }
 
 namespace {
@@ -95,7 +95,7 @@ std::unique_ptr<ClientChannelMethodParsedConfig::RetryPolicy> ParseRetryPolicy(
     grpc_json* field, grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   auto retry_policy =
-      MakeUnique<ClientChannelMethodParsedConfig::RetryPolicy>();
+      grpc_core::MakeUnique<ClientChannelMethodParsedConfig::RetryPolicy>();
   if (field->type != GRPC_JSON_OBJECT) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "field:retryPolicy error:should be of type object");
@@ -438,7 +438,7 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const grpc_json* json,
   *error = GRPC_ERROR_CREATE_FROM_VECTOR("Client channel global parser",
                                          &error_list);
   if (*error == GRPC_ERROR_NONE) {
-    return MakeUnique<ClientChannelGlobalParsedConfig>(
+    return grpc_core::MakeUnique<ClientChannelGlobalParsedConfig>(
         std::move(parsed_lb_config), std::move(lb_policy_name),
         retry_throttling, health_check_service_name);
   }
@@ -491,8 +491,8 @@ ClientChannelServiceConfigParser::ParsePerMethodParams(const grpc_json* json,
   }
   *error = GRPC_ERROR_CREATE_FROM_VECTOR("Client channel parser", &error_list);
   if (*error == GRPC_ERROR_NONE) {
-    return MakeUnique<ClientChannelMethodParsedConfig>(timeout, wait_for_ready,
-                                                       std::move(retry_policy));
+    return grpc_core::MakeUnique<ClientChannelMethodParsedConfig>(
+        timeout, wait_for_ready, std::move(retry_policy));
   }
   return nullptr;
 }

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -188,15 +188,15 @@ ResolvingLoadBalancingPolicy::ResolvingLoadBalancingPolicy(
   GPR_ASSERT(process_resolver_result != nullptr);
   resolver_ = ResolverRegistry::CreateResolver(
       target_uri_.get(), args.args, interested_parties(), combiner(),
-      MakeUnique<ResolverResultHandler>(Ref()));
+      grpc_core::MakeUnique<ResolverResultHandler>(Ref()));
   // Since the validity of args has been checked when create the channel,
   // CreateResolver() must return a non-null result.
   GPR_ASSERT(resolver_ != nullptr);
   if (GRPC_TRACE_FLAG_ENABLED(*tracer_)) {
     gpr_log(GPR_INFO, "resolving_lb=%p: starting name resolution", this);
   }
-  channel_control_helper()->UpdateState(GRPC_CHANNEL_CONNECTING,
-                                        MakeUnique<QueuePicker>(Ref()));
+  channel_control_helper()->UpdateState(
+      GRPC_CHANNEL_CONNECTING, grpc_core::MakeUnique<QueuePicker>(Ref()));
   resolver_->StartLocked();
 }
 
@@ -262,7 +262,7 @@ void ResolvingLoadBalancingPolicy::OnResolverError(grpc_error* error) {
         "Resolver transient failure", &error, 1);
     channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE,
-        MakeUnique<TransientFailurePicker>(state_error));
+        grpc_core::MakeUnique<TransientFailurePicker>(state_error));
   }
   GRPC_ERROR_UNREF(error);
 }

--- a/src/core/ext/filters/client_channel/service_config.cc
+++ b/src/core/ext/filters/client_channel/service_config.cc
@@ -104,7 +104,7 @@ grpc_error* ServiceConfig::ParseGlobalParams(const grpc_json* json_tree) {
 grpc_error* ServiceConfig::ParseJsonMethodConfigToServiceConfigVectorTable(
     const grpc_json* json,
     SliceHashTable<const ParsedConfigVector*>::Entry* entries, size_t* idx) {
-  auto objs_vector = MakeUnique<ParsedConfigVector>();
+  auto objs_vector = grpc_core::MakeUnique<ParsedConfigVector>();
   InlinedVector<grpc_error*, 4> error_list;
   for (size_t i = 0; i < g_registered_parsers->size(); i++) {
     grpc_error* parser_error = GRPC_ERROR_NONE;

--- a/src/core/ext/filters/client_channel/xds/xds_bootstrap.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_bootstrap.cc
@@ -39,7 +39,7 @@ std::unique_ptr<XdsBootstrap> XdsBootstrap::ReadFromFile(grpc_error** error) {
   grpc_slice contents;
   *error = grpc_load_file(path.get(), /*add_null_terminator=*/true, &contents);
   if (*error != GRPC_ERROR_NONE) return nullptr;
-  return MakeUnique<XdsBootstrap>(contents, error);
+  return grpc_core::MakeUnique<XdsBootstrap>(contents, error);
 }
 
 XdsBootstrap::XdsBootstrap(grpc_slice contents, grpc_error** error)
@@ -248,7 +248,7 @@ grpc_error* XdsBootstrap::ParseChannelCreds(grpc_json* json, size_t idx,
 
 grpc_error* XdsBootstrap::ParseNode(grpc_json* json) {
   InlinedVector<grpc_error*, 1> error_list;
-  node_ = MakeUnique<Node>();
+  node_ = grpc_core::MakeUnique<Node>();
   bool seen_metadata = false;
   bool seen_locality = false;
   for (grpc_json* child = json->child; child != nullptr; child = child->next) {

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -89,13 +89,13 @@ MessageSizeParser::ParsePerMethodParams(const grpc_json* json,
     *error = GRPC_ERROR_CREATE_FROM_VECTOR("Message size parser", &error_list);
     return nullptr;
   }
-  return MakeUnique<MessageSizeParsedConfig>(max_request_message_bytes,
-                                             max_response_message_bytes);
+  return grpc_core::MakeUnique<MessageSizeParsedConfig>(
+      max_request_message_bytes, max_response_message_bytes);
 }
 
 void MessageSizeParser::Register() {
   g_message_size_parser_index =
-      ServiceConfig::RegisterParser(MakeUnique<MessageSizeParser>());
+      ServiceConfig::RegisterParser(grpc_core::MakeUnique<MessageSizeParser>());
 }
 
 size_t MessageSizeParser::ParserIndex() { return g_message_size_parser_index; }

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -559,10 +559,10 @@ RefCountedPtr<Handshaker> SecurityHandshakerCreate(
 void SecurityRegisterHandshakerFactories() {
   HandshakerRegistry::RegisterHandshakerFactory(
       false /* at_start */, HANDSHAKER_CLIENT,
-      MakeUnique<ClientSecurityHandshakerFactory>());
+      grpc_core::MakeUnique<ClientSecurityHandshakerFactory>());
   HandshakerRegistry::RegisterHandshakerFactory(
       false /* at_start */, HANDSHAKER_SERVER,
-      MakeUnique<ServerSecurityHandshakerFactory>());
+      grpc_core::MakeUnique<ServerSecurityHandshakerFactory>());
 }
 
 }  // namespace grpc_core

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -464,8 +464,8 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsUuidAfterCompaction) {
     // these will delete and unregister themselves after this block.
     std::vector<std::unique_ptr<ChannelFixture>> odd_channels;
     for (int i = 0; i < kLoopIterations; i++) {
-      odd_channels.push_back(MakeUnique<ChannelFixture>());
-      even_channels.push_back(MakeUnique<ChannelFixture>());
+      odd_channels.push_back(grpc_core::MakeUnique<ChannelFixture>());
+      even_channels.push_back(grpc_core::MakeUnique<ChannelFixture>());
     }
   }
   char* json_str = ChannelzRegistry::GetTopChannels(0);

--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -60,7 +60,7 @@ class TestParser1 : public ServiceConfig::Parser {
               GRPC_ERROR_CREATE_FROM_STATIC_STRING(InvalidValueErrorMessage());
           return nullptr;
         }
-        return MakeUnique<TestParsedConfig1>(value);
+        return grpc_core::MakeUnique<TestParsedConfig1>(value);
       }
     }
     return nullptr;
@@ -97,7 +97,7 @@ class TestParser2 : public ServiceConfig::Parser {
               GRPC_ERROR_CREATE_FROM_STATIC_STRING(InvalidValueErrorMessage());
           return nullptr;
         }
-        return MakeUnique<TestParsedConfig1>(value);
+        return grpc_core::MakeUnique<TestParsedConfig1>(value);
       }
     }
     return nullptr;
@@ -146,8 +146,10 @@ class ServiceConfigTest : public ::testing::Test {
   void SetUp() override {
     ServiceConfig::Shutdown();
     ServiceConfig::Init();
-    EXPECT_TRUE(ServiceConfig::RegisterParser(MakeUnique<TestParser1>()) == 0);
-    EXPECT_TRUE(ServiceConfig::RegisterParser(MakeUnique<TestParser2>()) == 1);
+    EXPECT_TRUE(ServiceConfig::RegisterParser(
+                    grpc_core::MakeUnique<TestParser1>()) == 0);
+    EXPECT_TRUE(ServiceConfig::RegisterParser(
+                    grpc_core::MakeUnique<TestParser2>()) == 1);
   }
 };
 
@@ -308,8 +310,10 @@ class ErroredParsersScopingTest : public ::testing::Test {
   void SetUp() override {
     ServiceConfig::Shutdown();
     ServiceConfig::Init();
-    EXPECT_TRUE(ServiceConfig::RegisterParser(MakeUnique<ErrorParser>()) == 0);
-    EXPECT_TRUE(ServiceConfig::RegisterParser(MakeUnique<ErrorParser>()) == 1);
+    EXPECT_TRUE(ServiceConfig::RegisterParser(
+                    grpc_core::MakeUnique<ErrorParser>()) == 0);
+    EXPECT_TRUE(ServiceConfig::RegisterParser(
+                    grpc_core::MakeUnique<ErrorParser>()) == 1);
   }
 };
 
@@ -354,8 +358,8 @@ class ClientChannelParserTest : public ::testing::Test {
     ServiceConfig::Shutdown();
     ServiceConfig::Init();
     EXPECT_TRUE(ServiceConfig::RegisterParser(
-                    MakeUnique<internal::ClientChannelServiceConfigParser>()) ==
-                0);
+                    grpc_core::MakeUnique<
+                        internal::ClientChannelServiceConfigParser>()) == 0);
   }
 };
 
@@ -922,8 +926,8 @@ class MessageSizeParserTest : public ::testing::Test {
   void SetUp() override {
     ServiceConfig::Shutdown();
     ServiceConfig::Init();
-    EXPECT_TRUE(
-        ServiceConfig::RegisterParser(MakeUnique<MessageSizeParser>()) == 0);
+    EXPECT_TRUE(ServiceConfig::RegisterParser(
+                    grpc_core::MakeUnique<MessageSizeParser>()) == 0);
   }
 };
 

--- a/test/core/gprpp/inlined_vector_test.cc
+++ b/test/core/gprpp/inlined_vector_test.cc
@@ -63,7 +63,7 @@ TEST(InlinedVectorTest, ValuesAreInlined) {
 
 TEST(InlinedVectorTest, PushBackWithMove) {
   InlinedVector<std::unique_ptr<int>, 1> v;
-  std::unique_ptr<int> i = MakeUnique<int>(3);
+  std::unique_ptr<int> i = grpc_core::MakeUnique<int>(3);
   v.push_back(std::move(i));
   EXPECT_EQ(nullptr, i.get());
   EXPECT_EQ(1UL, v.size());
@@ -304,15 +304,15 @@ TEST(InlinedVectorTest, MoveAssignmentAllocatedAllocated) {
 // and move methods are called correctly.
 class Value {
  public:
-  explicit Value(int v) : value_(MakeUnique<int>(v)) {}
+  explicit Value(int v) : value_(grpc_core::MakeUnique<int>(v)) {}
 
   // copyable
   Value(const Value& v) {
-    value_ = MakeUnique<int>(*v.value_);
+    value_ = grpc_core::MakeUnique<int>(*v.value_);
     copied_ = true;
   }
   Value& operator=(const Value& v) {
-    value_ = MakeUnique<int>(*v.value_);
+    value_ = grpc_core::MakeUnique<int>(*v.value_);
     copied_ = true;
     return *this;
   }
@@ -463,10 +463,10 @@ TEST(InlinedVectorTest, MoveAssignmentMovesElementsAllocated) {
 TEST(InlinedVectorTest, PopBackInlined) {
   InlinedVector<std::unique_ptr<int>, 2> v;
   // Add two elements, pop one out
-  v.push_back(MakeUnique<int>(3));
+  v.push_back(grpc_core::MakeUnique<int>(3));
   EXPECT_EQ(1UL, v.size());
   EXPECT_EQ(3, *v[0]);
-  v.push_back(MakeUnique<int>(5));
+  v.push_back(grpc_core::MakeUnique<int>(5));
   EXPECT_EQ(2UL, v.size());
   EXPECT_EQ(5, *v[1]);
   v.pop_back();
@@ -478,7 +478,7 @@ TEST(InlinedVectorTest, PopBackAllocated) {
   InlinedVector<std::unique_ptr<int>, kInlinedSize> v;
   // Add elements to ensure allocated backing.
   for (size_t i = 0; i < kInlinedSize + 1; ++i) {
-    v.push_back(MakeUnique<int>(3));
+    v.push_back(grpc_core::MakeUnique<int>(3));
     EXPECT_EQ(i + 1, v.size());
   }
   size_t sz = v.size();
@@ -494,7 +494,7 @@ TEST(InlinedVectorTest, Resize) {
   EXPECT_EQ(5UL, v.size());
   EXPECT_EQ(nullptr, v[4]);
   // Size down.
-  v[4] = MakeUnique<int>(5);
+  v[4] = grpc_core::MakeUnique<int>(5);
   v.resize(1);
   EXPECT_EQ(1UL, v.size());
 }

--- a/test/core/handshake/readahead_handshaker_server_ssl.cc
+++ b/test/core/handshake/readahead_handshaker_server_ssl.cc
@@ -81,7 +81,7 @@ int main(int /*argc*/, char* /*argv*/ []) {
   grpc_init();
   HandshakerRegistry::RegisterHandshakerFactory(
       true /* at_start */, HANDSHAKER_SERVER,
-      MakeUnique<ReadAheadHandshakerFactory>());
+      grpc_core::MakeUnique<ReadAheadHandshakerFactory>());
   const char* full_alpn_list[] = {"grpc-exp", "h2"};
   GPR_ASSERT(server_ssl_test(full_alpn_list, 2, "grpc-exp"));
   grpc_shutdown_blocking();


### PR DESCRIPTION
To address the compiler error `call to 'MakeUnique' is ambiguous` due to symbols defined in absl and grpc_core, `grpc_core` namepsace is added to all code calling `MakeUnique`.
