### PR TITLE
Ruby docker for gRPC

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ require 'fileutils'
 
 require_relative 'build_config.rb'
 
+load 'tools/distrib/rake_compiler_docker_image.rb'
+
 # Add rubocop style checking tasks
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.options = ['-c', 'src/ruby/.rubocop.yml']
@@ -81,8 +83,6 @@ end
 
 desc 'Build the Windows gRPC DLLs for Ruby'
 task 'dlls' do
-  require 'rake_compiler_dock'
-
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   verbose = ENV['V'] || '0'
 
@@ -106,7 +106,7 @@ task 'dlls' do
     env_comp += "CXX=#{opt[:cross]}-g++ "
     env_comp += "LD=#{opt[:cross]}-gcc "
     env_comp += "LDXX=#{opt[:cross]}-g++ "
-    RakeCompilerDock.sh <<-EOT, platform: opt[:platform]
+    run_rake_compiler opt[:platform], <<-EOT
       gem update --system --no-document && \
       #{env} #{env_comp} make -j`nproc` #{out} && \
       #{opt[:cross]}-strip -x -S #{out} && \
@@ -132,14 +132,9 @@ task 'gem:native' do
     end
     system "rake cross native gem RUBY_CC_VERSION=2.7.0:2.6.0:2.5.0:2.4.0:2.3.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
-    require 'rake_compiler_dock'
-
     Rake::Task['dlls'].execute
     ['x86-mingw32', 'x64-mingw32', 'x86_64-linux', 'x86-linux'].each do |plat|
-      RakeCompilerDock.sh <<-EOT, platform: plat
-        # Avoid conflicting declarations of gettimeofday: https://github.com/rake-compiler/rake-compiler-dock/issues/32
-        find /usr/local/rake-compiler -name win32.h | while read f ; do sudo sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done && \
-
+      run_rake_compiler plat, <<-EOT
         gem update --system --no-document && \
         bundle && \
         rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem pkg/#{spec.full_name}.gem \

--- a/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
@@ -1,0 +1,3 @@
+FROM larskanis/rake-compiler-dock-mri-x64-mingw32:1.0.0
+
+RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done

--- a/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
@@ -1,0 +1,1 @@
+FROM larskanis/rake-compiler-dock-mri-x86-linux:1.0.0

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
@@ -1,0 +1,3 @@
+FROM larskanis/rake-compiler-dock-mri-x86-mingw32:1.0.0
+
+RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
@@ -1,0 +1,1 @@
+FROM larskanis/rake-compiler-dock-mri-x86_64-linux:1.0.0

--- a/tools/distrib/rake_compiler_docker_image.rb
+++ b/tools/distrib/rake_compiler_docker_image.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def grpc_root()
+  File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+end
+
+def docker_image_for_rake_compiler(platform)
+  require 'digest'
+
+  dockerfile = File.join(grpc_root, 'third_party', 'rake-compiler-dock', 'rake_' + platform, 'Dockerfile')
+  dockerpath = File.dirname(dockerfile)
+  version = Digest::SHA1.file(dockerfile).hexdigest
+  image_name = 'rake_' + platform + '_' + version
+  # if "DOCKERHUB_ORGANIZATION" env is set, we try to pull the pre-built
+  # rake-compiler-dock image from dockerhub rather then building from scratch.
+  if ENV.has_key?('DOCKERHUB_ORGANIZATION')
+    image_name = ENV['DOCKERHUB_ORGANIZATION'] + '/' + image_name
+    cmd = "docker pull #{image_name}"
+    puts cmd
+    system cmd
+    raise "Failed to pull the docker image." unless $? == 0
+  else
+    cmd = "docker build -t #{image_name} --file #{dockerfile} #{dockerpath}"
+    puts cmd
+    system cmd
+    raise "Failed to build the docker image." unless $? == 0
+  end
+  image_name
+end
+
+def run_rake_compiler(platform, args)
+  require 'rake_compiler_dock'
+
+  args = 'bash -l' if args.empty?
+
+  ENV['RCD_RUBYVM'] = 'mri'
+  ENV['RCD_PLATFORM'] = platform
+  ENV['RCD_IMAGE'] = docker_image_for_rake_compiler(platform)
+
+  RakeCompilerDock.sh args
+end
+
+if __FILE__ == $0
+  docker_for_windows 'x86_64-linux', $*.join(' ')
+end

--- a/tools/distrib/rake_compiler_docker_image.rb
+++ b/tools/distrib/rake_compiler_docker_image.rb
@@ -24,35 +24,14 @@ def docker_image_for_rake_compiler(platform)
   dockerpath = File.dirname(dockerfile)
   version = Digest::SHA1.file(dockerfile).hexdigest
   image_name = 'rake_' + platform + '_' + version
-  # if "DOCKERHUB_ORGANIZATION" env is set, we try to pull the pre-built
-  # rake-compiler-dock image from dockerhub rather then building from scratch.
-  if ENV.has_key?('DOCKERHUB_ORGANIZATION')
-    image_name = ENV['DOCKERHUB_ORGANIZATION'] + '/' + image_name
-    cmd = "docker pull #{image_name}"
-    puts cmd
-    system cmd
-    raise "Failed to pull the docker image." unless $? == 0
-  else
-    cmd = "docker build -t #{image_name} --file #{dockerfile} #{dockerpath}"
-    puts cmd
-    system cmd
-    raise "Failed to build the docker image." unless $? == 0
-  end
-  image_name
+  ENV.fetch('DOCKERHUB_ORGANIZATION', 'grpctesting') + '/' + image_name
 end
 
 def run_rake_compiler(platform, args)
   require 'rake_compiler_dock'
 
-  args = 'bash -l' if args.empty?
-
   ENV['RCD_RUBYVM'] = 'mri'
   ENV['RCD_PLATFORM'] = platform
   ENV['RCD_IMAGE'] = docker_image_for_rake_compiler(platform)
-
   RakeCompilerDock.sh args
-end
-
-if __FILE__ == $0
-  docker_for_windows 'x86_64-linux', $*.join(' ')
 end

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -29,7 +29,7 @@ cd -
 
 DOCKERHUB_ORGANIZATION=grpctesting
 
-for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* tools/dockerfile/distribtest/*
+for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* tools/dockerfile/distribtest/* third_party/rake-compiler-dock/*/
 do
   # Generate image name based on Dockerfile checksum. That works well as long
   # as can count on dockerfiles being written in a way that changing the logical 


### PR DESCRIPTION
Revived gRPC-specific docker images for Ruby to have a CentOS-based docker images later for better portability with advanced C++ features in future. These docker files were removed with #22039 to accommodate new breaking changes introduced with rake-compiler-dock [1.0](https://github.com/rake-compiler/rake-compiler-dock/releases/tag/1.0.0). This PR doesn't introduce anything except having dedicated gRPC Ruby docker images based on `rake-compiler-dock `.