### PR TITLE
Fix debug assert failed on Windows

### DIFF
--- a/src/compiler/python_generator_helpers.h
+++ b/src/compiler/python_generator_helpers.h
@@ -142,7 +142,14 @@ inline void Split(const grpc::string& s, char delim,
   while (current <= s.end()) {
     auto next = std::find(current, s.end(), delim);
     append_to->emplace_back(current, next);
+#if _ITERATOR_DEBUG_LEVEL >= 1
+    if (next == s.end()) {
+      break;
+    }
     current = next + 1;
+#else
+    current = next + 1;
+#endif
   }
 }
 


### PR DESCRIPTION
On Windows, there is a debug assert in xstring cause debug version of gprc_python_plugin failed.
It is because of when `next == s.end()`. the `current = next + 1` will make the debug assert failed.
![error](https://user-images.githubusercontent.com/17511625/77883331-1ebed700-728d-11ea-8e77-8c5f7e7dcfb2.png)

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
