### PR TITLE
Timestamp ObjC test outputs

### DIFF
--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -25,6 +25,8 @@ set -ev
 # CocoaPods requires the terminal to be using UTF-8 encoding.
 export LANG=en_US.UTF-8
 
+TEST_PATH=$(cd "$(dirname $0)" > /dev/null ; pwd)
+
 cd `dirname $0`/../../..
 
 cd $EXAMPLE_PATH
@@ -34,7 +36,7 @@ rm -rf Pods
 rm -rf *.xcworkspace
 rm -f Podfile.lock
 
-pod install
+pod install | $TEST_PATH/verbose_time.sh
 
 set -o pipefail
 XCODEBUILD_FILTER='(^CompileC |^Ld |^.*clang |^ *cd |^ *export |^Libtool |^.*libtool |^CpHeader |^ *builtin-copy )'
@@ -47,6 +49,7 @@ if [ "$SCHEME" == "tvOS-sample" ]; then
     -derivedDataPath Build/Build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
+    | $TEST_PATH/verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v "^$" -
 else
@@ -58,6 +61,7 @@ else
     -derivedDataPath Build/Build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
+    | $TEST_PATH/verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v "^$" -
 fi

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -36,5 +36,5 @@ rm -f Podfile.lock
 rm -f RemoteTestClient/*.{h,m}
 
 echo "TIME:  $(date)"
-pod install
+pod install | ./verbose_time.sh
 

--- a/src/objective-c/tests/run_one_test.sh
+++ b/src/objective-c/tests/run_one_test.sh
@@ -86,6 +86,7 @@ xcodebuild \
     HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
     HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
     test \
+    | ./verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -

--- a/src/objective-c/tests/verbose_time.sh
+++ b/src/objective-c/tests/verbose_time.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+while IFS= read -r line; do
+  echo "$(date) - $line"
+done


### PR DESCRIPTION
Will use the timestamp to find out what exactly is slow and causing the timeout in the objc tests.