### PR TITLE
avoid too long name for retry_exceeds_buffer_size_in_initial_batch

### DIFF
--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -282,6 +282,9 @@ END2END_TESTS = {
     "retry_exceeds_buffer_size_in_initial_batch": _test_options(
         needs_client_channel = True,
         proxyable = False,
+        # TODO(jtattermusch): too long bazel test name makes the test flaky on Windows RBE
+        # See b/151617965
+        short_name = "retry_exceeds_buffer_size_in_init",
     ),
     "retry_exceeds_buffer_size_in_subsequent_batch": _test_options(
         needs_client_channel = True,


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/22497/files.

Since merging the PR, I've spotted the same problem happening for one test case
https://source.cloud.google.com/results/invocations/ca814217-fc06-487c-b977-4701ceaf46d3/targets/%2F%2Ftest%2Fcore%2Fend2end:h2_ssl_cred_reload_nosec_test@retry_exceeds_buffer_size_in_initial_batch/log