### PR TITLE
Prevent client code from linking with incompatible gRPC library (ASAN / TSAN)

### DIFF
--- a/include/grpc/impl/codegen/sync_posix.h
+++ b/include/grpc/impl/codegen/sync_posix.h
@@ -32,6 +32,7 @@
  * This issue was reported at https://github.com/grpc/grpc/issues/17563
  * and discussed at https://github.com/grpc/grpc/pull/17586
  */
+#define GRPC_SYNC_POSIX_DEPENDS_ON_ASAN 1
 typedef struct {
   pthread_mutex_t mutex;
   int* leak_checker;
@@ -41,6 +42,7 @@ typedef struct {
   pthread_cond_t cond_var;
   int* leak_checker;
 } gpr_cv;
+
 #else
 typedef pthread_mutex_t gpr_mu;
 typedef pthread_cond_t gpr_cv;

--- a/include/grpcpp/create_channel.h
+++ b/include/grpcpp/create_channel.h
@@ -27,6 +27,8 @@ namespace grpc {
 static inline std::shared_ptr<::grpc::Channel> CreateChannel(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds) {
+  static const int client_code_compiler_options_check =
+      ::grpc_impl::PreventOneDefinitionRuleViolation();
   return ::grpc_impl::CreateChannelImpl(target, creds);
 }
 
@@ -34,6 +36,8 @@ static inline std::shared_ptr<::grpc::Channel> CreateCustomChannel(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
     const ChannelArguments& args) {
+  static const int client_code_compiler_options_check =
+      ::grpc_impl::PreventOneDefinitionRuleViolation();
   return ::grpc_impl::CreateCustomChannelImpl(target, creds, args);
 }
 
@@ -47,6 +51,8 @@ CreateCustomChannelWithInterceptors(
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators) {
+  static const int client_code_compiler_options_check =
+      ::grpc_impl::PreventOneDefinitionRuleViolation();
   return ::grpc_impl::experimental::CreateCustomChannelWithInterceptors(
       target, creds, args, std::move(interceptor_creators));
 }

--- a/src/core/lib/iomgr/call_combiner.h
+++ b/src/core/lib/iomgr/call_combiner.h
@@ -115,6 +115,7 @@ class CallCombiner {
   // or a grpc_error* (if the lowest bit is 1).
   gpr_atm cancel_state_ = 0;
 #ifdef GRPC_TSAN_ENABLED
+#define GRPC_CALL_COMBINER_DEPENDS_ON_TSAN 1
   // A fake ref-counted lock that is kept alive after the destruction of
   // grpc_call_combiner, when we are running the original closure.
   //

--- a/src/cpp/client/create_channel.cc
+++ b/src/cpp/client/create_channel.cc
@@ -27,6 +27,19 @@
 #include "src/cpp/client/create_channel_internal.h"
 
 namespace grpc_impl {
+    // list here the type definitions that are impacted by ASAN
+#ifdef GRPC_ASAN_ENABLED
+    int grpc_must_be_compiled_with_asan = GRPC_SYNC_POSIX_DEPENDS_ON_ASAN;
+#else
+    int grpc_must_be_compiled_without_asan;
+#endif
+    // list here the type definitions that are impacted by TSAN
+#ifdef GRPC_TSAN_ENABLED
+    int grpc_must_be_compiled_with_tsan = GRPC_CALL_COMBINER_DEPENDS_ON_TSAN;
+#else
+    int grpc_must_be_compiled_without_tsan;
+#endif
+
 std::shared_ptr<grpc::Channel> CreateChannelImpl(
     const grpc::string& target,
     const std::shared_ptr<grpc::ChannelCredentials>& creds) {


### PR DESCRIPTION
The PR is a proposal to address the issue #21838 that can cause unexpected run time errors that are hard to detect and understand.

## Principle

The idea is to take advantage of inlined `CreateChannel()` functions - which are mandatory calls for any grpc client code - to insert a check that makes the client code validate its compatibility with the gRPC library it is about to link with. If not, it will cause a linker error designed to help the user understand what's going wrong.

The runtime impact of those changes are almost null.

This PR also aims at creating an exhaustive list of the type definitions that are subject to change depending on the compiler options. This is done via dedicated macro constants that were added to help the maintainers know about the fact they must update this ODR violation check if they change those structure definitions.

## Example

Trying to link non ASAN client code with a gRPC library built with ASAN will create the following link error:

```
../grpc_services.a(grpc_client.cc.o): In function `grpc_impl::PreventOneDefinitionRuleViolation()':
/usr/local/grpc-asan/include/grpcpp/create_channel_impl.h:46: undefined reference to `grpc_impl::grpc_must_be_compiled_without_asan'
collect2: error: ld returned 1 exit status
```

What is more likely to happen is trying to link an ASAN client code with a gRPC library that is not ASAN, which will produce the following error with this PR:

```
../grpc_services.a(grpc_client.cc.o): In function `grpc_impl::PreventOneDefinitionRuleViolation()':
/usr/local/grpc-asan/include/grpcpp/create_channel_impl.h:43: undefined reference to `grpc_impl::grpc_must_be_compiled_with_asan'
/usr/local/grpc-asan/include/grpcpp/create_channel_impl.h:43: undefined reference to `grpc_impl::grpc_must_be_compiled_with_asan'
collect2: error: ld returned 1 exit status
```
## Alternative option

Another option would be to always build the types with the extra fields required to ASAN and TSAN. But I don't know the runtime impact of this approach.

@nicolasnoble
