### PR TITLE
[Aio] Add wait_for_connection API for streaming calls

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/_base_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_call.py
@@ -123,9 +123,9 @@ class Call(RpcContext, metaclass=ABCMeta):
 
         This is an EXPERIMENTAL method.
 
-        This method makes ensure if the RPC has been successfully connected.
-        Otherwise, an AioRpcError will be raised to explain the reason of the
-        connection failure.
+        This method ensures the RPC has been successfully connected. Otherwise,
+        an AioRpcError will be raised to explain the reason of the connection
+        failure.
 
         This method is recommended for building retry mechanisms.
         """

--- a/src/python/grpcio/grpc/experimental/aio/_base_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_call.py
@@ -164,13 +164,13 @@ class UnaryStreamCall(Generic[RequestType, ResponseType],
 
         This is an EXPERIMENTAL method.
 
-        This method is available for RPCs with streaming responses. This method
-        enables the application to ensure if the RPC has been successfully
-        connected. Otherwise, an AioRpcError will be raised to explain the
-        reason of the connection failure.
+        This method is available for streaming RPCs. This method enables the
+        application to ensure if the RPC has been successfully connected.
+        Otherwise, an AioRpcError will be raised to explain the reason of the
+        connection failure.
 
-        For RPCs with unary response, the connectivity issue will be raised
-        once the application awaits the call.
+        For unary-unary RPCs, the connectivity issue will be raised once the
+        application awaits the call.
 
         This method is recommended for building retry mechanisms.
         """
