### PR TITLE
Include the request object in c-ares address sorting trace logs

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -84,25 +84,32 @@ typedef struct grpc_ares_hostbyname_request {
   bool is_balancer;
 } grpc_ares_hostbyname_request;
 
-static void log_address_sorting_list(const ServerAddressList& addresses,
+static void log_address_sorting_list(const grpc_ares_request* r,
+                                     const ServerAddressList& addresses,
                                      const char* input_output_str) {
   for (size_t i = 0; i < addresses.size(); i++) {
     char* addr_str;
     if (grpc_sockaddr_to_string(&addr_str, &addresses[i].address(), true)) {
-      gpr_log(GPR_INFO, "c-ares address sorting: %s[%" PRIuPTR "]=%s",
-              input_output_str, i, addr_str);
+      gpr_log(
+          GPR_INFO,
+          "(c-ares resolver) request:%p c-ares address sorting: %s[%" PRIuPTR
+          "]=%s",
+          r, input_output_str, i, addr_str);
       gpr_free(addr_str);
     } else {
-      gpr_log(GPR_INFO,
-              "c-ares address sorting: %s[%" PRIuPTR "]=<unprintable>",
-              input_output_str, i);
+      gpr_log(
+          GPR_INFO,
+          "(c-ares resolver) request:%p c-ares address sorting: %s[%" PRIuPTR
+          "]=<unprintable>",
+          r, input_output_str, i);
     }
   }
 }
 
-void grpc_cares_wrapper_address_sorting_sort(ServerAddressList* addresses) {
+void grpc_cares_wrapper_address_sorting_sort(const grpc_ares_request* r,
+                                             ServerAddressList* addresses) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_cares_address_sorting)) {
-    log_address_sorting_list(*addresses, "input");
+    log_address_sorting_list(r, *addresses, "input");
   }
   address_sorting_sortable* sortables = (address_sorting_sortable*)gpr_zalloc(
       sizeof(address_sorting_sortable) * addresses->size());
@@ -121,7 +128,7 @@ void grpc_cares_wrapper_address_sorting_sort(ServerAddressList* addresses) {
   gpr_free(sortables);
   *addresses = std::move(sorted);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_cares_address_sorting)) {
-    log_address_sorting_list(*addresses, "output");
+    log_address_sorting_list(r, *addresses, "output");
   }
 }
 
