### PR TITLE
Add missing libuv specific sources to bazel BUILD (align build.yaml and BUILD)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -750,6 +750,7 @@ grpc_cc_library(
         "src/core/lib/iomgr/iomgr_internal.cc",
         "src/core/lib/iomgr/iomgr_posix.cc",
         "src/core/lib/iomgr/iomgr_posix_cfstream.cc",
+        "src/core/lib/iomgr/iomgr_uv.cc",
         "src/core/lib/iomgr/iomgr_windows.cc",
         "src/core/lib/iomgr/is_epollexclusive_available.cc",
         "src/core/lib/iomgr/load_file.cc",
@@ -773,6 +774,7 @@ grpc_cc_library(
         "src/core/lib/iomgr/socket_utils_common_posix.cc",
         "src/core/lib/iomgr/socket_utils_linux.cc",
         "src/core/lib/iomgr/socket_utils_posix.cc",
+        "src/core/lib/iomgr/socket_utils_uv.cc",
         "src/core/lib/iomgr/socket_utils_windows.cc",
         "src/core/lib/iomgr/socket_windows.cc",
         "src/core/lib/iomgr/tcp_client.cc",
@@ -992,6 +994,7 @@ grpc_cc_library(
     public_hdrs = GRPC_PUBLIC_HDRS,
     use_cfstream = True,
     deps = [
+        "eventmanager_libuv",
         "gpr_base",
         "grpc_codegen",
         "grpc_trace",


### PR DESCRIPTION
Prerequisite for: https://github.com/grpc/grpc/pull/21929

comparing build.yaml and bazel BUILD, bazel's version of //:grpc library is missing some libuv-related stuff.   It's better to get build.yaml and BUILD aligned first and try to import, to avoid surprises when merging the big PR https://github.com/grpc/grpc/pull/21929