### PR TITLE
Set TRAFFICDIRECTOR_NETWORK_NAME in bootstrap

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -155,7 +155,10 @@ _WAIT_FOR_URL_MAP_PATCH_SEC = 300
 _BOOTSTRAP_TEMPLATE = """
 {{
   "node": {{
-    "id": "{node_id}"
+    "id": "{node_id}",
+    "metadata": {{
+      "TRAFFICDIRECTOR_NETWORK_NAME": "%s"
+    }}
   }},
   "xds_servers": [{{
     "server_uri": "%s",
@@ -166,7 +169,7 @@ _BOOTSTRAP_TEMPLATE = """
       }}
     ]
   }}]
-}}""" % args.xds_server
+}}""" % (args.network.split('/')[-1], args.xds_server)
 _PATH_MATCHER_NAME = 'path-matcher'
 _BASE_TEMPLATE_NAME = 'test-template'
 _BASE_INSTANCE_GROUP_NAME = 'test-ig'


### PR DESCRIPTION
This field is not required for the default network, but may be needed when the VM is used a custom VPC. I'm just parsing the full network name (used to generate the VMs themselves) which will be of the form 'global/networks/default` or `project/networks/<name>` and grabbing the last slash-delimited identifier, which is what TD expects in the bootstrap field.