### PR TITLE
PHP: fix of a bit of memory leak

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -350,7 +350,6 @@ PHP_METHOD(Channel, __construct) {
                            1 TSRMLS_CC);
       return;
     } else {
-      Z_ADDREF(*creds_obj);
       creds = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel_credentials,
                                           creds_obj);
     }


### PR DESCRIPTION
on [#19737](https://github.com/grpc/grpc/pull/19737), addref() was added on user's request, it's a fix of [#19721](https://github.com/grpc/grpc/issues/19721) "Missing addref on ChannelCredentials in Channel constructor causes segfault"
At that time, grpc-php-ext was using php_grpc_zend_hash_del() to delete 3 objects, including "credentials", from args_array, but "credentials" object was used later. After fix, addref(increase ref) and delete(decrease ref) as a pair, made it OK, no memory leak then. 
Later on [#20249](https://github.com/grpc/grpc/pull/20249), when the code was modified, php-ext stopped using php_grpc_zend_hash_del() any more. addref() is not needed any more. 


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->
