### PR TITLE
Restructure XdsClient load reporting APIs

### DIFF
--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -176,6 +176,17 @@ class XdsApi {
 
   using EdsUpdateMap = std::map<std::string /*eds_service_name*/, EdsUpdate>;
 
+  struct ClusterLoadReport {
+    XdsClusterDropStats::DroppedRequestsMap dropped_requests;
+    std::map<XdsLocalityName*, XdsClusterLocalityStats::Snapshot,
+             XdsLocalityName::Less>
+        locality_stats;
+    grpc_millis load_report_interval;
+  };
+  using ClusterLoadReportMap = std::map<
+      std::pair<std::string /*cluster_name*/, std::string /*eds_service_name*/>,
+      ClusterLoadReport>;
+
   XdsApi(const XdsBootstrap::Node* node, const char* build_version)
       : node_(node), build_version_(build_version) {}
 
@@ -228,11 +239,8 @@ class XdsApi {
   // Creates an LRS request querying \a server_name.
   grpc_slice CreateLrsInitialRequest(const std::string& server_name);
 
-  // Creates an LRS request sending client-side load reports. If all the
-  // counters are zero, returns empty slice.
-  grpc_slice CreateLrsRequest(std::map<StringView /*cluster_name*/,
-                                       std::set<XdsClientStats*>, StringLess>
-                                  client_stats_map);
+  // Creates an LRS request sending a client-side load report.
+  grpc_slice CreateLrsRequest(ClusterLoadReportMap cluster_load_report_map);
 
   // Parses the LRS response and returns \a
   // load_reporting_interval for client-side load reporting. If there is any

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -101,11 +101,25 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   void CancelEndpointDataWatch(StringView eds_service_name,
                                EndpointWatcherInterface* watcher);
 
-  // Adds and removes client stats for \a cluster_name.
-  void AddClientStats(StringView /*lrs_server*/, StringView cluster_name,
-                      XdsClientStats* client_stats);
-  void RemoveClientStats(StringView /*lrs_server*/, StringView cluster_name,
-                         XdsClientStats* client_stats);
+  // Adds and removes drop stats for cluster_name and eds_service_name.
+  RefCountedPtr<XdsClusterDropStats> AddClusterDropStats(
+      StringView lrs_server, StringView cluster_name,
+      StringView eds_service_name);
+  void RemoveClusterDropStats(StringView /*lrs_server*/,
+                              StringView cluster_name,
+                              StringView eds_service_name,
+                              XdsClusterDropStats* cluster_drop_stats);
+
+  // Adds and removes locality stats for cluster_name and eds_service_name
+  // for the specified locality.
+  RefCountedPtr<XdsClusterLocalityStats> AddClusterLocalityStats(
+      StringView lrs_server, StringView cluster_name,
+      StringView eds_service_name, RefCountedPtr<XdsLocalityName> locality);
+  void RemoveClusterLocalityStats(
+      StringView /*lrs_server*/, StringView cluster_name,
+      StringView eds_service_name,
+      const RefCountedPtr<XdsLocalityName>& locality,
+      XdsClusterLocalityStats* cluster_locality_stats);
 
   // Resets connection backoff state.
   void ResetBackoff();
@@ -182,9 +196,16 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
     std::map<EndpointWatcherInterface*,
              std::unique_ptr<EndpointWatcherInterface>>
         watchers;
-    std::set<XdsClientStats*> client_stats;
     // The latest data seen from EDS.
     XdsApi::EdsUpdate update;
+  };
+
+  struct LoadReportState {
+    std::set<XdsClusterDropStats*> drop_stats;
+    std::map<RefCountedPtr<XdsLocalityName>, std::set<XdsClusterLocalityStats*>,
+             XdsLocalityName::Less>
+        locality_stats;
+    grpc_millis last_report_time = ExecCtx::Get()->Now();
   };
 
   // Sends an error notification to all watchers.
@@ -194,8 +215,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
       const std::string& cluster_name,
       RefCountedPtr<ServiceConfig>* service_config) const;
 
-  std::map<StringView, std::set<XdsClientStats*>, StringLess> ClientStatsMap()
-      const;
+  XdsApi::ClusterLoadReportMap BuildLoadReportSnapshot();
 
   // Channel arg vtable functions.
   static void* ChannelArgCopy(void* p);
@@ -227,6 +247,10 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   std::map<std::string /*cluster_name*/, ClusterState> cluster_map_;
   // Only the watched EDS service names are stored.
   std::map<std::string /*eds_service_name*/, EndpointState> endpoint_map_;
+  std::map<
+      std::pair<std::string /*cluster_name*/, std::string /*eds_service_name*/>,
+      LoadReportState>
+      load_report_map_;
 
   bool shutting_down_ = false;
 };

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.cc
@@ -20,63 +20,75 @@
 
 #include "src/core/ext/filters/client_channel/xds/xds_client_stats.h"
 
