### PR TITLE
Stop building performance artifacts for Android

### DIFF
--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -46,7 +46,7 @@ do
     ;;  # C++ has already been built.
   "java")
     (cd ../grpc-java/ &&
-      ./gradlew -PskipCodegen=true :grpc-benchmarks:installDist)
+      ./gradlew -PskipCodegen=true -PskipAndroid=true :grpc-benchmarks:installDist)
     ;;
   "go")
     tools/run_tests/performance/build_performance_go.sh


### PR DESCRIPTION
Our full performance benchmark has been broken since Jan 9th. This is the link to the first failure: https://fusion.corp.google.com/runanalysis/test/prod%3Agrpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_full_performance_master/prod%3Agrpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_full_performance_master/KOKORO/22b4aa53-f5a6-49df-b746-cd2b537a8db9/1578618684324/build%20%232950/Targets?target=grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_full_performance_master&drilldownTab=logs

The possible culprit is the Android build failure:
```
+ ./gradlew -PskipCodegen=true :grpc-benchmarks:installDist
Starting a Gradle Daemon (subsequent builds will be faster)
*** Skipping the build of codegen and compilation of proto files because skipCodegen=true
*** Android SDK is required. To avoid building Android projects, set -PskipAndroid=true

FAILURE: Build failed with an exception.

* Where:
Build file '/home/kbuilder/performance_workspace/grpc-java/cronet/build.gradle' line: 49

* What went wrong:
A problem occurred evaluating project ':grpc-cronet'.
> SDK location not found. Define location with sdk.dir in the local.properties file or with an ANDROID_HOME environment variable.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
```

Let's see if disabling it fix the performance benchmark or not.