### PR TITLE
Fix interceptor batch method FailHijackedRecvMessage for async APIs

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -421,8 +421,6 @@ Status CallOpSendMessage::SendMessagePtr(const M* message) {
 template <class R>
 class CallOpRecvMessage {
  public:
-  CallOpRecvMessage() {}
-
   void RecvMessage(R* message) { message_ = message; }
 
   // Do not change status if no message is received.
@@ -525,8 +523,6 @@ class DeserializeFuncType final : public DeserializeFunc {
 
 class CallOpGenericRecvMessage {
  public:
-  CallOpGenericRecvMessage() {}
-
   template <class R>
   void RecvMessage(R* message) {
     // Use an explicit base class pointer to avoid resolution error in the

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -453,8 +453,12 @@ class CallOpRecvMessage {
         recv_buf_.Clear();
       }
     } else if (hijacked_) {
-      if (!hijacked_recv_message_status_) {
+      if (hijacked_recv_message_failed_) {
         FinishOpRecvMessageFailureHandler(status);
+      } else {
+        // The op was hijacked and it was successful. There is no further action
+        // to be performed since the message is already in its non-serialized
+        // form.
       }
     } else {
       FinishOpRecvMessageFailureHandler(status);
@@ -465,7 +469,7 @@ class CallOpRecvMessage {
       InterceptorBatchMethodsImpl* interceptor_methods) {
     if (message_ == nullptr) return;
     interceptor_methods->SetRecvMessage(message_,
-                                        &hijacked_recv_message_status_);
+                                        &hijacked_recv_message_failed_);
   }
 
   void SetFinishInterceptionHookPoint(
@@ -496,7 +500,7 @@ class CallOpRecvMessage {
   ByteBuffer recv_buf_;
   bool allow_not_getting_message_ = false;
   bool hijacked_ = false;
-  bool hijacked_recv_message_status_ = true;
+  bool hijacked_recv_message_failed_ = false;
 };
 
 class DeserializeFunc {
@@ -559,8 +563,12 @@ class CallOpGenericRecvMessage {
         recv_buf_.Clear();
       }
     } else if (hijacked_) {
-      if (!hijacked_recv_message_status_) {
+      if (hijacked_recv_message_failed_) {
         FinishOpRecvMessageFailureHandler(status);
+      } else {
+        // The op was hijacked and it was successful. There is no further action
+        // to be performed since the message is already in its non-serialized
+        // form.
       }
     } else {
       got_message = false;
@@ -574,7 +582,7 @@ class CallOpGenericRecvMessage {
       InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!deserialize_) return;
     interceptor_methods->SetRecvMessage(message_,
-                                        &hijacked_recv_message_status_);
+                                        &hijacked_recv_message_failed_);
   }
 
   void SetFinishInterceptionHookPoint(
@@ -607,7 +615,7 @@ class CallOpGenericRecvMessage {
   ByteBuffer recv_buf_;
   bool allow_not_getting_message_ = false;
   bool hijacked_ = false;
-  bool hijacked_recv_message_status_ = true;
+  bool hijacked_recv_message_failed_ = false;
 };
 
 class CallOpClientSendClose {

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -166,9 +166,9 @@ class InterceptorBatchMethodsImpl
     send_trailing_metadata_ = metadata;
   }
 
-  void SetRecvMessage(void* message, bool* hijacked_recv_message_status) {
+  void SetRecvMessage(void* message, bool* hijacked_recv_message_failed) {
     recv_message_ = message;
-    hijacked_recv_message_status_ = hijacked_recv_message_status;
+    hijacked_recv_message_failed_ = hijacked_recv_message_failed;
   }
 
   void SetRecvInitialMetadata(MetadataMap* map) {
@@ -195,7 +195,7 @@ class InterceptorBatchMethodsImpl
   void FailHijackedRecvMessage() override {
     GPR_CODEGEN_ASSERT(hooks_[static_cast<size_t>(
         experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)]);
-    *hijacked_recv_message_status_ = false;
+    *hijacked_recv_message_failed_ = true;
   }
 
   // Clears all state
@@ -407,7 +407,7 @@ class InterceptorBatchMethodsImpl
   std::multimap<grpc::string, grpc::string>* send_trailing_metadata_ = nullptr;
 
   void* recv_message_ = nullptr;
-  bool* hijacked_recv_message_status_ = nullptr;
+  bool* hijacked_recv_message_failed_ = nullptr;
 
   MetadataMap* recv_initial_metadata_ = nullptr;
 

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -166,9 +166,9 @@ class InterceptorBatchMethodsImpl
     send_trailing_metadata_ = metadata;
   }
 
-  void SetRecvMessage(void* message, bool* got_message) {
+  void SetRecvMessage(void* message, bool* hijacked_recv_message_status) {
     recv_message_ = message;
-    got_message_ = got_message;
+    hijacked_recv_message_status_ = hijacked_recv_message_status;
   }
 
   void SetRecvInitialMetadata(MetadataMap* map) {
@@ -195,7 +195,7 @@ class InterceptorBatchMethodsImpl
   void FailHijackedRecvMessage() override {
     GPR_CODEGEN_ASSERT(hooks_[static_cast<size_t>(
         experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)]);
-    *got_message_ = false;
+    *hijacked_recv_message_status_ = false;
   }
 
   // Clears all state
@@ -407,7 +407,7 @@ class InterceptorBatchMethodsImpl
   std::multimap<grpc::string, grpc::string>* send_trailing_metadata_ = nullptr;
 
   void* recv_message_ = nullptr;
-  bool* got_message_ = nullptr;
+  bool* hijacked_recv_message_status_ = nullptr;
 
   MetadataMap* recv_initial_metadata_ = nullptr;
 

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -43,6 +43,17 @@ namespace grpc {
 namespace testing {
 namespace {
 
+enum class RPCType {
+  kSyncUnary,
+  kSyncClientStreaming,
+  kSyncServerStreaming,
+  kSyncBidiStreaming,
+  kAsyncCQUnary,
+  kAsyncCQClientStreaming,
+  kAsyncCQServerStreaming,
+  kAsyncCQBidiStreaming,
+};
+
 /* Hijacks Echo RPC and fills in the expected values */
 class HijackingInterceptor : public experimental::Interceptor {
  public:
@@ -400,6 +411,7 @@ class ServerStreamingRpcHijackingInterceptor
  public:
   ServerStreamingRpcHijackingInterceptor(experimental::ClientRpcInfo* info) {
     info_ = info;
+    got_failed_message_ = false;
   }
 
   virtual void Intercept(experimental::InterceptorBatchMethods* methods) {
@@ -531,10 +543,22 @@ class LoggingInterceptor : public experimental::Interceptor {
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_SEND_MESSAGE)) {
       EchoRequest req;
-      EXPECT_EQ(static_cast<const EchoRequest*>(methods->GetSendMessage())
-                    ->message()
-                    .find("Hello"),
-                0u);
+      auto* send_msg = methods->GetSendMessage();
+      if (send_msg == nullptr) {
+        // We did not get the non-serialized form of the message. Get the
+        // serialized form.
+        auto* buffer = methods->GetSerializedSendMessage();
+        auto copied_buffer = *buffer;
+        EchoRequest req;
+        EXPECT_TRUE(
+            SerializationTraits<EchoRequest>::Deserialize(&copied_buffer, &req)
+                .ok());
+        EXPECT_EQ(req.message(), "Hello");
+      } else {
+        EXPECT_EQ(
+            static_cast<const EchoRequest*>(send_msg)->message().find("Hello"),
+            0u);
+      }
       auto* buffer = methods->GetSerializedSendMessage();
       auto copied_buffer = *buffer;
       EXPECT_TRUE(
@@ -580,6 +604,27 @@ class LoggingInterceptor : public experimental::Interceptor {
       post_recv_status_ = true;
     }
     methods->Proceed();
+  }
+
+  static void VerifyCall(RPCType type) {
+    switch (type) {
+      case RPCType::kSyncUnary:
+      case RPCType::kAsyncCQUnary:
+        VerifyUnaryCall();
+        break;
+      case RPCType::kSyncClientStreaming:
+      case RPCType::kAsyncCQClientStreaming:
+        VerifyClientStreamingCall();
+        break;
+      case RPCType::kSyncServerStreaming:
+      case RPCType::kAsyncCQServerStreaming:
+        VerifyServerStreamingCall();
+        break;
+      case RPCType::kSyncBidiStreaming:
+      case RPCType::kAsyncCQBidiStreaming:
+        VerifyBidiStreamingCall();
+        break;
+    }
   }
 
   static void VerifyCallCommon() {
@@ -638,7 +683,103 @@ class LoggingInterceptorFactory
   }
 };
 
-class ClientInterceptorsEnd2endTest : public ::testing::Test {
+class TestScenario {
+ public:
+  explicit TestScenario(const RPCType& type) : type_(type) {}
+
+  RPCType type() const { return type_; }
+
+ private:
+  RPCType type_;
+};
+
+std::vector<TestScenario> CreateTestScenarios() {
+  std::vector<TestScenario> scenarios;
+  scenarios.emplace_back(RPCType::kSyncUnary);
+  scenarios.emplace_back(RPCType::kSyncClientStreaming);
+  scenarios.emplace_back(RPCType::kSyncServerStreaming);
+  scenarios.emplace_back(RPCType::kSyncBidiStreaming);
+  scenarios.emplace_back(RPCType::kAsyncCQUnary);
+  scenarios.emplace_back(RPCType::kAsyncCQServerStreaming);
+  return scenarios;
+}
+
+class ParameterizedClientInterceptorsEnd2endTest
+    : public ::testing::TestWithParam<TestScenario> {
+ protected:
+  ParameterizedClientInterceptorsEnd2endTest() {
+    int port = grpc_pick_unused_port_or_die();
+
+    ServerBuilder builder;
+    server_address_ = "localhost:" + std::to_string(port);
+    builder.AddListeningPort(server_address_, InsecureServerCredentials());
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+
+  ~ParameterizedClientInterceptorsEnd2endTest() { server_->Shutdown(); }
+
+  void SendRPC(const std::shared_ptr<Channel>& channel) {
+    switch (GetParam().type()) {
+      case RPCType::kSyncUnary:
+        MakeCall(channel);
+        break;
+      case RPCType::kSyncClientStreaming:
+        MakeClientStreamingCall(channel);
+        break;
+      case RPCType::kSyncServerStreaming:
+        MakeServerStreamingCall(channel);
+        break;
+      case RPCType::kSyncBidiStreaming:
+        MakeBidiStreamingCall(channel);
+        break;
+      case RPCType::kAsyncCQUnary:
+        MakeAsyncCQCall(channel);
+        break;
+      case RPCType::kAsyncCQClientStreaming:
+        // TODO(yashykt) : Fill this out
+        break;
+      case RPCType::kAsyncCQServerStreaming:
+        MakeAsyncCQServerStreamingCall(channel);
+        break;
+      case RPCType::kAsyncCQBidiStreaming:
+        // TODO(yashykt) : Fill this out
+        break;
+    }
+  }
+
+  std::string server_address_;
+  EchoTestServiceStreamingImpl service_;
+  std::unique_ptr<Server> server_;
+};
+
+TEST_P(ParameterizedClientInterceptorsEnd2endTest,
+       ClientInterceptorLoggingTest) {
+  ChannelArguments args;
+  DummyInterceptor::Reset();
+  std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
+      creators;
+  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
+      new LoggingInterceptorFactory()));
+  // Add 20 dummy interceptors
+  for (auto i = 0; i < 20; i++) {
+    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
+        new DummyInterceptorFactory()));
+  }
+  auto channel = experimental::CreateCustomChannelWithInterceptors(
+      server_address_, InsecureChannelCredentials(), args, std::move(creators));
+  SendRPC(channel);
+  LoggingInterceptor::VerifyCall(GetParam().type());
+  // Make sure all 20 dummy interceptors were run
+  EXPECT_EQ(DummyInterceptor::GetNumTimesRun(), 20);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedClientInterceptorsEnd2end,
+                         ParameterizedClientInterceptorsEnd2endTest,
+                         ::testing::ValuesIn(CreateTestScenarios()));
+
+class ClientInterceptorsEnd2endTest
+    : public ::testing::TestWithParam<TestScenario> {
  protected:
   ClientInterceptorsEnd2endTest() {
     int port = grpc_pick_unused_port_or_die();
@@ -656,26 +797,6 @@ class ClientInterceptorsEnd2endTest : public ::testing::Test {
   TestServiceImpl service_;
   std::unique_ptr<Server> server_;
 };
-
-TEST_F(ClientInterceptorsEnd2endTest, ClientInterceptorLoggingTest) {
-  ChannelArguments args;
-  DummyInterceptor::Reset();
-  std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-      creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
-  // Add 20 dummy interceptors
-  for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
-  }
-  auto channel = experimental::CreateCustomChannelWithInterceptors(
-      server_address_, InsecureChannelCredentials(), args, std::move(creators));
-  MakeCall(channel);
-  LoggingInterceptor::VerifyUnaryCall();
-  // Make sure all 20 dummy interceptors were run
-  EXPECT_EQ(DummyInterceptor::GetNumTimesRun(), 20);
-}
 
 TEST_F(ClientInterceptorsEnd2endTest,
        LameChannelClientInterceptorHijackingTest) {
@@ -757,7 +878,26 @@ TEST_F(ClientInterceptorsEnd2endTest,
   EXPECT_EQ(DummyInterceptor::GetNumTimesRun(), 12);
 }
 
-TEST_F(ClientInterceptorsEnd2endTest,
+class ClientInterceptorsCallbackEnd2endTest : public ::testing::Test {
+ protected:
+  ClientInterceptorsCallbackEnd2endTest() {
+    int port = grpc_pick_unused_port_or_die();
+
+    ServerBuilder builder;
+    server_address_ = "localhost:" + std::to_string(port);
+    builder.AddListeningPort(server_address_, InsecureServerCredentials());
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+
+  ~ClientInterceptorsCallbackEnd2endTest() { server_->Shutdown(); }
+
+  std::string server_address_;
+  TestServiceImpl service_;
+  std::unique_ptr<Server> server_;
+};
+
+TEST_F(ClientInterceptorsCallbackEnd2endTest,
        ClientInterceptorLoggingTestWithCallback) {
   ChannelArguments args;
   DummyInterceptor::Reset();
@@ -778,7 +918,7 @@ TEST_F(ClientInterceptorsEnd2endTest,
   EXPECT_EQ(DummyInterceptor::GetNumTimesRun(), 20);
 }
 
-TEST_F(ClientInterceptorsEnd2endTest,
+TEST_F(ClientInterceptorsCallbackEnd2endTest,
        ClientInterceptorFactoryAllowsNullptrReturn) {
   ChannelArguments args;
   DummyInterceptor::Reset();
@@ -900,6 +1040,21 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, ServerStreamingHijackingTest) {
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
   MakeServerStreamingCall(channel);
+  EXPECT_TRUE(ServerStreamingRpcHijackingInterceptor::GotFailedMessage());
+}
+
+TEST_F(ClientInterceptorsStreamingEnd2endTest,
+       AsyncCQServerStreamingHijackingTest) {
+  ChannelArguments args;
+  DummyInterceptor::Reset();
+  std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
+      creators;
+  creators.push_back(
+      std::unique_ptr<ServerStreamingRpcHijackingInterceptorFactory>(
+          new ServerStreamingRpcHijackingInterceptorFactory()));
+  auto channel = experimental::CreateCustomChannelWithInterceptors(
+      server_address_, InsecureChannelCredentials(), args, std::move(creators));
+  MakeAsyncCQServerStreamingCall(channel);
   EXPECT_TRUE(ServerStreamingRpcHijackingInterceptor::GotFailedMessage());
 }
 

--- a/test/cpp/end2end/interceptors_util.h
+++ b/test/cpp/end2end/interceptors_util.h
@@ -102,6 +102,16 @@ class EchoTestServiceStreamingImpl : public EchoTestService::Service {
  public:
   ~EchoTestServiceStreamingImpl() override {}
 
+  Status Echo(ServerContext* context, const EchoRequest* request,
+              EchoResponse* response) {
+    auto client_metadata = context->client_metadata();
+    for (const auto& pair : client_metadata) {
+      context->AddTrailingMetadata(ToString(pair.first), ToString(pair.second));
+    }
+    response->set_message(request->message());
+    return Status::OK;
+  }
+
   Status BidiStream(
       ServerContext* context,
       grpc::ServerReaderWriter<EchoResponse, EchoRequest>* stream) override {
@@ -161,6 +171,14 @@ void MakeClientStreamingCall(const std::shared_ptr<Channel>& channel);
 void MakeServerStreamingCall(const std::shared_ptr<Channel>& channel);
 
 void MakeBidiStreamingCall(const std::shared_ptr<Channel>& channel);
+
+void MakeAsyncCQCall(const std::shared_ptr<Channel>& channel);
+
+void MakeAsyncCQClientStreamingCall(const std::shared_ptr<Channel>& channel);
+
+void MakeAsyncCQServerStreamingCall(const std::shared_ptr<Channel>& channel);
+
+void MakeAsyncCQBidiStreamingCall(const std::shared_ptr<Channel>& channel);
 
 void MakeCallbackCall(const std::shared_ptr<Channel>& channel);
 


### PR DESCRIPTION
Fix interceptor batch method FailHijackedRecvMessage for async CQ APIs. Also, added a test that fails before this PR and succeeds after.

Note - This PR also starts adding additional testing for Async CQ APIs, but that should not block  this PR itself.