@@ -202,6 +202,23 @@ class StreamUnaryCall(Generic[RequestType, ResponseType],
 
         Returns:
           The response message of the stream.
+        """
+
+    @abstractmethod
+    async def try_connect(self) -> None:
+        """Tries to connect to peer and raise aio.AioRpcError if failed.
+
+        This is an EXPERIMENTAL method.
+
+        This method is available for streaming RPCs. This method enables the
+        application to ensure if the RPC has been successfully connected.
+        Otherwise, an AioRpcError will be raised to explain the reason of the
+        connection failure.
+
+        For unary-unary RPCs, the connectivity issue will be raised once the
+        application awaits the call.
+
+        This method is recommended for building retry mechanisms.
         """
 
 
@@ -253,13 +270,13 @@ class StreamStreamCall(Generic[RequestType, ResponseType],
 
         This is an EXPERIMENTAL method.
 
-        This method is available for RPCs with streaming responses. This method
-        enables the application to ensure if the RPC has been successfully
-        connected. Otherwise, an AioRpcError will be raised to explain the
-        reason of the connection failure.
+        This method is available for streaming RPCs. This method enables the
+        application to ensure if the RPC has been successfully connected.
+        Otherwise, an AioRpcError will be raised to explain the reason of the
+        connection failure.
 
-        For RPCs with unary response, the connectivity issue will be raised
-        once the application awaits the call.
+        For unary-unary RPCs, the connectivity issue will be raised once the
+        application awaits the call.
 
         This method is recommended for building retry mechanisms.
         """

--- a/src/python/grpcio/grpc/experimental/aio/_base_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_call.py
@@ -162,6 +162,8 @@ class UnaryStreamCall(Generic[RequestType, ResponseType],
     async def try_connect(self) -> None:
         """Tries to connect to peer and raise aio.AioRpcError if failed.
 
+        This is an EXPERIMENTAL method.
+
         This method is available for RPCs with streaming responses. This method
         enables the application to ensure if the RPC has been successfully
         connected. Otherwise, an AioRpcError will be raised to explain the
@@ -248,6 +250,8 @@ class StreamStreamCall(Generic[RequestType, ResponseType],
     @abstractmethod
     async def try_connect(self) -> None:
         """Tries to connect to peer and raise aio.AioRpcError if failed.
+
+        This is an EXPERIMENTAL method.
 
         This method is available for RPCs with streaming responses. This method
         enables the application to ensure if the RPC has been successfully

--- a/src/python/grpcio/grpc/experimental/aio/_base_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_call.py
@@ -117,6 +117,19 @@ class Call(RpcContext, metaclass=ABCMeta):
           The details string of the RPC.
         """
 
+    @abstractmethod
+    async def wait_for_connection(self) -> None:
+        """Waits until connected to peer and raises aio.AioRpcError if failed.
+
+        This is an EXPERIMENTAL method.
+
+        This method makes ensure if the RPC has been successfully connected.
+        Otherwise, an AioRpcError will be raised to explain the reason of the
+        connection failure.
+
+        This method is recommended for building retry mechanisms.
+        """
+
 
 class UnaryUnaryCall(Generic[RequestType, ResponseType],
                      Call,
@@ -158,23 +171,6 @@ class UnaryStreamCall(Generic[RequestType, ResponseType],
           stream.
         """
 
-    @abstractmethod
-    async def try_connect(self) -> None:
-        """Tries to connect to peer and raise aio.AioRpcError if failed.
-
-        This is an EXPERIMENTAL method.
-
-        This method is available for streaming RPCs. This method enables the
-        application to ensure if the RPC has been successfully connected.
-        Otherwise, an AioRpcError will be raised to explain the reason of the
-        connection failure.
-
-        For unary-unary RPCs, the connectivity issue will be raised once the
-        application awaits the call.
-
-        This method is recommended for building retry mechanisms.
-        """
-
 
 class StreamUnaryCall(Generic[RequestType, ResponseType],
                       Call,
@@ -202,23 +198,6 @@ class StreamUnaryCall(Generic[RequestType, ResponseType],
 
         Returns:
           The response message of the stream.
-        """
-
-    @abstractmethod
-    async def try_connect(self) -> None:
-        """Tries to connect to peer and raise aio.AioRpcError if failed.
-
-        This is an EXPERIMENTAL method.
-
-        This method is available for streaming RPCs. This method enables the
-        application to ensure if the RPC has been successfully connected.
-        Otherwise, an AioRpcError will be raised to explain the reason of the
-        connection failure.
-
-        For unary-unary RPCs, the connectivity issue will be raised once the
-        application awaits the call.
-
-        This method is recommended for building retry mechanisms.
         """
 
 
@@ -262,21 +241,4 @@ class StreamStreamCall(Generic[RequestType, ResponseType],
 
         After done_writing is called, any additional invocation to the write
         function will fail. This function is idempotent.
-        """
-
-    @abstractmethod
-    async def try_connect(self) -> None:
-        """Tries to connect to peer and raise aio.AioRpcError if failed.
-
-        This is an EXPERIMENTAL method.
-
-        This method is available for streaming RPCs. This method enables the
-        application to ensure if the RPC has been successfully connected.
-        Otherwise, an AioRpcError will be raised to explain the reason of the
-        connection failure.
-
-        For unary-unary RPCs, the connectivity issue will be raised once the
-        application awaits the call.
-
-        This method is recommended for building retry mechanisms.
         """

--- a/src/python/grpcio/grpc/experimental/aio/_base_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_call.py
@@ -158,6 +158,21 @@ class UnaryStreamCall(Generic[RequestType, ResponseType],
           stream.
         """
 
+    @abstractmethod
+    async def try_connect(self) -> None:
+        """Tries to connect to peer and raise aio.AioRpcError if failed.
+
+        This method is available for RPCs with streaming responses. This method
+        enables the application to ensure if the RPC has been successfully
+        connected. Otherwise, an AioRpcError will be raised to explain the
+        reason of the connection failure.
+
+        For RPCs with unary response, the connectivity issue will be raised
+        once the application awaits the call.
+
+        This method is recommended for building retry mechanisms.
+        """
+
 
 class StreamUnaryCall(Generic[RequestType, ResponseType],
                       Call,
@@ -228,4 +243,19 @@ class StreamStreamCall(Generic[RequestType, ResponseType],
 
         After done_writing is called, any additional invocation to the write
         function will fail. This function is idempotent.
+        """
+
+    @abstractmethod
+    async def try_connect(self) -> None:
+        """Tries to connect to peer and raise aio.AioRpcError if failed.
+
+        This method is available for RPCs with streaming responses. This method
+        enables the application to ensure if the RPC has been successfully
+        connected. Otherwise, an AioRpcError will be raised to explain the
+        reason of the connection failure.
+
+        For RPCs with unary response, the connectivity issue will be raised
+        once the application awaits the call.
+
+        This method is recommended for building retry mechanisms.
         """

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -572,13 +572,8 @@ class StreamUnaryCall(_StreamRequestMixin, _UnaryResponseMixin, Call,
             channel.call(method, deadline, credentials, wait_for_ready),
             metadata, request_serializer, response_deserializer, loop)
 
-<<<<<<< HEAD
         self._init_stream_request_mixin(request_iterator)
-        self._init_unary_response_mixin(self._conduct_rpc())
-=======
-        self._init_stream_request_mixin(request_async_iterator)
         self._init_unary_response_mixin(loop.create_task(self._conduct_rpc()))
->>>>>>> Rename to wait_for_conneciton && Add to unary-unary RPC
 
     async def _conduct_rpc(self) -> ResponseType:
         try:

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -458,6 +458,11 @@ class _StreamRequestMixin(Call):
         self._raise_for_different_style(_APIStyle.READER_WRITER)
         await self._done_writing()
 
+    async def try_connect(self) -> None:
+        await self._metadata_sent.wait()
+        if self.done():
+            await self._raise_for_status()
+
 
 class UnaryUnaryCall(_UnaryResponseMixin, Call, _base_call.UnaryUnaryCall):
     """Object for managing unary-unary RPC calls.
@@ -615,8 +620,3 @@ class StreamStreamCall(_StreamRequestMixin, _StreamResponseMixin, Call,
             if not self.cancelled():
                 self.cancel()
             # No need to raise RpcError here, because no one will `await` this task.
-
-    async def try_connect(self) -> None:
-        await self._metadata_sent.wait()
-        if self.done():
-            await self._raise_for_status()

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -18,7 +18,7 @@ import enum
 import inspect
 import logging
 from functools import partial
-from typing import AsyncIterable, Awaitable, Optional, Tuple
+from typing import AsyncIterable, Optional, Tuple
 
 import grpc
 from grpc import _common
@@ -250,9 +250,8 @@ class _APIStyle(enum.IntEnum):
 class _UnaryResponseMixin(Call):
     _call_response: asyncio.Task
 
-    def _init_unary_response_mixin(self,
-                                   response_coro: Awaitable[ResponseType]):
-        self._call_response = self._loop.create_task(response_coro)
+    def _init_unary_response_mixin(self, response_task: asyncio.Task):
+        self._call_response = response_task
 
     def cancel(self) -> bool:
         if super().cancel():
@@ -458,7 +457,7 @@ class _StreamRequestMixin(Call):
         self._raise_for_different_style(_APIStyle.READER_WRITER)
         await self._done_writing()
 
-    async def try_connect(self) -> None:
+    async def wait_for_connection(self) -> None:
         await self._metadata_sent.wait()
         if self.done():
             await self._raise_for_status()
@@ -470,6 +469,7 @@ class UnaryUnaryCall(_UnaryResponseMixin, Call, _base_call.UnaryUnaryCall):
     Returned when an instance of `UnaryUnaryMultiCallable` object is called.
     """
     _request: RequestType
+    _invocation_task: asyncio.Task
 
     # pylint: disable=too-many-arguments
     def __init__(self, request: RequestType, deadline: Optional[float],
@@ -483,7 +483,8 @@ class UnaryUnaryCall(_UnaryResponseMixin, Call, _base_call.UnaryUnaryCall):
             channel.call(method, deadline, credentials, wait_for_ready),
             metadata, request_serializer, response_deserializer, loop)
         self._request = request
-        self._init_unary_response_mixin(self._invoke())
+        self._invocation_task = loop.create_task(self._invoke())
+        self._init_unary_response_mixin(self._invocation_task)
 
     async def _invoke(self) -> ResponseType:
         serialized_request = _common.serialize(self._request,
@@ -504,6 +505,11 @@ class UnaryUnaryCall(_UnaryResponseMixin, Call, _base_call.UnaryUnaryCall):
                                        self._response_deserializer)
         else:
             return cygrpc.EOF
+
+    async def wait_for_connection(self) -> None:
+        await self._invocation_task
+        if self.done():
+            await self._raise_for_status()
 
 
 class UnaryStreamCall(_StreamResponseMixin, Call, _base_call.UnaryStreamCall):
@@ -541,7 +547,7 @@ class UnaryStreamCall(_StreamResponseMixin, Call, _base_call.UnaryStreamCall):
                 self.cancel()
             raise
 
-    async def try_connect(self) -> None:
+    async def wait_for_connection(self) -> None:
         await self._send_unary_request_task
         if self.done():
             await self._raise_for_status()
@@ -566,8 +572,13 @@ class StreamUnaryCall(_StreamRequestMixin, _UnaryResponseMixin, Call,
             channel.call(method, deadline, credentials, wait_for_ready),
             metadata, request_serializer, response_deserializer, loop)
 
+<<<<<<< HEAD
         self._init_stream_request_mixin(request_iterator)
         self._init_unary_response_mixin(self._conduct_rpc())
+=======
+        self._init_stream_request_mixin(request_async_iterator)
+        self._init_unary_response_mixin(loop.create_task(self._conduct_rpc()))
+>>>>>>> Rename to wait_for_conneciton && Add to unary-unary RPC
 
     async def _conduct_rpc(self) -> ResponseType:
         try:

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -536,6 +536,11 @@ class UnaryStreamCall(_StreamResponseMixin, Call, _base_call.UnaryStreamCall):
                 self.cancel()
             raise
 
+    async def try_connect(self) -> None:
+        await self._send_unary_request_task
+        if self.done():
+            await self._raise_for_status()
+
 
 class StreamUnaryCall(_StreamRequestMixin, _UnaryResponseMixin, Call,
                       _base_call.StreamUnaryCall):
@@ -610,3 +615,8 @@ class StreamStreamCall(_StreamRequestMixin, _StreamResponseMixin, Call,
             if not self.cancelled():
                 self.cancel()
             # No need to raise RpcError here, because no one will `await` this task.
+
+    async def try_connect(self) -> None:
+        await self._metadata_sent.wait()
+        if self.done():
+            await self._raise_for_status()

--- a/src/python/grpcio/grpc/experimental/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/experimental/aio/_interceptor.py
@@ -330,6 +330,10 @@ class InterceptedUnaryUnaryCall(_base_call.UnaryUnaryCall):
         response = yield from call.__await__()
         return response
 
+    async def wait_for_connection(self) -> None:
+        call = await self._interceptors_task
+        return await call.wait_for_connection()
+
 
 class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
     """Final UnaryUnaryCall class finished with a response."""
@@ -374,3 +378,6 @@ class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
             # for telling the interpreter that __await__ is a generator.
             yield None
         return self._response
+
+    async def wait_for_connection(self) -> None:
+        pass

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -28,5 +28,6 @@
   "unit.server_interceptor_test.TestServerInterceptor",
   "unit.server_test.TestServer",
   "unit.timeout_test.TestTimeout",
+  "unit.try_connect_test.TestTryConnect",
   "unit.wait_for_ready_test.TestWaitForReady"
 ]

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -28,6 +28,6 @@
   "unit.server_interceptor_test.TestServerInterceptor",
   "unit.server_test.TestServer",
   "unit.timeout_test.TestTimeout",
-  "unit.try_connect_test.TestTryConnect",
+  "unit.wait_for_connection_test.TestWaitForConnection",
   "unit.wait_for_ready_test.TestWaitForReady"
 ]

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -24,6 +24,7 @@ from grpc.experimental import aio
 from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
 from tests_aio.unit._test_base import AioTestBase
 from tests_aio.unit._test_server import start_test_server
+from tests_aio.unit._constants import UNREACHABLE_TARGET
 
 _SHORT_TIMEOUT_S = datetime.timedelta(seconds=1).total_seconds()
 
@@ -32,7 +33,6 @@ _RESPONSE_PAYLOAD_SIZE = 42
 _REQUEST_PAYLOAD_SIZE = 7
 _LOCAL_CANCEL_DETAILS_EXPECTATION = 'Locally cancelled by application!'
 _RESPONSE_INTERVAL_US = int(_SHORT_TIMEOUT_S * 1000 * 1000)
-_UNREACHABLE_TARGET = '0.1:1111'
 _INFINITE_INTERVAL_US = 2**31 - 1
 
 
@@ -78,7 +78,7 @@ class TestUnaryUnaryCall(_MulticallableTestMixin, AioTestBase):
         self.assertIs(response, response_retry)
 
     async def test_call_rpc_error(self):
-        async with aio.insecure_channel(_UNREACHABLE_TARGET) as channel:
+        async with aio.insecure_channel(UNREACHABLE_TARGET) as channel:
             stub = test_pb2_grpc.TestServiceStub(channel)
 
             call = stub.UnaryCall(messages_pb2.SimpleRequest())
@@ -577,7 +577,7 @@ class TestStreamUnaryCall(_MulticallableTestMixin, AioTestBase):
         self.assertEqual(await call.code(), grpc.StatusCode.OK)
 
     async def test_call_rpc_error(self):
-        async with aio.insecure_channel(_UNREACHABLE_TARGET) as channel:
+        async with aio.insecure_channel(UNREACHABLE_TARGET) as channel:
             stub = test_pb2_grpc.TestServiceStub(channel)
 
             # The error should be raised automatically without any traffic.

--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -16,22 +16,22 @@
 import asyncio
 import logging
 import unittest
+import datetime
 
 import grpc
 from grpc.experimental import aio
 
 from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
-from tests.unit.framework.common import test_constants
 from tests_aio.unit._test_base import AioTestBase
-from tests.unit import resources
-
 from tests_aio.unit._test_server import start_test_server
+
+_SHORT_TIMEOUT_S = datetime.timedelta(seconds=1).total_seconds()
 
 _NUM_STREAM_RESPONSES = 5
 _RESPONSE_PAYLOAD_SIZE = 42
 _REQUEST_PAYLOAD_SIZE = 7
 _LOCAL_CANCEL_DETAILS_EXPECTATION = 'Locally cancelled by application!'
-_RESPONSE_INTERVAL_US = test_constants.SHORT_TIMEOUT * 1000 * 1000
+_RESPONSE_INTERVAL_US = int(_SHORT_TIMEOUT_S * 1000 * 1000)
 _UNREACHABLE_TARGET = '0.1:1111'
 _INFINITE_INTERVAL_US = 2**31 - 1
 
@@ -434,24 +434,24 @@ class TestUnaryStreamCall(_MulticallableTestMixin, AioTestBase):
                 interval_us=_RESPONSE_INTERVAL_US,
             ))
 
-        call = self._stub.StreamingOutputCall(
-            request, timeout=test_constants.SHORT_TIMEOUT * 2)
+        call = self._stub.StreamingOutputCall(request,
+                                              timeout=_SHORT_TIMEOUT_S * 2)
 
         response = await call.read()
         self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
 
         # Should be around the same as the timeout
         remained_time = call.time_remaining()
-        self.assertGreater(remained_time, test_constants.SHORT_TIMEOUT * 3 / 2)
-        self.assertLess(remained_time, test_constants.SHORT_TIMEOUT * 5 / 2)
+        self.assertGreater(remained_time, _SHORT_TIMEOUT_S * 3 / 2)
+        self.assertLess(remained_time, _SHORT_TIMEOUT_S * 5 / 2)
 
         response = await call.read()
         self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
 
         # Should be around the timeout minus a unit of wait time
         remained_time = call.time_remaining()
-        self.assertGreater(remained_time, test_constants.SHORT_TIMEOUT / 2)
-        self.assertLess(remained_time, test_constants.SHORT_TIMEOUT * 3 / 2)
+        self.assertGreater(remained_time, _SHORT_TIMEOUT_S / 2)
+        self.assertLess(remained_time, _SHORT_TIMEOUT_S * 3 / 2)
 
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 
@@ -538,14 +538,14 @@ class TestStreamUnaryCall(_MulticallableTestMixin, AioTestBase):
             with self.assertRaises(asyncio.CancelledError):
                 for _ in range(_NUM_STREAM_RESPONSES):
                     yield request
-                    await asyncio.sleep(test_constants.SHORT_TIMEOUT)
+                    await asyncio.sleep(_SHORT_TIMEOUT_S)
             request_iterator_received_the_exception.set()
 
         call = self._stub.StreamingInputCall(request_iterator())
 
         # Cancel the RPC after at least one response
         async def cancel_later():
-            await asyncio.sleep(test_constants.SHORT_TIMEOUT * 2)
+            await asyncio.sleep(_SHORT_TIMEOUT_S * 2)
             call.cancel()
 
         cancel_later_task = self.loop.create_task(cancel_later())
@@ -575,6 +575,33 @@ class TestStreamUnaryCall(_MulticallableTestMixin, AioTestBase):
                          response.aggregated_payload_size)
 
         self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_call_rpc_error(self):
+        async with aio.insecure_channel(_UNREACHABLE_TARGET) as channel:
+            stub = test_pb2_grpc.TestServiceStub(channel)
+
+            # The error should be raised automatically without any traffic.
+            call = stub.StreamingInputCall()
+            with self.assertRaises(aio.AioRpcError) as exception_context:
+                await call
+
+            self.assertEqual(grpc.StatusCode.UNAVAILABLE,
+                             exception_context.exception.code())
+
+            self.assertTrue(call.done())
+            self.assertEqual(grpc.StatusCode.UNAVAILABLE, await call.code())
+
+    async def test_timeout(self):
+        call = self._stub.StreamingInputCall(timeout=_SHORT_TIMEOUT_S)
+
+        # The error should be raised automatically without any traffic.
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call
+
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.DEADLINE_EXCEEDED, rpc_error.code())
+        self.assertTrue(call.done())
+        self.assertEqual(grpc.StatusCode.DEADLINE_EXCEEDED, await call.code())
 
 
 # Prepares the request that stream in a ping-pong manner.
