### PR TITLE
Add Health Check and Proto Reflection to basic C++ example server.

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -114,6 +114,7 @@ cc_binary(
     deps = [
         ":helloworld_cc_grpc",
         "//:grpc++",
+        "//:grpc++_reflection",
     ],
 )
 

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -54,6 +54,7 @@ if(GRPC_AS_SUBMODULE)
   # After using add_subdirectory, we can now use the grpc targets directly from
   # this build.
   set(_PROTOBUF_LIBPROTOBUF libprotobuf)
+  set(_REFLECTION grpc++_reflection)
   if(CMAKE_CROSSCOMPILING)
     find_program(_PROTOBUF_PROTOC protoc)
   else()
@@ -84,6 +85,7 @@ elseif(GRPC_FETCHCONTENT)
   # Since FetchContent uses add_subdirectory under the hood, we can use
   # the grpc targets directly from this build.
   set(_PROTOBUF_LIBPROTOBUF libprotobuf)
+  set(_REFLECTION grpc++_reflection)
   set(_PROTOBUF_PROTOC $<TARGET_FILE:protoc>)
   set(_GRPC_GRPCPP_UNSECURE grpc++_unsecure)
   if(CMAKE_CROSSCOMPILING)
@@ -102,6 +104,7 @@ else()
   message(STATUS "Using protobuf ${protobuf_VERSION}")
 
   set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+  set(_REFLECTION gRPC::grpc++_reflection)
   if(CMAKE_CROSSCOMPILING)
     find_program(_PROTOBUF_PROTOC protoc)
   else()
@@ -151,6 +154,7 @@ foreach(_target
     ${hw_proto_srcs}
     ${hw_grpc_srcs})
   target_link_libraries(${_target}
+    ${_REFLECTION}
     ${_GRPC_GRPCPP_UNSECURE}
     ${_PROTOBUF_LIBPROTOBUF})
 endforeach()

--- a/examples/cpp/helloworld/greeter_server.cc
+++ b/examples/cpp/helloworld/greeter_server.cc
@@ -21,6 +21,8 @@
 #include <string>
 
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
 
 #ifdef BAZEL_BUILD
 #include "examples/protos/helloworld.grpc.pb.h"
@@ -50,6 +52,8 @@ void RunServer() {
   std::string server_address("0.0.0.0:50051");
   GreeterServiceImpl service;
 
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   // Listen on the given address without any authentication mechanism.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());


### PR DESCRIPTION
This way, the C++ server can be used as an XDS server example.

Tested

With grpc_cli:
grpc_cli ls localhost:50051 --loas2=false --channel_creds_type=insecure

Before change:
Received an error when querying services endpoint.
Reflection request not implemented; is the ServerReflection service enabled?

After adding reflection to BUILD file:
helloworld.Greeter
grpc.reflection.v1alpha.ServerReflection

After adding health check service to server:
helloworld.Greeter
grpc.reflection.v1alpha.ServerReflection
grpc.health.v1.Health

It is also verified that reflection is already in the
examples/cpp/helloworld/Makefile and the server can be built via make.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/22233)
<!-- Reviewable:end -->
