### PR TITLE
Also upload className in upload_rbe_results.py

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -37,6 +37,7 @@ _RESULTS_SCHEMA = [
     ('build_id', 'INTEGER', 'Build ID of Kokoro job'),
     ('build_url', 'STRING', 'URL of Kokoro build'),
     ('test_target', 'STRING', 'Bazel target path'),
+    ('test_class_name', 'STRING', 'Name of test class'),
     ('test_case', 'STRING', 'Name of test case'),
     ('result', 'STRING', 'Test or build result'),
     ('timestamp', 'TIMESTAMP', 'Timestamp of test run'),
@@ -241,6 +242,8 @@ if __name__ == "__main__":
                             % invocation_id,
                         'test_target':
                             action['id']['targetId'],
+                        'test_class_name':
+                            test_case['testCase'].get('className', ''),
                         'test_case':
                             test_case['testCase']['caseName'],
                         'result':
@@ -266,6 +269,8 @@ if __name__ == "__main__":
                             % invocation_id,
                         'test_target':
                             action['id']['targetId'],
+                        'test_class_name':
+                            'N/A',
                         'test_case':
                             'N/A',
                         'result':


### PR DESCRIPTION
In some tests, the className matters, so we want to upload it to BigQuery as well.

e.g.
https://source.cloud.google.com/results/invocations/3ba23382-cca9-4b69-a392-6a25ede42b1d/targets/%2F%2Ftest%2Fcpp%2Fend2end:xds_end2end_test@poller%3Dpoll;shard=2;run=1;attempt=1/tests;passed=true;group=XdsTest%2FBasicTest;test=Vanilla%2FXdsResolverWithLoadReporting;row=1