### PR TITLE
Add params for running in other test environments

### DIFF
--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -19,7 +19,7 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 sudo apt-get install -y python3-pip
-sudo python3 -m pip install grpcio grpcio-tools google-api-python-client google-auth-httplib2
+sudo python3 -m pip install grpcio grpcio-tools google-api-python-client google-auth-httplib2 oauth2client
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests


### PR DESCRIPTION
These additional parameters enable the xDS test runner to be used in internal test environments.