### PR TITLE
Add helper methods for getting metadata values

### DIFF
--- a/src/csharp/Grpc.Core.Api/Metadata.cs
+++ b/src/csharp/Grpc.Core.Api/Metadata.cs
@@ -76,7 +76,7 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the last metadata entry with the specified key. If no entries have the key then <c>null</c> is returned.
+        /// Gets the last metadata entry with the specified key. If there are no matching entries then <c>null</c> is returned.
         /// </summary>
         public Entry Get(string key)
         {
@@ -92,6 +92,22 @@ namespace Grpc.Core
         }
 
         /// <summary>
+        /// Gets the string value of the last metadata entry with the specified key. If there are no matching entries then <c>null</c> is returned.
+        /// </summary>
+        public string GetValue(string key)
+        {
+            return Get(key)?.Value;
+        }
+
+        /// <summary>
+        /// Gets the bytes value of the last metadata entry with the specified key. If there are no matching entries then <c>null</c> is returned.
+        /// </summary>
+        public byte[] GetValueBytes(string key)
+        {
+            return Get(key)?.ValueBytes;
+        }
+
+        /// <summary>
         /// Gets all metadata entries with the specified key.
         /// </summary>
         public IEnumerable<Entry> GetAll(string key)
@@ -103,22 +119,6 @@ namespace Grpc.Core
                     yield return entries[i];
                 }
             }
