### PR TITLE
Add v1.27.1 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -152,6 +152,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.24.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.25.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.26.0', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.27.1', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
See also #21880 which this will surely conflict with, unfortunately.