### PR TITLE
Let the proto gen rule be unified in OSS and g3

### DIFF
--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -57,11 +57,11 @@ def cc_grpc_library(
     proto_targets = []
 
     if not grpc_only:
-        proto_target = "_" + name + "_only"
-        cc_proto_target = name if proto_only else "_" + name + "_cc_proto"
+        proto_target = name + "_only"
+        cc_proto_target = name if proto_only else name + "_cc_proto"
 
-        proto_deps = ["_" + dep + "_only" for dep in deps if dep.find(":") == -1]
-        proto_deps += [dep.split(":")[0] + ":" + "_" + dep.split(":")[1] + "_only" for dep in deps if dep.find(":") != -1]
+        proto_deps = [dep + "_only" for dep in deps if dep.find(":") == -1]
+        proto_deps += [dep.split(":")[0] + ":" + dep.split(":")[1] + "_only" for dep in deps if dep.find(":") != -1]
         if well_known_protos:
             proto_deps += well_known_proto_libs()
         proto_library(
@@ -84,7 +84,7 @@ def cc_grpc_library(
         proto_targets += srcs
 
     if not proto_only:
-        codegen_grpc_target = "_" + name + "_grpc_codegen"
+        codegen_grpc_target = name + "_grpc_codegen"
         generate_cc(
             name = codegen_grpc_target,
             srcs = proto_targets,

--- a/src/proto/grpc/core/BUILD
+++ b/src/proto/grpc/core/BUILD
@@ -15,7 +15,6 @@
 licenses(["notice"])  # Apache v2
 
 load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
-load("//bazel:python_rules.bzl", "py_proto_library")
 
 grpc_package(
     name = "core",
@@ -25,14 +24,4 @@ grpc_package(
 grpc_proto_library(
     name = "stats_proto",
     srcs = ["stats.proto"],
-)
-
-proto_library(
-    name = "stats_descriptor",
-    srcs = ["stats.proto"],
-)
-
-py_proto_library(
-    name = "stats_py_pb2",
-    deps = [":stats_descriptor"],
 )

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -214,74 +214,29 @@ grpc_proto_library(
     ],
 )
 
-proto_library(
-    name = "test_proto_descriptor",
-    srcs = ["test.proto"],
-    deps = [
-        ":empty_proto_descriptor",
-        ":messages_proto_descriptor",
-    ],
-)
-
 py_proto_library(
     name = "py_test_proto",
-    deps = [":test_proto_descriptor"],
+    deps = [":test_proto_only"],
 )
 
 py_grpc_library(
     name = "test_py_pb2_grpc",
-    srcs = [":test_proto_descriptor"],
+    srcs = [":test_proto_only"],
     deps = [":py_test_proto"],
-)
-
-proto_library(
-    name = "worker_service_descriptor",
-    srcs = ["worker_service.proto"],
-    deps = [":control_descriptor"],
 )
 
 py_proto_library(
     name = "worker_service_py_pb2",
-    deps = [":worker_service_descriptor"],
+    deps = [":worker_service_proto_only"],
 )
 
 py_grpc_library(
     name = "worker_service_py_pb2_grpc",
-    srcs = [":worker_service_descriptor"],
+    srcs = [":worker_service_proto_only"],
     deps = [":worker_service_py_pb2"],
-)
-
-proto_library(
-    name = "stats_descriptor",
-    srcs = ["stats.proto"],
-    deps = ["//src/proto/grpc/core:stats_descriptor"],
-)
-
-py_proto_library(
-    name = "stats_py_pb2",
-    deps = [":stats_descriptor"],
-)
-
-proto_library(
-    name = "payloads_descriptor",
-    srcs = ["payloads.proto"],
-)
-
-py_proto_library(
-    name = "payloads_py_pb2",
-    deps = [":payloads_descriptor"],
-)
-
-proto_library(
-    name = "control_descriptor",
-    srcs = ["control.proto"],
-    deps = [
-        ":payloads_descriptor",
-        ":stats_descriptor",
-    ],
 )
 
 py_proto_library(
     name = "control_py_pb2",
-    deps = [":control_descriptor"],
+    deps = [":control_proto_only"],
 )

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -237,6 +237,11 @@ py_grpc_library(
 )
 
 py_proto_library(
+    name = "stats_py_pb2",
+    deps = [":stats_proto_only"],
+)
+
+py_proto_library(
     name = "control_py_pb2",
     deps = [":control_proto_only"],
 )

--- a/src/python/grpcio_tests/tests_aio/benchmark/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_aio/benchmark/BUILD.bazel
@@ -51,10 +51,8 @@ py_library(
     deps = [
         ":benchmark_client",
         ":benchmark_servicer",
-        "//src/proto/grpc/core:stats_py_pb2",
         "//src/proto/grpc/testing:benchmark_service_py_pb2_grpc",
         "//src/proto/grpc/testing:control_py_pb2",
-        "//src/proto/grpc/testing:payloads_py_pb2",
         "//src/proto/grpc/testing:stats_py_pb2",
         "//src/proto/grpc/testing:worker_service_py_pb2_grpc",
         "//src/python/grpcio/grpc:grpcio",

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -75,14 +75,14 @@ grpc_cc_binary(
 
 genrule(
     name = "copy_compiler_test_grpc_pb_h",
-    srcs = ["//src/proto/grpc/testing:_compiler_test_proto_grpc_codegen"],
+    srcs = ["//src/proto/grpc/testing:compiler_test_proto_grpc_codegen"],
     outs = ["compiler_test.grpc.pb.h"],
     cmd = "cat $(GENDIR)/src/proto/grpc/testing/compiler_test.grpc.pb.h > $@",
 )
 
 genrule(
     name = "copy_compiler_test_mock_grpc_pb_h",
-    srcs = ["//src/proto/grpc/testing:_compiler_test_proto_grpc_codegen"],
+    srcs = ["//src/proto/grpc/testing:compiler_test_proto_grpc_codegen"],
     outs = ["compiler_test_mock.grpc.pb.h"],
     cmd = "cat $(GENDIR)/src/proto/grpc/testing/compiler_test_mock.grpc.pb.h > $@",
 )


### PR DESCRIPTION
In google3, the generated proto target is suffixed with "_only". However, in OSS, the generated proto target is prefixed with "_" and suffixed with "_only". This PR unifies this difference, and removed additional `proto_library`s.