### PR TITLE
Add 3.5 to default interpreters to be tested.

### DIFF
--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -16,7 +16,11 @@
 
   <%include file="../../python_stretch.include"/>
   <%include file="../../compile_python_36.include"/>
-  
+  <%include file="../../compile_python_38.include"/>
+
+  RUN apt-get update && apt-get install -y python3.5 python3.5-dev
+  RUN curl https://bootstrap.pypa.io/get-pip.py | python3.5
+
   RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
   RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
 

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -84,6 +84,29 @@ RUN cd /tmp && \
 RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage
 
+#=================
+# Compile CPython 3.8.0b4 from source
+
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
+
+RUN cd /tmp && \
+    wget -q https://www.python.org/ftp/python/3.8.0/Python-3.8.0b4.tgz && \
+    tar xzvf Python-3.8.0b4.tgz && \
+    cd Python-3.8.0b4 && \
+    ./configure && \
+    make install
+
+RUN cd /tmp && \
+    echo "b8f4f897df967014ddb42033b90c3058 Python-3.8.0b4.tgz" > checksum.md5 && \
+    md5sum -c checksum.md5
+
+RUN python3.8 -m ensurepip && \
+    python3.8 -m pip install coverage
+
+
+RUN apt-get update && apt-get install -y python3.5 python3.5-dev
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.5
 
 RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -165,13 +165,13 @@ pip_install_dir() {
   cd "$PWD"
 }
 
-# On library/version/platforms combos that do not have a binary
+# On library/version/platforms combo that do not have a binary
 # published, we may end up building a dependency from source. In that
 # case, several of our build environment variables may disrupt the
 # third-party build process. This function pipes through only the
 # minimal environment necessary.
 pip_install() {
-  /usr/bin/env -i PATH="$PATH" $VENV_PYTHON -m pip install $@
+  /usr/bin/env -i PATH="$PATH" "$VENV_PYTHON" -m pip install $@
 }
 
 case "$VENV" in

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -171,7 +171,7 @@ pip_install_dir() {
 # third-party build process. This function pipes through only the
 # minimal environment necessary.
 pip_install() {
-  /usr/bin/env -i PATH="$PATH" "$VENV_PYTHON" -m pip install $@
+  /usr/bin/env -i PATH="$PATH" "$VENV_PYTHON" -m pip install "$@"
 }
 
 case "$VENV" in

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -224,8 +224,8 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 
 # Build/install tests
 pip_install coverage==4.4 oauth2client==4.1.0 \
-                            google-auth==1.0.0 requests==2.14.2 \
-                            googleapis-common-protos==1.5.5
+            google-auth==1.0.0 requests==2.14.2 \
+            googleapis-common-protos==1.5.5
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -165,24 +165,33 @@ pip_install_dir() {
   cd "$PWD"
 }
 
+# On library/version/platforms combos that do not have a binary
+# published, we may end up building a dependency from source. In that
+# case, several of our build environment variables may disrupt the
+# third-party build process. This function pipes through only the
+# minimal environment necessary.
+pip_install() {
+  /usr/bin/env -i PATH="$PATH" $VENV_PYTHON -m pip install $@
+}
+
 case "$VENV" in
   *py36_gevent*)
   # TODO(https://github.com/grpc/grpc/issues/15411) unpin this
-  $VENV_PYTHON -m pip install gevent==1.3.b1
+  pip_install gevent==1.3.b1
   ;;
   *gevent*)
-  $VENV_PYTHON -m pip install -U gevent
+  pip_install -U gevent
   ;;
 esac
 
-$VENV_PYTHON -m pip install --upgrade pip==19.3.1
-$VENV_PYTHON -m pip install --upgrade setuptools
-$VENV_PYTHON -m pip install --upgrade cython
-$VENV_PYTHON -m pip install --upgrade six enum34 protobuf
+pip_install --upgrade pip==19.3.1
+pip_install --upgrade setuptools
+pip_install --upgrade cython
+pip_install --upgrade six enum34 protobuf
 
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then
-  $VENV_PYTHON -m pip install futures
+  pip_install futures
 fi
 
 pip_install_dir "$ROOT"
@@ -214,7 +223,7 @@ pip_install_dir "$ROOT/src/python/grpcio_status"
 pip_install_dir "$ROOT/src/python/grpcio_testing"
 
 # Build/install tests
-$VENV_PYTHON -m pip install coverage==4.4 oauth2client==4.1.0 \
+pip_install coverage==4.4 oauth2client==4.1.0 \
                             google-auth==1.0.0 requests==2.14.2 \
                             googleapis-common-protos==1.5.5
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -866,7 +866,7 @@ class PythonLanguage(object):
             else:
                 if args.iomgr_platform == 'asyncio':
                     return (python36_config,)
-                else if os.uname()[0] == 'Darwin':
+                elif os.uname()[0] == 'Darwin':
                     # NOTE(rbellevi): Testing takes significantly longer on
                     # MacOS, so we restrict the number of interpreter versions
                     # tested.

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -869,6 +869,7 @@ class PythonLanguage(object):
                 else:
                     return (
                         python27_config,
+                        python35_config,
                         python36_config,
                         python37_config,
                     )

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -866,6 +866,15 @@ class PythonLanguage(object):
             else:
                 if args.iomgr_platform == 'asyncio':
                     return (python36_config,)
+                else if os.uname()[0] == 'Darwin':
+                    # NOTE(rbellevi): Testing takes significantly longer on
+                    # MacOS, so we restrict the number of interpreter versions
+                    # tested.
+                    return (
+                        python27_config,
+                        python36_config,
+                        python37_config,
+                    )
                 else:
                     return (
                         python27_config,


### PR DESCRIPTION
Also fixes the `all_the_cpythons` compiler argument.

Addresses https://github.com/grpc/grpc/issues/22548.

I had to make some changes to  `build_python.sh` due to failures observed in the Python 3.5 gevent MacOS build. Gevent has no MacOS binary published for 3.5 (though, oddly, it does for 3.4), so we build it from source. The build environment variables propagated through to the gevent build, causing it to crash. Instead, we now install third-party dependencies via pip with a clean environment.

Looks like this causes the Linux basictests job to increase from [27:22](https://source.cloud.google.com/results/invocations/fb31277e-0166-4f25-9480-92b263f288f4/targets) to [36:23](https://source.cloud.google.com/results/invocations/13b0ac87-689b-44b6-a3e9-5f536046370c/details). Seems reasonable to me. That's certainly not the longest job we have at the moment.