### PR TITLE
bm_metadata is not flaky anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2186,6 +2186,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/bm_fullstack_streaming_ping_pong || ( echo test bm_fullstack_streaming_ping_pong failed ; exit 1 )
 	$(E) "[RUN]     Testing bm_fullstack_unary_ping_pong"
 	$(Q) $(BINDIR)/$(CONFIG)/bm_fullstack_unary_ping_pong || ( echo test bm_fullstack_unary_ping_pong failed ; exit 1 )
+	$(E) "[RUN]     Testing bm_metadata"
+	$(Q) $(BINDIR)/$(CONFIG)/bm_metadata || ( echo test bm_metadata failed ; exit 1 )
 	$(E) "[RUN]     Testing bm_pollset"
 	$(Q) $(BINDIR)/$(CONFIG)/bm_pollset || ( echo test bm_pollset failed ; exit 1 )
 	$(E) "[RUN]     Testing bm_timer"

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5196,7 +5196,6 @@ targets:
   - posix
 - name: bm_metadata
   build: test
-  run: false
   language: c++
   headers: []
   src:

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -249,7 +249,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_metadata",
     srcs = ["bm_metadata.cc"],
-    flaky = True,  # TODO(b/149998903)
     tags = [
         "no_mac",
         "no_windows",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3862,6 +3862,26 @@
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 
+    "name": "bm_metadata", 
+    "platforms": [
+      "linux", 
+      "posix"
+    ], 
+    "uses_polling": false
+  }, 
+  {
+    "args": [], 
+    "benchmark": true, 
+    "ci_platforms": [
+      "linux", 
+      "posix"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
     "name": "bm_pollset", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
Was fixed by https://github.com/grpc/grpc/pull/22348
