### PR TITLE
Have more verbose test failure information in testTimeout

### DIFF
--- a/src/objective-c/tests/UnitTests/APIv2Tests.m
+++ b/src/objective-c/tests/UnitTests/APIv2Tests.m
@@ -409,6 +409,9 @@ static const NSTimeInterval kInvertedTimeout = 2;
                        XCTAssertNotNil(error,
                                        @"Failure: no error received; Expect: receive "
                                        @"deadline exceeded.");
+                       if (error.code != GRPCErrorCodeDeadlineExceeded) {
+                         NSLog(@"Unexpected error: %@", error);
+                       }
                        XCTAssertEqual(error.code, GRPCErrorCodeDeadlineExceeded);
                        [completion fulfill];
                      }]


### PR DESCRIPTION
`testTimeout` is flaky ([example](https://source.cloud.google.com/results/invocations/70207765-54b5-4eef-9148-1de5f0344da4/log)) but the error information is not verbose enough to diagnose. This PR is to allow Kokoro to generate more useful information for me to debug the problem.