### PR TITLE
Fix flaky ChannelzChannelTest::LastCallStartedTime test

### DIFF
--- a/src/core/lib/gpr/time.cc
+++ b/src/core/lib/gpr/time.cc
@@ -254,6 +254,10 @@ gpr_timespec gpr_convert_clock_type(gpr_timespec t, gpr_clock_type clock_type) {
     return gpr_time_add(gpr_now(clock_type), t);
   }
 
+  // If the given input hits this code, the same result is not guaranteed for
+  // the same input because it relies on `gpr_now` to calculate the difference
+  // between two different clocks. Please be careful when you want to use this
+  // function in unit tests. (e.g. https://github.com/grpc/grpc/pull/22655)
   return gpr_time_add(gpr_now(clock_type),
                       gpr_time_sub(t, gpr_now(t.clock_type)));
 }


### PR DESCRIPTION
This is to make the `LastCallStartedTime` of `channelz_test` stable. This test calls `last_call_started_time` to get the started_time which was previously calling `gpr_timespec_to_millis_round_up` function which doesn't return the same value for the same input every time because of `gpr_convert_clock_type` which uses `now` function to measure the difference between different clocks. Test itself doesn't need the real time so this is changed to use  the precise time which is stable over tests.

Alternatives:
- Make `gpr_convert_clock_type` return value over calls consistently. This is abandoned because it's not feasible in general because two different time have different speed (it's weird but quite common) and real-time can change by users.
- Make `gpr_timespec_to_millis_round_up` return value over calls consistently. This could be possible by having multiple `g_start_time` in `exec_ctx.cc` but I didn't do because of https://github.com/grpc/grpc/pull/13435 which changed it to have only one start-time.