### PR TITLE
Fix wrong version in gRPCConfigVersion.cmake and grpc++*.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15161,7 +15161,7 @@ include(CMakePackageConfigHelpers)
 configure_file(cmake/gRPCConfig.cmake.in
   gRPCConfig.cmake @ONLY)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/gRPCConfigVersion.cmake
-  VERSION ${PACKAGE_VERSION}
+  VERSION ${gRPC_CPP_VERSION}
   COMPATIBILITY AnyNewerVersion)
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/gRPCConfig.cmake
@@ -15228,7 +15228,7 @@ generate_pkgconfig(
 generate_pkgconfig(
   "gRPC++"
   "C++ wrapper for gRPC"
-  "${PACKAGE_VERSION}"
+  "${gRPC_CPP_VERSION}"
   "grpc"
   "-lgrpc++ -labsl_bad_optional_access -labsl_str_format_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_raw_logging_internal -labsl_log_severity -labsl_dynamic_annotations"
   ""
@@ -15238,7 +15238,7 @@ generate_pkgconfig(
 generate_pkgconfig(
   "gRPC++ unsecure"
   "C++ wrapper for gRPC without SSL"
-  "${PACKAGE_VERSION}"
+  "${gRPC_CPP_VERSION}"
   "grpc_unsecure"
   "-lgrpc++_unsecure -labsl_bad_optional_access -labsl_str_format_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_raw_logging_internal -labsl_log_severity -labsl_dynamic_annotations"
   ""

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -673,7 +673,7 @@
   configure_file(cmake/gRPCConfig.cmake.in
     gRPCConfig.cmake @ONLY)
   write_basic_package_version_file(<%text>${CMAKE_CURRENT_BINARY_DIR}/</%text>gRPCConfigVersion.cmake
-    VERSION <%text>${PACKAGE_VERSION}</%text>
+    VERSION <%text>${gRPC_CPP_VERSION}</%text>
     COMPATIBILITY AnyNewerVersion)
   install(FILES
       <%text>${CMAKE_CURRENT_BINARY_DIR}/</%text>gRPCConfig.cmake
@@ -740,7 +740,7 @@
   generate_pkgconfig(
     "gRPC++"
     "C++ wrapper for gRPC"
-    "<%text>${PACKAGE_VERSION}</%text>"
+    "<%text>${gRPC_CPP_VERSION}</%text>"
     "grpc"
     "${" ".join(("-l" + l) for l in ["grpc++",] + list_absl_lib_files_for("grpc++"))}"
     ""
@@ -750,7 +750,7 @@
   generate_pkgconfig(
     "gRPC++ unsecure"
     "C++ wrapper for gRPC without SSL"
-    "<%text>${PACKAGE_VERSION}</%text>"
+    "<%text>${gRPC_CPP_VERSION}</%text>"
     "grpc_unsecure"
     "${" ".join(("-l" + l) for l in ["grpc++_unsecure",] + list_absl_lib_files_for("grpc++_unsecure"))}"
     ""


### PR DESCRIPTION
They use PACKAGE_VERSION to generate version information but
PACKAGE_VERSION may be overridden by find_package(). For example,
-DgRPC_CARES_PROVIDER=package with c-ares 1.16.0 overrides
PACKAGE_VERSION to 1.16.0. Because c-ares-config-version.cmake has the
following line:

    set(PACKAGE_VERSION "1.16.0")

Setting PACKAGE_VERSION in version.cmake is a common CMake convention:

https://cmake.org/cmake/help/latest/command/find_package.html#version-selection

> PACKAGE_VERSION
>
>    full provided version string

So we should use gRPC_CPP_VERSION not PACKAGE_VERSION to generate
gRPCConfigVersion.cmake and grpc++*.pc.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
