### PR TITLE
Fix cronet transport crash

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -1072,15 +1072,11 @@ static enum e_op_result execute_stream_op(struct op_and_state* oas) {
              op_can_be_run(stream_op, s, &oas->state, OP_SEND_MESSAGE)) {
     CRONET_LOG(GPR_DEBUG, "running: %p  OP_SEND_MESSAGE", oas);
     stream_state->pending_send_message = false;
-    if (stream_state->state_op_done[OP_CANCEL_ERROR]) {
+    if (stream_state->state_op_done[OP_CANCEL_ERROR] ||
+        stream_state->state_callback_received[OP_FAILED] ||
+        stream_state->state_callback_received[OP_SUCCEEDED]) {
       result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream is cancelled.");
-    } else if (stream_state->state_callback_received[OP_FAILED]) {
-      result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream failed.");
-    } else if (stream_state->state_callback_received[OP_SUCCEEDED]) {
-      result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream is already finished.");
+      CRONET_LOG(GPR_DEBUG, "Stream is either cancelled, failed or finished");
     } else {
       grpc_slice_buffer write_slice_buffer;
       grpc_slice slice;
@@ -1137,15 +1133,11 @@ static enum e_op_result execute_stream_op(struct op_and_state* oas) {
              op_can_be_run(stream_op, s, &oas->state,
                            OP_SEND_TRAILING_METADATA)) {
     CRONET_LOG(GPR_DEBUG, "running: %p  OP_SEND_TRAILING_METADATA", oas);
-    if (stream_state->state_op_done[OP_CANCEL_ERROR]) {
+    if (stream_state->state_op_done[OP_CANCEL_ERROR] ||
+        stream_state->state_callback_received[OP_FAILED] ||
+        stream_state->state_callback_received[OP_SUCCEEDED]) {
       result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream is cancelled.");
-    } else if (stream_state->state_callback_received[OP_FAILED]) {
-      result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream failed.");
-    } else if (stream_state->state_callback_received[OP_SUCCEEDED]) {
-      result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream is already done.");
+      CRONET_LOG(GPR_DEBUG, "Stream is either cancelled, failed or finished");
     } else {
       CRONET_LOG(GPR_DEBUG, "bidirectional_stream_write (%p, 0)", s->cbs);
       stream_state->state_callback_received[OP_SEND_MESSAGE] = false;

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -1072,9 +1072,15 @@ static enum e_op_result execute_stream_op(struct op_and_state* oas) {
              op_can_be_run(stream_op, s, &oas->state, OP_SEND_MESSAGE)) {
     CRONET_LOG(GPR_DEBUG, "running: %p  OP_SEND_MESSAGE", oas);
     stream_state->pending_send_message = false;
-    if (stream_state->state_callback_received[OP_FAILED]) {
+    if (stream_state->state_op_done[OP_CANCEL_ERROR]) {
       result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream is either cancelled or failed.");
+      CRONET_LOG(GPR_DEBUG, "Stream is cancelled.");
+    } else if (stream_state->state_callback_received[OP_FAILED]) {
+      result = NO_ACTION_POSSIBLE;
+      CRONET_LOG(GPR_DEBUG, "Stream failed.");
+    } else if (stream_state->state_callback_received[OP_SUCCEEDED]) {
+      result = NO_ACTION_POSSIBLE;
+      CRONET_LOG(GPR_DEBUG, "Stream is already finished.");
     } else {
       grpc_slice_buffer write_slice_buffer;
       grpc_slice slice;
@@ -1131,9 +1137,15 @@ static enum e_op_result execute_stream_op(struct op_and_state* oas) {
              op_can_be_run(stream_op, s, &oas->state,
                            OP_SEND_TRAILING_METADATA)) {
     CRONET_LOG(GPR_DEBUG, "running: %p  OP_SEND_TRAILING_METADATA", oas);
-    if (stream_state->state_callback_received[OP_FAILED]) {
+    if (stream_state->state_op_done[OP_CANCEL_ERROR]) {
       result = NO_ACTION_POSSIBLE;
-      CRONET_LOG(GPR_DEBUG, "Stream is either cancelled or failed.");
+      CRONET_LOG(GPR_DEBUG, "Stream is cancelled.");
+    } else if (stream_state->state_callback_received[OP_FAILED]) {
+      result = NO_ACTION_POSSIBLE;
+      CRONET_LOG(GPR_DEBUG, "Stream failed.");
+    } else if (stream_state->state_callback_received[OP_SUCCEEDED]) {
+      result = NO_ACTION_POSSIBLE;
+      CRONET_LOG(GPR_DEBUG, "Stream is already done.");
     } else {
       CRONET_LOG(GPR_DEBUG, "bidirectional_stream_write (%p, 0)", s->cbs);
       stream_state->state_callback_received[OP_SEND_MESSAGE] = false;


### PR DESCRIPTION
We received a crash report on user device

```
0x000000010a87195c	(CronetChromeWebView -bidirectional_stream_c.cc:181 )		bidirectional_stream_write
0x0000000105fc06dc	(Google -cronet_transport.cc:1108 )		execute_from_storage(stream_obj*)
0x0000000105fc06dc	(Google -cronet_transport.cc:1108 )		execute_from_storage(stream_obj*)
0x0000000105fdeea4	(Google -connected_channel.cc:135 )		connected_channel_start_transport_stream_op_batch(grpc_call_element*, grpc_transport_stream_op_batch*)
0x0000000105fd5d7c	(Google -message_compress_filter.cc:442 )		compress_start_transport_stream_op_batch(grpc_call_element*, grpc_transport_stream_op_batch*)
0x0000000105fd48e0	(Google -http_client_filter.cc:463 )		http_client_start_transport_stream_op_batch(grpc_call_element*, grpc_transport_stream_op_batch*)
0x0000000105fe8dbc	(Google -exec_ctx.cc:40 )		grpc_core::ExecCtx::Flush()
0x0000000105ffa854	(Google -exec_ctx.h:124 )		grpc_core::ExecCtx::~ExecCtx()
0x0000000105ffb7ec	(Google -exec_ctx.h:122 )		grpc_call_start_batch
0x0000000105f5db18	(Google -GRPCWrappedCall.m:279 )		-[GRPCWrappedCall startBatchWithOperations:errorHandler:]
0x0000000105f56aac	(Google -GRPCCallLegacy.m:435 )		-[GRPCCall writeMessage:withErrorHandler:]
0x000000018ef6d9a4	(libdispatch.dylib + 0x0005a9a4 )		_dispatch_call_block_and_release
0x000000018ef6e520	(libdispatch.dylib + 0x0005b520 )		_dispatch_client_callout
0x000000018ef1a8a0	(libdispatch.dylib + 0x000078a0 )		_dispatch_lane_serial_drain$VARIANT$mp
0x000000018ef1b290	(libdispatch.dylib + 0x00008290 )		_dispatch_lane_invoke$VARIANT$mp
0x000000018ef24788	(libdispatch.dylib + 0x00011788 )		_dispatch_workloop_worker_thread
0x000000018efbfb70	(libsystem_pthread.dylib + 0x0000bb70 )		_pthread_wqthread
```

We examined the code in `cronet_transport.cc` and determined that in certain cases, `s->cbs` could have been already set to `nullptr`, prior to us still trying to use it `bidirectional_stream_write(s->cbs, stream_state->ws.write_buffer ...`.

This PR adds a few more checks that were actually found in some other parts of the code.

Tested with: `bazel build src/core/ext/transport/cronet:grpc_transport_cronet_client_secure`