### PR TITLE
Remove all std::mem_fn and std::bind from service definitions and setup

### DIFF
--- a/include/grpcpp/impl/codegen/method_handler_impl.h
+++ b/include/grpcpp/impl/codegen/method_handler_impl.h
@@ -303,10 +303,13 @@ class BidiStreamingHandler
           ::grpc_impl::ServerReaderWriter<ResponseType, RequestType>*)>
           func,
       ServiceType* service)
+      // TODO(vjpai): When gRPC supports C++14, move-capture func in the below
       : TemplatedBidiStreamingHandler<
             ::grpc_impl::ServerReaderWriter<ResponseType, RequestType>, false>(
-            std::bind(func, service, std::placeholders::_1,
-                      std::placeholders::_2)) {}
+            [func, service](
+                ::grpc_impl::ServerContext* ctx,
+                ::grpc_impl::ServerReaderWriter<ResponseType, RequestType>*
+                    streamer) { return func(service, ctx, streamer); }) {}
 };
 
 template <class RequestType, class ResponseType>
@@ -321,7 +324,7 @@ class StreamedUnaryHandler
           func)
       : TemplatedBidiStreamingHandler<
             ::grpc_impl::ServerUnaryStreamer<RequestType, ResponseType>, true>(
-            func) {}
+            std::move(func)) {}
 };
 
 template <class RequestType, class ResponseType>
@@ -336,7 +339,7 @@ class SplitServerStreamingHandler
           func)
       : TemplatedBidiStreamingHandler<
             ::grpc_impl::ServerSplitStreamer<RequestType, ResponseType>, false>(
-            func) {}
+            std::move(func)) {}
 };
 
 /// General method handler class for errors that prevent real method use

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -839,7 +839,14 @@ class ServiceA final {
    public:
     WithStreamedUnaryMethod_MethodA1() {
       ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(std::bind(&WithStreamedUnaryMethod_MethodA1<BaseClass>::StreamedMethodA1, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](::grpc_impl::ServerContext* context,
+                   ::grpc_impl::ServerUnaryStreamer<
+                     ::grpc::testing::Request, ::grpc::testing::Response>* streamer) {
+                       return this->StreamedMethodA1(context,
+                         streamer);
+                  }));
     }
     ~WithStreamedUnaryMethod_MethodA1() override {
       BaseClassMustBeDerivedFromService(this);
@@ -860,7 +867,14 @@ class ServiceA final {
    public:
     WithSplitStreamingMethod_MethodA3() {
       ::grpc::Service::MarkMethodStreamed(2,
-        new ::grpc::internal::SplitServerStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(std::bind(&WithSplitStreamingMethod_MethodA3<BaseClass>::StreamedMethodA3, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](::grpc_impl::ServerContext* context,
+                   ::grpc_impl::ServerSplitStreamer<
+                     ::grpc::testing::Request, ::grpc::testing::Response>* streamer) {
+                       return this->StreamedMethodA3(context,
+                         streamer);
+                  }));
     }
     ~WithSplitStreamingMethod_MethodA3() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1129,7 +1143,14 @@ class ServiceB final {
    public:
     WithStreamedUnaryMethod_MethodB1() {
       ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(std::bind(&WithStreamedUnaryMethod_MethodB1<BaseClass>::StreamedMethodB1, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::grpc::testing::Request, ::grpc::testing::Response>(
+            [this](::grpc_impl::ServerContext* context,
+                   ::grpc_impl::ServerUnaryStreamer<
+                     ::grpc::testing::Request, ::grpc::testing::Response>* streamer) {
+                       return this->StreamedMethodB1(context,
+                         streamer);
+                  }));
     }
     ~WithStreamedUnaryMethod_MethodB1() override {
       BaseClassMustBeDerivedFromService(this);


### PR DESCRIPTION
Switch out all the std::bind and std::mem_fn with lambdas so that overloading actually takes effect when needed. I did not remove std::bind use in other places like the health checker that are not connected to user API.

