### PR TITLE
Fix the windows build failure

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -237,15 +237,13 @@ class BuildExt(build_ext.build_ext):
         if not compiler_ok_with_extra_std():
             old_compile = self.compiler._compile
 
-            def new_compile(obj, src, ext, cc_args, extra_postargs,
-                            pp_opts):
+            def new_compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
                 if src[-2:] == '.c':
                     extra_postargs = [
-                        arg for arg in extra_postargs
-                        if not '-std=c++' in arg
+                        arg for arg in extra_postargs if not '-std=c++' in arg
                     ]
                 return old_compile(obj, src, ext, cc_args, extra_postargs,
-                                    pp_opts)
+                                   pp_opts)
 
             self.compiler._compile = new_compile
 

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -232,18 +232,21 @@ class BuildExt(build_ext.build_ext):
         #   If we are not using a permissive compiler that's OK with being
         #   passed wrong std flags, swap out compile function by adding a filter
         #   for it.
-        if not compiler_ok_with_extra_std():
-            old_compile = self.compiler._compile
+        if platform.system() != 'Windows':
+            if not compiler_ok_with_extra_std():
+                old_compile = self.compiler._compile
 
-            def new_compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
-                if src[-2:] == '.c':
-                    extra_postargs = [
-                        arg for arg in extra_postargs if not '-std=c++' in arg
-                    ]
-                return old_compile(obj, src, ext, cc_args, extra_postargs,
-                                   pp_opts)
+                def new_compile(obj, src, ext, cc_args, extra_postargs,
+                                pp_opts):
+                    if src[-2:] == '.c':
+                        extra_postargs = [
+                            arg for arg in extra_postargs
+                            if not '-std=c++' in arg
+                        ]
+                    return old_compile(obj, src, ext, cc_args, extra_postargs,
+                                       pp_opts)
 
-            self.compiler._compile = new_compile
+                self.compiler._compile = new_compile
 
         compiler = self.compiler.compiler_type
         if compiler in BuildExt.C_OPTIONS:


### PR DESCRIPTION
Finally, the bug that stops Windows build has been found. This is a backfire from a hack that we used to get gRPC Python compile on macOS, which silently broke the Windows build.

In the function `compiler_ok_with_extra_std`, it explicitly calls out `cc` (implies c compiler usually `gcc` or `clang`). However, both `gcc` and `clang` are not normally installed on Windows machines. Then, when users try to compile gRPC Python, even if they have Visual Studio installed properly, the compilation will fail due to `cc` not found.

So, the fix is easy. Don't look for `cc` if it is a Windows machine.

Fixes #20879