### PR TITLE
Weaken reinterpret_cast to static_cast

### DIFF
--- a/src/cpp/server/health/default_health_check_service.cc
+++ b/src/cpp/server/health/default_health_check_service.cc
@@ -182,8 +182,7 @@ void DefaultHealthCheckService::HealthCheckServiceImpl::StartServingThread() {
 }
 
 void DefaultHealthCheckService::HealthCheckServiceImpl::Serve(void* arg) {
-  HealthCheckServiceImpl* service =
-      reinterpret_cast<HealthCheckServiceImpl*>(arg);
+  HealthCheckServiceImpl* service = static_cast<HealthCheckServiceImpl*>(arg);
   void* tag;
   bool ok;
   while (true) {

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -85,7 +85,7 @@ void LoadReporterAsyncServiceImpl::FetchAndSample(bool ok) {
 
 void LoadReporterAsyncServiceImpl::Work(void* arg) {
   LoadReporterAsyncServiceImpl* service =
-      reinterpret_cast<LoadReporterAsyncServiceImpl*>(arg);
+      static_cast<LoadReporterAsyncServiceImpl*>(arg);
   service->FetchAndSample(true /* ok */);
   // TODO(juanlishen): This is a workaround to wait for the cq to be ready. Need
   // to figure out why cq is not ready after service starts.


### PR DESCRIPTION
Prefer static_cast to reinterpret_cast for void->ptr conversions

I'll do a broader cleanup later.