### PR TITLE
Grpc.Tools readme update - duplicated .proto names

### DIFF
--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -105,6 +105,17 @@ button](https://stackoverflow.com/a/9770061). Click on it, and choose "Add as
 link". If you do not select this option, Visual Studio will copy files to the
 project directory instead.
 
+#### My .proto files have same filename in different folders
+
+By default Grpc.Tools compiles all .proto files into `obj` directory, flattening relative paths. For proto files with duplicated names it will cause following error `NETSDK1022 Duplicate 'Compile' items were included. [...]`. If you want to keep relative paths in your `obj` folder, define `OutputDir="$(Protobuf_OutputPath)%(RelativeDir)"`.
+
+```xml
+  <ItemGroup>
+    <Protobuf Include="Protos/v2/http.proto" OutputDir="$(Protobuf_OutputPath)%(RelativeDir)"  />
+    <Protobuf Include="Protos/v3/http.proto" OutputDir="$(Protobuf_OutputPath)%(RelativeDir)"  />
+  </ItemGroup>
+```
+
 ### I just want to generate proto and gRPC C# sources from my .proto files (no C# compile)
 
 Suppose you want to place generated files right beside each respective source

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -107,7 +107,27 @@ project directory instead.
 
 #### My .proto files have same filename in different folders
 
-By default Grpc.Tools compiles all .proto files into `obj` directory, flattening relative paths. For proto files with duplicated names it will cause following error `NETSDK1022 Duplicate 'Compile' items were included. [...]`. If you want to keep relative paths in your `obj` folder, define `OutputDir="$(Protobuf_OutputPath)%(RelativeDir)"`.
+Starting from Grpc.Tools version 2.31, protocol buffers compilation preserves original folder structure for generated files. Eg.
+
+- `../ProjectFolder/Protos/v2/http.proto`
+- `../ProjectFolder/Protos/v3/http.proto`
+
+Will result in:
+
+- `../ProjectFolder/obj/CONFIGURATION/FRAMEWORK/Protos/v2/Greet.cs`
+- `../ProjectFolder/obj/CONFIGURATION/FRAMEWORK/Protos/v2/GreetGrpc.cs`
+- `../ProjectFolder/obj/CONFIGURATION/FRAMEWORK/Protos/v3/Greet.cs`
+- `../ProjectFolder/obj/CONFIGURATION/FRAMEWORK/Protos/v3/GreetGrpc.cs`
+
+This feature resolves problems we have faced in large projects. Moreover, There is now also a project-wide new option Protobuf_ProtoRoot to define the fallback ProtoRoot. If the ProtoRoot is set, this also reduces the amount of problems that lead to duplicates. Eg.
+
+```xml
+  <ItemGroup>
+    <Protobuf Include="Protos\v2\greet.proto" ProtoRoot="Protos" />
+  </ItemGroup>
+```
+
+Before Grpc.Tools version 2.31 all .proto files were compiled into `obj` directory, flattening relative paths. For proto files with duplicated names it cause following errors `NETSDK1022 Duplicate 'Compile' items were included. [...]` or `MSB3105 [...] Duplicate items are not supported by the "Sources" parameter`. The workaround for this problem was introducing relative paths in your `obj` folder, by manipulating output path. Eg. 
 
 ```xml
   <ItemGroup>
@@ -115,6 +135,8 @@ By default Grpc.Tools compiles all .proto files into `obj` directory, flattening
     <Protobuf Include="Protos/v3/http.proto" OutputDir="$(Protobuf_OutputPath)%(RelativeDir)"  />
   </ItemGroup>
 ```
+
+__Note, this was a workaround approach, we recommend updating Grpc.Tools to the latest version.__
 
 ### I just want to generate proto and gRPC C# sources from my .proto files (no C# compile)
 


### PR DESCRIPTION
Hello,
This PR is only about updating documentation. I have been using Grpc.Tools NuGet package for building my .proto files. However, when working with duplicated names it returned me an error.  `Grpc.Tools` by default flatten file structure, which place C# files to the same folder causing MSBuild and C# compiler to throw an error.

This PR is a solution for:
https://github.com/grpc/grpc/issues/17672

This PR is also related to other PR that will solve the same problem but with different approach, which is adding new variable, rather than playing around existing implementation.
https://github.com/grpc/grpc/pull/22627 

Proposed documentation will be updated if latter succeed. This PR is for those who are strugling with the problem today.

@nicolasnoble
