### PR TITLE
Fix YARD annotation of GRPC::ClientInterceptor

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -38,7 +38,7 @@ module GRPC
     #
     # @param [Object] request
     # @param [GRPC::ActiveCall] call
-    # @param [Method] method
+    # @param [String] method
     # @param [Hash] metadata
     #
     def request_response(request: nil, call: nil, method: nil, metadata: nil)
@@ -52,7 +52,7 @@ module GRPC
     #
     # @param [Enumerable] requests
     # @param [GRPC::ActiveCall] call
-    # @param [Method] method
+    # @param [String] method
     # @param [Hash] metadata
     #
     def client_streamer(requests: nil, call: nil, method: nil, metadata: nil)
@@ -66,7 +66,7 @@ module GRPC
     #
     # @param [Object] request
     # @param [GRPC::ActiveCall] call
-    # @param [Method] method
+    # @param [String] method
     # @param [Hash] metadata
     #
     def server_streamer(request: nil, call: nil, method: nil, metadata: nil)
@@ -80,7 +80,7 @@ module GRPC
     #
     # @param [Enumerable] requests
     # @param [GRPC::ActiveCall] call
-    # @param [Method] method
+    # @param [String] method
     # @param [Hash] metadata
     #
     def bidi_streamer(requests: nil, call: nil, method: nil, metadata: nil)


### PR DESCRIPTION
## Why
In the current implementation of `grpc` gem, `@param [Method] method` is written as YARD annotation to indicate the type of `method` parameter in `GRPC::ClientInterceptor`.

However, this annotation is incorrect. `String` object is passed as the `method` parameter now. The following code indicates it.

https://github.com/grpc/grpc/blob/c07ddb45047f38c871fbb2519b4832144d09afe7/src/ruby/lib/grpc/generic/client_stub.rb#L136

https://github.com/grpc/grpc/blob/c07ddb45047f38c871fbb2519b4832144d09afe7/src/ruby/lib/grpc/generic/client_stub.rb#L159-L164

https://github.com/grpc/grpc/blob/c07ddb45047f38c871fbb2519b4832144d09afe7/src/ruby/lib/grpc/generic/client_stub.rb#L171-L173

I only attached the code of `#request_response`, but this is same with other methods (`#client_streamer`, `#server_streamer`, `#bidi_streamer`).

I noticed this issue when creating some client interceptors.
- https://github.com/wantedly/grpc_opencensus_interceptor
- https://github.com/wantedly/grpc_newrelic_interceptor

## What
Fixed the YARD annotation of `GRPC::ClientInterceptor`.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
