### PR TITLE
Update docker images for Ruby

### DIFF
--- a/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_4/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_4/Dockerfile
@@ -27,11 +27,11 @@ RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A170311380
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.4
-RUN /bin/bash -l -c "rvm install ruby-2.4.5"
-RUN /bin/bash -l -c "rvm use --default ruby-2.4.5"
+RUN /bin/bash -l -c "rvm install ruby-2.4.9"
+RUN /bin/bash -l -c "rvm use --default ruby-2.4.9"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.4.5' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.4.9' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler -v 1.17.3 --no-document"
 
 RUN mkdir /var/local/jenkins

--- a/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_6/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_6/Dockerfile
@@ -27,11 +27,11 @@ RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A170311380
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.6
-RUN /bin/bash -l -c "rvm install ruby-2.6.0"
-RUN /bin/bash -l -c "rvm use --default ruby-2.6.0"
+RUN /bin/bash -l -c "rvm install ruby-2.6.5"
+RUN /bin/bash -l -c "rvm use --default ruby-2.6.5"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.6.0' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.6.5' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document"
 
 RUN mkdir /var/local/jenkins

--- a/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_7/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64_ruby_2_7/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,13 +26,13 @@ RUN apt-get update && apt-get install -y \
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
-# Install Ruby 2.5
-RUN /bin/bash -l -c "rvm install ruby-2.5.7"
-RUN /bin/bash -l -c "rvm use --default ruby-2.5.7"
+# Install Ruby 2.7
+RUN /bin/bash -l -c "rvm install ruby-2.7.0"
+RUN /bin/bash -l -c "rvm use --default ruby-2.7.0"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5.7' >> ~/.bashrc"
-RUN /bin/bash -l -c "gem install bundler -v 1.17.3 --no-document"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.7.0' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler --no-document"
 
 RUN mkdir /var/local/jenkins
 

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -340,6 +340,7 @@ def targets():
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_4'),
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_5'),
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_6'),
+        # RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_7'),
         RubyDistribTest('linux', 'x64', 'centos6'),
         RubyDistribTest('linux', 'x64', 'centos7'),
         RubyDistribTest('linux', 'x64', 'fedora23'),


### PR DESCRIPTION
Updated docker images for Ruby to have the latest Ruby runtimes.
Added new docker image for Ruby 2.7 but not used yet.

[grpc_build_artifacts_multiplatform](https://sponge.corp.google.com/eb01fe4e-1e43-4c0a-b1f5-c3e2768c5675): passed