### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/tools/run_tests/run_build_statistics.py
+++ b/tools/run_tests/run_build_statistics.py
@@ -75,7 +75,7 @@ _KNOWN_ERRORS = [
     'LLVM ERROR: IO failure on output stream.',
     'MSBUILD : error MSB1009: Project file does not exist.',
     'fatal: git fetch_pack: expected ACK/NAK',
-    'Failed to fetch from http://github.com/grpc/grpc.git',
+    'Failed to fetch from https://github.com/grpc/grpc.git',
     ('hudson.remoting.RemotingSystemException: java.io.IOException: '
      'Backing channel is disconnected.'),
     'hudson.remoting.ChannelClosedException',


### PR DESCRIPTION
Currently, when we access github.com with HTTP, it is redirected to HTTPS automatically. So this commit aims to replace http://github.com by https://github.com for security.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
