### PR TITLE
Pin virtualenv to 16.7.9

### DIFF
--- a/templates/tools/dockerfile/python_deps.include
+++ b/templates/tools/dockerfile/python_deps.include
@@ -10,5 +10,5 @@ RUN apt-get update && apt-get install -y ${'\\'}
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -28,8 +28,8 @@
         libtool ${"\\"}
         curl ${"\\"}
         shellcheck
-  RUN python2 -m pip install simplejson mako virtualenv lxml
-  RUN python3 -m pip install simplejson mako virtualenv lxml
+  RUN python2 -m pip install simplejson mako virtualenv==16.7.9 lxml
+  RUN python3 -m pip install simplejson mako virtualenv==16.7.9 lxml
 
   <%include file="../../clang5.include"/>
   <%include file="../../bazel.include"/>

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 ADD clang_tidy_all_the_things.sh /

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #================

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #================

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 # Define the default command.

--- a/tools/dockerfile/interoptest/grpc_interop_go1.11/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.11/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 # Define the default command.

--- a/tools/dockerfile/interoptest/grpc_interop_go1.7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.7/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 # Define the default command.

--- a/tools/dockerfile/interoptest/grpc_interop_go1.8/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.8/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 # Define the default command.

--- a/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 RUN pip install twisted h2==2.6.1 hyper

--- a/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #==================

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #==================

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 

--- a/tools/dockerfile/test/csharp_stretch_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_stretch_x64/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #================

--- a/tools/dockerfile/test/cxx_buster_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_buster_x64/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/cxx_ubuntu1804_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1804_x64/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/fuzzer/Dockerfile
+++ b/tools/dockerfile/test/fuzzer/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/node_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/node_jessie_x64/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #==================

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================	

--- a/tools/dockerfile/test/php_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php_jessie_x64/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #=================

--- a/tools/dockerfile/test/ruby_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_jessie_x64/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv
+RUN pip install virtualenv==16.7.9
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 #==================

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -80,8 +80,8 @@ RUN apt-get update && apt-get install -y \
       libtool \
       curl \
       shellcheck
-RUN python2 -m pip install simplejson mako virtualenv lxml
-RUN python3 -m pip install simplejson mako virtualenv lxml
+RUN python2 -m pip install simplejson mako virtualenv==16.7.9 lxml
+RUN python3 -m pip install simplejson mako virtualenv==16.7.9 lxml
 
 RUN apt-get update && apt-get -y install wget xz-utils
 RUN wget http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -136,7 +136,7 @@ then
 fi
 
 # Ensure the generated artifacts are valid.
-"${PYTHON}" -m virtualenv venv || { "${PYTHON}" -m pip install virtualenv && "${PYTHON}" -m virtualenv venv; }
+"${PYTHON}" -m virtualenv venv || { "${PYTHON}" -m pip install virtualenv==16.7.9 && "${PYTHON}" -m virtualenv venv; }
 venv/bin/python -m pip install "twine<=2.0"
 venv/bin/python -m twine check dist/* tools/distrib/python/grpcio_tools/dist/*
 rm -rf venv/

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -145,7 +145,7 @@ if [[ "$(inside_venv)" ]]; then
   VENV_PYTHON="$PYTHON"
 else
   # Instantiate the virtualenv from the Python version passed in.
-  $PYTHON -m pip install --user virtualenv
+  $PYTHON -m pip install --user virtualenv==16.7.9
   $PYTHON -m virtualenv "$VENV"
   VENV_PYTHON=$(script_realpath "$VENV/$VENV_RELATIVE_PYTHON")
 fi


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21966

In short, `virtualenv >= 20.0.0` + `realpath` doesn't work.

`virtualenv` introduces a breaking change in their `20.0.x` release, where the Python binary changed from a script to a symlink. Our infrastructure code depended on previous behavior, and invokes `realpath` on the Python binary to get the full file path. However, for symlinks, `realpath` always traces down the symlinks and eventually gets the system version of Python. Then, the build script installed gRPC Python packages in the wrong Python environment, resulted in test failure.

```
root@4a3f61c8c7a9:/var/local/git/grpc# ls -l py37_asyncio/bin/python
lrwxrwxrwx 3 root staff 18 Feb 11 18:45 py37_asyncio/bin/python -> /usr/bin/python3.7
root@4a3f61c8c7a9:/var/local/git/grpc# realpath py37_asyncio/bin/python
/usr/bin/python3.7
```

---

Manual sanity check passed:
```
tools/run_tests/run_interop_tests.py -l python -s python --use_docker --http2_interop --internal_ci -t -j 1
```