### PR TITLE
Adding base_namespace option support to grpc_csharp_plugin

### DIFF
--- a/src/compiler/csharp_generator_helpers.h
+++ b/src/compiler/csharp_generator_helpers.h
@@ -22,12 +22,30 @@
 #include "src/compiler/config.h"
 #include "src/compiler/generator_helpers.h"
 
+#include <google/protobuf/compiler/csharp/csharp_names.h>
+
+using google::protobuf::compiler::csharp::GetOutputFile;
+
 namespace grpc_csharp_generator {
 
 inline bool ServicesFilename(const grpc::protobuf::FileDescriptor* file,
+                             const bool generate_directories,
+                             const std::string base_namespace, 
                              grpc::string* file_name_or_error) {
-  *file_name_or_error =
-      grpc_generator::FileNameInUpperCamel(file, false) + "Grpc.cs";
+
+  grpc::string filename_error = "";
+  std::string filename = GetOutputFile(file,
+      "Grpc.cs",
+      generate_directories,
+      base_namespace,
+      &filename_error);
+
+  if (filename.empty()) {
+    *file_name_or_error = filename_error;
+    return false;
+  }
+  
+  *file_name_or_error = filename;
   return true;
 }
 

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -115,33 +115,6 @@ inline grpc::string LowercaseFirstLetter(grpc::string s) {
   return s;
 }
 
-inline grpc::string LowerUnderscoreToUpperCamel(grpc::string str) {
-  std::vector<grpc::string> tokens = tokenize(str, "_");
-  grpc::string result = "";
-  for (unsigned int i = 0; i < tokens.size(); i++) {
-    result += CapitalizeFirstLetter(tokens[i]);
-  }
-  return result;
-}
-
-inline grpc::string FileNameInUpperCamel(
-    const grpc::protobuf::FileDescriptor* file, bool include_package_path) {
-  std::vector<grpc::string> tokens = tokenize(StripProto(file->name()), "/");
-  grpc::string result = "";
-  if (include_package_path) {
-    for (unsigned int i = 0; i < tokens.size() - 1; i++) {
-      result += tokens[i] + "/";
-    }
-  }
-  result += LowerUnderscoreToUpperCamel(tokens.back());
-  return result;
-}
-
-inline grpc::string FileNameInUpperCamel(
-    const grpc::protobuf::FileDescriptor* file) {
-  return FileNameInUpperCamel(file, true);
-}
-
 enum MethodType {
   METHODTYPE_NO_STREAMING,
   METHODTYPE_CLIENT_STREAMING,


### PR DESCRIPTION
Add full `base_namespace` option support as implemented in protoc.

Fixes #13724

The fix was rather simple as we only use functions already existing and even removed some duplicated logic.

/CC: @jtattermusch @kkm000 