@@ -733,14 +760,14 @@ class TestStreamStreamCall(_MulticallableTestMixin, AioTestBase):
             with self.assertRaises(asyncio.CancelledError):
                 for _ in range(_NUM_STREAM_RESPONSES):
                     yield request
-                    await asyncio.sleep(test_constants.SHORT_TIMEOUT)
+                    await asyncio.sleep(_SHORT_TIMEOUT_S)
             request_iterator_received_the_exception.set()
 
         call = self._stub.FullDuplexCall(request_iterator())
 
         # Cancel the RPC after at least one response
         async def cancel_later():
-            await asyncio.sleep(test_constants.SHORT_TIMEOUT * 2)
+            await asyncio.sleep(_SHORT_TIMEOUT_S * 2)
             call.cancel()
 
         cancel_later_task = self.loop.create_task(cancel_later())

--- a/src/python/grpcio_tests/tests_aio/unit/try_connect_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/try_connect_test.py
@@ -121,7 +121,7 @@ class TestTryConnect(AioTestBase):
         self.assertEqual(grpc.StatusCode.UNAVAILABLE, rpc_error.code())
 
     async def test_stream_unary_error(self):
-        call = self._dummy_channel.stream_unary(_TEST_METHOD)(_REQUEST)
+        call = self._dummy_channel.stream_unary(_TEST_METHOD)()
 
         with self.assertRaises(aio.AioRpcError) as exception_context:
             await call.try_connect()

