### PR TITLE
Revert "Revert "Revert "Revert "Log an error (in dbg mode) if CQ is Shutdown before its Server(s)""""

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue_impl.h
+++ b/include/grpcpp/impl/codegen/completion_queue_impl.h
@@ -406,14 +406,15 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
     return true;
   }
 
-#ifndef NDEBUG
-  mutable grpc::internal::Mutex server_list_mutex_;
-  std::list<const Server*> server_list_ /* GUARDED_BY(server_list_mutex_) */;
-#endif
-
   grpc_completion_queue* cq_;  // owned
 
   gpr_atm avalanches_in_flight_;
+
+  // List of servers associated with this CQ. Even though this is only used with
+  // NDEBUG, instantiate it in all cases since otherwise the size will be
+  // inconsistent.
+  mutable grpc::internal::Mutex server_list_mutex_;
+  std::list<const Server*> server_list_ /* GUARDED_BY(server_list_mutex_) */;
 };
 
 /// A specific type of completion queue used by the processing of notifications

--- a/include/grpcpp/impl/codegen/completion_queue_impl.h
+++ b/include/grpcpp/impl/codegen/completion_queue_impl.h
@@ -32,11 +32,14 @@
 #ifndef GRPCPP_IMPL_CODEGEN_COMPLETION_QUEUE_IMPL_H
 #define GRPCPP_IMPL_CODEGEN_COMPLETION_QUEUE_IMPL_H
 
+#include <list>
+
 #include <grpc/impl/codegen/atm.h>
 #include <grpcpp/impl/codegen/completion_queue_tag.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/impl/codegen/status.h>
+#include <grpcpp/impl/codegen/sync.h>
 #include <grpcpp/impl/codegen/time.h>
 
 struct grpc_completion_queue;
@@ -250,6 +253,11 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   }
 
  private:
+  // Friends for access to server registration lists that enable checking and
+  // logging on shutdown
+  friend class ::grpc_impl::ServerBuilder;
+  friend class ::grpc_impl::Server;
+
   // Friend synchronous wrappers so that they can access Pluck(), which is
   // a semi-private API geared towards the synchronous implementation.
   template <class R>
@@ -274,7 +282,6 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   friend class ::grpc_impl::internal::TemplatedBidiStreamingHandler;
   template <::grpc::StatusCode code>
   friend class ::grpc_impl::internal::ErrorMethodHandler;
-  friend class ::grpc_impl::Server;
   friend class ::grpc_impl::ServerContextBase;
   friend class ::grpc::ServerInterface;
   template <class InputMessage, class OutputMessage>
@@ -379,13 +386,38 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
     }
   }
 
+  void RegisterServer(const Server* server) {
+#ifndef NDEBUG
+    grpc::internal::MutexLock l(&server_list_mutex_);
+    server_list_.push_back(server);
+#endif
+  }
+  void UnregisterServer(const Server* server) {
+#ifndef NDEBUG
+    grpc::internal::MutexLock l(&server_list_mutex_);
+    server_list_.remove(server);
+#endif
+  }
+  bool ServerListEmpty() const {
+#ifndef NDEBUG
+    grpc::internal::MutexLock l(&server_list_mutex_);
+    return server_list_.empty();
+#endif
+    return true;
+  }
+
+#ifndef NDEBUG
+  mutable grpc::internal::Mutex server_list_mutex_;
+  std::list<const Server*> server_list_ /* GUARDED_BY(server_list_mutex_) */;
+#endif
+
   grpc_completion_queue* cq_;  // owned
 
   gpr_atm avalanches_in_flight_;
 };
 
 /// A specific type of completion queue used by the processing of notifications
-/// by servers. Instantiated by \a ServerBuilder.
+/// by servers. Instantiated by \a ServerBuilder or Server (for health checker).
 class ServerCompletionQueue : public CompletionQueue {
  public:
   bool IsFrequentlyPolled() { return polling_type_ != GRPC_CQ_NON_LISTENING; }

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -386,11 +386,10 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   // It is protected by mu_
   CompletionQueue* callback_cq_ = nullptr;
 
-#ifndef NDEBUG
   // List of CQs passed in by user that must be Shutdown only after Server is
-  // Shutdown.
+  // Shutdown.  Even though this is only used with NDEBUG, instantiate it in all
+  // cases since otherwise the size will be inconsistent.
   std::vector<CompletionQueue*> cq_list_;
-#endif
 };
 
 }  // namespace grpc_impl

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -385,6 +385,12 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   // shutdown callback tag (invoked when the CQ is fully shutdown).
   // It is protected by mu_
   CompletionQueue* callback_cq_ = nullptr;
+
+#ifndef NDEBUG
+  // List of CQs passed in by user that must be Shutdown only after Server is
+  // Shutdown.
+  std::vector<CompletionQueue*> cq_list_;
+#endif
 };
 
 }  // namespace grpc_impl

--- a/src/cpp/common/completion_queue_cc.cc
+++ b/src/cpp/common/completion_queue_cc.cc
@@ -39,6 +39,12 @@ CompletionQueue::CompletionQueue(grpc_completion_queue* take)
 
 void CompletionQueue::Shutdown() {
   g_gli_initializer.summon();
+#ifndef NDEBUG
+  if (!ServerListEmpty()) {
+    gpr_log(GPR_ERROR,
+            "CompletionQueue shutdown being shutdown before its server.");
+  }
+#endif
   CompleteAvalanching();
 }
 


### PR DESCRIPTION
Impurely reverts #21806 . 
Rolls-forward #21680 .

The new content is in commit 06ca713 . The problem with why this would keep breaking is that it added data members to CompletionQueue and Server that were only instantiated under `#ifndef NDEBUG` . But some dependent projects had their own definition of that same macro so they were seeing two different sizes for the same object in different parts of the code. Instead, we now have these objects instantiated always and only actually use them under `#ifndef NDEBUG` . I added a comment also to explain why it is done this way.
