### PR TITLE
Add param to echo captured client output in logs

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -169,6 +169,12 @@ argp.add_argument('--verbose',
                   help='verbose log output',
                   default=False,
                   action='store_true')
+# TODO(ericgribkoff) Remove this param once the sponge-formatted log files are
+# visible in all test environments.
+argp.add_argument('--log_client_output',
+                  help='Log captured client output',
+                  default=False,
+                  action='store_true')
 args = argp.parse_args()
 
 if args.verbose:
@@ -1103,7 +1109,8 @@ try:
         log_dir = os.path.join(_TEST_LOG_BASE_DIR, test_case)
         if not os.path.exists(log_dir):
             os.makedirs(log_dir)
-        test_log_file = open(os.path.join(log_dir, _SPONGE_LOG_NAME), 'w+')
+        test_log_filename = os.path.join(log_dir, _SPONGE_LOG_NAME)
+        test_log_file = open(test_log_filename, 'w+')
         client_process = None
         try:
             client_process = subprocess.Popen(client_cmd,
@@ -1149,10 +1156,15 @@ try:
         finally:
             if client_process:
                 client_process.terminate()
+            test_log_file.close()
             # Workaround for Python 3, as report_utils will invoke decode() on
             # result.message, which has a default value of ''.
             result.message = result.message.encode('UTF-8')
             test_results[test_case] = [result]
+            if args.log_client_output:
+                logger.info('Client output:')
+                with open(test_log_filename, 'r') as client_output:
+                    logger.info(client_output.read())
     if not os.path.exists(_TEST_LOG_BASE_DIR):
         os.makedirs(_TEST_LOG_BASE_DIR)
     report_utils.render_junit_xml_report(test_results,


### PR DESCRIPTION
Our internal staging tests cannot (easily) pick up the nicely outputted files produced by `report_utils.render_junit_xml_report`. This is a temporary-ish workaround for that to allow us to at least see the client output in any staging failures.

Also considered an argument to just disable capturing the output from the `subprocess.Popen` call and including them inline in the script's output, but went with this approach as it seems helpful to still have the separation (albeit still in stdout, but at least not jumbled together) between `run_xds_test.py` logs and the client logs. If that seems preferable let me know and I'll switch to that approach.