### PR TITLE
Unmark flaky on streaming_pump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2176,6 +2176,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/bm_error || ( echo test bm_error failed ; exit 1 )
 	$(E) "[RUN]     Testing bm_fullstack_streaming_ping_pong"
 	$(Q) $(BINDIR)/$(CONFIG)/bm_fullstack_streaming_ping_pong || ( echo test bm_fullstack_streaming_ping_pong failed ; exit 1 )
+	$(E) "[RUN]     Testing bm_fullstack_streaming_pump"
+	$(Q) $(BINDIR)/$(CONFIG)/bm_fullstack_streaming_pump || ( echo test bm_fullstack_streaming_pump failed ; exit 1 )
 	$(E) "[RUN]     Testing bm_fullstack_unary_ping_pong"
 	$(Q) $(BINDIR)/$(CONFIG)/bm_fullstack_unary_ping_pong || ( echo test bm_fullstack_unary_ping_pong failed ; exit 1 )
 	$(E) "[RUN]     Testing bm_metadata"

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5127,7 +5127,6 @@ targets:
   - posix
 - name: bm_fullstack_streaming_pump
   build: test
-  run: false
   language: c++
   headers:
   - test/cpp/microbenchmarks/fullstack_streaming_pump.h

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -206,7 +206,6 @@ grpc_cc_test(
     srcs = [
         "bm_fullstack_streaming_pump.cc",
     ],
-    flaky = True,  # TODO(b/150422385)
     tags = [
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3770,6 +3770,26 @@
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 
+    "name": "bm_fullstack_streaming_pump", 
+    "platforms": [
+      "linux", 
+      "posix"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": true, 
+    "ci_platforms": [
+      "linux", 
+      "posix"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
     "name": "bm_fullstack_unary_ping_pong", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
#22619 makes this benchmark non-flaky as far as we know, so let's bring it back into the test cycle once that merges.
