### PR TITLE
Stop Leak of one thread per call in case of reference cycle

### DIFF
--- a/src/python/grpcio/grpc/_auth.py
+++ b/src/python/grpcio/grpc/_auth.py
@@ -40,9 +40,10 @@ def _create_get_token_callback(callback):
 class GoogleCallCredentials(grpc.AuthMetadataPlugin):
     """Metadata wrapper for GoogleCredentials from the oauth2client library."""
 
+    _THREAD_POOL = futures.ThreadPoolExecutor()
+
     def __init__(self, credentials):
         self._credentials = credentials
-        self._pool = futures.ThreadPoolExecutor(max_workers=1)
 
         # Hack to determine if these are JWT creds and we need to pass
         # additional_claims when getting a token
@@ -52,15 +53,13 @@ class GoogleCallCredentials(grpc.AuthMetadataPlugin):
     def __call__(self, context, callback):
         # MetadataPlugins cannot block (see grpc.beta.interfaces.py)
         if self._is_jwt:
-            future = self._pool.submit(
+            future = self._THREAD_POOL.submit(
                 self._credentials.get_access_token,
                 additional_claims={'aud': context.service_url})
         else:
-            future = self._pool.submit(self._credentials.get_access_token)
+            future = self._THREAD_POOL.submit(
+                self._credentials.get_access_token)
         future.add_done_callback(_create_get_token_callback(callback))
-
-    def __del__(self):
-        self._pool.shutdown(wait=False)
 
 
 class AccessTokenAuthMetadataPlugin(grpc.AuthMetadataPlugin):


### PR DESCRIPTION
There are no guarantees on when `__del__` will be called. In the case of a reference cycle, we leak threads like a sieve. Instead, we use a single thread pool (whose threads are lazily spawned). It's worth noting that this effectively limits the concurrency a channel using these creds to `5 * multiprocessing.cpu_count()`

Related to https://github.com/googleapis/google-auth-library-python/issues/455