### PR TITLE
Use a more compressable client message in compression example

### DIFF
--- a/examples/cpp/compression/greeter_client.cc
+++ b/examples/cpp/compression/greeter_client.cc
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
   args.SetCompressionAlgorithm(GRPC_COMPRESS_GZIP);
   GreeterClient greeter(grpc::CreateCustomChannel(
       "localhost:50051", grpc::InsecureChannelCredentials(), args));
-  std::string user("world");
+  std::string user("world world world world");
   std::string reply = greeter.SayHello(user);
   std::cout << "Greeter received: " << reply << std::endl;
 


### PR DESCRIPTION
The message `world` is deflated from 7 bytes to 15 bytes. As a result the message is sent out raw without compression. To make this example a real compression example, changing the message to `world world world world`. This affects both client and server sides (because server echos `Hello world world world world`).

Fixes #22494