### PR TITLE
PHP: Dockerfile grpc-src error

### DIFF
--- a/src/php/docker/grpc-src/Dockerfile
+++ b/src/php/docker/grpc-src/Dockerfile
@@ -30,12 +30,16 @@ RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
 
 WORKDIR /github/grpc
 
-COPY . .
-
-RUN make && make install
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init && \
+  make && make install
 
 
 WORKDIR /github/grpc/src/php/ext/grpc
+
+COPY src/php/ext/grpc/*.c ./
+COPY src/php/ext/grpc/*.h ./
+COPY src/php/ext/grpc/config.m4 ./
 
 RUN phpize && \
   ./configure --enable-tests && \

--- a/templates/src/php/docker/grpc-src/Dockerfile.template
+++ b/templates/src/php/docker/grpc-src/Dockerfile.template
@@ -29,12 +29,16 @@
 
   WORKDIR /github/grpc
 
-  COPY . .
-
-  RUN make && make install
+  RUN git clone https://github.com/grpc/grpc . && \
+    git submodule update --init && \
+    make && make install
 
 
   WORKDIR /github/grpc/src/php/ext/grpc
+
+  COPY src/php/ext/grpc/*.c ./
+  COPY src/php/ext/grpc/*.h ./
+  COPY src/php/ext/grpc/config.m4 ./
 
   RUN phpize && ${'\\'}
     ./configure --enable-tests && ${'\\'}


### PR DESCRIPTION
fix: grpc-src dockerfile build.
This image builds the grpc PECL extension in a 'thin' way--showing can not find third_party error.


@stanley-cheung 
