### PR TITLE
Avoid too long test names on RBE Windows

### DIFF
--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -183,7 +183,8 @@ def _test_options(
         needs_http2 = False,
         needs_proxy_auth = False,
         needs_write_buffering = False,
-        needs_client_channel = False):
+        needs_client_channel = False,
+        short_name = None):
     return struct(
         needs_fullstack = needs_fullstack,
         needs_dns = needs_dns,
@@ -196,6 +197,7 @@ def _test_options(
         needs_proxy_auth = needs_proxy_auth,
         needs_write_buffering = needs_write_buffering,
         needs_client_channel = needs_client_channel,
+        short_name = short_name,
     )
 
 # maps test names to options
@@ -284,12 +286,21 @@ END2END_TESTS = {
     "retry_exceeds_buffer_size_in_subsequent_batch": _test_options(
         needs_client_channel = True,
         proxyable = False,
+        # TODO(jtattermusch): too long bazel test name makes the test flaky on Windows RBE
+        # See b/151617965
+        short_name = "retry_exceeds_buffer_size_in_subseq",
     ),
     "retry_non_retriable_status": _test_options(
         needs_client_channel = True,
         proxyable = False,
     ),
-    "retry_non_retriable_status_before_recv_trailing_metadata_started": _test_options(needs_client_channel = True, proxyable = False),
+    "retry_non_retriable_status_before_recv_trailing_metadata_started": _test_options(
+        needs_client_channel = True,
+        proxyable = False,
+        # TODO(jtattermusch): too long bazel test name makes the test flaky on Windows RBE
+        # See b/151617965
+        short_name = "retry_non_retriable_status2",
+    ),
     "retry_recv_initial_metadata": _test_options(
         needs_client_channel = True,
         proxyable = False,
@@ -314,6 +325,9 @@ END2END_TESTS = {
     "retry_streaming_succeeds_before_replay_finished": _test_options(
         needs_client_channel = True,
         proxyable = False,
+        # TODO(jtattermusch): too long bazel test name makes the test flaky on Windows RBE
+        # See b/151617965
+        short_name = "retry_streaming2",
     ),
     "retry_throttled": _test_options(
         needs_client_channel = True,
@@ -429,8 +443,9 @@ def grpc_end2end_tests():
             if not _compatible(fopt, topt):
                 continue
 
+            test_short_name = str(t) if not topt.short_name else topt.short_name
             native.sh_test(
-                name = "%s_test@%s" % (f, t),
+                name = "%s_test@%s" % (f, test_short_name),
                 data = [":%s_test" % f],
                 srcs = ["end2end_test.sh"],
                 args = [
@@ -443,7 +458,7 @@ def grpc_end2end_tests():
 
             for poller in POLLERS:
                 native.sh_test(
-                    name = "%s_test@%s@poller=%s" % (f, t, poller),
+                    name = "%s_test@%s@poller=%s" % (f, test_short_name, poller),
                     data = [":%s_test" % f],
                     srcs = ["end2end_test.sh"],
                     args = [
@@ -499,8 +514,9 @@ def grpc_end2end_nosec_tests():
             if topt.secure:
                 continue
 
+            test_short_name = str(t) if not topt.short_name else topt.short_name
             native.sh_test(
-                name = "%s_nosec_test@%s" % (f, t),
+                name = "%s_nosec_test@%s" % (f, test_short_name),
                 data = [":%s_nosec_test" % f],
                 srcs = ["end2end_test.sh"],
                 args = [
@@ -513,7 +529,7 @@ def grpc_end2end_nosec_tests():
 
             for poller in POLLERS:
                 native.sh_test(
-                    name = "%s_nosec_test@%s@poller=%s" % (f, t, poller),
+                    name = "%s_nosec_test@%s@poller=%s" % (f, test_short_name, poller),
                     data = [":%s_nosec_test" % f],
                     srcs = ["end2end_test.sh"],
                     args = [


### PR DESCRIPTION
Shortening the name of some tests cases makes them less readable, but eliminates one of the top flakes on windows RBE.
See internal bug b/151617965 for details.

Example failure:
https://source.cloud.google.com/results/invocations/e00e94f1-8321-43ef-bd02-1a321134ffef/targets/%2F%2Ftest%2Fcore%2Fend2end:h2_fakesec_test@retry_non_retriable_status_before_recv_trailing_metadata_started/log