+#include <string.h>
+
 #include <grpc/support/atm.h>
 #include <grpc/support/string_util.h>
-#include <string.h>
+
+#include "src/core/ext/filters/client_channel/xds/xds_client.h"
 
 namespace grpc_core {
 
+//
+// XdsClusterDropStats
+//
+
+XdsClusterDropStats::XdsClusterDropStats(RefCountedPtr<XdsClient> xds_client,
+                                         StringView lrs_server_name,
+                                         StringView cluster_name,
+                                         StringView eds_service_name)
+    : xds_client_(std::move(xds_client)),
+      lrs_server_name_(lrs_server_name),
+      cluster_name_(cluster_name),
+      eds_service_name_(eds_service_name) {}
+
+XdsClusterDropStats::~XdsClusterDropStats() {
+  xds_client_->RemoveClusterDropStats(lrs_server_name_, cluster_name_,
+                                      eds_service_name_, this);
+  xds_client_.reset(DEBUG_LOCATION, "DropStats");
+}
+
+XdsClusterDropStats::DroppedRequestsMap
+XdsClusterDropStats::GetSnapshotAndReset() {
+  MutexLock lock(&mu_);
+  return std::move(dropped_requests_);
+}
+
+void XdsClusterDropStats::AddCallDropped(const std::string& category) {
+  MutexLock lock(&mu_);
+  ++dropped_requests_[category];
+}
+
+//
+// XdsClusterLocalityStats
+//
+
+XdsClusterLocalityStats::XdsClusterLocalityStats(
+    RefCountedPtr<XdsClient> xds_client, StringView lrs_server_name,
+    StringView cluster_name, StringView eds_service_name,
+    RefCountedPtr<XdsLocalityName> name)
+    : xds_client_(std::move(xds_client)),
+      lrs_server_name_(lrs_server_name),
+      cluster_name_(cluster_name),
+      eds_service_name_(eds_service_name),
+      name_(std::move(name)) {}
+
+XdsClusterLocalityStats::~XdsClusterLocalityStats() {
+  xds_client_->RemoveClusterLocalityStats(lrs_server_name_, cluster_name_,
+                                          eds_service_name_, name_, this);
+  xds_client_.reset(DEBUG_LOCATION, "LocalityStats");
+}
+
 namespace {
 
-template <typename T>
-T GetAndResetCounter(Atomic<T>* from) {
+uint64_t GetAndResetCounter(Atomic<uint64_t>* from) {
   return from->Exchange(0, MemoryOrder::RELAXED);
 }
 
 }  // namespace
 
-//
-// XdsClientStats::LocalityStats::LoadMetric::Snapshot
-//
-
-bool XdsClientStats::LocalityStats::LoadMetric::Snapshot::IsAllZero() const {
-  return total_metric_value == 0 && num_requests_finished_with_metric == 0;
-}
-
-//
-// XdsClientStats::LocalityStats::LoadMetric
-//
-
-XdsClientStats::LocalityStats::LoadMetric::Snapshot
-XdsClientStats::LocalityStats::LoadMetric::GetSnapshotAndReset() {
-  Snapshot metric = {num_requests_finished_with_metric_, total_metric_value_};
-  num_requests_finished_with_metric_ = 0;
-  total_metric_value_ = 0;
-  return metric;
-}
-
-//
-// XdsClientStats::LocalityStats::Snapshot
-//
-
-bool XdsClientStats::LocalityStats::Snapshot::IsAllZero() {
-  if (total_successful_requests != 0 || total_requests_in_progress != 0 ||
-      total_error_requests != 0 || total_issued_requests != 0) {
-    return false;
-  }
-  for (auto& p : load_metric_stats) {
-    const LoadMetric::Snapshot& metric_value = p.second;
-    if (!metric_value.IsAllZero()) return false;
-  }
-  return true;
-}
-
-//
-// XdsClientStats::LocalityStats
-//
-
-XdsClientStats::LocalityStats::Snapshot
-XdsClientStats::LocalityStats::GetSnapshotAndReset() {
+XdsClusterLocalityStats::Snapshot
+XdsClusterLocalityStats::GetSnapshotAndReset() {
   Snapshot snapshot = {
       GetAndResetCounter(&total_successful_requests_),
       // Don't reset total_requests_in_progress because it's not
@@ -84,108 +96,21 @@ XdsClientStats::LocalityStats::GetSnapshotAndReset() {
       total_requests_in_progress_.Load(MemoryOrder::RELAXED),
       GetAndResetCounter(&total_error_requests_),
       GetAndResetCounter(&total_issued_requests_)};
-  {
-    MutexLock lock(&load_metric_stats_mu_);
-    for (auto& p : load_metric_stats_) {
-      const std::string& metric_name = p.first;
-      LoadMetric& metric_value = p.second;
-      snapshot.load_metric_stats.emplace(metric_name,
-                                         metric_value.GetSnapshotAndReset());
-    }
-  }
+  MutexLock lock(&backend_metrics_mu_);
+  snapshot.backend_metrics = std::move(backend_metrics_);
   return snapshot;
 }
 
-void XdsClientStats::LocalityStats::AddCallStarted() {
+void XdsClusterLocalityStats::AddCallStarted() {
   total_issued_requests_.FetchAdd(1, MemoryOrder::RELAXED);
   total_requests_in_progress_.FetchAdd(1, MemoryOrder::RELAXED);
 }
 
-void XdsClientStats::LocalityStats::AddCallFinished(bool fail) {
+void XdsClusterLocalityStats::AddCallFinished(bool fail) {
   Atomic<uint64_t>& to_increment =
       fail ? total_error_requests_ : total_successful_requests_;
   to_increment.FetchAdd(1, MemoryOrder::RELAXED);
   total_requests_in_progress_.FetchAdd(-1, MemoryOrder::ACQ_REL);
-}
-
-//
-// XdsClientStats::Snapshot
-//
-
-bool XdsClientStats::Snapshot::IsAllZero() {
-  for (auto& p : upstream_locality_stats) {
-    if (!p.second.IsAllZero()) return false;
-  }
-  for (auto& p : dropped_requests) {
-    if (p.second != 0) return false;
-  }
-  return total_dropped_requests == 0;
-}
-
-//
-// XdsClientStats
-//
-
-XdsClientStats::Snapshot XdsClientStats::GetSnapshotAndReset() {
-  grpc_millis now = ExecCtx::Get()->Now();
-  // Record total_dropped_requests and reporting interval in the snapshot.
-  Snapshot snapshot;
-  snapshot.total_dropped_requests =
-      GetAndResetCounter(&total_dropped_requests_);
-  snapshot.load_report_interval = now - last_report_time_;
-  // Update last report time.
-  last_report_time_ = now;
-  // Snapshot all the other stats.
-  for (auto& p : upstream_locality_stats_) {
-    snapshot.upstream_locality_stats.emplace(p.first,
-                                             p.second->GetSnapshotAndReset());
-  }
-  {
-    MutexLock lock(&dropped_requests_mu_);
-    // This is a workaround for the case where some compilers cannot build
-    // move-assignment of map with non-copyable but movable key.
-    // https://stackoverflow.com/questions/36475497
-    std::swap(snapshot.dropped_requests, dropped_requests_);
-    dropped_requests_.clear();
-  }
-  return snapshot;
-}
-
-void XdsClientStats::MaybeInitLastReportTime() {
-  if (last_report_time_ == -1) last_report_time_ = ExecCtx::Get()->Now();
-}
-
-RefCountedPtr<XdsClientStats::LocalityStats> XdsClientStats::FindLocalityStats(
-    const RefCountedPtr<XdsLocalityName>& locality_name) {
-  auto iter = upstream_locality_stats_.find(locality_name);
-  if (iter == upstream_locality_stats_.end()) {
-    iter = upstream_locality_stats_
-               .emplace(locality_name, MakeRefCounted<LocalityStats>())
-               .first;
-  }
-  return iter->second;
-}
-
-void XdsClientStats::PruneLocalityStats() {
-  auto iter = upstream_locality_stats_.begin();
-  while (iter != upstream_locality_stats_.end()) {
-    if (iter->second->IsSafeToDelete()) {
-      iter = upstream_locality_stats_.erase(iter);
-    } else {
-      ++iter;
-    }
-  }
-}
-
-void XdsClientStats::AddCallDropped(const std::string& category) {
-  total_dropped_requests_.FetchAdd(1, MemoryOrder::RELAXED);
-  MutexLock lock(&dropped_requests_mu_);
-  auto iter = dropped_requests_.find(category);
-  if (iter == dropped_requests_.end()) {
-    dropped_requests_.emplace(category, 1);
-  } else {
-    ++iter->second;
-  }
 }
 
 }  // namespace grpc_core


### PR DESCRIPTION
This PR is being done in preparation to refactor the `xds` LB policy into several pieces.  In the new design, the drop data and the data for each locality will each come from a different LB policy, so the APIs need to be split up accordingly.

As part of this PR, I have also cleaned up the code to provide better laying and a simpler design.  In particular, the lifecycle management for the stats objects is now much cleaner: they are created when they are added to the XdsClient, refs to them are held by both the LB policy and the picker, and when their ref-count goes to zero, they are automatically removed from the XdsClient.  In addition, I have addressed an existing TODO about avoiding stats collection when load reporting is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/22011)
<!-- Reviewable:end -->
