### PR TITLE
[Aio] Accepts normal iterable of request messages

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/_base_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_channel.py
@@ -14,12 +14,13 @@
 """Abstract base classes for Channel objects and Multicallable objects."""
 
 import abc
-from typing import Any, AsyncIterable, Optional
+from typing import Any, AsyncIterable, Iterable, Optional
 
 import grpc
 
 from . import _base_call
-from ._typing import DeserializingFunction, MetadataType, SerializingFunction
+from ._typing import (DeserializingFunction, MetadataType, RequestIterableType,
+                      SerializingFunction)
 
 _IMMUTABLE_EMPTY_TUPLE = tuple()
 
@@ -105,7 +106,7 @@ class StreamUnaryMultiCallable(abc.ABC):
 
     @abc.abstractmethod
     def __call__(self,
-                 request_async_iterator: Optional[AsyncIterable[Any]] = None,
+                 request_iterator: Optional[RequestIterableType] = None,
                  timeout: Optional[float] = None,
                  metadata: Optional[MetadataType] = _IMMUTABLE_EMPTY_TUPLE,
                  credentials: Optional[grpc.CallCredentials] = None,
@@ -115,7 +116,8 @@ class StreamUnaryMultiCallable(abc.ABC):
         """Asynchronously invokes the underlying RPC.
 
         Args:
-          request: The request value for the RPC.
+          request_iterator: An optional async iterable or iterable of request
+            messages for the RPC.
           timeout: An optional duration of time in seconds to allow
             for the RPC.
           metadata: Optional :term:`metadata` to be transmitted to the
@@ -142,7 +144,7 @@ class StreamStreamMultiCallable(abc.ABC):
 
     @abc.abstractmethod
     def __call__(self,
-                 request_async_iterator: Optional[AsyncIterable[Any]] = None,
+                 request_iterator: Optional[RequestIterableType] = None,
                  timeout: Optional[float] = None,
                  metadata: Optional[MetadataType] = _IMMUTABLE_EMPTY_TUPLE,
                  credentials: Optional[grpc.CallCredentials] = None,
@@ -152,7 +154,8 @@ class StreamStreamMultiCallable(abc.ABC):
         """Asynchronously invokes the underlying RPC.
 
         Args:
-          request: The request value for the RPC.
+          request_iterator: An optional async iterable or iterable of request
+            messages for the RPC.
           timeout: An optional duration of time in seconds to allow
             for the RPC.
           metadata: Optional :term:`metadata` to be transmitted to the

--- a/src/python/grpcio/grpc/experimental/aio/_base_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_base_channel.py
@@ -14,7 +14,7 @@
 """Abstract base classes for Channel objects and Multicallable objects."""
 
 import abc
-from typing import Any, AsyncIterable, Iterable, Optional
+from typing import Any, Optional
 
 import grpc
 

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -400,11 +400,11 @@ class _StreamRequestMixin(Call):
             if inspect.isasyncgen(request_iterator):
                 async for request in request_iterator:
                     await self._write(request)
-                await self._done_writing()
             else:
                 for request in request_iterator:
                     await self._write(request)
-                await self._done_writing()
+
+            await self._done_writing()
         except AioRpcError as rpc_error:
             # Rpc status should be exposed through other API. Exceptions raised
             # within this Task won't be retrieved by another coroutine. It's

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import enum
+import inspect
 import logging
 from functools import partial
 from typing import AsyncIterable, Awaitable, Optional, Tuple
@@ -25,8 +26,8 @@ from grpc._cython import cygrpc
 
 from . import _base_call
 from ._typing import (DeserializingFunction, DoneCallbackType, MetadataType,
-                      MetadatumType, RequestType, ResponseType,
-                      SerializingFunction)
+                      MetadatumType, RequestIterableType, RequestType,
+                      ResponseType, SerializingFunction)
 
 __all__ = 'AioRpcError', 'Call', 'UnaryUnaryCall', 'UnaryStreamCall'
 