-        }
-
-        /// <summary>
-        /// Gets the last metadata entry string value with the specified key. If no entries have the key then <c>null</c> is returned.
-        /// </summary>
-        public string GetValue(string key)
-        {
-            return Get(key)?.Value;
-        }
-
-        /// <summary>
-        /// Gets the last metadata entry bytes value with the specified key. If no entries have the key then <c>null</c> is returned.
-        /// </summary>
-        public byte[] GetValueBytes(string key)
-        {
-            return Get(key)?.ValueBytes;
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core.Api/Metadata.cs
+++ b/src/csharp/Grpc.Core.Api/Metadata.cs
@@ -76,7 +76,7 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the last metadata entry with the specified key.
+        /// Gets the last metadata entry with the specified key. If no entries have the key then <c>null</c> is returned.
         /// </summary>
         public Entry Get(string key)
         {
@@ -106,7 +106,7 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the last metadata entry string value with the specified key.
+        /// Gets the last metadata entry string value with the specified key. If no entries have the key then <c>null</c> is returned.
         /// </summary>
         public string GetValue(string key)
         {
@@ -114,7 +114,7 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the last metadata entry bytes value with the specified key.
+        /// Gets the last metadata entry bytes value with the specified key. If no entries have the key then <c>null</c> is returned.
         /// </summary>
         public byte[] GetValueBytes(string key)
         {

--- a/src/csharp/Grpc.Core.Api/Metadata.cs
+++ b/src/csharp/Grpc.Core.Api/Metadata.cs
@@ -75,7 +75,67 @@ namespace Grpc.Core
             return this;
         }
 
-        // TODO: add support for access by key
+        /// <summary>
+        /// Gets the last metadata entry with the specified key.
+        /// </summary>
+        public Entry Get(string key)
+        {
+            for (int i = entries.Count - 1; i >= 0; i--)
+            {
+                if (entries[i].Key == key)
+                {
+                    return entries[i];
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets all metadata entries with the specified key.
+        /// </summary>
+        public IEnumerable<Entry> GetAll(string key)
+        {
+            for (int i = 0; i < entries.Count; i++)
+            {
+                if (entries[i].Key == key)
+                {
+                    yield return entries[i];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the last metadata entry string value with the specified key.
+        /// </summary>
+        public string GetValue(string key)
+        {
+            return Get(key)?.Value;
+        }
+
+        /// <summary>
+        /// Gets the last metadata entry bytes value with the specified key.
+        /// </summary>
+        public byte[] GetValueBytes(string key)
+        {
+            return Get(key)?.ValueBytes;
+        }
+
+        /// <summary>
+        /// Adds a new ASCII-valued metadata entry. See <c>Metadata.Entry</c> constructor for params.
+        /// </summary>
+        public void Add(string key, string value)
+        {
+            Add(new Entry(key, value));
+        }
+
+        /// <summary>
+        /// Adds a new binary-valued metadata entry. See <c>Metadata.Entry</c> constructor for params.
+        /// </summary>
+        public void Add(string key, byte[] valueBytes)
+        {
+            Add(new Entry(key, valueBytes));
+        }
 
         #region IList members
 
@@ -133,22 +193,6 @@ namespace Grpc.Core
             GrpcPreconditions.CheckNotNull(item);
             CheckWriteable();
             entries.Add(item);
-        }
-
-        /// <summary>
-        /// Adds a new ASCII-valued metadata entry. See <c>Metadata.Entry</c> constructor for params.
-        /// </summary>
-        public void Add(string key, string value)
-        {
-            Add(new Entry(key, value));
-        }
-
-        /// <summary>
-        /// Adds a new binary-valued metadata entry. See <c>Metadata.Entry</c> constructor for params.
-        /// </summary>
-        public void Add(string key, byte[] valueBytes)
-        {
-            Add(new Entry(key, valueBytes));
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core.Api/Metadata.cs
+++ b/src/csharp/Grpc.Core.Api/Metadata.cs
@@ -76,7 +76,8 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the last metadata entry with the specified key. If there are no matching entries then <c>null</c> is returned.
+        /// Gets the last metadata entry with the specified key.
+        /// If there are no matching entries then <c>null</c> is returned.
         /// </summary>
         public Entry Get(string key)
         {
@@ -92,7 +93,9 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the string value of the last metadata entry with the specified key. If there are no matching entries then <c>null</c> is returned.
+        /// Gets the string value of the last metadata entry with the specified key.
+        /// If the metadata entry is binary then an exception is thrown.
+        /// If there are no matching entries then <c>null</c> is returned.
         /// </summary>
         public string GetValue(string key)
         {
@@ -100,7 +103,9 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Gets the bytes value of the last metadata entry with the specified key. If there are no matching entries then <c>null</c> is returned.
+        /// Gets the bytes value of the last metadata entry with the specified key.
+        /// If the metadata entry is not binary the string value will be returned as ASCII encoded bytes.
+        /// If there are no matching entries then <c>null</c> is returned.
         /// </summary>
         public byte[] GetValueBytes(string key)
         {
@@ -324,6 +329,7 @@ namespace Grpc.Core
 
             /// <summary>
             /// Gets the binary value of this metadata entry.
+            /// If the metadata entry is not binary the string value will be returned as ASCII encoded bytes.
             /// </summary>
             public byte[] ValueBytes
             {
@@ -343,13 +349,14 @@ namespace Grpc.Core
 
             /// <summary>
             /// Gets the string value of this metadata entry.
+            /// If the metadata entry is binary then an exception is thrown.
             /// </summary>
             public string Value
             {
                 get
                 {
                     GrpcPreconditions.CheckState(!IsBinary, "Cannot access string value of a binary metadata entry");
-                    return value ?? EncodingASCII.GetString(valueBytes);
+                    return value;
                 }
             }
 

--- a/src/csharp/Grpc.Core.Tests/MetadataTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MetadataTest.cs
@@ -18,7 +18,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -240,6 +242,110 @@ namespace Grpc.Core.Tests
             Assert.Throws<InvalidOperationException>(() => metadata.Add("new-key-bin", new byte[] { 0xaa }));
             Assert.Throws<InvalidOperationException>(() => metadata.Clear());
             Assert.Throws<InvalidOperationException>(() => metadata.Remove(metadata[0]));
+        }
+
+        [Test]
+        public void GetAll()
+        {
+            var metadata = new Metadata
+            {
+                { "abc", "abc-value1" },
+                { "abc", "abc-value2" },
+                { "xyz", "xyz-value1" },
+            };
+
+            var abcEntries = metadata.GetAll("abc").ToList();
+            Assert.AreEqual(2, abcEntries.Count);
+            Assert.AreEqual("abc-value1", abcEntries[0].Value);
+            Assert.AreEqual("abc-value2", abcEntries[1].Value);
+
+            var xyzEntries = metadata.GetAll("xyz").ToList();
+            Assert.AreEqual(1, xyzEntries.Count);
+            Assert.AreEqual("xyz-value1", xyzEntries[0].Value);
+        }
+
+        [Test]
+        public void Get()
+        {
+            var metadata = new Metadata
+            {
+                { "abc", "abc-value1" },
+                { "abc", "abc-value2" },
+                { "xyz", "xyz-value1" },
+            };
+
+            var abcEntry = metadata.Get("abc");
+            Assert.AreEqual("abc-value2", abcEntry.Value);
+
+            var xyzEntry = metadata.Get("xyz");
+            Assert.AreEqual("xyz-value1", xyzEntry.Value);
+
+            var notFound = metadata.Get("not-found");
+            Assert.AreEqual(null, notFound);
+        }
+
+        [Test]
+        public void GetValue()
+        {
+            var metadata = new Metadata
+            {
+                { "abc", "abc-value1" },
+                { "abc", "abc-value2" },
+                { "xyz", "xyz-value1" },
+                { "xyz-bin", Encoding.ASCII.GetBytes("xyz-value1") },
+            };
+
+            var abcEntry = metadata.GetValue("abc");
+            Assert.AreEqual("abc-value2", abcEntry);
+
+            var xyzEntry = metadata.GetValue("xyz");
+            Assert.AreEqual("xyz-value1", xyzEntry);
+
+            var notFound = metadata.GetValue("not-found");
+            Assert.AreEqual(null, notFound);
+        }
+
+        [Test]
+        public void GetValue_BytesValue()
+        {
+            var metadata = new Metadata
+            {
+                { "xyz-bin", Encoding.ASCII.GetBytes("xyz-value1") },
+            };
+
+            Assert.Throws<InvalidOperationException>(() => metadata.GetValue("xyz-bin"));
+        }
+
+        [Test]
+        public void GetValueBytes()
+        {
+            var metadata = new Metadata
+            {
+                { "abc-bin", Encoding.ASCII.GetBytes("abc-value1") },
+                { "abc-bin", Encoding.ASCII.GetBytes("abc-value2") },
+                { "xyz-bin", Encoding.ASCII.GetBytes("xyz-value1") },
+            };
+
+            var abcEntry = metadata.GetValueBytes("abc-bin");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("abc-value2"), abcEntry);
+
+            var xyzEntry = metadata.GetValueBytes("xyz-bin");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzEntry);
+
+            var notFound = metadata.GetValueBytes("not-found");
+            Assert.AreEqual(null, notFound);
+        }
+
+        [Test]
+        public void GetValueBytes_StringValue()
+        {
+            var metadata = new Metadata
+            {
+                { "xyz", "xyz-value1" },
+            };
+
+            var xyzEntry = metadata.GetValueBytes("xyz");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzEntry);
         }
 
         private Metadata CreateMetadata()

--- a/src/csharp/Grpc.Core.Tests/MetadataTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MetadataTest.cs
@@ -295,11 +295,11 @@ namespace Grpc.Core.Tests
                 { "xyz-bin", Encoding.ASCII.GetBytes("xyz-value1") },
             };
 
-            var abcEntry = metadata.GetValue("abc");
-            Assert.AreEqual("abc-value2", abcEntry);
+            var abcValue = metadata.GetValue("abc");
+            Assert.AreEqual("abc-value2", abcValue);
 
-            var xyzEntry = metadata.GetValue("xyz");
-            Assert.AreEqual("xyz-value1", xyzEntry);
+            var xyzValue = metadata.GetValue("xyz");
+            Assert.AreEqual("xyz-value1", xyzValue);
 
             var notFound = metadata.GetValue("not-found");
             Assert.AreEqual(null, notFound);
@@ -326,11 +326,11 @@ namespace Grpc.Core.Tests
                 { "xyz-bin", Encoding.ASCII.GetBytes("xyz-value1") },
             };
 
-            var abcEntry = metadata.GetValueBytes("abc-bin");
-            Assert.AreEqual(Encoding.ASCII.GetBytes("abc-value2"), abcEntry);
+            var abcValue = metadata.GetValueBytes("abc-bin");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("abc-value2"), abcValue);
 
-            var xyzEntry = metadata.GetValueBytes("xyz-bin");
-            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzEntry);
+            var xyzValue = metadata.GetValueBytes("xyz-bin");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzValue);
 
             var notFound = metadata.GetValueBytes("not-found");
             Assert.AreEqual(null, notFound);
@@ -344,8 +344,8 @@ namespace Grpc.Core.Tests
                 { "xyz", "xyz-value1" },
             };
 
-            var xyzEntry = metadata.GetValueBytes("xyz");
-            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzEntry);
+            var xyzValue = metadata.GetValueBytes("xyz");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzValue);
         }
 
         private Metadata CreateMetadata()


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/22728

I will add unit tests once we are happy with the API surface.

These helper methods follow what the Java Metadata collection does - https://github.com/grpc/grpc-java/blob/4a644cb8764afc946ff8325992d1bab1e0360ed3/api/src/main/java/io/grpc/Metadata.java#L239-L252 - and returns the last value.

I didn't go with an indexer because it feels weird in this situation. It would be get only (if set, what position would the entry be?), and it would either only get the last entry, or would throw an error if there are multiple. Neither feel like intuitive behavior for an indexer. The only type I can think of like this in .NET is NameValueCollection. Its indexer will concatinate strings together if there are multiple - https://docs.microsoft.com/en-us/dotnet/api/system.collections.specialized.namevaluecollection.item?view=netframework-4.8

tl;dr; I think a `Entry Get(string key)` method is a little less confusing.

@jtattermusch 