### PR TITLE
Switch grpc-dart interop test to dart2.7

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile.template
@@ -14,10 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM google/dart:2.3
-
-  # Upgrade Dart to version 2.
-  RUN apt-get update && apt-get upgrade -y dart
+  FROM google/dart:2.7
 
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/dart:2.3
-
-# Upgrade Dart to version 2.
-RUN apt-get update && apt-get upgrade -y dart
+FROM google/dart:2.7
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/22512 (but not confirmed).