### PR TITLE
Build xds client before launching test driver

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -45,9 +45,11 @@ touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
     "$PROTO_SOURCE_DIR"/messages.proto \
     "$PROTO_SOURCE_DIR"/empty.proto
 
+bazel build test/cpp/interop:xds_interop_client
+
 "$PYTHON" tools/run_tests/run_xds_tests.py \
     --test_case=all \
     --project_id=grpc-testing \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    --client_cmd='bazel run test/cpp/interop:xds_interop_client -- --server=xds-experimental:///{service_host}:{service_port} --stats_port={stats_port} --qps={qps}'
+    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds-experimental:///{service_host}:{service_port} --stats_port={stats_port} --qps={qps}'


### PR DESCRIPTION
Run `bazel build` before launch the test driver to avoid the test driver timing out while waiting for the `bazel run` command to complete.

Overlooked that after https://github.com/grpc/grpc/pull/22142 the test driver would no longer wait indefinitely for the client to build and start.