### PR TITLE
[Aio] Implement health checking servicer in AsyncIO

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -466,6 +466,8 @@ async def _handle_exceptions(RPCState rpc_state, object rpc_coro, object loop):
                 )
     except (KeyboardInterrupt, SystemExit):
         raise
+    except asyncio.CancelledError:
+        _LOGGER.debug('RPC cancelled for servicer method [%s]', _decode(rpc_state.method()))
     except _ServerStoppedError:
         _LOGGER.info('Aborting RPC due to server stop.')
     except Exception as e:

--- a/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
+++ b/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
@@ -16,7 +16,10 @@ py_grpc_library(
 
 py_library(
     name = "grpc_health",
-    srcs = ["health.py"],
+    srcs = [
+        "health.py",
+        "_async.py",
+    ],
     imports = ["../../"],
     deps = [
         ":health_py_pb2",

--- a/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
+++ b/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
@@ -17,8 +17,8 @@ py_grpc_library(
 py_library(
     name = "grpc_health",
     srcs = [
-        "health.py",
         "_async.py",
+        "health.py",
     ],
     imports = ["../../"],
     deps = [

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -55,7 +55,7 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
                         _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
 
                     # NOTE(lidiz) If the observed status is the same, it means
-                    # intermediate statuses has been discarded. It's consider
+                    # there are missing intermediate statuses. It's considered
                     # acceptable since peer only interested in eventual status.
                     if status != last_status:
                         # Responds with current health state

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -43,18 +43,13 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
         try:
             async with condition:
                 while True:
-                    status = self._server_status.get(request.service)
+                    status = self._server_status.get(
+                        request.service,
+                        _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
 
-                    if status:
-                        # Responds with current health state
-                        await context.write(
-                            _health_pb2.HealthCheckResponse(status=status))
-                    else:
-                        # Responds with default value
-                        await context.write(
-                            _health_pb2.HealthCheckResponse(
-                                status=_health_pb2.HealthCheckResponse.
-                                SERVICE_UNKNOWN))
+                    # Responds with current health state
+                    await context.write(
+                        _health_pb2.HealthCheckResponse(status=status))
 
                     # Polling on health state changes
                     await condition.wait()

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 """Reference implementation for health checking in gRPC Python."""
 
-import logging
 import asyncio
 import collections
 
 import grpc
-from grpc.experimental import aio
 
 from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
@@ -28,14 +26,12 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
     """An AsyncIO implementation of health checking servicer."""
 
     def __init__(self):
-        self._lock = asyncio.Lock()
         self._server_status = dict()
         self._server_watchers = collections.defaultdict(asyncio.Condition)
         self._gracefully_shutting_down = False
 
     async def Check(self, request: _health_pb2.HealthCheckRequest, context):
         status = self._server_status.get(request.service)
-        logging.debug('Status %s, %s', request.service, status)
 
         if status is None:
             await context.abort(grpc.StatusCode.NOT_FOUND)

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -1,0 +1,107 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reference implementation for health checking in gRPC Python."""
+
+import logging
+import asyncio
+import collections
+
+import grpc
+from grpc.experimental import aio
+
+from grpc_health.v1 import health_pb2 as _health_pb2
+from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
+
+
+class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
+    """An AsyncIO implementation of health checking servicer."""
+
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self._server_status = dict()
+        self._server_watchers = collections.defaultdict(asyncio.Condition)
+        self._gracefully_shutting_down = False
+
+    async def Check(self, request: _health_pb2.HealthCheckRequest, context):
+        status = self._server_status.get(request.service)
+        logging.debug('Status %s, %s', request.service, status)
+
+        if status is None:
+            await context.abort(grpc.StatusCode.NOT_FOUND)
+        else:
+            return _health_pb2.HealthCheckResponse(status=status)
+
+    async def Watch(self, request: _health_pb2.HealthCheckRequest, context):
+        status = self._server_status.get(request.service)
+
+        if status is None:
+            status = _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
+
+        try:
+            condition = self._server_watchers[request.service]
+            async with condition:
+                # Responds with current health state
+                await context.write(
+                    _health_pb2.HealthCheckResponse(status=status))
+
+                # Polling on health state changes
+                while True:
+                    await condition.wait()
+
+                    status = self._server_status.get(request.service)
+                    await context.write(
+                        _health_pb2.HealthCheckResponse(status=status))
+        finally:
+            del self._server_watchers[request.service]
+
+    async def _set(self, service: str,
+                   status: _health_pb2.HealthCheckResponse.ServingStatus):
+        if service in self._server_watchers:
+            condition = self._server_watchers.get(service)
+            async with condition:
+                self._server_status[service] = status
+                condition.notify_all()
+        else:
+            self._server_status[service] = status
+
+    async def set(self, service: str,
+                  status: _health_pb2.HealthCheckResponse.ServingStatus):
+        """Sets the status of a service.
+
+        Args:
+          service: string, the name of the service. NOTE, '' must be set.
+          status: HealthCheckResponse.status enum value indicating the status of
+            the service
+        """
+        if self._gracefully_shutting_down:
+            return
+        else:
+            await self._set(service, status)
+
+    async def enter_graceful_shutdown(self):
+        """Permanently sets the status of all services to NOT_SERVING.
+
+        This should be invoked when the server is entering a graceful shutdown
+        period. After this method is invoked, future attempts to set the status
+        of a service will be ignored.
+
+        This is an EXPERIMENTAL API.
+        """
+        if self._gracefully_shutting_down:
+            return
+        else:
+            self._gracefully_shutting_down = True
+            for service in self._server_status:
+                await self._set(service,
+                                _health_pb2.HealthCheckResponse.NOT_SERVING)

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import collections
-from typing import Mapping, AbstractSet
 
 import grpc
 
@@ -25,14 +24,10 @@ from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 
 class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
     """An AsyncIO implementation of health checking servicer."""
-    _server_status: Mapping[str,
-                            '_health_pb2.HealthCheckResponse.ServingStatus']
-    _server_watchers: Mapping[str, AbstractSet[asyncio.Queue]]
-    _gracefully_shutting_down: bool
 
     def __init__(self):
         self._server_status = dict()
-        self._server_watchers = collections.defaultdict(set)
+        self._server_watchers = collections.defaultdict(asyncio.Condition)
         self._gracefully_shutting_down = False
 
     async def Check(self, request: _health_pb2.HealthCheckRequest, context):
@@ -44,37 +39,35 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
             return _health_pb2.HealthCheckResponse(status=status)
 
     async def Watch(self, request: _health_pb2.HealthCheckRequest, context):
-        queue = asyncio.Queue()
-        self._server_watchers[request.service].add(queue)
-
+        condition = self._server_watchers[request.service]
         try:
-            status = self._server_status.get(
-                request.service,
-                _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
-            while True:
-                # Responds with current health state
-                await context.write(
-                    _health_pb2.HealthCheckResponse(status=status))
+            async with condition:
+                while True:
+                    status = self._server_status.get(
+                        request.service,
+                        _health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
 
-                # Polling on health state changes
-                status = await queue.get()
+                    # Responds with current health state
+                    await context.write(
+                        _health_pb2.HealthCheckResponse(status=status))
+
+                    # Polling on health state changes
+                    await condition.wait()
         finally:
-            self._server_watchers[request.service].remove(queue)
-            if not self._server_watchers[request.service]:
-                del self._server_watchers[request.service]
+            del self._server_watchers[request.service]
 
-    def _set(self, service: str,
-             status: _health_pb2.HealthCheckResponse.ServingStatus):
-        self._server_status[service] = status
-
+    async def _set(self, service: str,
+                   status: _health_pb2.HealthCheckResponse.ServingStatus):
         if service in self._server_watchers:
-            # Only iterate through the watchers if there is at least one.
-            # Otherwise, it creates empty sets.
-            for watcher in self._server_watchers[service]:
-                watcher.put_nowait(status)
+            condition = self._server_watchers.get(service)
+            async with condition:
+                self._server_status[service] = status
+                condition.notify_all()
+        else:
+            self._server_status[service] = status
 
-    def set(self, service: str,
-            status: _health_pb2.HealthCheckResponse.ServingStatus):
+    async def set(self, service: str,
+                  status: _health_pb2.HealthCheckResponse.ServingStatus):
         """Sets the status of a service.
 
         Args:
@@ -85,7 +78,7 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
         if self._gracefully_shutting_down:
             return
         else:
-            self._set(service, status)
+            await self._set(service, status)
 
     async def enter_graceful_shutdown(self):
         """Permanently sets the status of all services to NOT_SERVING.
@@ -101,4 +94,5 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
         else:
             self._gracefully_shutting_down = True
             for service in self._server_status:
-                self._set(service, _health_pb2.HealthCheckResponse.NOT_SERVING)
+                await self._set(service,
+                                _health_pb2.HealthCheckResponse.NOT_SERVING)

--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -22,7 +22,7 @@ from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 
 
-class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
+class HealthServicer(_health_pb2_grpc.HealthServicer):
     """An AsyncIO implementation of health checking servicer."""
     _server_status: MutableMapping[
         str, '_health_pb2.HealthCheckResponse.ServingStatus']
@@ -88,7 +88,7 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
         """Sets the status of a service.
 
         Args:
-          service: string, the name of the service. NOTE, '' must be set.
+          service: string, the name of the service.
           status: HealthCheckResponse.status enum value indicating the status of
             the service
         """
@@ -103,8 +103,6 @@ class AsyncHealthServicer(_health_pb2_grpc.HealthServicer):
         This should be invoked when the server is entering a graceful shutdown
         period. After this method is invoked, future attempts to set the status
         of a service will be ignored.
-
-        This is an EXPERIMENTAL API.
         """
         if self._gracefully_shutting_down:
             return

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -21,7 +21,7 @@ import grpc
 from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 
-if sys.version_info[0] > 2:
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 6:
     from ._async import AsyncHealthServicer
 
 SERVICE_NAME = _health_pb2.DESCRIPTOR.services_by_name['Health'].full_name

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -23,9 +23,12 @@ from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 6:
     # Exposes AsyncHealthServicer as public API.
-    from ._async import AsyncHealthServicer  # pylint: disable=unused-import
+    from . import _async as aio  # pylint: disable=unused-import
 
+# The service name of the health checking servicer.
 SERVICE_NAME = _health_pb2.DESCRIPTOR.services_by_name['Health'].full_name
+# The entry of overall health for the entire server.
+OVERALL_HEALTH = ''
 
 
 class _Watcher():
@@ -135,7 +138,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         """Sets the status of a service.
 
         Args:
-          service: string, the name of the service. NOTE, '' must be set.
+          service: string, the name of the service.
           status: HealthCheckResponse.status enum value indicating the status of
             the service
         """

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -22,7 +22,8 @@ from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
 
 if sys.version_info[0] >= 3 and sys.version_info[1] >= 6:
-    from ._async import AsyncHealthServicer
+    # Exposes AsyncHealthServicer as public API.
+    from ._async import AsyncHealthServicer  # pylint: disable=unused-import
 
 SERVICE_NAME = _health_pb2.DESCRIPTOR.services_by_name['Health'].full_name
 

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -15,11 +15,14 @@
 
 import collections
 import threading
-
+import sys
 import grpc
 
 from grpc_health.v1 import health_pb2 as _health_pb2
 from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
+
+if sys.version_info[0] > 2:
+    from ._async import AsyncHealthServicer
 
 SERVICE_NAME = _health_pb2.DESCRIPTOR.services_by_name['Health'].full_name
 

--- a/src/python/grpcio_tests/tests_aio/health_check/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_aio/health_check/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+package(default_testonly = 1)
 
 py_test(
     name = "health_servicer_test",

--- a/src/python/grpcio_tests/tests_aio/health_check/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_aio/health_check/BUILD.bazel
@@ -1,0 +1,29 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "health_servicer_test",
+    size = "small",
+    srcs = ["health_servicer_test.py"],
+    imports = ["../../"],
+    python_version = "PY3",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_health_checking/grpc_health/v1:grpc_health",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
+        "//src/python/grpcio_tests/tests_aio/unit:_test_base",
+    ],
+)

--- a/src/python/grpcio_tests/tests_aio/health_check/__init__.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -35,7 +35,7 @@ _UNKNOWN_SERVICE = 'grpc.test.TestServiceUnknown'
 _NOT_SERVING_SERVICE = 'grpc.test.TestServiceNotServing'
 _WATCH_SERVICE = 'grpc.test.WatchService'
 
-_LARGE_NUMBER_OF_STATUS_CHANGE = 1000
+_LARGE_NUMBER_OF_STATUS_CHANGES = 1000
 
 
 async def _pipe_to_queue(call, queue):
@@ -239,7 +239,7 @@ class HealthServicerTest(AioTestBase):
                          (await queue.get()).status)
         last_status = health_pb2.HealthCheckResponse.SERVICE_UNKNOWN
 
-        for _ in range(_LARGE_NUMBER_OF_STATUS_CHANGE):
+        for _ in range(_LARGE_NUMBER_OF_STATUS_CHANGES):
             if random.randint(0, 1) == 0:
                 status = health_pb2.HealthCheckResponse.SERVING
             else:

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -44,13 +44,13 @@ class HealthServicerTest(AioTestBase):
 
     async def setUp(self):
         self._servicer = health.AsyncHealthServicer()
-        await self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
-        await self._servicer.set(_SERVING_SERVICE,
-                                 health_pb2.HealthCheckResponse.SERVING)
-        await self._servicer.set(_UNKNOWN_SERVICE,
-                                 health_pb2.HealthCheckResponse.UNKNOWN)
-        await self._servicer.set(_NOT_SERVING_SERVICE,
-                                 health_pb2.HealthCheckResponse.NOT_SERVING)
+        self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set(_SERVING_SERVICE,
+                           health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set(_UNKNOWN_SERVICE,
+                           health_pb2.HealthCheckResponse.UNKNOWN)
+        self._servicer.set(_NOT_SERVING_SERVICE,
+                           health_pb2.HealthCheckResponse.NOT_SERVING)
         self._server = aio.server()
         port = self._server.add_insecure_port('[::]:0')
         health_pb2_grpc.add_HealthServicer_to_server(self._servicer,
@@ -118,13 +118,13 @@ class HealthServicerTest(AioTestBase):
         self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
                          (await queue.get()).status)
 
-        await self._servicer.set(_WATCH_SERVICE,
-                                 health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set(_WATCH_SERVICE,
+                           health_pb2.HealthCheckResponse.SERVING)
         self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
                          (await queue.get()).status)
 
-        await self._servicer.set(_WATCH_SERVICE,
-                                 health_pb2.HealthCheckResponse.NOT_SERVING)
+        self._servicer.set(_WATCH_SERVICE,
+                           health_pb2.HealthCheckResponse.NOT_SERVING)
         self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,
                          (await queue.get()).status)
 
@@ -141,8 +141,8 @@ class HealthServicerTest(AioTestBase):
         self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
                          (await queue.get()).status)
 
-        await self._servicer.set('some-other-service',
-                                 health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set('some-other-service',
+                           health_pb2.HealthCheckResponse.SERVING)
         # The change of health status in other service should be isolated.
         # Hence, no additional notification should be observed.
         with self.assertRaises(asyncio.TimeoutError):
@@ -166,8 +166,8 @@ class HealthServicerTest(AioTestBase):
         self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
                          (await queue2.get()).status)
 
-        await self._servicer.set(_WATCH_SERVICE,
-                                 health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set(_WATCH_SERVICE,
+                           health_pb2.HealthCheckResponse.SERVING)
         self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
                          (await queue1.get()).status)
         self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
@@ -190,8 +190,8 @@ class HealthServicerTest(AioTestBase):
                          (await queue.get()).status)
 
         call.cancel()
-        await self._servicer.set(_WATCH_SERVICE,
-                                 health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set(_WATCH_SERVICE,
+                           health_pb2.HealthCheckResponse.SERVING)
         await task
 
         # Wait for the serving coroutine to process client cancellation.
@@ -216,7 +216,7 @@ class HealthServicerTest(AioTestBase):
                          (await queue.get()).status)
 
         # This should be a no-op.
-        await self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+        self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
 
         resp = await self._stub.Check(request)
         self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -44,13 +44,13 @@ class HealthServicerTest(AioTestBase):
 
     async def setUp(self):
         self._servicer = health.AsyncHealthServicer()
-        self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
-        self._servicer.set(_SERVING_SERVICE,
-                           health_pb2.HealthCheckResponse.SERVING)
-        self._servicer.set(_UNKNOWN_SERVICE,
-                           health_pb2.HealthCheckResponse.UNKNOWN)
-        self._servicer.set(_NOT_SERVING_SERVICE,
-                           health_pb2.HealthCheckResponse.NOT_SERVING)
+        await self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_SERVING_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_UNKNOWN_SERVICE,
+                                 health_pb2.HealthCheckResponse.UNKNOWN)
+        await self._servicer.set(_NOT_SERVING_SERVICE,
+                                 health_pb2.HealthCheckResponse.NOT_SERVING)
         self._server = aio.server()
         port = self._server.add_insecure_port('[::]:0')
         health_pb2_grpc.add_HealthServicer_to_server(self._servicer,
@@ -118,13 +118,13 @@ class HealthServicerTest(AioTestBase):
         self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
                          (await queue.get()).status)
 
-        self._servicer.set(_WATCH_SERVICE,
-                           health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
         self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
                          (await queue.get()).status)
 
-        self._servicer.set(_WATCH_SERVICE,
-                           health_pb2.HealthCheckResponse.NOT_SERVING)
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.NOT_SERVING)
         self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,
                          (await queue.get()).status)
 
