### PR TITLE
Make check_call_host not segfault when overridden_target_name_ is null

### DIFF
--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -190,11 +190,10 @@ class grpc_ssl_channel_security_connector final
                        grpc_auth_context* auth_context,
                        grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
-    return grpc_ssl_check_call_host(host, target_name_.get(),
-                                    overridden_target_name_ != nullptr
-                                        ? overridden_target_name_.get()
-                                        : "",
-                                    auth_context, error);
+    return grpc_ssl_check_call_host(
+        host, target_name_.get(),
+        overridden_target_name_ != nullptr ? overridden_target_name_.get() : "",
+        auth_context, error);
   }
 
   void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -191,8 +191,10 @@ class grpc_ssl_channel_security_connector final
                        grpc_closure* /*on_call_host_checked*/,
                        grpc_error** error) override {
     return grpc_ssl_check_call_host(host, target_name_.get(),
-                                    overridden_target_name_.get(), auth_context,
-                                    error);
+                                    overridden_target_name_ != nullptr
+                                        ? overridden_target_name_.get()
+                                        : "",
+                                    auth_context, error);
   }
 
   void cancel_check_call_host(grpc_closure* /*on_call_host_checked*/,


### PR DESCRIPTION
This was broken by [40dd4a3](https://github.com/grpc/grpc/commit/40dd4a3301ff554c9715e99863b41dde05003035).