### PR TITLE
Add SDS capability to XdsClient

### DIFF
--- a/src/core/ext/filters/client_channel/xds/xds_api.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_api.cc
@@ -1260,7 +1260,7 @@ grpc_error* SdsResponseParse(XdsClient* client, TraceFlag* tracer,
     XdsApi::SdsUpdate sds_update;
     // Check type_url of the resource.
     const upb_strview type_url = google_protobuf_Any_type_url(resources[i]);
-    if (!upb_strview_eql(type_url, upb_strview_makez(XdsApi::kCdsTypeUrl))) {
+    if (!upb_strview_eql(type_url, upb_strview_makez(XdsApi::kSdsTypeUrl))) {
       return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Resource is not SDS.");
     }
     // Decode the secret.

--- a/src/core/ext/filters/client_channel/xds/xds_api.h
+++ b/src/core/ext/filters/client_channel/xds/xds_api.h
@@ -43,6 +43,7 @@ class XdsApi {
   static const char* kRdsTypeUrl;
   static const char* kCdsTypeUrl;
   static const char* kEdsTypeUrl;
+  static const char* kSdsTypeUrl;
 
   struct RdsUpdate {
     // The name to use in the CDS request.
@@ -84,6 +85,26 @@ class XdsApi {
   };
 
   using CdsUpdateMap = std::map<std::string /*cluster_name*/, CdsUpdate>;
+
+  struct SdsUpdate {
+    // Resource name
+    std::string name;
+
+    // Local TLS certificate chain in PEM format.
+    absl::optional<std::string> certificate_chain;
+
+    // Local TLS certificate private key in PEM format.
+    absl::optional<std::string> private_key;
+
+    // Trusted root CAs in PEM format.
+    absl::optional<std::string> trusted_ca;
+
+    // A list of valid subject names for ACL validation.
+    absl::optional<std::vector<std::string>> subject_alt_names;
+
+  };
+
+  using SdsUpdateMap = std::map<std::string /*secret_name*/, SdsUpdate>;
 
   class PriorityListUpdate {
    public:
@@ -249,9 +270,10 @@ class XdsApi {
       const std::string& expected_route_config_name,
       const std::set<StringView>& expected_cluster_names,
       const std::set<StringView>& expected_eds_service_names,
+      const std::set<StringView>& expected_secret_names,
       absl::optional<LdsUpdate>* lds_update,
       absl::optional<RdsUpdate>* rds_update, CdsUpdateMap* cds_update_map,
-      EdsUpdateMap* eds_update_map, std::string* version, std::string* nonce,
+      EdsUpdateMap* eds_update_map, SdsUpdateMap* sds_update_map, std::string* version, std::string* nonce,
       std::string* type_url);
 
   // Creates an LRS request querying \a server_name.

--- a/src/core/ext/filters/client_channel/xds/xds_channel.h
+++ b/src/core/ext/filters/client_channel/xds/xds_channel.h
@@ -39,6 +39,9 @@ grpc_channel_args* ModifyXdsChannelArgs(grpc_channel_args* args);
 grpc_channel* CreateXdsChannel(const XdsBootstrap& bootstrap,
                                const grpc_channel_args& args,
                                grpc_error** error);
+grpc_channel* CreateSdsChannel(envoy_api_v2_ConfigSource* config_source,
+                               const grpc_channel_args& args,
+                               grpc_error** error);
 
 }  // namespace grpc_core
 


### PR DESCRIPTION
** WIP **

Since sDS stream is very similar to xDS ADS stream, we reuse the XdsClient to make sDS requests.

The change is not straightforward because sDS calls are targeted to a different server (specified from xDS configurations), and uses a different path. We are making a separate channel for sDS watchers that only makes sDS calls, and makes `AdsCallState` to be configurable on its path and call credentials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/22676)
<!-- Reviewable:end -->