@@ -141,8 +141,8 @@ class HealthServicerTest(AioTestBase):
         self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
                          (await queue.get()).status)
 
-        self._servicer.set('some-other-service',
-                           health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set('some-other-service',
+                                 health_pb2.HealthCheckResponse.SERVING)
         # The change of health status in other service should be isolated.
         # Hence, no additional notification should be observed.
         with self.assertRaises(asyncio.TimeoutError):
@@ -166,8 +166,8 @@ class HealthServicerTest(AioTestBase):
         self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
                          (await queue2.get()).status)
 
-        self._servicer.set(_WATCH_SERVICE,
-                           health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
         self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
                          (await queue1.get()).status)
         self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
@@ -190,8 +190,8 @@ class HealthServicerTest(AioTestBase):
                          (await queue.get()).status)
 
         call.cancel()
-        self._servicer.set(_WATCH_SERVICE,
-                           health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
         await task
 
         # Wait for the serving coroutine to process client cancellation.
@@ -216,7 +216,7 @@ class HealthServicerTest(AioTestBase):
                          (await queue.get()).status)
 
         # This should be a no-op.
-        self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
 
         resp = await self._stub.Check(request)
         self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016 gRPC authors.
+# Copyright 2020 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -1,0 +1,242 @@
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests AsyncIO version of grpcio-health-checking."""
+
+import asyncio
+import logging
+import time
+import unittest
+
+import grpc
+
+from grpc_health.v1 import health
+from grpc_health.v1 import health_pb2
+from grpc_health.v1 import health_pb2_grpc
+from grpc.experimental import aio
+
+from tests.unit.framework.common import test_constants
+
+from tests_aio.unit._test_base import AioTestBase
+
+_SERVING_SERVICE = 'grpc.test.TestServiceServing'
+_UNKNOWN_SERVICE = 'grpc.test.TestServiceUnknown'
+_NOT_SERVING_SERVICE = 'grpc.test.TestServiceNotServing'
+_WATCH_SERVICE = 'grpc.test.WatchService'
+
+
+async def _pipe_to_queue(call, queue):
+    async for response in call:
+        await queue.put(response)
+
+
+class HealthServicerTest(AioTestBase):
+
+    async def setUp(self):
+        self._servicer = health.AsyncHealthServicer()
+        await self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_SERVING_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
+        await self._servicer.set(_UNKNOWN_SERVICE,
+                                 health_pb2.HealthCheckResponse.UNKNOWN)
+        await self._servicer.set(_NOT_SERVING_SERVICE,
+                                 health_pb2.HealthCheckResponse.NOT_SERVING)
+        self._server = aio.server()
+        port = self._server.add_insecure_port('[::]:0')
+        health_pb2_grpc.add_HealthServicer_to_server(self._servicer,
+                                                     self._server)
+        await self._server.start()
+
+        self._channel = aio.insecure_channel('localhost:%d' % port)
+        self._stub = health_pb2_grpc.HealthStub(self._channel)
+
+    async def tearDown(self):
+        await self._channel.close()
+        await self._server.stop(None)
+
+    async def test_check_empty_service(self):
+        request = health_pb2.HealthCheckRequest()
+        resp = await self._stub.Check(request)
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING, resp.status)
+
+    async def test_check_serving_service(self):
+        request = health_pb2.HealthCheckRequest(service=_SERVING_SERVICE)
+        resp = await self._stub.Check(request)
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING, resp.status)
+
+    async def test_check_unknown_service(self):
+        request = health_pb2.HealthCheckRequest(service=_UNKNOWN_SERVICE)
+        resp = await self._stub.Check(request)
+        self.assertEqual(health_pb2.HealthCheckResponse.UNKNOWN, resp.status)
+
+    async def test_check_not_serving_service(self):
+        request = health_pb2.HealthCheckRequest(service=_NOT_SERVING_SERVICE)
+        resp = await self._stub.Check(request)
+        self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,
+                         resp.status)
+
+    async def test_check_not_found_service(self):
+        request = health_pb2.HealthCheckRequest(service='not-found')
+        with self.assertRaises(grpc.RpcError) as context:
+            await self._stub.Check(request)
+
+        self.assertEqual(grpc.StatusCode.NOT_FOUND, context.exception.code())
+
+    async def test_health_service_name(self):
+        self.assertEqual(health.SERVICE_NAME, 'grpc.health.v1.Health')
+
+    async def test_watch_empty_service(self):
+        request = health_pb2.HealthCheckRequest(service='')
+
+        call = self._stub.Watch(request)
+        queue = asyncio.Queue()
+        task = self.loop.create_task(_pipe_to_queue(call, queue))
+
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
+                         response.status)
+
+        call.cancel()
+        await task
+        self.assertTrue(queue.empty())
+
+    async def test_watch_new_service(self):
+        request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
+        call = self._stub.Watch(request)
+        queue = asyncio.Queue()
+        task = self.loop.create_task(_pipe_to_queue(call, queue))
+
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+                         response.status)
+
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
+                         response.status)
+
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.NOT_SERVING)
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,
+                         response.status)
+
+        call.cancel()
+        await task
+        self.assertTrue(queue.empty())
+
+    async def test_watch_service_isolation(self):
+        request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
+        call = self._stub.Watch(request)
+        queue = asyncio.Queue()
+        task = self.loop.create_task(_pipe_to_queue(call, queue))
+
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+                         response.status)
+
+        await self._servicer.set('some-other-service',
+                                 health_pb2.HealthCheckResponse.SERVING)
+        with self.assertRaises(asyncio.TimeoutError):
+            await asyncio.wait_for(queue.get(), test_constants.SHORT_TIMEOUT)
+
+        call.cancel()
+        await task
+        self.assertTrue(queue.empty())
+
+    async def test_two_watchers(self):
+        request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
+        queue1 = asyncio.Queue()
+        queue2 = asyncio.Queue()
+        call1 = self._stub.Watch(request)
+        call2 = self._stub.Watch(request)
+        task1 = self.loop.create_task(_pipe_to_queue(call1, queue1))
+        task2 = self.loop.create_task(_pipe_to_queue(call2, queue2))
+
+        response1 = await queue1.get()
+        response2 = await queue2.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+                         response1.status)
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+                         response2.status)
+
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
+        response1 = await queue1.get()
+        response2 = await queue2.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
+                         response1.status)
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
+                         response2.status)
+
+        call1.cancel()
+        call2.cancel()
+        await task1
+        await task2
+        self.assertTrue(queue1.empty())
+        self.assertTrue(queue2.empty())
+
+    async def test_cancelled_watch_removed_from_watch_list(self):
+        request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
+        call = self._stub.Watch(request)
+        queue = asyncio.Queue()
+        task = self.loop.create_task(_pipe_to_queue(call, queue))
+
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVICE_UNKNOWN,
+                         response.status)
+
+        call.cancel()
+        await self._servicer.set(_WATCH_SERVICE,
+                                 health_pb2.HealthCheckResponse.SERVING)
+        await task
+
+        # Wait for the serving coroutine to process client cancellation.
+        timeout = time.time() + test_constants.TIME_ALLOWANCE
+        while (time.time() < timeout and self._servicer._server_watchers):
+            await asyncio.sleep(1)
+        self.assertFalse(self._servicer._server_watchers,
+                         'There should not be any watcher left')
+        self.assertTrue(queue.empty())
+
+    async def test_graceful_shutdown(self):
+        request = health_pb2.HealthCheckRequest(service='')
+        call = self._stub.Watch(request)
+        queue = asyncio.Queue()
+        task = self.loop.create_task(_pipe_to_queue(call, queue))
+
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.SERVING,
+                         response.status)
+
+        await self._servicer.enter_graceful_shutdown()
+        response = await queue.get()
+        self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,
+                         response.status)
+
+        # This should be a no-op.
+        await self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+
+        resp = await self._stub.Check(request)
+        self.assertEqual(health_pb2.HealthCheckResponse.NOT_SERVING,
+                         resp.status)
+
+        call.cancel()
+        await task
+        self.assertTrue(queue.empty())
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -1,5 +1,6 @@
 [
   "_sanity._sanity_test.AioSanityTest",
+  "health_check.health_servicer_test.HealthServicerTest",
   "interop.local_interop_test.InsecureLocalInteropTest",
   "interop.local_interop_test.SecureLocalInteropTest",
   "unit.abort_test.TestAbort",


### PR DESCRIPTION
This PR implements a health checking servicer using AsyncIO stack. This should unblock @pfreixes. The logic is simplified a lot for both the servicer itself and the unit test.