### PR TITLE
Add ruby 2.7 to mac binary packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,7 +130,7 @@ task 'gem:native' do
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
         "build should be running on ruby 2.5."
     end
-    system "rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    system "rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     require 'rake_compiler_dock'
 

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -19,7 +19,7 @@ rm -rf ~/.rake-compiler
 
 CROSS_RUBY=$(mktemp tmpfile.XXXXXXXX)
 
-curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.3/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
+curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.1.0/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
 
 # See https://github.com/grpc/grpc/issues/12161 for verconf.h patch details
 patch "$CROSS_RUBY" << EOF
@@ -49,6 +49,19 @@ EOF
 
 MAKE="make -j8"
 
+set +x # rvm commands are very verbose
+source ~/.rvm/scripts/rvm
+rvm use 2.7.0
+set -x
+ruby --version | grep 'ruby 2.7.0'
+for v in 2.7.0 ; do
+  ccache -c
+  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
+done
+set +x
+rvm use 2.5.0
+set -x
+ruby --version | grep 'ruby 2.5.0'
 for v in 2.6.0 2.5.0 2.4.0 2.3.0 2.2.2 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
@@ -56,4 +69,3 @@ done
 
 sed 's/x86_64-darwin-11/universal-darwin/' ~/.rake-compiler/config.yml > "$CROSS_RUBY"
 mv "$CROSS_RUBY" ~/.rake-compiler/config.yml
-

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -39,14 +39,16 @@ then
   set +ex  # rvm script is very verbose and exits with errorcode
   # Advice from https://github.com/Homebrew/homebrew-cask/issues/8629#issuecomment-68641176
   brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
-  rvm --debug requirements ruby-2.5.0
-  source $HOME/.rvm/scripts/rvm
   set -e  # rvm commands are very verbose
-  time rvm install 2.5.0
+  source $HOME/.rvm/scripts/rvm
+  for RUBY_VERSION in 2.5.0 2.7.0; do
+    rvm --debug requirements "ruby-${RUBY_VERSION}"
+    time rvm install "$RUBY_VERSION"
+    time gem install bundler -v 1.17.3 --no-document
+    time gem install rake-compiler --no-document
+  done;
   rvm use 2.5.0 --default
-  time gem install bundler -v 1.17.3 --no-ri --no-doc
-  time gem install cocoapods --version 1.3.1 --no-ri --no-doc
-  time gem install rake-compiler --no-ri --no-doc
+  time gem install cocoapods --version 1.3.1 --no-document
   rvm osx-ssl-certs status all
   rvm osx-ssl-certs update all
   set -ex


### PR DESCRIPTION
Add ruby 2.7 to mac binary packages

Towards https://github.com/grpc/grpc/issues/21514

Successful macos artifacts build with grpc-ruby libraries that target ruby 2.7: 


https://console.cloud.google.com/storage/browser/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/macos/grpc_build_artifacts/15633/20200302-010750




Some logic here in order to:
* run `rake cross-ruby ...` for ruby versions 2.3 through 2.6 under ruby 2.5
* run `rake cross-ruby ...` for ruby version under ruby 2.7. Cross-compiling ruby 2.7 under anything else seems to hit:

```
/Users/kbuilder/.rvm/rubies/ruby-2.5.0/bin/ruby --disable=gems -I/Users/kbuilder/.rake-compiler/builds/x86_64-darwin11/ruby-2.7.0 -rx86_64-darwin11-fake  -I`cd /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib; pwd` --disable-gems -r./x86_64-darwin11-fake /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/tool/rbinstall.rb --make="make -j8" --dest-dir="" --extout=".ext" --mflags="- --jobserver-fds=4,5 -j" --make-flags=" --jobserver-fds=4,5 -j" --data-mode=0644 --prog-mode=0755 --installed-list .installed.list --mantype="doc" --exclude=doc
/Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/delegate.rb:78:in `<class:Delegator>': undefined method `ruby2_keywords' for Delegator:Class (NoMethodError)
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/delegate.rb:39:in `<top (required)>'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/tempfile.rb:8:in `<top (required)>'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/ext/ext_conf_builder.rb:9:in `<top (required)>'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/ext.rb:16:in `<top (required)>'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/installer.rb:12:in `<top (required)>'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/lib/rubygems/core_ext/kernel_require.rb:72:in `require'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/tool/rbinstall.rb:708:in `<module:RbInstall>'
	from /Users/kbuilder/.rake-compiler/sources/ruby-2.7.0/tool/rbinstall.rb:644:in `<main>'
```