### PR TITLE
add grpc++_test filegroup to build_handwritten.yaml to fix import

### DIFF
--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -16,6 +16,17 @@ settings:
   csharp_major_version: 2
   g_stands_for: gringotts
   version: 1.29.0-dev
+filegroups:
+- name: grpc++_test
+  public_headers:
+  - include/grpc++/test/mock_stream.h
+  - include/grpc++/test/server_context_test_spouse.h
+  - include/grpcpp/test/default_reactor_test_peer.h
+  - include/grpcpp/test/mock_stream.h
+  - include/grpcpp/test/server_context_test_spouse.h
+  deps:
+  - grpc++
+  - grpc
 targets:
 - name: check_epollexclusive
   build: tool


### PR DESCRIPTION
Looks like this otherwise useless filegroup is used as a hack
to import some headers that are used internally.
