### PR TITLE
[Aio] Fix the server credentials & improve socket implementation

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
@@ -18,9 +18,11 @@ cdef class _AsyncioSocket:
         # Common attributes
         grpc_custom_socket * _grpc_socket
         grpc_custom_read_callback _grpc_read_cb
+        grpc_custom_write_callback _grpc_write_cb
         object _reader
         object _writer
         object _task_read
+        object _task_write
         object _task_connect
         char * _read_buffer
         # Caches the picked event loop, so we can avoid the 30ns overhead each

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
@@ -25,10 +25,12 @@ cdef class _AsyncioSocket:
         self._grpc_socket = NULL
         self._grpc_connect_cb = NULL
         self._grpc_read_cb = NULL
+        self._grpc_write_cb = NULL
         self._reader = None
         self._writer = None
         self._task_connect = None
         self._task_read = None
+        self._task_write = None
         self._read_buffer = NULL
         self._server = None
         self._py_socket = None
@@ -82,33 +84,26 @@ cdef class _AsyncioSocket:
             <grpc_error*>0
         )
 
-    def _read_cb(self, future):
-        error = False
+    async def _async_read(self, size_t length):
+        self._task_read = None
         try:
-            buffer_ = future.result()
-        except Exception as e:
-            error = True
-            error_msg = "%s: %s" % (type(e), str(e))
-            _LOGGER.debug(e)
-        finally:
-            self._task_read = None
-
-        if not error:
-            string.memcpy(
-                <void*>self._read_buffer,
-                <char*>buffer_,
-                len(buffer_)
-            )
-            self._grpc_read_cb(
-                <grpc_custom_socket*>self._grpc_socket,
-                len(buffer_),
-                <grpc_error*>0
-            )
-        else:
+            inbound_buffer = await self._reader.read(n=length)
+        except ConnectionError as e:
             self._grpc_read_cb(
                 <grpc_custom_socket*>self._grpc_socket,
                 -1,
-                grpc_socket_error("Read failed: {}".format(error_msg).encode())
+                grpc_socket_error("Read failed: {}".format(e).encode())
+            )
+        else:
+            string.memcpy(
+                <void*>self._read_buffer,
+                <char*>inbound_buffer,
+                len(inbound_buffer)
+            )
+            self._grpc_read_cb(
+                <grpc_custom_socket*>self._grpc_socket,
+                len(inbound_buffer),
+                <grpc_error*>0
             )
 
     cdef void connect(self,
@@ -127,13 +122,25 @@ cdef class _AsyncioSocket:
     cdef void read(self, char * buffer_, size_t length, grpc_custom_read_callback grpc_read_cb):
         assert not self._task_read
 
-        self._task_read = self._loop.create_task(
-            self._reader.read(n=length)
-        )
         self._grpc_read_cb = grpc_read_cb
-        self._task_read.add_done_callback(self._read_cb)
         self._read_buffer = buffer_
- 
+        self._task_read = self._loop.create_task(self._async_read(length))
+
+    async def _async_write(self, bytearray outbound_buffer):
+        self._writer.write(outbound_buffer)
+        self._task_write = None
+        try:
+            await self._writer.drain()
+            self._grpc_write_cb(
+                <grpc_custom_socket*>self._grpc_socket,
+                <grpc_error*>0
+            )
+        except ConnectionError as connection_error:
+            self._grpc_write_cb(
+                <grpc_custom_socket*>self._grpc_socket,
+                grpc_socket_error("Socket write failed: {}".format(connection_error).encode()),
+            )
+
     cdef void write(self, grpc_slice_buffer * g_slice_buffer, grpc_custom_write_callback grpc_write_cb):
         """Performs write to network socket in AsyncIO.
         
@@ -141,6 +148,7 @@ cdef class _AsyncioSocket:
         When the write is finished, we need to call grpc_write_cb to notify
         Core that the work is done.
         """
+        assert not self._task_write
         cdef char* start
         cdef bytearray outbound_buffer = bytearray()
         for i in range(g_slice_buffer.count):
@@ -148,11 +156,8 @@ cdef class _AsyncioSocket:
             length = grpc_slice_buffer_length(g_slice_buffer, i)
             outbound_buffer.extend(<bytes>start[:length])
 
-        self._writer.write(outbound_buffer)
-        grpc_write_cb(
-            <grpc_custom_socket*>self._grpc_socket,
-            <grpc_error*>0
-        )
+        self._grpc_write_cb = grpc_write_cb
+        self._task_write = self._loop.create_task(self._async_write(outbound_buffer))
 
     cdef bint is_connected(self):
         return self._reader and not self._reader._transport.is_closing()

--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -30,11 +30,12 @@ from ._channel import Channel, UnaryUnaryMultiCallable
 from ._interceptor import (ClientCallDetails, InterceptedUnaryUnaryCall,
                            UnaryUnaryClientInterceptor)
 from ._server import Server, server
+from ._typing import ChannelArgumentType
 
 
 def insecure_channel(
         target: Text,
-        options: Optional[Sequence[Tuple[Text, Any]]] = None,
+        options: Optional[ChannelArgumentType] = None,
         compression: Optional[grpc.Compression] = None,
         interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]] = None):
     """Creates an insecure asynchronous Channel to a server.
@@ -58,7 +59,7 @@ def insecure_channel(
 def secure_channel(
         target: Text,
         credentials: grpc.ChannelCredentials,
-        options: Optional[list] = None,
+        options: Optional[ChannelArgumentType] = None,
         compression: Optional[grpc.Compression] = None,
         interceptors: Optional[Sequence[UnaryUnaryClientInterceptor]] = None):
     """Creates a secure asynchronous Channel to a server.

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -1,6 +1,7 @@
 [
   "_sanity._sanity_test.AioSanityTest",
   "interop.local_interop_test.InsecureLocalInteropTest",
+  "interop.local_interop_test.SecureLocalInteropTest",
   "unit.abort_test.TestAbort",
   "unit.aio_rpc_error_test.TestAioRpcError",
   "unit.call_test.TestStreamStreamCall",

--- a/src/python/grpcio_tests/tests_aio/unit/abort_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/abort_test.py
@@ -136,6 +136,7 @@ class TestAbort(AioTestBase):
 
         with self.assertRaises(aio.AioRpcError) as exception_context:
             await call.read()
+            await call.read()
 
         rpc_error = exception_context.exception
         self.assertEqual(_ABORT_CODE, rpc_error.code())


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21749 https://github.com/grpc/grpc/issues/21348
This is a children PR of https://github.com/grpc/grpc/pull/21714

The server cannot handle credentials due to a data race before this PR. There is an inherent problem with `ExecCtx` usage in `tcp_custom.cc`. This PR tries to make the implementation more conservative (ensure write gets through before returning) to workaround it.

In current implementation, the `AsyncioSocket.write` completes immediately with returning because we didn't invoke `await drain()` (flush the buffers). Invoking multiple custom IO operations with in the same stack is unexpected by the original design of `tcp_custom`.

Ideally, the `ExecCtx` should only be created once upon the entrance from Cython to Core. Or we should use other mechanism to synchronize. For me, I think it can be delayed until the fine-tuning of performance, which may introduce more changes in `tcp_custom.cc`.

---

The data race happens due to:
1. The server tried to read from a new connection;
1. The `custom_read_callback` created an `ExecCtx` object;
2. New connection provided a certificate;
3. The server invoked `SecurityHandshaker::OnHandshakeNextDoneLocked`;
3. Then scheduled `SecurityHandshaker::OnHandshakeDataReceivedFromPeerFn` onto `ExecCtx` which needs a lock;
3. Read operation finished, the `OnHandshakeDataReceivedFromPeerFn` being executed by `ExecCtx`;
4. In `OnHandshakeDataReceivedFromPeerFn`, the server finished security check, and tried to write it back onto wire;
5. The server invoked `endpoint_write`, which is implemented by `custom_write_callback`;
6. `custom_write_callback` created another `ExecCtx` object;
7. `custom_write_callback` scheduled `OnHandshakeDataSentToPeerFn` which also needs a lock;
8. Write completed by AsyncIO manager immediately (__without return__);
9. The `ExecCtx` deallocated, and `OnHandshakeDataSentToPeerFn` being triggered, but the lock was still held by `OnHandshakeDataReceivedFromPeerFn`.
10. Deadlock!

The traceback for the deadlock:
```c
#0  __lll_lock_wait () at ../sysdeps/unix/sysv/linux/x86_64/lowlevellock.S:103
#1  0x00007ffff79893d4 in __GI___pthread_mutex_lock (mutex=mutex@entry=0xea7e60) at ../nptl/pthread_mutex_lock.c:80
#2  0x00007ffff43e9fa9 in gpr_mu_lock (mu=mu@entry=0xea7e60) at src/core/lib/gpr/sync_posix.cc:65
#3  0x00007ffff442db89 in grpc_core::MutexLock::MutexLock (mu=0xea7e60, this=<synthetic pointer>)
    at ./src/core/lib/gprpp/sync.h:59
#4  grpc_core::(anonymous namespace)::SecurityHandshaker::OnHandshakeDataSentToPeerFn (arg=0xea7e40, error=<optimized out>)
    at src/core/lib/security/transport/security_handshaker.cc:431
#5  0x00007ffff43f8e61 in exec_ctx_run (closure=<optimized out>, closure=<optimized out>, error=0x0)
    at src/core/lib/iomgr/exec_ctx.cc:153
#6  grpc_core::ExecCtx::Flush (this=this@entry=0x7fffffffbb40) at src/core/lib/iomgr/exec_ctx.cc:153
#7  0x00007ffff4403baf in grpc_core::ExecCtx::~ExecCtx (this=0x7fffffffbb40, __in_chrg=<optimized out>)
    at ./src/core/lib/iomgr/exec_ctx.h:124
#8  custom_write_callback (socket=<optimized out>, error=error@entry=0x0) at src/core/lib/iomgr/tcp_custom.cc:214
#9  0x00007ffff42e0fc7 in __pyx_f_4grpc_7_cython_6cygrpc_14_AsyncioSocket_write (__pyx_v_self=0x7ffff3851d60,
    __pyx_v_g_slice_buffer=<optimized out>,
    __pyx_v_grpc_write_cb=0x7ffff4403a40 <custom_write_callback(grpc_custom_socket*, grpc_error*)>)
    at src/python/grpcio/grpc/_cython/cygrpc.cpp:61825
#10 0x00007ffff4294331 in __pyx_f_4grpc_7_cython_6cygrpc_asyncio_socket_write (__pyx_v_grpc_socket=<optimized out>,
    __pyx_v_slice_buffer=0xea7ec0,
    __pyx_v_write_cb=0x7ffff4403a40 <custom_write_callback(grpc_custom_socket*, grpc_error*)>)
    at src/python/grpcio/grpc/_cython/cygrpc.cpp:57823
#11 0x00007ffff44033d1 in endpoint_write (ep=0xf13d20, write_slices=0xea7ec0, cb=0xea7fe8)
    at src/core/lib/iomgr/tcp_custom.cc:261
#12 0x00007ffff442d487 in grpc_core::(anonymous namespace)::SecurityHandshaker::OnHandshakeNextDoneLocked (
    handshaker_result=<optimized out>, bytes_to_send_size=<optimized out>, bytes_to_send=<optimized out>,
    result=<optimized out>, this=0xea7e40) at ./src/core/lib/iomgr/closure.h:110
#13 grpc_core::(anonymous namespace)::SecurityHandshaker::OnHandshakeNextDoneLocked (this=0xea7e40,
    result=<optimized out>, bytes_to_send=<optimized out>, bytes_to_send_size=<optimized out>,
    handshaker_result=<optimized out>) at src/core/lib/security/transport/security_handshaker.cc:285
#14 0x00007ffff442d560 in grpc_core::(anonymous namespace)::SecurityHandshaker::DoHandshakerNextLocked (
    this=this@entry=0xea7e40, bytes_received=<optimized out>, bytes_received_size=<optimized out>)
    at src/core/lib/security/transport/security_handshaker.cc:375
#15 0x00007ffff442dab7 in grpc_core::(anonymous namespace)::SecurityHandshaker::OnHandshakeDataReceivedFromPeerFn (
    arg=0xea7e40, error=<optimized out>) at src/core/lib/security/transport/security_handshaker.cc:405
#16 0x00007ffff43f8e61 in exec_ctx_run (closure=<optimized out>, closure=<optimized out>, error=0x0)
    at src/core/lib/iomgr/exec_ctx.cc:153
#17 grpc_core::ExecCtx::Flush (this=this@entry=0x7fffffffbe30) at src/core/lib/iomgr/exec_ctx.cc:153
#18 0x00007ffff440371f in grpc_core::ExecCtx::~ExecCtx (this=0x7fffffffbe30, __in_chrg=<optimized out>)
    at ./src/core/lib/iomgr/exec_ctx.h:124
#19 custom_read_callback (socket=<optimized out>, nread=<optimized out>, error=0x0) at src/core/lib/iomgr/tcp_custom.cc:149
#20 0x00007ffff4361fc2 in __pyx_pf_4grpc_7_cython_6cygrpc_14_AsyncioSocket_6_read_cb (__pyx_v_future=<optimized out>,
    __pyx_v_self=0x7ffff3851d60) at src/python/grpcio/grpc/_cython/cygrpc.cpp:61230
#21 __pyx_pw_4grpc_7_cython_6cygrpc_14_AsyncioSocket_7_read_cb (__pyx_v_self=0x7ffff3851d60,
    __pyx_v_future=<optimized out>) at src/python/grpcio/grpc/_cython/cygrpc.cpp:60904
#22 0x00000000005d8781 in _PyMethodDef_RawFastCallKeywords (
    method=0x7ffff467f2a0 <__pyx_methods_4grpc_7_cython_6cygrpc__AsyncioSocket+32>, self=0x7ffff3851d60,
    args=0x7ffff3867bb0, nargs=<optimized out>, kwnames=<optimized out>) at ../Objects/call.c:648
#23 0x00000000005da280 in _PyCFunction_FastCallKeywords (kwnames=0x0, nargs=<optimized out>, args=0x7ffff3867bb0,
    func=0x7ffff386a910) at ../Objects/call.c:725
#24 _PyObject_FastCallKeywords (callable=0x7ffff386a910, stack=0x7ffff3867bb0, nargs=<optimized out>, kwnames=0x0)
    at ../Objects/call.c:156
#25 0x000000000063234f in context_run (self=<optimized out>, args=<optimized out>, nargs=<optimized out>,
    kwnames=<optimized out>, self=<optimized out>, args=<optimized out>, nargs=<optimized out>, kwnames=<optimized out>)
    at ../Python/context.c:618
#26 0x00000000005d8d13 in _PyMethodDef_RawFastCallDict (method=0x81dfe0 <PyContext_methods+160>, self=0x7ffff386a960,
    args=<optimized out>, nargs=2, kwargs=0x0) at ../Objects/call.c:544
#27 0x00000000005d8f6a in _PyCFunction_FastCallDict (kwargs=<optimized out>, nargs=<optimized out>, args=<optimized out>,
    func=0x7ffff38c3b90) at ../Objects/call.c:577
#28 PyCFunction_Call (func=0x7ffff38c3b90, args=<optimized out>, kwargs=<optimized out>) at ../Objects/call.c:791
#29 0x0000000000552803 in do_call_core (kwdict=0x0, callargs=0x7ffff3867b90, func=0x7ffff38c3b90) at ../Python/ceval.c:4641
#30 _PyEval_EvalFrameDefault (f=<optimized out>, throwflag=<optimized out>) at ../Python/ceval.c:3191
```