@@ -142,7 +149,7 @@ void grpc_ares_complete_request_locked(grpc_ares_request* r) {
   r->ev_driver = nullptr;
   ServerAddressList* addresses = r->addresses_out->get();
   if (addresses != nullptr) {
-    grpc_cares_wrapper_address_sorting_sort(addresses);
+    grpc_cares_wrapper_address_sorting_sort(r, addresses);
     GRPC_ERROR_UNREF(r->error);
     r->error = GRPC_ERROR_NONE;
     // TODO(apolcyn): allow c-ares to return a service config
@@ -520,7 +527,7 @@ static bool target_matches_localhost(const char* name) {
 
 #ifdef GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY
 static bool inner_maybe_resolve_localhost_manually_locked(
-    const char* name, const char* default_port,
+    const grpc_ares_request* r, const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs,
     grpc_core::UniquePtr<char>* host, grpc_core::UniquePtr<char>* port) {
   grpc_core::SplitHostPort(name, host, port);
@@ -563,23 +570,24 @@ static bool inner_maybe_resolve_localhost_manually_locked(
     (*addrs)->emplace_back(&ipv4_loopback_addr, sizeof(ipv4_loopback_addr),
                            nullptr /* args */);
     // Let the address sorter figure out which one should be tried first.
-    grpc_cares_wrapper_address_sorting_sort(addrs->get());
+    grpc_cares_wrapper_address_sorting_sort(r, addrs->get());
     return true;
   }
   return false;
 }
 
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
-    const char* name, const char* default_port,
+    const grpc_ares_request* r, const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs) {
   grpc_core::UniquePtr<char> host;
   grpc_core::UniquePtr<char> port;
-  return inner_maybe_resolve_localhost_manually_locked(name, default_port,
+  return inner_maybe_resolve_localhost_manually_locked(r, name, default_port,
                                                        addrs, &host, &port);
 }
 #else  /* GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY */
 static bool grpc_ares_maybe_resolve_localhost_manually_locked(
-    const char* /*name*/, const char* /*default_port*/,
+    const grpc_ares_request* r, const char* /*name*/,
+    const char* /*default_port*/,
     std::unique_ptr<grpc_core::ServerAddressList>* /*addrs*/) {
   return false;
 }
@@ -609,7 +617,7 @@ static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
     return r;
   }
   // Early out if the target is localhost and we're on Windows.
-  if (grpc_ares_maybe_resolve_localhost_manually_locked(name, default_port,
+  if (grpc_ares_maybe_resolve_localhost_manually_locked(r, name, default_port,
                                                         addrs)) {
     grpc_ares_complete_request_locked(r);
     return r;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -89,7 +89,7 @@ bool grpc_ares_query_ipv6();
 
 /* Sorts destinations in lb_addrs according to RFC 6724. */
 void grpc_cares_wrapper_address_sorting_sort(
-    grpc_core::ServerAddressList* addresses);
+    const grpc_ares_request* request, grpc_core::ServerAddressList* addresses);
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_RESOLVER_DNS_C_ARES_GRPC_ARES_WRAPPER_H \
         */

--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -55,7 +55,7 @@ if cur_resolver and cur_resolver != 'ares':
       'needs to use GRPC_DNS_RESOLVER=ares.'))
   test_runner_log('Exit 1 without running tests.')
   sys.exit(1)
-os.environ.update({'GRPC_TRACE': 'cares_resolver'})
+os.environ.update({'GRPC_TRACE': 'cares_resolver,cares_address_sorting'})
 
 def wait_until_dns_server_is_up(args,
                                 dns_server_subprocess,

--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -212,7 +212,7 @@ TEST_F(AddressSortingTest, TestDepriotizesUnreachableAddresses) {
       {"1.2.3.4:443", AF_INET},
       {"5.6.7.8:443", AF_INET},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "1.2.3.4:443",
                                     "5.6.7.8:443",
@@ -231,7 +231,7 @@ TEST_F(AddressSortingTest, TestDepriotizesUnsupportedDomainIpv6) {
       {"[2607:f8b0:400a:801::1002]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "1.2.3.4:443",
                                     "[2607:f8b0:400a:801::1002]:443",
@@ -251,7 +251,7 @@ TEST_F(AddressSortingTest, TestDepriotizesUnsupportedDomainIpv4) {
       {"[2607:f8b0:400a:801::1002]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2607:f8b0:400a:801::1002]:443",
                                     "1.2.3.4:443",
@@ -275,7 +275,7 @@ TEST_F(AddressSortingTest, TestDepriotizesNonMatchingScope) {
       {"[2000:f8b0:400a:801::1002]:443", AF_INET6},
       {"[fec0::5000]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[fec0::5000]:443",
                                     "[2000:f8b0:400a:801::1002]:443",
@@ -298,7 +298,7 @@ TEST_F(AddressSortingTest, TestUsesLabelFromDefaultTable) {
       {"[2002::5001]:443", AF_INET6},
       {"[2001::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2001::5001]:443",
                                     "[2002::5001]:443",
@@ -321,7 +321,7 @@ TEST_F(AddressSortingTest, TestUsesLabelFromDefaultTableInputFlipped) {
       {"[2001::5001]:443", AF_INET6},
       {"[2002::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2001::5001]:443",
                                     "[2002::5001]:443",
@@ -344,7 +344,7 @@ TEST_F(AddressSortingTest,
       {"[3ffe::5001]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(
       lb_addrs, {
                     // The AF_INET address should be IPv4-mapped by the sort,
@@ -377,7 +377,7 @@ TEST_F(AddressSortingTest,
       {v4_compat_dest, AF_INET6},
       {"[::1]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::1]:443",
                                     v4_compat_dest,
@@ -400,7 +400,7 @@ TEST_F(AddressSortingTest,
       {"[1234::2]:443", AF_INET6},
       {"[::1]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(
       lb_addrs,
       {
@@ -424,7 +424,7 @@ TEST_F(AddressSortingTest,
       {"[2001::1234]:443", AF_INET6},
       {"[2000::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(
       lb_addrs, {
                     // The 2000::/16 address should match the ::/0 prefix rule
@@ -448,7 +448,7 @@ TEST_F(
       {"[2001::1231]:443", AF_INET6},
       {"[2000::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2000::5001]:443",
                                     "[2001::1231]:443",
@@ -469,7 +469,7 @@ TEST_F(AddressSortingTest,
       {"[fec0::1234]:443", AF_INET6},
       {"[fc00::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[fc00::5001]:443",
                                     "[fec0::1234]:443",
@@ -494,7 +494,7 @@ TEST_F(
       {"[::ffff:1.1.1.2]:443", AF_INET6},
       {"[1234::2]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     // ::ffff:0:2 should match the v4-mapped
                                     // precedence entry and be deprioritized.
@@ -521,7 +521,7 @@ TEST_F(AddressSortingTest, TestPrefersSmallerScope) {
       {"[3ffe::5001]:443", AF_INET6},
       {"[fec0::1234]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[fec0::1234]:443",
                                     "[3ffe::5001]:443",
@@ -546,7 +546,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestMatchingSrcDstPrefix) {
       {"[3ffe:5001::]:443", AF_INET6},
       {"[3ffe:1234::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:1234::]:443",
                                     "[3ffe:5001::]:443",
@@ -567,7 +567,7 @@ TEST_F(AddressSortingTest,
       {"[3ffe::5001]:443", AF_INET6},
       {"[3ffe::1234]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1234]:443",
                                     "[3ffe::5001]:443",
@@ -587,7 +587,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestPrefixStressInnerBytePrefix) {
       {"[3ffe:8000::]:443", AF_INET6},
       {"[3ffe:2000::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:2000::]:443",
                                     "[3ffe:8000::]:443",
@@ -607,7 +607,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestPrefixDiffersOnHighestBitOfByte) {
       {"[3ffe:6::]:443", AF_INET6},
       {"[3ffe:c::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:c::]:443",
                                     "[3ffe:6::]:443",
@@ -629,7 +629,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestPrefixDiffersByLastBit) {
       {"[3ffe:1111:1111:1110::]:443", AF_INET6},
       {"[3ffe:1111:1111:1111::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:1111:1111:1111::]:443",
                                     "[3ffe:1111:1111:1110::]:443",
@@ -651,7 +651,7 @@ TEST_F(AddressSortingTest, TestStableSort) {
       {"[3ffe::1234]:443", AF_INET6},
       {"[3ffe::1235]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1234]:443",
                                     "[3ffe::1235]:443",
@@ -677,7 +677,7 @@ TEST_F(AddressSortingTest, TestStableSortFiveElements) {
       {"[3ffe::1234]:443", AF_INET6},
       {"[3ffe::1235]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1231]:443",
                                     "[3ffe::1232]:443",
@@ -698,7 +698,7 @@ TEST_F(AddressSortingTest, TestStableSortNoSrcAddrsExist) {
       {"[3ffe::1234]:443", AF_INET6},
       {"[3ffe::1235]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1231]:443",
                                     "[3ffe::1232]:443",
@@ -716,7 +716,7 @@ TEST_F(AddressSortingTest, TestStableSortNoSrcAddrsExistWithIpv4) {
       {"[::ffff:5.6.7.8]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::ffff:5.6.7.8]:443",
                                     "1.2.3.4:443",
@@ -744,7 +744,7 @@ TEST_F(AddressSortingTest, TestStableSortV4CompatAndSiteLocalAddresses) {
       {"[fec0::2000]:443", AF_INET6},
       {v4_compat_dest, AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs,
                       {
                           // The sort should be stable since
@@ -765,7 +765,7 @@ TEST_F(AddressSortingTest, TestPrefersIpv6Loopback) {
       {"[::1]:443", AF_INET6},
       {"127.0.0.1:443", AF_INET},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::1]:443",
                                     "127.0.0.1:443",
@@ -779,7 +779,7 @@ TEST_F(AddressSortingTest, TestPrefersIpv6LoopbackInputsFlipped) {
       {"127.0.0.1:443", AF_INET},
       {"[::1]:443", AF_INET6},
   });
-  grpc_cares_wrapper_address_sorting_sort(&lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(nullptr, &lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::1]:443",
                                     "127.0.0.1:443",

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -55,7 +55,7 @@ if cur_resolver and cur_resolver != 'ares':
       'needs to use GRPC_DNS_RESOLVER=ares.'))
   test_runner_log('Exit 1 without running tests.')
   sys.exit(1)
-os.environ.update({'GRPC_TRACE': 'cares_resolver'})
+os.environ.update({'GRPC_TRACE': 'cares_resolver,cares_address_sorting'})
 
 def wait_until_dns_server_is_up(args,
                                 dns_server_subprocess,


### PR DESCRIPTION
The request object is the key for all other c-ares trace logs, but is missing from these ones, which were added before the other c-ares trace logs were added.