### PR TITLE
Implicit conversion of size_t to int in proto_utils.h causes conversion warnings

### DIFF
--- a/include/grpcpp/impl/codegen/proto_utils.h
+++ b/include/grpcpp/impl/codegen/proto_utils.h
@@ -49,7 +49,7 @@ Status GenericSerialize(const grpc::protobuf::MessageLite& msg, ByteBuffer* bb,
                 "ProtoBufferWriter must be a subclass of "
                 "::protobuf::io::ZeroCopyOutputStream");
   *own_buffer = true;
-  int byte_size = msg.ByteSizeLong();
+  int byte_size = (int)msg.ByteSizeLong();
   if ((size_t)byte_size <= GRPC_SLICE_INLINED_SIZE) {
     Slice slice(byte_size);
     // We serialize directly into the allocated slices memory


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/21827 switched from using the deprecated `int MessageLite::ByteSize()` to `size_t MessageLite::ByteSizeLong()`, but the variable this call is assigned to was left as `int`. This causes conversion warnings (when these are enabled) and even build failures (with `-Werror`, [for example](https://ci.appveyor.com/project/BenjaminKietzman/arrow/build/job/9cl0vqa8e495knn3#L1126)) in projects which `#include` this header.

Added an explicit to `int`.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
