### PR TITLE
PHP: Fix include path for boringssl in windows build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -786,7 +786,7 @@ if (PHP_GRPC != "no") {
     "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
     "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
     "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+
-    "/I"+configure_module_dirname+"\\third_party\\boringssl\\include "+
+    "/I"+configure_module_dirname+"\\third_party\\boringssl-with-bazel\\src\\include "+
     "/I"+configure_module_dirname+"\\third_party\\upb "+
     "/I"+configure_module_dirname+"\\third_party\\zlib ");
 

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -33,7 +33,7 @@
       "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
       "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
       "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+
-      "/I"+configure_module_dirname+"\\third_party\\boringssl\\include "+
+      "/I"+configure_module_dirname+"\\third_party\\boringssl-with-bazel\\src\\include "+
       "/I"+configure_module_dirname+"\\third_party\\upb "+
       "/I"+configure_module_dirname+"\\third_party\\zlib ");
   <%


### PR DESCRIPTION
Fixes #22273 

Probably because in #21833, we fixed `templates/config.m4.template`, but forgot `templates/config.w32.template`.