### PR TITLE
QPS async server test: insist on a clean server shutdown

### DIFF
--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -162,10 +162,7 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
       std::lock_guard<std::mutex> lock((*ss)->mutex);
       (*ss)->shutdown = true;
     }
-    // TODO(vjpai): Remove the following deadline and allow full proper
-    // shutdown.
-    server_->Shutdown(std::chrono::system_clock::now() +
-                      std::chrono::seconds(3));
+    server_->Shutdown();
     for (auto cq = srv_cqs_.begin(); cq != srv_cqs_.end(); ++cq) {
       (*cq)->Shutdown();
     }


### PR DESCRIPTION
Stop putting a deadline on server shutdown, insist on a clean shutdown as in the sync and callback versions.
