### PR TITLE
make check_call_host() in ssl_security_connector to use ssl_utils

### DIFF
--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -190,21 +190,9 @@ class grpc_ssl_channel_security_connector final
                        grpc_auth_context* auth_context,
                        grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
-    grpc_security_status status = GRPC_SECURITY_ERROR;
-    tsi_peer peer = grpc_shallow_peer_from_ssl_auth_context(auth_context);
-    if (grpc_ssl_host_matches_name(&peer, host)) status = GRPC_SECURITY_OK;
-    /* If the target name was overridden, then the original target_name was
-       'checked' transitively during the previous peer check at the end of the
-       handshake. */
-    if (overridden_target_name_ != nullptr && host == target_name_.get()) {
-      status = GRPC_SECURITY_OK;
-    }
-    if (status != GRPC_SECURITY_OK) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "call host does not match SSL server name");
-    }
-    grpc_shallow_peer_destruct(&peer);
-    return true;
+    return grpc_ssl_check_call_host(host, target_name_.get(),
+                                    overridden_target_name_.get(), auth_context,
+                                    error);
   }
 
   void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -167,11 +167,13 @@ bool grpc_ssl_check_call_host(grpc_core::StringView host,
                               grpc_core::StringView target_name,
                               grpc_core::StringView overridden_target_name,
                               grpc_auth_context* auth_context,
-                              grpc_closure* /*on_call_host_checked*/,
                               grpc_error** error) {
   grpc_security_status status = GRPC_SECURITY_ERROR;
   tsi_peer peer = grpc_shallow_peer_from_ssl_auth_context(auth_context);
   if (grpc_ssl_host_matches_name(&peer, host)) status = GRPC_SECURITY_OK;
+  /* If the target name was overridden, then the original target_name was
+   'checked' transitively during the previous peer check at the end of the
+   handshake. */
   if (!overridden_target_name.empty() && host == target_name) {
     status = GRPC_SECURITY_OK;
   }

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -57,7 +57,6 @@ bool grpc_ssl_check_call_host(grpc_core::StringView host,
                               grpc_core::StringView target_name,
                               grpc_core::StringView overridden_target_name,
                               grpc_auth_context* auth_context,
-                              grpc_closure* on_call_host_checked,
                               grpc_error** error);
 /* Return HTTP2-compliant cipher suites that gRPC accepts by default. */
 const char* grpc_get_ssl_cipher_suites(void);

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -245,7 +245,7 @@ bool TlsChannelSecurityConnector::check_call_host(
     grpc_closure* on_call_host_checked, grpc_error** error) {
   return grpc_ssl_check_call_host(host, target_name_.get(),
                                   overridden_target_name_.get(), auth_context,
-                                  on_call_host_checked, error);
+                                  error);
 }
 
 void TlsChannelSecurityConnector::cancel_check_call_host(


### PR DESCRIPTION
I noticed that in the check_call_host() function of ssl_security_connector, we are not taking advantage of a helper function grpc_ssl_check_call_host defined in ssl_utils, as we did in tls_security_connector.

check_call_host() function of ssl_security_connector uses the same logic of the helper function, so we'd better use the util code instead of writing our own. 