### PR TITLE
Generate simple stubs code

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -70,10 +70,16 @@ typedef set<StringPair> StringPairSet;
 class IndentScope {
  public:
   explicit IndentScope(grpc_generator::Printer* printer) : printer_(printer) {
+    // NOTE(rbellevi): Two-space tabs are hard-coded in the protocol compiler.
+    // Doubling our indents and outdents guarantees compliance with PEP8.
+    printer_->Indent();
     printer_->Indent();
   }
 
-  ~IndentScope() { printer_->Outdent(); }
+  ~IndentScope() {
+    printer_->Outdent();
+    printer_->Outdent();
+  }
 
  private:
   grpc_generator::Printer* printer_;
@@ -92,8 +98,7 @@ void PrivateGenerator::PrintAllComments(StringVector comments,
     // smarter and more sophisticated, but at the moment, if there is
     // no docstring to print, we simply emit "pass" to ensure validity
     // of the generated code.
-    out->Print("# missing associated documentation comment in .proto file\n");
-    out->Print("pass\n");
+    out->Print("\"\"\"Missing associated documentation comment in .proto file\"\"\"\n");
     return;
   }
   out->Print("\"\"\"");
@@ -653,6 +658,7 @@ bool PrivateGenerator::PrintServiceClass(
       }
     }
   }
+  // TODO(rbellevi): Add methods pertinent to the server side as well.
   return true;
 }
 

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -570,6 +570,89 @@ bool PrivateGenerator::PrintAddServicerToServer(
   return true;
 }
 
+/* Prints out a service class used as a container for static methods pertaining
+ * to a class. This class has the exact name of service written in the ".proto"
+ * file, with no suffixes. Since this class merely acts as a namespace, it
+ * should never be instantiated.
+ */
+bool PrivateGenerator::PrintServiceClass(const grpc::string& package_qualified_service_name,
+                                         const grpc_generator::Service* service,
+                                         grpc_generator::Printer* out)
+{
+  StringMap dict;
+  dict["Service"] = service->name();
+  out->Print("\n\n");
+  out->Print(" # This class is part of an EXPERIMENTAL API.\n");
+  out->Print(dict, "class $Service$(object):\n");
+  {
+    IndentScope class_indent(out);
+    StringVector service_comments = service->GetAllComments();
+    PrintAllComments(service_comments, out);
+    for (int i = 0; i < service->method_count(); ++i) {
+      const auto& method = service->method(i);
+      grpc::string request_module_and_class;
+      if (!method->get_module_and_message_path_input(
+              &request_module_and_class, generator_file_name,
+              generate_in_pb2_grpc, config.import_prefix,
+              config.prefixes_to_filter)) {
+        return false;
+      }
+      grpc::string response_module_and_class;
+      if (!method->get_module_and_message_path_output(
+              &response_module_and_class, generator_file_name,
+              generate_in_pb2_grpc, config.import_prefix,
+              config.prefixes_to_filter)) {
+        return false;
+      }
+      out->Print("\n");
+      StringMap method_dict;
+      method_dict["Method"] = method->name();
+      out->Print("@staticmethod\n");
+      out->Print(method_dict, "def $Method$(");
+      {
+        IndentScope args_indent(out);
+        IndentScope args_double_indent(out);
+        grpc::string request_parameter(method->ClientStreaming() ? "request_iterator" : "request");
+        StringMap args_dict;
+        args_dict["RequestParameter"] = request_parameter;
+        out->Print(args_dict, "$RequestParameter$,\n");
+        out->Print("target,\n");
+        out->Print("request_serializer=None,\n");
+        out->Print("request_deserializer=None,\n");
+        out->Print("options=(),\n");
+        out->Print("channel_credentials=None,\n");
+        out->Print("call_credentials=None,\n");
+        out->Print("compression=None,\n");
+        out->Print("wait_for_ready=None,\n");
+        out->Print("timeout=None,\n");
+        out->Print("metadata=None):\n");
+      }
+      {
+        IndentScope method_indent(out);
+        grpc::string arity_method_name =
+            grpc::string(method->ClientStreaming() ? "stream" : "unary") + "_" +
+            grpc::string(method->ServerStreaming() ? "stream" : "unary");
+        StringMap invocation_dict;
+        invocation_dict["ArityMethodName"] = arity_method_name;
+        invocation_dict["PackageQualifiedService"] = package_qualified_service_name;
+        invocation_dict["Method"] = method->name();
+        out->Print(invocation_dict, "return grpc.experimental.$ArityMethodName$(request, target, '/$PackageQualifiedService$/$Method$',\n");
+        {
+          IndentScope continuation_indent(out);
+          StringMap serializer_dict;
+          serializer_dict["RequestModuleAndClass"] = request_module_and_class;
+          serializer_dict["ResponseModuleAndClass"] = response_module_and_class;
+          out->Print(serializer_dict, "$RequestModuleAndClass$.SerializeToString,\n");
+          out->Print(serializer_dict, "$ResponseModuleAndClass$.FromString,\n");
+          out->Print("options, channel_credentials,\n");
+          out->Print("call_credentials, compression, wait_for_ready, timeout, metadata)\n");
+        }
+      }
+    }
+  }
+  return true;
+}
+
 bool PrivateGenerator::PrintBetaPreamble(grpc_generator::Printer* out) {
   StringMap var;
   var["Package"] = config.beta_package_root;
@@ -646,7 +729,8 @@ bool PrivateGenerator::PrintGAServices(grpc_generator::Printer* out) {
     if (!(PrintStub(package_qualified_service_name, service.get(), out) &&
           PrintServicer(service.get(), out) &&
           PrintAddServicerToServer(package_qualified_service_name,
-                                   service.get(), out))) {
+                                   service.get(), out) &&
+          PrintServiceClass(package_qualified_service_name, service.get(), out))) {
       return false;
     }
   }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -98,7 +98,9 @@ void PrivateGenerator::PrintAllComments(StringVector comments,
     // smarter and more sophisticated, but at the moment, if there is
     // no docstring to print, we simply emit "pass" to ensure validity
     // of the generated code.
-    out->Print("\"\"\"Missing associated documentation comment in .proto file\"\"\"\n");
+    out->Print(
+        "\"\"\"Missing associated documentation comment in .proto "
+        "file\"\"\"\n");
     return;
   }
   out->Print("\"\"\"");

