### PR TITLE
Get rid of the long deprecated --incompatible_windows_native_test_wrapper flag

### DIFF
--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -38,9 +38,6 @@ build --define GRPC_PORT_ISOLATED_RUNTIME=1
 build --test_tag_filters=-no_windows
 build --build_tag_filters=-no_windows
 
-# required for the tests to pass on Windows RBE
-build --incompatible_windows_native_test_wrapper
-
 # without verbose gRPC logs the test outputs are not very useful
 test --test_env=GRPC_VERBOSITY=debug
 


### PR DESCRIPTION
The flag was removed in bazel 0.28 and around that time it also became the default behavior, so the flag is not needed anymore (we're currently on bazel 1.0)
