### PR TITLE
Backport: Fix regression in MSVC runtime flag (for v1.27.x)

### DIFF
--- a/cmake/msvc_static_runtime.cmake
+++ b/cmake/msvc_static_runtime.cmake
@@ -22,7 +22,7 @@ if(gRPC_MSVC_STATIC_RUNTIME)
     CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
     CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
 
-    if(flag_var MATCHES "/MD")
+    if(${flag_var} MATCHES "/MD")
       string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
     endif()
   endforeach()


### PR DESCRIPTION
Backport https://github.com/grpc/grpc/pull/21792 into v1.27.x
