### PR TITLE
Revert #20329 which cuts details when Status::OK is received in C++

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -766,24 +766,17 @@ class CallOpClientRecvStatus {
 
   void FinishOp(bool* /*status*/) {
     if (recv_status_ == nullptr || hijacked_) return;
-    if (static_cast<StatusCode>(status_code_) == StatusCode::OK) {
-      *recv_status_ = Status();
-      GPR_CODEGEN_DEBUG_ASSERT(debug_error_string_ == nullptr);
-    } else {
-      *recv_status_ =
-          Status(static_cast<StatusCode>(status_code_),
-                 GRPC_SLICE_IS_EMPTY(error_message_)
-                     ? grpc::string()
-                     : grpc::string(GRPC_SLICE_START_PTR(error_message_),
-                                    GRPC_SLICE_END_PTR(error_message_)),
-                 metadata_map_->GetBinaryErrorDetails());
-      if (debug_error_string_ != nullptr) {
-        client_context_->set_debug_error_string(debug_error_string_);
-        g_core_codegen_interface->gpr_free((void*)debug_error_string_);
-      }
+    *recv_status_ =
+        Status(static_cast<StatusCode>(status_code_),
+                GRPC_SLICE_IS_EMPTY(error_message_)
+                    ? grpc::string()
+                    : grpc::string(GRPC_SLICE_START_PTR(error_message_),
+                                  GRPC_SLICE_END_PTR(error_message_)),
+                metadata_map_->GetBinaryErrorDetails());
+    if (debug_error_string_ != nullptr) {
+      client_context_->set_debug_error_string(debug_error_string_);
+      g_core_codegen_interface->gpr_free((void*)debug_error_string_);
     }
-    // TODO(soheil): Find callers that set debug string even for status OK,
-    //               and fix them.
     g_core_codegen_interface->grpc_slice_unref(error_message_);
   }
 


### PR DESCRIPTION
PR #20329 never populates details and message when
the RPC terminates successfully causing a regression, but the spec
does not disallow sending details alongside OK status (does it?)
In fact, other languages such as Python provide such
API and [have tests for it][1] and not propagating details
properly is a potential interop issue.

[1]: https://github.com/grpc/grpc/blob/master/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py#L253