### PR TITLE
[7/n] Avoid using hardcoded test credentials

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -74,6 +74,11 @@ grpc_cc_library(
         "create_test_channel.h",
         "test_credentials_provider.h",
     ],
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
     external_deps = [
         "gflags",
         "protobuf",

--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -31,7 +31,6 @@
 #include <unordered_map>
 
 #include "src/core/lib/iomgr/load_file.h"
-#include "test/core/end2end/data/ssl_test_data.h"
 
 #define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
 #define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"

--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -19,19 +19,23 @@
 
 #include "test/cpp/util/test_credentials_provider.h"
 
-#include <cstdio>
-#include <fstream>
-#include <iostream>
-
-#include <mutex>
-#include <unordered_map>
-
 #include <gflags/gflags.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpcpp/security/server_credentials.h>
 
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <unordered_map>
+
+#include "src/core/lib/iomgr/load_file.h"
 #include "test/core/end2end/data/ssl_test_data.h"
+
+#define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
+#define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
+#define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 DEFINE_string(tls_cert_file, "", "The TLS cert file used when --use_tls=true");
 DEFINE_string(tls_key_file, "", "The TLS key file used when --use_tls=true");
@@ -90,9 +94,17 @@ class DefaultCredentialsProvider : public CredentialsProvider {
       grpc::experimental::AltsCredentialsOptions alts_opts;
       return grpc::experimental::AltsCredentials(alts_opts);
     } else if (type == grpc::testing::kTlsCredentialsType) {
+      grpc_slice ca_slice;
+      GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                                   grpc_load_file(CA_CERT_PATH, 1, &ca_slice)));
+      const char* test_root_cert =
+          reinterpret_cast<const char*> GRPC_SLICE_START_PTR(ca_slice);
       SslCredentialsOptions ssl_opts = {test_root_cert, "", ""};
       args->SetSslTargetNameOverride("foo.test.google.fr");
-      return grpc::SslCredentials(ssl_opts);
+      std::shared_ptr<grpc::ChannelCredentials> credential_ptr =
+          grpc::SslCredentials(grpc::SslCredentialsOptions(ssl_opts));
+      grpc_slice_unref(ca_slice);
+      return credential_ptr;
     } else if (type == grpc::testing::kGoogleDefaultCredentialsType) {
       return grpc::GoogleDefaultCredentials();
     } else {
@@ -122,12 +134,26 @@ class DefaultCredentialsProvider : public CredentialsProvider {
         SslServerCredentialsOptions::PemKeyCertPair pkcp = {
             custom_server_key_, custom_server_cert_};
         ssl_opts.pem_key_cert_pairs.push_back(pkcp);
+        return SslServerCredentials(ssl_opts);
       } else {
-        SslServerCredentialsOptions::PemKeyCertPair pkcp = {test_server1_key,
-                                                            test_server1_cert};
+        grpc_slice cert_slice, key_slice;
+        GPR_ASSERT(GRPC_LOG_IF_ERROR(
+            "load_file", grpc_load_file(SERVER_CERT_PATH, 1, &cert_slice)));
+        GPR_ASSERT(GRPC_LOG_IF_ERROR(
+            "load_file", grpc_load_file(SERVER_KEY_PATH, 1, &key_slice)));
+        const char* server_cert =
+            reinterpret_cast<const char*> GRPC_SLICE_START_PTR(cert_slice);
+        const char* server_key =
+            reinterpret_cast<const char*> GRPC_SLICE_START_PTR(key_slice);
+        SslServerCredentialsOptions::PemKeyCertPair pkcp = {server_key,
+                                                            server_cert};
         ssl_opts.pem_key_cert_pairs.push_back(pkcp);
+        std::shared_ptr<ServerCredentials> credential_ptr =
+            SslServerCredentials(ssl_opts);
+        grpc_slice_unref(cert_slice);
+        grpc_slice_unref(key_slice);
+        return credential_ptr;
       }
-      return SslServerCredentials(ssl_opts);
     } else {
       std::unique_lock<std::mutex> lock(mu_);
       auto it(std::find(added_secure_type_names_.begin(),

--- a/test/cpp/util/test_credentials_provider.h
+++ b/test/cpp/util/test_credentials_provider.h
@@ -19,10 +19,6 @@
 #ifndef GRPC_TEST_CPP_UTIL_TEST_CREDENTIALS_PROVIDER_H
 #define GRPC_TEST_CPP_UTIL_TEST_CREDENTIALS_PROVIDER_H
 
-extern const char test_root_cert[];
-extern const char server_cert[];
-extern const char server_key[];
-
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/support/channel_arguments.h>

--- a/test/cpp/util/test_credentials_provider.h
+++ b/test/cpp/util/test_credentials_provider.h
@@ -19,11 +19,15 @@
 #ifndef GRPC_TEST_CPP_UTIL_TEST_CREDENTIALS_PROVIDER_H
 #define GRPC_TEST_CPP_UTIL_TEST_CREDENTIALS_PROVIDER_H
 
-#include <memory>
+extern const char test_root_cert[];
+extern const char server_cert[];
+extern const char server_key[];
 
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/support/channel_arguments.h>
+
+#include <memory>
 
 namespace grpc {
 namespace testing {


### PR DESCRIPTION
This is 7th part of the PR to clean up the test credentials used in C Core(more specifically, in `test/core/end2end/...`).
The ultimate goal is to remove the dependencies on `test/core/end2end/data/ssl_test_data.h`, which contains strings of hard-coded certificates.