### PR TITLE
Mark bm_fullstack_streaming_pump large

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -202,10 +202,10 @@ grpc_cc_library(
 
 grpc_cc_test(
     name = "bm_fullstack_streaming_pump",
+    size = "large",
     srcs = [
         "bm_fullstack_streaming_pump.cc",
     ],
-    flaky = True,  # TODO(b/150422385)
     tags = [
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",


### PR DESCRIPTION
For some reason, the streaming_ping_pong microbenchmark consistently showed up as needing large timeouts during the initial testing of the conversion of microbenchmarks to tests, but not streaming_pump. In production, both seem to need large timeouts.
