### PR TITLE
[Aio] Add tests for timeout mechanism on the client-side

### DIFF
--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -16,10 +16,6 @@
   "unit.interceptor_test.TestUnaryUnaryClientInterceptor",
   "unit.metadata_test.TestMetadata",
   "unit.server_test.TestServer",
-<<<<<<< HEAD
   "unit.timeout_test.TestTimeout",
   "unit.wait_for_ready_test.TestWaitForReady"
-=======
-  "unit.timeout_test.TestTimeout"
->>>>>>> Fix the json
 ]

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -16,5 +16,6 @@
   "unit.interceptor_test.TestUnaryUnaryClientInterceptor",
   "unit.metadata_test.TestMetadata",
   "unit.server_test.TestServer",
+  "unit.timeout_test.TestTimeout",
   "unit.wait_for_ready_test.TestWaitForReady"
 ]

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -16,6 +16,10 @@
   "unit.interceptor_test.TestUnaryUnaryClientInterceptor",
   "unit.metadata_test.TestMetadata",
   "unit.server_test.TestServer",
+<<<<<<< HEAD
   "unit.timeout_test.TestTimeout",
   "unit.wait_for_ready_test.TestWaitForReady"
+=======
+  "unit.timeout_test.TestTimeout"
+>>>>>>> Fix the json
 ]

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests behavior of the grpc.aio.UnaryUnaryCall class."""
+"""Tests behavior of the Call classes."""
 
 import asyncio
 import datetime

--- a/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
@@ -1,0 +1,178 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests behavior of the timeout mechanism on client side."""
+
+import asyncio
+import logging
+import platform
+import random
+import unittest
+import datetime
+
+import grpc
+from grpc.experimental import aio
+
+from tests_aio.unit._test_base import AioTestBase
+from tests_aio.unit import _common
+
+_SLEEP_TIME_UNIT_S = datetime.timedelta(seconds=1).total_seconds()
+
+_TEST_SLEEPY_UNARY_UNARY = '/test/Test/SleepyUnaryUnary'
+_TEST_SLEEPY_UNARY_STREAM = '/test/Test/SleepyUnaryStream'
+_TEST_SLEEPY_STREAM_UNARY = '/test/Test/SleepyStreamUnary'
+_TEST_SLEEPY_STREAM_STREAM = '/test/Test/SleepyStreamStream'
+
+_REQUEST = b'\x00\x00\x00'
+_RESPONSE = b'\x01\x01\x01'
+
+# logging.getLogger('asyncio').setLevel(logging.WARNING)
+
+class _GenericHandler(grpc.GenericRpcHandler):
+
+    def __init__(self):
+        self._routing_table = {
+            _TEST_SLEEPY_UNARY_UNARY:
+                grpc.unary_unary_rpc_method_handler(self._test_sleepy_unary_unary
+                                                   ),
+            _TEST_SLEEPY_UNARY_STREAM:
+                grpc.unary_stream_rpc_method_handler(self._test_sleepy_unary_stream),
+            _TEST_SLEEPY_STREAM_UNARY:
+                grpc.stream_unary_rpc_method_handler(self._test_sleepy_stream_unary),
+            _TEST_SLEEPY_STREAM_STREAM:
+                grpc.stream_stream_rpc_method_handler(self._test_sleepy_stream_stream)
+        }
+
+    @staticmethod
+    async def _test_sleepy_unary_unary(unused_request, unused_context):
+        await asyncio.sleep(_SLEEP_TIME_UNIT_S)
+        return _RESPONSE
+
+    @staticmethod
+    async def _test_sleepy_unary_stream(unused_request, unused_context):
+        yield _RESPONSE
+        await asyncio.sleep(_SLEEP_TIME_UNIT_S)
+        yield _RESPONSE
+
+    @staticmethod
+    async def _test_sleepy_stream_unary(unused_request_iterator, context):
+        assert _REQUEST == await context.read()
+        await asyncio.sleep(_SLEEP_TIME_UNIT_S)
+        assert _REQUEST == await context.read()
+        return _RESPONSE
+
+    @staticmethod
+    async def _test_sleepy_stream_stream(unused_request_iterator, context):
+        assert _REQUEST == await context.read()
+        await asyncio.sleep(_SLEEP_TIME_UNIT_S)
+        await context.write(_RESPONSE)
+
+    def service(self, handler_call_details):
+        return self._routing_table.get(handler_call_details.method)
+
+
+async def _start_test_server():
+    server = aio.server()
+    port = server.add_insecure_port('[::]:0')
+    server.add_generic_rpc_handlers((_GenericHandler(),))
+    await server.start()
+    return 'localhost:%d' % port, server
+
+
+class TestTimeout(AioTestBase):
+
+    async def setUp(self):
+        address, self._server = await _start_test_server()
+        self._client = aio.insecure_channel(address)
+
+    async def tearDown(self):
+        await self._client.close()
+        await self._server.stop(None)
+
+    async def test_unary_unary_success_with_timeout(self):
+        multicallable = self._client.unary_unary(_TEST_SLEEPY_UNARY_UNARY)
+        call = multicallable(_REQUEST, timeout=2*_SLEEP_TIME_UNIT_S)
+        self.assertEqual(_RESPONSE, await call)
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_unary_unary_deadline_exceeded(self):
+        multicallable = self._client.unary_unary(_TEST_SLEEPY_UNARY_UNARY)
+        call = multicallable(_REQUEST, timeout=0.5*_SLEEP_TIME_UNIT_S)
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call
+
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.DEADLINE_EXCEEDED, rpc_error.code())
+
+    async def test_unary_stream_success_with_timeout(self):
+        multicallable = self._client.unary_stream(_TEST_SLEEPY_UNARY_STREAM)
+        call = multicallable(_REQUEST, timeout=2*_SLEEP_TIME_UNIT_S)
+        self.assertEqual(_RESPONSE, await call.read())
+        self.assertEqual(_RESPONSE, await call.read())
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_unary_stream_deadline_exceeded(self):
+        multicallable = self._client.unary_stream(_TEST_SLEEPY_UNARY_STREAM)
+        call = multicallable(_REQUEST, timeout=0.5*_SLEEP_TIME_UNIT_S)
+        self.assertEqual(_RESPONSE, await call.read())
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call.read()
+
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.DEADLINE_EXCEEDED, rpc_error.code())
+
+    async def test_stream_unary_success_with_timeout(self):
+        multicallable = self._client.stream_unary(_TEST_SLEEPY_STREAM_UNARY)
+        call = multicallable(timeout=2*_SLEEP_TIME_UNIT_S)
+        await call.write(_REQUEST)
+        await call.write(_REQUEST)
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_stream_unary_deadline_exceeded(self):
+        multicallable = self._client.stream_unary(_TEST_SLEEPY_STREAM_UNARY)
+        call = multicallable(timeout=0.5*_SLEEP_TIME_UNIT_S)
+
+        await call.write(_REQUEST)
+        await call.write(_REQUEST)
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call
+
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.DEADLINE_EXCEEDED, rpc_error.code())
+
+    async def test_stream_stream_success_with_timeout(self):
+        multicallable = self._client.stream_stream(_TEST_SLEEPY_STREAM_STREAM)
+        call = multicallable(timeout=2*_SLEEP_TIME_UNIT_S)
+        await call.write(_REQUEST)
+        self.assertEqual(_RESPONSE, await call.read())
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_stream_stream_deadline_exceeded(self):
+        multicallable = self._client.stream_stream(_TEST_SLEEPY_STREAM_STREAM)
+        call = multicallable(timeout=0.5*_SLEEP_TIME_UNIT_S)
+
+        await call.write(_REQUEST)
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call.read()
+
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.DEADLINE_EXCEEDED, rpc_error.code())
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
@@ -85,7 +85,7 @@ async def _start_test_server():
     port = server.add_insecure_port('[::]:0')
     server.add_generic_rpc_handlers((_GenericHandler(),))
     await server.start()
-    return 'localhost:%d' % port, server
+    return f'localhost:{port}', server
 
 
 class TestTimeout(AioTestBase):

--- a/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/timeout_test.py
@@ -36,7 +36,6 @@ _TEST_SLEEPY_STREAM_STREAM = '/test/Test/SleepyStreamStream'
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x01\x01\x01'
 
-# logging.getLogger('asyncio').setLevel(logging.WARNING)
 
 class _GenericHandler(grpc.GenericRpcHandler):
 


### PR DESCRIPTION
Adding 8 more test cases. 4 test cases ensures that RPCs can finish with timeout, and 4 test cases ensures that the RPCs will timeout if it surpass the deadline.

This PR confirms that the timeout mechanism actually works for all arities of RPC.

CC @pfreixes 

Children PR of https://github.com/grpc/grpc/pull/21803