### PR TITLE
Port server must be used for mac bazel tests

### DIFF
--- a/tools/remote_build/mac.bazelrc
+++ b/tools/remote_build/mac.bazelrc
@@ -4,9 +4,6 @@
 # but try to use RBE build cache and upload results
 # to ResultStore
 
-# don't use port server
-build --define GRPC_PORT_ISOLATED_RUNTIME=1
-
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 
 # remote cache is needed not only for build speedup,


### PR DESCRIPTION
Mac bazel tests are not running on a remote cluster (which doesn't exist for macs), but are running locally instead (with some extra goodness like results link etc). As such, they need to use port server.

Because of an oversight, it looks like mac tests were using an "isolated_runtime_environment" version of port server that just assigns port randomly (and should be only used under Linux and Win RBE)
So from time to time tests happen to get assigned the same port and they just flake without an apparent reason.

It seems that fixing this could remove the long tail of a large number of "flaky" mac bazel tests that flake randomly.