### PR TITLE
get rid of the https://grpc.io/release plague

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,13 +72,13 @@ To prepare for cmake + Microsoft Visual C++ compiler build
 # Clone the repository (including submodules)
 
 Before building, you need to clone the gRPC github repository and download submodules containing source code
-for gRPC's dependencies (that's done by the `submodule` command or `--recursive` flag). The following commands will clone the gRPC
-repository at the latest stable version.
+for gRPC's dependencies (that's done by the `submodule` command or `--recursive` flag). Use following commands
+to clone the gRPC repository at the [latest stable release tag](https://github.com/grpc/grpc/releases)
 
 ## Unix
 
 ```sh
- $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+ $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
  $ cd grpc
  $ git submodule update --init
  ```
@@ -86,10 +86,9 @@ repository at the latest stable version.
 ## Windows
 
 ```
-> @rem You can also do just "git clone --recursive -b THE_BRANCH_YOU_WANT https://github.com/grpc/grpc"
-> powershell git clone --recursive -b ((New-Object System.Net.WebClient).DownloadString(\"https://grpc.io/release\").Trim()) https://github.com/grpc/grpc
+> git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 > cd grpc
-> @rem To update submodules at later time, run "git submodule update --init"
+> git submodule update --init
 ```
 
 NOTE: The `bazel` build tool uses a different model for dependencies. You only need to worry about downloading submodules if you're building

--- a/examples/cpp/compression/README.md
+++ b/examples/cpp/compression/README.md
@@ -5,11 +5,11 @@ Make sure you have run the [hello world example](../helloworld) or understood th
 
 ### Get the tutorial source code
 
-The example code for this and our other examples lives in the `examples` directory. Clone this repository to your local machine by running the following command:
+The example code for this and our other examples lives in the `examples` directory. Clone this repository at the [latest stable release tag](https://github.com/grpc/grpc/releases) to your local machine  by running the following command:
 
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 ```
 
 Change your current directory to examples/cpp/compression

--- a/examples/cpp/helloworld/README.md
+++ b/examples/cpp/helloworld/README.md
@@ -7,12 +7,12 @@ Make sure you have installed gRPC on your system. Follow the
 ### Get the tutorial source code
 
 The example code for this and our other examples lives in the `examples`
-directory. Clone this repository to your local machine by running the
-following command:
+directory. Clone this repository at the [latest stable release tag](https://github.com/grpc/grpc/releases)
+to your local machine by running the following command:
 
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 ```
 
 Change your current directory to examples/cpp/helloworld

--- a/examples/cpp/load_balancing/README.md
+++ b/examples/cpp/load_balancing/README.md
@@ -5,11 +5,12 @@ Make sure you have run the [hello world example](../helloworld) or understood th
 
 ### Get the tutorial source code
 
-The example code for this and our other examples lives in the `examples` directory. Clone this repository to your local machine by running the following command:
+The example code for this and our other examples lives in the `examples` directory. Clone this repository 
+at the [latest stable release tag](https://github.com/grpc/grpc/releases) to your local machine by running the following command:
 
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 ```
 
 Change your current directory to examples/cpp/load_balancing

--- a/examples/cpp/metadata/README.md
+++ b/examples/cpp/metadata/README.md
@@ -10,9 +10,10 @@ https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md, with the
 exception of binary headers, which don't have to be base64 encoded.
 
 ### Get the tutorial source code
- The example code for this and our other examples lives in the `examples` directory. Clone this repository to your local machine by running the following command:
+ The example code for this and our other examples lives in the `examples` directory. Clone this repository 
+ at the [latest stable release tag](https://github.com/grpc/grpc/releases) to your local machine by running the following command:
  ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 ```
  Change your current directory to examples/cpp/metadata
  ```sh

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -12,7 +12,7 @@ INSTALL
    ```sh
    $ # Get the gRPC repository
    $ export REPO_ROOT=grpc # REPO root can be any directory of your choice
-   $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
+   $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc $REPO_ROOT
    $ cd $REPO_ROOT
 
    $ cd examples/node

--- a/examples/objective-c/helloworld/README.md
+++ b/examples/objective-c/helloworld/README.md
@@ -18,11 +18,11 @@ Here's how to build and run the Objective-C implementation of the [Hello World](
 example used in [Getting started](https://github.com/grpc/grpc/tree/master/examples).
 
 The example code for this and our other examples lives in the `examples` directory. Clone
-this repository to your local machine by running the following commands:
+this repository at the [latest stable release tag](https://github.com/grpc/grpc/releases) to your local machine by running the following commands:
 
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -16,7 +16,7 @@ This requires `php` >= 5.5, `pecl`, `composer`
  - Install the `protoc` compiler plugin `grpc_php_plugin`
 
    ```sh
-   $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+   $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
    $ cd grpc
    $ make grpc_php_plugin
    ```

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -47,10 +47,10 @@ You can download the pre-compiled `grpc.dll` extension from the PECL
 
 ### Build from source
 
-Clone this repository
+Clone this repository at the [latest stable release tag](https://github.com/grpc/grpc/releases)
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 ```
 
 #### Build and install the gRPC C core library
@@ -184,7 +184,7 @@ in the future.
 You can also just build the `grpc_php_plugin` by running:
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 $ make grpc_php_plugin
@@ -246,7 +246,7 @@ $ protoc -I=. echo.proto --php_out=. --grpc_out=. \
 You will need the source code to run tests
 
 ```sh
-$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```

--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -59,7 +59,7 @@ package named :code:`python-dev`).
 ::
 
   $ export REPO_ROOT=grpc  # REPO_ROOT can be any directory of your choice
-  $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
+  $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc $REPO_ROOT
   $ cd $REPO_ROOT
   $ git submodule update --init
 

--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -61,7 +61,7 @@ GCC-like stuff, but you may end up having a bad time.
 ::
 
   $ export REPO_ROOT=grpc  # REPO_ROOT can be any directory of your choice
-  $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
+  $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc $REPO_ROOT
   $ cd $REPO_ROOT
   $ git submodule update --init
 


### PR DESCRIPTION
Also see internal issue b/148844497

Generally the `curl -L https://grpc.io/release` subcommand does more harm than good
- it makes the cmdline hard to read and obfuscates the real command
- https://grpc.io/release requires maintenance: https://grpc.io/release is now way out of date which proves we continue forgetting to update it
- it's not easy to figure out how the `https://grpc.io/release` file is updated (I didn't figure it out).

In short the `https://grpc.io/release` is harmful and we should get rid of it.