### PR TITLE
WIP Only Unary Stream partially implemented

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/__init__.py
+++ b/src/python/grpcio/grpc/experimental/aio/__init__.py
@@ -31,7 +31,11 @@ from ._base_channel import (Channel, StreamStreamMultiCallable,
                             UnaryUnaryMultiCallable)
 from ._call import AioRpcError
 from ._interceptor import (ClientCallDetails, InterceptedUnaryUnaryCall,
-                           UnaryUnaryClientInterceptor, ServerInterceptor)
+                           UnaryUnaryClientInterceptor,
+                           UnaryStreamClientInterceptor,
+                           StreamUnaryClientInterceptor,
+                           StreamStreamClientInterceptor,
+                           ServerInterceptor)
 from ._server import server
 from ._base_server import Server, ServicerContext
 from ._typing import ChannelArgumentType

--- a/src/python/grpcio/grpc/experimental/aio/_call.py
+++ b/src/python/grpcio/grpc/experimental/aio/_call.py
@@ -318,6 +318,9 @@ class _StreamResponseMixin(Call):
             yield message
             message = await self._read()
 
+        # If the read operation failed, Core should explain why.
+        await self._raise_for_status()
+
     def __aiter__(self) -> AsyncIterable[ResponseType]:
         self._update_response_style(_APIStyle.ASYNC_GENERATOR)
         if self._message_aiter is None:

--- a/src/python/grpcio_tests/tests_aio/unit/client_streaming_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_streaming_interceptor_test.py
@@ -1,0 +1,314 @@
+# Copyright 2019 The gRPC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import logging
+import unittest
+
+import grpc
+
+from grpc.experimental import aio
+from tests_aio.unit._test_server import start_test_server
+from tests_aio.unit._test_base import AioTestBase
+from src.proto.grpc.testing import messages_pb2, test_pb2_grpc
+
+
+_NUM_STREAM_RESPONSES = 5
+_REQUEST_PAYLOAD_SIZE = 7
+_RESPONSE_PAYLOAD_SIZE = 7
+
+
+class ResponseIterator:
+    def __init__(self, response_iterator):
+        self._response_cnt = 0
+        self._response_iterator = response_iterator
+
+    async def _forward_responses(self):
+        async for response in self._response_iterator:
+            self._response_cnt += 1
+            yield response
+
+    def __aiter__(self):
+        return self._forward_responses()
+
+    @property
+    def response_cnt(self):
+        return self._response_cnt
+
+
+class RequestIterator:
+    def __init__(self, resquest_iterator):
+        self._request_cnt = 0
+        self._request_iterator = request_iterator
+
+    def _forward_requests(self):
+        for request in self._request_iterator:
+            self._request_cnt += 1
+            yield request
+
+    def __iter__(self):
+        return self._forward_requests()
+
+    @property
+    def request_cnt(self):
+        return self._request_cnt
+
+
+class TestUnaryStreamClientInterceptor(AioTestBase):
+
+    async def setUp(self):
+        self._server_target, self._server = await start_test_server()
+
+    async def tearDown(self):
+        await self._server.stop(None)
+
+    async def test_none_intercepts_response_iterator(self):
+
+        class Interceptor(aio.UnaryStreamClientInterceptor):
+
+            async def intercept_unary_stream(self, continuation,
+                                             client_call_details, request, response_iterator):
+                call = await continuation(client_call_details, request, response_iterator)
+                return call
+
+
+        interceptor = Interceptor()
+
+        channel = aio.insecure_channel(self._server_target, interceptors=[interceptor])
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        request = messages_pb2.StreamingOutputCallRequest()
+        for _ in range(_NUM_STREAM_RESPONSES):
+            request.response_parameters.append(
+                messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        call = stub.StreamingOutputCall(request)
+
+        response_cnt = 0
+        async for response in call:
+            response_cnt += 1
+            self.assertIs(type(response),
+                          messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+
+        self.assertTrue(response_cnt, _NUM_STREAM_RESPONSES)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+        await channel.close()
+
+    async def test_intercepts_response_iterator(self):
+
+        class Interceptor(aio.UnaryStreamClientInterceptor):
+
+            def __init__(self):
+                self._response_iterator = None
+
+            async def intercept_unary_stream(self, continuation,
+                                             client_call_details, request, response_iterator):
+                self._response_iterator = ResponseIterator(response_iterator)
+                call = await continuation(client_call_details, request, self._response_iterator)
+                return call
+
+            @property
+            def response_iterator(self):
+                return self._response_iterator
+
+        interceptor = Interceptor()
+
+        channel = aio.insecure_channel(self._server_target, interceptors=[interceptor])
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        request = messages_pb2.StreamingOutputCallRequest()
+        for _ in range(_NUM_STREAM_RESPONSES):
+            request.response_parameters.append(
+                messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        call = stub.StreamingOutputCall(request)
+
+        response_cnt = 0
+        async for response in call:
+            response_cnt += 1
+            self.assertIs(type(response),
+                          messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        self.assertTrue(response_cnt, _NUM_STREAM_RESPONSES)
+        self.assertTrue(interceptor.response_iterator.response_cnt, _NUM_STREAM_RESPONSES)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+        await channel.close()
+
+    async def test_intercepts_response_iterator_using_read(self):
+
+        class Interceptor(aio.UnaryStreamClientInterceptor):
+
+            def __init__(self):
+                self._response_iterator = None
+
+            async def intercept_unary_stream(self, continuation,
+                                             client_call_details, request, response_iterator):
+                self._response_iterator = ResponseIterator(response_iterator)
+                call = await continuation(client_call_details, request, self._response_iterator)
+                return call
+
+            @property
+            def response_iterator(self):
+                return self._response_iterator
+
+        interceptor = Interceptor()
+
+        channel = aio.insecure_channel(self._server_target, interceptors=[interceptor])
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        request = messages_pb2.StreamingOutputCallRequest()
+        for _ in range(_NUM_STREAM_RESPONSES):
+            request.response_parameters.append(
+                messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        call = stub.StreamingOutputCall(request)
+
+        response_cnt = 0
+        for response in range(_NUM_STREAM_RESPONSES):
+            response = await call.read()
+            response_cnt += 1
+            self.assertIs(type(response),
+                          messages_pb2.StreamingOutputCallResponse)
+            self.assertEqual(_RESPONSE_PAYLOAD_SIZE, len(response.payload.body))
+
+        self.assertTrue(response_cnt, _NUM_STREAM_RESPONSES)
+        self.assertTrue(interceptor.response_iterator.response_cnt, _NUM_STREAM_RESPONSES)
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+        await channel.close()
+
+
+
+@unittest.skip("TODO")
+class TestStreamUnaryClientInterceptor(AioTestBase):
+
+    async def setUp(self):
+        self._server_target, self._server = await start_test_server()
+
+    async def tearDown(self):
+        await self._server.stop(None)
+
+    async def test_intercepts_request_iterator(self):
+
+        class Interceptor(aio.StreamUnaryClientInterceptor):
+            def __init__(self):
+                self._request_iterator = None
+
+            async def intercept_stream_unary(self, continuation,
+                                            client_call_details, request_iterator):
+                proxied_request_iterator = RequestItearor(request_iterator)
+                call = await continuation(client_call_details, proxied_request_iterator)
+                return call
+
+            @property
+            def request_interceptor(self):
+                return self._request_iterator
+
+        interceptor = Interceptor()
+
+        channel = aio.insecure_channel(self._server_target, interceptors=[interceptor])
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        # Prepares the request
+        payload = messages_pb2.Payload(body=b'\0' * _REQUEST_PAYLOAD_SIZE)
+        request = messages_pb2.StreamingInputCallRequest(payload=payload)
+
+        async def gen():
+            for _ in range(_NUM_STREAM_RESPONSES):
+                yield request
+
+        call = stub.StreamingInputCall(gen())
+        await call
+
+        self.assertEqual(await call.code(), grpc.StatusCode.OK)
+
+        # Validates that all messages have been intercepted
+        self.assertTrue(interceptor.request_iterator.response_cnt, _NUM_STREAM_RESPONSES)
+
+        await channel.close()
+
+
+@unittest.skip("TODO")
+class TestStreamStreamClientInterceptor(AioTestBase):
+
+    async def setUp(self):
+        self._server_target, self._server = await start_test_server()
+
+    async def tearDown(self):
+        await self._server.stop(None)
+
+    async def test_intercepts_request_response_iterator(self):
+
+        class Interceptor(aio.StreamStreamClientInterceptor):
+
+            def __init__(self):
+                self._request_iterator = None
+                self._response_iterator = None
+
+            async def intercept_stream_stream(self, continuation,
+                                             client_call_details,
+                                             request_iterator,
+                                             response_iterator):
+                proxied_request_iterator = RequestIterator(request_iterator)
+                proxied_response_iterator = ResponseIterator(response_iterator)
+                call = await continuation(
+                    client_call_details, 
+                    proxied_request_iterator,
+                    proxied_response_iterator
+                )
+                return call
+
+            @property
+            def request_interceptor(self):
+                return self._request_iterator
+
+            @property
+            def response_interceptor(self):
+                return self._response_iterator
+
+        interceptor = Interceptor()
+
+        channel = aio.insecure_channel(self._server_target, interceptors=[interceptor])
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        # Prepares the request
+        request = messages_pb2.StreamingOutputCallRequest()
+        request.response_parameters.append(
+            messages_pb2.ResponseParameters(size=_RESPONSE_PAYLOAD_SIZE))
+
+        async def gen():
+            for _ in range(_NUM_STREAM_RESPONSES):
+                yield request
+
+        call = stub.FullDuplexCall(gen())
+
+        async for response in call:
+            pass
+
+        self.assertEqual(grpc.StatusCode.OK, await call.code())
+ 
+        # Validates that all messages have been intercepted
+        self.assertTrue(interceptor.request_iterator.response_cnt, _NUM_STREAM_RESPONSES)
+        self.assertTrue(interceptor.response_iterator.response_cnt, _NUM_STREAM_RESPONSES)
+
+        await channel.close()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Draft implementation of the Unary Stream Client Interceptor for receiving early feedback. There are still some missing pieces, and many tests are missing but the way that the developer will be using the interceptor is well defined and ready to receive feedback.

The rationale is to keep using the same technique used by the current stack, so providing to the user a way of adding an iterator, in the use case of the  Unary Stream Client Interceptor a response iterator, for intercepting messages that are being sent by the RPC and acting as a proxy to the iterator consumed by the caller.

So the idea would be having a final PR that would provide support for the Unary Stream Client Interceptor.