### PR TITLE
Add 1.27.3 to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -104,6 +104,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.24.0', ReleaseInfo()),
             ('v1.25.0', ReleaseInfo()),
             ('v1.26.0', ReleaseInfo()),
+            ('v1.27.3', ReleaseInfo()),
         ]),
     'go':
         OrderedDict([
@@ -268,6 +269,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.24.0', ReleaseInfo(runtimes=['python'])),
             ('v1.25.0', ReleaseInfo(runtimes=['python'])),
             ('v1.26.0', ReleaseInfo(runtimes=['python'])),
+            ('v1.27.3', ReleaseInfo(runtimes=['python'])),
         ]),
     'node':
         OrderedDict([
@@ -325,6 +327,7 @@ LANG_RELEASE_MATRIX = {
             # If you are not encountering the error in above issue
             # go ahead and upload the docker image for new releases.
             ('v1.26.0', ReleaseInfo()),
+            ('v1.27.3', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([
@@ -355,6 +358,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.24.0', ReleaseInfo()),
             ('v1.25.0', ReleaseInfo()),
             ('v1.26.0', ReleaseInfo()),
+            ('v1.27.3', ReleaseInfo()),
         ]),
     'csharp':
         OrderedDict([
@@ -390,5 +394,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.24.0', ReleaseInfo()),
             ('v1.25.0', ReleaseInfo()),
             ('v1.26.0', ReleaseInfo()),
+            ('v1.27.3', ReleaseInfo()),
         ]),
 }


### PR DESCRIPTION
Tested:

```
tools/interop_matrix/run_interop_matrix_tests.py -l all --release v1.27.3
```

(images were uploaded after a fix in https://github.com/grpc/grpc/pull/22256)