### PR TITLE
Re-initialize submodules after checking out a tag in interop matrix builder

### DIFF
--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -327,7 +327,8 @@ def checkout_grpc_stack(lang, release):
 
     # git submodule update
     jobset.message('START',
-                   'git submodule update --init at %s from %s' % (release, stack_base),
+                   'git submodule update --init at %s from %s' %
+                   (release, stack_base),
                    do_newline=True)
     subprocess.check_call(['git', 'submodule', 'update', '--init'],
                           cwd=stack_base,

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -325,6 +325,18 @@ def checkout_grpc_stack(lang, release):
                    '%s: %s' % (str(output), commit_log),
                    do_newline=True)
 
+    # git submodule update
+    jobset.message('START',
+                   'git submodule update --init at %s from %s' % (release, stack_base),
+                   do_newline=True)
+    subprocess.check_call(['git', 'submodule', 'update', '--init'],
+                          cwd=stack_base,
+                          stderr=subprocess.STDOUT)
+    jobset.message('SUCCESS',
+                   'git submodule update --init',
+                   '%s: %s' % (str(output), commit_log),
+                   do_newline=True)
+
     # Write git log to commit_log so it can be packaged with the docker image.
     with open(os.path.join(stack_base, 'commit_log'), 'w') as f:
         f.write(commit_log)


### PR DESCRIPTION
This is needed to upload the 1.27.3 images

Attempts to do this were failing because I was invoking the `create_matrix_images.py` script from master (which deleted the old `boringssl` submodule in favor of the `boringssl-with-bazel` submodule, but building clients on 1.27.3 requires the `boringssl` submodule).

I believe the reason this kind error wasn't happening before is likely because the script was never used to build images on a release tag that relied on a submodule which had been since deleted on master.
