### PR TITLE
Fix generating method output with nested resource

### DIFF
--- a/src/compiler/ruby_generator_string-inl.h
+++ b/src/compiler/ruby_generator_string-inl.h
@@ -119,14 +119,13 @@ inline grpc::string RubyPackage(const grpc::protobuf::FileDescriptor* file) {
 inline grpc::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor,
                                const grpc::string& package) {
   std::string proto_type = descriptor->full_name();
-  ReplacePrefix(&proto_type, package, "");  // remove the leading package if present
-  ReplacePrefix(&proto_type, ".", "");      // remove the leading . (no package)
-
+  ReplacePrefix(&proto_type, package,
+                "");                    // remove the leading package if present
+  ReplacePrefix(&proto_type, ".", "");  // remove the leading . (no package)
   if (descriptor->file()->options().has_ruby_package()) {
     proto_type = RubyPackage(descriptor->file()) + "." + proto_type;
   }
   grpc::string res(proto_type);
-
   if (res.find('.') == grpc::string::npos) {
     return res;
   } else {

--- a/src/compiler/ruby_generator_string-inl.h
+++ b/src/compiler/ruby_generator_string-inl.h
@@ -119,12 +119,14 @@ inline grpc::string RubyPackage(const grpc::protobuf::FileDescriptor* file) {
 inline grpc::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor,
                                const grpc::string& package) {
   std::string proto_type = descriptor->full_name();
+  ReplacePrefix(&proto_type, package, "");  // remove the leading package if present
+  ReplacePrefix(&proto_type, ".", "");      // remove the leading . (no package)
+
   if (descriptor->file()->options().has_ruby_package()) {
-    proto_type = RubyPackage(descriptor->file()) + "." + descriptor->name();
+    proto_type = RubyPackage(descriptor->file()) + "." + proto_type;
   }
   grpc::string res(proto_type);
-  ReplacePrefix(&res, package, "");  // remove the leading package if present
-  ReplacePrefix(&res, ".", "");      // remove the leading . (no package)
+
   if (res.find('.') == grpc::string::npos) {
     return res;
   } else {

--- a/src/ruby/spec/pb/codegen/grpc/testing/package_options_ruby_style.proto
+++ b/src/ruby/spec/pb/codegen/grpc/testing/package_options_ruby_style.proto
@@ -27,8 +27,13 @@ message AnotherTestResponse { }
 
 message Foo { }
 
+message Bar {
+  message Baz { }
+}
+
 service AnotherTestService {
   rpc GetTest(AnotherTestRequest) returns (AnotherTestResponse) { }
   rpc OtherTest(Thing) returns (Thing) { }
   rpc FooTest(Foo) returns (Foo) { }
+  rpc NestedMessageTest(Foo) returns (Bar.Baz) { }
 }

--- a/src/ruby/spec/pb/codegen/package_option_spec.rb
+++ b/src/ruby/spec/pb/codegen/package_option_spec.rb
@@ -40,6 +40,8 @@ describe 'Code Generation Options' do
       expect(services[:OtherTest].output).to eq(A::Other::Thing)
       expect(services[:FooTest].input).to eq(RPC::Test::New::Package::Options::Foo)
       expect(services[:FooTest].output).to eq(RPC::Test::New::Package::Options::Foo)
+      expect(services[:NestedMessageTest].input).to eq(RPC::Test::New::Package::Options::Foo)
+      expect(services[:NestedMessageTest].output).to eq(RPC::Test::New::Package::Options::Bar::Baz)
     end
   end
 end


### PR DESCRIPTION


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

Fixes https://github.com/grpc/grpc/issues/21561

> The grpc_ruby_plugin protoc plugin has a bug in generating Ruby output for proto files with nested resources and using the ruby_package option.
> 
> The plugin works fine when using either nested resources or ruby_package, but not both.
> https://github.com/grpc/grpc/issues/21561

Fix to use `descriptor->full_name()` removed package name instead of `descriptor->name()` when using the `ruby_package` option.

@apolcyn
