### PR TITLE
Skip building Android for Java benchmarks

### DIFF
--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -46,7 +46,7 @@ do
     ;;  # C++ has already been built.
   "java")
     (cd ../grpc-java/ &&
-      ./gradlew -PskipCodegen=true :grpc-benchmarks:installDist)
+      ./gradlew -PskipCodegen=true -PskipAndroid=true :grpc-benchmarks:installDist)
     ;;
   "go")
     tools/run_tests/performance/build_performance_go.sh


### PR DESCRIPTION
At present, the benchmarks are not building due to missing the Android
SDK on the CI VMs.  The Android SDK is a "default" dependency for
grpc/grpc-java, but it is not required for gRPC benchmarks.

This commit modifies the performance test build script to skip Android
and to not start the gradle daemon, similar to PR #21628.

See also:
- PR #21628 for a similar change and description (fixing interop tests)
- PR #21848 for related documentation changes.

Review requested from @jtattermusch or @nicolasnoble  