@@ -363,14 +364,14 @@ class _StreamRequestMixin(Call):
     _request_style: _APIStyle
 
     def _init_stream_request_mixin(
-            self, request_async_iterator: Optional[AsyncIterable[RequestType]]):
+            self, request_iterator: Optional[RequestIterableType]):
         self._metadata_sent = asyncio.Event(loop=self._loop)
         self._done_writing_flag = False
 
         # If user passes in an async iterator, create a consumer Task.
-        if request_async_iterator is not None:
+        if request_iterator is not None:
             self._async_request_poller = self._loop.create_task(
-                self._consume_request_iterator(request_async_iterator))
+                self._consume_request_iterator(request_iterator))
             self._request_style = _APIStyle.ASYNC_GENERATOR
         else:
             self._async_request_poller = None
@@ -392,12 +393,18 @@ class _StreamRequestMixin(Call):
     def _metadata_sent_observer(self):
         self._metadata_sent.set()
 
-    async def _consume_request_iterator(
-            self, request_async_iterator: AsyncIterable[RequestType]) -> None:
+    async def _consume_request_iterator(self,
+                                        request_iterator: RequestIterableType
+                                       ) -> None:
         try:
-            async for request in request_async_iterator:
-                await self._write(request)
-            await self._done_writing()
+            if inspect.isasyncgen(request_iterator):
+                async for request in request_iterator:
+                    await self._write(request)
+                await self._done_writing()
+            else:
+                for request in request_iterator:
+                    await self._write(request)
+                await self._done_writing()
         except AioRpcError as rpc_error:
             # Rpc status should be exposed through other API. Exceptions raised
             # within this Task won't be retrieved by another coroutine. It's
