### PR TITLE
Skip building Android for Java benchmarks

### DIFF
--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -46,7 +46,7 @@ do
     ;;  # C++ has already been built.
   "java")
     (cd ../grpc-java/ &&
-      ./gradlew -PskipCodegen=true :grpc-benchmarks:installDist)
+      ./gradlew --no-daemon -PskipCodegen=true -PskipAndroid=true :grpc-benchmarks:installDist)
     ;;
   "go")
     tools/run_tests/performance/build_performance_go.sh


### PR DESCRIPTION
At present, the benchmarks are not building due to missing the Android
SDK on the CI VMs. The grpc/grpc-java repository makes a "default"
assumption that it should also build for Android, but this is not
required for gRPC benchmarks.

This commit modifies the performance test build script, skipping
Android and using gradle without a daemon, similar to PR #21628.

See also:
- PR #21628 for a similar change and description (fixing interop tests)
- PR #21848 for related documentation changes.

:heavy_check_mark: Tested: Local workstation (removing RVM setup) with success.

```
benreed@benreed ~/grpc/grpc % tools/run_tests/performance/build_performance.sh java

+ ./gradlew --no-daemon -PskipCodegen=true -PskipAndroid=true :grpc-benchmarks:installDist
*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
  * Skipping the build of Android projects because skipAndroid=true

BUILD SUCCESSFUL in 7s
39 actionable tasks: 39 up-to-date
``` 

Requesting review from @jtattermusch or @nicolasnoble.