### PR TITLE
[Aio] Another fix for close mechanism on Windows

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -395,10 +395,9 @@ class Channel:
         # A new set is created acting as a shallow copy because
         # when cancellation happens the calls are automatically
         # removed from the originally set.
-        calls = WeakSet(self._ongoing_calls.calls)
+        calls = WeakSet(data=self._ongoing_calls.calls)
         for call in calls:
-            if call is not None:
-                call.cancel()
+            call.cancel()
 
         self._channel.close()
 

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -395,9 +395,10 @@ class Channel:
         # A new set is created acting as a shallow copy because
         # when cancellation happens the calls are automatically
         # removed from the originally set.
-        calls = WeakSet(data=self._ongoing_calls.calls)
+        calls = frozenset(self._ongoing_calls.calls)
         for call in calls:
-            call.cancel()
+            if call is not None:
+                call.cancel()
 
         self._channel.close()
 

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -395,7 +395,7 @@ class Channel:
         # A new set is created acting as a shallow copy because
         # when cancellation happens the calls are automatically
         # removed from the originally set.
-        calls = frozenset(self._ongoing_calls.calls)
+        calls = WeakSet(self._ongoing_calls.calls)
         for call in calls:
             if call is not None:
                 call.cancel()

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -210,6 +210,8 @@ class TestMetadata(AioTestBase):
         self.assertEqual(_RESPONSE, await call)
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 
+    @unittest.skipIf(platform.system() == 'Windows',
+                     'https://github.com/grpc/grpc/issues/21943')
     async def test_invalid_metadata(self):
         multicallable = self._client.unary_unary(_TEST_CLIENT_TO_SERVER)
         for exception_type, metadata in _INVALID_METADATA_TEST_CASES:


### PR DESCRIPTION
The `WeakSet` seems not making a shallow copy of the given set. This change might make the call live slightly longer in the shutdown path, but it should make the failure go away.

https://source.cloud.google.com/results/invocations/418cdd64-0133-44a8-9a90-10224e454143/targets/github%2Fgrpc%2Frun_tests%2Fpython_windows_opt_asyncio%2Fpy36_asyncio.test_aio.unit.metadata_test.TestMetadata/tests

Fixes https://github.com/grpc/grpc/issues/21907