### PR TITLE
Increase timeout for GCP API operations

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -147,10 +147,10 @@ if args.verbose:
 
 _DEFAULT_SERVICE_PORT = 80
 _WAIT_FOR_BACKEND_SEC = args.wait_for_backend_sec
-_WAIT_FOR_OPERATION_SEC = 120
+_WAIT_FOR_OPERATION_SEC = 300
 _INSTANCE_GROUP_SIZE = 2
 _NUM_TEST_RPCS = 10 * args.qps
-_WAIT_FOR_STATS_SEC = 120
+_WAIT_FOR_STATS_SEC = 180
 _WAIT_FOR_URL_MAP_PATCH_SEC = 300
 _BOOTSTRAP_TEMPLATE = """
 {{
@@ -715,7 +715,10 @@ def patch_backend_instances(gcp,
     wait_for_global_operation(gcp, result['name'])
 
 
-def resize_instance_group(gcp, instance_group, new_size, timeout_sec=120):
+def resize_instance_group(gcp,
+                          instance_group,
+                          new_size,
+                          timeout_sec=_WAIT_FOR_OPERATION_SEC):
     result = gcp.compute.instanceGroupManagers().resize(
         project=gcp.project,
         zone=instance_group.zone,


### PR DESCRIPTION
Resize operation took longer than 120 seconds causing a test flake.
