### PR TITLE
fix 21321 folk subprocess crash

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -130,6 +130,11 @@ typedef struct grpc_channel_credentials grpc_channel_credentials;
    The creator of the credentials object is responsible for its release. */
 GRPCAPI void grpc_channel_credentials_release(grpc_channel_credentials* creds);
 
+/** Copy a channel credentials object.
+ */
+GRPCAPI grpc_channel_credentials* grpc_channel_credentials_copy(
+    grpc_channel_credentials* creds);
+
 /** Creates default credentials to connect to a google gRPC service.
    WARNING: Do NOT use this credentials to connect to a non-google service as
    this could result in an oauth2 token leak. The security level of the

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -45,6 +45,14 @@ void grpc_channel_credentials_release(grpc_channel_credentials* creds) {
   if (creds) creds->Unref();
 }
 
+grpc_channel_credentials* grpc_channel_credentials_copy(
+    grpc_channel_credentials* creds) {
+  GRPC_API_TRACE("grpc_channel_credentials_copy(creds=%p)", 1, (creds));
+  grpc_core::ExecCtx exec_ctx;
+  if (creds) creds->Ref().release();
+  return creds;
+}
+
 static std::map<grpc_core::UniquePtr<char>,
                 grpc_core::RefCountedPtr<grpc_channel_credentials>,
                 grpc_core::StringLess>* g_grpc_control_plane_creds;

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -33,8 +33,8 @@ typedef struct _grpc_channel_wrapper {
   char *creds_hashstr;
   size_t ref_count;
   gpr_mu mu;
-  grpc_channel_args args;
-  wrapped_grpc_channel_credentials *creds;
+  grpc_channel_args *args;
+  grpc_channel_credentials *creds;
 } grpc_channel_wrapper;
 
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -106,14 +106,14 @@ ZEND_GET_MODULE(grpc)
 void create_new_channel(
     wrapped_grpc_channel *channel,
     char *target,
-    grpc_channel_args args,
-    wrapped_grpc_channel_credentials *creds) {
+    grpc_channel_args *args,
+    grpc_channel_credentials *creds) {
   if (creds == NULL) {
-    channel->wrapper->wrapped = grpc_insecure_channel_create(target, &args,
+    channel->wrapper->wrapped = grpc_insecure_channel_create(target, args,
                                                              NULL);
   } else {
     channel->wrapper->wrapped =
-        grpc_secure_channel_create(creds->wrapped, target, &args, NULL);
+        grpc_secure_channel_create(creds, target, args, NULL);
   }
 }
 

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -76,11 +76,11 @@ PHP_METHOD(Server, __construct) {
     server->wrapped = grpc_server_create(NULL, NULL);
   } else {
     if (php_grpc_read_args_array(args_array, &args TSRMLS_CC) == FAILURE) {
-      efree(args.args);
+      free(args.args);
       return;
     }
     server->wrapped = grpc_server_create(&args, NULL);
-    efree(args.args);
+    free(args.args);
   }
   grpc_server_register_completion_queue(server->wrapped, completion_queue,
                                         NULL);


### PR DESCRIPTION
use malloc (instead of emalloc) for args.args, and not free it after channel created, also hard copy creds as a grpc object. So that, when forked(child) process restart_channels, these two are safe to use.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
