### PR TITLE
Avoid traversing trace flags when trace is not specified

### DIFF
--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -40,6 +40,9 @@ TraceFlag* TraceFlagList::root_tracer_ = nullptr;
 
 bool TraceFlagList::Set(const char* name, bool enabled) {
   TraceFlag* t;
+  if (0 == strcmp(name, "")) {
+    return true;
+  }
   if (0 == strcmp(name, "all")) {
     for (t = root_tracer_; t; t = t->next_tracer_) {
       t->set_enabled(enabled);
@@ -60,8 +63,7 @@ bool TraceFlagList::Set(const char* name, bool enabled) {
         found = true;
       }
     }
-    // check for unknowns, but ignore "", to allow to GRPC_TRACE=
-    if (!found && 0 != strcmp(name, "")) {
+    if (!found) {
       gpr_log(GPR_ERROR, "Unknown trace var: '%s'", name);
       return false; /* early return */
     }


### PR DESCRIPTION
With this change, the trace flags would not be traversed when GRPC_TRACE
= "". This is equivalent semantically but slightly more efficient
compared to the implementation before.

The purpose of this change is to avoid a dead loop traversal when the
global trace flags are initialized twice from an ODR violation caused by
dynamic linkage of grpc++.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
