### PR TITLE
[3/n] Avoid using hardcoded test credentials

### DIFF
--- a/test/core/end2end/fixtures/h2_oauth2.cc
+++ b/test/core/end2end/fixtures/h2_oauth2.cc
@@ -31,8 +31,6 @@
 #include "test/core/util/test_config.h"
 
 #define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
-#define CLIENT_CERT_PATH "src/core/tsi/test_creds/client.pem"
-#define CLIENT_KEY_PATH "src/core/tsi/test_creds/client.key"
 #define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
 #define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 

--- a/test/core/end2end/fixtures/h2_ssl.cc
+++ b/test/core/end2end/fixtures/h2_ssl.cc
@@ -31,9 +31,8 @@
 #include "test/core/end2end/end2end_tests.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
+
 #define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
-#define CLIENT_CERT_PATH "src/core/tsi/test_creds/client.pem"
-#define CLIENT_KEY_PATH "src/core/tsi/test_creds/client.key"
 #define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
 #define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 

--- a/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
+++ b/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
@@ -16,23 +16,25 @@
  *
  */
 
-#include "test/core/end2end/end2end_tests.h"
-
-#include <stdio.h>
-#include <string.h>
-
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/tmpfile.h"
 #include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/iomgr/load_file.h"
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/core/lib/security/security_connector/ssl_utils_config.h"
-#include "test/core/end2end/data/ssl_test_data.h"
+#include "test/core/end2end/end2end_tests.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
+
+#define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
+#define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
+#define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 struct fullstack_secure_fixture_data {
   grpc_core::UniquePtr<char> localaddr;
