### PR TITLE
Temporarily disable client_channel_stress_test for msan and tsan.

### DIFF
--- a/test/cpp/client/BUILD
+++ b/test/cpp/client/BUILD
@@ -34,7 +34,6 @@ grpc_cc_test(
 
 grpc_cc_test(
     name = "client_channel_stress_test",
-    size = "large",
     srcs = ["client_channel_stress_test.cc"],
     # TODO(jtattermusch): test fails frequently on Win RBE, but passes locally
     # reenable the tests once it works reliably on Win RBE.

--- a/test/cpp/client/BUILD
+++ b/test/cpp/client/BUILD
@@ -38,9 +38,15 @@ grpc_cc_test(
     srcs = ["client_channel_stress_test.cc"],
     # TODO(jtattermusch): test fails frequently on Win RBE, but passes locally
     # reenable the tests once it works reliably on Win RBE.
+    # TODO(roth): Test disabled on msan and tsan due to variable
+    # duration problem triggered by https://github.com/grpc/grpc/pull/22481.
+    # Re-enable once the problem is diagnosed and fixed.  Tracked
+    # internally in b/153136407.
     tags = [
         "no_test_android",  # fails on android due to "Too many open files".
         "no_windows",
+        "nomsan",
+        "notsan",
     ],
     deps = [
         "//:gpr",


### PR DESCRIPTION
Avoids a problem triggered by #22481 while we debug the root cause.