### PR TITLE
bm_arena needs more time

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -90,6 +90,7 @@ grpc_cc_test(
 
 grpc_cc_test(
     name = "bm_arena",
+    size = "large",
     srcs = ["bm_arena.cc"],
     tags = [
         "no_mac",


### PR DESCRIPTION
Internal tests show that it needs a large timeout. This has passed 1000x without timeout.
