### PR TITLE
Fix mixed-signed comparison in security code

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1122,7 +1122,8 @@ static void tsi_ssl_handshaker_factory_init(
 tsi_result tsi_ssl_get_cert_chain_contents(STACK_OF(X509) * peer_chain,
                                            tsi_peer_property* property) {
   BIO* bio = BIO_new(BIO_s_mem());
-  for (int i = 0; i < sk_X509_num(peer_chain); i++) {
+  const auto peer_chain_len = sk_X509_num(peer_chain);
+  for (auto i = decltype(peer_chain_len){0}; i < peer_chain_len; i++) {
     if (!PEM_write_bio_X509(bio, sk_X509_value(peer_chain, i))) {
       BIO_free(bio);
       return TSI_INTERNAL_ERROR;


### PR DESCRIPTION
issues a warning on gcc.

(disappointed in recent sloppiness in gRPC security code tbh)

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
