### PR TITLE
PHP: expose grpc_channel_credentials_copy() API from c-core

### DIFF
--- a/grpc.def
+++ b/grpc.def
@@ -49,6 +49,8 @@ EXPORTS
     grpc_insecure_channel_create
     grpc_lame_client_channel_create
     grpc_channel_destroy
+    grpc_channel_args_copy
+    grpc_channel_args_destroy
     grpc_call_cancel
     grpc_call_cancel_with_status
     grpc_call_ref
@@ -98,6 +100,7 @@ EXPORTS
     grpc_ssl_session_cache_destroy
     grpc_ssl_session_cache_create_channel_arg
     grpc_channel_credentials_release
+    grpc_channel_credentials_copy
     grpc_google_default_credentials_create
     grpc_set_ssl_roots_override_callback
     grpc_ssl_credentials_create

--- a/grpc.def
+++ b/grpc.def
@@ -49,8 +49,6 @@ EXPORTS
     grpc_insecure_channel_create
     grpc_lame_client_channel_create
     grpc_channel_destroy
-    grpc_channel_args_copy
-    grpc_channel_args_destroy
     grpc_call_cancel
     grpc_call_cancel_with_status
     grpc_call_ref

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -319,12 +319,6 @@ GRPCAPI grpc_channel* grpc_lame_client_channel_create(
 /** Close and destroy a grpc channel */
 GRPCAPI void grpc_channel_destroy(grpc_channel* channel);
 
-/** Copy the arguments in \a src into a new instance */
-GRPCAPI grpc_channel_args* grpc_channel_args_copy(const grpc_channel_args* src);
-
-/** Destroy arguments created by \a grpc_channel_args_copy */
-GRPCAPI void grpc_channel_args_destroy(grpc_channel_args* a);
-
 /** Error handling for grpc_call
    Most grpc_call functions return a grpc_error. If the error is not GRPC_OK
    then the operation failed due to some unsatisfied precondition.

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -319,6 +319,12 @@ GRPCAPI grpc_channel* grpc_lame_client_channel_create(
 /** Close and destroy a grpc channel */
 GRPCAPI void grpc_channel_destroy(grpc_channel* channel);
 
+/** Copy the arguments in \a src into a new instance */
+GRPCAPI grpc_channel_args* grpc_channel_args_copy(const grpc_channel_args* src);
+
+/** Destroy arguments created by \a grpc_channel_args_copy */
+GRPCAPI void grpc_channel_args_destroy(grpc_channel_args* a);
+
 /** Error handling for grpc_call
    Most grpc_call functions return a grpc_error. If the error is not GRPC_OK
    then the operation failed due to some unsatisfied precondition.

--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -130,6 +130,11 @@ typedef struct grpc_channel_credentials grpc_channel_credentials;
    The creator of the credentials object is responsible for its release. */
 GRPCAPI void grpc_channel_credentials_release(grpc_channel_credentials* creds);
 
+/** Copy a channel credentials object.
+ */
+GRPCAPI grpc_channel_credentials* grpc_channel_credentials_copy(
+    grpc_channel_credentials* creds);
+
 /** Creates default credentials to connect to a google gRPC service.
    WARNING: Do NOT use this credentials to connect to a non-google service as
    this could result in an oauth2 token leak. The security level of the

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -45,6 +45,14 @@ void grpc_channel_credentials_release(grpc_channel_credentials* creds) {
   if (creds) creds->Unref();
 }
 
+grpc_channel_credentials* grpc_channel_credentials_copy(
+    grpc_channel_credentials* creds) {
+  GRPC_API_TRACE("grpc_channel_credentials_copy(creds=%p)", 1, (creds));
+  grpc_core::ExecCtx exec_ctx;
+  if (creds) creds->Ref().release();
+  return creds;
+}
+
 void grpc_call_credentials_release(grpc_call_credentials* creds) {
   GRPC_API_TRACE("grpc_call_credentials_release(creds=%p)", 1, (creds));
   grpc_core::ExecCtx exec_ctx;

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.c
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.c
@@ -72,6 +72,8 @@ grpc_channel_reset_connect_backoff_type grpc_channel_reset_connect_backoff_impor
 grpc_insecure_channel_create_type grpc_insecure_channel_create_import;
 grpc_lame_client_channel_create_type grpc_lame_client_channel_create_import;
 grpc_channel_destroy_type grpc_channel_destroy_import;
+grpc_channel_args_copy_type grpc_channel_args_copy_import;
+grpc_channel_args_destroy_type grpc_channel_args_destroy_import;
 grpc_call_cancel_type grpc_call_cancel_import;
 grpc_call_cancel_with_status_type grpc_call_cancel_with_status_import;
 grpc_call_ref_type grpc_call_ref_import;
@@ -121,6 +123,7 @@ grpc_ssl_session_cache_create_lru_type grpc_ssl_session_cache_create_lru_import;
 grpc_ssl_session_cache_destroy_type grpc_ssl_session_cache_destroy_import;
 grpc_ssl_session_cache_create_channel_arg_type grpc_ssl_session_cache_create_channel_arg_import;
 grpc_channel_credentials_release_type grpc_channel_credentials_release_import;
+grpc_channel_credentials_copy_type grpc_channel_credentials_copy_import;
 grpc_google_default_credentials_create_type grpc_google_default_credentials_create_import;
 grpc_set_ssl_roots_override_callback_type grpc_set_ssl_roots_override_callback_import;
 grpc_ssl_credentials_create_type grpc_ssl_credentials_create_import;
@@ -344,6 +347,8 @@ void grpc_rb_load_imports(HMODULE library) {
   grpc_insecure_channel_create_import = (grpc_insecure_channel_create_type) GetProcAddress(library, "grpc_insecure_channel_create");
   grpc_lame_client_channel_create_import = (grpc_lame_client_channel_create_type) GetProcAddress(library, "grpc_lame_client_channel_create");
   grpc_channel_destroy_import = (grpc_channel_destroy_type) GetProcAddress(library, "grpc_channel_destroy");
+  grpc_channel_args_copy_import = (grpc_channel_args_copy_type) GetProcAddress(library, "grpc_channel_args_copy");
+  grpc_channel_args_destroy_import = (grpc_channel_args_destroy_type) GetProcAddress(library, "grpc_channel_args_destroy");
   grpc_call_cancel_import = (grpc_call_cancel_type) GetProcAddress(library, "grpc_call_cancel");
   grpc_call_cancel_with_status_import = (grpc_call_cancel_with_status_type) GetProcAddress(library, "grpc_call_cancel_with_status");
   grpc_call_ref_import = (grpc_call_ref_type) GetProcAddress(library, "grpc_call_ref");
@@ -393,6 +398,7 @@ void grpc_rb_load_imports(HMODULE library) {
   grpc_ssl_session_cache_destroy_import = (grpc_ssl_session_cache_destroy_type) GetProcAddress(library, "grpc_ssl_session_cache_destroy");
   grpc_ssl_session_cache_create_channel_arg_import = (grpc_ssl_session_cache_create_channel_arg_type) GetProcAddress(library, "grpc_ssl_session_cache_create_channel_arg");
   grpc_channel_credentials_release_import = (grpc_channel_credentials_release_type) GetProcAddress(library, "grpc_channel_credentials_release");
+  grpc_channel_credentials_copy_import = (grpc_channel_credentials_copy_type) GetProcAddress(library, "grpc_channel_credentials_copy");
   grpc_google_default_credentials_create_import = (grpc_google_default_credentials_create_type) GetProcAddress(library, "grpc_google_default_credentials_create");
   grpc_set_ssl_roots_override_callback_import = (grpc_set_ssl_roots_override_callback_type) GetProcAddress(library, "grpc_set_ssl_roots_override_callback");
   grpc_ssl_credentials_create_import = (grpc_ssl_credentials_create_type) GetProcAddress(library, "grpc_ssl_credentials_create");

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.c
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.c
@@ -72,8 +72,6 @@ grpc_channel_reset_connect_backoff_type grpc_channel_reset_connect_backoff_impor
 grpc_insecure_channel_create_type grpc_insecure_channel_create_import;
 grpc_lame_client_channel_create_type grpc_lame_client_channel_create_import;
 grpc_channel_destroy_type grpc_channel_destroy_import;
-grpc_channel_args_copy_type grpc_channel_args_copy_import;
-grpc_channel_args_destroy_type grpc_channel_args_destroy_import;
 grpc_call_cancel_type grpc_call_cancel_import;
 grpc_call_cancel_with_status_type grpc_call_cancel_with_status_import;
 grpc_call_ref_type grpc_call_ref_import;
@@ -347,8 +345,6 @@ void grpc_rb_load_imports(HMODULE library) {
   grpc_insecure_channel_create_import = (grpc_insecure_channel_create_type) GetProcAddress(library, "grpc_insecure_channel_create");
   grpc_lame_client_channel_create_import = (grpc_lame_client_channel_create_type) GetProcAddress(library, "grpc_lame_client_channel_create");
   grpc_channel_destroy_import = (grpc_channel_destroy_type) GetProcAddress(library, "grpc_channel_destroy");
-  grpc_channel_args_copy_import = (grpc_channel_args_copy_type) GetProcAddress(library, "grpc_channel_args_copy");
-  grpc_channel_args_destroy_import = (grpc_channel_args_destroy_type) GetProcAddress(library, "grpc_channel_args_destroy");
   grpc_call_cancel_import = (grpc_call_cancel_type) GetProcAddress(library, "grpc_call_cancel");
   grpc_call_cancel_with_status_import = (grpc_call_cancel_with_status_type) GetProcAddress(library, "grpc_call_cancel_with_status");
   grpc_call_ref_import = (grpc_call_ref_type) GetProcAddress(library, "grpc_call_ref");

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -191,12 +191,6 @@ extern grpc_lame_client_channel_create_type grpc_lame_client_channel_create_impo
 typedef void(*grpc_channel_destroy_type)(grpc_channel* channel);
 extern grpc_channel_destroy_type grpc_channel_destroy_import;
 #define grpc_channel_destroy grpc_channel_destroy_import
-typedef grpc_channel_args*(*grpc_channel_args_copy_type)(const grpc_channel_args* src);
-extern grpc_channel_args_copy_type grpc_channel_args_copy_import;
-#define grpc_channel_args_copy grpc_channel_args_copy_import
-typedef void(*grpc_channel_args_destroy_type)(grpc_channel_args* a);
-extern grpc_channel_args_destroy_type grpc_channel_args_destroy_import;
-#define grpc_channel_args_destroy grpc_channel_args_destroy_import
 typedef grpc_call_error(*grpc_call_cancel_type)(grpc_call* call, void* reserved);
 extern grpc_call_cancel_type grpc_call_cancel_import;
 #define grpc_call_cancel grpc_call_cancel_import

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -191,6 +191,12 @@ extern grpc_lame_client_channel_create_type grpc_lame_client_channel_create_impo
 typedef void(*grpc_channel_destroy_type)(grpc_channel* channel);
 extern grpc_channel_destroy_type grpc_channel_destroy_import;
 #define grpc_channel_destroy grpc_channel_destroy_import
+typedef grpc_channel_args*(*grpc_channel_args_copy_type)(const grpc_channel_args* src);
+extern grpc_channel_args_copy_type grpc_channel_args_copy_import;
+#define grpc_channel_args_copy grpc_channel_args_copy_import
+typedef void(*grpc_channel_args_destroy_type)(grpc_channel_args* a);
+extern grpc_channel_args_destroy_type grpc_channel_args_destroy_import;
+#define grpc_channel_args_destroy grpc_channel_args_destroy_import
 typedef grpc_call_error(*grpc_call_cancel_type)(grpc_call* call, void* reserved);
 extern grpc_call_cancel_type grpc_call_cancel_import;
 #define grpc_call_cancel grpc_call_cancel_import
@@ -338,6 +344,9 @@ extern grpc_ssl_session_cache_create_channel_arg_type grpc_ssl_session_cache_cre
 typedef void(*grpc_channel_credentials_release_type)(grpc_channel_credentials* creds);
 extern grpc_channel_credentials_release_type grpc_channel_credentials_release_import;
 #define grpc_channel_credentials_release grpc_channel_credentials_release_import
+typedef grpc_channel_credentials*(*grpc_channel_credentials_copy_type)(grpc_channel_credentials* creds);
+extern grpc_channel_credentials_copy_type grpc_channel_credentials_copy_import;
+#define grpc_channel_credentials_copy grpc_channel_credentials_copy_import
 typedef grpc_channel_credentials*(*grpc_google_default_credentials_create_type)(void);
 extern grpc_google_default_credentials_create_type grpc_google_default_credentials_create_import;
 #define grpc_google_default_credentials_create grpc_google_default_credentials_create_import

--- a/test/core/surface/public_headers_must_be_c89.c
+++ b/test/core/surface/public_headers_must_be_c89.c
@@ -118,6 +118,8 @@ int main(int argc, char **argv) {
   printf("%lx", (unsigned long) grpc_insecure_channel_create);
   printf("%lx", (unsigned long) grpc_lame_client_channel_create);
   printf("%lx", (unsigned long) grpc_channel_destroy);
+  printf("%lx", (unsigned long) grpc_channel_args_copy);
+  printf("%lx", (unsigned long) grpc_channel_args_destroy);
   printf("%lx", (unsigned long) grpc_call_cancel);
   printf("%lx", (unsigned long) grpc_call_cancel_with_status);
   printf("%lx", (unsigned long) grpc_call_ref);
@@ -165,6 +167,7 @@ int main(int argc, char **argv) {
   printf("%lx", (unsigned long) grpc_ssl_session_cache_destroy);
   printf("%lx", (unsigned long) grpc_ssl_session_cache_create_channel_arg);
   printf("%lx", (unsigned long) grpc_channel_credentials_release);
+  printf("%lx", (unsigned long) grpc_channel_credentials_copy);
   printf("%lx", (unsigned long) grpc_google_default_credentials_create);
   printf("%lx", (unsigned long) grpc_set_ssl_roots_override_callback);
   printf("%lx", (unsigned long) grpc_ssl_credentials_create);

--- a/test/core/surface/public_headers_must_be_c89.c
+++ b/test/core/surface/public_headers_must_be_c89.c
@@ -118,8 +118,6 @@ int main(int argc, char **argv) {
   printf("%lx", (unsigned long) grpc_insecure_channel_create);
   printf("%lx", (unsigned long) grpc_lame_client_channel_create);
   printf("%lx", (unsigned long) grpc_channel_destroy);
-  printf("%lx", (unsigned long) grpc_channel_args_copy);
-  printf("%lx", (unsigned long) grpc_channel_args_destroy);
   printf("%lx", (unsigned long) grpc_call_cancel);
   printf("%lx", (unsigned long) grpc_call_cancel_with_status);
   printf("%lx", (unsigned long) grpc_call_ref);


### PR DESCRIPTION
add 2 APIs in c-core to support php needs(put channel args and creds in persistent list, to prevent crash when folk)
related to #21321 and #21832 



<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->
