### PR TITLE
Remove some excessive logs

### DIFF
--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -225,7 +225,6 @@ experimental::ServerUnaryReactor* CallbackTestServiceImpl::Echo(
         FinishWhenCancelledAsync();
         return;
       }
-      gpr_log(GPR_DEBUG, "Request message was %s", req_->message().c_str());
       resp_->set_message(req_->message());
       internal::MaybeEchoDeadline(ctx_, req_, resp_);
       if (service_->host_) {
@@ -568,7 +567,6 @@ CallbackTestServiceImpl::BidiStream(
     void OnReadDone(bool ok) override {
       if (ok) {
         num_msgs_read_++;
-        gpr_log(GPR_INFO, "recv msg %s", request_.message().c_str());
         response_.set_message(request_.message());
         if (num_msgs_read_ == server_write_last_) {
           StartWriteLast(&response_, WriteOptions());


### PR DESCRIPTION
These log messages are polluting the test log files and making things hard to debug. I know for a fact that one of them was left in by mistake because of my big PR a few months ago.
