### PR TITLE
fix encoding issue with python 3

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1107,10 +1107,13 @@ try:
             result.returncode = 0
         except Exception as e:
             result.state = 'FAILED'
-            result.message = str(e).encode('UTF-8')
+            result.message = str(e)
         finally:
             if client_process:
                 client_process.terminate()
+            # Workaround for Python 3, as report_utils will invoke decode() on
+            # result.message, which has a default value of ''.
+            result.message = result.message.encode('UTF-8')
             test_results[test_case] = [result]
     if not os.path.exists(_TEST_LOG_BASE_DIR):
         os.makedirs(_TEST_LOG_BASE_DIR)


### PR DESCRIPTION
I overlooked that the default value of `JobResult.message` is `''`, which results in the following failure when running under Python 3:

```
Traceback (most recent call last):
  File "grpc/tools/run_tests/run_xds_tests.py", line 1121, in <module>
    multi_target=True)
  File "/tmpfs/src/github/grpc/tools/run_tests/python_utils/report_utils.py", line 69, in render_junit_xml_report
    replace_dots)
  File "/tmpfs/src/github/grpc/tools/run_tests/python_utils/report_utils.py", line 110, in append_junit_xml_results
    filtered_msg = _filter_msg(result.message, 'XML')
  File "/tmpfs/src/github/grpc/tools/run_tests/python_utils/report_utils.py", line 36, in _filter_msg
    msg.decode('UTF-8', 'ignore')))
AttributeError: 'str' object has no attribute 'decode'
```

AFAICT this bit of ugliness is the best way to address the difference between Python 2 and Python 3 and the existence/non-existence of the `str#decode` method.