### PR TITLE
Improve local credentials integration for Windows

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -907,25 +907,12 @@ const char* Subchannel::GetUriFromSubchannelAddressArg(
   return addr_str;
 }
 
-namespace {
-
-void UriToSockaddr(const char* uri_str, grpc_resolved_address* addr) {
-  absl::StatusOr<URI> uri = URI::Parse(uri_str);
-  if (!uri.ok()) {
-    gpr_log(GPR_ERROR, "%s", uri.status().ToString().c_str());
-    GPR_ASSERT(uri.ok());
-  }
-  if (!grpc_parse_uri(*uri, addr)) memset(addr, 0, sizeof(*addr));
-}
-
-}  // namespace
-
 void Subchannel::GetAddressFromSubchannelAddressArg(
     const grpc_channel_args* args, grpc_resolved_address* addr) {
   const char* addr_uri_str = GetUriFromSubchannelAddressArg(args);
   memset(addr, 0, sizeof(*addr));
   if (*addr_uri_str != '\0') {
-    UriToSockaddr(addr_uri_str, addr);
+    grpc_string_to_sockaddr(addr_uri_str, addr);
   }
 }
 

--- a/src/core/lib/iomgr/parse_address.cc
+++ b/src/core/lib/iomgr/parse_address.cc
@@ -320,3 +320,13 @@ uint16_t grpc_strhtons(const char* port) {
   }
   return htons(static_cast<unsigned short>(atoi(port)));
 }
+
+void grpc_string_to_sockaddr(absl::string_view uri_str,
+                             grpc_resolved_address* addr) {
+  absl::StatusOr<grpc_core::URI> uri = grpc_core::URI::Parse(uri_str);
+  if (!uri.ok()) {
+    gpr_log(GPR_ERROR, "%s", uri.status().ToString().c_str());
+    GPR_ASSERT(uri.ok());
+  }
+  if (!grpc_parse_uri(*uri, addr)) memset(addr, 0, sizeof(*addr));
+}

