### PR TITLE
support arbitrary IPs in forwarding rule creation

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -52,4 +52,4 @@ bazel build test/cpp/interop:xds_interop_client
     --project_id=grpc-testing \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds-experimental:///{service_host}:{service_port} --stats_port={stats_port} --qps={qps}'
+    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds-experimental:///{server_uri} --stats_port={stats_port} --qps={qps}'


### PR DESCRIPTION
This will allow multiple tests run to use the default port in the same project.

Sample run on gRPC Java repo (need to increase timeout, so job failed, but GCP resource creation succeeded): https://source.cloud.google.com/results/invocations/8f34597b-9193-45b4-8367-c0814a6f61e5/targets/grpc%2Fjava%2Fmaster%2Fpresubmit%2Fandroid/log

I left the port range logic in place to support using `0.0.0.0` in the future if needed.