### PR TITLE
Remove RefCountedPtrLess.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -305,8 +305,7 @@ class ChannelData {
   // Pending ConnectedSubchannel updates for each SubchannelWrapper.
   // Updates are queued here in the control plane work_serializer and then
   // applied in the data plane mutex when the picker is updated.
-  std::map<RefCountedPtr<SubchannelWrapper>, RefCountedPtr<ConnectedSubchannel>,
-           RefCountedPtrLess<SubchannelWrapper>>
+  std::map<RefCountedPtr<SubchannelWrapper>, RefCountedPtr<ConnectedSubchannel>>
       pending_subchannel_updates_;
 
   //

--- a/src/core/lib/gprpp/map.h
+++ b/src/core/lib/gprpp/map.h
@@ -46,14 +46,6 @@ struct StringLess {
   }
 };
 
-template <typename T>
-struct RefCountedPtrLess {
-  bool operator()(const RefCountedPtr<T>& p1,
-                  const RefCountedPtr<T>& p2) const {
-    return p1.get() < p2.get();
-  }
-};
-
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_GPRPP_MAP_H */

--- a/src/core/lib/gprpp/ref_counted_ptr.h
+++ b/src/core/lib/gprpp/ref_counted_ptr.h
@@ -182,6 +182,11 @@ inline RefCountedPtr<T> MakeRefCounted(Args&&... args) {
   return RefCountedPtr<T>(new T(std::forward<Args>(args)...));
 }
 
+template <typename T>
+bool operator<(const RefCountedPtr<T>& p1, const RefCountedPtr<T>& p2) {
+  return p1.get() < p2.get();
+}
+
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_GPRPP_REF_COUNTED_PTR_H */


### PR DESCRIPTION
Instead, we define `operator<()` for `RefCountedPtr<>`.