### PR TITLE
[Aio] Eliminate suspicious exceptions in tests

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -70,7 +70,8 @@ cdef CallbackFailureHandler CQ_SHUTDOWN_FAILURE_HANDLER = CallbackFailureHandler
     InternalError)
 
 
-class ExecuteBatchError(Exception): pass
+class ExecuteBatchError(InternalError):
+    """Raised upon execute batch returns a fail from Core."""
 
 
 async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
@@ -128,7 +129,7 @@ async def _receive_message(GrpcCallWrapper grpc_call_wrapper,
         # the callback (e.g. cancelled).
         #
         # Since they all indicates finish, they are better be merged.
-        _LOGGER.debug(e)
+        _LOGGER.debug('Failed to received message from Core')
     return receive_op.message()
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -71,7 +71,7 @@ cdef CallbackFailureHandler CQ_SHUTDOWN_FAILURE_HANDLER = CallbackFailureHandler
 
 
 class ExecuteBatchError(InternalError):
-    """Raised upon execute batch returns a fail from Core."""
+    """Raised when execute batch returns a failure from Core."""
 
 
 async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
@@ -129,7 +129,7 @@ async def _receive_message(GrpcCallWrapper grpc_call_wrapper,
         # the callback (e.g. cancelled).
         #
         # Since they all indicates finish, they are better be merged.
-        _LOGGER.debug('Failed to received message from Core')
+        _LOGGER.debug('Failed to receive any message from Core')
     return receive_op.message()
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -41,6 +41,18 @@ cdef class RPCState(GrpcCallWrapper):
     cdef Operation create_send_initial_metadata_op_if_not_sent(self)
 
 
+cdef class _ServicerContext:
+    cdef RPCState _rpc_state
+    cdef object _loop
+    cdef object _request_deserializer
+    cdef object _response_serializer
+
+
+cdef class _MessageReceiver:
+    cdef _ServicerContext _servicer_context
+    cdef object _agen
+
+
 cdef enum AioServerStatus:
     AIO_SERVER_STATUS_UNKNOWN
     AIO_SERVER_STATUS_READY

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -43,9 +43,9 @@ cdef class RPCState(GrpcCallWrapper):
 
 cdef class _ServicerContext:
     cdef RPCState _rpc_state
-    cdef object _loop
-    cdef object _request_deserializer
-    cdef object _response_serializer
+    cdef object _loop  # asyncio.AbstractEventLoop
+    cdef object _request_deserializer  # Callable[[bytes], Any]
+    cdef object _response_serializer  # Callable[[Any], bytes]
 
 
 cdef class _MessageReceiver:

--- a/src/python/grpcio_tests/tests_aio/interop/local_interop_test.py
+++ b/src/python/grpcio_tests/tests_aio/interop/local_interop_test.py
@@ -64,7 +64,6 @@ class InteropTestCaseMixin:
         await methods.test_interoperability(
             methods.TestCase.CANCEL_AFTER_FIRST_RESPONSE, self._stub, None)
 
-    @unittest.skip('TODO(https://github.com/grpc/grpc/issues/21707)')
     async def test_timeout_on_sleeping_server(self):
         await methods.test_interoperability(
             methods.TestCase.TIMEOUT_ON_SLEEPING_SERVER, self._stub, None)

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -740,5 +740,5 @@ class TestStreamStreamCall(_MulticallableTestMixin, AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_test.py
@@ -226,5 +226,5 @@ class TestChannel(AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/client_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_interceptor_test.py
@@ -686,5 +686,5 @@ class TestInterceptedUnaryUnaryCall(AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
@@ -134,5 +134,5 @@ class TestCloseChannel(AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -35,7 +35,7 @@ class TestChannel(AioTestBase):
         channel = aio.insecure_channel(server_target)
         self.assertIsInstance(channel, aio.Channel)
 
-    async def tests_secure_channel(self):
+    async def test_secure_channel(self):
         server_target, _ = await start_test_server(secure=True)  # pylint: disable=unused-variable
         credentials = grpc.ssl_channel_credentials(
             root_certificates=_TEST_ROOT_CERTIFICATES,
@@ -48,5 +48,5 @@ class TestChannel(AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/server_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_interceptor_test.py
@@ -164,5 +164,5 @@ class TestServerInterceptor(AioTestBase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)


### PR DESCRIPTION
From time to time, some exceptions slipped through our attention into our unit tests. Although most of them are reported as `debug`, it might not be readable for our users. This PR try to resolve all the warning, error, and exception in `debug` across all unit tests.

Also, fixes https://github.com/grpc/grpc/issues/21707. It was failing because the test logic was slightly wrong.
