### PR TITLE
Mitigate #21966

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -630,13 +630,13 @@ class PythonLanguage:
 
     def client_cmd(self, args):
         return [
-            'py37_native/bin/python', 'src/python/grpcio_tests/setup.py',
+            '/usr/bin/python3.7', 'src/python/grpcio_tests/setup.py',
             'run_interop', '--client', '--args="{}"'.format(' '.join(args))
         ]
 
     def client_cmd_http2interop(self, args):
         return [
-            'py37_native/bin/python',
+            '/usr/bin/python3.7',
             'src/python/grpcio_tests/tests/http2/negative_http2_client.py',
         ] + args
 


### PR DESCRIPTION
We're not completely sure yet what *triggered* the breakage, but we do know that Python packages are not being installed in the virtual environments that they used to be. This should stop the continuous breakage for now. We will follow up with an investigation into the root cause.

Fixes https://github.com/grpc/grpc/issues/21966.