### PR TITLE
Ignore `cmake/build/` anywhere in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,7 +136,7 @@ bm_diff_old/
 bm_*.json
 
 # cmake build files
-/cmake/build
+**/cmake/build/
 
 # Visual Studio Code artifacts
 .vscode/*


### PR DESCRIPTION
Ignore `cmake/build/` anywhere in the repo, not just at the root level. This is helpful when working on the examples.

cc @jtattermusch @ejona86 @srini100 