### PR TITLE
grpc_cli: add info about cmake gRPC_BUILD_TESTS flag

### DIFF
--- a/doc/command_line_tool.md
+++ b/doc/command_line_tool.md
@@ -52,18 +52,12 @@ Mac systems with Homebrew:
 brew install gflags
 ```
 
-Once the prerequisites are satisfied, generate makefiles:
+Once the prerequisites are satisfied, you can build with cmake:
 
 ```
 $ mkdir -p cmake/build
 $ cd cmake/build
 $ cmake -DgRPC_BUILD_TESTS=ON ../..
-```
-
-Finally you can build the command line tool with the command:
-
-```
-# run from cmake/build directory
 $ make grpc_cli
 ```
 

--- a/doc/command_line_tool.md
+++ b/doc/command_line_tool.md
@@ -63,13 +63,8 @@ $ cmake -DgRPC_BUILD_TESTS=ON ../..
 Finally you can build the command line tool with the command:
 
 ```
+# run from cmake/build directory
 $ make grpc_cli
-```
-
-To speed up compilation time on linux, you can use make with following flag:
-
-```
-$ make grpc_cli -j$(nproc)
 ```
 
 The main file can be found at

--- a/doc/command_line_tool.md
+++ b/doc/command_line_tool.md
@@ -52,11 +52,24 @@ Mac systems with Homebrew:
 brew install gflags
 ```
 
-Once the prerequisites are satisfied, you can build the command line tool with
-the command:
+Once the prerequisites are satisfied, generate makefiles:
+
+```
+$ mkdir -p cmake/build
+$ cd cmake/build
+$ cmake -DgRPC_BUILD_TESTS=ON ../..
+```
+
+Finally you can build the command line tool with the command:
 
 ```
 $ make grpc_cli
+```
+
+To speed up compilation time on linux, you can use make with following flag:
+
+```
+$ make grpc_cli -j$(nproc)
 ```
 
 The main file can be found at


### PR DESCRIPTION
To get grpc_cli make target generated with cmake, `gRPC_BUILD_TESTS` flag has to be defined. This is currently not specified in build section of grpc_cli documentation.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
