### PR TITLE
Increase wait for VMs to come online

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -82,7 +82,7 @@ argp.add_argument('--secondary_zone',
 argp.add_argument('--qps', default=10, type=int, help='Client QPS')
 argp.add_argument(
     '--wait_for_backend_sec',
-    default=600,
+    default=1200,
     type=int,
     help='Time limit for waiting for created backend services to report '
     'healthy when launching or updated GCP resources')


### PR DESCRIPTION
https://source.cloud.google.com/results/invocations/fbc42789-784c-45b4-9e71-fd928aa1a114/targets timed out while waiting up to 10 minutes for two new VMs to report healthy. This bumps the timeout to 20 minutes;  need to take some steps to speed up backend creation time (each VM needs to build and start the server, could save some work there by using a pre-existing image) but this should help in the meantime.