### PR TITLE
[Aio] Run IO operations in a separated Asyncio loop

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -47,7 +47,7 @@ cdef class CallbackWrapper:
     @staticmethod
     cdef void functor_run(
             grpc_experimental_completion_queue_functor* functor,
-            int succeed)
+            int succeed) with gil
 
     cdef grpc_experimental_completion_queue_functor *c_functor(self)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -18,7 +18,7 @@ cdef class CallbackFailureHandler:
     cdef object _error_details
     cdef object _exception_type
 
-    cdef handle(self, object future)
+    cdef handle(self, object future, object future_loop)
 
 
 cdef struct CallbackContext:
@@ -29,12 +29,14 @@ cdef struct CallbackContext:
     #       callback function in the only way Core understands.
     #     waiter: An asyncio.Future object that fulfills when the callback is
     #       invoked by Core.
+    #     waiter_loop: Asyncio loop where the future is being awaited.
     #     failure_handler: A CallbackFailureHandler object that called when Core
     #       returns 'success == 0' state.
     #     wrapper: A self-reference to the CallbackWrapper to help life cycle
     #       management.
     grpc_experimental_completion_queue_functor functor
     cpython.PyObject *waiter
+    cpython.PyObject *waiter_loop
     cpython.PyObject *failure_handler
     cpython.PyObject *callback_wrapper
 
@@ -42,6 +44,7 @@ cdef struct CallbackContext:
 cdef class CallbackWrapper:
     cdef CallbackContext context
     cdef object _reference_of_future
