### PR TITLE
[Aio] Handle the empty response with error code from server handler

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -265,17 +265,18 @@ async def _finish_handler_with_unary_response(RPCState rpc_state,
 
     # Serializes the response message
     cdef bytes response_raw
-    cdef SendMessageOperation send_message_op
     if rpc_state.status_code == StatusCode.ok:
         response_raw = serialize(
             response_serializer,
             response_message,
         )
-        send_message_op = SendMessageOperation(response_raw, rpc_state.get_write_flag())
+    else:
+        response_raw = b''
 
     # Assembles the batch operations
     cdef tuple finish_ops
     finish_ops = (
+        SendMessageOperation(response_raw, rpc_state.get_write_flag()),
         SendStatusFromServerOperation(
             rpc_state.trailing_metadata,
             rpc_state.status_code,
@@ -283,8 +284,6 @@ async def _finish_handler_with_unary_response(RPCState rpc_state,
             _EMPTY_FLAGS,
         ),
     )
-    if rpc_state.status_code == StatusCode.ok:
-        finish_ops += (send_message_op,)
     if not rpc_state.metadata_sent:
         finish_ops = prepend_send_initial_metadata_op(
             finish_ops,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -264,14 +264,10 @@ async def _finish_handler_with_unary_response(RPCState rpc_state,
     rpc_state.raise_for_termination()
 
     # Serializes the response message
-    cdef bytes response_raw
-    if rpc_state.status_code == StatusCode.ok:
-        response_raw = serialize(
-            response_serializer,
-            response_message,
-        )
-    else:
-        response_raw = b''
+    cdef bytes response_raw = serialize(
+        response_serializer,
+        response_message,
+    )
 
     # Assembles the batch operations
     cdef tuple finish_ops

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -264,10 +264,15 @@ async def _finish_handler_with_unary_response(RPCState rpc_state,
     rpc_state.raise_for_termination()
 
     # Serializes the response message
-    cdef bytes response_raw = serialize(
-        response_serializer,
-        response_message,
-    )
+    cdef bytes response_raw
+    if rpc_state.status_code == StatusCode.ok:
+        response_raw = serialize(
+            response_serializer,
+            response_message,
+        )
+    else:
+        # Discards the response message if the status code is non-OK.
+        response_raw = b''
 
     # Assembles the batch operations
     cdef tuple finish_ops

--- a/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
@@ -49,7 +49,10 @@ cdef class SendInitialMetadataOperation(Operation):
 cdef class SendMessageOperation(Operation):
 
   def __cinit__(self, bytes message, int flags):
-    self._message = message
+    if message is None:
+      self._message = b''
+    else:
+      self._message = message
     self._flags = flags
 
   def type(self):

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -38,6 +38,8 @@ _STREAM_STREAM_READER_WRITER = '/test/StreamStreamReaderWriter'
 _STREAM_STREAM_EVILLY_MIXED = '/test/StreamStreamEvillyMixed'
 _UNIMPLEMENTED_METHOD = '/test/UnimplementedMethod'
 _ERROR_IN_STREAM_STREAM = '/test/ErrorInStreamStream'
+_ERROR_WITHOUT_RAISE_IN_UNARY_UNARY = '/test/ErrorWithoutRaiseInUnaryUnary'
+_ERROR_WITHOUT_RAISE_IN_STREAM_STREAM = '/test/ErrorWithoutRaiseInStreamStream'
 
 _REQUEST = b'\x00\x00\x00'
 _RESPONSE = b'\x01\x01\x01'
@@ -86,6 +88,12 @@ class _GenericHandler(grpc.GenericRpcHandler):
             _ERROR_IN_STREAM_STREAM:
                 grpc.stream_stream_rpc_method_handler(
                     self._error_in_stream_stream),
+            _ERROR_WITHOUT_RAISE_IN_UNARY_UNARY:
+                grpc.unary_unary_rpc_method_handler(
+                    self._error_without_raise_in_unary_unary),
+            _ERROR_WITHOUT_RAISE_IN_STREAM_STREAM:
+                grpc.stream_stream_rpc_method_handler(
+                    self._error_without_raise_in_stream_stream),
         }
 
     @staticmethod
@@ -167,6 +175,16 @@ class _GenericHandler(grpc.GenericRpcHandler):
             assert _REQUEST == request
             raise RuntimeError('A testing RuntimeError!')
         yield _RESPONSE
+
+    async def _error_without_raise_in_unary_unary(self, request, context):
+        assert _REQUEST == request
+        context.set_code(grpc.StatusCode.INTERNAL)
+
+    async def _error_without_raise_in_stream_stream(self, request_iterator,
+                                                    context):
+        async for request in request_iterator:
+            assert _REQUEST == request
+        context.set_code(grpc.StatusCode.INTERNAL)
 
     def service(self, handler_details):
         self._called.set_result(None)
@@ -425,6 +443,26 @@ class TestServer(AioTestBase):
 
         # Don't segfault here
         self.assertEqual(grpc.StatusCode.UNKNOWN, await call.code())
+
+    async def test_error_without_raise_in_unary_unary(self):
+        call = self._channel.unary_unary(_ERROR_WITHOUT_RAISE_IN_UNARY_UNARY)(
+            _REQUEST)
+
+        with self.assertRaises(aio.AioRpcError) as exception_context:
+            await call
+
+        rpc_error = exception_context.exception
+        self.assertEqual(grpc.StatusCode.INTERNAL, rpc_error.code())
+
+    async def test_error_without_raise_in_stream_stream(self):
+        call = self._channel.stream_stream(
+            _ERROR_WITHOUT_RAISE_IN_STREAM_STREAM)()
+
+        for _ in range(_NUM_STREAM_REQUESTS):
+            await call.write(_REQUEST)
+        await call.done_writing()
+
+        self.assertEqual(grpc.StatusCode.INTERNAL, await call.code())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a bug that if the server handler returns `None` with non-OK status code, that the server will still try to serialize the returned value (`None`) and causes exception. Server handlers still can return `None` as their response message, but if the status code is not OK the server won't try to serialize the message.