### PR TITLE
Improve python testing

### DIFF
--- a/src/python/grpcio_tests/tests/_loader.py
+++ b/src/python/grpcio_tests/tests/_loader.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import importlib
 import pkgutil
+import os
 import re
 import unittest
 
@@ -46,7 +47,9 @@ class Loader(object):
     setuptools.setup argument `test_loader`."""
         # ensure that we capture decorators and definitions (else our coverage
         # measure unnecessarily suffers)
-        coverage_context = coverage.Coverage(data_suffix=True)
+        data_file = os.environ.get('COVERAGE_DATA_FILE', '.coverage') or None
+        coverage_context = coverage.Coverage(data_file=data_file,
+                                             data_suffix=True)
         coverage_context.start()
         imported_modules = tuple(
             importlib.import_module(name) for name in names)
@@ -59,7 +62,8 @@ class Loader(object):
                 continue
             self.walk_packages(package_paths)
         coverage_context.stop()
-        coverage_context.save()
+        if data_file:
+            coverage_context.save()
         return self.suite
 
     def walk_packages(self, package_paths):

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import collections
 import itertools
+import os
 import traceback
 import unittest
 from xml.etree import ElementTree
@@ -233,7 +234,10 @@ class CoverageResult(AugmentedResult):
 
     Additionally initializes and begins code coverage tracking."""
         super(CoverageResult, self).startTest(test)
-        self.coverage_context = coverage.Coverage(data_suffix=True)
+        self.data_file = os.environ.get('COVERAGE_DATA_FILE',
+                                        '.coverage') or None
+        self.coverage_context = coverage.Coverage(data_file=self.data_file,
+                                                  data_suffix=True)
         self.coverage_context.start()
 
     def stopTest(self, test):
