### PR TITLE
Fix doxygen comment warning

### DIFF
--- a/include/grpcpp/impl/codegen/rpc_service_method.h
+++ b/include/grpcpp/impl/codegen/rpc_service_method.h
@@ -48,7 +48,7 @@ class MethodHandler {
     /// \param context : the ServerContext structure for this server call
     /// \param req : the request payload, if appropriate for this RPC
     /// \param req_status : the request status after any interceptors have run
-    /// \param handler_data: internal data for the handler.
+    /// \param handler_data : internal data for the handler.
     /// \param requester : used only by the callback API. It is a function
     ///        called by the RPC Controller to request another RPC (and also
     ///        to set up the state required to make that request possible)

--- a/include/grpcpp/impl/codegen/sync_stream_impl.h
+++ b/include/grpcpp/impl/codegen/sync_stream_impl.h
@@ -852,6 +852,7 @@ class ServerUnaryStreamer final
     return body_.Read(request);
   }
 
+  using internal::WriterInterface<ResponseType>::Write;
   /// Block to write \a msg to the stream with WriteOptions \a options.
   /// This is thread-safe with respect to \a ReaderInterface::Read
   ///
@@ -859,7 +860,6 @@ class ServerUnaryStreamer final
   /// \param options The WriteOptions affecting the write operation.
   ///
   /// \return \a true on success, \a false when the stream has been closed.
-  using internal::WriterInterface<ResponseType>::Write;
   bool Write(const ResponseType& response,
              ::grpc::WriteOptions options) override {
     if (write_done_ || !read_done_) {
@@ -919,6 +919,7 @@ class ServerSplitStreamer final
     return body_.Read(request);
   }
 
+  using internal::WriterInterface<ResponseType>::Write;
   /// Block to write \a msg to the stream with WriteOptions \a options.
   /// This is thread-safe with respect to \a ReaderInterface::Read
   ///
@@ -926,7 +927,6 @@ class ServerSplitStreamer final
   /// \param options The WriteOptions affecting the write operation.
   ///
   /// \return \a true on success, \a false when the stream has been closed.
-  using internal::WriterInterface<ResponseType>::Write;
   bool Write(const ResponseType& response,
              ::grpc::WriteOptions options) override {
     return read_done_ && body_.Write(response, options);

--- a/include/grpcpp/server_builder_impl.h
+++ b/include/grpcpp/server_builder_impl.h
@@ -126,7 +126,7 @@ class ServerBuilder {
   /// connections.  Valid values include dns:///localhost:1234, /
   /// 192.168.1.1:31416, dns:///[::1]:27182, etc.).
   /// \param creds The credentials associated with the server.
-  /// \param selected_port[out] If not `nullptr`, gets populated with the port
+  /// \param selected_port [out] If not `nullptr`, gets populated with the port
   /// number bound to the \a grpc::Server for the corresponding endpoint after
   /// it is successfully bound by BuildAndStart(), 0 otherwise. AddListeningPort
   /// does not modify this pointer.


### PR DESCRIPTION
Xcode reports them as documentation warnings. This PR fixes them.

<img width="827" alt="grpc01" src="https://user-images.githubusercontent.com/554281/76822161-8ddf0900-6853-11ea-99b3-52ccd2bee0ed.png">
<img width="831" alt="grpc02" src="https://user-images.githubusercontent.com/554281/76822168-90d9f980-6853-11ea-921a-2a9dbd00d165.png">
<img width="812" alt="grpc03" src="https://user-images.githubusercontent.com/554281/76822170-920b2680-6853-11ea-92e9-3007cae8f14d.png">



