### PR TITLE
Remove deprecated variant of JoinHostPort().

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -450,18 +450,17 @@ grpc_core::UniquePtr<char> GrpcLb::Serverlist::AsText() const {
   gpr_strvec_init(&entries);
   for (size_t i = 0; i < serverlist_.size(); ++i) {
     const GrpcLbServer& server = serverlist_[i];
-    char* ipport;
+    std::string ipport;
     if (server.drop) {
-      ipport = gpr_strdup("(drop)");
+      ipport = "(drop)";
     } else {
       grpc_resolved_address addr;
       ParseServer(server, &addr);
-      grpc_sockaddr_to_string(&ipport, &addr, false);
+      ipport = grpc_sockaddr_to_string(&addr, false);
     }
     char* entry;
-    gpr_asprintf(&entry, "  %" PRIuPTR ": %s token=%s\n", i, ipport,
+    gpr_asprintf(&entry, "  %" PRIuPTR ": %s token=%s\n", i, ipport.c_str(),
                  server.load_balance_token);
-    gpr_free(ipport);
     gpr_strvec_add(&entries, entry);
   }
   grpc_core::UniquePtr<char> result(gpr_strvec_flatten(&entries, nullptr));

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -53,11 +53,10 @@ RefCountedPtr<TargetAuthorityTable> CreateTargetAuthorityTable(
       static_cast<TargetAuthorityTable::Entry*>(
           gpr_zalloc(sizeof(*target_authority_entries) * addresses.size()));
   for (size_t i = 0; i < addresses.size(); ++i) {
-    char* addr_str;
-    GPR_ASSERT(
-        grpc_sockaddr_to_string(&addr_str, &addresses[i].address(), true) > 0);
-    target_authority_entries[i].key = grpc_slice_from_copied_string(addr_str);
-    gpr_free(addr_str);
+    std::string addr_str =
+        grpc_sockaddr_to_string(&addresses[i].address(), true);
+    target_authority_entries[i].key =
+        grpc_slice_from_copied_string(addr_str.c_str());
     const char* balancer_name =
         FindGrpclbBalancerNameInChannelArgs(*addresses[i].args());
     target_authority_entries[i].value.reset(gpr_strdup(balancer_name));

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -123,21 +123,12 @@ static void log_address_sorting_list(const grpc_ares_request* r,
                                      const ServerAddressList& addresses,
                                      const char* input_output_str) {
   for (size_t i = 0; i < addresses.size(); i++) {
-    char* addr_str;
-    if (grpc_sockaddr_to_string(&addr_str, &addresses[i].address(), true)) {
-      gpr_log(
-          GPR_INFO,
-          "(c-ares resolver) request:%p c-ares address sorting: %s[%" PRIuPTR
-          "]=%s",
-          r, input_output_str, i, addr_str);
-      gpr_free(addr_str);
-    } else {
-      gpr_log(
-          GPR_INFO,
-          "(c-ares resolver) request:%p c-ares address sorting: %s[%" PRIuPTR
-          "]=<unprintable>",
-          r, input_output_str, i);
-    }
+    std::string addr_str =
+        grpc_sockaddr_to_string(&addresses[i].address(), true);
+    gpr_log(GPR_INFO,
+            "(c-ares resolver) request:%p c-ares address sorting: %s[%" PRIuPTR
+            "]=%s",
+            r, input_output_str, i, addr_str.c_str());
   }
 }
 

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -1115,15 +1115,13 @@ void XdsClient::ChannelState::AdsCallState::AcceptEdsUpdate(
                   locality.name->AsHumanReadableString(), locality.lb_weight,
                   locality.serverlist.size());
           for (size_t i = 0; i < locality.serverlist.size(); ++i) {
-            char* ipport;
-            grpc_sockaddr_to_string(&ipport, &locality.serverlist[i].address(),
-                                    false);
+            std::string ipport = grpc_sockaddr_to_string(
+                &locality.serverlist[i].address(), false);
             gpr_log(GPR_INFO,
                     "[xds_client %p] Priority %" PRIuPTR ", locality %" PRIuPTR
                     " %s, server address %" PRIuPTR ": %s",
                     xds_client(), priority, locality_count,
-                    locality.name->AsHumanReadableString(), i, ipport);
-            gpr_free(ipport);
+                    locality.name->AsHumanReadableString(), i, ipport.c_str());
           }
           ++locality_count;
         }

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.h
@@ -21,10 +21,13 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <map>
+
+#include "absl/strings/string_view.h"
+
 #include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/atomic.h"
-#include "src/core/lib/gprpp/map.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/sync.h"

--- a/src/core/lib/gprpp/host_port.cc
+++ b/src/core/lib/gprpp/host_port.cc
@@ -20,40 +20,20 @@
 
 #include "src/core/lib/gprpp/host_port.h"
 
-#include <string.h>
-
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 
-#include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
-
-#include "src/core/lib/gpr/string.h"
 
 namespace grpc_core {
 
 std::string JoinHostPort(absl::string_view host, int port) {
-  if (host[0] != '[' && host.rfind(':') != host.npos) {
+  if (!host.empty() && host[0] != '[' && host.rfind(':') != host.npos) {
     // IPv6 literals must be enclosed in brackets.
     return absl::StrFormat("[%s]:%d", host, port);
   }
   // Ordinary non-bracketed host:port.
   return absl::StrFormat("%s:%d", host, port);
-}
-
-int JoinHostPort(grpc_core::UniquePtr<char>* out, const char* host, int port) {
-  char* tmp;
-  int ret;
-  if (host[0] != '[' && strchr(host, ':') != nullptr) {
-    /* IPv6 literals must be enclosed in brackets. */
-    ret = gpr_asprintf(&tmp, "[%s]:%d", host, port);
-  } else {
-    /* Ordinary non-bracketed host:port. */
-    ret = gpr_asprintf(&tmp, "%s:%d", host, port);
-  }
-  out->reset(tmp);
-  return ret;
 }
 
 namespace {

--- a/src/core/lib/gprpp/host_port.h
+++ b/src/core/lib/gprpp/host_port.h
@@ -21,9 +21,9 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "absl/strings/string_view.h"
+#include <string>
 
-#include "src/core/lib/gprpp/memory.h"
+#include "absl/strings/string_view.h"
 
 namespace grpc_core {
 
@@ -32,12 +32,6 @@ namespace grpc_core {
 // like an IPv6 literal.  If the host is already bracketed, then additional
 // brackets will not be added.
 std::string JoinHostPort(absl::string_view host, int port);
-// TODO(roth): Change all callers to use the above variant and then
-// remove this one.
-/* Usage is similar to gpr_asprintf: returns the number of bytes written
-   (excluding the final '\0'), and *out points to a string.
-   In the unlikely event of an error, returns -1 and sets *out to NULL. */
-int JoinHostPort(grpc_core::UniquePtr<char>* out, const char* host, int port);
 
 /** Given a name in the form "host:port" or "[ho:st]:port", split into hostname
    and port number.

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -113,14 +113,6 @@ static grpc_error* windows_blocking_resolve_address(
     i++;
   }
 
-  {
-    for (i = 0; i < (*addresses)->naddrs; i++) {
-      char* buf;
-      grpc_sockaddr_to_string(&buf, &(*addresses)->addrs[i], 0);
-      gpr_free(buf);
-    }
-  }
-
 done:
   if (result) {
     freeaddrinfo(result);

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -24,6 +24,8 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -150,23 +152,18 @@ void grpc_sockaddr_make_wildcard6(int port,
   resolved_wild_out->len = static_cast<socklen_t>(sizeof(grpc_sockaddr_in6));
 }
 
-int grpc_sockaddr_to_string(char** out,
-                            const grpc_resolved_address* resolved_addr,
-                            int normalize) {
-  const grpc_sockaddr* addr;
+std::string grpc_sockaddr_to_string(const grpc_resolved_address* resolved_addr,
+                                    bool normalize) {
   const int save_errno = errno;
   grpc_resolved_address addr_normalized;
-  char ntop_buf[GRPC_INET6_ADDRSTRLEN];
-  const void* ip = nullptr;
-  int port = 0;
-  uint32_t sin6_scope_id = 0;
-  int ret;
-
-  *out = nullptr;
   if (normalize && grpc_sockaddr_is_v4mapped(resolved_addr, &addr_normalized)) {
     resolved_addr = &addr_normalized;
   }
-  addr = reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
+  const grpc_sockaddr* addr =
+      reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
+  const void* ip = nullptr;
+  int port = 0;
+  uint32_t sin6_scope_id = 0;
   if (addr->sa_family == GRPC_AF_INET) {
     const grpc_sockaddr_in* addr4 =
         reinterpret_cast<const grpc_sockaddr_in*>(addr);
@@ -179,25 +176,24 @@ int grpc_sockaddr_to_string(char** out,
     port = grpc_ntohs(addr6->sin6_port);
     sin6_scope_id = addr6->sin6_scope_id;
   }
+  char ntop_buf[GRPC_INET6_ADDRSTRLEN];
+  std::string out;
   if (ip != nullptr && grpc_inet_ntop(addr->sa_family, ip, ntop_buf,
                                       sizeof(ntop_buf)) != nullptr) {
-    grpc_core::UniquePtr<char> tmp_out;
     if (sin6_scope_id != 0) {
-      char* host_with_scope;
-      /* Enclose sin6_scope_id with the format defined in RFC 6784 section 2. */
-      gpr_asprintf(&host_with_scope, "%s%%25%" PRIu32, ntop_buf, sin6_scope_id);
-      ret = grpc_core::JoinHostPort(&tmp_out, host_with_scope, port);
-      gpr_free(host_with_scope);
+      // Enclose sin6_scope_id with the format defined in RFC 6784 section 2.
+      std::string host_with_scope =
+          absl::StrFormat("%s%%25%" PRIu32, ntop_buf, sin6_scope_id);
+      out = grpc_core::JoinHostPort(host_with_scope, port);
     } else {
-      ret = grpc_core::JoinHostPort(&tmp_out, ntop_buf, port);
+      out = grpc_core::JoinHostPort(ntop_buf, port);
     }
-    *out = tmp_out.release();
   } else {
-    ret = gpr_asprintf(out, "(sockaddr family=%d)", addr->sa_family);
+    out = absl::StrFormat("(sockaddr family=%d)", addr->sa_family);
   }
   /* This is probably redundant, but we wouldn't want to log the wrong error. */
   errno = save_errno;
-  return ret;
+  return out;
 }
 
 void grpc_string_to_sockaddr(grpc_resolved_address* out, char* addr, int port) {
@@ -226,15 +222,13 @@ char* grpc_sockaddr_to_uri(const grpc_resolved_address* resolved_addr) {
   if (scheme == nullptr || strcmp("unix", scheme) == 0) {
     return grpc_sockaddr_to_uri_unix_if_possible(resolved_addr);
   }
-  char* path = nullptr;
+  std::string path =
+      grpc_sockaddr_to_string(resolved_addr, false /* normalize */);
   char* uri_str = nullptr;
-  if (grpc_sockaddr_to_string(&path, resolved_addr,
-                              false /* suppress errors */) &&
-      scheme != nullptr) {
-    gpr_asprintf(&uri_str, "%s:%s", scheme, path);
+  if (scheme != nullptr) {
+    gpr_asprintf(&uri_str, "%s:%s", scheme, path.c_str());
   }
-  gpr_free(path);
-  return uri_str != nullptr ? uri_str : nullptr;
+  return uri_str;
 }
 
 const char* grpc_sockaddr_get_uri_scheme(

--- a/src/core/lib/iomgr/sockaddr_utils.h
+++ b/src/core/lib/iomgr/sockaddr_utils.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <string>
+
 #include "src/core/lib/iomgr/resolve_address.h"
 
 /* Returns true if addr is an IPv4-mapped IPv6 address within the
@@ -56,22 +58,13 @@ int grpc_sockaddr_get_port(const grpc_resolved_address* addr);
 /* Set IP port number of a sockaddr */
 int grpc_sockaddr_set_port(const grpc_resolved_address* addr, int port);
 
-/* Converts a sockaddr into a newly-allocated human-readable string.
-
-   Currently, only the AF_INET and AF_INET6 families are recognized.
-   If the normalize flag is enabled, ::ffff:0.0.0.0/96 IPv6 addresses are
-   displayed as plain IPv4.
-
-   Usage is similar to gpr_asprintf: returns the number of bytes written
-   (excluding the final '\0'), and *out points to a string which must later be
-   destroyed using gpr_free().
-
-   In the unlikely event of an error, returns -1 and sets *out to NULL.
-   The existing value of errno is always preserved. */
-// TODO(roth): Change this to return std::string as part of eliminating
-// the old API for JoinHostPort().
-int grpc_sockaddr_to_string(char** out, const grpc_resolved_address* addr,
-                            int normalize);
+// Converts a sockaddr into a newly-allocated human-readable string.
+//
+// Currently, only the AF_INET and AF_INET6 families are recognized.
+// If the normalize flag is enabled, ::ffff:0.0.0.0/96 IPv6 addresses are
+// displayed as plain IPv4.
+std::string grpc_sockaddr_to_string(const grpc_resolved_address* addr,
+                                    bool normalize);
 
 void grpc_string_to_sockaddr(grpc_resolved_address* out, char* addr, int port);
 

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -41,6 +41,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <string>
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
@@ -396,12 +398,10 @@ int grpc_ipv6_loopback_available(void) {
 
 static grpc_error* error_for_fd(int fd, const grpc_resolved_address* addr) {
   if (fd >= 0) return GRPC_ERROR_NONE;
-  char* addr_str;
-  grpc_sockaddr_to_string(&addr_str, addr, 0);
-  grpc_error* err = grpc_error_set_str(GRPC_OS_ERROR(errno, "socket"),
-                                       GRPC_ERROR_STR_TARGET_ADDRESS,
-                                       grpc_slice_from_copied_string(addr_str));
-  gpr_free(addr_str);
+  std::string addr_str = grpc_sockaddr_to_string(addr, false);
+  grpc_error* err = grpc_error_set_str(
+      GRPC_OS_ERROR(errno, "socket"), GRPC_ERROR_STR_TARGET_ADDRESS,
+      grpc_slice_from_copied_string(addr_str.c_str()));
   return err;
 }
 

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -143,14 +143,12 @@ static void OnOpen(void* arg, grpc_error* error) {
 
 static void ParseResolvedAddress(const grpc_resolved_address* addr,
                                  CFStringRef* host, int* port) {
-  char* host_port;
-  grpc_sockaddr_to_string(&host_port, addr, 1);
+  std::string host_port = grpc_sockaddr_to_string(addr, true);
   std::string host_string;
   std::string port_string;
   grpc_core::SplitHostPort(host_port, &host_string, &port_string);
   *host = CFStringCreateWithCString(NULL, host_string.c_str(),
                                     kCFStringEncodingUTF8);
-  gpr_free(host_port);
   *port = grpc_sockaddr_get_port(addr);
 }
 

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -23,6 +23,8 @@
 #include <assert.h>
 #include <string.h>
 
+#include <string>
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
@@ -389,15 +391,9 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   }
 
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
-    char* port_string;
-    grpc_sockaddr_to_string(&port_string, addr, 0);
-    const char* str = grpc_error_string(error);
-    if (port_string) {
-      gpr_log(GPR_INFO, "SERVER %p add_port %s error=%s", s, port_string, str);
-      gpr_free(port_string);
-    } else {
-      gpr_log(GPR_INFO, "SERVER %p add_port error=%s", s, str);
-    }
+    gpr_log(GPR_INFO, "SERVER %p add_port %s error=%s", s,
+            grpc_sockaddr_to_string(addr, false).c_str(),
+            grpc_error_string(error));
   }
 
   family = grpc_sockaddr_get_family(addr);

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -37,6 +37,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <string>
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -349,7 +351,7 @@ static grpc_error* add_wildcard_addrs_to_server(grpc_tcp_server* s,
 
 static grpc_error* clone_port(grpc_tcp_listener* listener, unsigned count) {
   grpc_tcp_listener* sp = nullptr;
-  char* addr_str;
+  std::string addr_str;
   char* name;
   grpc_error* err;
 
@@ -368,8 +370,8 @@ static grpc_error* clone_port(grpc_tcp_listener* listener, unsigned count) {
                                          true, &port);
     if (err != GRPC_ERROR_NONE) return err;
     listener->server->nports++;
-    grpc_sockaddr_to_string(&addr_str, &listener->addr, 1);
-    gpr_asprintf(&name, "tcp-server-listener:%s/clone-%d", addr_str, i);
+    addr_str = grpc_sockaddr_to_string(&listener->addr, true);
+    gpr_asprintf(&name, "tcp-server-listener:%s/clone-%d", addr_str.c_str(), i);
     sp = static_cast<grpc_tcp_listener*>(gpr_malloc(sizeof(grpc_tcp_listener)));
     sp->next = listener->next;
     listener->next = sp;
@@ -389,7 +391,6 @@ static grpc_error* clone_port(grpc_tcp_listener* listener, unsigned count) {
     while (listener->server->tail->next != nullptr) {
       listener->server->tail = listener->server->tail->next;
     }
-    gpr_free(addr_str);
     gpr_free(name);
   }
 

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -29,6 +29,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -83,15 +85,15 @@ static grpc_error* add_socket_to_server(grpc_tcp_server* s, int fd,
                                         grpc_tcp_listener** listener) {
   grpc_tcp_listener* sp = nullptr;
   int port = -1;
-  char* addr_str;
+  std::string addr_str;
   char* name;
 
   grpc_error* err =
       grpc_tcp_server_prepare_socket(s, fd, addr, s->so_reuseport, &port);
   if (err == GRPC_ERROR_NONE) {
     GPR_ASSERT(port > 0);
-    grpc_sockaddr_to_string(&addr_str, addr, 1);
-    gpr_asprintf(&name, "tcp-server-listener:%s", addr_str);
+    addr_str = grpc_sockaddr_to_string(addr, true);
+    gpr_asprintf(&name, "tcp-server-listener:%s", addr_str.c_str());
     gpr_mu_lock(&s->mu);
     s->nports++;
     GPR_ASSERT(!s->on_accept_cb && "must add ports before starting server");
@@ -114,7 +116,6 @@ static grpc_error* add_socket_to_server(grpc_tcp_server* s, int fd,
     sp->sibling = nullptr;
     GPR_ASSERT(sp->emfd);
     gpr_mu_unlock(&s->mu);
-    gpr_free(addr_str);
     gpr_free(name);
   }
 

--- a/src/core/lib/iomgr/udp_server.cc
+++ b/src/core/lib/iomgr/udp_server.cc
@@ -148,11 +148,9 @@ GrpcUdpListener::GrpcUdpListener(grpc_udp_server* server, int fd,
       server_(server),
       orphan_notified_(false),
       already_shutdown_(false) {
-  char* addr_str;
   char* name;
-  grpc_sockaddr_to_string(&addr_str, addr, 1);
-  gpr_asprintf(&name, "udp-server-listener:%s", addr_str);
-  gpr_free(addr_str);
+  std::string addr_str = grpc_sockaddr_to_string(addr, true);
+  gpr_asprintf(&name, "udp-server-listener:%s", addr_str.c_str());
   emfd_ = grpc_fd_create(fd, name, true);
   memcpy(&addr_, addr, sizeof(grpc_resolved_address));
   GPR_ASSERT(emfd_);
@@ -413,10 +411,8 @@ static int prepare_socket(grpc_socket_factory* socket_factory, int fd,
   }
 
   if (bind_socket(socket_factory, fd, addr) < 0) {
-    char* addr_str;
-    grpc_sockaddr_to_string(&addr_str, addr, 0);
-    gpr_log(GPR_ERROR, "bind addr=%s: %s", addr_str, strerror(errno));
-    gpr_free(addr_str);
+    std::string addr_str = grpc_sockaddr_to_string(addr, false);
+    gpr_log(GPR_ERROR, "bind addr=%s: %s", addr_str.c_str(), strerror(errno));
     goto error;
   }
 
@@ -583,10 +579,8 @@ int grpc_udp_server_add_port(grpc_udp_server* s,
             "Try to have multiple listeners on same port, but SO_REUSEPORT is "
             "not supported. Only create 1 listener.");
   }
-  char* addr_str;
-  grpc_sockaddr_to_string(&addr_str, addr, 1);
-  gpr_log(GPR_DEBUG, "add address: %s to server", addr_str);
-  gpr_free(addr_str);
+  std::string addr_str = grpc_sockaddr_to_string(addr, true);
+  gpr_log(GPR_DEBUG, "add address: %s to server", addr_str.c_str());
 
   int allocated_port1 = -1;
   int allocated_port2 = -1;

--- a/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
+++ b/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
@@ -52,7 +52,7 @@
 #import "../ConfigureCronet.h"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   fullstack_secure_fixture_data *ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
 
-  grpc_core::JoinHostPort(&ffd->localaddr, "127.0.0.1", port);
+  ffd->localaddr = grpc_core::JoinHostPort("127.0.0.1", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(NULL);
@@ -83,7 +83,7 @@ static void cronet_init_client_secure_fullstack(grpc_end2end_test_fixture *f,
                                                 stream_engine *cronetEngine) {
   fullstack_secure_fixture_data *ffd = (fullstack_secure_fixture_data *)f->fixture_data;
   f->client =
-      grpc_cronet_secure_channel_create(cronetEngine, ffd->localaddr.get(), client_args, NULL);
+      grpc_cronet_secure_channel_create(cronetEngine, ffd->localaddr.c_str(), client_args, NULL);
   GPR_ASSERT(f->client != NULL);
 }
 
@@ -96,7 +96,7 @@ static void chttp2_init_server_secure_fullstack(grpc_end2end_test_fixture *f,
   }
   f->server = grpc_server_create(server_args, NULL);
   grpc_server_register_completion_queue(f->server, f->cq, NULL);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(), server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -130,11 +130,10 @@ unsigned int parse_h2_length(const char *field) {
                               {{NULL, NULL, NULL, NULL}}}};
 
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
-  grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
+  std::string addr = grpc_core::JoinHostPort("127.0.0.1", port);
   grpc_completion_queue *cq = grpc_completion_queue_create_for_next(NULL);
   stream_engine *cronetEngine = [Cronet getGlobalEngine];
-  grpc_channel *client = grpc_cronet_secure_channel_create(cronetEngine, addr.get(), NULL, NULL);
+  grpc_channel *client = grpc_cronet_secure_channel_create(cronetEngine, addr.c_str(), NULL, NULL);
 
   cq_verifier *cqv = cq_verifier_create(cq);
   grpc_op ops[6];
@@ -261,11 +260,10 @@ unsigned int parse_h2_length(const char *field) {
                               {{NULL, NULL, NULL, NULL}}}};
 
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
-  grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
+  std::string addr = grpc_core::JoinHostPort("127.0.0.1", port);
   grpc_completion_queue *cq = grpc_completion_queue_create_for_next(NULL);
   stream_engine *cronetEngine = [Cronet getGlobalEngine];
-  grpc_channel *client = grpc_cronet_secure_channel_create(cronetEngine, addr.get(), args, NULL);
+  grpc_channel *client = grpc_cronet_secure_channel_create(cronetEngine, addr.c_str(), args, NULL);
 
   cq_verifier *cqv = cq_verifier_create(cq);
   grpc_op ops[6];

--- a/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
@@ -13,6 +13,9 @@
 # limitations under the License.
 # distutils: language=c++
 
+from libcpp cimport bool as bool_t
+from libcpp.string cimport string as cppstring
+
 cdef extern from "grpc/impl/codegen/slice.h":
   struct grpc_slice_buffer:
     int count
@@ -118,8 +121,8 @@ cdef extern from "src/core/lib/iomgr/iomgr_custom.h":
 
 cdef extern from "src/core/lib/iomgr/sockaddr_utils.h":
   int grpc_sockaddr_get_port(const grpc_resolved_address *addr);
-  int grpc_sockaddr_to_string(char **out, const grpc_resolved_address *addr,
-                              int normalize);
+  cppstring grpc_sockaddr_to_string(const grpc_resolved_address *addr,
+                                 bool_t normalize);
   void grpc_string_to_sockaddr(grpc_resolved_address *out, char* addr, int port);
   int grpc_sockaddr_set_port(const grpc_resolved_address *resolved_addr,
                              int port)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pyx.pxi
@@ -15,6 +15,7 @@
 
 from libc cimport string
 from libc.stdlib cimport malloc
+from libcpp.string cimport string as cppstring
 
 cdef grpc_error* grpc_error_none():
   return <grpc_error*>0
@@ -25,10 +26,10 @@ cdef grpc_error* socket_error(str syscall, str err):
   return grpc_socket_error(error_bytes)
 
 cdef resolved_addr_to_tuple(grpc_resolved_address* address):
-  cdef char* res_str
+  cdef cppstring res_str
   port = grpc_sockaddr_get_port(address)
-  str_len = grpc_sockaddr_to_string(&res_str, address, 0) 
-  byte_str = _decode(<bytes>res_str[:str_len])
+  res_str = grpc_sockaddr_to_string(address, False)
+  byte_str = _decode(res_str)
   if byte_str.endswith(':' + str(port)):
     byte_str = byte_str[:(0 - len(str(port)) - 1)]
   byte_str = byte_str.lstrip('[')

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -145,9 +145,8 @@ int main(int argc, char** argv) {
   gpr_asprintf(&args[0], "%s/bad_ssl_%s_server%s", root, test,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  grpc_core::UniquePtr<char> joined;
-  grpc_core::JoinHostPort(&joined, "::", port);
-  args[2] = joined.get();
+  std::string joined = grpc_core::JoinHostPort("::", port);
+  args[2] = const_cast<char*>(joined.c_str());
   svr = gpr_subprocess_create(4, (const char**)args);
   gpr_free(args[0]);
 

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -71,7 +71,7 @@
 #define SERVER_INCOMING_DATA_LENGTH_LOWER_THRESHOLD (size_t)200
 
 struct rpc_state {
-  grpc_core::UniquePtr<char> target;
+  std::string target;
   grpc_completion_queue* cq;
   grpc_channel* channel;
   grpc_call* call;
@@ -165,9 +165,9 @@ static void start_rpc(int target_port, grpc_status_code expected_status,
 
   state.cq = grpc_completion_queue_create_for_next(nullptr);
   cqv = cq_verifier_create(state.cq);
-  grpc_core::JoinHostPort(&state.target, "127.0.0.1", target_port);
+  state.target = grpc_core::JoinHostPort("127.0.0.1", target_port);
   state.channel =
-      grpc_insecure_channel_create(state.target.get(), nullptr, nullptr);
+      grpc_insecure_channel_create(state.target.c_str(), nullptr, nullptr);
   grpc_slice host = grpc_slice_from_static_string("localhost");
   state.call = grpc_channel_create_call(
       state.channel, nullptr, GRPC_PROPAGATE_DEFAULTS, state.cq,
@@ -231,7 +231,7 @@ static void cleanup_rpc() {
   } while (ev.type != GRPC_QUEUE_SHUTDOWN);
   grpc_completion_queue_destroy(state.cq);
   grpc_channel_destroy(state.channel);
-  state.target.reset();
+  state.target.clear();
 }
 
 typedef struct {

--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -77,10 +77,9 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
 
   /* create a call, channel to a port which will refuse connection */
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
-  grpc_core::JoinHostPort(&addr, "127.0.0.1", port);
-  gpr_log(GPR_INFO, "server: %s", addr.get());
-  chan = grpc_insecure_channel_create(addr.get(), args, nullptr);
+  std::string addr = grpc_core::JoinHostPort("127.0.0.1", port);
+  gpr_log(GPR_INFO, "server: %s", addr.c_str());
+  chan = grpc_insecure_channel_create(addr.c_str(), args, nullptr);
   grpc_slice host = grpc_slice_from_static_string("nonexistant");
   gpr_timespec deadline = grpc_timeout_seconds_to_deadline(2);
   call =

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -23,6 +23,13 @@
 
 #include <string.h>
 
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -50,8 +57,6 @@ static void drain_cq(grpc_completion_queue* cq) {
         cq, grpc_timeout_milliseconds_to_deadline(5000), nullptr);
   } while (ev.type != GRPC_QUEUE_SHUTDOWN);
 }
-
-static void do_nothing(void* /*ignored*/) {}
 
 static void log_resolved_addrs(const char* label, const char* hostname) {
   grpc_resolved_addresses* res = nullptr;
@@ -97,8 +102,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
     picked_port = 1;
   }
 
-  grpc_core::UniquePtr<char> server_hostport;
-  grpc_core::JoinHostPort(&server_hostport, server_host, port);
+  std::string server_hostport = grpc_core::JoinHostPort(server_host, port);
 
   grpc_metadata_array_init(&initial_metadata_recv);
   grpc_metadata_array_init(&trailing_metadata_recv);
@@ -110,7 +114,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
   server = grpc_server_create(nullptr, nullptr);
   grpc_server_register_completion_queue(server, cq, nullptr);
   GPR_ASSERT((got_port = grpc_server_add_insecure_http2_port(
-                  server, server_hostport.get())) > 0);
+                  server, server_hostport.c_str())) > 0);
   if (port == 0) {
     port = got_port;
   } else {
@@ -120,41 +124,25 @@ void test_connect(const char* server_host, const char* client_host, int port,
   cqv = cq_verifier_create(cq);
 
   /* Create client. */
-  grpc_core::UniquePtr<char> client_hostport;
+  std::string client_hostport;
   if (client_host[0] == 'i') {
     /* for ipv4:/ipv6: addresses, concatenate the port to each of the parts */
-    size_t i;
-    grpc_slice uri_slice;
-    grpc_slice_buffer uri_parts;
-    char** hosts_with_port;
-
-    uri_slice = grpc_slice_new(const_cast<char*>(client_host),
-                               strlen(client_host), do_nothing);
-    grpc_slice_buffer_init(&uri_parts);
-    grpc_slice_split(uri_slice, ",", &uri_parts);
-    hosts_with_port =
-        static_cast<char**>(gpr_malloc(sizeof(char*) * uri_parts.count));
-    for (i = 0; i < uri_parts.count; i++) {
-      char* uri_part_str = grpc_slice_to_c_string(uri_parts.slices[i]);
-      gpr_asprintf(&hosts_with_port[i], "%s:%d", uri_part_str, port);
-      gpr_free(uri_part_str);
+    std::vector<absl::string_view> uri_parts =
+        absl::StrSplit(client_host, ",", absl::SkipEmpty());
+    std::vector<std::string> hosts_with_port;
+    hosts_with_port.reserve(uri_parts.size());
+    for (const absl::string_view& uri_part : uri_parts) {
+      hosts_with_port.push_back(absl::StrFormat("%s:%d", uri_part, port));
     }
-    client_hostport.reset(gpr_strjoin_sep((const char**)hosts_with_port,
-                                          uri_parts.count, ",", nullptr));
-    for (i = 0; i < uri_parts.count; i++) {
-      gpr_free(hosts_with_port[i]);
-    }
-    gpr_free(hosts_with_port);
-    grpc_slice_buffer_destroy(&uri_parts);
-    grpc_slice_unref(uri_slice);
+    client_hostport = absl::StrJoin(hosts_with_port, ",");
   } else {
-    grpc_core::JoinHostPort(&client_hostport, client_host, port);
+    client_hostport = grpc_core::JoinHostPort(client_host, port);
   }
   client =
-      grpc_insecure_channel_create(client_hostport.get(), nullptr, nullptr);
+      grpc_insecure_channel_create(client_hostport.c_str(), nullptr, nullptr);
 
   gpr_log(GPR_INFO, "Testing with server=%s client=%s (expecting %s)",
-          server_hostport.get(), client_hostport.get(),
+          server_hostport.c_str(), client_hostport.c_str(),
           expect_ok ? "success" : "failure");
   log_resolved_addrs("server resolved addr", server_host);
   log_resolved_addrs("client resolved addr", client_host);

--- a/test/core/end2end/fixtures/h2_census.cc
+++ b/test/core/end2end/fixtures/h2_census.cc
@@ -36,7 +36,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
@@ -45,7 +45,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
   int port = grpc_pick_unused_port_or_die();
   fullstack_fixture_data* ffd = new fullstack_fixture_data();
   memset(&f, 0, sizeof(f));
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -68,8 +68,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
       static_cast<fullstack_fixture_data*>(f->fixture_data);
   grpc_arg arg = make_census_enable_arg();
   client_args = grpc_channel_args_copy_and_add(client_args, &arg, 1);
-  f->client =
-      grpc_insecure_channel_create(ffd->localaddr.get(), client_args, nullptr);
+  f->client = grpc_insecure_channel_create(ffd->localaddr.c_str(), client_args,
+                                           nullptr);
   GPR_ASSERT(f->client);
   {
     grpc_core::ExecCtx exec_ctx;
@@ -93,7 +93,7 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   }
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
 }
 

--- a/test/core/end2end/fixtures/h2_compress.cc
+++ b/test/core/end2end/fixtures/h2_compress.cc
@@ -41,7 +41,7 @@ struct fullstack_compression_fixture_data {
     grpc_channel_args_destroy(client_args_compression);
     grpc_channel_args_destroy(server_args_compression);
   }
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
   grpc_channel_args* client_args_compression = nullptr;
   grpc_channel_args* server_args_compression = nullptr;
 };
@@ -52,7 +52,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack_compression(
   int port = grpc_pick_unused_port_or_die();
   fullstack_compression_fixture_data* ffd =
       new fullstack_compression_fixture_data();
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   memset(&f, 0, sizeof(f));
   f.fixture_data = ffd;
@@ -74,7 +74,7 @@ void chttp2_init_client_fullstack_compression(grpc_end2end_test_fixture* f,
       grpc_channel_args_set_channel_default_compression_algorithm(
           client_args, GRPC_COMPRESS_GZIP);
   f->client = grpc_insecure_channel_create(
-      ffd->localaddr.get(), ffd->client_args_compression, nullptr);
+      ffd->localaddr.c_str(), ffd->client_args_compression, nullptr);
 }
 
 void chttp2_init_server_fullstack_compression(grpc_end2end_test_fixture* f,
@@ -94,7 +94,7 @@ void chttp2_init_server_fullstack_compression(grpc_end2end_test_fixture* f,
   f->server = grpc_server_create(ffd->server_args_compression, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
 }
 

--- a/test/core/end2end/fixtures/h2_fakesec.cc
+++ b/test/core/end2end/fixtures/h2_fakesec.cc
@@ -31,7 +31,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
@@ -40,7 +40,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   int port = grpc_pick_unused_port_or_die();
   fullstack_secure_fixture_data* ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -63,7 +63,7 @@ static void chttp2_init_client_secure_fullstack(
     grpc_channel_credentials* creds) {
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -79,8 +79,8 @@ static void chttp2_init_server_secure_fullstack(
   }
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(
+      f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/fixtures/h2_full+pipe.cc
+++ b/test/core/end2end/fixtures/h2_full+pipe.cc
@@ -41,7 +41,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
@@ -51,7 +51,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
   fullstack_fixture_data* ffd = new fullstack_fixture_data();
   memset(&f, 0, sizeof(f));
 
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -64,8 +64,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
                                   grpc_channel_args* client_args) {
   fullstack_fixture_data* ffd =
       static_cast<fullstack_fixture_data*>(f->fixture_data);
-  f->client =
-      grpc_insecure_channel_create(ffd->localaddr.get(), client_args, nullptr);
+  f->client = grpc_insecure_channel_create(ffd->localaddr.c_str(), client_args,
+                                           nullptr);
   GPR_ASSERT(f->client);
 }
 
@@ -79,7 +79,7 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
 }
 

--- a/test/core/end2end/fixtures/h2_full+trace.cc
+++ b/test/core/end2end/fixtures/h2_full+trace.cc
@@ -41,7 +41,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
@@ -51,7 +51,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
   fullstack_fixture_data* ffd = new fullstack_fixture_data();
   memset(&f, 0, sizeof(f));
 
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -64,8 +64,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
                                   grpc_channel_args* client_args) {
   fullstack_fixture_data* ffd =
       static_cast<fullstack_fixture_data*>(f->fixture_data);
-  f->client =
-      grpc_insecure_channel_create(ffd->localaddr.get(), client_args, nullptr);
+  f->client = grpc_insecure_channel_create(ffd->localaddr.c_str(), client_args,
+                                           nullptr);
   GPR_ASSERT(f->client);
 }
 
@@ -79,7 +79,7 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
 }
 

--- a/test/core/end2end/fixtures/h2_full+workarounds.cc
+++ b/test/core/end2end/fixtures/h2_full+workarounds.cc
@@ -40,7 +40,7 @@ static char* workarounds_arg[GRPC_MAX_WORKAROUND_ID] = {
     const_cast<char*>(GRPC_ARG_WORKAROUND_CRONET_COMPRESSION)};
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
@@ -49,7 +49,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
   int port = grpc_pick_unused_port_or_die();
   fullstack_fixture_data* ffd = new fullstack_fixture_data();
   memset(&f, 0, sizeof(f));
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
   f.shutdown_cq = grpc_completion_queue_create_for_pluck(nullptr);
@@ -60,8 +60,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
                                   grpc_channel_args* client_args) {
   fullstack_fixture_data* ffd =
       static_cast<fullstack_fixture_data*>(f->fixture_data);
-  f->client =
-      grpc_insecure_channel_create(ffd->localaddr.get(), client_args, nullptr);
+  f->client = grpc_insecure_channel_create(ffd->localaddr.c_str(), client_args,
+                                           nullptr);
   GPR_ASSERT(f->client);
 }
 
@@ -85,7 +85,7 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   f->server = grpc_server_create(server_args_new, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
   grpc_channel_args_destroy(server_args_new);
 }

--- a/test/core/end2end/fixtures/h2_full.cc
+++ b/test/core/end2end/fixtures/h2_full.cc
@@ -35,7 +35,7 @@
 #include "test/core/util/test_config.h"
 
 struct fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
@@ -45,7 +45,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
   fullstack_fixture_data* ffd = new fullstack_fixture_data();
   memset(&f, 0, sizeof(f));
 
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -58,8 +58,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
                                   grpc_channel_args* client_args) {
   fullstack_fixture_data* ffd =
       static_cast<fullstack_fixture_data*>(f->fixture_data);
-  f->client =
-      grpc_insecure_channel_create(ffd->localaddr.get(), client_args, nullptr);
+  f->client = grpc_insecure_channel_create(ffd->localaddr.c_str(), client_args,
+                                           nullptr);
   GPR_ASSERT(f->client);
 }
 
@@ -73,7 +73,7 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
 }
 

--- a/test/core/end2end/fixtures/h2_http_proxy.cc
+++ b/test/core/end2end/fixtures/h2_http_proxy.cc
@@ -39,7 +39,7 @@
 
 struct fullstack_fixture_data {
   ~fullstack_fixture_data() { grpc_end2end_http_proxy_destroy(proxy); }
-  grpc_core::UniquePtr<char> server_addr;
+  std::string server_addr;
   grpc_end2end_http_proxy* proxy = nullptr;
 };
 
@@ -49,7 +49,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
   memset(&f, 0, sizeof(f));
   fullstack_fixture_data* ffd = new fullstack_fixture_data();
   const int server_port = grpc_pick_unused_port_or_die();
-  grpc_core::JoinHostPort(&ffd->server_addr, "localhost", server_port);
+  ffd->server_addr = grpc_core::JoinHostPort("localhost", server_port);
 
   /* Passing client_args to proxy_create for the case of checking for proxy auth
    */
@@ -81,8 +81,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
   }
   gpr_setenv("http_proxy", proxy_uri);
   gpr_free(proxy_uri);
-  f->client = grpc_insecure_channel_create(ffd->server_addr.get(), client_args,
-                                           nullptr);
+  f->client = grpc_insecure_channel_create(ffd->server_addr.c_str(),
+                                           client_args, nullptr);
   GPR_ASSERT(f->client);
 }
 
@@ -96,7 +96,7 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
   GPR_ASSERT(
-      grpc_server_add_insecure_http2_port(f->server, ffd->server_addr.get()));
+      grpc_server_add_insecure_http2_port(f->server, ffd->server_addr.c_str()));
   grpc_server_start(f->server);
 }
 

--- a/test/core/end2end/fixtures/h2_local_ipv4.cc
+++ b/test/core/end2end/fixtures/h2_local_ipv4.cc
@@ -31,10 +31,8 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack_ipv4(
   grpc_end2end_test_fixture f =
       grpc_end2end_local_chttp2_create_fixture_fullstack();
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::JoinHostPort(
-      &static_cast<grpc_end2end_local_fullstack_fixture_data*>(f.fixture_data)
-           ->localaddr,
-      "127.0.0.1", port);
+  static_cast<grpc_end2end_local_fullstack_fixture_data*>(f.fixture_data)
+      ->localaddr = grpc_core::JoinHostPort("127.0.0.1", port);
   return f;
 }
 

--- a/test/core/end2end/fixtures/h2_local_ipv6.cc
+++ b/test/core/end2end/fixtures/h2_local_ipv6.cc
@@ -31,10 +31,8 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack_ipv6(
   grpc_end2end_test_fixture f =
       grpc_end2end_local_chttp2_create_fixture_fullstack();
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::JoinHostPort(
-      &static_cast<grpc_end2end_local_fullstack_fixture_data*>(f.fixture_data)
-           ->localaddr,
-      "[::1]", port);
+  static_cast<grpc_end2end_local_fullstack_fixture_data*>(f.fixture_data)
+      ->localaddr = grpc_core::JoinHostPort("[::1]", port);
   return f;
 }
 

--- a/test/core/end2end/fixtures/h2_local_uds.cc
+++ b/test/core/end2end/fixtures/h2_local_uds.cc
@@ -18,6 +18,8 @@
 
 #include <unistd.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/string_util.h>
 
 #include "test/core/end2end/end2end_tests.h"
@@ -30,10 +32,9 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack_uds(
     grpc_channel_args* /*client_args*/, grpc_channel_args* /*server_args*/) {
   grpc_end2end_test_fixture f =
       grpc_end2end_local_chttp2_create_fixture_fullstack();
-  char* out = nullptr;
-  gpr_asprintf(&out, "unix:/tmp/grpc_fullstack_test.%d.%d", getpid(), unique++);
   static_cast<grpc_end2end_local_fullstack_fixture_data*>(f.fixture_data)
-      ->localaddr.reset(out);
+      ->localaddr = absl::StrFormat("unix:/tmp/grpc_fullstack_test.%d.%d",
+                                    getpid(), unique++);
   return f;
 }
 

--- a/test/core/end2end/fixtures/h2_oauth2.cc
+++ b/test/core/end2end/fixtures/h2_oauth2.cc
@@ -39,7 +39,7 @@ static const char* client_identity_property_name = "smurf_name";
 static const char* client_identity = "Brainy Smurf";
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static const grpc_metadata* find_metadata(const grpc_metadata* md,
@@ -98,7 +98,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   int port = grpc_pick_unused_port_or_die();
   fullstack_secure_fixture_data* ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
   f.shutdown_cq = grpc_completion_queue_create_for_pluck(nullptr);
@@ -110,7 +110,7 @@ static void chttp2_init_client_secure_fullstack(
     grpc_channel_credentials* creds) {
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -126,8 +126,8 @@ static void chttp2_init_server_secure_fullstack(
   }
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(
+      f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/fixtures/h2_ssl.cc
+++ b/test/core/end2end/fixtures/h2_ssl.cc
@@ -37,7 +37,7 @@
 #define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
@@ -47,7 +47,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   fullstack_secure_fixture_data* ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
 
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -70,7 +70,7 @@ static void chttp2_init_client_secure_fullstack(
     grpc_channel_credentials* creds) {
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -86,8 +86,8 @@ static void chttp2_init_server_secure_fullstack(
   }
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(
+      f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
+++ b/test/core/end2end/fixtures/h2_ssl_cred_reload.cc
@@ -37,7 +37,7 @@
 #define SERVER_KEY_PATH "src/core/tsi/test_creds/server1.key"
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
   bool server_credential_reloaded = false;
 };
 
@@ -82,7 +82,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   int port = grpc_pick_unused_port_or_die();
   fullstack_secure_fixture_data* ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -105,7 +105,7 @@ static void chttp2_init_client_secure_fullstack(
     grpc_channel_credentials* creds) {
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -122,8 +122,8 @@ static void chttp2_init_server_secure_fullstack(
   ffd->server_credential_reloaded = false;
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(
+      f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/fixtures/h2_tls.cc
+++ b/test/core/end2end/fixtures/h2_tls.cc
@@ -51,7 +51,7 @@ struct fullstack_secure_fixture_data {
       thd_list[ind].Join();
     }
   }
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
   ThreadList thd_list;
 };
 
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   int port = grpc_pick_unused_port_or_die();
   fullstack_secure_fixture_data* ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
   f.shutdown_cq = grpc_completion_queue_create_for_pluck(nullptr);
@@ -82,7 +82,7 @@ static void chttp2_init_client_secure_fullstack(
     grpc_channel_credentials* creds) {
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -98,8 +98,8 @@ static void chttp2_init_server_secure_fullstack(
   }
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(
+      f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -61,7 +61,7 @@ struct grpc_end2end_http_proxy {
     gpr_ref_init(&users, 1);
     combiner = grpc_combiner_create();
   }
-  grpc_core::UniquePtr<char> proxy_name;
+  std::string proxy_name;
   grpc_core::Thread thd;
   grpc_tcp_server* server;
   grpc_channel_args* channel_args;
@@ -612,8 +612,8 @@ grpc_end2end_http_proxy* grpc_end2end_http_proxy_create(
   grpc_end2end_http_proxy* proxy = new grpc_end2end_http_proxy();
   // Construct proxy address.
   const int proxy_port = grpc_pick_unused_port_or_die();
-  grpc_core::JoinHostPort(&proxy->proxy_name, "localhost", proxy_port);
-  gpr_log(GPR_INFO, "Proxy address: %s", proxy->proxy_name.get());
+  proxy->proxy_name = grpc_core::JoinHostPort("localhost", proxy_port);
+  gpr_log(GPR_INFO, "Proxy address: %s", proxy->proxy_name.c_str());
   // Create TCP server.
   proxy->channel_args = grpc_channel_args_copy(args);
   grpc_error* error =
@@ -663,5 +663,5 @@ void grpc_end2end_http_proxy_destroy(grpc_end2end_http_proxy* proxy) {
 
 const char* grpc_end2end_http_proxy_get_proxy_name(
     grpc_end2end_http_proxy* proxy) {
-  return proxy->proxy_name.get();
+  return proxy->proxy_name.c_str();
 }

--- a/test/core/end2end/fixtures/local_util.cc
+++ b/test/core/end2end/fixtures/local_util.cc
@@ -50,7 +50,7 @@ void grpc_end2end_local_chttp2_init_client_fullstack(
   grpc_channel_credentials* creds = grpc_local_credentials_create(type);
   grpc_end2end_local_fullstack_fixture_data* ffd =
       static_cast<grpc_end2end_local_fullstack_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -98,8 +98,8 @@ void grpc_end2end_local_chttp2_init_server_fullstack(
                                               nullptr};
     grpc_server_credentials_set_auth_metadata_processor(creds, processor);
   }
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server,
+                                               ffd->localaddr.c_str(), creds));
   grpc_server_credentials_release(creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/fixtures/local_util.h
+++ b/test/core/end2end/fixtures/local_util.h
@@ -23,7 +23,7 @@
 #include "src/core/lib/surface/channel.h"
 
 struct grpc_end2end_local_fullstack_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 /* Utility functions shared by h2_local tests. */

--- a/test/core/end2end/fixtures/proxy.cc
+++ b/test/core/end2end/fixtures/proxy.cc
@@ -41,8 +41,8 @@ struct grpc_end2end_proxy {
     memset(&new_call_metadata, 0, sizeof(new_call_metadata));
   }
   grpc_core::Thread thd;
-  grpc_core::UniquePtr<char> proxy_port;
-  grpc_core::UniquePtr<char> server_port;
+  std::string proxy_port;
+  std::string server_port;
   grpc_completion_queue* cq;
   grpc_server* server;
   grpc_channel* client;
@@ -91,15 +91,15 @@ grpc_end2end_proxy* grpc_end2end_proxy_create(const grpc_end2end_proxy_def* def,
 
   grpc_end2end_proxy* proxy = new grpc_end2end_proxy();
 
-  grpc_core::JoinHostPort(&proxy->proxy_port, "localhost", proxy_port);
-  grpc_core::JoinHostPort(&proxy->server_port, "localhost", server_port);
+  proxy->proxy_port = grpc_core::JoinHostPort("localhost", proxy_port);
+  proxy->server_port = grpc_core::JoinHostPort("localhost", server_port);
 
-  gpr_log(GPR_DEBUG, "PROXY ADDR:%s BACKEND:%s", proxy->proxy_port.get(),
-          proxy->server_port.get());
+  gpr_log(GPR_DEBUG, "PROXY ADDR:%s BACKEND:%s", proxy->proxy_port.c_str(),
+          proxy->server_port.c_str());
 
   proxy->cq = grpc_completion_queue_create_for_next(nullptr);
-  proxy->server = def->create_server(proxy->proxy_port.get(), server_args);
-  proxy->client = def->create_client(proxy->server_port.get(), client_args);
+  proxy->server = def->create_server(proxy->proxy_port.c_str(), server_args);
+  proxy->client = def->create_client(proxy->server_port.c_str(), client_args);
 
   grpc_server_register_completion_queue(proxy->server, proxy->cq, nullptr);
   grpc_server_start(proxy->server);
@@ -440,9 +440,9 @@ static void thread_main(void* arg) {
 }
 
 const char* grpc_end2end_proxy_get_client_target(grpc_end2end_proxy* proxy) {
-  return proxy->proxy_port.get();
+  return proxy->proxy_port.c_str();
 }
 
 const char* grpc_end2end_proxy_get_server_port(grpc_end2end_proxy* proxy) {
-  return proxy->server_port.get();
+  return proxy->server_port.c_str();
 }

--- a/test/core/end2end/h2_ssl_cert_test.cc
+++ b/test/core/end2end/h2_ssl_cert_test.cc
@@ -48,7 +48,7 @@ namespace grpc {
 namespace testing {
 
 struct fullstack_secure_fixture_data {
-  grpc_core::UniquePtr<char> localaddr;
+  std::string localaddr;
 };
 
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
@@ -58,7 +58,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   fullstack_secure_fixture_data* ffd = new fullstack_secure_fixture_data();
   memset(&f, 0, sizeof(f));
 
-  grpc_core::JoinHostPort(&ffd->localaddr, "localhost", port);
+  ffd->localaddr = grpc_core::JoinHostPort("localhost", port);
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
@@ -79,7 +79,7 @@ static void chttp2_init_client_secure_fullstack(
     grpc_channel_credentials* creds) {
   fullstack_secure_fixture_data* ffd =
       static_cast<fullstack_secure_fixture_data*>(f->fixture_data);
-  f->client = grpc_secure_channel_create(creds, ffd->localaddr.get(),
+  f->client = grpc_secure_channel_create(creds, ffd->localaddr.c_str(),
                                          client_args, nullptr);
   GPR_ASSERT(f->client != nullptr);
   grpc_channel_credentials_release(creds);
@@ -95,8 +95,8 @@ static void chttp2_init_server_secure_fullstack(
   }
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(f->server, ffd->localaddr.get(),
-                                               server_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(
+      f->server, ffd->localaddr.c_str(), server_creds));
   grpc_server_credentials_release(server_creds);
   grpc_server_start(f->server);
 }

--- a/test/core/end2end/invalid_call_argument_test.cc
+++ b/test/core/end2end/invalid_call_argument_test.cc
@@ -77,13 +77,13 @@ static void prepare_test(int is_client) {
   } else {
     g_state.server = grpc_server_create(nullptr, nullptr);
     grpc_server_register_completion_queue(g_state.server, g_state.cq, nullptr);
-    grpc_core::UniquePtr<char> server_hostport;
-    grpc_core::JoinHostPort(&server_hostport, "0.0.0.0", port);
-    grpc_server_add_insecure_http2_port(g_state.server, server_hostport.get());
+    std::string server_hostport = grpc_core::JoinHostPort("0.0.0.0", port);
+    grpc_server_add_insecure_http2_port(g_state.server,
+                                        server_hostport.c_str());
     grpc_server_start(g_state.server);
-    grpc_core::JoinHostPort(&server_hostport, "localhost", port);
+    server_hostport = grpc_core::JoinHostPort("localhost", port);
     g_state.chan =
-        grpc_insecure_channel_create(server_hostport.get(), nullptr, nullptr);
+        grpc_insecure_channel_create(server_hostport.c_str(), nullptr, nullptr);
     grpc_slice host = grpc_slice_from_static_string("bar");
     g_state.call = grpc_channel_create_call(
         g_state.chan, nullptr, GRPC_PROPAGATE_DEFAULTS, g_state.cq,

--- a/test/core/fling/fling_stream_test.cc
+++ b/test/core/fling/fling_stream_test.cc
@@ -46,9 +46,8 @@ int main(int /*argc*/, char** argv) {
   gpr_asprintf(&args[0], "%s/fling_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  grpc_core::UniquePtr<char> joined;
-  grpc_core::JoinHostPort(&joined, "::", port);
-  args[2] = joined.get();
+  std::string joined = grpc_core::JoinHostPort("::", port);
+  args[2] = const_cast<char*>(joined.c_str());
   args[3] = const_cast<char*>("--no-secure");
   svr = gpr_subprocess_create(4, (const char**)args);
   gpr_free(args[0]);
@@ -57,8 +56,8 @@ int main(int /*argc*/, char** argv) {
   gpr_asprintf(&args[0], "%s/fling_client%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--target");
-  grpc_core::JoinHostPort(&joined, "127.0.0.1", port);
-  args[2] = joined.get();
+  joined = grpc_core::JoinHostPort("127.0.0.1", port);
+  args[2] = const_cast<char*>(joined.c_str());
   args[3] = const_cast<char*>("--scenario=ping-pong-stream");
   args[4] = const_cast<char*>("--no-secure");
   args[5] = nullptr;

--- a/test/core/fling/fling_test.cc
+++ b/test/core/fling/fling_test.cc
@@ -47,9 +47,8 @@ int main(int /*argc*/, const char** argv) {
   gpr_asprintf(&args[0], "%s/fling_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
-  grpc_core::UniquePtr<char> joined;
-  grpc_core::JoinHostPort(&joined, "::", port);
-  args[2] = joined.get();
+  std::string joined = grpc_core::JoinHostPort("::", port);
+  args[2] = const_cast<char*>(joined.c_str());
   args[3] = const_cast<char*>("--no-secure");
   svr = gpr_subprocess_create(4, (const char**)args);
   gpr_free(args[0]);
@@ -58,8 +57,8 @@ int main(int /*argc*/, const char** argv) {
   gpr_asprintf(&args[0], "%s/fling_client%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--target");
-  grpc_core::JoinHostPort(&joined, "127.0.0.1", port);
-  args[2] = joined.get();
+  joined = grpc_core::JoinHostPort("127.0.0.1", port);
+  args[2] = const_cast<char*>(joined.c_str());
   args[3] = const_cast<char*>("--scenario=ping-pong-request");
   args[4] = const_cast<char*>("--no-secure");
   args[5] = nullptr;

--- a/test/core/fling/server.cc
+++ b/test/core/fling/server.cc
@@ -172,7 +172,7 @@ static void sigint_handler(int /*x*/) { _exit(0); }
 int main(int argc, char** argv) {
   grpc_event ev;
   call_state* s;
-  grpc_core::UniquePtr<char> addr_buf;
+  std::string addr_buf;
   gpr_cmdline* cl;
   grpc_completion_queue* shutdown_cq;
   int shutdown_started = 0;
@@ -199,8 +199,8 @@ int main(int argc, char** argv) {
   gpr_cmdline_destroy(cl);
 
   if (addr == nullptr) {
-    grpc_core::JoinHostPort(&addr_buf, "::", grpc_pick_unused_port_or_die());
-    addr = addr_buf.get();
+    addr_buf = grpc_core::JoinHostPort("::", grpc_pick_unused_port_or_die());
+    addr = addr_buf.c_str();
   }
   gpr_log(GPR_INFO, "creating server on: %s", addr);
 
@@ -221,7 +221,7 @@ int main(int argc, char** argv) {
   grpc_server_start(server);
 
   addr = nullptr;
-  addr_buf.reset();
+  addr_buf.clear();
 
   grpc_call_details_init(&call_details);
 

--- a/test/core/gprpp/host_port_test.cc
+++ b/test/core/gprpp/host_port_test.cc
@@ -26,12 +26,8 @@
 
 static void join_host_port_expect(const char* host, int port,
                                   const char* expected) {
-  grpc_core::UniquePtr<char> buf;
-  int len;
-  len = grpc_core::JoinHostPort(&buf, host, port);
-  GPR_ASSERT(len >= 0);
-  GPR_ASSERT(strlen(expected) == static_cast<size_t>(len));
-  GPR_ASSERT(strcmp(expected, buf.get()) == 0);
+  std::string actual = grpc_core::JoinHostPort(host, port);
+  GPR_ASSERT(actual == expected);
 }
 
 static void test_join_host_port(void) {

--- a/test/core/iomgr/sockaddr_utils_test.cc
+++ b/test/core/iomgr/sockaddr_utils_test.cc
@@ -175,15 +175,9 @@ static void test_sockaddr_is_wildcard(void) {
 
 static void expect_sockaddr_str(const char* expected,
                                 grpc_resolved_address* addr, int normalize) {
-  int result;
-  char* str;
   gpr_log(GPR_INFO, "  expect_sockaddr_str(%s)", expected);
-  result = grpc_sockaddr_to_string(&str, addr, normalize);
-  GPR_ASSERT(str != nullptr);
-  GPR_ASSERT(result >= 0);
-  GPR_ASSERT((size_t)result == strlen(str));
-  GPR_ASSERT(strcmp(expected, str) == 0);
-  gpr_free(str);
+  std::string actual = grpc_sockaddr_to_string(addr, normalize);
+  GPR_ASSERT(actual == expected);
 }
 
 static void expect_sockaddr_uri(const char* expected,

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -32,6 +32,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <string>
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -133,15 +135,10 @@ static void server_weak_ref_set(server_weak_ref* weak_ref,
 }
 
 static void test_addr_init_str(test_addr* addr) {
-  char* str = nullptr;
-  if (grpc_sockaddr_to_string(&str, &addr->addr, 0) != -1) {
-    size_t str_len;
-    memcpy(addr->str, str, (str_len = strnlen(str, sizeof(addr->str) - 1)));
-    addr->str[str_len] = '\0';
-    gpr_free(str);
-  } else {
-    addr->str[0] = '\0';
-  }
+  std::string str = grpc_sockaddr_to_string(&addr->addr, false);
+  size_t str_len = std::min(str.size(), sizeof(addr->str) - 1);
+  memcpy(addr->str, str.c_str(), str_len);
+  addr->str[str_len] = '\0';
 }
 
 static void on_connect(void* /*arg*/, grpc_endpoint* tcp,

--- a/test/core/surface/num_external_connectivity_watchers_test.cc
+++ b/test/core/surface/num_external_connectivity_watchers_test.cc
@@ -69,11 +69,11 @@ static void channel_idle_poll_for_timeout(grpc_channel* channel,
 static void run_timeouts_test(const test_fixture* fixture) {
   gpr_log(GPR_INFO, "TEST: %s", fixture->name);
 
-  grpc_core::UniquePtr<char> addr;
   grpc_init();
-  grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
+  std::string addr =
+      grpc_core::JoinHostPort("localhost", grpc_pick_unused_port_or_die());
 
-  grpc_channel* channel = fixture->create_channel(addr.get());
+  grpc_channel* channel = fixture->create_channel(addr.c_str());
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
 
   /* start 1 watcher and then let it time out */
@@ -120,11 +120,11 @@ static void run_channel_shutdown_before_timeout_test(
     const test_fixture* fixture) {
   gpr_log(GPR_INFO, "TEST: %s", fixture->name);
 
-  grpc_core::UniquePtr<char> addr;
   grpc_init();
-  grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
+  std::string addr =
+      grpc_core::JoinHostPort("localhost", grpc_pick_unused_port_or_die());
 
-  grpc_channel* channel = fixture->create_channel(addr.get());
+  grpc_channel* channel = fixture->create_channel(addr.c_str());
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
 
   /* start 1 watcher and then shut down the channel before the timer goes off */

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -66,11 +66,11 @@ static void run_test(const test_fixture* fixture) {
 
   grpc_init();
 
-  grpc_core::UniquePtr<char> addr;
-  grpc_core::JoinHostPort(&addr, "localhost", grpc_pick_unused_port_or_die());
+  std::string addr =
+      grpc_core::JoinHostPort("localhost", grpc_pick_unused_port_or_die());
 
   grpc_server* server = grpc_server_create(nullptr, nullptr);
-  fixture->add_server_port(server, addr.get());
+  fixture->add_server_port(server, addr.c_str());
   grpc_completion_queue* server_cq =
       grpc_completion_queue_create_for_next(nullptr);
   grpc_server_register_completion_queue(server, server_cq, nullptr);
@@ -83,7 +83,7 @@ static void run_test(const test_fixture* fixture) {
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   grpc_channel* channels[NUM_CONNECTIONS];
   for (size_t i = 0; i < NUM_CONNECTIONS; i++) {
-    channels[i] = fixture->create_channel(addr.get());
+    channels[i] = fixture->create_channel(addr.c_str());
 
     gpr_timespec connect_deadline = grpc_timeout_seconds_to_deadline(30);
     grpc_connectivity_state state;

--- a/test/core/surface/server_chttp2_test.cc
+++ b/test/core/surface/server_chttp2_test.cc
@@ -47,15 +47,15 @@ void test_add_same_port_twice() {
   grpc_channel_args args = {1, &a};
 
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
   grpc_completion_queue* cq = grpc_completion_queue_create_for_pluck(nullptr);
   grpc_server* server = grpc_server_create(&args, nullptr);
   grpc_server_credentials* fake_creds =
       grpc_fake_transport_security_server_credentials_create();
-  grpc_core::JoinHostPort(&addr, "localhost", port);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(server, addr.get(), fake_creds));
+  std::string addr = grpc_core::JoinHostPort("localhost", port);
   GPR_ASSERT(
-      grpc_server_add_secure_http2_port(server, addr.get(), fake_creds) == 0);
+      grpc_server_add_secure_http2_port(server, addr.c_str(), fake_creds));
+  GPR_ASSERT(
+      grpc_server_add_secure_http2_port(server, addr.c_str(), fake_creds) == 0);
 
   grpc_server_credentials_release(fake_creds);
   grpc_server_shutdown_and_notify(server, cq, nullptr);

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -106,19 +106,18 @@ void test_bind_server_twice(void) {
 
 void test_bind_server_to_addr(const char* host, bool secure) {
   int port = grpc_pick_unused_port_or_die();
-  grpc_core::UniquePtr<char> addr;
-  grpc_core::JoinHostPort(&addr, host, port);
-  gpr_log(GPR_INFO, "Test bind to %s", addr.get());
+  std::string addr = grpc_core::JoinHostPort(host, port);
+  gpr_log(GPR_INFO, "Test bind to %s", addr.c_str());
 
   grpc_server* server = grpc_server_create(nullptr, nullptr);
   if (secure) {
     grpc_server_credentials* fake_creds =
         grpc_fake_transport_security_server_credentials_create();
     GPR_ASSERT(
-        grpc_server_add_secure_http2_port(server, addr.get(), fake_creds));
+        grpc_server_add_secure_http2_port(server, addr.c_str(), fake_creds));
     grpc_server_credentials_release(fake_creds);
   } else {
-    GPR_ASSERT(grpc_server_add_insecure_http2_port(server, addr.get()));
+    GPR_ASSERT(grpc_server_add_insecure_http2_port(server, addr.c_str()));
   }
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   grpc_server_register_completion_queue(server, cq, nullptr);

--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -108,19 +108,17 @@ class MockSourceAddrFactory : public address_sorting_source_addr_factory {
          !ipv6_supported_)) {
       return false;
     }
-    char* ip_addr_str;
     grpc_resolved_address dest_addr_as_resolved_addr;
     memcpy(&dest_addr_as_resolved_addr.addr, dest_addr, dest_addr->len);
     dest_addr_as_resolved_addr.len = dest_addr->len;
-    grpc_sockaddr_to_string(&ip_addr_str, &dest_addr_as_resolved_addr,
-                            false /* normalize */);
+    std::string ip_addr_str = grpc_sockaddr_to_string(
+        &dest_addr_as_resolved_addr, false /* normalize */);
     auto it = dest_addr_to_src_addr_.find(ip_addr_str);
     if (it == dest_addr_to_src_addr_.end()) {
-      gpr_log(GPR_DEBUG, "can't find |%s| in dest to src map", ip_addr_str);
-      gpr_free(ip_addr_str);
+      gpr_log(GPR_DEBUG, "can't find |%s| in dest to src map",
+              ip_addr_str.c_str());
       return false;
     }
-    gpr_free(ip_addr_str);
     grpc_resolved_address source_addr_as_resolved_addr =
         TestAddressToGrpcResolvedAddress(it->second);
     memcpy(source_addr->addr, &source_addr_as_resolved_addr.addr,
@@ -180,13 +178,10 @@ void VerifyLbAddrOutputs(const grpc_core::ServerAddressList& addresses,
                          std::vector<std::string> expected_addrs) {
   EXPECT_EQ(addresses.size(), expected_addrs.size());
   for (size_t i = 0; i < addresses.size(); ++i) {
-    char* ip_addr_str;
-    grpc_sockaddr_to_string(&ip_addr_str, &addresses[i].address(),
-                            false /* normalize */);
+    std::string ip_addr_str =
+        grpc_sockaddr_to_string(&addresses[i].address(), false /* normalize */);
     EXPECT_EQ(expected_addrs[i], ip_addr_str);
-    gpr_free(ip_addr_str);
   }
-  grpc_core::ExecCtx exec_ctx;
 }
 
 /* We need to run each test case inside of its own

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -503,11 +503,10 @@ class CheckingResultHandler : public ResultHandler {
                                  std::vector<GrpcLBAddress>* out) {
     for (size_t i = 0; i < addresses.size(); i++) {
       const grpc_core::ServerAddress& addr = addresses[i];
-      char* str;
-      grpc_sockaddr_to_string(&str, &addr.address(), 1 /* normalize */);
-      gpr_log(GPR_INFO, "%s", str);
-      out->emplace_back(GrpcLBAddress(std::string(str), is_balancer));
-      gpr_free(str);
+      std::string str =
+          grpc_sockaddr_to_string(&addr.address(), true /* normalize */);
+      gpr_log(GPR_INFO, "%s", str.c_str());
+      out->emplace_back(GrpcLBAddress(std::move(str), is_balancer));
     }
   }
 };

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -347,11 +347,10 @@ std::unique_ptr<ScenarioResult> RunScenario(
       cli_target += std::to_string(i);
       client_config.add_server_targets(cli_target);
     } else {
-      std::string host;
-      grpc_core::UniquePtr<char> cli_target;
-      host = get_host(workers[i]);
-      grpc_core::JoinHostPort(&cli_target, host.c_str(), init_status.port());
-      client_config.add_server_targets(cli_target.get());
+      std::string host = get_host(workers[i]);
+      std::string cli_target =
+          grpc_core::JoinHostPort(host.c_str(), init_status.port());
+      client_config.add_server_targets(cli_target.c_str());
     }
   }
 

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -279,10 +279,9 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
 
   std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
   if (driver_port >= 0) {
-    grpc_core::UniquePtr<char> server_address;
-    grpc_core::JoinHostPort(&server_address, "::", driver_port);
+    std::string server_address = grpc_core::JoinHostPort("::", driver_port);
     builder->AddListeningPort(
-        server_address.get(),
+        server_address.c_str(),
         GetCredentialsProvider()->GetServerCredentials(credential_type));
   }
   builder->RegisterService(impl_.get());

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -80,9 +80,8 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      grpc_core::UniquePtr<char> server_address;
-      grpc_core::JoinHostPort(&server_address, "::", port_num);
-      builder->AddListeningPort(server_address.get(),
+      std::string server_address = grpc_core::JoinHostPort("::", port_num);
+      builder->AddListeningPort(server_address.c_str(),
                                 Server::CreateServerCredentials(config));
     }
 

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -102,9 +102,8 @@ class CallbackServer final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      grpc_core::UniquePtr<char> server_address;
-      grpc_core::JoinHostPort(&server_address, "::", port_num);
-      builder->AddListeningPort(server_address.get(),
+      std::string server_address = grpc_core::JoinHostPort("::", port_num);
+      builder->AddListeningPort(server_address.c_str(),
                                 Server::CreateServerCredentials(config));
     }
 

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -160,9 +160,8 @@ class SynchronousServer final : public grpc::testing::Server {
     auto port_num = port();
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
-      grpc_core::UniquePtr<char> server_address;
-      grpc_core::JoinHostPort(&server_address, "::", port_num);
-      builder->AddListeningPort(server_address.get(),
+      std::string server_address = grpc_core::JoinHostPort("::", port_num);
+      builder->AddListeningPort(server_address.c_str(),
                                 Server::CreateServerCredentials(config));
     }
 


### PR DESCRIPTION
Also change `grpc_sockaddr_to_string()` to return `std::string`.