@@ -538,8 +545,7 @@ class StreamUnaryCall(_StreamRequestMixin, _UnaryResponseMixin, Call,
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self,
-                 request_async_iterator: Optional[AsyncIterable[RequestType]],
+    def __init__(self, request_iterator: Optional[RequestIterableType],
                  deadline: Optional[float], metadata: MetadataType,
                  credentials: Optional[grpc.CallCredentials],
                  wait_for_ready: Optional[bool], channel: cygrpc.AioChannel,
@@ -550,7 +556,7 @@ class StreamUnaryCall(_StreamRequestMixin, _UnaryResponseMixin, Call,
             channel.call(method, deadline, credentials, wait_for_ready),
             metadata, request_serializer, response_deserializer, loop)
 
-        self._init_stream_request_mixin(request_async_iterator)
+        self._init_stream_request_mixin(request_iterator)
         self._init_unary_response_mixin(self._conduct_rpc())
 
     async def _conduct_rpc(self) -> ResponseType:
@@ -577,8 +583,7 @@ class StreamStreamCall(_StreamRequestMixin, _StreamResponseMixin, Call,
     _initializer: asyncio.Task
 
     # pylint: disable=too-many-arguments
-    def __init__(self,
-                 request_async_iterator: Optional[AsyncIterable[RequestType]],
+    def __init__(self, request_iterator: Optional[RequestIterableType],
                  deadline: Optional[float], metadata: MetadataType,
                  credentials: Optional[grpc.CallCredentials],
                  wait_for_ready: Optional[bool], channel: cygrpc.AioChannel,
@@ -589,7 +594,7 @@ class StreamStreamCall(_StreamRequestMixin, _StreamResponseMixin, Call,
             channel.call(method, deadline, credentials, wait_for_ready),
             metadata, request_serializer, response_deserializer, loop)
         self._initializer = self._loop.create_task(self._prepare_rpc())
-        self._init_stream_request_mixin(request_async_iterator)
+        self._init_stream_request_mixin(request_iterator)
         self._init_stream_response_mixin(self._initializer)
 
     async def _prepare_rpc(self):

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -15,7 +15,7 @@
 
 import asyncio
 import sys
-from typing import Any, AsyncIterable, Iterable, Optional, Sequence
+from typing import Any, Iterable, Optional, Sequence
 
 import grpc
 from grpc import _common, _compression, _grpcio_metadata

--- a/src/python/grpcio/grpc/experimental/aio/_channel.py
+++ b/src/python/grpcio/grpc/experimental/aio/_channel.py
@@ -27,7 +27,7 @@ from ._call import (StreamStreamCall, StreamUnaryCall, UnaryStreamCall,
 from ._interceptor import (InterceptedUnaryUnaryCall,
                            UnaryUnaryClientInterceptor)
 from ._typing import (ChannelArgumentType, DeserializingFunction, MetadataType,
-                      SerializingFunction)
+                      SerializingFunction, RequestIterableType)
 from ._utils import _timeout_to_deadline
 
 _IMMUTABLE_EMPTY_TUPLE = tuple()
@@ -146,7 +146,7 @@ class StreamUnaryMultiCallable(_BaseMultiCallable,
                                _base_channel.StreamUnaryMultiCallable):
 
     def __call__(self,
-                 request_async_iterator: Optional[AsyncIterable[Any]] = None,
+                 request_iterator: Optional[RequestIterableType] = None,
                  timeout: Optional[float] = None,
                  metadata: Optional[MetadataType] = _IMMUTABLE_EMPTY_TUPLE,
                  credentials: Optional[grpc.CallCredentials] = None,
@@ -158,7 +158,7 @@ class StreamUnaryMultiCallable(_BaseMultiCallable,
 
         deadline = _timeout_to_deadline(timeout)
 
-        call = StreamUnaryCall(request_async_iterator, deadline, metadata,
+        call = StreamUnaryCall(request_iterator, deadline, metadata,
                                credentials, wait_for_ready, self._channel,
                                self._method, self._request_serializer,
                                self._response_deserializer, self._loop)
@@ -170,7 +170,7 @@ class StreamStreamMultiCallable(_BaseMultiCallable,
                                 _base_channel.StreamStreamMultiCallable):
 
     def __call__(self,
-                 request_async_iterator: Optional[AsyncIterable[Any]] = None,
+                 request_iterator: Optional[RequestIterableType] = None,
                  timeout: Optional[float] = None,
                  metadata: Optional[MetadataType] = _IMMUTABLE_EMPTY_TUPLE,
                  credentials: Optional[grpc.CallCredentials] = None,
@@ -182,7 +182,7 @@ class StreamStreamMultiCallable(_BaseMultiCallable,
 
         deadline = _timeout_to_deadline(timeout)
 
-        call = StreamStreamCall(request_async_iterator, deadline, metadata,
+        call = StreamStreamCall(request_iterator, deadline, metadata,
                                 credentials, wait_for_ready, self._channel,
                                 self._method, self._request_serializer,
                                 self._response_deserializer, self._loop)

--- a/src/python/grpcio/grpc/experimental/aio/_typing.py
+++ b/src/python/grpcio/grpc/experimental/aio/_typing.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Common types for gRPC Async API"""
 
-from typing import Any, AnyStr, Callable, Sequence, Tuple, TypeVar
+from typing import (Any, AnyStr, AsyncIterable, Callable, Iterable, Sequence,
+                    Tuple, TypeVar, Union)
+
 from grpc._cython.cygrpc import EOF
 
 RequestType = TypeVar('RequestType')
@@ -25,3 +27,4 @@ MetadataType = Sequence[MetadatumType]
 ChannelArgumentType = Sequence[Tuple[str, Any]]
 EOFType = type(EOF)
 DoneCallbackType = Callable[[Any], None]
+RequestIterableType = Union[Iterable[Any], AsyncIterable[Any]]


### PR DESCRIPTION
To improve the usability of our library, this PR enables stream-unary and stream-stream RPCs to accept normal iterable of request messages, instead of only allowing async iterable. So, it is backward compatible.

We was in favor of using async generator and trying to publicize it. However, there are several issues with it:
1. Async generator doesn't have good API as `asyncio.Task`(no cancel(), done(), cancelled(), etc.);
2. There is no `aiter(...)` built-in function (I don't understand CPython team);
3. It requires extra effort of memory management otherwise the interpreter generates warning (see [code](https://github.com/grpc/grpc/pull/22484/files#diff-b53c077f7911f53dc8ce7656e16d35cdR413)).

Also, accepting iterables makes non-complex logic much easier (see [example](https://github.com/grpc/proposal/pull/155/files#diff-c1bf1c6c3c5e8b0ac99daee5ef83ba52R406)).