### PR TITLE
Check .code() before .cancelled() in Python RPC tests

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_rpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test.py
@@ -532,6 +532,7 @@ class RPCTest(unittest.TestCase):
                 metadata=(('test', 'CancelledUnaryRequestUnaryResponse'),))
             response_future.cancel()
 
+        self.assertIs(grpc.StatusCode.CANCELLED, response_future.code())
         self.assertTrue(response_future.cancelled())
         with self.assertRaises(grpc.FutureCancelledError):
             response_future.result()
@@ -539,7 +540,6 @@ class RPCTest(unittest.TestCase):
             response_future.exception()
         with self.assertRaises(grpc.FutureCancelledError):
             response_future.traceback()
-        self.assertIs(grpc.StatusCode.CANCELLED, response_future.code())
 
     def testCancelledUnaryRequestStreamResponse(self):
         self._cancelled_unary_request_stream_response(
@@ -562,6 +562,7 @@ class RPCTest(unittest.TestCase):
             self._control.block_until_paused()
             response_future.cancel()
 
+        self.assertIs(grpc.StatusCode.CANCELLED, response_future.code())
         self.assertTrue(response_future.cancelled())
         with self.assertRaises(grpc.FutureCancelledError):
             response_future.result()
@@ -570,7 +571,6 @@ class RPCTest(unittest.TestCase):
         with self.assertRaises(grpc.FutureCancelledError):
             response_future.traceback()
         self.assertIsNotNone(response_future.initial_metadata())
-        self.assertIs(grpc.StatusCode.CANCELLED, response_future.code())
         self.assertIsNotNone(response_future.details())
         self.assertIsNotNone(response_future.trailing_metadata())
 


### PR DESCRIPTION
Call object's `.cancelled()` is not guaranteed to immediately return
True per spec even if `cancel()` is called. `.code()` ensures that
the RPC is terminated before we check for `.cancelled()` to ensure
our test is not stricter than necessary (a conforming implementation
should be allowed to return `False` on `cancelled()` for a bit due
to a race or something.  This change makes the test more generically
applicable to other implementations.

@lidizheng @gnossen 
