### PR TITLE
Use image

### DIFF
--- a/tools/internal_ci/linux/grpc_python_bazel_test.cfg
+++ b/tools/internal_ci/linux/grpc_python_bazel_test.cfg
@@ -1,4 +1,4 @@
-# Copyright 2018 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,15 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_bazel.sh"
-timeout_mins: 240
+build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
+timeout_mins: 90
 env_vars {
   key: "BAZEL_SCRIPT"
-  value: "tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh"
+  value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
 }

--- a/tools/internal_ci/linux/grpc_python_bazel_test.cfg
+++ b/tools/internal_ci/linux/grpc_python_bazel_test.cfg
@@ -1,4 +1,4 @@
-# Copyright 2020 gRPC authors.
+# Copyright 2018 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +15,9 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
-timeout_mins: 90
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel.sh"
+timeout_mins: 240
 env_vars {
   key: "BAZEL_SCRIPT"
-  value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"
-}
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.*"
-    regex: "github/grpc/reports/**"
-  }
+  value: "tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh"
 }

--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -51,6 +51,8 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,cds_lb,xds_lb "$PYTHON" 
   tools/run_tests/run_xds_tests.py \
     --test_case=all \
     --project_id=grpc-testing \
+    --source_image=projects/grpc-testing/global/images/xds-test-server \
+    --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
     --client_cmd='bazel run //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client -- --server=xds-experimental:///{server_uri} --stats_port={stats_port} --qps={qps} --verbose'

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -51,6 +51,8 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,cds_lb,xds_lb "$PYTHON" 
   tools/run_tests/run_xds_tests.py \
     --test_case=all \
     --project_id=grpc-testing \
+    --source_image=projects/grpc-testing/global/images/xds-test-server \
+    --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
     --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds-experimental:///{server_uri} --stats_port={stats_port} --qps={qps}'


### PR DESCRIPTION
This adds a `--path_to_server_binary` arg that, if set, allows the test runner to use a server binary already built on the source image rather than recompiling a backend server from scratch. This should reduce the time to start a new VM before and during the tests from 6+ minutes to ~1 minute.

Please ignore the third commit that hijacks `grpc_python_bazel_test.cfg`. I tested this manually but want to verify that I got the command line right on Kokoro. Will revert this commit before merging.