### PR TITLE
Drop commands about Python 3.4 in manylinux2010 Dockerfile

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
@@ -24,7 +24,6 @@ RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-de
 # Install Python build requirements
 RUN /opt/python/cp27-cp27m/bin/pip install --upgrade cython
 RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
-RUN /opt/python/cp34-cp34m/bin/pip install --upgrade cython
 RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
 RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
 RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
@@ -24,7 +24,6 @@ RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-de
 # Install Python build requirements
 RUN /opt/python/cp27-cp27m/bin/pip install --upgrade cython
 RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
-RUN /opt/python/cp34-cp34m/bin/pip install --upgrade cython
 RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
 RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
 RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython


### PR DESCRIPTION
As title.

Official manylinux2010 image dropped 3.4. So we can't rebuild our manylinux2010 image unless we remove those lines about 3.4.