### PR TITLE
Backport Simple Stubs Codegen to 1.28

### DIFF
--- a/src/compiler/python_private_generator.h
+++ b/src/compiler/python_private_generator.h
@@ -59,6 +59,9 @@ struct PrivateGenerator {
                  const grpc_generator::Service* service,
                  grpc_generator::Printer* out);
 
+  bool PrintServiceClass(const grpc::string& package_qualified_service_name,
+                         const grpc_generator::Service* service,
+                         grpc_generator::Printer* out);
   bool PrintBetaServicer(const grpc_generator::Service* service,
                          grpc_generator::Printer* out);
   bool PrintBetaServerFactory(

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -193,6 +193,7 @@ class TestGevent(setuptools.Command):
         'unit._server_ssl_cert_config_test',
         # TODO(https://github.com/grpc/grpc/issues/14901) enable this test
         'protoc_plugin._python_plugin_test.PythonPluginTest',
+        'protoc_plugin._python_plugin_test.SimpleStubsPluginTest',
         # Beta API is unsupported for gevent
         'protoc_plugin.beta_python_plugin_test',
         'unit.beta._beta_features_test',

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -27,6 +27,7 @@ import unittest
 from six import moves
 
 import grpc
+import grpc.experimental
 from tests.unit import test_common
 from tests.unit.framework.common import test_constants
 
@@ -501,6 +502,119 @@ class PythonPluginTest(unittest.TestCase):
         self.assertIs(exception_context.exception.code(),
                       grpc.StatusCode.DEADLINE_EXCEEDED)
         service.server.stop(None)
+
+
+@unittest.skipIf(sys.version_info[0] < 3, "Unsupported on Python 2.")
+class SimpleStubsPluginTest(unittest.TestCase):
+    servicer_methods = _ServicerMethods()
+
+    class Servicer(service_pb2_grpc.TestServiceServicer):
+
+        def UnaryCall(self, request, context):
+            return SimpleStubsPluginTest.servicer_methods.UnaryCall(
+                request, context)
+
+        def StreamingOutputCall(self, request, context):
+            return SimpleStubsPluginTest.servicer_methods.StreamingOutputCall(
+                request, context)
+
+        def StreamingInputCall(self, request_iterator, context):
+            return SimpleStubsPluginTest.servicer_methods.StreamingInputCall(
+                request_iterator, context)
+
+        def FullDuplexCall(self, request_iterator, context):
+            return SimpleStubsPluginTest.servicer_methods.FullDuplexCall(
+                request_iterator, context)
+
+        def HalfDuplexCall(self, request_iterator, context):
+            return SimpleStubsPluginTest.servicer_methods.HalfDuplexCall(
+                request_iterator, context)
+
+    def setUp(self):
+        super(SimpleStubsPluginTest, self).setUp()
+        self._server = test_common.test_server()
+        service_pb2_grpc.add_TestServiceServicer_to_server(
+            self.Servicer(), self._server)
+        self._port = self._server.add_insecure_port('[::]:0')
+        self._server.start()
+        self._target = 'localhost:{}'.format(self._port)
+
+    def tearDown(self):
+        self._server.stop(None)
+        super(SimpleStubsPluginTest, self).tearDown()
+
+    def testUnaryCall(self):
+        request = request_pb2.SimpleRequest(response_size=13)
+        response = service_pb2_grpc.TestService.UnaryCall(
+            request,
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
+        expected_response = self.servicer_methods.UnaryCall(
+            request, 'not a real context!')
+        self.assertEqual(expected_response, response)
+
+    def testStreamingOutputCall(self):
+        request = _streaming_output_request()
+        expected_responses = self.servicer_methods.StreamingOutputCall(
+            request, 'not a real RpcContext!')
+        responses = service_pb2_grpc.TestService.StreamingOutputCall(
+            request,
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
+        for expected_response, response in moves.zip_longest(
+                expected_responses, responses):
+            self.assertEqual(expected_response, response)
+
+    def testStreamingInputCall(self):
+        response = service_pb2_grpc.TestService.StreamingInputCall(
+            _streaming_input_request_iterator(),
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
+        expected_response = self.servicer_methods.StreamingInputCall(
+            _streaming_input_request_iterator(), 'not a real RpcContext!')
+        self.assertEqual(expected_response, response)
+
+    def testFullDuplexCall(self):
+        responses = service_pb2_grpc.TestService.FullDuplexCall(
+            _full_duplex_request_iterator(),
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
+        expected_responses = self.servicer_methods.FullDuplexCall(
+            _full_duplex_request_iterator(), 'not a real RpcContext!')
+        for expected_response, response in moves.zip_longest(
+                expected_responses, responses):
+            self.assertEqual(expected_response, response)
+
+    def testHalfDuplexCall(self):
+
+        def half_duplex_request_iterator():
+            request = request_pb2.StreamingOutputCallRequest()
+            request.response_parameters.add(size=1, interval_us=0)
+            yield request
+            request = request_pb2.StreamingOutputCallRequest()
+            request.response_parameters.add(size=2, interval_us=0)
+            request.response_parameters.add(size=3, interval_us=0)
+            yield request
+
+        responses = service_pb2_grpc.TestService.HalfDuplexCall(
+            half_duplex_request_iterator(),
+            self._target,
+            channel_credentials=grpc.experimental.insecure_channel_credentials(
+            ),
+            wait_for_ready=True)
+        expected_responses = self.servicer_methods.HalfDuplexCall(
+            half_duplex_request_iterator(), 'not a real RpcContext!')
+        for expected_response, response in moves.zip_longest(
+                expected_responses, responses):
+            self.assertEqual(expected_response, response)
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -7,6 +7,7 @@
   "interop._insecure_intraop_test.InsecureIntraopTest",
   "interop._secure_intraop_test.SecureIntraopTest",
   "protoc_plugin._python_plugin_test.PythonPluginTest",
+  "protoc_plugin._python_plugin_test.SimpleStubsPluginTest",
   "protoc_plugin._split_definitions_test.SameProtoGrpcBeforeProtoProtocStyleTest",
   "protoc_plugin._split_definitions_test.SameProtoMid2016ProtocStyleTest",
   "protoc_plugin._split_definitions_test.SameProtoProtoBeforeGrpcProtocStyleTest",

--- a/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/unit/_simple_stubs_test.py
@@ -174,13 +174,6 @@ class SimpleStubsTest(unittest.TestCase):
                 channel_credentials=grpc.local_channel_credentials())
             self.assertEqual(_REQUEST, response)
 
-    def test_channel_credentials_default(self):
-        with _server(grpc.local_server_credentials()) as port:
-            target = f'localhost:{port}'
-            response = grpc.experimental.unary_unary(_REQUEST, target,
-                                                     _UNARY_UNARY)
-            self.assertEqual(_REQUEST, response)
-
     def test_channels_cached(self):
         with _server(grpc.local_server_credentials()) as port:
             target = f'localhost:{port}'


### PR DESCRIPTION
Original implementation in #22218. Still just an experimental API.