### PR TITLE
Remove unneeded assignment

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -577,7 +577,6 @@ static void publish_new_rpc(void* arg, grpc_error* error) {
     rm->pending_tail->pending_next = calld;
     rm->pending_tail = calld;
   }
-  calld->pending_next = nullptr;
   gpr_mu_unlock(&server->mu_call);
 }
 


### PR DESCRIPTION
Bigger reorg coming, but starting with some minor cleanup. This assignment is already present in the default initializer for call_data (ever since #17191)