### PR TITLE
Use the working dashboard link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Sometimes things go wrong. Please check out the [Troubleshooting guide](TROUBLES
 
 # Performance 
 
-See the [Performance dashboard](http://performance-dot-grpc-testing.appspot.com/explore?dashboard=5636470266134528) for performance numbers of the latest released version.
+See the [Performance dashboard](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584) for performance numbers of master branch daily builds.
 
 # Concepts
 


### PR DESCRIPTION
In 2020-01-09, the Java build started to fail if we are not passing an argument to disable Android build. The problem seems due to `gradlaw` itself instead of our usage. We might need to backport changes to fix this error in old releases (e.g., #21881).

The dashboard for release benchmarks will require some effort to fix. Alternatively, we could use a dashboard that is working and informative in our `README.md`.