### PR TITLE
Be careful about when to inline user's OnDone server callback

### DIFF
--- a/include/grpcpp/impl/codegen/server_context_impl.h
+++ b/include/grpcpp/impl/codegen/server_context_impl.h
@@ -474,7 +474,7 @@ class ServerContextBase {
     ::grpc::Status status() const { return status_; }
 
    private:
-    void MaybeDone() override {}
+    void CallOnDone() override {}
     ::grpc_impl::internal::ServerReactor* reactor() override {
       return reactor_;
     }

--- a/src/cpp/server/server_callback.cc
+++ b/src/cpp/server/server_callback.cc
@@ -24,27 +24,59 @@
 namespace grpc_impl {
 namespace internal {
 
+void ServerCallbackCall::ScheduleOnDone(bool inline_ondone) {
+  if (inline_ondone) {
+    CallOnDone();
+  } else {
+    // Unlike other uses of closure, do not Ref or Unref here since at this
+    // point, all the Ref'fing and Unref'fing is done for this call.
+    grpc_core::ExecCtx exec_ctx;
+    struct ClosureWithArg {
+      grpc_closure closure;
+      ServerCallbackCall* call;
+      explicit ClosureWithArg(ServerCallbackCall* call_arg) : call(call_arg) {
+        GRPC_CLOSURE_INIT(&closure,
+                          [](void* void_arg, grpc_error*) {
+                            ClosureWithArg* arg =
+                                static_cast<ClosureWithArg*>(void_arg);
+                            arg->call->CallOnDone();
+                            delete arg;
+                          },
+                          this, grpc_schedule_on_exec_ctx);
+      }
+    };
+    ClosureWithArg* arg = new ClosureWithArg(this);
+    grpc_core::Executor::Run(&arg->closure, GRPC_ERROR_NONE);
+  }
+}
+
 void ServerCallbackCall::CallOnCancel(ServerReactor* reactor) {
   if (reactor->InternalInlineable()) {
     reactor->OnCancel();
   } else {
+    // Ref to make sure that the closure executes before the whole call gets
+    // destructed, and Unref within the closure.
     Ref();
     grpc_core::ExecCtx exec_ctx;
-    struct ClosureArg {
+    struct ClosureWithArg {
+      grpc_closure closure;
       ServerCallbackCall* call;
       ServerReactor* reactor;
+      ClosureWithArg(ServerCallbackCall* call_arg, ServerReactor* reactor_arg)
+          : call(call_arg), reactor(reactor_arg) {
+        GRPC_CLOSURE_INIT(&closure,
+                          [](void* void_arg, grpc_error*) {
+                            ClosureWithArg* arg =
+                                static_cast<ClosureWithArg*>(void_arg);
+                            arg->reactor->OnCancel();
+                            arg->call->MaybeDone();
+                            delete arg;
+                          },
+                          this, grpc_schedule_on_exec_ctx);
+      }
     };
-    ClosureArg* arg = new ClosureArg{this, reactor};
-    grpc_core::Executor::Run(GRPC_CLOSURE_CREATE(
-                                 [](void* void_arg, grpc_error*) {
-                                   ClosureArg* arg =
-                                       static_cast<ClosureArg*>(void_arg);
-                                   arg->reactor->OnCancel();
-                                   arg->call->MaybeDone();
-                                   delete arg;
-                                 },
-                                 arg, nullptr),
-                             GRPC_ERROR_NONE);
+    ClosureWithArg* arg = new ClosureWithArg(this, reactor);
+    grpc_core::Executor::Run(&arg->closure, GRPC_ERROR_NONE);
   }
 }
 


### PR DESCRIPTION
Callbacks should only be scheduled to the ApplicationCallbackExecCtx (aka inlined) in 3 cases. If none of these 3 cases apply, any callback should be scheduled to run on the Executor.

1. A core-generated internal (library-generated) callback - this should only apply to server request calls (new RPCs starting at the server, but not yet calling the method handler)
1. A C++-layer internal inlineable callback - this should only apply to the `DefaultReactor` reactions
1. A callback executed on the background poller - safe since the ApplicationCallbackExecCtx for such threads is at the base of the stack with no user code sitting below you

This PR will make sure that this is properly enforced. The test change shows a case that deadlocks before this PR but proceeds properly after this PR is complete.

