### PR TITLE
[4/n] Avoid using hardcoded test credentials

### DIFF
--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -37,6 +37,11 @@ grpc_fuzzer(
     name = "ssl_server_fuzzer",
     srcs = ["ssl_server_fuzzer.cc"],
     corpus = "corpus/ssl_server_corpus",
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [
@@ -248,6 +253,11 @@ grpc_cc_test(
 grpc_cc_test(
     name = "tls_security_connector_test",
     srcs = ["tls_security_connector_test.cc"],
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
     external_deps = [
         "gtest",
     ],
@@ -266,6 +276,11 @@ grpc_cc_test(
 grpc_cc_test(
     name = "grpc_tls_credentials_options_test",
     srcs = ["grpc_tls_credentials_options_test.cc"],
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
     external_deps = ["gtest"],
     language = "C++",
     deps = [

--- a/test/core/security/grpc_tls_credentials_options_test.cc
+++ b/test/core/security/grpc_tls_credentials_options_test.cc
@@ -17,7 +17,6 @@
  */
 
 #include "src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h"
-#include "test/core/end2end/data/ssl_test_data.h"
 
 #include <gmock/gmock.h>
 #include <grpc/support/alloc.h>
@@ -25,28 +24,61 @@
 #include <grpc/support/string_util.h>
 #include <gtest/gtest.h>
 
+#include "src/core/lib/iomgr/load_file.h"
+
+#define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
+#define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
+#define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
+
 namespace testing {
 
 static void SetKeyMaterials(grpc_tls_key_materials_config* config) {
-  const grpc_ssl_pem_key_cert_pair pem_key_pair = {
-      test_server1_key,
-      test_server1_cert,
-  };
-  const auto* pem_key_pair_ptr = &pem_key_pair;
-  grpc_tls_key_materials_config_set_key_materials(config, test_root_cert,
-                                                  &pem_key_pair_ptr, 1);
+  grpc_slice ca_slice, cert_slice, key_slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(CA_CERT_PATH, 1, &ca_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+  const char* ca_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(ca_slice);
+  const char* server_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+  const char* server_key =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+  grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {server_key, server_cert};
+  const auto* pem_key_cert_pair_ptr = &pem_key_cert_pair;
+  grpc_tls_key_materials_config_set_key_materials(config, ca_cert,
+                                                  &pem_key_cert_pair_ptr, 1);
+  grpc_slice_unref(cert_slice);
+  grpc_slice_unref(key_slice);
+  grpc_slice_unref(ca_slice);
 }
 
 TEST(GrpcTlsCredentialsOptionsTest, SetKeyMaterials) {
   grpc_tls_key_materials_config* config =
       grpc_tls_key_materials_config_create();
   SetKeyMaterials(config);
-  EXPECT_STREQ(config->pem_root_certs(), test_root_cert);
+  grpc_slice ca_slice, cert_slice, key_slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(CA_CERT_PATH, 1, &ca_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+  const char* ca_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(ca_slice);
+  const char* server_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+  const char* server_key =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+  EXPECT_STREQ(config->pem_root_certs(), ca_cert);
   EXPECT_EQ(config->pem_key_cert_pair_list().size(), 1);
-  EXPECT_STREQ(config->pem_key_cert_pair_list()[0].private_key(),
-               test_server1_key);
-  EXPECT_STREQ(config->pem_key_cert_pair_list()[0].cert_chain(),
-               test_server1_cert);
+  EXPECT_STREQ(config->pem_key_cert_pair_list()[0].private_key(), server_key);
+  EXPECT_STREQ(config->pem_key_cert_pair_list()[0].cert_chain(), server_cert);
+  grpc_slice_unref(cert_slice);
+  grpc_slice_unref(key_slice);
+  grpc_slice_unref(ca_slice);
   delete config;
 }
 

--- a/test/core/surface/BUILD
+++ b/test/core/surface/BUILD
@@ -136,6 +136,11 @@ grpc_cc_test(
 grpc_cc_test(
     name = "sequential_connectivity_test",
     srcs = ["sequential_connectivity_test.cc"],
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
     flaky = True,  # TODO(b/151696318)
     language = "C++",
     deps = [

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -25,9 +25,13 @@
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
-#include "test/core/end2end/data/ssl_test_data.h"
+#include "src/core/lib/iomgr/load_file.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
+
+#define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
+#define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
+#define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 typedef struct test_fixture {
   const char* name;
@@ -139,17 +143,33 @@ static const test_fixture insecure_test = {
 };
 
 static void secure_test_add_port(grpc_server* server, const char* addr) {
-  grpc_ssl_pem_key_cert_pair pem_cert_key_pair = {test_server1_key,
-                                                  test_server1_cert};
+  grpc_slice cert_slice, key_slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+  const char* server_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+  const char* server_key =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+  grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {server_key, server_cert};
   grpc_server_credentials* ssl_creds = grpc_ssl_server_credentials_create(
-      nullptr, &pem_cert_key_pair, 1, 0, nullptr);
+      nullptr, &pem_key_cert_pair, 1, 0, nullptr);
+  grpc_slice_unref(cert_slice);
+  grpc_slice_unref(key_slice);
   grpc_server_add_secure_http2_port(server, addr, ssl_creds);
   grpc_server_credentials_release(ssl_creds);
 }
 
 static grpc_channel* secure_test_create_channel(const char* addr) {
+  grpc_slice ca_slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(CA_CERT_PATH, 1, &ca_slice)));
+  const char* test_root_cert =
+      reinterpret_cast<const char*> GRPC_SLICE_START_PTR(ca_slice);
   grpc_channel_credentials* ssl_creds =
       grpc_ssl_credentials_create(test_root_cert, nullptr, nullptr, nullptr);
+  grpc_slice_unref(ca_slice);
   grpc_arg ssl_name_override = {
       GRPC_ARG_STRING,
       const_cast<char*>(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG),

--- a/test/core/util/grpc_fuzzer.bzl
+++ b/test/core/util/grpc_fuzzer.bzl
@@ -14,12 +14,12 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
-def grpc_fuzzer(name, corpus, srcs = [], deps = [], size = "large", **kwargs):
+def grpc_fuzzer(name, corpus, srcs = [], deps = [], data = [], size = "large", **kwargs):
     grpc_cc_test(
         name = name,
         srcs = srcs,
         deps = deps + ["//test/core/util:fuzzer_corpus_test"],
-        data = native.glob([corpus + "/**"]),
+        data = data + native.glob([corpus + "/**"]),
         external_deps = [
             "gtest",
         ],


### PR DESCRIPTION
This is fourth part of the PR to clean up the test credentials used in C Core(more specifically, in `test/core/end2end/...`).
The ultimate goal is to remove the dependencies on `test/core/end2end/data/ssl_test_data.h`, which contains strings of hard-coded certificates.