### PR TITLE
Remove run_tests.py based sanitizers from run_tests_matrix.py

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -30,12 +30,8 @@ os.chdir(_ROOT)
 
 _DEFAULT_RUNTESTS_TIMEOUT = 1 * 60 * 60
 
-# Set the timeout high to allow enough time for sanitizers and pre-building
-# clang docker.
+# C/C++ tests can take long time
 _CPP_RUNTESTS_TIMEOUT = 4 * 60 * 60
-
-# C++ TSAN takes longer than other sanitizers
-_CPP_TSAN_RUNTESTS_TIMEOUT = 8 * 60 * 60
 
 # Set timeout high for ObjC for Cocoapods to install pods
 _OBJC_RUNTESTS_TIMEOUT = 90 * 60
@@ -260,35 +256,6 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
                                 ['--report_multi_target'],
                                 inner_jobs=inner_jobs,
                                 timeout_seconds=_OBJC_RUNTESTS_TIMEOUT)
-
-    # sanitizers
-    test_jobs += _generate_jobs(languages=['c'],
-                                configs=['msan', 'asan', 'tsan', 'ubsan'],
-                                platforms=['linux'],
-                                arch='x64',
-                                compiler='clang7.0',
-                                labels=['sanitizers', 'corelang'],
-                                extra_args=extra_args,
-                                inner_jobs=inner_jobs,
-                                timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
-    test_jobs += _generate_jobs(languages=['c++'],
-                                configs=['asan'],
-                                platforms=['linux'],
-                                arch='x64',
-                                compiler='clang7.0',
-                                labels=['sanitizers', 'corelang'],
-                                extra_args=extra_args,
-                                inner_jobs=inner_jobs,
-                                timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
-    test_jobs += _generate_jobs(languages=['c++'],
-                                configs=['tsan'],
-                                platforms=['linux'],
-                                arch='x64',
-                                compiler='clang7.0',
-                                labels=['sanitizers', 'corelang'],
-                                extra_args=extra_args,
-                                inner_jobs=inner_jobs,
-                                timeout_seconds=_CPP_TSAN_RUNTESTS_TIMEOUT)
 
     return test_jobs
 


### PR DESCRIPTION
- Fixes https://github.com/grpc/grpc/issues/22394 (currently the only place where the old sanitizer tests are running are the grpc_build_protobuf_at_head and grpc_build_boringssl_at_head jobs): https://github.com/grpc/grpc/blob/d6e2514d0797861b0be62b52345fa120ec5f9c89/tools/internal_ci/linux/grpc_build_submodule_at_head.sh#L53

- we don't really need the run_tests.py based sanitizers (bazel should be the source of truth).

The sanitizers can still be run with run_tests.py if someone really wants to, but we're not building / running them anymore on the CI.

