### PR TITLE
Add ignore android flag in performance README.md

### DIFF
--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -48,7 +48,7 @@ $ tools/run_tests/performance/run_worker_<language>.sh
 
 ```
 $ cd <grpc-java-repo>
-$ ./gradlew -PskipCodegen=true :grpc-benchmarks:installDist
+$ ./gradlew -PskipCodegen=true -PskipAndroid=true :grpc-benchmarks:installDist
 $ benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker --driver_port <driver_port>
 ```
 


### PR DESCRIPTION
The tools/run_tests/performance/README.md file provides an example to run workers in Java. However, this example does not work out of the box, because the Java build requires an Android SDK. This change adds a Gradle flag `-PskipAndroid=true` to the existing example, allowing it to work as intended.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