+    cdef object _reference_of_loop
     cdef object _reference_of_failure_handler
 
     @staticmethod

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -78,6 +78,7 @@ cdef class AioChannel:
         cdef object future = self.loop.create_future()
         cdef CallbackWrapper wrapper = CallbackWrapper(
             future,
+            self.loop,
             _WATCH_CONNECTIVITY_FAILURE_HANDLER)
         grpc_channel_watch_connectivity_state(
             self.channel,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
@@ -16,6 +16,9 @@
 cdef bint _grpc_aio_initialized = 0
 
 
+cdef bint grpc_aio_initialized():
+    return _grpc_aio_initialized
+
 def init_grpc_aio():
     global _grpc_aio_initialized
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
@@ -16,9 +16,6 @@
 cdef bint _grpc_aio_initialized = 0
 
 
-cdef bint grpc_aio_initialized():
-    return _grpc_aio_initialized
-
 def init_grpc_aio():
     global _grpc_aio_initialized
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
@@ -14,10 +14,10 @@
 
 cdef class _IOLoop:
     cdef:
-        cdef object _asyncio_loop
-        cdef object _thread
-        cdef object _io_ev
-        cdef object _loop_started_ev
+        object _asyncio_loop
+        object _thread
+        object _io_ev
+        object _loop_started_ev
 
     cpdef void io_mark(self)
     cdef void io_wait(self, size_t timeout_ms)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
@@ -22,6 +22,6 @@ cdef class _IOLoop:
         cdef object _loop_started_cv
         cdef object _loop_started
 
-    cpdef void io_mark(self)
+    cdef inline void io_mark(self)
     cdef void io_wait(self, size_t timeout_ms)
     cdef object asyncio_loop(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
@@ -1,4 +1,4 @@
-# Copyright 2019 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cdef class _AsyncioTimer:
+cdef class _IOLoop:
     cdef:
-        grpc_custom_timer * _grpc_timer
-        object _deadline
-        object _timer_handler
-        object _loop
-        int _active
+        cdef object _asyncio_loop
+        cdef object _thread
+        cdef object _io_ev
+  
+        # Starting synchronization attributes
+        cdef object _loop_started_cv
+        cdef object _loop_started
 
-    @staticmethod
-    cdef _AsyncioTimer create(grpc_custom_timer * grpc_timer, deadline)
-
-    cdef stop(self)
+    cpdef void io_mark(self)
+    cdef void io_wait(self, size_t timeout_ms)
+    cdef object asyncio_loop(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
@@ -22,6 +22,6 @@ cdef class _IOLoop:
         cdef object _loop_started_cv
         cdef object _loop_started
 
-    cdef inline void io_mark(self)
+    cpdef void io_mark(self)
     cdef void io_wait(self, size_t timeout_ms)
     cdef object asyncio_loop(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pxd.pxi
@@ -17,10 +17,7 @@ cdef class _IOLoop:
         cdef object _asyncio_loop
         cdef object _thread
         cdef object _io_ev
-  
-        # Starting synchronization attributes
-        cdef object _loop_started_cv
-        cdef object _loop_started
+        cdef object _loop_started_ev
 
     cpdef void io_mark(self)
     cdef void io_wait(self, size_t timeout_ms)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
@@ -1,0 +1,87 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import threading
+
+_RESOLUTION_MS = 0.001
+cdef _IOLoop _io_loop = None
+
+cdef class _IOLoop:
+
+    def __init__(self):
+        global _io_loop
+
+        # Only one instantiation is exepected        
+        assert _io_loop is None
+
+        self._asyncio_loop = None
+        self._io_ev = threading.Event()
+        self._loop_started_cv = threading.Condition()
+        self._loop_started = False
+
+        self._thread = threading.Thread(target=self._run_forever, daemon=True)
+        self._thread.start()
+
+        # Some attributes are initialitzated when
+        # the thread is really started, we wait till
+        # the whole Asyncio loop is initialized and
+        # ready to be used.
+        with self._loop_started_cv:
+            if not self._loop_started:
+                self._loop_started_cv.wait()
+
+        _io_loop = self
+
+
+    def _loop_started_cb(self):
+        with self._loop_started_cv:
+            self._loop_started = True
+            self._loop_started_cv.notify_all()
+
+    def _run_forever(self):
+        self._asyncio_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._asyncio_loop)
+        self._asyncio_loop.call_soon(self._loop_started_cb)
+        try:
+            self._asyncio_loop.run_forever()
+        except Exception as exp:
+            print("An error ocurred with the IO loop {}".format(exp))
+            # Without the IO loop running the program would become
+            # unresponsive, proactively we close the process.
+            sys.exit(1)
+
+    cpdef void io_mark(self):
+        # Wake up all threads that were waiting
+        # for an IO event.
+        self._io_ev.set()
+
+        # Clear the status, further threads will get
+        # block.
+        self._io_ev.clear()
+
+    cdef void io_wait(self, size_t timeout_ms):
+        if threading.get_ident() == self._thread.ident:
+            # Reentrance is not allowed, otherwise we will be
+            # blocking the Asyncio loop.
+            return
+
+        if timeout_ms > 0:
+            self._io_ev.wait(timeout_ms * _RESOLUTION_MS)
+
+    cdef object asyncio_loop(self):
+        return self._asyncio_loop
+
+cdef _IOLoop _current_io_loop():
+    global _io_loop
+    return _io_loop

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
@@ -61,7 +61,7 @@ cdef class _IOLoop:
             # unresponsive, proactively we close the process.
             sys.exit(1)
 
-    cpdef void io_mark(self):
+    cdef inline void io_mark(self):
         # Wake up all threads that were waiting
         # for an IO event.
         self._io_ev.set()
@@ -82,6 +82,11 @@ cdef class _IOLoop:
     cdef object asyncio_loop(self):
         return self._asyncio_loop
 
+
 cdef _IOLoop _current_io_loop():
     global _io_loop
     return _io_loop
+
+cdef inline void _fast_io_mark():
+    global _io_loop
+    _io_loop.io_mark()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
@@ -1,4 +1,4 @@
-# Copyright 2019 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@ cdef class _IOLoop:
     def __init__(self):
         global _io_loop
 
-        # Only one instantiation is exepected        
-        assert _io_loop is None
+        assert _io_loop is None, "IO Loop already instantiated"
 
         self._asyncio_loop = None
         self._io_ev = threading.Event()
@@ -51,7 +50,7 @@ cdef class _IOLoop:
         try:
             self._asyncio_loop.run_forever()
         except Exception as exp:
-            sys.stderr("An error ocurred with the IO loop {}{}".format(exp, os.linesep))
+            _LOGGER.error("An error ocurred with the IO loop, aborting the whole process {}".format(exp))
             # Without the IO loop running the program would become
             # unresponsive, proactively we close the process.
             sys.exit(1)
@@ -67,7 +66,7 @@ cdef class _IOLoop:
 
     cdef void io_wait(self, size_t timeout_ms):
         if threading.get_ident() == self._thread.ident:
-            # (TODO) Fix any use case that could imply io loop reentrance.
+            # (TODO) Fix any use case that could imply IO loop reentrance.
             # As an example, the backup channel poller is executing this code path
             _LOGGER.warning("IO Loop reentrance is not allowed")
             return

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/io_loop.pyx.pxi
@@ -61,7 +61,7 @@ cdef class _IOLoop:
             # unresponsive, proactively we close the process.
             sys.exit(1)
 
-    cdef inline void io_mark(self):
+    cpdef void io_mark(self):
         # Wake up all threads that were waiting
         # for an IO event.
         self._io_ev.set()
@@ -82,11 +82,6 @@ cdef class _IOLoop:
     cdef object asyncio_loop(self):
         return self._asyncio_loop
 
-
 cdef _IOLoop _current_io_loop():
     global _io_loop
     return _io_loop
-
-cdef inline void _fast_io_mark():
-    global _io_loop
-    _io_loop.io_mark()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -11,10 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import platform
-
 from cpython cimport Py_INCREF, Py_DECREF
 from libc cimport string
 
@@ -195,23 +192,29 @@ cdef void asyncio_timer_stop(grpc_custom_timer* grpc_timer) with gil:
     Py_DECREF(timer)
 
 
-cdef void asyncio_init_loop() with gil:
+cdef void asyncio_init_loop():
     pass
 
 
-cdef void asyncio_destroy_loop() with gil:
+cdef void asyncio_destroy_loop():
     pass
 
 
-cdef void asyncio_kick_loop() with gil:
+cdef void asyncio_kick_loop():
+    # GIL is not acquired in purpose, holding the GIL 
+    # would mean having a deadlock when the synchronous stack
+    # is executed on top of the Aio module
     pass
 
 
 cdef void asyncio_run_loop(size_t timeout_ms) with gil:
-    pass
+    # Block until arrives a new input/output event
+    _current_io_loop().io_wait(timeout_ms)
 
-
+ 
 def install_asyncio_iomgr():
+    _IOLoop()
+
     asyncio_resolver_vtable.resolve = asyncio_resolve
     asyncio_resolver_vtable.resolve_async = asyncio_resolve_async
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/iomgr.pyx.pxi
@@ -57,7 +57,8 @@ cdef void asyncio_socket_close(
         grpc_custom_close_callback close_cb) with gil:
     socket = (<_AsyncioSocket>grpc_socket.impl)
     socket.close()
-    close_cb(grpc_socket)
+    with nogil:
+        close_cb(grpc_socket)
 
 
 cdef void asyncio_socket_shutdown(grpc_custom_socket* grpc_socket) with gil:
@@ -201,7 +202,7 @@ cdef void asyncio_destroy_loop():
 
 
 cdef void asyncio_kick_loop():
-    # GIL is not acquired in purpose, holding the GIL 
+    # GIL is not acquired in purpose, holding the GIL
     # would mean having a deadlock when the synchronous stack
     # is executed on top of the Aio module
     pass

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/resolver.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/resolver.pxd.pxi
@@ -16,6 +16,7 @@ cdef class _AsyncioResolver:
     cdef:
         grpc_custom_resolver* _grpc_resolver
         object _task_resolve
+        object _loop
 
     @staticmethod
     cdef _AsyncioResolver create(grpc_custom_resolver* grpc_resolver)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/resolver.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/resolver.pyx.pxi
@@ -54,7 +54,7 @@ cdef class _AsyncioResolver:
                 grpc_socket_error("getaddrinfo {}".format(error_msg).encode())
             )
 
-        _current_io_loop().io_mark()
+        _fast_io_mark()
 
     cdef void resolve(self, char* host, char* port):
         assert not self._task_resolve

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/resolver.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/resolver.pyx.pxi
@@ -54,7 +54,7 @@ cdef class _AsyncioResolver:
                 grpc_socket_error("getaddrinfo {}".format(error_msg).encode())
             )
 
-        _fast_io_mark()
+        _current_io_loop().io_mark()
 
     cdef void resolve(self, char* host, char* port):
         assert not self._task_resolve

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
@@ -39,9 +39,6 @@ cdef class _AsyncioSocket:
         object _py_socket
         object _peername
 
-        # Caches the IOLoop.
-        object _io_loop
-
 
     @staticmethod
     cdef _AsyncioSocket create(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
@@ -39,6 +39,10 @@ cdef class _AsyncioSocket:
         object _py_socket
         object _peername
 
+        # Caches the IOLoop.
+        object _io_loop
+
+
     @staticmethod
     cdef _AsyncioSocket create(
             grpc_custom_socket * grpc_socket,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pxd.pxi
@@ -39,6 +39,9 @@ cdef class _AsyncioSocket:
         object _py_socket
         object _peername
 
+        # Caches the IOLoop.
+        object _io_loop
+
 
     @staticmethod
     cdef _AsyncioSocket create(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/socket.pyx.pxi
@@ -35,6 +35,7 @@ cdef class _AsyncioSocket:
         self._server = None
         self._py_socket = None
         self._peername = None
+        self._io_loop = None
         self._loop = None 
 
     @staticmethod
@@ -47,6 +48,7 @@ cdef class _AsyncioSocket:
         socket._writer = writer
         if writer is not None:
             socket._peername = writer.get_extra_info('peername')
+        socket._io_loop = _current_io_loop()
         socket._loop = _current_io_loop().asyncio_loop()
         return socket
 
@@ -55,6 +57,7 @@ cdef class _AsyncioSocket:
         socket = _AsyncioSocket()
         socket._grpc_socket = grpc_socket
         socket._py_socket = py_socket
+        socket._io_loop = _current_io_loop()
         socket._loop = _current_io_loop().asyncio_loop()
         return socket
 
@@ -84,7 +87,7 @@ cdef class _AsyncioSocket:
                 <grpc_error*>0
             )
 
-        _fast_io_mark()
+        self._io_loop.io_mark()
 
     async def _async_read(self, size_t length):
         self._task_read = None
@@ -108,7 +111,7 @@ cdef class _AsyncioSocket:
                 <grpc_error*>0
             )
 
-        _fast_io_mark()
+        self._io_loop.io_mark()
 
     cdef void connect(self,
                       object host,
@@ -153,7 +156,7 @@ cdef class _AsyncioSocket:
                 grpc_socket_error("Socket write failed: {}".format(connection_error).encode()),
             )
 
-        _fast_io_mark()
+        self._io_loop.io_mark()
 
     cdef void write(self, grpc_slice_buffer * g_slice_buffer, grpc_custom_write_callback grpc_write_cb):
         """Performs write to network socket in AsyncIO.
@@ -210,7 +213,7 @@ cdef class _AsyncioSocket:
         # * grpc_error: An error object
         self._grpc_accept_cb(self._grpc_socket, self._grpc_client_socket, grpc_error_none())
 
-        _fast_io_mark()
+        self._io_loop.io_mark()
 
     cdef listen(self):
         self._py_socket.listen(_ASYNCIO_STREAM_DEFAULT_SOCKET_BACKLOG)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/timer.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/timer.pyx.pxi
@@ -41,7 +41,7 @@ cdef class _AsyncioTimer:
 
         self._active = 0
         grpc_custom_timer_callback(self._grpc_timer, <grpc_error*>0)
-        _current_io_loop().io_mark()
+        _fast_io_mark()
 
     def __repr__(self):
         class_name = self.__class__.__name__ 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/timer.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/timer.pyx.pxi
@@ -41,7 +41,7 @@ cdef class _AsyncioTimer:
 
         self._active = 0
         grpc_custom_timer_callback(self._grpc_timer, <grpc_error*>0)
-        _fast_io_mark()
+        _current_io_loop().io_mark()
 
     def __repr__(self):
         class_name = self.__class__.__name__ 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/timer.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/iomgr/timer.pyx.pxi
@@ -36,11 +36,18 @@ cdef class _AsyncioTimer:
         return timer
 
     def _on_deadline(self):
+        cdef grpc_error* error
+        cdef grpc_custom_timer* timer = <grpc_custom_timer*> self._grpc_timer
+
         if self._active == 0:
             return
 
         self._active = 0
-        grpc_custom_timer_callback(self._grpc_timer, <grpc_error*>0)
+        
+        error = grpc_error_none()
+        with nogil:
+            grpc_custom_timer_callback(timer, error)
+
         _current_io_loop().io_mark()
 
     def __repr__(self):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -604,6 +604,7 @@ cdef class AioServer:
         self._shutdown_completed = self._loop.create_future()
         self._shutdown_callback_wrapper = CallbackWrapper(
             self._shutdown_completed,
+            self._loop,
             SERVER_SHUTDOWN_FAILURE_HANDLER)
         self._crash_exception = None
 
@@ -631,6 +632,7 @@ cdef class AioServer:
         cdef object future = self._loop.create_future()
         cdef CallbackWrapper wrapper = CallbackWrapper(
             future,
+            self._loop,
             REQUEST_CALL_FAILURE_HANDLER)
         error = grpc_server_request_call(
             self._server.c_server, &rpc_state.call, &rpc_state.details,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -393,6 +393,7 @@ cdef _close(Channel channel, grpc_status_code code, object details,
     drain_calls):
   cdef _ChannelState state = channel._state
   cdef _CallState call_state
+
   encoded_details = _encode(details)
   with state.condition:
     if state.open:
@@ -421,7 +422,8 @@ cdef _close(Channel channel, grpc_status_code code, object details,
 
       _destroy_c_completion_queue(state.c_call_completion_queue)
       _destroy_c_completion_queue(state.c_connectivity_completion_queue)
-      grpc_channel_destroy(state.c_channel)
+      with nogil:
+          grpc_channel_destroy(state.c_channel)
       state.c_channel = NULL
       grpc_shutdown_blocking()
       state.condition.notify_all()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -26,16 +26,6 @@ ctypedef unsigned int       uint32_t
 ctypedef unsigned long long uint64_t
 
 
-cdef extern from "grpc/support/sync.h":
-
-  ctypedef struct gpr_event:
-    # We don't care about the internals
-    pass
-
-  void gpr_event_init(gpr_event* ev) nogil
-  void* gpr_event_set(gpr_event* ev, void* value) nogil
-  void* gpr_event_wait(gpr_event* ev, gpr_timespec abs_deadline) nogil
-
 cdef extern from "grpc/support/alloc.h":
 
   void *gpr_malloc(size_t size) nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -26,6 +26,16 @@ ctypedef unsigned int       uint32_t
 ctypedef unsigned long long uint64_t
 
 
+cdef extern from "grpc/support/sync.h":
+
+  ctypedef struct gpr_event:
+    # We don't care about the internals
+    pass
+
+  void gpr_event_init(gpr_event* ev) nogil
+  void* gpr_event_set(gpr_event* ev, void* value) nogil
+  void* gpr_event_wait(gpr_event* ev, gpr_timespec abs_deadline) nogil
+
 cdef extern from "grpc/support/alloc.h":
 
   void *gpr_malloc(size_t size) nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
@@ -51,7 +51,7 @@ cdef extern from "src/core/lib/iomgr/resolve_address_custom.h":
 
   void grpc_custom_resolve_callback(grpc_custom_resolver* resolver,
                                     grpc_resolved_addresses* result,
-                                    grpc_error* error);
+                                    grpc_error* error) nogil;
 
 cdef extern from "src/core/lib/iomgr/tcp_custom.h":
   cdef int GRPC_CUSTOM_SOCKET_OPT_SO_REUSEPORT
@@ -60,15 +60,15 @@ cdef extern from "src/core/lib/iomgr/tcp_custom.h":
     void* impl
     # We don't care about the rest of the fields
   ctypedef void (*grpc_custom_connect_callback)(grpc_custom_socket* socket,
-                                             grpc_error* error)
+                                             grpc_error* error) nogil
   ctypedef void (*grpc_custom_write_callback)(grpc_custom_socket* socket,
-                                           grpc_error* error)
+                                           grpc_error* error) nogil
   ctypedef void (*grpc_custom_read_callback)(grpc_custom_socket* socket,
-                                          size_t nread, grpc_error* error)
+                                          size_t nread, grpc_error* error) nogil
   ctypedef void (*grpc_custom_accept_callback)(grpc_custom_socket* socket,
                                             grpc_custom_socket* client,
-                                            grpc_error* error)
-  ctypedef void (*grpc_custom_close_callback)(grpc_custom_socket* socket)
+                                            grpc_error* error) nogil
+  ctypedef void (*grpc_custom_close_callback)(grpc_custom_socket* socket) nogil
 
   struct grpc_socket_vtable:
       grpc_error* (*init)(grpc_custom_socket* socket, int domain);
@@ -101,7 +101,7 @@ cdef extern from "src/core/lib/iomgr/timer_custom.h":
     void (*start)(grpc_custom_timer* t);
     void (*stop)(grpc_custom_timer* t);
 
-  void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error);
+  void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error) nogil;
 
 cdef extern from "src/core/lib/iomgr/pollset_custom.h":
   struct grpc_custom_poller_vtable:

--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
@@ -42,6 +42,7 @@ IF UNAME_SYSNAME != "Windows":
     include "_cygrpc/fork_posix.pxd.pxi"
 
 # Following pxi files are part of the Aio module
+include "_cygrpc/aio/iomgr/io_loop.pxd.pxi"
 include "_cygrpc/aio/iomgr/socket.pxd.pxi"
 include "_cygrpc/aio/iomgr/timer.pxd.pxi"
 include "_cygrpc/aio/iomgr/resolver.pxd.pxi"

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -65,6 +65,7 @@ ELSE:
     include "_cygrpc/fork_posix.pyx.pxi"
 
 # Following pxi files are part of the Aio module
+include "_cygrpc/aio/iomgr/io_loop.pyx.pxi"
 include "_cygrpc/aio/iomgr/iomgr.pyx.pxi"
 include "_cygrpc/aio/iomgr/socket.pyx.pxi"
 include "_cygrpc/aio/iomgr/timer.pyx.pxi"

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -240,7 +240,7 @@ class Channel(_base_channel.Channel):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._close(None)
 
-    async def _close(self, grace):
+    async def _close(self, grace):  # pylint: disable=too-many-branches
         if self._channel.closed():
             return
 

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -261,8 +261,16 @@ class TestGevent(setuptools.Command):
             sys.exit('Test failure')
 
 
-class TestAsyncio(setuptools.Command):
-    """Command to run tests w/asyncio."""
+class TestSyncOverAio(setuptools.Command):
+    """Command to run sync tests with asyncio.
+
+    Run all original tests that are written for the synchronous stack by first
+    initializing the Aio module. This would assert the synchronous stack is able
+    to work using the IOMGR installed by the Aio module.
+
+    Some of the synchronous features, like forking, can not be provided in this
+    specific scenario, tests that were designed for checking these features are banned. 
+    """
 
     BANNED_TESTS = (
         # Fork support is not compatible with Aio

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -281,7 +281,14 @@ class TestAsyncio(setuptools.Command):
         # hangs forever
         'unit._cython._channel_test.ChannelTest.test_single_channel_lonely_connectivity',
         'unit._cython._channel_test.ChannelTest.test_multiple_channels_lonely_connectivity',
-        'unit._abort_test.AbortTest.test_abort'
+        'unit._abort_test.AbortTest.test_abort',
+        'unit._resource_exhausted_test.ResourceExhaustedTest.testUnaryStream',
+        
+        # Failing
+        'unit._compression_test.CompressionTest.testUnaryStreamChannelUncompressedMulticallableUncompressedServerGzipCompressionServerCallUncompressed',
+        'unit._compression_test.CompressionTest.testUnaryStreamChannelUncompressedMulticallableUncompressedServerGzipCompressionServerCallGzipCompression',
+        'unit._compression_test.CompressionTest.testUnaryStreamChannelUncompressedMulticallableUncompressedServerUncompressedServerCallGzipCompression',
+        'unit._compression_test.CompressionTest.testUnaryStreamChannelUncompressedMulticallableUncompressedServerUncompressedServerCallUncompressed'
     )
     description = 'run tests with Asyncio IO manager.'
     user_options = []

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -260,6 +260,7 @@ class TestGevent(setuptools.Command):
         if not result.value.wasSuccessful():
             sys.exit('Test failure')
 
+
 class TestAsyncio(setuptools.Command):
     """Command to run tests w/asyncio."""
 
@@ -283,7 +284,7 @@ class TestAsyncio(setuptools.Command):
         'unit._cython._channel_test.ChannelTest.test_multiple_channels_lonely_connectivity',
         'unit._abort_test.AbortTest.test_abort',
         'unit._resource_exhausted_test.ResourceExhaustedTest.testUnaryStream',
-        
+
         # Failing
         'unit._compression_test.CompressionTest.testUnaryStreamChannelUncompressedMulticallableUncompressedServerGzipCompressionServerCallUncompressed',
         'unit._compression_test.CompressionTest.testUnaryStreamChannelUncompressedMulticallableUncompressedServerGzipCompressionServerCallGzipCompression',

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -60,7 +60,7 @@ COMMAND_CLASS = {
     'test_gevent': commands.TestGevent,
     'test_aio': commands.TestAio,
     'test_py3_only': commands.TestPy3Only,
-    'test_asyncio': commands.TestAsyncio
+    'test_sync_over_aio': commands.TestSyncOverAio
 }
 
 PACKAGE_DATA = {

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -60,6 +60,7 @@ COMMAND_CLASS = {
     'test_gevent': commands.TestGevent,
     'test_aio': commands.TestAio,
     'test_py3_only': commands.TestPy3Only,
+    'test_asyncio': commands.TestAsyncio
 }
 
 PACKAGE_DATA = {


### PR DESCRIPTION
All IO operations are executed using its own loop and thread, allowing the synchronous client to run without getting blocked.

Recipe for running the synchronous tests using the `Aio` iomgr:

```bash
python ./src/python/grpcio_tests/setup.py test_sync_over_aio
```
Related to #19955

## Performance impact

The following table shows the performance of the Python gRPC driver in its three different ways of making RPC calls comparing the PR with master. Each value shows the maximum QPS reached with the same level of concurrency (25 threads/25 Asyncio tasks)

_stack_ | Master | PR
--- | --- | ---
sync | 11K | 11K
sync over Aio | x | 6K
Aio| 19K| 18K

For testing has been using the following tool [1] for stressing a CPP gRPC server from a Python gRPC client by making unary calls, having both of them living in different machines. All tests that required the `Aio` module were executed using the `uvloop` implementation of the  Asyncio loop.

[1] https://github.com/pfreixes/grpcio_stress

## What is missing

- The `init_grpc_aio` is still the way of initializing the `Aio` module.
- Several tests have been disabled [1] we would need to tackle the ones that are critical.
- The new test command for running all of the synchronous tests on top of an initialized `Aio` module would need to be added into the CI for having them running automatically at each new PR.
- For detecting regressions with the solution proposed we could also consider having an entry into the current benchmark tests for checking the performance. We could consider testing all arities

## Other notes

None last minor versions of 3.6 and 3.7 have this bug [2] where asynchronous generators might end up being closed from another thread, all last minor versions have this bug fixed.

[1] https://github.com/grpc/grpc/pull/22076/files#diff-f4932b2c9567e7075b28bc8ddf591120R266
[2] https://bugs.python.org/issue34769

---

**EDIT(@lidizheng)**: This PR needs cherry-pick import. Fixes https://github.com/grpc/grpc/issues/19985