### PR TITLE
Gracefully switch xds policy instances when cluster name changes.

### DIFF
--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -192,7 +192,7 @@ class XdsApi {
 
   struct ClusterLoadReport {
     XdsClusterDropStats::DroppedRequestsMap dropped_requests;
-    std::map<XdsLocalityName*, XdsClusterLocalityStats::Snapshot,
+    std::map<RefCountedPtr<XdsLocalityName>, XdsClusterLocalityStats::Snapshot,
              XdsLocalityName::Less>
         locality_stats;
     grpc_millis load_report_interval;

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -209,8 +209,14 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   };
 
   struct LoadReportState {
+    struct LocalityState {
+      std::set<XdsClusterLocalityStats*> locality_stats;
+      std::vector<XdsClusterLocalityStats::Snapshot> deleted_locality_stats;
+    };
+
     std::set<XdsClusterDropStats*> drop_stats;
-    std::map<RefCountedPtr<XdsLocalityName>, std::set<XdsClusterLocalityStats*>,
+    XdsClusterDropStats::DroppedRequestsMap deleted_drop_stats;
+    std::map<RefCountedPtr<XdsLocalityName>, LocalityState,
              XdsLocalityName::Less>
         locality_stats;
     grpc_millis last_report_time = ExecCtx::Get()->Now();
@@ -223,7 +229,8 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
       const std::string& cluster_name,
       RefCountedPtr<ServiceConfig>* service_config) const;
 
-  XdsApi::ClusterLoadReportMap BuildLoadReportSnapshot();
+  XdsApi::ClusterLoadReportMap BuildLoadReportSnapshot(
+      const std::set<std::string>& clusters);
 
   // Channel arg vtable functions.
   static void* ChannelArgCopy(void* p);


### PR DESCRIPTION
This fixes a problem whereby locality stats were reported under the wrong cluster name in LRS load reports.  The problem was related to the fact that the locality data structures get updates from two places: (1) the config update that is handed down from the CDS policy, which was changing the cluster name, and (2) the EDS updates being received from the XdsClient, which was changing the set of localities.  When we saw (1), we would change the original locality object to use the new cluster name for load reporting (which was incorrect), and then when we saw (2), we would deactivate the old locality and create a new one.  To make matters worse, if we later switch back to the original cluster, we would reactivate the original locality object, but we would never update it to use the new cluster name for load reporting.

I could probably have fixed this by tweaking the logic for handling the config updates from the CDS policy and the EDS updates from the XdsClient.  However, that would have made the existing logic inside of the xds policy even more stateful and complicated.  So instead, I have taken a more general approach (stolen from Java) whereby the xds policy wraps itself in a ChildPolicyHandler and performs a graceful switch to a new policy instance whenever the config changes the cluster name.  This way, it is no longer necessary for an individual xds policy instance to handle a config change that changes the cluster name.

The only down-side of this approach is that if we switch from cluster A to cluster B and then back to cluster A, all within a 15-minute period of time, the old code would have retained the deactivated locality object from cluster A, so it would not need to reestablish connections to those backends, whereas this new code will not do that.  However, this should be an extremely rare case, so I think that's okay.  And I believe that Java (and probably Go) also do the same thing here.  And we were going to make the same change in C++ anyway in the upcoming change to refactor the xds LB policy anyway.

In order to write a non-flaky test for this, I also addressed an existing TODO to make sure that we send the final data from each stats object when the stats object is destroyed.

As part of this, I have also fixed a bug that I accidentally introduced in #22011 whereby we were not honoring the cluster list sent by the LRS server.