### PR TITLE
Add dbghelp.lib to windows artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ LDFLAGS += -pthread
 endif
 
 ifeq ($(SYSTEM),MINGW32)
-LIBS = m pthread ws2_32
+LIBS = m pthread ws2_32 dbghelp
 LDFLAGS += -pthread
 endif
 

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ if "linux" in sys.platform:
 if not "win32" in sys.platform:
   EXTENSION_LIBRARIES += ('m',)
 if "win32" in sys.platform:
-  EXTENSION_LIBRARIES += ('advapi32', 'ws2_32',)
+  EXTENSION_LIBRARIES += ('advapi32', 'ws2_32', 'dbghelp',)
 if BUILD_WITH_SYSTEM_OPENSSL:
   EXTENSION_LIBRARIES += ('ssl', 'crypto',)
 if BUILD_WITH_SYSTEM_ZLIB:

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -274,7 +274,7 @@
   endif
 
   ifeq ($(SYSTEM),MINGW32)
-  LIBS = m pthread ws2_32
+  LIBS = m pthread ws2_32 dbghelp
   LDFLAGS += -pthread
   endif
 


### PR DESCRIPTION
This is required for abseil debugging APIs.