### PR TITLE
Delete default TimePoint constructor to detect error at compile time

### DIFF
--- a/include/grpcpp/impl/codegen/time.h
+++ b/include/grpcpp/impl/codegen/time.h
@@ -39,6 +39,10 @@ namespace grpc {
 template <typename T>
 class TimePoint {
  public:
+  // If you see the error with methods below, you may need either
+  // i) using the existing types having a conversion class such as
+  // gpr_timespec and std::chrono::system_clock::time_point or
+  // ii) writing a new TimePoint<YourType> to address your case.
   TimePoint(const T& /*time*/) = delete;
   gpr_timespec raw_time() = delete;
 };

--- a/include/grpcpp/impl/codegen/time.h
+++ b/include/grpcpp/impl/codegen/time.h
@@ -39,14 +39,8 @@ namespace grpc {
 template <typename T>
 class TimePoint {
  public:
-  TimePoint(const T& /*time*/) { you_need_a_specialization_of_TimePoint(); }
-  gpr_timespec raw_time() {
-    gpr_timespec t;
-    return t;
-  }
-
- private:
-  void you_need_a_specialization_of_TimePoint();
+  TimePoint(const T& /*time*/) = delete;
+  gpr_timespec raw_time() = delete;
 };
 
 template <>


### PR DESCRIPTION
The previous way detects an error at link time but this way does it at compile time.