### PR TITLE
PHP: doc update: Set a flag(allow fork) before c-core make

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -58,7 +58,7 @@ $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 ```sh
 $ cd grpc
 $ git submodule update --init
-$ make
+$ EXTRA_DEFINES=GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK make
 $ [sudo] make install
 ```
 


### PR DESCRIPTION
Added an instruction of setting a flag(allow fork) before c-core make. This is related to #22416 merged
Both c-core and grpc-php need set an allow-fork-flag before make, to make sure grpc-php-ext unit tests run properly. it's the same as what pecl does.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->