--- a/src/core/lib/iomgr/parse_address.h
+++ b/src/core/lib/iomgr/parse_address.h
@@ -61,6 +61,10 @@ bool grpc_parse_ipv6_hostport(absl::string_view hostport,
 /* Converts named or numeric port to a uint16 suitable for use in a sockaddr. */
 uint16_t grpc_strhtons(const char* port);
 
+// Parse the string into an URI struct and then convert to resolved address.
+void grpc_string_to_sockaddr(absl::string_view uri_str,
+                             grpc_resolved_address* addr);
+
 namespace grpc_core {
 
 /** Populate \a resolved_addr to be a unix socket at |path| */

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -142,10 +142,8 @@ bool grpc_sockaddr_is_loopback(const grpc_resolved_address* resolved_addr) {
     // Check for ::1
     const grpc_sockaddr_in6* addr6 =
         reinterpret_cast<const grpc_sockaddr_in6*>(addr);
-    for (int i = 0; i < 15; i++) {
-      if (addr6->sin6_addr.s6_addr[i] != 0) return false;
-    }
-    return addr6->sin6_addr.s6_addr[15] == 1;
+    return memcmp(&addr6->sin6_addr, &in6addr_loopback,
+                  sizeof(in6addr_loopback)) == 0;
   } else {
     // UDP socket is not considered as loopback.
     return false;

--- a/src/core/lib/iomgr/sockaddr_utils.h
+++ b/src/core/lib/iomgr/sockaddr_utils.h
@@ -42,6 +42,9 @@ int grpc_sockaddr_to_v4mapped(const grpc_resolved_address* addr,
  *port_out (if not NULL) and returns true, otherwise returns false. */
 int grpc_sockaddr_is_wildcard(const grpc_resolved_address* addr, int* port_out);
 
+// If addr is a loopback address in either IPv4 or IPv6, return true
+bool grpc_sockaddr_is_loopback(const grpc_resolved_address* resolved_addr);
+
 /* Writes 0.0.0.0:port and [::]:port to separate sockaddrs. */
 void grpc_sockaddr_make_wildcards(int port, grpc_resolved_address* wild4_out,
                                   grpc_resolved_address* wild6_out);

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -29,6 +29,7 @@
   "unit.context_peer_test.TestContextPeer",
   "unit.done_callback_test.TestDoneCallback",
   "unit.init_test.TestInit",
+  "unit.local_credentials_test.TestLocalCredentials",
   "unit.metadata_test.TestMetadata",
   "unit.outside_init_test.TestOutsideInit",
   "unit.secure_call_test.TestStreamStreamSecureCall",

--- a/src/python/grpcio_tests/tests_aio/unit/local_credentials_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/local_credentials_test.py
@@ -1,0 +1,82 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test of RPCs made using local credentials."""
+
+import unittest
+import os
+import logging
+import grpc
+from grpc.experimental import aio
+from tests_aio.unit._test_base import AioTestBase
+
+
+class _GenericHandler(grpc.GenericRpcHandler):
+
+    @staticmethod
+    async def _identical(request, unused_context):
+        return request
+
+    def service(self, handler_call_details):
+        return grpc.unary_unary_rpc_method_handler(self._identical)
+
+
+def _create_server():
+    server = aio.server()
+    server.add_generic_rpc_handlers((_GenericHandler(),))
+    return server
+
+
+class TestLocalCredentials(AioTestBase):
+
+    async def test_local_tcp(self):
+        server_addr = 'localhost:{}'
+        channel_creds = grpc.local_channel_credentials(
+            grpc.LocalConnectionType.LOCAL_TCP)
+        server_creds = grpc.local_server_credentials(
+            grpc.LocalConnectionType.LOCAL_TCP)
+
+        server = _create_server()
+        port = server.add_secure_port(server_addr.format(0), server_creds)
+        await server.start()
+
+        async with aio.secure_channel(server_addr.format(port),
+                                      channel_creds) as channel:
+            self.assertEqual(
+                b'abc', await channel.unary_unary('/test/method')
+                (b'abc', wait_for_ready=True))
+
+        await server.stop(None)
+
+    async def test_non_local_tcp(self):
+        server_addr = '0.0.0.0:{}'
+        channel_creds = grpc.local_channel_credentials(
+            grpc.LocalConnectionType.LOCAL_TCP)
+        server_creds = grpc.local_server_credentials(
+            grpc.LocalConnectionType.LOCAL_TCP)
+
+        server = _create_server()
+        port = server.add_secure_port(server_addr.format(0), server_creds)
+        await server.start()
+
+        async with aio.secure_channel(server_addr.format(port),
+                                      channel_creds) as channel:
+            with self.assertRaises(grpc.aio.AioRpcError):
+                await channel.unary_unary('/test/method')(b'abc')
+
+        await server.stop(None)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/test/core/iomgr/sockaddr_utils_test.cc
+++ b/test/core/iomgr/sockaddr_utils_test.cc
@@ -67,15 +67,6 @@ static void set_addr6_scope_id(grpc_resolved_address* addr, uint32_t scope_id) {
   addr6->sin6_scope_id = scope_id;
 }
 
-static void uri_to_sockaddr(const char* uri_str, grpc_resolved_address* addr) {
-  absl::StatusOr<grpc_core::URI> uri = grpc_core::URI::Parse(uri_str);
-  if (!uri.ok()) {
-    gpr_log(GPR_ERROR, "%s", uri.status().ToString().c_str());
-    GPR_ASSERT(uri.ok());
-  }
-  if (!grpc_parse_uri(*uri, addr)) memset(addr, 0, sizeof(*addr));
-}
-
 static const uint8_t kMapped[] = {0, 0, 0,    0,    0,   0, 0, 0,
                                   0, 0, 0xff, 0xff, 192, 0, 2, 1};
 
@@ -189,11 +180,11 @@ static void test_sockaddr_is_loopback(void) {
   gpr_log(GPR_INFO, "%s", "test_sockaddr_is_loopback");
 
   grpc_resolved_address v4_loopback;
-  uri_to_sockaddr("ipv4:127.0.0.1:0", &v4_loopback);
+  grpc_string_to_sockaddr("ipv4:127.0.0.1:0", &v4_loopback);
   GPR_ASSERT(grpc_sockaddr_is_loopback(&v4_loopback));
 
   grpc_resolved_address v6_loopback;
-  uri_to_sockaddr("ipv6:[::1]:0", &v6_loopback);
+  grpc_string_to_sockaddr("ipv6:[::1]:0", &v6_loopback);
   GPR_ASSERT(grpc_sockaddr_is_loopback(&v6_loopback));
 
   grpc_resolved_address v4mapped_loopback;
@@ -201,15 +192,15 @@ static void test_sockaddr_is_loopback(void) {
   GPR_ASSERT(grpc_sockaddr_is_loopback(&v4mapped_loopback));
 
   grpc_resolved_address v4_not_loopback;
-  uri_to_sockaddr("ipv4:192.168.0.1:0", &v4_not_loopback);
+  grpc_string_to_sockaddr("ipv4:192.168.0.1:0", &v4_not_loopback);
   GPR_ASSERT(!grpc_sockaddr_is_loopback(&v4_not_loopback));
 
   grpc_resolved_address v6_not_loopback;
-  uri_to_sockaddr("ipv6:[::1]:0", &v6_not_loopback);
+  grpc_string_to_sockaddr("ipv6:[::1]:0", &v6_not_loopback);
   GPR_ASSERT(!grpc_sockaddr_is_loopback(&v6_not_loopback));
 
   grpc_resolved_address uds_addr;
-  uri_to_sockaddr("unix:/tmp/foo", &uds_addr);
+  grpc_string_to_sockaddr("unix:/tmp/foo", &uds_addr);
   GPR_ASSERT(!grpc_sockaddr_is_loopback(&uds_addr));
 }
 


### PR DESCRIPTION
~~In custom IO managers, the `fd` is not exposed in `tcp_custom`. However, the local credential requires the `fd` to get underlying socket name. So, this PR changes the mechanism to testing against the `peer_string` in tcp endpoints.~~

~~Let's see if tests are happy.~~

---

Fixes https://github.com/grpc/grpc/issues/22020 https://github.com/grpc/grpc/issues/21940 https://github.com/grpc/grpc/issues/20855

This fix is needed by Windows where `fd` does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/22082)
<!-- Reviewable:end -->
