### PR TITLE
Annotate channel context manager methods to make pytype happy

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1076,6 +1076,14 @@ class Channel(six.with_metaclass(abc.ABCMeta)):
         """
         raise NotImplementedError()
 
+    def __enter__(self):
+        """Enters the runtime context related to the channel object."""
+        raise NotImplementedError()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exits the runtime context related to the channel object."""
+        raise NotImplementedError()
+
 
 ##########################  Service-Side Context  ##############################
 


### PR DESCRIPTION
As title. Magic number [b/151480630](http://b/151480630)

For Python 3 users, `pytype`  complains the missing context manager methods. Quick repro:

```python
import abc

class A(abc.ABC):
    pass


class B(A):

    def __enter__(self):
        return self

    def __exit__(self, exc_type, exc_val, exc_tb):
        return False


def strange_a() -> A:
    return B()


with strange_a() as a:  # <-- pytype complain
    pass
```