### PR TITLE
Allow marking bazel test as flaky, under certain rules

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -168,7 +168,7 @@ def ios_cc_test(
             deps = ios_test_deps,
         )
 
-def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = [], exec_properties = {}, shard_count = None):
+def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = [], exec_properties = {}, shard_count = None, flaky = None):
     copts = if_mac(["-DGRPC_CFSTREAM"])
     if language.upper() == "C":
         copts = copts + if_not_windows(["-std=c99"])
@@ -187,6 +187,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         "exec_compatible_with": exec_compatible_with,
         "exec_properties": exec_properties,
         "shard_count": shard_count,
+        "flaky": flaky,
     }
     if uses_polling:
         # the vanilla version of the test should run on platforms that only
@@ -218,6 +219,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
                 exec_compatible_with = exec_compatible_with,
                 exec_properties = exec_properties,
                 shard_count = shard_count,
+                flaky = flaky,
             )
     else:
         # the test behavior doesn't depend on polling, just generate the test

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -134,6 +134,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    flaky = True,  # TODO(b/148399919)
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -502,6 +502,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    flaky = True,  # TODO(b/144705388)
     shard_count = 10,
     tags = [
         "no_test_ios",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -205,6 +205,7 @@ grpc_cc_test(
     srcs = [
         "bm_fullstack_streaming_pump.cc",
     ],
+    flaky = True,  # TODO(b/150422385)
     tags = [
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",
@@ -248,6 +249,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_metadata",
     srcs = ["bm_metadata.cc"],
+    flaky = True,  # TODO(b/149998903)
     tags = [
         "no_mac",
         "no_windows",


### PR DESCRIPTION
Just trying things out for now. I'll come up with a draft for a process that will make sure that tests won't deteriorate over time.