### PR TITLE
Grpc.Tools: Fix cpp paths in tools to match actual codegen.

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/CppGeneratorTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/CppGeneratorTest.cs
@@ -72,8 +72,8 @@ namespace Grpc.Tools.Tests
             Assert.AreEqual(4, poss.Length);
             Assert.Contains("foo.pb.cc", poss);
             Assert.Contains("foo.pb.h", poss);
-            Assert.Contains("foo_grpc.pb.cc", poss);
-            Assert.Contains("foo_grpc.pb.h", poss);
+            Assert.Contains("foo.grpc.pb.cc", poss);
+            Assert.Contains("foo.grpc.pb.h", poss);
         }
 
         [Test]

--- a/src/csharp/Grpc.Tools/GeneratorServices.cs
+++ b/src/csharp/Grpc.Tools/GeneratorServices.cs
@@ -157,8 +157,8 @@ namespace Grpc.Tools
                 {
                     fileStem = Path.Combine(outdir, relative, filename);
                 }
-                outputs[2] = fileStem + "_grpc.pb.cc";
-                outputs[3] = fileStem + "_grpc.pb.h";
+                outputs[2] = fileStem + ".grpc.pb.cc";
+                outputs[3] = fileStem + ".grpc.pb.h";
             }
             return outputs;
         }


### PR DESCRIPTION
The C++ output filenames generated by the Grpc.Tools build task doesn't match what the C++ gRPC plugin actually outputs.  This fixes that.

(Incidentally, if you're interested in a patch that allows Grpc.Tools to actually do the codegen for C++ as well, I have that too.)

@nicolasnoble