### PR TITLE
Allow Grpc.Tools to work in WPF projects

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -111,7 +111,7 @@
        Protobuf_Compile directly where required. -->
   <!-- TODO(kkm): Do shared compile in outer multitarget project? -->
   <Target Name="_Protobuf_Compile_BeforeCsCompile"
-          BeforeTargets="BeforeCompile"
+          BeforeTargets="CoreCompile"
           DependsOnTargets="Protobuf_Compile"
           Condition=" '$(Language)' == 'C#' " />
 


### PR DESCRIPTION
Using Grpc.Tools 2.27.

Protobuf file generation does not work correctly in WPF; this is listed as a [known issue for .NET Core](https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.0#wpf-projects-unable-to-generate-grpc-c-assets-from-proto-files) but does also affect .NET Framework as well.

The problem is that Grpc.Tools is hooking into the wrong part of the build process -- in particular a part that does not get executed for a particular compilation step used by WPF.

See https://github.com/dotnet/wpf/issues/810#issuecomment-587982956 for more info.

The suggested fix is to change `_Protobuf_Compile_BeforeCsCompile` to hook `CoreCompile` instead of `BeforeCompile`.

I have not checked if this resolves the issue with .NET Core as well, although I would assume so.  Defining the extra property (as shown in the comment above) definitely does resolve it for .NET Framework, and changing the `BeforeTargets` does have the same effect in Framework.

(This was originally posted as https://github.com/grpc/grpc-dotnet/issues/780, since it was related to some other issues in there, but it seems more on-topic here.)