### PR TITLE
Add close notify TSI result.

### DIFF
--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -44,6 +44,7 @@ typedef enum {
   TSI_OUT_OF_RESOURCES = 12,
   TSI_ASYNC = 13,
   TSI_HANDSHAKE_SHUTDOWN = 14,
+  TSI_CLOSE_NOTIFY = 15,  // Indicates that the connection should be closed.
 } tsi_result;
 
 typedef enum {


### PR DESCRIPTION
In TLS, the peer can send a "close notify" alert that tells us that the connection will be closed, similar to the "Fin" message at the TCP layer. This PR adds a "close notify" TSI result that can be returned by a TSI frame protector when it receives a close notify alert from the peer.

Note that there is no difference in how the gRPC stack handles e.g. a TSI_PROTOCOL_FAILURE result and this new TSI_CLOSE_NOTIFY result. Indeed, see the implementation of the [`on_read`](https://github.com/grpc/grpc/blob/67ca5501470349323226a3dceeea2311c83e0ae4/src/core/lib/security/transport/secure_endpoint.cc#L172) method from `secure_endpoint.cc`.
