### PR TITLE
[Aio] Attempt to fix recent AsyncIO windows flake

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -44,7 +44,10 @@ class _OngoingCalls:
         self._calls = WeakSet()
 
     def _remove_call(self, call: _base_call.RpcContext):
-        self._calls.remove(call)
+        try:
+            self._calls.remove(call)
+        except KeyError:
+            pass
 
     @property
     def calls(self) -> AbstractSet[_base_call.RpcContext]:

--- a/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
@@ -24,11 +24,11 @@ from grpc.experimental.aio import _base_call
 from grpc.experimental.aio._channel import _OngoingCalls
 
 from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
-from tests_aio.unit._constants import UNARY_CALL_WITH_SLEEP_VALUE
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
 
 _UNARY_CALL_METHOD_WITH_SLEEP = '/grpc.testing.TestService/UnaryCallWithSleep'
+_LONG_TIMEOUT_THAT_SHOULD_NOT_EXPIRE = 60
 
 
 class TestOngoingCalls(unittest.TestCase):
@@ -90,7 +90,7 @@ class TestCloseChannel(AioTestBase):
 
         call = UnaryCallWithSleep(messages_pb2.SimpleRequest())
 
-        await channel.close(grace=UNARY_CALL_WITH_SLEEP_VALUE * 4)
+        await channel.close(grace=_LONG_TIMEOUT_THAT_SHOULD_NOT_EXPIRE)
 
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 


### PR DESCRIPTION
There are two types of flake I am observing after https://github.com/grpc/grpc/pull/21819:
1. An `KeyError` in done callback;
2. A cancelled RPC in graceful channel close test.

As discussed with @gnossen, the fix for the first type of flake should guarantee thread safety for potential integration with other threads / applications. So, a try-catch is better than an if condition.

As for the second fix, the issue is Windows connection takes much longer to initiate.