### PR TITLE
xDS test improvements

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -646,7 +646,7 @@ def create_url_map(gcp, name, backend_service, host_name):
     gcp.url_map = GcpResource(config['name'], result['targetLink'])
 
 
-def patch_url_map_host_rule(gcp, name, backend_service, host_name):
+def patch_url_map_host_rule_with_port(gcp, name, backend_service, host_name):
     config = {
         'hostRules': [{
             'hosts': ['%s:%d' % (host_name, gcp.service_port)],
@@ -1007,8 +1007,10 @@ try:
         if not gcp.service_port:
             raise Exception(
                 'Failed to find a valid ip:port for the forwarding rule')
-        patch_url_map_host_rule(gcp, url_map_name, backend_service,
-                                service_host_name)
+        if gcp.service_port != _DEFAULT_SERVICE_PORT:
+            patch_url_map_host_rule_with_port(gcp, url_map_name,
+                                              backend_service,
+                                              service_host_name)
         startup_script = get_startup_script(args.path_to_server_binary,
                                             gcp.service_port)
         create_instance_template(gcp, template_name, args.network,

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -797,7 +797,9 @@ def patch_backend_instances(gcp,
     result = gcp.alpha_compute.backendServices().patch(
         project=gcp.project, backendService=backend_service.name,
         body=config).execute()
-    wait_for_global_operation(gcp, result['name'])
+    wait_for_global_operation(gcp,
+                              result['name'],
+                              timeout_sec=_WAIT_FOR_BACKEND_SEC)
 
 
 def resize_instance_group(gcp,

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -640,7 +640,7 @@ def add_backend_service(gcp, name):
     }
     logger.debug('Sending GCP request with body=%s', config)
     result = compute_to_use.backendServices().insert(project=gcp.project,
-                                                        body=config).execute()
+                                                     body=config).execute()
     wait_for_global_operation(gcp, result['name'])
     backend_service = GcpResource(config['name'], result['targetLink'])
     gcp.backend_services.append(backend_service)
@@ -1009,6 +1009,7 @@ class GcpState(object):
         self.service_port = None
         self.instance_template = None
         self.instance_groups = []
+
 
 alpha_compute = None
 if args.compute_discovery_document:

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -749,7 +749,7 @@ def delete_target_proxy(gcp):
                 project=gcp.project,
                 targetGrpcProxy=gcp.target_proxy.name).execute()
         else:
-            result = gcp.alpha_compute.targetHttpProxies().delete(
+            result = gcp.compute.targetHttpProxies().delete(
                 project=gcp.project,
                 targetHttpProxy=gcp.target_proxy.name).execute()
         wait_for_global_operation(gcp, result['name'])


### PR DESCRIPTION
Fixes for the xds test runner: do not include the port in the host rule if the service is using the default port (80), increase wait for patched instance group size to update, and make alpha api use optional