### PR TITLE
PHP: update devtoolset gcc version

### DIFF
--- a/src/php/docker/README.md
+++ b/src/php/docker/README.md
@@ -97,17 +97,17 @@ $ docker run -it --rm grpc-php/alpine
 ```
 ### `centos7`
 
-This image builds the `grpc` extension against the GCC version in Centos7 base image.
+This image builds the `grpc` extension against the GCC version in Centos7 base image. The default version of gcc in centos7 is gcc-4.8.5. Run `scl enable devtoolset-7 bash` command to enable gcc-7.3.1.
 
 Build `centos7` docker image:
 ```sh
 $ cd grpc
-$ docker build -t grpc-gcc5/centos -f ./src/php/docker/centos7/Dockerfile .
+$ docker build -t grpc-gcc7/centos -f ./src/php/docker/centos7/Dockerfile .
 ```
 
 Run image:
 ```sh
-$ docker run -it --rm grpc-gcc5/centos
+$ docker run -it --rm grpc-gcc7/centos
 ```
 
 ### `php-src`

--- a/src/php/docker/centos7/Dockerfile
+++ b/src/php/docker/centos7/Dockerfile
@@ -14,13 +14,13 @@
 
 FROM centos:centos7
 
-RUN yum install -y centos-release-scl && \
+RUN yum update -y && \
+  yum install -y centos-release-scl && \
   yum install -y devtoolset-7-gcc*
 
 SHELL [ "/usr/bin/scl", "enable", "devtoolset-7"]
 
-RUN yum update -y && \
-  yum install epel-release -y && \
+RUN yum install epel-release -y && \
   rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm && \
   rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm && \
   yum --enablerepo=remi-php72 install php -y && \
@@ -28,7 +28,7 @@ RUN yum update -y && \
   yum install -y make wget which \
     gmp-devel libmpc-devel mpfr-devel yum-utils \                                                            
     php-devel php-fpm php-pear && \                                                                          
- yum clean all -y  
+  yum clean all -y  
 
 ARG MAKEFLAGS=-j8
 

--- a/src/php/docker/centos7/Dockerfile
+++ b/src/php/docker/centos7/Dockerfile
@@ -14,24 +14,26 @@
 
 FROM centos:centos7
 
+RUN yum install -y centos-release-scl && \
+  yum install -y devtoolset-7-gcc*
+
+SHELL [ "/usr/bin/scl", "enable", "devtoolset-7"]
+
 RUN yum update -y && \
   yum install epel-release -y && \
   rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm && \
   rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm && \
   yum --enablerepo=remi-php72 install php -y && \
-  yum-config-manager --enable remi-php72 && \
-  yum install -y php-fpm php-pear make php-devel wget libmpc-devel mpfr-devel gmp-devel yum-utils && \
-  yum clean all -y
+  yum-config-manager --enable remi-php72 > /dev/null && \
+  yum install -y make wget which \
+    gmp-devel libmpc-devel mpfr-devel yum-utils \                                                            
+    php-devel php-fpm php-pear && \                                                                          
+ yum clean all -y  
 
 ARG MAKEFLAGS=-j8
 
 
 WORKDIR /tmp
-
-RUN yum install -y centos-release-scl && \
-  yum install -y devtoolset-4-gcc*
-
-SHELL [ "/usr/bin/scl", "enable", "devtoolset-4"]
 
 RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
   mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \

--- a/templates/src/php/docker/centos7/Dockerfile.template
+++ b/templates/src/php/docker/centos7/Dockerfile.template
@@ -16,24 +16,26 @@
 
   FROM centos:centos7
 
+  RUN yum install -y centos-release-scl && ${'\\'}
+    yum install -y devtoolset-7-gcc*
+
+  SHELL [ "/usr/bin/scl", "enable", "devtoolset-7"]
+  
   RUN yum update -y && ${'\\'}
     yum install epel-release -y && ${'\\'}
     rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm && ${'\\'}
     rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm && ${'\\'}
     yum --enablerepo=remi-php72 install php -y && ${'\\'}
-    yum-config-manager --enable remi-php72 && ${'\\'}
-    yum install -y php-fpm php-pear make php-devel wget libmpc-devel mpfr-devel gmp-devel yum-utils && ${'\\'}
-    yum clean all -y
+    yum-config-manager --enable remi-php72 > /dev/null && ${'\\'}
+    yum install -y make wget which ${'\\'}
+      gmp-devel libmpc-devel mpfr-devel yum-utils ${'\\'}                                                            
+      php-devel php-fpm php-pear && ${'\\'}                                                                          
+   yum clean all -y  
 
   ARG MAKEFLAGS=-j8
 
 
   WORKDIR /tmp
-
-  RUN yum install -y centos-release-scl && ${'\\'}
-    yum install -y devtoolset-4-gcc*
-
-  SHELL [ "/usr/bin/scl", "enable", "devtoolset-4"]
 
   <%include file="../download_phpunit.include" />
 

--- a/templates/src/php/docker/centos7/Dockerfile.template
+++ b/templates/src/php/docker/centos7/Dockerfile.template
@@ -16,13 +16,13 @@
 
   FROM centos:centos7
 
-  RUN yum install -y centos-release-scl && ${'\\'}
+  RUN yum update -y && ${'\\'}
+    yum install -y centos-release-scl && ${'\\'}
     yum install -y devtoolset-7-gcc*
 
   SHELL [ "/usr/bin/scl", "enable", "devtoolset-7"]
   
-  RUN yum update -y && ${'\\'}
-    yum install epel-release -y && ${'\\'}
+  RUN yum install epel-release -y && ${'\\'}
     rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm && ${'\\'}
     rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm && ${'\\'}
     yum --enablerepo=remi-php72 install php -y && ${'\\'}
@@ -30,7 +30,7 @@
     yum install -y make wget which ${'\\'}
       gmp-devel libmpc-devel mpfr-devel yum-utils ${'\\'}                                                            
       php-devel php-fpm php-pear && ${'\\'}                                                                          
-   yum clean all -y  
+    yum clean all -y  
 
   ARG MAKEFLAGS=-j8
 


### PR DESCRIPTION
Centos7 removed devtooset-4,5 and 6 version package. fixed No package devtoolset-4-gcc* available.  

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@stanley-cheung 
