### PR TITLE
Backport #22388 and #22371 to 1.28

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -25,6 +25,8 @@
 #include <limits.h>
 #include <string.h>
 
+#include "absl/types/optional.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
@@ -80,7 +82,7 @@ class XdsConfig : public LoadBalancingPolicy::Config {
   XdsConfig(RefCountedPtr<LoadBalancingPolicy::Config> child_policy,
             RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy,
             std::string eds_service_name,
-            Optional<std::string> lrs_load_reporting_server_name)
+            absl::optional<std::string> lrs_load_reporting_server_name)
       : child_policy_(std::move(child_policy)),
         fallback_policy_(std::move(fallback_policy)),
         eds_service_name_(std::move(eds_service_name)),
@@ -101,7 +103,7 @@ class XdsConfig : public LoadBalancingPolicy::Config {
     return eds_service_name_.empty() ? nullptr : eds_service_name_.c_str();
   };
 
-  const Optional<std::string>& lrs_load_reporting_server_name() const {
+  const absl::optional<std::string>& lrs_load_reporting_server_name() const {
     return lrs_load_reporting_server_name_;
   };
 
@@ -109,7 +111,7 @@ class XdsConfig : public LoadBalancingPolicy::Config {
   RefCountedPtr<LoadBalancingPolicy::Config> child_policy_;
   RefCountedPtr<LoadBalancingPolicy::Config> fallback_policy_;
   std::string eds_service_name_;
-  Optional<std::string> lrs_load_reporting_server_name_;
+  absl::optional<std::string> lrs_load_reporting_server_name_;
 };
 
 class XdsLb : public LoadBalancingPolicy {
@@ -1656,7 +1658,7 @@ class XdsFactory : public LoadBalancingPolicyFactory {
       }
     }
     if (error_list.empty()) {
-      Optional<std::string> optional_lrs_load_reporting_server_name;
+      absl::optional<std::string> optional_lrs_load_reporting_server_name;
       if (lrs_load_reporting_server_name != nullptr) {
         optional_lrs_load_reporting_server_name.emplace(
             std::string(lrs_load_reporting_server_name));

--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -25,12 +25,13 @@
 
 #include <set>
 
+#include "absl/types/optional.h"
+
 #include <grpc/slice_buffer.h>
 
 #include "src/core/ext/filters/client_channel/server_address.h"
 #include "src/core/ext/filters/client_channel/xds/xds_bootstrap.h"
 #include "src/core/ext/filters/client_channel/xds/xds_client_stats.h"
-#include "src/core/lib/gprpp/optional.h"
 
 namespace grpc_core {
 
@@ -46,14 +47,25 @@ class XdsApi {
   struct RdsUpdate {
     // The name to use in the CDS request.
     std::string cluster_name;
+
+    bool operator==(const RdsUpdate& other) const {
+      return cluster_name == other.cluster_name;
+    }
   };
 
+  // TODO(roth): When we can use absl::variant<>, consider using that
+  // here, to enforce the fact that only one of the two fields can be set.
   struct LdsUpdate {
     // The name to use in the RDS request.
     std::string route_config_name;
     // The name to use in the CDS request. Present if the LDS response has it
     // inlined.
-    Optional<RdsUpdate> rds_update;
+    absl::optional<RdsUpdate> rds_update;
+
+    bool operator==(const LdsUpdate& other) const {
+      return route_config_name == other.route_config_name &&
+             rds_update == other.rds_update;
+    }
   };
 
   using LdsUpdateMap = std::map<std::string /*server_name*/, LdsUpdate>;
@@ -68,7 +80,7 @@ class XdsApi {
     // If not set, load reporting will be disabled.
     // If set to the empty string, will use the same server we obtained the CDS
     // data from.
-    Optional<std::string> lrs_load_reporting_server_name;
+    absl::optional<std::string> lrs_load_reporting_server_name;
   };
 
   using CdsUpdateMap = std::map<std::string /*cluster_name*/, CdsUpdate>;

--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -192,7 +192,7 @@ class XdsApi {
 
   struct ClusterLoadReport {
     XdsClusterDropStats::DroppedRequestsMap dropped_requests;
-    std::map<XdsLocalityName*, XdsClusterLocalityStats::Snapshot,
+    std::map<RefCountedPtr<XdsLocalityName>, XdsClusterLocalityStats::Snapshot,
              XdsLocalityName::Less>
         locality_stats;
     grpc_millis load_report_interval;

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -21,13 +21,14 @@
 
 #include <set>
 
+#include "absl/types/optional.h"
+
 #include "src/core/ext/filters/client_channel/service_config.h"
 #include "src/core/ext/filters/client_channel/xds/xds_api.h"
 #include "src/core/ext/filters/client_channel/xds/xds_bootstrap.h"
 #include "src/core/ext/filters/client_channel/xds/xds_client_stats.h"
 #include "src/core/lib/gprpp/map.h"
 #include "src/core/lib/gprpp/memory.h"
-#include "src/core/lib/gprpp/optional.h"
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
@@ -246,8 +247,9 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   // The channel for communicating with the xds server.
   OrphanablePtr<ChannelState> chand_;
 
-  std::string route_config_name_;
-  std::string cluster_name_;
+  absl::optional<XdsApi::LdsUpdate> lds_result_;
+  absl::optional<XdsApi::RdsUpdate> rds_result_;
+
   // One entry for each watched CDS resource.
   std::map<std::string /*cluster_name*/, ClusterState> cluster_map_;
   // One entry for each watched EDS resource.

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -209,8 +209,14 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   };
 
   struct LoadReportState {
+    struct LocalityState {
+      std::set<XdsClusterLocalityStats*> locality_stats;
+      std::vector<XdsClusterLocalityStats::Snapshot> deleted_locality_stats;
+    };
+
     std::set<XdsClusterDropStats*> drop_stats;
-    std::map<RefCountedPtr<XdsLocalityName>, std::set<XdsClusterLocalityStats*>,
+    XdsClusterDropStats::DroppedRequestsMap deleted_drop_stats;
+    std::map<RefCountedPtr<XdsLocalityName>, LocalityState,
              XdsLocalityName::Less>
         locality_stats;
     grpc_millis last_report_time = ExecCtx::Get()->Now();
@@ -223,7 +229,8 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
       const std::string& cluster_name,
       RefCountedPtr<ServiceConfig>* service_config) const;
 
-  XdsApi::ClusterLoadReportMap BuildLoadReportSnapshot();
+  XdsApi::ClusterLoadReportMap BuildLoadReportSnapshot(
+      const std::set<std::string>& clusters);
 
   // Channel arg vtable functions.
   static void* ChannelArgCopy(void* p);

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -22,7 +22,9 @@
 #include <numeric>
 #include <set>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
@@ -296,8 +298,9 @@ class ClientStats {
   };
 
   // Converts from proto message class.
-  ClientStats(const ClusterStats& cluster_stats)
-      : total_dropped_requests_(cluster_stats.total_dropped_requests()) {
+  explicit ClientStats(const ClusterStats& cluster_stats)
+      : cluster_name_(cluster_stats.cluster_name()),
+        total_dropped_requests_(cluster_stats.total_dropped_requests()) {
     for (const auto& input_locality_stats :
          cluster_stats.upstream_locality_stats()) {
       locality_stats_.emplace(input_locality_stats.locality().sub_zone(),
@@ -310,6 +313,11 @@ class ClientStats {
     }
   }
 
+  const std::string& cluster_name() const { return cluster_name_; }
+
+  const std::map<grpc::string, LocalityStats>& locality_stats() const {
+    return locality_stats_;
+  }
   uint64_t total_successful_requests() const {
     uint64_t sum = 0;
     for (auto& p : locality_stats_) {
@@ -338,7 +346,9 @@ class ClientStats {
     }
     return sum;
   }
+
   uint64_t total_dropped_requests() const { return total_dropped_requests_; }
+
   uint64_t dropped_requests(const grpc::string& category) const {
     auto iter = dropped_requests_.find(category);
     GPR_ASSERT(iter != dropped_requests_.end());
@@ -346,6 +356,7 @@ class ClientStats {
   }
 
  private:
+  std::string cluster_name_;
   std::map<grpc::string, LocalityStats> locality_stats_;
   uint64_t total_dropped_requests_;
   std::map<grpc::string, uint64_t> dropped_requests_;
@@ -391,7 +402,6 @@ class AdsServiceImpl : public AggregatedDiscoveryService::Service,
   };
 
   using Stream = ServerReaderWriter<DiscoveryResponse, DiscoveryRequest>;
-  using ResponseDelayPair = std::pair<DiscoveryResponse, int>;
 
   // A queue of resource type/name pairs that have changed since the client
   // subscribed to them.
@@ -933,60 +943,62 @@ class LrsServiceImpl : public LrsService,
 
   explicit LrsServiceImpl(int client_load_reporting_interval_seconds)
       : client_load_reporting_interval_seconds_(
-            client_load_reporting_interval_seconds) {}
+            client_load_reporting_interval_seconds),
+        cluster_names_({kDefaultResourceName}) {}
 
   Status StreamLoadStats(ServerContext* /*context*/, Stream* stream) override {
     gpr_log(GPR_INFO, "LRS[%p]: StreamLoadStats starts", this);
+    GPR_ASSERT(client_load_reporting_interval_seconds_ > 0);
     // Take a reference of the LrsServiceImpl object, reference will go
     // out of scope after this method exits.
     std::shared_ptr<LrsServiceImpl> lrs_service_impl = shared_from_this();
-    // Read request.
+    // Read initial request.
     LoadStatsRequest request;
     if (stream->Read(&request)) {
-      if (client_load_reporting_interval_seconds_ > 0) {
-        IncreaseRequestCount();
-        // Send response.
-        LoadStatsResponse response;
-        std::string server_name;
-        auto it = request.node().metadata().fields().find(
-            "PROXYLESS_CLIENT_HOSTNAME");
-        if (it != request.node().metadata().fields().end()) {
-          server_name = it->second.string_value();
+      IncreaseRequestCount();  // Only for initial request.
+      // Verify server name set in metadata.
+      auto it =
+          request.node().metadata().fields().find("PROXYLESS_CLIENT_HOSTNAME");
+      GPR_ASSERT(it != request.node().metadata().fields().end());
+      EXPECT_EQ(it->second.string_value(), kDefaultResourceName);
+      // Send initial response.
+      LoadStatsResponse response;
+      for (const std::string& cluster_name : cluster_names_) {
+        response.add_clusters(cluster_name);
+      }
+      response.mutable_load_reporting_interval()->set_seconds(
+          client_load_reporting_interval_seconds_);
+      stream->Write(response);
+      IncreaseResponseCount();
+      // Wait for report.
+      request.Clear();
+      while (stream->Read(&request)) {
+        gpr_log(GPR_INFO, "LRS[%p]: received client load report message: %s",
+                this, request.DebugString().c_str());
+        std::vector<ClientStats> stats;
+        for (const auto& cluster_stats : request.cluster_stats()) {
+          stats.emplace_back(cluster_stats);
         }
-        GPR_ASSERT(server_name != "");
-        response.add_clusters(server_name);
-        response.mutable_load_reporting_interval()->set_seconds(
-            client_load_reporting_interval_seconds_);
-        stream->Write(response);
-        IncreaseResponseCount();
-        // Wait for report.
-        request.Clear();
-        if (stream->Read(&request)) {
-          gpr_log(GPR_INFO, "LRS[%p]: received client load report message '%s'",
-                  this, request.DebugString().c_str());
-          GPR_ASSERT(request.cluster_stats().size() == 1);
-          const ClusterStats& cluster_stats = request.cluster_stats()[0];
-          // We need to acquire the lock here in order to prevent the notify_one
-          // below from firing before its corresponding wait is executed.
-          grpc_core::MutexLock lock(&load_report_mu_);
-          GPR_ASSERT(client_stats_ == nullptr);
-          client_stats_.reset(new ClientStats(cluster_stats));
-          load_report_ready_ = true;
-          load_report_cond_.Signal();
-        }
+        grpc_core::MutexLock lock(&load_report_mu_);
+        result_queue_.emplace_back(std::move(stats));
+        if (load_report_cond_ != nullptr) load_report_cond_->Signal();
       }
       // Wait until notified done.
       grpc_core::MutexLock lock(&lrs_mu_);
-      lrs_cv_.WaitUntil(&lrs_mu_, [this] { return lrs_done; });
+      lrs_cv_.WaitUntil(&lrs_mu_, [this] { return lrs_done_; });
     }
     gpr_log(GPR_INFO, "LRS[%p]: StreamLoadStats done", this);
     return Status::OK;
   }
 
+  // Must be called before the LRS call is started.
+  void set_cluster_names(const std::set<std::string>& cluster_names) {
+    cluster_names_ = cluster_names;
+  }
+
   void Start() {
-    lrs_done = false;
-    load_report_ready_ = false;
-    client_stats_.reset();
+    lrs_done_ = false;
+    result_queue_.clear();
   }
 
   void Shutdown() {
@@ -997,12 +1009,18 @@ class LrsServiceImpl : public LrsService,
     gpr_log(GPR_INFO, "LRS[%p]: shut down", this);
   }
 
-  ClientStats* WaitForLoadReport() {
+  std::vector<ClientStats> WaitForLoadReport() {
     grpc_core::MutexLock lock(&load_report_mu_);
-    load_report_cond_.WaitUntil(&load_report_mu_,
-                                [this] { return load_report_ready_; });
-    load_report_ready_ = false;
-    return client_stats_.get();
+    grpc_core::CondVar cv;
+    if (result_queue_.empty()) {
+      load_report_cond_ = &cv;
+      load_report_cond_->WaitUntil(&load_report_mu_,
+                                   [this] { return !result_queue_.empty(); });
+      load_report_cond_ = nullptr;
+    }
+    std::vector<ClientStats> result = std::move(result_queue_.front());
+    result_queue_.pop_front();
+    return result;
   }
 
   void NotifyDoneWithLrsCall() {
@@ -1010,26 +1028,24 @@ class LrsServiceImpl : public LrsService,
     NotifyDoneWithLrsCallLocked();
   }
 
+ private:
   void NotifyDoneWithLrsCallLocked() {
-    if (!lrs_done) {
-      lrs_done = true;
+    if (!lrs_done_) {
+      lrs_done_ = true;
       lrs_cv_.Broadcast();
     }
   }
 
- private:
   const int client_load_reporting_interval_seconds_;
+  std::set<std::string> cluster_names_;
 
   grpc_core::CondVar lrs_cv_;
-  // Protect lrs_done.
-  grpc_core::Mutex lrs_mu_;
-  bool lrs_done = false;
+  grpc_core::Mutex lrs_mu_;  // Protects lrs_done_.
+  bool lrs_done_ = false;
 
-  grpc_core::CondVar load_report_cond_;
-  // Protect the members below.
-  grpc_core::Mutex load_report_mu_;
-  std::unique_ptr<ClientStats> client_stats_;
-  bool load_report_ready_ = false;
+  grpc_core::Mutex load_report_mu_;  // Protects the members below.
+  grpc_core::CondVar* load_report_cond_ = nullptr;
+  std::deque<std::vector<ClientStats>> result_queue_;
 };
 
 class TestType {
@@ -1718,6 +1734,141 @@ TEST_P(XdsResolverOnlyTest, ClusterRemoved) {
   // Make sure we ACK'ed the update.
   EXPECT_EQ(balancers_[0]->ads_service()->cds_response_state(),
             AdsServiceImpl::ACKED);
+}
+
+class XdsResolverLoadReportingOnlyTest : public XdsEnd2endTest {
+ public:
+  XdsResolverLoadReportingOnlyTest() : XdsEnd2endTest(4, 1, 3) {}
+};
+
+// Tests load reporting when switching over from one cluster to another.
+TEST_P(XdsResolverLoadReportingOnlyTest, ChangeClusters) {
+  const char* kNewClusterName = "new_cluster_name";
+  balancers_[0]->lrs_service()->set_cluster_names(
+      {kDefaultResourceName, kNewClusterName});
+  SetNextResolution({});
+  SetNextResolutionForLbChannelAllBalancers();
+  // cluster kDefaultResourceName -> locality0 -> backends 0 and 1
+  AdsServiceImpl::EdsResourceArgs args({
+      {"locality0", GetBackendPorts(0, 2)},
+  });
+  balancers_[0]->ads_service()->SetEdsResource(
+      AdsServiceImpl::BuildEdsResource(args), kDefaultResourceName);
+  // cluster kNewClusterName -> locality1 -> backends 2 and 3
+  AdsServiceImpl::EdsResourceArgs args2({
+      {"locality1", GetBackendPorts(2, 4)},
+  });
+  balancers_[0]->ads_service()->SetEdsResource(
+      AdsServiceImpl::BuildEdsResource(args2, kNewClusterName),
+      kNewClusterName);
+  // CDS resource for kNewClusterName.
+  Cluster new_cluster = balancers_[0]->ads_service()->default_cluster();
+  new_cluster.set_name(kNewClusterName);
+  balancers_[0]->ads_service()->SetCdsResource(new_cluster, kNewClusterName);
+  // Wait for all backends to come online.
+  int num_ok = 0;
+  int num_failure = 0;
+  int num_drops = 0;
+  std::tie(num_ok, num_failure, num_drops) = WaitForAllBackends(0, 2);
+  // The load report received at the balancer should be correct.
+  std::vector<ClientStats> load_report =
+      balancers_[0]->lrs_service()->WaitForLoadReport();
+  EXPECT_THAT(
+      load_report,
+      ::testing::ElementsAre(::testing::AllOf(
+          ::testing::Property(&ClientStats::cluster_name, kDefaultResourceName),
+          ::testing::Property(
+              &ClientStats::locality_stats,
+              ::testing::ElementsAre(::testing::Pair(
+                  "locality0",
+                  ::testing::AllOf(
+                      ::testing::Field(&ClientStats::LocalityStats::
+                                           total_successful_requests,
+                                       num_ok),
+                      ::testing::Field(&ClientStats::LocalityStats::
+                                           total_requests_in_progress,
+                                       0UL),
+                      ::testing::Field(
+                          &ClientStats::LocalityStats::total_error_requests,
+                          num_failure),
+                      ::testing::Field(
+                          &ClientStats::LocalityStats::total_issued_requests,
+                          num_failure + num_ok))))),
+          ::testing::Property(&ClientStats::total_dropped_requests,
+                              num_drops))));
+  // Change RDS resource to point to new cluster.
+  RouteConfiguration new_route_config =
+      balancers_[0]->ads_service()->default_route_config();
+  new_route_config.mutable_virtual_hosts(0)
+      ->mutable_routes(0)
+      ->mutable_route()
+      ->set_cluster(kNewClusterName);
+  Listener listener =
+      balancers_[0]->ads_service()->BuildListener(new_route_config);
+  balancers_[0]->ads_service()->SetLdsResource(listener, kDefaultResourceName);
+  // Wait for all new backends to be used.
+  std::tie(num_ok, num_failure, num_drops) = WaitForAllBackends(2, 4);
+  // The load report received at the balancer should be correct.
+  load_report = balancers_[0]->lrs_service()->WaitForLoadReport();
+  EXPECT_THAT(
+      load_report,
+      ::testing::ElementsAre(
+          ::testing::AllOf(
+              ::testing::Property(&ClientStats::cluster_name,
+                                  kDefaultResourceName),
+              ::testing::Property(
+                  &ClientStats::locality_stats,
+                  ::testing::ElementsAre(::testing::Pair(
+                      "locality0",
+                      ::testing::AllOf(
+                          ::testing::Field(&ClientStats::LocalityStats::
+                                               total_successful_requests,
+                                           ::testing::Lt(num_ok)),
+                          ::testing::Field(&ClientStats::LocalityStats::
+                                               total_requests_in_progress,
+                                           0UL),
+                          ::testing::Field(
+                              &ClientStats::LocalityStats::total_error_requests,
+                              ::testing::Le(num_failure)),
+                          ::testing::Field(
+                              &ClientStats::LocalityStats::
+                                  total_issued_requests,
+                              ::testing::Le(num_failure + num_ok)))))),
+              ::testing::Property(&ClientStats::total_dropped_requests,
+                                  num_drops)),
+          ::testing::AllOf(
+              ::testing::Property(&ClientStats::cluster_name, kNewClusterName),
+              ::testing::Property(
+                  &ClientStats::locality_stats,
+                  ::testing::ElementsAre(::testing::Pair(
+                      "locality1",
+                      ::testing::AllOf(
+                          ::testing::Field(&ClientStats::LocalityStats::
+                                               total_successful_requests,
+                                           ::testing::Le(num_ok)),
+                          ::testing::Field(&ClientStats::LocalityStats::
+                                               total_requests_in_progress,
+                                           0UL),
+                          ::testing::Field(
+                              &ClientStats::LocalityStats::total_error_requests,
+                              ::testing::Le(num_failure)),
+                          ::testing::Field(
+                              &ClientStats::LocalityStats::
+                                  total_issued_requests,
+                              ::testing::Le(num_failure + num_ok)))))),
+              ::testing::Property(&ClientStats::total_dropped_requests,
+                                  num_drops))));
+  int total_ok = 0;
+  int total_failure = 0;
+  for (const ClientStats& client_stats : load_report) {
+    total_ok += client_stats.total_successful_requests();
+    total_failure += client_stats.total_error_requests();
+  }
+  EXPECT_EQ(total_ok, num_ok);
+  EXPECT_EQ(total_failure, num_failure);
+  // The LRS service got a single request, and sent a single response.
+  EXPECT_EQ(1U, balancers_[0]->lrs_service()->request_count());
+  EXPECT_EQ(1U, balancers_[0]->lrs_service()->response_count());
 }
 
 using SecureNamingTest = BasicTest;
@@ -3229,14 +3380,50 @@ TEST_P(ClientLoadReportingTest, Vanilla) {
   EXPECT_EQ(1U, balancers_[0]->lrs_service()->request_count());
   EXPECT_EQ(1U, balancers_[0]->lrs_service()->response_count());
   // The load report received at the balancer should be correct.
-  ClientStats* client_stats = balancers_[0]->lrs_service()->WaitForLoadReport();
+  std::vector<ClientStats> load_report =
+      balancers_[0]->lrs_service()->WaitForLoadReport();
+  ASSERT_EQ(load_report.size(), 1UL);
+  ClientStats& client_stats = load_report.front();
   EXPECT_EQ(kNumRpcsPerAddress * num_backends_ + num_ok,
-            client_stats->total_successful_requests());
-  EXPECT_EQ(0U, client_stats->total_requests_in_progress());
+            client_stats.total_successful_requests());
+  EXPECT_EQ(0U, client_stats.total_requests_in_progress());
   EXPECT_EQ(kNumRpcsPerAddress * num_backends_ + num_ok,
-            client_stats->total_issued_requests());
-  EXPECT_EQ(0U, client_stats->total_error_requests());
-  EXPECT_EQ(0U, client_stats->total_dropped_requests());
+            client_stats.total_issued_requests());
+  EXPECT_EQ(0U, client_stats.total_error_requests());
+  EXPECT_EQ(0U, client_stats.total_dropped_requests());
+}
+
+// Tests that we don't include stats for clusters that are not requested
+// by the LRS server.
+TEST_P(ClientLoadReportingTest, HonorsClustersRequestedByLrsServer) {
+  balancers_[0]->lrs_service()->set_cluster_names({"bogus"});
+  SetNextResolution({});
+  SetNextResolutionForLbChannel({balancers_[0]->port()});
+  const size_t kNumRpcsPerAddress = 100;
+  AdsServiceImpl::EdsResourceArgs args({
+      {"locality0", GetBackendPorts()},
+  });
+  balancers_[0]->ads_service()->SetEdsResource(
+      AdsServiceImpl::BuildEdsResource(args), kDefaultResourceName);
+  // Wait until all backends are ready.
+  int num_ok = 0;
+  int num_failure = 0;
+  int num_drops = 0;
+  std::tie(num_ok, num_failure, num_drops) = WaitForAllBackends();
+  // Send kNumRpcsPerAddress RPCs per server.
+  CheckRpcSendOk(kNumRpcsPerAddress * num_backends_);
+  // Each backend should have gotten 100 requests.
+  for (size_t i = 0; i < backends_.size(); ++i) {
+    EXPECT_EQ(kNumRpcsPerAddress,
+              backends_[i]->backend_service()->request_count());
+  }
+  // The LRS service got a single request, and sent a single response.
+  EXPECT_EQ(1U, balancers_[0]->lrs_service()->request_count());
+  EXPECT_EQ(1U, balancers_[0]->lrs_service()->response_count());
+  // The load report received at the balancer should be correct.
+  std::vector<ClientStats> load_report =
+      balancers_[0]->lrs_service()->WaitForLoadReport();
+  ASSERT_EQ(load_report.size(), 0UL);
 }
 
 // Tests that if the balancer restarts, the client load report contains the
@@ -3259,12 +3446,15 @@ TEST_P(ClientLoadReportingTest, BalancerRestart) {
   std::tie(num_ok, num_failure, num_drops) =
       WaitForAllBackends(/* start_index */ 0,
                          /* stop_index */ kNumBackendsFirstPass);
-  ClientStats* client_stats = balancers_[0]->lrs_service()->WaitForLoadReport();
+  std::vector<ClientStats> load_report =
+      balancers_[0]->lrs_service()->WaitForLoadReport();
+  ASSERT_EQ(load_report.size(), 1UL);
+  ClientStats client_stats = std::move(load_report.front());
   EXPECT_EQ(static_cast<size_t>(num_ok),
-            client_stats->total_successful_requests());
-  EXPECT_EQ(0U, client_stats->total_requests_in_progress());
-  EXPECT_EQ(0U, client_stats->total_error_requests());
-  EXPECT_EQ(0U, client_stats->total_dropped_requests());
+            client_stats.total_successful_requests());
+  EXPECT_EQ(0U, client_stats.total_requests_in_progress());
+  EXPECT_EQ(0U, client_stats.total_error_requests());
+  EXPECT_EQ(0U, client_stats.total_dropped_requests());
   // Shut down the balancer.
   balancers_[0]->Shutdown();
   // We should continue using the last EDS response we received from the
@@ -3296,11 +3486,13 @@ TEST_P(ClientLoadReportingTest, BalancerRestart) {
   CheckRpcSendOk(kNumBackendsSecondPass);
   num_started += kNumBackendsSecondPass;
   // Check client stats.
-  client_stats = balancers_[0]->lrs_service()->WaitForLoadReport();
-  EXPECT_EQ(num_started, client_stats->total_successful_requests());
-  EXPECT_EQ(0U, client_stats->total_requests_in_progress());
-  EXPECT_EQ(0U, client_stats->total_error_requests());
-  EXPECT_EQ(0U, client_stats->total_dropped_requests());
+  load_report = balancers_[0]->lrs_service()->WaitForLoadReport();
+  ASSERT_EQ(load_report.size(), 1UL);
+  client_stats = std::move(load_report.front());
+  EXPECT_EQ(num_started, client_stats.total_successful_requests());
+  EXPECT_EQ(0U, client_stats.total_requests_in_progress());
+  EXPECT_EQ(0U, client_stats.total_error_requests());
+  EXPECT_EQ(0U, client_stats.total_dropped_requests());
 }
 
 class ClientLoadReportingWithDropTest : public XdsEnd2endTest {
@@ -3354,15 +3546,18 @@ TEST_P(ClientLoadReportingWithDropTest, Vanilla) {
           ::testing::Ge(KDropRateForLbAndThrottle * (1 - kErrorTolerance)),
           ::testing::Le(KDropRateForLbAndThrottle * (1 + kErrorTolerance))));
   // Check client stats.
-  ClientStats* client_stats = balancers_[0]->lrs_service()->WaitForLoadReport();
-  EXPECT_EQ(num_drops, client_stats->total_dropped_requests());
+  std::vector<ClientStats> load_report =
+      balancers_[0]->lrs_service()->WaitForLoadReport();
+  ASSERT_EQ(load_report.size(), 1UL);
+  ClientStats& client_stats = load_report.front();
+  EXPECT_EQ(num_drops, client_stats.total_dropped_requests());
   const size_t total_rpc = num_warmup + kNumRpcs;
   EXPECT_THAT(
-      client_stats->dropped_requests(kLbDropType),
+      client_stats.dropped_requests(kLbDropType),
       ::testing::AllOf(
           ::testing::Ge(total_rpc * kDropRateForLb * (1 - kErrorTolerance)),
           ::testing::Le(total_rpc * kDropRateForLb * (1 + kErrorTolerance))));
-  EXPECT_THAT(client_stats->dropped_requests(kThrottleDropType),
+  EXPECT_THAT(client_stats.dropped_requests(kThrottleDropType),
               ::testing::AllOf(
                   ::testing::Ge(total_rpc * (1 - kDropRateForLb) *
                                 kDropRateForThrottle * (1 - kErrorTolerance)),
@@ -3417,6 +3612,11 @@ INSTANTIATE_TEST_SUITE_P(XdsTest, EdsTest,
 INSTANTIATE_TEST_SUITE_P(XdsTest, XdsResolverOnlyTest,
                          ::testing::Values(TestType(true, false),
                                            TestType(true, true)),
+                         &TestTypeName);
+
+// XdsResolverLoadReprtingOnlyTest depends on XdsResolver and load reporting.
+INSTANTIATE_TEST_SUITE_P(XdsTest, XdsResolverLoadReportingOnlyTest,
+                         ::testing::Values(TestType(true, true)),
                          &TestTypeName);
 
 INSTANTIATE_TEST_SUITE_P(XdsTest, LocalityMapTest,


### PR DESCRIPTION
This PR backports the following PRs to 1.28:

 - [xds: fix duplicate LDS update detection](https://github.com/grpc/grpc/pull/22388)
 - [Gracefully switch xds policy instances when cluster name changes.](https://github.com/grpc/grpc/pull/22371)

After this PR, to the best of my knowledge, https://github.com/grpc/grpc/pull/22400 is the only blocker for the 1.28 release.