--- a/src/python/grpcio_tests/tests_aio/unit/try_connect_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/try_connect_test.py
@@ -1,0 +1,114 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests behavior of the try connect API on client side."""
+
+import asyncio
+import logging
+import unittest
+import datetime
+from typing import Callable, Tuple
+
+import grpc
+from grpc.experimental import aio
+
+from tests_aio.unit._test_base import AioTestBase
+from tests_aio.unit._test_server import start_test_server
+from tests_aio.unit import _common
+from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+
+_REQUEST = b'\x01\x02\x03'
+_UNREACHABLE_TARGET = '0.1:1111'
+_TEST_METHOD = '/test/Test'
+
+_NUM_STREAM_RESPONSES = 5
+_REQUEST_PAYLOAD_SIZE = 7
+_RESPONSE_PAYLOAD_SIZE = 42
+
+
+class TestTryConnect(AioTestBase):
+    """Tests if try connect raises connectivity issue."""
+
+    async def setUp(self):
+        address, self._server = await start_test_server()
+        self._channel = aio.insecure_channel(address)
+        self._dummy_channel = aio.insecure_channel(_UNREACHABLE_TARGET)
+        self._stub = test_pb2_grpc.TestServiceStub(self._channel)
+
+    async def tearDown(self):
+        await self._dummy_channel.close()
+        await self._channel.close()
+        await self._server.stop(None)
+
+    async def test_unary_stream_ok(self):
+        request = messages_pb2.StreamingOutputCallRequest()
+        for _ in range(_NUM_STREAM_RESPONSES):
+            request.response_parameters.append(
+                messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        call = self._stub.StreamingOutputCall(request)
+
+        # No exception raised and no message swallowed.
+        await call.try_connect()
+
+        response_cnt = 0
+        async for response in call:
+            response_cnt += 1
+            self.assertIs(type(response),
+                          messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        self.assertEqual(_NUM_STREAM_RESPONSES, response_cnt)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+    async def test_stream_stream_ok(self):
+        call = self._stub.FullDuplexCall()
+
+        # No exception raised and no message swallowed.
+        await call.try_connect()
+
+        request = messages_pb2.StreamingOutputCallRequest()
+        request.response_parameters.append(
+            messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        for _ in range(_NUM_STREAM_RESPONSES):
+            await call.write(request)
+            response = await call.read()
+            self.assertIsInstance(response,
+                                  messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        await call.done_writing()
+
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+
+    async def test_unary_stream_error(self):
+        call = self._dummy_channel.unary_stream(_TEST_METHOD)(_REQUEST)
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call.try_connect()
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.UNAVAILABLE, rpc_error.code())
+
+    async def test_stream_stream_error(self):
+        call = self._dummy_channel.stream_stream(_TEST_METHOD)()
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call.try_connect()
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.UNAVAILABLE, rpc_error.code())
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
TL;DR: `try_connect` expose connectivity issue without traffic which is important for retry plugins. Unit tests are included.

---

Retry in gRPC Python is harder than expected, especially for streaming calls. If we are connecting to an unreachable target or having issue with credentials, the exception won't be raised until the application read or write another message, or checking the status code in round-robin manner.

There isn't a clean way to expose connectivity error early in higher abstractions. This PR adds a `try_connect` API:

```python
    @abstractmethod
    async def try_connect(self) -> None:
        """Tries to connect to peer and raise aio.AioRpcError if failed.

        This is an EXPERIMENTAL method.

        This method is available for RPCs with streaming responses. This method
        enables the application to ensure if the RPC has been successfully
        connected. Otherwise, an AioRpcError will be raised to explain the
        reason of the connection failure.

        For RPCs with unary response, the connectivity issue will be raised
        once the application awaits the call.

        This method is recommended for building retry mechanisms.
        """
```

I came around this issue from the [`_wrap_stream_errors`](https://github.com/googleapis/python-api-core/blob/0c2c556e149b0b6696b515f3cdbd10a698b4e30b/google/api_core/grpc_helpers.py#L131). This PR proposes a potentially cleaner semantic by using `try_connect`~~, then we can avoid re-[implementing the request iterator again](https://github.com/googleapis/python-api-core/commit/2b103b60ece16a1e1bc98cfda7ec375191a90f75).~~ It doesn't require the wrapping iterator to fetch the first response, which behaves correctly if the server won't send responses immediately.

CC @crwilcox Do you think this API works? If you got some time, please help me review this PR.

Since this will be an EXPERIMENTAL API, I can make it available in AsyncIO stack rather easily. But to make it in current stack, there are some paper work (gRFC) to do. So, I want to make sure it make sense first.