@@ -242,7 +246,8 @@ class CoverageResult(AugmentedResult):
     Additionally stops and deinitializes code coverage tracking."""
         super(CoverageResult, self).stopTest(test)
         self.coverage_context.stop()
-        self.coverage_context.save()
+        if self.data_file:
+            self.coverage_context.save()
         self.coverage_context = None
 
 

--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -235,6 +235,9 @@ class Runner(object):
         sys.stdout.write(result_out.getvalue())
         sys.stdout.flush()
         signal.signal(signal.SIGINT, signal.SIG_DFL)
-        with open('report.xml', 'wb') as report_xml_file:
-            _result.jenkins_junit_xml(result).write(report_xml_file)
+        data_dir = os.environ.get('DATA_OUT_DIR', './')
+        if data_dir != '':
+            filename = os.path.join(data_dir, 'report.xml')
+            with open(filename, 'wb') as report_xml_file:
+                _result.jenkins_junit_xml(result).write(report_xml_file)
         return result

--- a/tools/distrib/run_clang_tidy.py
+++ b/tools/distrib/run_clang_tidy.py
@@ -62,5 +62,5 @@ for filename in args.files:
         shortname=filename,
     ))  #verbose_success=True))
 
-num_fails, res_set = jobset.run(jobs, maxjobs=args.jobs)
+num_fails, _, _ = jobset.run(jobs, maxjobs=args.jobs)
 sys.exit(num_fails)

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -216,9 +216,9 @@ def build_all_images_for_release(lang, release):
     jobset.message('START', 'Building interop docker images.', do_newline=True)
     print('Jobs to run: \n%s\n' % '\n'.join(str(j) for j in build_jobs))
 
-    num_failures, _ = jobset.run(build_jobs,
-                                 newline_on_success=True,
-                                 maxjobs=multiprocessing.cpu_count())
+    num_failures, _, _ = jobset.run(build_jobs,
+                                    newline_on_success=True,
+                                    maxjobs=multiprocessing.cpu_count())
     if num_failures:
         jobset.message('FAILED',
                        'Failed to build interop docker images.',

--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -225,9 +225,9 @@ def _pull_images_for_lang(lang, images):
         download_specs.append(spec)
     # too many image downloads at once tend to get stuck
     max_pull_jobs = min(args.jobs, _MAX_PARALLEL_DOWNLOADS)
-    num_failures, resultset = jobset.run(download_specs,
-                                         newline_on_success=True,
-                                         maxjobs=max_pull_jobs)
+    num_failures, resultset, _ = jobset.run(download_specs,
+                                            newline_on_success=True,
+                                            maxjobs=max_pull_jobs)
     if num_failures:
         jobset.message('FAILED',
                        'Failed to download some images',
@@ -266,20 +266,20 @@ def _run_tests_for_lang(lang, runtime, images, xml_report_tree):
             total_num_failures += 1
             continue
 
-        num_failures, resultset = jobset.run(job_spec_list,
-                                             newline_on_success=True,
-                                             add_env={'docker_image': image},
-                                             maxjobs=args.jobs,
-                                             skip_jobs=skip_tests)
+        num_failed, resultset, _ = jobset.run(job_spec_list,
+                                              newline_on_success=True,
+                                              add_env={'docker_image': image},
+                                              maxjobs=args.jobs,
+                                              skip_jobs=skip_tests)
         if args.bq_result_table and resultset:
             upload_test_results.upload_interop_results_to_bq(
                 resultset, args.bq_result_table)
         if skip_tests:
             jobset.message('FAILED', 'Tests were skipped', do_newline=True)
             total_num_failures += 1
-        elif num_failures:
+        elif num_failed:
             jobset.message('FAILED', 'Some tests failed', do_newline=True)
-            total_num_failures += num_failures
+            total_num_failures += num_failed
         else:
             jobset.message('SUCCESS', 'All tests passed', do_newline=True)
 

--- a/tools/run_tests/helper_scripts/post_tests_python.sh
+++ b/tools/run_tests/helper_scripts/post_tests_python.sh
@@ -18,7 +18,7 @@ set -ex
 if [ "$CONFIG" != "gcov" ] ; then exit ; fi
 
 # change to directory of Python coverage files
-cd "$(dirname "$0")/../../../src/python/grpcio_tests/"
+cd "$(dirname "$0")/../.coverage/"
 
 coverage combine .
 coverage html -i -d ./../../../reports/python

--- a/tools/run_tests/run_grpclb_interop_tests.py
+++ b/tools/run_tests/run_grpclb_interop_tests.py
@@ -436,9 +436,9 @@ else:
 if build_jobs:
     jobset.message('START', 'Building interop docker images.', do_newline=True)
     print('Jobs to run: \n%s\n' % '\n'.join(str(j) for j in build_jobs))
-    num_failures, _ = jobset.run(build_jobs,
-                                 newline_on_success=True,
-                                 maxjobs=args.jobs)
+    num_failures, _, _ = jobset.run(build_jobs,
+                                    newline_on_success=True,
+                                    maxjobs=args.jobs)
     if num_failures == 0:
         jobset.message('SUCCESS',
                        'All docker images built successfully.',
@@ -563,9 +563,9 @@ def run_one_scenario(scenario_config):
             jobs.append(test_job)
         jobset.message(
             'IDLE', 'Jobs to run: \n%s\n' % '\n'.join(str(job) for job in jobs))
-        num_failures, resultset = jobset.run(jobs,
-                                             newline_on_success=True,
-                                             maxjobs=args.jobs)
+        num_failures, resultset, _ = jobset.run(jobs,
+                                                newline_on_success=True,
+                                                maxjobs=args.jobs)
         report_utils.render_junit_xml_report(resultset, 'sponge_log.xml')
         if num_failures:
             suppress_server_logs = False

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1430,9 +1430,9 @@ if args.use_docker:
         if args.verbose:
             print('Jobs to run: \n%s\n' % '\n'.join(str(j) for j in build_jobs))
 
-        num_failures, build_resultset = jobset.run(build_jobs,
-                                                   newline_on_success=True,
-                                                   maxjobs=args.jobs)
+        num_failures, build_resultset, _ = jobset.run(build_jobs,
+                                                      newline_on_success=True,
+                                                      maxjobs=args.jobs)
 
         report_utils.render_junit_xml_report(build_resultset,
                                              _DOCKER_BUILD_XML_REPORT)
@@ -1676,10 +1676,10 @@ try:
     if args.verbose:
         print('Jobs to run: \n%s\n' % '\n'.join(str(job) for job in jobs))
 
-    num_failures, resultset = jobset.run(jobs,
-                                         newline_on_success=True,
-                                         maxjobs=args.jobs,
-                                         skip_jobs=args.manual_run)
+    num_failures, resultset, _ = jobset.run(jobs,
+                                            newline_on_success=True,
+                                            maxjobs=args.jobs,
+                                            skip_jobs=args.manual_run)
     if args.bq_result_table and resultset:
         upload_interop_results_to_bq(resultset, args.bq_result_table)
     if num_failures:

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -203,9 +203,9 @@ def archive_repo(languages):
                                  timeout_seconds=3 * 60)
 
     jobset.message('START', 'Archiving local repository.', do_newline=True)
-    num_failures, _ = jobset.run([archive_job],
-                                 newline_on_success=True,
-                                 maxjobs=1)
+    num_failures, _, _ = jobset.run([archive_job],
+                                    newline_on_success=True,
+                                    maxjobs=1)
     if num_failures == 0:
         jobset.message('SUCCESS',
                        'Archive with local repository created successfully.',
@@ -237,9 +237,9 @@ def prepare_remote_hosts(hosts, prepare_local=False):
                 shortname='local_prepare',
                 timeout_seconds=prepare_timeout))
     jobset.message('START', 'Preparing hosts.', do_newline=True)
-    num_failures, _ = jobset.run(prepare_jobs,
-                                 newline_on_success=True,
-                                 maxjobs=10)
+    num_failures, _, _ = jobset.run(prepare_jobs,
+                                    newline_on_success=True,
+                                    maxjobs=10)
     if num_failures == 0:
         jobset.message('SUCCESS',
                        'Prepare step completed successfully.',
@@ -287,9 +287,9 @@ def build_on_remote_hosts(hosts,
                 environ={'CONFIG': 'opt'},
                 timeout_seconds=local_build_timeout))
     jobset.message('START', 'Building.', do_newline=True)
-    num_failures, _ = jobset.run(build_jobs,
-                                 newline_on_success=True,
-                                 maxjobs=10)
+    num_failures, _, _ = jobset.run(build_jobs,
+                                    newline_on_success=True,
+                                    maxjobs=10)
     if num_failures == 0:
         jobset.message('SUCCESS', 'Built successfully.', do_newline=True)
     else:
@@ -480,9 +480,9 @@ def run_collect_perf_profile_jobs(hosts_and_base_names, scenario_name,
     jobset.message('START',
                    'Collecting perf reports from qps workers',
                    do_newline=True)
-    failures, _ = jobset.run(perf_report_jobs,
-                             newline_on_success=True,
-                             maxjobs=1)
+    failures, _, _ = jobset.run(perf_report_jobs,
+                                newline_on_success=True,
+                                maxjobs=1)
     jobset.message('SUCCESS',
                    'Collecting perf reports from qps workers',
                    do_newline=True)
@@ -669,7 +669,7 @@ def main():
                         create_quit_jobspec(
                             scenario.workers,
                             remote_host=args.remote_driver_host))
-                scenario_failures, resultset = jobset.run(
+                scenario_failures, resultset, _ = jobset.run(
                     jobs, newline_on_success=True, maxjobs=1)
                 total_scenario_failures += scenario_failures
                 merged_resultset = dict(

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1411,7 +1411,8 @@ argp.add_argument(
 argp.add_argument(
     '--data_out_dir',
     # This means where tests are running, ie: src/python/grpcio_tests/
-    default=None,
+    default=os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                         '.coverage'),
     type=data_out_dir_type,
     help='Location to write output files such as coverage and reports.  Set '
          'to empty string to not save data, which is useful to avoid running '

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -585,13 +585,13 @@ if __name__ == "__main__":
         sys.exit(1)
 
     jobset.message('START', 'Running test matrix.', do_newline=True)
-    num_failures, resultset = jobset.run(jobs,
-                                         newline_on_success=True,
-                                         travis=True,
-                                         maxjobs=args.jobs)
+    num_failures, resultset, _ = jobset.run(jobs,
+                                            newline_on_success=True,
+                                            travis=True,
+                                            maxjobs=args.jobs)
     # Merge skipped tests into results to show skipped tests on report.xml
     if skipped_jobs:
-        ignored_num_skipped_failures, skipped_results = jobset.run(
+        ignored_num_skipped_failures, skipped_results, _ = jobset.run(
             skipped_jobs, skip_jobs=True)
         resultset.update(skipped_results)
     report_utils.render_junit_xml_report(resultset,

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -90,9 +90,9 @@ prebuild_jobs = []
 for target in targets:
     prebuild_jobs += target.pre_build_jobspecs()
 if prebuild_jobs:
-    num_failures, _ = jobset.run(prebuild_jobs,
-                                 newline_on_success=True,
-                                 maxjobs=args.jobs)
+    num_failures, _, _ = jobset.run(prebuild_jobs,
+                                    newline_on_success=True,
+                                    maxjobs=args.jobs)
     if num_failures != 0:
         jobset.message('FAILED', 'Pre-build phase failed.', do_newline=True)
         sys.exit(1)
@@ -105,9 +105,9 @@ if not build_jobs:
     sys.exit(1)
 
 jobset.message('START', 'Building targets.', do_newline=True)
-num_failures, resultset = jobset.run(build_jobs,
-                                     newline_on_success=True,
-                                     maxjobs=args.jobs)
+num_failures, resultset, _ = jobset.run(build_jobs,
+                                        newline_on_success=True,
+                                        maxjobs=args.jobs)
 report_utils.render_junit_xml_report(resultset,
                                      'report_taskrunner_sponge_log.xml',
                                      suite_name='tasks')


### PR DESCRIPTION
When working on the [eventlet Python I/O manager](https://github.com/grpc/grpc/pull/22062) I found some deficiencies when running Python tests with `run_tests.py`:

- The `--forever` parameter doesn't work as expected, because there are false detection of changed source files because we write coverage and results in watched directories.

- When passing `--runs_per_test` we cannot tell how many runs actually failed, we can only tell how many tests failed, but multiple tests may have failed in a single run.

- Flaky tests in Python Custom I/O managers can only be disabled, we cannot do a single retry for them.

- Passing `--runs_per_tests=1000` with `--use_docker` will result in all tests failing after a while because the container runs out of disk space.

This PR includes the changes I did to resolve these and be able to evaluate the impact that running the eventlet tests in the CI would have.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
