### PR TITLE
[6/n] Avoid using hardcoded test credentials

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -180,6 +180,9 @@ grpc_cc_test(
         "grpc_tool_test.cc",
     ],
     data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
         "//src/proto/grpc/testing:echo.proto",
         "//src/proto/grpc/testing:echo_messages.proto",
         "//src/proto/grpc/testing:simple_messages.proto",

--- a/test/cpp/util/grpc_tool_test.cc
+++ b/test/cpp/util/grpc_tool_test.cc
@@ -18,8 +18,6 @@
 
 #include "test/cpp/util/grpc_tool.h"
 
-#include <sstream>
-
 #include <gflags/gflags.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
@@ -32,14 +30,20 @@
 #include <grpcpp/server_context.h>
 #include <gtest/gtest.h>
 
+#include <sstream>
+
 #include "src/core/lib/gpr/env.h"
+#include "src/core/lib/iomgr/load_file.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.pb.h"
-#include "test/core/end2end/data/ssl_test_data.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/cli_credentials.h"
 #include "test/cpp/util/string_ref_helper.h"
+
+#define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
+#define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
+#define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 using grpc::testing::EchoRequest;
 using grpc::testing::EchoResponse;
@@ -121,8 +125,16 @@ class TestCliCredentials final : public grpc::testing::CliCredentials {
     if (!secure_) {
       return InsecureChannelCredentials();
     }
+    grpc_slice ca_slice;
+    GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                                 grpc_load_file(CA_CERT_PATH, 1, &ca_slice)));
+    const char* test_root_cert =
+        reinterpret_cast<const char*> GRPC_SLICE_START_PTR(ca_slice);
     SslCredentialsOptions ssl_opts = {test_root_cert, "", ""};
-    return grpc::SslCredentials(grpc::SslCredentialsOptions(ssl_opts));
+    std::shared_ptr<grpc::ChannelCredentials> credential_ptr =
+        grpc::SslCredentials(grpc::SslCredentialsOptions(ssl_opts));
+    grpc_slice_unref(ca_slice);
+    return credential_ptr;
   }
   const grpc::string GetCredentialUsage() const override { return ""; }
 
@@ -240,9 +252,18 @@ class GrpcToolTest : public ::testing::Test {
     // Setup server
     ServerBuilder builder;
     std::shared_ptr<grpc::ServerCredentials> creds;
+    grpc_slice cert_slice, key_slice;
+    GPR_ASSERT(GRPC_LOG_IF_ERROR(
+        "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+    GPR_ASSERT(GRPC_LOG_IF_ERROR(
+        "load_file", grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+    const char* server_cert =
+        reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+    const char* server_key =
+        reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+    SslServerCredentialsOptions::PemKeyCertPair pkcp = {server_key,
+                                                        server_cert};
     if (secure) {
-      SslServerCredentialsOptions::PemKeyCertPair pkcp = {test_server1_key,
-                                                          test_server1_cert};
       SslServerCredentialsOptions ssl_opts;
       ssl_opts.pem_root_certs = "";
       ssl_opts.pem_key_cert_pairs.push_back(pkcp);
@@ -253,6 +274,8 @@ class GrpcToolTest : public ::testing::Test {
     builder.AddListeningPort(server_address.str(), creds);
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();
+    grpc_slice_unref(cert_slice);
+    grpc_slice_unref(key_slice);
     return server_address.str();
   }
 


### PR DESCRIPTION
This is 6th part of the PR to clean up the test credentials used in C Core(more specifically, in `test/core/end2end/...`).
The ultimate goal is to remove the dependencies on `test/core/end2end/data/ssl_test_data.h`, which contains strings of hard-coded certificates.