@@ -48,10 +50,25 @@ ssl_server_certificate_config_callback(
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(user_data);
   if (!ffd->server_credential_reloaded) {
-    grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {test_server1_key,
-                                                    test_server1_cert};
-    *config = grpc_ssl_server_certificate_config_create(test_root_cert,
+    grpc_slice ca_slice, cert_slice, key_slice;
+    GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                                 grpc_load_file(CA_CERT_PATH, 1, &ca_slice)));
+    GPR_ASSERT(GRPC_LOG_IF_ERROR(
+        "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+    GPR_ASSERT(GRPC_LOG_IF_ERROR(
+        "load_file", grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+    const char* ca_cert =
+        reinterpret_cast<const char*> GRPC_SLICE_START_PTR(ca_slice);
+    const char* server_cert =
+        reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+    const char* server_key =
+        reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+    grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {server_key, server_cert};
+    *config = grpc_ssl_server_certificate_config_create(ca_cert,
                                                         &pem_key_cert_pair, 1);
+    grpc_slice_unref(cert_slice);
+    grpc_slice_unref(key_slice);
+    grpc_slice_unref(ca_slice);
     ffd->server_credential_reloaded = true;
     return GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_NEW;
   } else {
@@ -175,20 +192,10 @@ static grpc_end2end_test_config configs[] = {
 
 int main(int argc, char** argv) {
   size_t i;
-  FILE* roots_file;
-  size_t roots_size = strlen(test_root_cert);
-  char* roots_filename;
 
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_end2end_tests_pre_init();
-
-  /* Set the SSL roots env var. */
-  roots_file = gpr_tmpfile("chttp2_simple_ssl_fullstack_test", &roots_filename);
-  GPR_ASSERT(roots_filename != nullptr);
-  GPR_ASSERT(roots_file != nullptr);
-  GPR_ASSERT(fwrite(test_root_cert, 1, roots_size, roots_file) == roots_size);
-  fclose(roots_file);
-  GPR_GLOBAL_CONFIG_SET(grpc_default_ssl_roots_file_path, roots_filename);
+  GPR_GLOBAL_CONFIG_SET(grpc_default_ssl_roots_file_path, CA_CERT_PATH);
 
   grpc_init();
 
@@ -197,10 +204,6 @@ int main(int argc, char** argv) {
   }
 
   grpc_shutdown();
-
-  /* Cleanup. */
-  remove(roots_filename);
-  gpr_free(roots_filename);
 
   return 0;
 }

--- a/test/core/end2end/fixtures/h2_ssl_proxy.cc
+++ b/test/core/end2end/fixtures/h2_ssl_proxy.cc
@@ -16,23 +16,25 @@
  *
  */
 
-#include "test/core/end2end/end2end_tests.h"
-
-#include <stdio.h>
-#include <string.h>
-
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/tmpfile.h"
+#include "src/core/lib/iomgr/load_file.h"
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/core/lib/security/security_connector/ssl_utils_config.h"
-#include "test/core/end2end/data/ssl_test_data.h"
+#include "test/core/end2end/end2end_tests.h"
 #include "test/core/end2end/fixtures/proxy.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
+
+#define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
+#define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
+#define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 typedef struct fullstack_secure_fixture_data {
   grpc_end2end_proxy* proxy;
@@ -41,10 +43,20 @@ typedef struct fullstack_secure_fixture_data {
 static grpc_server* create_proxy_server(const char* port,
                                         grpc_channel_args* server_args) {
   grpc_server* s = grpc_server_create(server_args, nullptr);
-  grpc_ssl_pem_key_cert_pair pem_cert_key_pair = {test_server1_key,
-                                                  test_server1_cert};
+  grpc_slice cert_slice, key_slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+  const char* server_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+  const char* server_key =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+  grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {server_key, server_cert};
   grpc_server_credentials* ssl_creds = grpc_ssl_server_credentials_create(
-      nullptr, &pem_cert_key_pair, 1, 0, nullptr);
+      nullptr, &pem_key_cert_pair, 1, 0, nullptr);
+  grpc_slice_unref(cert_slice);
+  grpc_slice_unref(key_slice);
   GPR_ASSERT(grpc_server_add_secure_http2_port(s, port, ssl_creds));
   grpc_server_credentials_release(ssl_creds);
   return s;
@@ -166,10 +178,20 @@ static int fail_server_auth_check(grpc_channel_args* server_args) {
 
 static void chttp2_init_server_simple_ssl_secure_fullstack(
     grpc_end2end_test_fixture* f, grpc_channel_args* server_args) {
-  grpc_ssl_pem_key_cert_pair pem_cert_key_pair = {test_server1_key,
-                                                  test_server1_cert};
+  grpc_slice cert_slice, key_slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+  const char* server_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+  const char* server_key =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+  grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {server_key, server_cert};
   grpc_server_credentials* ssl_creds = grpc_ssl_server_credentials_create(
-      nullptr, &pem_cert_key_pair, 1, 0, nullptr);
+      nullptr, &pem_key_cert_pair, 1, 0, nullptr);
+  grpc_slice_unref(cert_slice);
+  grpc_slice_unref(key_slice);
   if (fail_server_auth_check(server_args)) {
     grpc_auth_metadata_processor processor = {process_auth_failure, nullptr,
                                               nullptr};
@@ -195,20 +217,10 @@ static grpc_end2end_test_config configs[] = {
 
 int main(int argc, char** argv) {
   size_t i;
-  FILE* roots_file;
-  size_t roots_size = strlen(test_root_cert);
-  char* roots_filename;
 
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_end2end_tests_pre_init();
-
-  /* Set the SSL roots env var. */
-  roots_file = gpr_tmpfile("chttp2_simple_ssl_fullstack_test", &roots_filename);
-  GPR_ASSERT(roots_filename != nullptr);
-  GPR_ASSERT(roots_file != nullptr);
-  GPR_ASSERT(fwrite(test_root_cert, 1, roots_size, roots_file) == roots_size);
-  fclose(roots_file);
-  GPR_GLOBAL_CONFIG_SET(grpc_default_ssl_roots_file_path, roots_filename);
+  GPR_GLOBAL_CONFIG_SET(grpc_default_ssl_roots_file_path, CA_CERT_PATH);
 
   grpc_init();
 
@@ -217,10 +229,6 @@ int main(int argc, char** argv) {
   }
 
   grpc_shutdown();
-
-  /* Cleanup. */
-  remove(roots_filename);
-  gpr_free(roots_filename);
 
   return 0;
 }

--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -431,8 +431,6 @@ def grpc_end2end_tests():
             language = "C++",
             data = [
                 "//src/core/tsi/test_creds:ca.pem",
-                "//src/core/tsi/test_creds:client.key",
-                "//src/core/tsi/test_creds:client.pem",
                 "//src/core/tsi/test_creds:server1.key",
                 "//src/core/tsi/test_creds:server1.pem",
             ],
@@ -508,8 +506,6 @@ def grpc_end2end_nosec_tests():
             language = "C++",
             data = [
                 "//src/core/tsi/test_creds:ca.pem",
-                "//src/core/tsi/test_creds:client.key",
-                "//src/core/tsi/test_creds:client.pem",
                 "//src/core/tsi/test_creds:server1.key",
                 "//src/core/tsi/test_creds:server1.pem",
             ],


### PR DESCRIPTION
This is third part of the PR to clean up the test credentials used in C Core(more specifically, in `test/core/end2end/...`).
The ultimate goal is to remove the dependencies on `test/core/end2end/data/ssl_test_data.h`, which contains strings of hard-coded certificates.
