### PR TITLE
Initialize C-core for secure server credentials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,7 +776,9 @@ if(gRPC_BUILD_TESTS)
     add_dependencies(buildtests_cxx server_builder_with_socket_mutator_test)
   endif()
   add_dependencies(buildtests_cxx server_context_test_spouse_test)
-  add_dependencies(buildtests_cxx server_credentials_test)
+  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+    add_dependencies(buildtests_cxx server_credentials_test)
+  endif()
   add_dependencies(buildtests_cxx server_early_return_test)
   add_dependencies(buildtests_cxx server_interceptors_end2end_test)
   add_dependencies(buildtests_cxx server_registered_method_bad_client_test)
@@ -13063,42 +13065,44 @@ target_link_libraries(server_context_test_spouse_test
 
 endif()
 if(gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
-add_executable(server_credentials_test
-  test/cpp/server/server_credentials_test.cc
-  third_party/googletest/googletest/src/gtest-all.cc
-  third_party/googletest/googlemock/src/gmock-all.cc
-)
+  add_executable(server_credentials_test
+    test/cpp/server/server_credentials_test.cc
+    third_party/googletest/googletest/src/gtest-all.cc
+    third_party/googletest/googlemock/src/gmock-all.cc
+  )
 
-target_include_directories(server_credentials_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-    third_party/googletest/googletest/include
-    third_party/googletest/googletest
-    third_party/googletest/googlemock/include
-    third_party/googletest/googlemock
-    ${_gRPC_PROTO_GENS_DIR}
-)
+  target_include_directories(server_credentials_test
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+      ${_gRPC_SSL_INCLUDE_DIR}
+      ${_gRPC_UPB_GENERATED_DIR}
+      ${_gRPC_UPB_GRPC_GENERATED_DIR}
+      ${_gRPC_UPB_INCLUDE_DIR}
+      ${_gRPC_ZLIB_INCLUDE_DIR}
+      third_party/googletest/googletest/include
+      third_party/googletest/googletest
+      third_party/googletest/googlemock/include
+      third_party/googletest/googlemock
+      ${_gRPC_PROTO_GENS_DIR}
+  )
 
-target_link_libraries(server_credentials_test
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_GFLAGS_LIBRARIES}
-)
+  target_link_libraries(server_credentials_test
+    ${_gRPC_PROTOBUF_LIBRARIES}
+    ${_gRPC_ALLTARGETS_LIBRARIES}
+    grpc++
+    grpc
+    gpr
+    address_sorting
+    upb
+    ${_gRPC_GFLAGS_LIBRARIES}
+  )
 
 
+endif()
 endif()
 if(gRPC_BUILD_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,7 @@ if(gRPC_BUILD_TESTS)
     add_dependencies(buildtests_cxx server_builder_with_socket_mutator_test)
   endif()
   add_dependencies(buildtests_cxx server_context_test_spouse_test)
+  add_dependencies(buildtests_cxx server_credentials_test)
   add_dependencies(buildtests_cxx server_early_return_test)
   add_dependencies(buildtests_cxx server_interceptors_end2end_test)
   add_dependencies(buildtests_cxx server_registered_method_bad_client_test)
@@ -13051,6 +13052,44 @@ target_link_libraries(server_context_test_spouse_test
   grpc++_test_util
   grpc++_test
   grpc_test_util
+  grpc++
+  grpc
+  gpr
+  address_sorting
+  upb
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(server_credentials_test
+  test/cpp/server/server_credentials_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(server_credentials_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(server_credentials_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
   grpc
   gpr

--- a/Makefile
+++ b/Makefile
@@ -1272,6 +1272,7 @@ server_builder_plugin_test: $(BINDIR)/$(CONFIG)/server_builder_plugin_test
 server_builder_test: $(BINDIR)/$(CONFIG)/server_builder_test
 server_builder_with_socket_mutator_test: $(BINDIR)/$(CONFIG)/server_builder_with_socket_mutator_test
 server_context_test_spouse_test: $(BINDIR)/$(CONFIG)/server_context_test_spouse_test
+server_credentials_test: $(BINDIR)/$(CONFIG)/server_credentials_test
 server_early_return_test: $(BINDIR)/$(CONFIG)/server_early_return_test
 server_fuzzer: $(BINDIR)/$(CONFIG)/server_fuzzer
 server_interceptors_end2end_test: $(BINDIR)/$(CONFIG)/server_interceptors_end2end_test
@@ -1634,6 +1635,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/server_builder_test \
   $(BINDIR)/$(CONFIG)/server_builder_with_socket_mutator_test \
   $(BINDIR)/$(CONFIG)/server_context_test_spouse_test \
+  $(BINDIR)/$(CONFIG)/server_credentials_test \
   $(BINDIR)/$(CONFIG)/server_early_return_test \
   $(BINDIR)/$(CONFIG)/server_interceptors_end2end_test \
   $(BINDIR)/$(CONFIG)/server_registered_method_bad_client_test \
@@ -1790,6 +1792,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/server_builder_test \
   $(BINDIR)/$(CONFIG)/server_builder_with_socket_mutator_test \
   $(BINDIR)/$(CONFIG)/server_context_test_spouse_test \
+  $(BINDIR)/$(CONFIG)/server_credentials_test \
   $(BINDIR)/$(CONFIG)/server_early_return_test \
   $(BINDIR)/$(CONFIG)/server_interceptors_end2end_test \
   $(BINDIR)/$(CONFIG)/server_registered_method_bad_client_test \
@@ -2320,6 +2323,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/server_builder_with_socket_mutator_test || ( echo test server_builder_with_socket_mutator_test failed ; exit 1 )
 	$(E) "[RUN]     Testing server_context_test_spouse_test"
 	$(Q) $(BINDIR)/$(CONFIG)/server_context_test_spouse_test || ( echo test server_context_test_spouse_test failed ; exit 1 )
+	$(E) "[RUN]     Testing server_credentials_test"
+	$(Q) $(BINDIR)/$(CONFIG)/server_credentials_test || ( echo test server_credentials_test failed ; exit 1 )
 	$(E) "[RUN]     Testing server_early_return_test"
 	$(Q) $(BINDIR)/$(CONFIG)/server_early_return_test || ( echo test server_early_return_test failed ; exit 1 )
 	$(E) "[RUN]     Testing server_interceptors_end2end_test"
@@ -17356,6 +17361,49 @@ deps_server_context_test_spouse_test: $(SERVER_CONTEXT_TEST_SPOUSE_TEST_OBJS:.o=
 ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
 -include $(SERVER_CONTEXT_TEST_SPOUSE_TEST_OBJS:.o=.dep)
+endif
+endif
+
+
+SERVER_CREDENTIALS_TEST_SRC = \
+    test/cpp/server/server_credentials_test.cc \
+
+SERVER_CREDENTIALS_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(SERVER_CREDENTIALS_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/server_credentials_test: openssl_dep_error
+
+else
+
+
+
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.5.0+.
+
+$(BINDIR)/$(CONFIG)/server_credentials_test: protobuf_dep_error
+
+else
+
+$(BINDIR)/$(CONFIG)/server_credentials_test: $(PROTOBUF_DEP) $(SERVER_CREDENTIALS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) $(SERVER_CREDENTIALS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/server_credentials_test
+
+endif
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/cpp/server/server_credentials_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
+
+deps_server_credentials_test: $(SERVER_CREDENTIALS_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(SERVER_CREDENTIALS_TEST_OBJS:.o=.dep)
 endif
 endif
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -6931,6 +6931,10 @@ targets:
   - gpr
   - address_sorting
   - upb
+  platforms:
+  - linux
+  - posix
+  - mac
 - name: server_early_return_test
   gtest: true
   build: test

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -6918,6 +6918,19 @@ targets:
   - gpr
   - address_sorting
   - upb
+- name: server_credentials_test
+  gtest: true
+  build: test
+  language: c++
+  headers: []
+  src:
+  - test/cpp/server/server_credentials_test.cc
+  deps:
+  - grpc++
+  - grpc
+  - gpr
+  - address_sorting
+  - upb
 - name: server_early_return_test
   gtest: true
   build: test

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -111,6 +111,7 @@ void SecureServerCredentials::SetAuthMetadataProcessor(
 
 std::shared_ptr<ServerCredentials> SslServerCredentials(
     const grpc::SslServerCredentialsOptions& options) {
+  grpc::GrpcLibraryCodegen init;
   std::vector<grpc_ssl_pem_key_cert_pair> pem_key_cert_pairs;
   for (const auto& key_cert_pair : options.pem_key_cert_pairs) {
     grpc_ssl_pem_key_cert_pair p = {key_cert_pair.private_key.c_str(),
@@ -133,6 +134,7 @@ namespace experimental {
 
 std::shared_ptr<ServerCredentials> AltsServerCredentials(
     const AltsServerCredentialsOptions& /* options */) {
+  grpc::GrpcLibraryCodegen init;
   grpc_alts_credentials_options* c_options =
       grpc_alts_credentials_server_options_create();
   grpc_server_credentials* c_creds =
@@ -144,6 +146,7 @@ std::shared_ptr<ServerCredentials> AltsServerCredentials(
 
 std::shared_ptr<ServerCredentials> LocalServerCredentials(
     grpc_local_connect_type type) {
+  grpc::GrpcLibraryCodegen init;
   return std::shared_ptr<ServerCredentials>(
       new SecureServerCredentials(grpc_local_server_credentials_create(type)));
 }

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -66,6 +66,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    tags = ["no_windows"],
     deps = [
         "//:grpc++",
     ],

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -59,3 +59,14 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util_unsecure",
     ],
 )
+
+grpc_cc_test(
+    name = "server_credentials_test",
+    srcs = ["server_credentials_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    deps = [
+        "//:grpc++",
+    ],
+)

--- a/test/cpp/server/server_credentials_test.cc
+++ b/test/cpp/server/server_credentials_test.cc
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include <gmock/gmock.h>
+#include <grpc/grpc.h>
 #include <gtest/gtest.h>
 
 namespace {
@@ -27,7 +28,7 @@ namespace {
 /** The 3 tests below ensure that the C-core is properly initialized when a
  *  server credentials instance is created by itself. **/
 TEST(ServerCredentialsTest, AltsServerCredentials) {
-  AltsServerCredentialsOptions options;
+  ::grpc_impl::experimental::AltsServerCredentialsOptions options;
   std::shared_ptr<::grpc_impl::ServerCredentials> server_credentials =
       grpc::experimental::AltsServerCredentials(options);
   EXPECT_NE(server_credentials.get(), nullptr);
@@ -40,7 +41,7 @@ TEST(ServerCredentialsTest, LocalServerCredentials) {
 }
 
 TEST(ServerCredentialsTest, SslServerCredentials) {
-  SslServerCredentialsOptions options;
+  grpc::SslServerCredentialsOptions options;
   std::shared_ptr<::grpc_impl::ServerCredentials> server_credentials =
       grpc::SslServerCredentials(options);
   EXPECT_NE(server_credentials.get(), nullptr);

--- a/test/cpp/server/server_credentials_test.cc
+++ b/test/cpp/server/server_credentials_test.cc
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpcpp/security/server_credentials.h>
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+/** The 3 tests below ensure that the C-core is properly initialized when a
+ *  server credentials instance is created by itself. **/
+TEST(ServerCredentialsTest, AltsServerCredentials) {
+  AltsServerCredentialsOptions options;
+  std::shared_ptr<::grpc_impl::ServerCredentials> server_credentials =
+      grpc::experimental::AltsServerCredentials(options);
+  EXPECT_NE(server_credentials.get(), nullptr);
+}
+
+TEST(ServerCredentialsTest, LocalServerCredentials) {
+  std::shared_ptr<::grpc_impl::ServerCredentials> server_credentials =
+      grpc::experimental::LocalServerCredentials(LOCAL_TCP);
+  EXPECT_NE(server_credentials.get(), nullptr);
+}
+
+TEST(ServerCredentialsTest, SslServerCredentials) {
+  SslServerCredentialsOptions options;
+  std::shared_ptr<::grpc_impl::ServerCredentials> server_credentials =
+      grpc::SslServerCredentials(options);
+  EXPECT_NE(server_credentials.get(), nullptr);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
+}

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5503,8 +5503,7 @@
     "ci_platforms": [
       "linux", 
       "mac", 
-      "posix", 
-      "windows"
+      "posix"
     ], 
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
@@ -5516,8 +5515,7 @@
     "platforms": [
       "linux", 
       "mac", 
-      "posix", 
-      "windows"
+      "posix"
     ], 
     "uses_polling": true
   }, 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5512,6 +5512,30 @@
     "flaky": false, 
     "gtest": true, 
     "language": "c++", 
+    "name": "server_credentials_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": true, 
+    "language": "c++", 
     "name": "server_early_return_test", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
 NOT READY FOR REVIEW/SUBMIT

This PR adds a `GrpcLibraryCodegen` instance to the implementation of 3 C++ server credential APIs: `AltsServerCredentials`, `LocalServerCredentials`, and `SslServerCredentials`. This mimics what is done in PR #22187 for the `TlsServerCredentials`.

Why is this needed? All 3 of the above APIs create a `SecureServerCredentials` instance and, when they are destroyed, they initiate a call to `grpc_core::ExecCtx` (see [here](https://github.com/grpc/grpc/blob/27c8e2751dd805f7db3e807be9b0f2a4af02807c/src/core/lib/security/credentials/credentials.cc#L184)). Prior to this point, there must be some call to `grpc_init` or `GrpcLibraryCodegen`. (For an example of this, see the test failures for commit hash 191afa9 on this PR, e.g. [here](https://source.cloud.google.com/results/invocations/692a3971-ee53-459a-af27-d81b493eec39/targets).)

Why was this not a problem so far? 
