### PR TITLE
Redundant get() call on smart pointer

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_routing.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_routing.cc
@@ -231,7 +231,7 @@ XdsRoutingLb::PickResult XdsRoutingLb::RoutePicker::Pick(PickArgs args) {
          (path_elements[1] == route.matcher.method ||
           route.matcher.method.empty())) ||
         (route.matcher.service.empty() && route.matcher.method.empty())) {
-      return route.picker.get()->Pick(args);
+      return route.picker->Pick(args);
     }
   }
   PickResult result;


### PR DESCRIPTION
I caught this ClangTide error while doing the import. Applied a quick fix here to follow the go/clang-tidy/checks/readability-redundant-smartptr-get.md.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
