### PR TITLE
Fix regression in MSVC runtime flag

### DIFF
--- a/cmake/msvc_static_runtime.cmake
+++ b/cmake/msvc_static_runtime.cmake
@@ -22,7 +22,7 @@ if(gRPC_MSVC_STATIC_RUNTIME)
     CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
     CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
 
-    if(flag_var MATCHES "/MD")
+    if(${flag_var} MATCHES "/MD")
       string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
     endif()
   endforeach()


### PR DESCRIPTION
In attempting to fix a CMake style issue, a variable dereference
was accidentally removed that should have been left alone. Restore
it to how it was.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@jtattermusch 
