### PR TITLE
Update TlsServerCredentials to initialize C-core

### DIFF
--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include <grpcpp/impl/codegen/slice.h>
+#include <grpcpp/impl/grpc_library.h>
 #include <grpcpp/security/auth_metadata_processor.h>
 
 #include "src/cpp/common/secure_auth_context.h"
@@ -149,6 +150,7 @@ std::shared_ptr<ServerCredentials> LocalServerCredentials(
 
 std::shared_ptr<ServerCredentials> TlsServerCredentials(
     const TlsCredentialsOptions& options) {
+  grpc::GrpcLibraryCodegen init;
   return std::shared_ptr<ServerCredentials>(new SecureServerCredentials(
       grpc_tls_server_credentials_create(options.c_credentials_options())));
 }

--- a/test/cpp/client/credentials_test.cc
+++ b/test/cpp/client/credentials_test.cc
@@ -682,7 +682,6 @@ TEST_F(CredentialsTest, LoadTlsChannelCredentials) {
 // This test demonstrates how the TLS credentials will be used to create
 // server credentials.
 TEST_F(CredentialsTest, LoadTlsServerCredentials) {
-  grpc_init();
   std::shared_ptr<TestTlsCredentialReload> test_credential_reload(
       new TestTlsCredentialReload());
   std::shared_ptr<TlsCredentialReloadConfig> credential_reload_config(
@@ -694,7 +693,6 @@ TEST_F(CredentialsTest, LoadTlsServerCredentials) {
   std::shared_ptr<::grpc_impl::ServerCredentials> server_credentials =
       grpc::experimental::TlsServerCredentials(options);
   GPR_ASSERT(server_credentials.get() != nullptr);
-  grpc_shutdown();
 }
 
 TEST_F(CredentialsTest, TlsCredentialReloadConfigErrorMessages) {


### PR DESCRIPTION
This initializes the C-core when the |TlsServerCredentials| are used, which hides this work from the user.
