### PR TITLE
Move xds API code into a class, so that common state can be cached.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -63,7 +63,7 @@ class CdsLb : public LoadBalancingPolicy {
    public:
     explicit ClusterWatcher(RefCountedPtr<CdsLb> parent)
         : parent_(std::move(parent)) {}
-    void OnClusterChanged(CdsUpdate cluster_data) override;
+    void OnClusterChanged(XdsApi::CdsUpdate cluster_data) override;
     void OnError(grpc_error* error) override;
 
    private:
@@ -111,7 +111,7 @@ class CdsLb : public LoadBalancingPolicy {
 // CdsLb::ClusterWatcher
 //
 
-void CdsLb::ClusterWatcher::OnClusterChanged(CdsUpdate cluster_data) {
+void CdsLb::ClusterWatcher::OnClusterChanged(XdsApi::CdsUpdate cluster_data) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_cds_lb_trace)) {
     gpr_log(GPR_INFO, "[cdslb %p] received CDS update from xds client",
             parent_.get());

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -172,7 +172,7 @@ class XdsLb : public LoadBalancingPolicy {
 
     RefCountedPtr<XdsLb> xds_policy_;
     PickerList pickers_;
-    RefCountedPtr<XdsDropConfig> drop_config_;
+    RefCountedPtr<XdsApi::DropConfig> drop_config_;
   };
 
   class FallbackHelper : public ChannelControlHelper {
@@ -286,7 +286,7 @@ class XdsLb : public LoadBalancingPolicy {
     ~LocalityMap() { xds_policy_.reset(DEBUG_LOCATION, "LocalityMap"); }
 
     void UpdateLocked(
-        const XdsPriorityListUpdate::LocalityMap& locality_map_update);
+        const XdsApi::PriorityListUpdate::LocalityMap& locality_map_update);
     void ResetBackoffLocked();
     void UpdateXdsPickerLocked();
     OrphanablePtr<Locality> ExtractLocalityLocked(
@@ -316,10 +316,10 @@ class XdsLb : public LoadBalancingPolicy {
     static void OnDelayedRemovalTimerLocked(void* arg, grpc_error* error);
     static void OnFailoverTimerLocked(void* arg, grpc_error* error);
 
-    const XdsPriorityListUpdate& priority_list_update() const {
+    const XdsApi::PriorityListUpdate& priority_list_update() const {
       return xds_policy_->priority_list_update_;
     }
-    const XdsPriorityListUpdate::LocalityMap* locality_map_update() const {
+    const XdsApi::PriorityListUpdate::LocalityMap* locality_map_update() const {
       return xds_policy_->priority_list_update_.Find(priority_);
     }
 
@@ -431,10 +431,10 @@ class XdsLb : public LoadBalancingPolicy {
   // The priority that is being used.
   uint32_t current_priority_ = UINT32_MAX;
   // The update for priority_list_.
-  XdsPriorityListUpdate priority_list_update_;
+  XdsApi::PriorityListUpdate priority_list_update_;
 
   // The config for dropping calls.
-  RefCountedPtr<XdsDropConfig> drop_config_;
+  RefCountedPtr<XdsApi::DropConfig> drop_config_;
 
   // The stats for client-side load reporting.
   XdsClientStats client_stats_;
@@ -594,7 +594,7 @@ class XdsLb::EndpointWatcher : public XdsClient::EndpointWatcherInterface {
 
   ~EndpointWatcher() { xds_policy_.reset(DEBUG_LOCATION, "EndpointWatcher"); }
 
-  void OnEndpointChanged(EdsUpdate update) override {
+  void OnEndpointChanged(XdsApi::EdsUpdate update) override {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_xds_trace)) {
       gpr_log(GPR_INFO, "[xdslb %p] Received EDS update from xds client",
               xds_policy_.get());
@@ -1154,7 +1154,7 @@ XdsLb::LocalityMap::LocalityMap(RefCountedPtr<XdsLb> xds_policy,
 }
 
 void XdsLb::LocalityMap::UpdateLocked(
-    const XdsPriorityListUpdate::LocalityMap& locality_map_update) {
+    const XdsApi::PriorityListUpdate::LocalityMap& locality_map_update) {
   if (xds_policy_->shutting_down_) return;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_xds_trace)) {
     gpr_log(GPR_INFO, "[xdslb %p] Start Updating priority %" PRIu32,

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -187,17 +187,18 @@ class XdsClient::ChannelState::AdsCallState
           gpr_log(GPR_INFO, "[xds_client %p] %s",
                   self->ads_calld_->xds_client(), grpc_error_string(error));
         }
-        if (self->type_url_ == kLdsTypeUrl || self->type_url_ == kRdsTypeUrl) {
+        if (self->type_url_ == XdsApi::kLdsTypeUrl ||
+            self->type_url_ == XdsApi::kRdsTypeUrl) {
           self->ads_calld_->xds_client()->service_config_watcher_->OnError(
               error);
-        } else if (self->type_url_ == kCdsTypeUrl) {
+        } else if (self->type_url_ == XdsApi::kCdsTypeUrl) {
           ClusterState& state =
               self->ads_calld_->xds_client()->cluster_map_[self->name_];
           for (const auto& p : state.watchers) {
             p.first->OnError(GRPC_ERROR_REF(error));
           }
           GRPC_ERROR_UNREF(error);
-        } else if (self->type_url_ == kEdsTypeUrl) {
+        } else if (self->type_url_ == XdsApi::kEdsTypeUrl) {
           EndpointState& state =
               self->ads_calld_->xds_client()->endpoint_map_[self->name_];
           for (const auto& p : state.watchers) {
@@ -237,10 +238,10 @@ class XdsClient::ChannelState::AdsCallState
 
   void SendMessageLocked(const std::string& type_url);
 
-  void AcceptLdsUpdate(LdsUpdate lds_update);
-  void AcceptRdsUpdate(RdsUpdate rds_update);
-  void AcceptCdsUpdate(CdsUpdateMap cds_update_map);
-  void AcceptEdsUpdate(EdsUpdateMap eds_update_map);
+  void AcceptLdsUpdate(XdsApi::LdsUpdate lds_update);
+  void AcceptRdsUpdate(XdsApi::RdsUpdate rds_update);
+  void AcceptCdsUpdate(XdsApi::CdsUpdateMap cds_update_map);
+  void AcceptEdsUpdate(XdsApi::EdsUpdateMap eds_update_map);
 
   static void OnRequestSent(void* arg, grpc_error* error);
   static void OnRequestSentLocked(void* arg, grpc_error* error);
@@ -710,13 +711,13 @@ XdsClient::ChannelState::AdsCallState::AdsCallState(
   GRPC_CLOSURE_INIT(&on_request_sent_, OnRequestSent, this,
                     grpc_schedule_on_exec_ctx);
   if (xds_client()->service_config_watcher_ != nullptr) {
-    Subscribe(kLdsTypeUrl, xds_client()->server_name_);
+    Subscribe(XdsApi::kLdsTypeUrl, xds_client()->server_name_);
   }
   for (const auto& p : xds_client()->cluster_map_) {
-    Subscribe(kCdsTypeUrl, std::string(p.first));
+    Subscribe(XdsApi::kCdsTypeUrl, std::string(p.first));
   }
   for (const auto& p : xds_client()->endpoint_map_) {
-    Subscribe(kEdsTypeUrl, std::string(p.first));
+    Subscribe(XdsApi::kEdsTypeUrl, std::string(p.first));
   }
   // Op: recv initial metadata.
   op = ops;
@@ -789,35 +790,31 @@ void XdsClient::ChannelState::AdsCallState::SendMessageLocked(
   auto& state = state_map_[type_url];
   grpc_error* error = state.error;
   state.error = GRPC_ERROR_NONE;
-  const XdsBootstrap::Node* node =
-      sent_initial_message_ ? nullptr : xds_client()->bootstrap_->node();
-  const char* build_version =
-      sent_initial_message_ ? nullptr : xds_client()->build_version_.get();
-  sent_initial_message_ = true;
   grpc_slice request_payload_slice;
-  if (type_url == kLdsTypeUrl) {
-    request_payload_slice = XdsLdsRequestCreateAndEncode(
-        xds_client()->server_name_, node, build_version, state.version,
-        state.nonce, error);
+  if (type_url == XdsApi::kLdsTypeUrl) {
+    request_payload_slice = xds_client()->api_.CreateLdsRequest(
+        xds_client()->server_name_, state.version, state.nonce, error,
+        !sent_initial_message_);
     state.subscribed_resources[xds_client()->server_name_]->Start(Ref());
-  } else if (type_url == kRdsTypeUrl) {
-    request_payload_slice = XdsRdsRequestCreateAndEncode(
-        xds_client()->route_config_name_, node, build_version, state.version,
-        state.nonce, error);
+  } else if (type_url == XdsApi::kRdsTypeUrl) {
+    request_payload_slice = xds_client()->api_.CreateRdsRequest(
+        xds_client()->route_config_name_, state.version, state.nonce, error,
+        !sent_initial_message_);
     state.subscribed_resources[xds_client()->route_config_name_]->Start(Ref());
-  } else if (type_url == kCdsTypeUrl) {
-    request_payload_slice = XdsCdsRequestCreateAndEncode(
-        ClusterNamesForRequest(), node, build_version, state.version,
-        state.nonce, error);
-  } else if (type_url == kEdsTypeUrl) {
-    request_payload_slice = XdsEdsRequestCreateAndEncode(
-        EdsServiceNamesForRequest(), node, build_version, state.version,
-        state.nonce, error);
+  } else if (type_url == XdsApi::kCdsTypeUrl) {
+    request_payload_slice = xds_client()->api_.CreateCdsRequest(
+        ClusterNamesForRequest(), state.version, state.nonce, error,
+        !sent_initial_message_);
+  } else if (type_url == XdsApi::kEdsTypeUrl) {
+    request_payload_slice = xds_client()->api_.CreateEdsRequest(
+        EdsServiceNamesForRequest(), state.version, state.nonce, error,
+        !sent_initial_message_);
   } else {
-    request_payload_slice = XdsUnsupportedTypeNackRequestCreateAndEncode(
+    request_payload_slice = xds_client()->api_.CreateUnsupportedTypeNackRequest(
         type_url, state.nonce, state.error);
     state_map_.erase(type_url);
   }
+  sent_initial_message_ = true;
   // Create message payload.
   send_message_payload_ =
       grpc_raw_byte_buffer_create(&request_payload_slice, 1);
@@ -863,7 +860,7 @@ bool XdsClient::ChannelState::AdsCallState::HasSubscribedResources() const {
 }
 
 void XdsClient::ChannelState::AdsCallState::AcceptLdsUpdate(
-    LdsUpdate lds_update) {
+    XdsApi::LdsUpdate lds_update) {
   const std::string& cluster_name =
       lds_update.rds_update.has_value()
           ? lds_update.rds_update.value().cluster_name
@@ -876,7 +873,7 @@ void XdsClient::ChannelState::AdsCallState::AcceptLdsUpdate(
             xds_client(), lds_update.route_config_name.c_str(),
             cluster_name.c_str());
   }
-  auto& lds_state = state_map_[kLdsTypeUrl];
+  auto& lds_state = state_map_[XdsApi::kLdsTypeUrl];
   auto& state = lds_state.subscribed_resources[xds_client()->server_name_];
   if (state != nullptr) state->Finish();
   // Ignore identical update.
@@ -906,19 +903,19 @@ void XdsClient::ChannelState::AdsCallState::AcceptLdsUpdate(
     }
   } else {
     // Send RDS request for dynamic resolution.
-    Subscribe(kRdsTypeUrl, xds_client()->route_config_name_);
+    Subscribe(XdsApi::kRdsTypeUrl, xds_client()->route_config_name_);
   }
 }
 
 void XdsClient::ChannelState::AdsCallState::AcceptRdsUpdate(
-    RdsUpdate rds_update) {
+    XdsApi::RdsUpdate rds_update) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
     gpr_log(GPR_INFO,
             "[xds_client %p] RDS update received: "
             "cluster_name=%s",
             xds_client(), rds_update.cluster_name.c_str());
   }
-  auto& rds_state = state_map_[kRdsTypeUrl];
+  auto& rds_state = state_map_[XdsApi::kRdsTypeUrl];
   auto& state =
       rds_state.subscribed_resources[xds_client()->route_config_name_];
   if (state != nullptr) state->Finish();
@@ -945,11 +942,11 @@ void XdsClient::ChannelState::AdsCallState::AcceptRdsUpdate(
 }
 
 void XdsClient::ChannelState::AdsCallState::AcceptCdsUpdate(
-    CdsUpdateMap cds_update_map) {
-  auto& cds_state = state_map_[kCdsTypeUrl];
+    XdsApi::CdsUpdateMap cds_update_map) {
+  auto& cds_state = state_map_[XdsApi::kCdsTypeUrl];
   for (auto& p : cds_update_map) {
     const char* cluster_name = p.first.c_str();
-    CdsUpdate& cds_update = p.second;
+    XdsApi::CdsUpdate& cds_update = p.second;
     auto& state = cds_state.subscribed_resources[cluster_name];
     if (state != nullptr) state->Finish();
     if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
@@ -987,11 +984,11 @@ void XdsClient::ChannelState::AdsCallState::AcceptCdsUpdate(
 }
 
 void XdsClient::ChannelState::AdsCallState::AcceptEdsUpdate(
-    EdsUpdateMap eds_update_map) {
-  auto& eds_state = state_map_[kEdsTypeUrl];
+    XdsApi::EdsUpdateMap eds_update_map) {
+  auto& eds_state = state_map_[XdsApi::kEdsTypeUrl];
   for (auto& p : eds_update_map) {
     const char* eds_service_name = p.first.c_str();
-    EdsUpdate& eds_update = p.second;
+    XdsApi::EdsUpdate& eds_update = p.second;
     auto& state = eds_state.subscribed_resources[eds_service_name];
     if (state != nullptr) state->Finish();
     if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
@@ -1035,7 +1032,7 @@ void XdsClient::ChannelState::AdsCallState::AcceptEdsUpdate(
       }
       for (size_t i = 0;
            i < eds_update.drop_config->drop_category_list().size(); ++i) {
-        const XdsDropConfig::DropCategory& drop_category =
+        const XdsApi::DropConfig::DropCategory& drop_category =
             eds_update.drop_config->drop_category_list()[i];
         gpr_log(GPR_INFO,
                 "[xds_client %p] Drop category %s has drop rate %d per million",
@@ -1046,7 +1043,7 @@ void XdsClient::ChannelState::AdsCallState::AcceptEdsUpdate(
     EndpointState& endpoint_state =
         xds_client()->endpoint_map_[eds_service_name];
     // Ignore identical update.
-    const EdsUpdate& prev_update = endpoint_state.update;
+    const XdsApi::EdsUpdate& prev_update = endpoint_state.update;
     const bool priority_list_changed =
         prev_update.priority_list_update != eds_update.priority_list_update;
     const bool drop_config_changed =
@@ -1138,15 +1135,15 @@ void XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked(
   // mode. We will also need to cancel the timer when we receive a serverlist
   // from the balancer.
   // Parse the response.
-  LdsUpdate lds_update;
-  RdsUpdate rds_update;
-  CdsUpdateMap cds_update_map;
-  EdsUpdateMap eds_update_map;
+  XdsApi::LdsUpdate lds_update;
+  XdsApi::RdsUpdate rds_update;
+  XdsApi::CdsUpdateMap cds_update_map;
+  XdsApi::EdsUpdateMap eds_update_map;
   std::string version;
   std::string nonce;
   std::string type_url;
-  // Note that XdsAdsResponseDecodeAndParse() also validate the response.
-  grpc_error* parse_error = XdsAdsResponseDecodeAndParse(
+  // Note that ParseAdsResponse() also validates the response.
+  grpc_error* parse_error = xds_client->api_.ParseAdsResponse(
       response_slice, xds_client->server_name_, xds_client->route_config_name_,
       ads_calld->EdsServiceNamesForRequest(), &lds_update, &rds_update,
       &cds_update_map, &eds_update_map, &version, &nonce, &type_url);
@@ -1173,13 +1170,13 @@ void XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked(
     } else {
       ads_calld->seen_response_ = true;
       // Accept the ADS response according to the type_url.
-      if (type_url == kLdsTypeUrl) {
+      if (type_url == XdsApi::kLdsTypeUrl) {
         ads_calld->AcceptLdsUpdate(std::move(lds_update));
-      } else if (type_url == kRdsTypeUrl) {
+      } else if (type_url == XdsApi::kRdsTypeUrl) {
         ads_calld->AcceptRdsUpdate(std::move(rds_update));
-      } else if (type_url == kCdsTypeUrl) {
+      } else if (type_url == XdsApi::kCdsTypeUrl) {
         ads_calld->AcceptCdsUpdate(std::move(cds_update_map));
-      } else if (type_url == kEdsTypeUrl) {
+      } else if (type_url == XdsApi::kEdsTypeUrl) {
         ads_calld->AcceptEdsUpdate(std::move(eds_update_map));
       }
       state.version = std::move(version);
@@ -1258,7 +1255,7 @@ bool XdsClient::ChannelState::AdsCallState::IsCurrentCallOnChannel() const {
 std::set<StringView>
 XdsClient::ChannelState::AdsCallState::ClusterNamesForRequest() {
   std::set<StringView> cluster_names;
-  for (auto& p : state_map_[kCdsTypeUrl].subscribed_resources) {
+  for (auto& p : state_map_[XdsApi::kCdsTypeUrl].subscribed_resources) {
     cluster_names.insert(p.first);
     OrphanablePtr<ResourceState>& state = p.second;
     state->Start(Ref());
@@ -1269,7 +1266,7 @@ XdsClient::ChannelState::AdsCallState::ClusterNamesForRequest() {
 std::set<StringView>
 XdsClient::ChannelState::AdsCallState::EdsServiceNamesForRequest() {
   std::set<StringView> eds_names;
-  for (auto& p : state_map_[kEdsTypeUrl].subscribed_resources) {
+  for (auto& p : state_map_[XdsApi::kEdsTypeUrl].subscribed_resources) {
     eds_names.insert(p.first);
     OrphanablePtr<ResourceState>& state = p.second;
     state->Start(Ref());
@@ -1320,7 +1317,7 @@ void XdsClient::ChannelState::LrsCallState::Reporter::OnNextReportTimerLocked(
 void XdsClient::ChannelState::LrsCallState::Reporter::SendReportLocked() {
   // Create a request that contains the load report.
   grpc_slice request_payload_slice =
-      XdsLrsRequestCreateAndEncode(xds_client()->ClientStatsMap());
+      xds_client()->api_.CreateLrsRequest(xds_client()->ClientStatsMap());
   // Skip client load report if the counters were all zero in the last
   // report and they are still zero in this one.
   const bool old_val = last_report_counters_were_zero_;
@@ -1396,9 +1393,8 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
       nullptr, GRPC_MILLIS_INF_FUTURE, nullptr);
   GPR_ASSERT(call_ != nullptr);
   // Init the request payload.
-  grpc_slice request_payload_slice = XdsLrsRequestCreateAndEncode(
-      xds_client()->server_name_, xds_client()->bootstrap_->node(),
-      xds_client()->build_version_.get());
+  grpc_slice request_payload_slice =
+      xds_client()->api_.CreateLrsInitialRequest(xds_client()->server_name_);
   send_message_payload_ =
       grpc_raw_byte_buffer_create(&request_payload_slice, 1);
   grpc_slice_unref_internal(request_payload_slice);
@@ -1577,7 +1573,7 @@ void XdsClient::ChannelState::LrsCallState::OnResponseReceivedLocked(
     // Parse the response.
     std::set<std::string> new_cluster_names;
     grpc_millis new_load_reporting_interval;
-    grpc_error* parse_error = XdsLrsResponseDecodeAndParse(
+    grpc_error* parse_error = xds_client->api_.ParseLrsResponse(
         response_slice, &new_cluster_names, &new_load_reporting_interval);
     if (parse_error != GRPC_ERROR_NONE) {
       gpr_log(GPR_ERROR,
@@ -1722,6 +1718,8 @@ XdsClient::XdsClient(Combiner* combiner, grpc_pollset_set* interested_parties,
       combiner_(GRPC_COMBINER_REF(combiner, "xds_client")),
       interested_parties_(interested_parties),
       bootstrap_(XdsBootstrap::ReadFromFile(error)),
+      api_(bootstrap_ == nullptr ? nullptr : bootstrap_->node(),
+           build_version_.get()),
       server_name_(server_name),
       service_config_watcher_(std::move(watcher)) {
   if (*error != GRPC_ERROR_NONE) {
@@ -1744,7 +1742,7 @@ XdsClient::XdsClient(Combiner* combiner, grpc_pollset_set* interested_parties,
   chand_ = MakeOrphanable<ChannelState>(
       Ref(DEBUG_LOCATION, "XdsClient+ChannelState"), channel);
   if (service_config_watcher_ != nullptr) {
-    chand_->Subscribe(kLdsTypeUrl, std::string(server_name));
+    chand_->Subscribe(XdsApi::kLdsTypeUrl, std::string(server_name));
   }
 }
 
@@ -1769,7 +1767,7 @@ void XdsClient::WatchClusterData(
   if (cluster_state.update.has_value()) {
     w->OnClusterChanged(cluster_state.update.value());
   }
-  chand_->Subscribe(kCdsTypeUrl, cluster_name_str);
+  chand_->Subscribe(XdsApi::kCdsTypeUrl, cluster_name_str);
 }
 
 void XdsClient::CancelClusterDataWatch(StringView cluster_name,
@@ -1782,7 +1780,7 @@ void XdsClient::CancelClusterDataWatch(StringView cluster_name,
     cluster_state.watchers.erase(it);
     if (cluster_state.watchers.empty()) {
       cluster_map_.erase(cluster_name_str);
-      chand_->Unsubscribe(kCdsTypeUrl, cluster_name_str);
+      chand_->Unsubscribe(XdsApi::kCdsTypeUrl, cluster_name_str);
     }
   }
 }
@@ -1799,7 +1797,7 @@ void XdsClient::WatchEndpointData(
   if (!endpoint_state.update.priority_list_update.empty()) {
     w->OnEndpointChanged(endpoint_state.update);
   }
-  chand_->Subscribe(kEdsTypeUrl, eds_service_name_str);
+  chand_->Subscribe(XdsApi::kEdsTypeUrl, eds_service_name_str);
 }
 
 void XdsClient::CancelEndpointDataWatch(StringView eds_service_name,
@@ -1812,7 +1810,7 @@ void XdsClient::CancelEndpointDataWatch(StringView eds_service_name,
     endpoint_state.watchers.erase(it);
     if (endpoint_state.watchers.empty()) {
       endpoint_map_.erase(eds_service_name_str);
-      chand_->Unsubscribe(kEdsTypeUrl, eds_service_name_str);
+      chand_->Unsubscribe(XdsApi::kEdsTypeUrl, eds_service_name_str);
     }
   }
 }

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -56,7 +56,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
    public:
     virtual ~ClusterWatcherInterface() = default;
 
-    virtual void OnClusterChanged(CdsUpdate cluster_data) = 0;
+    virtual void OnClusterChanged(XdsApi::CdsUpdate cluster_data) = 0;
 
     virtual void OnError(grpc_error* error) = 0;
   };
@@ -66,7 +66,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
    public:
     virtual ~EndpointWatcherInterface() = default;
 
-    virtual void OnEndpointChanged(EdsUpdate update) = 0;
+    virtual void OnEndpointChanged(XdsApi::EdsUpdate update) = 0;
 
     virtual void OnError(grpc_error* error) = 0;
   };
@@ -175,7 +175,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
     std::map<ClusterWatcherInterface*, std::unique_ptr<ClusterWatcherInterface>>
         watchers;
     // The latest data seen from CDS.
-    Optional<CdsUpdate> update;
+    Optional<XdsApi::CdsUpdate> update;
   };
 
   struct EndpointState {
@@ -184,7 +184,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
         watchers;
     std::set<XdsClientStats*> client_stats;
     // The latest data seen from EDS.
-    EdsUpdate update;
+    XdsApi::EdsUpdate update;
   };
 
   // Sends an error notification to all watchers.
@@ -212,6 +212,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   grpc_pollset_set* interested_parties_;
 
   std::unique_ptr<XdsBootstrap> bootstrap_;
+  XdsApi api_;
 
   const std::string server_name_;
 


### PR DESCRIPTION
There are no functional changes here; this is just a small refactoring to prepare for a subsequent PR that will add some additional logging.