### PR TITLE
fix memory leak of grpc_resource_user_quota

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1352,13 +1352,6 @@ void grpc_server_shutdown_and_notify(grpc_server* server,
 
   channel_broadcaster_shutdown(&broadcaster, true /* send_goaway */,
                                GRPC_ERROR_NONE);
-
-  if (server->default_resource_user != nullptr) {
-    grpc_resource_quota_unref(
-        grpc_resource_user_quota(server->default_resource_user));
-    grpc_resource_user_shutdown(server->default_resource_user);
-    grpc_resource_user_unref(server->default_resource_user);
-  }
 }
 
 void grpc_server_cancel_all_calls(grpc_server* server) {
@@ -1396,6 +1389,12 @@ void grpc_server_destroy(grpc_server* server) {
 
   gpr_mu_unlock(&server->mu_global);
 
+  if (server->default_resource_user != nullptr) {
+    grpc_resource_quota_unref(
+        grpc_resource_user_quota(server->default_resource_user));
+    grpc_resource_user_shutdown(server->default_resource_user);
+    grpc_resource_user_unref(server->default_resource_user);
+  }
   server_unref(server);
 }
 


### PR DESCRIPTION
### Summary
When starting a grpc-Server without a service it stops with 'At least one of the completion queues must be frequently polled' but its resource-quota (if given) leaks memory.

### Error seen with valgrind memcheck
```
Memcheck, a memory error detector
Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
HEAP SUMMARY:
    in use at exit: 4,716 bytes in 67 blocks
  total heap usage: 904 allocs, 837 frees, 177,134 bytes allocated

892 (424 direct, 468 indirect) bytes in 1 blocks are definitely lost in loss record 26 of 27
   at 0x4C29EC0: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x2FBAAB: gpr_malloc
   by 0x3150D4: grpc_resource_user_create(grpc_resource_quota*, char const*)
   by 0x330930: grpc_server_create 
   by 0x2DDC46: grpc_impl::Server::Server(int, grpc_impl::ChannelArguments*, std::__1::shared_ptr<std::__1::vector<std::__1::unique_ptr<grpc_impl::ServerCompletionQueue, std::__1::default_delete<grpc_impl::ServerCompletionQueue> >, std::__1::allocator<std::__1::unique_ptr<grpc_impl::ServerCompletionQueue, std::__1::default_delete<grpc_impl::ServerCompletionQueue> > > > >, int, int, int, std::__1::vector<std::__1::shared_ptr<grpc::internal::ExternalConnectionAcceptorImpl>, std::__1::allocator<std::__1::shared_ptr<grpc::internal::ExternalConnectionAcceptorImpl> > >, grpc_resource_quota*, std::__1::vector<std::__1::unique_ptr<grpc::experimental::ServerInterceptorFactoryInterface, std::__1::default_delete<grpc::experimental::ServerInterceptorFactoryInterface> >, std::__1::allocator<std::__1::unique_ptr<grpc::experimental::ServerInterceptorFactoryInterface, std::__1::default_delete<grpc::experimental::ServerInterceptorFactoryInterface> > > >)
   by 0x2D83A1: grpc_impl::ServerBuilder::BuildAndStart()
   by 0x2AF30E: RunServer() (greeter_server.cc:65)
   by 0x2AF76A: main (greeter_server.cc:75)
LEAK SUMMARY:
   definitely lost: 424 bytes in 1 blocks
   indirectly lost: 468 bytes in 4 blocks
     possibly lost: 0 bytes in 0 blocks
   still reachable: 3,824 bytes in 62 blocks
        suppressed: 0 bytes in 0 blocks
```

### Reproducing the leak
Modified greeter_server.cc that produces this behaviour
```
void RunServer() {
  std::string server_address("0.0.0.0:50051");
  GreeterServiceImpl service;

  ServerBuilder builder;
  // Listen on the given address without any authentication mechanism.
  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());

  ::grpc::ResourceQuota resourceQuota("ServerResourceQuota");
  resourceQuota.SetMaxThreads(11);
  builder.SetResourceQuota(resourceQuota);

  // Register "service" as the instance through which we'll communicate with
  // clients. In this case it corresponds to an *synchronous* service.
  //builder.RegisterService(&service);
  // Finally assemble the server.
  std::unique_ptr<Server> server(builder.BuildAndStart());
  std::cout << "Server listening on " << server_address << std::endl;

  // Wait for the server to shutdown. Note that some other thread must be
  // responsible for shutting down the server for this call to ever return.
  if (server)
      server->Wait();
}
```

### Analysis

```
cpp/server/server_builder.cc:321:std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
...
  std::unique_ptr<grpc::Server> server(new grpc::Server(
      max_receive_message_size_, &args, sync_server_cqs,
      sync_server_settings_.min_pollers, sync_server_settings_.max_pollers,
      sync_server_settings_.cq_timeout_msec, std::move(acceptors_),
      resource_quota_, std::move(interceptor_creators_)));
...
```
=> creates a grpc::Server

returns with an error:

```
  if (!has_frequently_polled_cqs) {
    gpr_log(GPR_ERROR,
            "At least one of the completion queues must be frequently polled");
    return nullptr;
  }
```
=> ... deconstructor of grpc::Server is called implicitly, as "server" is not passed on

==============================

`cpp/server/server_cc.cc:936:Server::Server(`
calls grpc_server_create

`cpp/server/server_cc.cc:1006:Server::~Server() {`
=> calls grpc_server_destroy


========================================

core/lib/surface/server.cc:1057:grpc_server_create():
```
  ...
  if (args != nullptr) {
    grpc_resource_quota* resource_quota =
        grpc_resource_quota_from_channel_args(args, false /* create */);
    if (resource_quota != nullptr) {
      server->default_resource_user =
          grpc_resource_user_create(resource_quota, "default");
    }
  }
```
=>  grpc_resource_user_create() calls: core/lib/iomgr/resource_quota.cc:767:grpc_resource_user* grpc_resource_user_create() => gpr_malloc()

core/lib/surface/server.cc:1373:grpc_server_destroy()
=> here the resource "server->default_resource_user" is not freed

**via this PR** i move the following code from grpc_server_shutdown_and_notify() to grpc_server_destroy():

```
core/lib/surface/server.cc:1349:grpc_server_shutdown_and_notify
  if (server->default_resource_user != nullptr) {
    grpc_resource_quota_unref(
        grpc_resource_user_quota(server->default_resource_user));
    grpc_resource_user_shutdown(server->default_resource_user);
    grpc_resource_user_unref(server->default_resource_user);
  }
```
=> grpc_resource_quota_unref() calls: core/lib/iomgr/resource_quota.cc:grpc_resource_quota_unref() => grpc_resource_quota_unref_internal() => gpr_free(resource_quota)

I checked that
* the leak does not show in valgrind anymore
* my grpc code is still working as it should
* the grpc-tests complete successfully on my machine

But please have in mind, that my knowledge of the grpc codebase is very limited. :)

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
