### PR TITLE
[Health Checking] Make the empty service default to SERVING state

### DIFF
--- a/src/python/grpcio_health_checking/grpc_health/v1/_async.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/_async.py
@@ -30,7 +30,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
     _gracefully_shutting_down: bool
 
     def __init__(self) -> None:
-        self._server_status = dict()
+        self._server_status = {"": _health_pb2.HealthCheckResponse.SERVING}
         self._server_watchers = collections.defaultdict(asyncio.Condition)
         self._gracefully_shutting_down = False
 

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -85,7 +85,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
                  experimental_non_blocking=True,
                  experimental_thread_pool=None):
         self._lock = threading.RLock()
-        self._server_status = {}
+        self._server_status = {"": _health_pb2.HealthCheckResponse.SERVING}
         self._send_response_callbacks = {}
         self.Watch.__func__.experimental_non_blocking = experimental_non_blocking
         self.Watch.__func__.experimental_thread_pool = experimental_thread_pool

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -50,7 +50,6 @@ class BaseWatchTests(object):
             self._servicer = health.HealthServicer(
                 experimental_non_blocking=non_blocking,
                 experimental_thread_pool=thread_pool)
-            self._servicer.set('', health_pb2.HealthCheckResponse.SERVING)
             self._servicer.set(_SERVING_SERVICE,
                                health_pb2.HealthCheckResponse.SERVING)
             self._servicer.set(_UNKNOWN_SERVICE,

--- a/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/health_check/health_servicer_test.py
@@ -47,8 +47,6 @@ class HealthServicerTest(AioTestBase):
 
     async def setUp(self):
         self._servicer = health.aio.HealthServicer()
-        await self._servicer.set(health.OVERALL_HEALTH,
-                                 health_pb2.HealthCheckResponse.SERVING)
         await self._servicer.set(_SERVING_SERVICE,
                                  health_pb2.HealthCheckResponse.SERVING)
         await self._servicer.set(_UNKNOWN_SERVICE,


### PR DESCRIPTION
This PR makes gRPC Python's health checking module set the empty service (overall service) to `SERVING` when the server starts.

I thought it might require some hook in the server to make this change clean, but after discussing with @gnossen , the state of the health checking servicer is not going to be accessible before the server start. So, we can safely set the default value in the constructor. Also, tests are updated.

CC @markdroth 