### PR TITLE
Fix Windows PECL build

### DIFF
--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -33,7 +33,7 @@
       "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
       "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
       "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+
-      "/I"+configure_module_dirname+"\\third_party\\boringssl\\include "+
+      "/I"+configure_module_dirname+"\\third_party\\boringssl-with-bazel\\src\\include "+
       "/I"+configure_module_dirname+"\\third_party\\upb "+
       "/I"+configure_module_dirname+"\\third_party\\zlib ");
   <%


### PR DESCRIPTION
Apparently, the path to the boringssl include directory has changed,
but this is not yet reflected in config.w32, so Windows builds of the
PECL package are failing.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
