### PR TITLE
[Aio] Support all sequential metadata

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -14,10 +14,10 @@
 """Invocation-side implementation of gRPC Asyncio Python."""
 
 import asyncio
-from functools import partial
-import logging
 import enum
-from typing import AsyncIterable, Awaitable, Optional
+import logging
+from functools import partial
+from typing import AsyncIterable, Awaitable, Optional, Tuple
 
 import grpc
 from grpc import _common
@@ -25,7 +25,8 @@ from grpc._cython import cygrpc
 
 from . import _base_call
 from ._typing import (DeserializingFunction, DoneCallbackType, MetadataType,
-                      RequestType, ResponseType, SerializingFunction)
+                      MetadatumType, RequestType, ResponseType,
+                      SerializingFunction)
 
 __all__ = 'AioRpcError', 'Call', 'UnaryUnaryCall', 'UnaryStreamCall'
 
@@ -161,7 +162,7 @@ class Call:
     _loop: asyncio.AbstractEventLoop
     _code: grpc.StatusCode
     _cython_call: cygrpc._AioCall
-    _metadata: MetadataType
+    _metadata: Tuple[MetadatumType]
     _request_serializer: SerializingFunction
     _response_deserializer: DeserializingFunction
 

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -105,7 +105,7 @@ class AioRpcError(grpc.RpcError):
         """
         return self._details
 
-    def initial_metadata(self) -> Optional[Dict]:
+    def initial_metadata(self) -> Optional[MetadataType]:
         """Accesses the initial metadata sent by the server.
 
         Returns:
@@ -113,7 +113,7 @@ class AioRpcError(grpc.RpcError):
         """
         return self._initial_metadata
 
-    def trailing_metadata(self) -> Optional[Dict]:
+    def trailing_metadata(self) -> Optional[MetadataType]:
         """Accesses the trailing metadata sent by the server.
 
         Returns:
@@ -171,7 +171,7 @@ class Call:
                  loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
         self._cython_call = cython_call
-        self._metadata = metadata
+        self._metadata = tuple(metadata)
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
 

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -17,7 +17,7 @@ import asyncio
 from functools import partial
 import logging
 import enum
-from typing import AsyncIterable, Awaitable, Dict, Optional
+from typing import AsyncIterable, Awaitable, Optional
 
 import grpc
 from grpc import _common

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -210,6 +210,20 @@ class TestMetadata(AioTestBase):
         self.assertEqual(_RESPONSE, await call)
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 
+    async def test_from_client_to_server_with_list(self):
+        multicallable = self._client.unary_unary(_TEST_CLIENT_TO_SERVER)
+        call = multicallable(
+            _REQUEST, metadata=list(_INITIAL_METADATA_FROM_CLIENT_TO_SERVER))
+        self.assertEqual(_RESPONSE, await call)
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_from_client_to_server_with_iterator(self):
+        multicallable = self._client.unary_unary(_TEST_CLIENT_TO_SERVER)
+        call = multicallable(
+            _REQUEST, metadata=iter(_INITIAL_METADATA_FROM_CLIENT_TO_SERVER))
+        self.assertEqual(_RESPONSE, await call)
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
     @unittest.skipIf(platform.system() == 'Windows',
                      'https://github.com/grpc/grpc/issues/21943')
     async def test_invalid_metadata(self):

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -216,8 +216,8 @@ class TestMetadata(AioTestBase):
         multicallable = self._client.unary_unary(_TEST_CLIENT_TO_SERVER)
         for exception_type, metadata in _INVALID_METADATA_TEST_CASES:
             with self.subTest(metadata=metadata):
-                call = multicallable(_REQUEST, metadata=metadata)
                 with self.assertRaises(exception_type):
+                    call = multicallable(_REQUEST, metadata=metadata)
                     await call
 
     async def test_generic_handler(self):

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -217,13 +217,6 @@ class TestMetadata(AioTestBase):
         self.assertEqual(_RESPONSE, await call)
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 
-    async def test_from_client_to_server_with_iterator(self):
-        multicallable = self._client.unary_unary(_TEST_CLIENT_TO_SERVER)
-        call = multicallable(
-            _REQUEST, metadata=iter(_INITIAL_METADATA_FROM_CLIENT_TO_SERVER))
-        self.assertEqual(_RESPONSE, await call)
-        self.assertEqual(grpc.StatusCode.OK, await call.code())
-
     @unittest.skipIf(platform.system() == 'Windows',
                      'https://github.com/grpc/grpc/issues/21943')
     async def test_invalid_metadata(self):


### PR DESCRIPTION
Interestingly, the Cloud client library are passing `list` as our metadata. Our definition in [doc](https://grpc.github.io/grpc/python/glossary.html#term-metadata) didn't rule out that possibility. Source code in `api-core`: https://github.com/googleapis/python-api-core/blob/master/google/api_core/gapic_v1/method.py#L133

This behavior has been wide-spread that we can't break it. So, this PR cast the metadata to `tuple`, in order to accept all `Sequence` type of metadatum.

This will block the GCP Python client from using AsyncIO.