### PR TITLE
Use correct status code type in xDS e2e test

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2450,7 +2450,7 @@ TEST_P(LocalityMapTest, NoLocalities) {
       AdsServiceImpl::BuildEdsResource({}), kDefaultResourceName);
   Status status = SendRpc();
   EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.error_code(), GRPC_STATUS_UNAVAILABLE);
+  EXPECT_EQ(status.error_code(), StatusCode::UNAVAILABLE);
 }
 
 // Tests that the locality map can work properly even when it contains a large


### PR DESCRIPTION
Fix a (import) build error in the xDS end2end test