### PR TITLE
xds: fix duplicate LDS update detection

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -25,6 +25,8 @@
 #include <limits.h>
 #include <string.h>
 
+#include "absl/types/optional.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
@@ -80,7 +82,7 @@ class XdsConfig : public LoadBalancingPolicy::Config {
   XdsConfig(RefCountedPtr<LoadBalancingPolicy::Config> child_policy,
             RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy,
             std::string eds_service_name,
-            Optional<std::string> lrs_load_reporting_server_name)
+            absl::optional<std::string> lrs_load_reporting_server_name)
       : child_policy_(std::move(child_policy)),
         fallback_policy_(std::move(fallback_policy)),
         eds_service_name_(std::move(eds_service_name)),
@@ -101,7 +103,7 @@ class XdsConfig : public LoadBalancingPolicy::Config {
     return eds_service_name_.empty() ? nullptr : eds_service_name_.c_str();
   };
 
-  const Optional<std::string>& lrs_load_reporting_server_name() const {
+  const absl::optional<std::string>& lrs_load_reporting_server_name() const {
     return lrs_load_reporting_server_name_;
   };
 
@@ -109,7 +111,7 @@ class XdsConfig : public LoadBalancingPolicy::Config {
   RefCountedPtr<LoadBalancingPolicy::Config> child_policy_;
   RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy_;
   std::string eds_service_name_;
-  Optional<std::string> lrs_load_reporting_server_name_;
+  absl::optional<std::string> lrs_load_reporting_server_name_;
 };
 
 class XdsLb : public LoadBalancingPolicy {
@@ -1656,7 +1658,7 @@ class XdsFactory : public LoadBalancingPolicyFactory {
       }
     }
     if (error_list.empty()) {
-      Optional<std::string> optional_lrs_load_reporting_server_name;
+      absl::optional<std::string> optional_lrs_load_reporting_server_name;
       if (lrs_load_reporting_server_name != nullptr) {
         optional_lrs_load_reporting_server_name.emplace(
             std::string(lrs_load_reporting_server_name));

--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -25,12 +25,13 @@
 
 #include <set>
 
+#include "absl/types/optional.h"
+
 #include <grpc/slice_buffer.h>
 
 #include "src/core/ext/filters/client_channel/server_address.h"
 #include "src/core/ext/filters/client_channel/xds/xds_bootstrap.h"
 #include "src/core/ext/filters/client_channel/xds/xds_client_stats.h"
-#include "src/core/lib/gprpp/optional.h"
 
 namespace grpc_core {
 
@@ -46,14 +47,25 @@ class XdsApi {
   struct RdsUpdate {
     // The name to use in the CDS request.
     std::string cluster_name;
+
+    bool operator==(const RdsUpdate& other) const {
+      return cluster_name == other.cluster_name;
+    }
   };
 
+  // TODO(roth): When we can use absl::variant<>, consider using that
+  // here, to enforce the fact that only one of the two fields can be set.
   struct LdsUpdate {
     // The name to use in the RDS request.
     std::string route_config_name;
     // The name to use in the CDS request. Present if the LDS response has it
     // inlined.
-    Optional<RdsUpdate> rds_update;
+    absl::optional<RdsUpdate> rds_update;
+
+    bool operator==(const LdsUpdate& other) const {
+      return route_config_name == other.route_config_name &&
+             rds_update == other.rds_update;
+    }
   };
 
   using LdsUpdateMap = std::map<std::string /*server_name*/, LdsUpdate>;
@@ -68,7 +80,7 @@ class XdsApi {
     // If not set, load reporting will be disabled.
     // If set to the empty string, will use the same server we obtained the CDS
     // data from.
-    Optional<std::string> lrs_load_reporting_server_name;
+    absl::optional<std::string> lrs_load_reporting_server_name;
   };
 
   using CdsUpdateMap = std::map<std::string /*cluster_name*/, CdsUpdate>;

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -21,13 +21,14 @@
 
 #include <set>
 
+#include "absl/types/optional.h"
+
 #include "src/core/ext/filters/client_channel/service_config.h"
 #include "src/core/ext/filters/client_channel/xds/xds_api.h"
 #include "src/core/ext/filters/client_channel/xds/xds_bootstrap.h"
 #include "src/core/ext/filters/client_channel/xds/xds_client_stats.h"
 #include "src/core/lib/gprpp/map.h"
 #include "src/core/lib/gprpp/memory.h"
-#include "src/core/lib/gprpp/optional.h"
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
@@ -246,8 +247,9 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   // The channel for communicating with the xds server.
   OrphanablePtr<ChannelState> chand_;
 
-  std::string route_config_name_;
-  std::string cluster_name_;
+  absl::optional<XdsApi::LdsUpdate> lds_result_;
+  absl::optional<XdsApi::RdsUpdate> rds_result_;
+
   // One entry for each watched CDS resource.
   std::map<std::string /*cluster_name*/, ClusterState> cluster_map_;
   // One entry for each watched EDS resource.


### PR DESCRIPTION
This fixes a bug that was causing the client to not correctly detect duplicate LDS updates.  This was causing harmless but annoying errors to be logged about a timeout fetching the RDS resource.