### PR TITLE
set timeout on rpc call

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -148,8 +148,11 @@ def get_client_stats(num_rpcs, timeout_sec):
         request = messages_pb2.LoadBalancerStatsRequest()
         request.num_rpcs = num_rpcs
         request.timeout_sec = timeout_sec
+        rpc_timeout = timeout_sec * 2  # Allow time for connection establishment
         try:
-            response = stub.GetClientStats(request, wait_for_ready=True)
+            response = stub.GetClientStats(request,
+                                           wait_for_ready=True,
+                                           timeout=rpc_timeout)
             logger.debug('Invoked GetClientStats RPC: %s', response)
             return response
         except grpc.RpcError as rpc_error:


### PR DESCRIPTION
Without this, the test can wait forever if something goes wrong with the client process and there is no server to connect to (since `wait_for_ready=True`)