--- a/src/compiler/python_private_generator.h
+++ b/src/compiler/python_private_generator.h
@@ -59,6 +59,9 @@ struct PrivateGenerator {
                  const grpc_generator::Service* service,
                  grpc_generator::Printer* out);
 
+  bool PrintServiceClass(const grpc::string& package_qualified_service_name,
+                         const grpc_generator::Service* service,
+                         grpc_generator::Printer* out);
   bool PrintBetaServicer(const grpc_generator::Service* service,
                          grpc_generator::Printer* out);
   bool PrintBetaServerFactory(

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -55,7 +55,8 @@ def _create_channel(target: str, options: Sequence[Tuple[str, str]],
                     compression: Optional[grpc.Compression]) -> grpc.Channel:
     # TODO(rbellevi): Revisit the default value for this.
     if channel_credentials is None:
-        raise NotImplementedError("channel_credentials must be supplied explicitly.")
+        raise NotImplementedError(
+            "channel_credentials must be supplied explicitly.")
     if channel_credentials._credentials is grpc.experimental._insecure_channel_credentials:
         _LOGGER.debug(f"Creating insecure channel with options '{options}' " +
                       f"and compression '{compression}'")

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -156,26 +156,13 @@ class ChannelCache:
             return len(self._mapping)
 
 
-# TODO(rbellevi): Consider a credential type that has the
-#   following functionality matrix:
-#
-#   +----------+-------+--------+
-#   |          | local | remote |
-#   |----------+-------+--------+
-#   | secure   | o     | o      |
-#   | insecure | o     | x      |
-#   +----------+-------+--------+
-#
-#  Make this the default option.
-
-
 @experimental_api
 def unary_unary(
         request: RequestType,
         target: str,
         method: str,
         request_serializer: Optional[Callable[[Any], bytes]] = None,
-        request_deserializer: Optional[Callable[[bytes], Any]] = None,
+        response_deserializer: Optional[Callable[[bytes], Any]] = None,
         options: Sequence[Tuple[AnyStr, AnyStr]] = (),
         channel_credentials: Optional[grpc.ChannelCredentials] = None,
         call_credentials: Optional[grpc.CallCredentials] = None,
@@ -232,7 +219,7 @@ def unary_unary(
     channel = ChannelCache.get().get_channel(target, options,
                                              channel_credentials, compression)
     multicallable = channel.unary_unary(method, request_serializer,
-                                        request_deserializer)
+                                        response_deserializer)
     return multicallable(request,
                          metadata=metadata,
                          wait_for_ready=wait_for_ready,
@@ -246,7 +233,7 @@ def unary_stream(
         target: str,
         method: str,
         request_serializer: Optional[Callable[[Any], bytes]] = None,
-        request_deserializer: Optional[Callable[[bytes], Any]] = None,
+        response_deserializer: Optional[Callable[[bytes], Any]] = None,
         options: Sequence[Tuple[AnyStr, AnyStr]] = (),
         channel_credentials: Optional[grpc.ChannelCredentials] = None,
         call_credentials: Optional[grpc.CallCredentials] = None,
@@ -302,7 +289,7 @@ def unary_stream(
     channel = ChannelCache.get().get_channel(target, options,
                                              channel_credentials, compression)
     multicallable = channel.unary_stream(method, request_serializer,
-                                         request_deserializer)
+                                         response_deserializer)
     return multicallable(request,
                          metadata=metadata,
                          wait_for_ready=wait_for_ready,
@@ -316,7 +303,7 @@ def stream_unary(
         target: str,
         method: str,
         request_serializer: Optional[Callable[[Any], bytes]] = None,
-        request_deserializer: Optional[Callable[[bytes], Any]] = None,
+        response_deserializer: Optional[Callable[[bytes], Any]] = None,
         options: Sequence[Tuple[AnyStr, AnyStr]] = (),
         channel_credentials: Optional[grpc.ChannelCredentials] = None,
         call_credentials: Optional[grpc.CallCredentials] = None,
@@ -372,7 +359,7 @@ def stream_unary(
     channel = ChannelCache.get().get_channel(target, options,
                                              channel_credentials, compression)
     multicallable = channel.stream_unary(method, request_serializer,
-                                         request_deserializer)
+                                         response_deserializer)
     return multicallable(request_iterator,
                          metadata=metadata,
                          wait_for_ready=wait_for_ready,
@@ -386,7 +373,7 @@ def stream_stream(
         target: str,
         method: str,
         request_serializer: Optional[Callable[[Any], bytes]] = None,
-        request_deserializer: Optional[Callable[[bytes], Any]] = None,
+        response_deserializer: Optional[Callable[[bytes], Any]] = None,
         options: Sequence[Tuple[AnyStr, AnyStr]] = (),
         channel_credentials: Optional[grpc.ChannelCredentials] = None,
         call_credentials: Optional[grpc.CallCredentials] = None,
@@ -442,7 +429,7 @@ def stream_stream(
     channel = ChannelCache.get().get_channel(target, options,
                                              channel_credentials, compression)
     multicallable = channel.stream_stream(method, request_serializer,
-                                          request_deserializer)
+                                          response_deserializer)
     return multicallable(request_iterator,
                          metadata=metadata,
                          wait_for_ready=wait_for_ready,

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -53,8 +53,9 @@ else:
 def _create_channel(target: str, options: Sequence[Tuple[str, str]],
                     channel_credentials: Optional[grpc.ChannelCredentials],
                     compression: Optional[grpc.Compression]) -> grpc.Channel:
-    channel_credentials = channel_credentials or grpc.local_channel_credentials(
-    )
+    # TODO(rbellevi): Revisit the default value for this.
+    if channel_credentials is None:
+        raise NotImplementedError("channel_credentials must be supplied explicitly.")
     if channel_credentials._credentials is grpc.experimental._insecure_channel_credentials:
         _LOGGER.debug(f"Creating insecure channel with options '{options}' " +
                       f"and compression '{compression}'")

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -193,6 +193,7 @@ class TestGevent(setuptools.Command):
         'unit._server_ssl_cert_config_test',
         # TODO(https://github.com/grpc/grpc/issues/14901) enable this test
         'protoc_plugin._python_plugin_test.PythonPluginTest',
+        'protoc_plugin._python_plugin_test.SimpleStubsPluginTest',
         # Beta API is unsupported for gevent
         'protoc_plugin.beta_python_plugin_test',
         'unit.beta._beta_features_test',

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -502,6 +502,7 @@ class PythonPluginTest(unittest.TestCase):
                       grpc.StatusCode.DEADLINE_EXCEEDED)
         service.server.stop(None)
 
+    @unittest.skipIf(sys.version_info[0] < 3, "Unsupported on Python 2.")
     def testUnaryCallSimple(self):
         # TODO: Use getattr?
         servicer_methods = _ServicerMethods()

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -27,6 +27,7 @@ import unittest
 from six import moves
 
 import grpc
+import grpc.experimental
 from tests.unit import test_common
 from tests.unit.framework.common import test_constants
 
@@ -544,9 +545,12 @@ class SimpleStubsPluginTest(unittest.TestCase):
 
     def testUnaryCall(self):
         request = request_pb2.SimpleRequest(response_size=13)
-        response = service_pb2_grpc.TestService.UnaryCall(request,
-                                                          self._target,
-                                                          wait_for_ready=True)
+        response = service_pb2_grpc.TestService.UnaryCall(
+            request,
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
         expected_response = self.servicer_methods.UnaryCall(
             request, 'not a real context!')
         self.assertEqual(expected_response, response)
@@ -556,7 +560,11 @@ class SimpleStubsPluginTest(unittest.TestCase):
         expected_responses = self.servicer_methods.StreamingOutputCall(
             request, 'not a real RpcContext!')
         responses = service_pb2_grpc.TestService.StreamingOutputCall(
-            request, self._target, wait_for_ready=True)
+            request,
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
         for expected_response, response in moves.zip_longest(
                 expected_responses, responses):
             self.assertEqual(expected_response, response)
@@ -565,6 +573,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
         response = service_pb2_grpc.TestService.StreamingInputCall(
             _streaming_input_request_iterator(),
             self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
             wait_for_ready=True)
         expected_response = self.servicer_methods.StreamingInputCall(
             _streaming_input_request_iterator(), 'not a real RpcContext!')
@@ -572,7 +582,11 @@ class SimpleStubsPluginTest(unittest.TestCase):
 
     def testFullDuplexCall(self):
         responses = service_pb2_grpc.TestService.FullDuplexCall(
-            _full_duplex_request_iterator(), self._target, wait_for_ready=True)
+            _full_duplex_request_iterator(),
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
         expected_responses = self.servicer_methods.FullDuplexCall(
             _full_duplex_request_iterator(), 'not a real RpcContext!')
         for expected_response, response in moves.zip_longest(
@@ -591,7 +605,11 @@ class SimpleStubsPluginTest(unittest.TestCase):
             yield request
 
         responses = service_pb2_grpc.TestService.HalfDuplexCall(
-            half_duplex_request_iterator(), self._target, wait_for_ready=True)
+            half_duplex_request_iterator(),
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
         expected_responses = self.servicer_methods.HalfDuplexCall(
             half_duplex_request_iterator(), 'not a real RpcContext!')
         for expected_response, response in moves.zip_longest(

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -544,7 +544,9 @@ class SimpleStubsPluginTest(unittest.TestCase):
 
     def testUnaryCall(self):
         request = request_pb2.SimpleRequest(response_size=13)
-        response = service_pb2_grpc.TestService.UnaryCall(request, self._target)
+        response = service_pb2_grpc.TestService.UnaryCall(request,
+                                                          self._target,
+                                                          wait_for_ready=True)
         expected_response = self.servicer_methods.UnaryCall(
             request, 'not a real context!')
         self.assertEqual(expected_response, response)
@@ -554,21 +556,23 @@ class SimpleStubsPluginTest(unittest.TestCase):
         expected_responses = self.servicer_methods.StreamingOutputCall(
             request, 'not a real RpcContext!')
         responses = service_pb2_grpc.TestService.StreamingOutputCall(
-            request, self._target)
+            request, self._target, wait_for_ready=True)
         for expected_response, response in moves.zip_longest(
                 expected_responses, responses):
             self.assertEqual(expected_response, response)
 
     def testStreamingInputCall(self):
         response = service_pb2_grpc.TestService.StreamingInputCall(
-            _streaming_input_request_iterator(), self._target)
+            _streaming_input_request_iterator(),
+            self._target,
+            wait_for_ready=True)
         expected_response = self.servicer_methods.StreamingInputCall(
             _streaming_input_request_iterator(), 'not a real RpcContext!')
         self.assertEqual(expected_response, response)
 
     def testFullDuplexCall(self):
         responses = service_pb2_grpc.TestService.FullDuplexCall(
-            _full_duplex_request_iterator(), self._target)
+            _full_duplex_request_iterator(), self._target, wait_for_ready=True)
         expected_responses = self.servicer_methods.FullDuplexCall(
             _full_duplex_request_iterator(), 'not a real RpcContext!')
         for expected_response, response in moves.zip_longest(
@@ -587,7 +591,7 @@ class SimpleStubsPluginTest(unittest.TestCase):
             yield request
 
         responses = service_pb2_grpc.TestService.HalfDuplexCall(
-            half_duplex_request_iterator(), self._target)
+            half_duplex_request_iterator(), self._target, wait_for_ready=True)
         expected_responses = self.servicer_methods.HalfDuplexCall(
             half_duplex_request_iterator(), 'not a real RpcContext!')
         for expected_response, response in moves.zip_longest(

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -502,6 +502,27 @@ class PythonPluginTest(unittest.TestCase):
                       grpc.StatusCode.DEADLINE_EXCEEDED)
         service.server.stop(None)
 
+    def testUnaryCallSimple(self):
+        # TODO: Use getattr?
+        servicer_methods = _ServicerMethods()
+
+        class Servicer(service_pb2_grpc.TestServiceServicer):
+
+            def UnaryCall(self, request, context):
+                return servicer_methods.UnaryCall(request, context)
+
+        server = test_common.test_server()
+        service_pb2_grpc.add_TestServiceServicer_to_server(Servicer(), server)
+        port = server.add_insecure_port('[::]:0')
+        server.start()
+        target = 'localhost:{}'.format(port)
+        request = request_pb2.SimpleRequest(response_size=13)
+        response = service_pb2_grpc.TestService.UnaryCall(request, target)
+        expected_response = servicer_methods.UnaryCall(
+            request, 'not a real context!')
+        self.assertEqual(expected_response, response)
+        server.stop(None)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -7,6 +7,7 @@
   "interop._insecure_intraop_test.InsecureIntraopTest",
   "interop._secure_intraop_test.SecureIntraopTest",
   "protoc_plugin._python_plugin_test.PythonPluginTest",
+  "protoc_plugin._python_plugin_test.SimpleStubsPluginTest",
   "protoc_plugin._split_definitions_test.SameProtoGrpcBeforeProtoProtocStyleTest",
   "protoc_plugin._split_definitions_test.SameProtoMid2016ProtocStyleTest",
   "protoc_plugin._split_definitions_test.SameProtoProtoBeforeGrpcProtocStyleTest",

--- a/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
@@ -174,13 +174,6 @@ class SimpleStubsTest(unittest.TestCase):
                 channel_credentials=grpc.local_channel_credentials())
             self.assertEqual(_REQUEST, response)
 
-    def test_channel_credentials_default(self):
-        with _server(grpc.local_server_credentials()) as port:
-            target = f'localhost:{port}'
-            response = grpc.experimental.unary_unary(_REQUEST, target,
-                                                     _UNARY_UNARY)
-            self.assertEqual(_REQUEST, response)
-
     def test_channels_cached(self):
         with _server(grpc.local_server_credentials()) as port:
             target = f'localhost:{port}'


### PR DESCRIPTION
This PR completes the implementation of simple stubs, which allows users to invoke RPCs without explicitly instantiating a channel or a stub. For the moment, this is an experimental API.

This enables the following code transformation:

```python
import grpc
import request_pb2
import test_service_pb2_grpc

with grpc.insecure_channel("localhost:50051") as channel:
  test_service_stub = test_service_pb2_grpc.TestServiceStub(channel)
  response = test_service_stub.UnaryCall(request_pb2.SimpleRequest)
```
to

```python
from request_pb2 import SimpleRequest
from test_service_pb2_grpc import TestService

response = TestService.UnaryCall(SimpleRequest(), "localhost:50051")
```

Example generated code:
```python
  # This class is part of an EXPERIMENTAL API.
class TestService(object):
    """Missing associated documentation comment in .proto file"""

    @staticmethod
    def UnaryCall(request,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.unary_unary(request, target, '/grpc_protoc_plugin.TestService/UnaryCall',
            tests_dot_protoc__plugin_dot_protos_dot_requests_dot_r_dot_test__requests__pb2.SimpleRequest.SerializeToString,
            tests_dot_protoc__plugin_dot_protos_dot_responses_dot_test__responses__pb2.SimpleResponse.FromString,
            options, channel_credentials,
            call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def StreamingOutputCall(request,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.unary_stream(request, target, '/grpc_protoc_plugin.TestService/StreamingOutputCall',
            tests_dot_protoc__plugin_dot_protos_dot_requests_dot_r_dot_test__requests__pb2.StreamingOutputCallRequest.SerializeToString,
            tests_dot_protoc__plugin_dot_protos_dot_responses_dot_test__responses__pb2.StreamingOutputCallResponse.FromString,
            options, channel_credentials,
            call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def StreamingInputCall(request_iterator,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.stream_unary(request_iterator, target, '/grpc_protoc_plugin.TestService/StreamingInputCall',
            tests_dot_protoc__plugin_dot_protos_dot_requests_dot_r_dot_test__requests__pb2.StreamingInputCallRequest.SerializeToString,
            tests_dot_protoc__plugin_dot_protos_dot_responses_dot_test__responses__pb2.StreamingInputCallResponse.FromString,
            options, channel_credentials,
            call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def FullDuplexCall(request_iterator,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.stream_stream(request_iterator, target, '/grpc_protoc_plugin.TestService/FullDuplexCall',
            tests_dot_protoc__plugin_dot_protos_dot_requests_dot_r_dot_test__requests__pb2.StreamingOutputCallRequest.SerializeToString,
            tests_dot_protoc__plugin_dot_protos_dot_responses_dot_test__responses__pb2.StreamingOutputCallResponse.FromString,
            options, channel_credentials,
            call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def HalfDuplexCall(request_iterator,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.stream_stream(request_iterator, target, '/grpc_protoc_plugin.TestService/HalfDuplexCall',
            tests_dot_protoc__plugin_dot_protos_dot_requests_dot_r_dot_test__requests__pb2.StreamingOutputCallRequest.SerializeToString,
            tests_dot_protoc__plugin_dot_protos_dot_responses_dot_test__responses__pb2.StreamingOutputCallResponse.FromString,
            options, channel_credentials,
            call_credentials, compression, wait_for_ready, timeout, metadata)
```