### PR TITLE
C++ify grpc_server

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -23,6 +23,7 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <string.h>
+#include <vector>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -64,8 +65,8 @@ class Chttp2ServerListener : public ServerListenerInterface {
   Chttp2ServerListener(grpc_server* server, grpc_channel_args* args);
   ~Chttp2ServerListener();
 
-  void Start(grpc_server* server, grpc_pollset** pollsets,
-             size_t npollsets) override;
+  void Start(grpc_server* server,
+             const std::vector<grpc_pollset*>* pollsets) override;
 
   channelz::ListenSocketNode* channelz_listen_socket_node() const override {
     return channelz_listen_socket_.get();
@@ -383,13 +384,12 @@ Chttp2ServerListener::~Chttp2ServerListener() {
 
 /* Server callback: start listening on our ports */
 void Chttp2ServerListener::Start(grpc_server* /*server*/,
-                                 grpc_pollset** pollsets,
-                                 size_t pollset_count) {
+                                 const std::vector<grpc_pollset*>* pollsets) {
   {
     MutexLock lock(&mu_);
     shutdown_ = false;
   }
-  grpc_tcp_server_start(tcp_server_, pollsets, pollset_count, OnAccept, this);
+  grpc_tcp_server_start(tcp_server_, pollsets, OnAccept, this);
 }
 
 void Chttp2ServerListener::SetOnDestroyDone(grpc_closure* on_destroy_done) {

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.cc
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.cc
@@ -51,12 +51,8 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server* server,
   grpc_transport* transport = grpc_create_chttp2_transport(
       server_args, server_endpoint, false /* is_client */);
 
-  grpc_pollset** pollsets;
-  size_t num_pollsets = 0;
-  grpc_server_get_pollsets(server, &pollsets, &num_pollsets);
-
-  for (size_t i = 0; i < num_pollsets; i++) {
-    grpc_endpoint_add_to_pollset(server_endpoint, pollsets[i]);
+  for (grpc_pollset* pollset : grpc_server_get_pollsets(server)) {
+    grpc_endpoint_add_to_pollset(server_endpoint, pollset);
   }
 
   grpc_server_setup_transport(server, transport, nullptr, server_args, nullptr);

--- a/src/core/lib/iomgr/tcp_server.cc
+++ b/src/core/lib/iomgr/tcp_server.cc
@@ -28,11 +28,10 @@ grpc_error* grpc_tcp_server_create(grpc_closure* shutdown_complete,
   return grpc_tcp_server_impl->create(shutdown_complete, args, server);
 }
 
-void grpc_tcp_server_start(grpc_tcp_server* server, grpc_pollset** pollsets,
-                           size_t pollset_count,
+void grpc_tcp_server_start(grpc_tcp_server* server,
+                           const std::vector<grpc_pollset*>* pollsets,
                            grpc_tcp_server_cb on_accept_cb, void* cb_arg) {
-  grpc_tcp_server_impl->start(server, pollsets, pollset_count, on_accept_cb,
-                              cb_arg);
+  grpc_tcp_server_impl->start(server, pollsets, on_accept_cb, cb_arg);
 }
 
 grpc_error* grpc_tcp_server_add_port(grpc_tcp_server* s,

--- a/src/core/lib/iomgr/tcp_server.h
+++ b/src/core/lib/iomgr/tcp_server.h
@@ -24,6 +24,8 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
 
+#include <vector>
+
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/resolve_address.h"
@@ -64,9 +66,9 @@ typedef struct grpc_tcp_server_vtable {
   grpc_error* (*create)(grpc_closure* shutdown_complete,
                         const grpc_channel_args* args,
                         grpc_tcp_server** server);
-  void (*start)(grpc_tcp_server* server, grpc_pollset** pollsets,
-                size_t pollset_count, grpc_tcp_server_cb on_accept_cb,
-                void* cb_arg);
+  void (*start)(grpc_tcp_server* server,
+                const std::vector<grpc_pollset*>* pollsets,
+                grpc_tcp_server_cb on_accept_cb, void* cb_arg);
   grpc_error* (*add_port)(grpc_tcp_server* s, const grpc_resolved_address* addr,
                           int* out_port);
   grpc_core::TcpServerFdHandler* (*create_fd_handler)(grpc_tcp_server* s);
@@ -87,8 +89,8 @@ grpc_error* grpc_tcp_server_create(grpc_closure* shutdown_complete,
                                    grpc_tcp_server** server);
 
 /* Start listening to bound ports */
-void grpc_tcp_server_start(grpc_tcp_server* server, grpc_pollset** pollsets,
-                           size_t pollset_count,
+void grpc_tcp_server_start(grpc_tcp_server* server,
+                           const std::vector<grpc_pollset*>* pollsets,
                            grpc_tcp_server_cb on_accept_cb, void* cb_arg);
 
 /* Add a port to the server, returning the newly allocated port on success, or

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -417,12 +417,10 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   return error;
 }
 
-static void tcp_server_start(grpc_tcp_server* server, grpc_pollset** pollsets,
-                             size_t pollset_count,
+static void tcp_server_start(grpc_tcp_server* server,
+                             const std::vector<grpc_pollset*>* /*pollsets*/,
                              grpc_tcp_server_cb on_accept_cb, void* cb_arg) {
   grpc_tcp_listener* sp;
-  (void)pollsets;
-  (void)pollset_count;
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_INFO, "SERVER_START %p", server);

--- a/src/core/lib/iomgr/tcp_server_utils_posix.h
+++ b/src/core/lib/iomgr/tcp_server_utils_posix.h
@@ -82,10 +82,9 @@ struct grpc_tcp_server {
   /* shutdown callback */
   grpc_closure* shutdown_complete;
 
-  /* all pollsets interested in new connections */
-  grpc_pollset** pollsets;
-  /* number of pollsets in the pollsets array */
-  size_t pollset_count;
+  /* all pollsets interested in new connections. The object pointed at is not
+   * owned by this struct */
+  const std::vector<grpc_pollset*>* pollsets;
 
   /* next pollset to assign a channel to */
   gpr_atm next_pollset_to_assign;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -27,6 +27,8 @@
 #include <inttypes.h>
 #include <io.h>
 
+#include <vector>
+
 #include "absl/strings/str_cat.h"
 
 #include <grpc/support/alloc.h>
@@ -518,8 +520,8 @@ done:
   return error;
 }
 
-static void tcp_server_start(grpc_tcp_server* s, grpc_pollset** pollset,
-                             size_t pollset_count,
+static void tcp_server_start(grpc_tcp_server* s,
+                             const std::vector<grpc_pollset*>* /*pollsets*/,
                              grpc_tcp_server_cb on_accept_cb,
                              void* on_accept_cb_arg) {
   grpc_tcp_listener* sp;

--- a/src/core/lib/iomgr/udp_server.h
+++ b/src/core/lib/iomgr/udp_server.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <vector>
+
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/ev_posix.h"
 #include "src/core/lib/iomgr/resolve_address.h"
@@ -72,8 +74,9 @@ class GrpcUdpHandlerFactory {
 grpc_udp_server* grpc_udp_server_create(const grpc_channel_args* args);
 
 /* Start listening to bound ports. user_data is passed to callbacks. */
-void grpc_udp_server_start(grpc_udp_server* udp_server, grpc_pollset** pollsets,
-                           size_t pollset_count, void* user_data);
+void grpc_udp_server_start(grpc_udp_server* udp_server,
+                           const std::vector<grpc_pollset*>* pollsets,
+                           void* user_data);
 
 int grpc_udp_server_get_fd(grpc_udp_server* s, unsigned port_index);
 

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <algorithm>
+#include <atomic>
+#include <iterator>
 #include <list>
 #include <utility>
 #include <vector>
@@ -32,6 +35,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
+#include "absl/types/optional.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/channel/connected_channel.h"
@@ -50,9 +54,9 @@
 #include "src/core/lib/transport/metadata.h"
 #include "src/core/lib/transport/static_metadata.h"
 
-grpc_core::TraceFlag grpc_server_channel_trace(false, "server_channel");
+namespace grpc_core {
 
-using grpc_core::LockedMultiProducerSingleConsumerQueue;
+TraceFlag grpc_server_channel_trace(false, "server_channel");
 
 namespace {
 
@@ -60,15 +64,14 @@ void server_on_recv_initial_metadata(void* ptr, grpc_error* error);
 void server_recv_trailing_metadata_ready(void* user_data, grpc_error* error);
 
 struct Listener {
-  explicit Listener(
-      grpc_core::OrphanablePtr<grpc_core::ServerListenerInterface> l)
+  explicit Listener(OrphanablePtr<ServerListenerInterface> l)
       : listener(std::move(l)) {}
 
-  grpc_core::OrphanablePtr<grpc_core::ServerListenerInterface> listener;
+  OrphanablePtr<ServerListenerInterface> listener;
   grpc_closure destroy_done;
 };
 
-enum requested_call_type { BATCH_CALL, REGISTERED_CALL };
+enum class RequestedCallType { BATCH_CALL, REGISTERED_CALL };
 
 struct registered_method;
 
@@ -76,7 +79,7 @@ struct requested_call {
   requested_call(void* tag_arg, grpc_completion_queue* call_cq,
                  grpc_call** call_arg, grpc_metadata_array* initial_md,
                  grpc_call_details* details)
-      : type(BATCH_CALL),
+      : type(RequestedCallType::BATCH_CALL),
         tag(tag_arg),
         cq_bound_to_call(call_cq),
         call(call_arg),
@@ -89,7 +92,7 @@ struct requested_call {
                  grpc_call** call_arg, grpc_metadata_array* initial_md,
                  registered_method* rm, gpr_timespec* deadline,
                  grpc_byte_buffer** optional_payload)
-      : type(REGISTERED_CALL),
+      : type(RequestedCallType::REGISTERED_CALL),
         tag(tag_arg),
         cq_bound_to_call(call_cq),
         call(call_arg),
@@ -99,8 +102,8 @@ struct requested_call {
     data.registered.optional_payload = optional_payload;
   }
 
-  grpc_core::MultiProducerSingleConsumerQueue::Node mpscq_node;
-  const requested_call_type type;
+  MultiProducerSingleConsumerQueue::Node mpscq_node;
+  const RequestedCallType type;
   void* const tag;
   grpc_completion_queue* const cq_bound_to_call;
   grpc_call** const call;
@@ -119,34 +122,43 @@ struct requested_call {
 };
 
 struct channel_registered_method {
-  registered_method* server_registered_method;
+  registered_method* server_registered_method = nullptr;
   uint32_t flags;
   bool has_host;
-  grpc_core::ExternallyManagedSlice method;
-  grpc_core::ExternallyManagedSlice host;
+  ExternallyManagedSlice method;
+  ExternallyManagedSlice host;
 };
 
 struct channel_data {
-  grpc_server* server;
+  channel_data() = default;
+  ~channel_data();
+
+  grpc_server* server = nullptr;
   grpc_channel* channel;
   size_t cq_idx;
-  /* linked list of all channels on a server */
-  channel_data* next;
-  channel_data* prev;
-  channel_registered_method* registered_methods;
-  uint32_t registered_method_slots;
+  absl::optional<std::list<channel_data*>::iterator> list_position;
+
+  // registered_methods is a hash-table of the methods and hosts of the
+  // registered methods.
+  // TODO(vjpai): Convert this to an STL map type as opposed to a direct bucket
+  // implementation. (Consider performance impact, hash function to use, etc.)
+  std::unique_ptr<std::vector<channel_registered_method>> registered_methods;
   uint32_t registered_method_max_probes;
+
   grpc_closure finish_destroy_channel_closure;
   intptr_t channelz_socket_uuid;
 };
 
 struct shutdown_tag {
-  void* tag;
-  grpc_completion_queue* cq;
+  shutdown_tag(void* tag_arg, grpc_completion_queue* cq_arg)
+      : tag(tag_arg), cq(cq_arg) {}
+
+  void* const tag;
+  grpc_completion_queue* const cq;
   grpc_cq_completion completion;
 };
 
-enum call_state {
+enum class CallState {
   /* waiting for metadata */
   NOT_STARTED,
   /* initial metadata read, not flow controlled in yet */
@@ -214,15 +226,16 @@ struct call_data {
   call_data(grpc_call_element* elem, const grpc_call_element_args& args)
       : call(grpc_call_from_top_element(elem)),
         call_combiner(args.call_combiner) {
-    GRPC_CLOSURE_INIT(&server_on_recv_initial_metadata,
-                      ::server_on_recv_initial_metadata, elem,
+    GRPC_CLOSURE_INIT(&on_recv_initial_metadata,
+                      server_on_recv_initial_metadata, elem,
                       grpc_schedule_on_exec_ctx);
     GRPC_CLOSURE_INIT(&recv_trailing_metadata_ready,
-                      ::server_recv_trailing_metadata_ready, elem,
+                      server_recv_trailing_metadata_ready, elem,
                       grpc_schedule_on_exec_ctx);
   }
   ~call_data() {
-    GPR_ASSERT(state != PENDING);
+    GPR_ASSERT(state.Load(grpc_core::MemoryOrder::RELAXED) !=
+               CallState::PENDING);
     GRPC_ERROR_UNREF(recv_initial_metadata_error);
     if (host_set) {
       grpc_slice_unref_internal(host);
@@ -236,7 +249,7 @@ struct call_data {
 
   grpc_call* call;
 
-  gpr_atm state = NOT_STARTED;
+  Atomic<CallState> state{CallState::NOT_STARTED};
 
   bool path_set = false;
   bool host_set = false;
@@ -255,7 +268,7 @@ struct call_data {
   grpc_byte_buffer* payload = nullptr;
 
   grpc_closure got_initial_metadata;
-  grpc_closure server_on_recv_initial_metadata;
+  grpc_closure on_recv_initial_metadata;
   grpc_closure kill_zombie_closure;
   grpc_closure* on_done_recv_initial_metadata;
   grpc_closure recv_trailing_metadata_ready;
@@ -266,8 +279,7 @@ struct call_data {
 
   grpc_closure publish;
 
-  call_data* pending_next = nullptr;
-  grpc_core::CallCombiner* call_combiner;
+  CallCombiner* call_combiner;
 };
 
 struct registered_method {
@@ -288,24 +300,50 @@ struct registered_method {
   const uint32_t flags;
   /* one request matcher per method */
   std::unique_ptr<RequestMatcherInterface> matcher;
-  registered_method* next;
 };
 
-struct channel_broadcaster {
-  grpc_channel** channels;
-  size_t num_channels;
-};
 }  // namespace
+}  // namespace grpc_core
 
 struct grpc_server {
-  grpc_channel_args* channel_args = nullptr;
+  explicit grpc_server(const grpc_channel_args* args)
+      : channel_args(grpc_channel_args_copy(args)) {
+    if (grpc_channel_args_find_bool(args, GRPC_ARG_ENABLE_CHANNELZ,
+                                    GRPC_ENABLE_CHANNELZ_DEFAULT)) {
+      size_t channel_tracer_max_memory = grpc_channel_args_find_integer(
+          args, GRPC_ARG_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE,
+          {GRPC_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE_DEFAULT, 0, INT_MAX});
+      channelz_server =
+          grpc_core::MakeRefCounted<grpc_core::channelz::ServerNode>(
+              this, channel_tracer_max_memory);
+      channelz_server->AddTraceEvent(
+          grpc_core::channelz::ChannelTrace::Severity::Info,
+          grpc_slice_from_static_string("Server created"));
+    }
+
+    if (args != nullptr) {
+      grpc_resource_quota* resource_quota =
+          grpc_resource_quota_from_channel_args(args, false /* create */);
+      if (resource_quota != nullptr) {
+        default_resource_user =
+            grpc_resource_user_create(resource_quota, "default");
+      }
+    }
+  }
+
+  ~grpc_server() {
+    grpc_channel_args_destroy(channel_args);
+    for (size_t i = 0; i < cqs.size(); i++) {
+      GRPC_CQ_INTERNAL_UNREF(cqs[i], "server");
+    }
+  }
+
+  grpc_channel_args* const channel_args;
 
   grpc_resource_user* default_resource_user = nullptr;
 
-  grpc_completion_queue** cqs = nullptr;
-  grpc_pollset** pollsets = nullptr;
-  size_t cq_count = 0;
-  size_t pollset_count = 0;
+  std::vector<grpc_completion_queue*> cqs;
+  std::vector<grpc_pollset*> pollsets;
   bool started = false;
 
   /* The two following mutexes control access to server-state
@@ -315,31 +353,28 @@ struct grpc_server {
      If they are ever required to be nested, you must lock mu_global
      before mu_call. This is currently used in shutdown processing
      (grpc_server_shutdown_and_notify and maybe_finish_shutdown) */
-  gpr_mu mu_global; /* mutex for server and channel state */
-  gpr_mu mu_call;   /* mutex for call-specific state */
+  grpc_core::Mutex mu_global;  // mutex for server and channel state
+  grpc_core::Mutex mu_call;    // mutex for call-specific state
 
   /* startup synchronization: flag is protected by mu_global, signals whether
      we are doing the listener start routine or not */
   bool starting = false;
-  gpr_cv starting_cv;
+  grpc_core::CondVar starting_cv;
 
-  // TODO(vjpai): Convert from a linked-list head pointer to a std::vector once
-  // grpc_server has a real constructor/destructor
-  registered_method* registered_methods = nullptr;
-  /** one request matcher for unregistered methods */
-  // TODO(vjpai): Convert to a std::unique_ptr once grpc_server has a real
-  // constructor and destructor.
-  RequestMatcherInterface* unregistered_request_matcher = nullptr;
+  std::vector<std::unique_ptr<grpc_core::registered_method>> registered_methods;
 
-  gpr_atm shutdown_flag = 0;
-  uint8_t shutdown_published = 0;
-  size_t num_shutdown_tags = 0;
-  shutdown_tag* shutdown_tags = nullptr;
+  // one request matcher for unregistered methods
+  std::unique_ptr<grpc_core::RequestMatcherInterface>
+      unregistered_request_matcher;
 
-  channel_data root_channel_data;
+  std::atomic_bool shutdown_flag{false};
+  bool shutdown_published = false;
+  std::vector<grpc_core::shutdown_tag> shutdown_tags;
 
-  std::list<Listener> listeners;
-  int listeners_destroyed = 0;
+  std::list<grpc_core::channel_data*> channels;
+
+  std::list<grpc_core::Listener> listeners;
+  size_t listeners_destroyed = 0;
   grpc_core::RefCount internal_refcount;
 
   /** when did we print the last shutdown progress message */
@@ -348,10 +383,43 @@ struct grpc_server {
   grpc_core::RefCountedPtr<grpc_core::channelz::ServerNode> channelz_server;
 };
 
-#define SERVER_FROM_CALL_ELEM(elem) \
-  (((channel_data*)(elem)->channel_data)->server)
+// Non-API functions of the server that are only for gRPC core internal use.
+// TODO(markdroth): Make these class member functions
+void grpc_server_add_listener(
+    grpc_server* server,
+    grpc_core::OrphanablePtr<grpc_core::ServerListenerInterface> listener) {
+  grpc_core::channelz::ListenSocketNode* listen_socket_node =
+      listener->channelz_listen_socket_node();
+  if (listen_socket_node != nullptr && server->channelz_server != nullptr) {
+    server->channelz_server->AddChildListenSocket(listen_socket_node->Ref());
+  }
+  server->listeners.emplace_back(std::move(listener));
+}
 
+const grpc_channel_args* grpc_server_get_channel_args(grpc_server* server) {
+  return server->channel_args;
+}
+
+grpc_resource_user* grpc_server_get_default_resource_user(grpc_server* server) {
+  return server->default_resource_user;
+}
+
+bool grpc_server_has_open_connections(grpc_server* server) {
+  grpc_core::MutexLock lock(&server->mu_global);
+  return !server->channels.empty();
+}
+
+grpc_core::channelz::ServerNode* grpc_server_get_channelz_node(
+    grpc_server* server) {
+  if (server == nullptr) {
+    return nullptr;
+  }
+  return server->channelz_server.get();
+}
+
+namespace grpc_core {
 namespace {
+
 void publish_call(grpc_server* server, call_data* calld, size_t cq_idx,
                   requested_call* rc);
 void fail_call(grpc_server* server, size_t cq_idx, requested_call* rc,
@@ -365,26 +433,47 @@ void kill_zombie(void* elem, grpc_error* /*error*/) {
       grpc_call_from_top_element(static_cast<grpc_call_element*>(elem)));
 }
 
+// Validate a requested RPC for a server CQ and bind it to that CQ
+grpc_call_error ValidateServerRequest(
+    grpc_completion_queue* cq_for_notification, void* tag,
+    grpc_byte_buffer** optional_payload, registered_method* rm) {
+  if ((rm == nullptr && optional_payload != nullptr) ||
+      ((rm != nullptr) && ((optional_payload == nullptr) !=
+                           (rm->payload_handling == GRPC_SRM_PAYLOAD_NONE)))) {
+    return GRPC_CALL_ERROR_PAYLOAD_TYPE_MISMATCH;
+  }
+  if (grpc_cq_begin_op(cq_for_notification, tag) == false) {
+    return GRPC_CALL_ERROR_COMPLETION_QUEUE_SHUTDOWN;
+  }
+  return GRPC_CALL_OK;
+}
+
+// Validate that a requested RPC has a valid server CQ and is valid, and bind it
+grpc_call_error ValidateServerRequestAndCq(
+    size_t* cq_idx, grpc_server* server,
+    grpc_completion_queue* cq_for_notification, void* tag,
+    grpc_byte_buffer** optional_payload, registered_method* rm) {
+  size_t idx;
+  for (idx = 0; idx < server->cqs.size(); idx++) {
+    if (server->cqs[idx] == cq_for_notification) {
+      break;
+    }
+  }
+  if (idx == server->cqs.size()) {
+    return GRPC_CALL_ERROR_NOT_SERVER_COMPLETION_QUEUE;
+  }
+  grpc_call_error error =
+      ValidateServerRequest(cq_for_notification, tag, optional_payload, rm);
+  if (error != GRPC_CALL_OK) {
+    return error;
+  }
+
+  *cq_idx = idx;
+  return GRPC_CALL_OK;
+}
 /*
  * channel broadcaster
  */
-
-/* assumes server locked */
-void channel_broadcaster_init(grpc_server* s, channel_broadcaster* cb) {
-  channel_data* c;
-  size_t count = 0;
-  for (c = s->root_channel_data.next; c != &s->root_channel_data; c = c->next) {
-    count++;
-  }
-  cb->num_channels = count;
-  cb->channels = static_cast<grpc_channel**>(
-      gpr_malloc(sizeof(*cb->channels) * cb->num_channels));
-  count = 0;
-  for (c = s->root_channel_data.next; c != &s->root_channel_data; c = c->next) {
-    cb->channels[count++] = c->channel;
-    GRPC_CHANNEL_INTERNAL_REF(c->channel, "broadcast");
-  }
-}
 
 struct shutdown_cleanup_args {
   grpc_closure closure;
@@ -392,16 +481,14 @@ struct shutdown_cleanup_args {
 };
 
 void shutdown_cleanup(void* arg, grpc_error* /*error*/) {
-  struct shutdown_cleanup_args* a =
-      static_cast<struct shutdown_cleanup_args*>(arg);
+  shutdown_cleanup_args* a = static_cast<shutdown_cleanup_args*>(arg);
   grpc_slice_unref_internal(a->slice);
-  gpr_free(a);
+  delete a;
 }
 
 void send_shutdown(grpc_channel* channel, bool send_goaway,
                    grpc_error* send_disconnect) {
-  struct shutdown_cleanup_args* sc =
-      static_cast<struct shutdown_cleanup_args*>(gpr_malloc(sizeof(*sc)));
+  shutdown_cleanup_args* sc = new shutdown_cleanup_args;
   GRPC_CLOSURE_INIT(&sc->closure, shutdown_cleanup, sc,
                     grpc_schedule_on_exec_ctx);
   grpc_transport_op* op = grpc_make_transport_op(&sc->closure);
@@ -420,18 +507,34 @@ void send_shutdown(grpc_channel* channel, bool send_goaway,
   elem->filter->start_transport_op(elem, op);
 }
 
-void channel_broadcaster_shutdown(channel_broadcaster* cb, bool send_goaway,
-                                  grpc_error* force_disconnect) {
-  size_t i;
+class ChannelBroadcaster {
+ public:
+  // This can have an empty constructor and destructor since we want to control
+  // when the actual setup and shutdown broadcast take place
 
-  for (i = 0; i < cb->num_channels; i++) {
-    send_shutdown(cb->channels[i], send_goaway,
-                  GRPC_ERROR_REF(force_disconnect));
-    GRPC_CHANNEL_INTERNAL_UNREF(cb->channels[i], "broadcast");
+  // This function copies over the channels from the locked server
+  void FillChannelsLocked(const grpc_server* s) {
+    GPR_DEBUG_ASSERT(channels_.empty());
+    channels_.reserve(s->channels.size());
+    for (const channel_data* chand : s->channels) {
+      channels_.push_back(chand->channel);
+      GRPC_CHANNEL_INTERNAL_REF(chand->channel, "broadcast");
+    }
   }
-  gpr_free(cb->channels);
-  GRPC_ERROR_UNREF(force_disconnect);
-}
+
+  // Broadcast a shutdown on each channel
+  void BroadcastShutdown(bool send_goaway, grpc_error* force_disconnect) {
+    for (grpc_channel* channel : channels_) {
+      send_shutdown(channel, send_goaway, GRPC_ERROR_REF(force_disconnect));
+      GRPC_CHANNEL_INTERNAL_UNREF(channel, "broadcast");
+    }
+    channels_.clear();  // just for safety against double broadcast
+    GRPC_ERROR_UNREF(force_disconnect);
+  }
+
+ private:
+  std::vector<grpc_channel*> channels_;
+};
 
 /*
  * request_matcher
@@ -445,7 +548,7 @@ void channel_broadcaster_shutdown(channel_broadcaster* cb, bool send_goaway,
 class RealRequestMatcher : public RequestMatcherInterface {
  public:
   explicit RealRequestMatcher(grpc_server* server)
-      : server_(server), requests_per_cq_(server->cq_count) {}
+      : server_(server), requests_per_cq_(server->cqs.size()) {}
 
   ~RealRequestMatcher() override {
     for (LockedMultiProducerSingleConsumerQueue& queue : requests_per_cq_) {
@@ -454,17 +557,16 @@ class RealRequestMatcher : public RequestMatcherInterface {
   }
 
   void ZombifyPending() override {
-    while (pending_head_ != nullptr) {
-      call_data* calld = pending_head_;
-      pending_head_ = calld->pending_next;
-      gpr_atm_no_barrier_store(&calld->state, ZOMBIED);
+    for (call_data* calld : pending_) {
+      calld->state.Store(CallState::ZOMBIED, grpc_core::MemoryOrder::RELAXED);
       GRPC_CLOSURE_INIT(
           &calld->kill_zombie_closure, kill_zombie,
           grpc_call_stack_element(grpc_call_get_call_stack(calld->call), 0),
           grpc_schedule_on_exec_ctx);
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
-                              GRPC_ERROR_NONE);
+      ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
+                   GRPC_ERROR_NONE);
     }
+    pending_.clear();
   }
 
   void KillRequests(grpc_error* error) override {
@@ -487,28 +589,46 @@ class RealRequestMatcher : public RequestMatcherInterface {
     if (requests_per_cq_[request_queue_index].Push(&call->mpscq_node)) {
       /* this was the first queued request: we need to lock and start
          matching calls */
-      gpr_mu_lock(&server_->mu_call);
-      call_data* calld;
-      while ((calld = pending_head_) != nullptr) {
-        requested_call* rc = reinterpret_cast<requested_call*>(
-            requests_per_cq_[request_queue_index].Pop());
-        if (rc == nullptr) break;
-        pending_head_ = calld->pending_next;
-        gpr_mu_unlock(&server_->mu_call);
-        if (!gpr_atm_full_cas(&calld->state, PENDING, ACTIVATED)) {
+      struct PendingCall {
+        requested_call* rc = nullptr;
+        call_data* calld;
+      };
+      auto pop_next_pending = [this, request_queue_index] {
+        PendingCall pending;
+        {
+          MutexLock lock(&server_->mu_call);
+          if (!pending_.empty()) {
+            pending.rc = reinterpret_cast<requested_call*>(
+                requests_per_cq_[request_queue_index].Pop());
+            if (pending.rc != nullptr) {
+              pending.calld = pending_.front();
+              pending_.pop_front();
+            }
+          }
+        }
+        return pending;
+      };
+      while (true) {
+        PendingCall next_pending = pop_next_pending();
+        if (next_pending.rc == nullptr) break;
+        CallState expect_pending = CallState::PENDING;
+        if (!next_pending.calld->state.CompareExchangeStrong(
+                &expect_pending, CallState::ACTIVATED,
+                grpc_core::MemoryOrder::ACQ_REL,
+                grpc_core::MemoryOrder::RELAXED)) {
           // Zombied Call
           GRPC_CLOSURE_INIT(
-              &calld->kill_zombie_closure, kill_zombie,
-              grpc_call_stack_element(grpc_call_get_call_stack(calld->call), 0),
+              &next_pending.calld->kill_zombie_closure, kill_zombie,
+              grpc_call_stack_element(
+                  grpc_call_get_call_stack(next_pending.calld->call), 0),
               grpc_schedule_on_exec_ctx);
-          grpc_core::ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
-                                  GRPC_ERROR_NONE);
+          ExecCtx::Run(DEBUG_LOCATION, &next_pending.calld->kill_zombie_closure,
+                       GRPC_ERROR_NONE);
         } else {
-          publish_call(server_, calld, request_queue_index, rc);
+          publish_call(server_, next_pending.calld, request_queue_index,
+                       next_pending.rc);
         }
-        gpr_mu_lock(&server_->mu_call);
       }
-      gpr_mu_unlock(&server_->mu_call);
     }
   }
 
@@ -522,7 +642,8 @@ class RealRequestMatcher : public RequestMatcherInterface {
         continue;
       } else {
         GRPC_STATS_INC_SERVER_CQS_CHECKED(i);
-        gpr_atm_no_barrier_store(&calld->state, ACTIVATED);
+        calld->state.Store(CallState::ACTIVATED,
+                           grpc_core::MemoryOrder::RELAXED);
         publish_call(server_, calld, cq_idx, rc);
         return; /* early out */
       }
@@ -530,43 +651,40 @@ class RealRequestMatcher : public RequestMatcherInterface {
 
     /* no cq to take the request found: queue it on the slow list */
     GRPC_STATS_INC_SERVER_SLOWPATH_REQUESTS_QUEUED();
-    gpr_mu_lock(&server_->mu_call);
 
     // We need to ensure that all the queues are empty.  We do this under
     // the server mu_call lock to ensure that if something is added to
     // an empty request queue, it will block until the call is actually
     // added to the pending list.
-    for (size_t i = 0; i < requests_per_cq_.size(); i++) {
-      size_t cq_idx = (start_request_queue_index + i) % requests_per_cq_.size();
-      requested_call* rc =
-          reinterpret_cast<requested_call*>(requests_per_cq_[cq_idx].Pop());
+    requested_call* rc = nullptr;
+    size_t cq_idx = 0;
+    size_t loop_count;
+    {
+      MutexLock lock(&server_->mu_call);
+      for (loop_count = 0; loop_count < requests_per_cq_.size(); loop_count++) {
+        cq_idx =
+            (start_request_queue_index + loop_count) % requests_per_cq_.size();
+        rc = reinterpret_cast<requested_call*>(requests_per_cq_[cq_idx].Pop());
+        if (rc != nullptr) {
+          break;
+        }
+      }
       if (rc == nullptr) {
-        continue;
-      } else {
-        gpr_mu_unlock(&server_->mu_call);
-        GRPC_STATS_INC_SERVER_CQS_CHECKED(i + requests_per_cq_.size());
-        gpr_atm_no_barrier_store(&calld->state, ACTIVATED);
-        publish_call(server_, calld, cq_idx, rc);
-        return; /* early out */
+        calld->state.Store(CallState::PENDING, grpc_core::MemoryOrder::RELAXED);
+        pending_.push_back(calld);
+        return;
       }
     }
-
-    gpr_atm_no_barrier_store(&calld->state, PENDING);
-    if (pending_head_ == nullptr) {
-      pending_tail_ = pending_head_ = calld;
-    } else {
-      pending_tail_->pending_next = calld;
-      pending_tail_ = calld;
-    }
-    gpr_mu_unlock(&server_->mu_call);
+    GRPC_STATS_INC_SERVER_CQS_CHECKED(loop_count + requests_per_cq_.size());
+    calld->state.Store(CallState::ACTIVATED, grpc_core::MemoryOrder::RELAXED);
+    publish_call(server_, calld, cq_idx, rc);
   }
 
   grpc_server* server() const override { return server_; }
 
  private:
   grpc_server* const server_;
-  call_data* pending_head_ = nullptr;
-  call_data* pending_tail_ = nullptr;
+  std::list<call_data*> pending_;
   std::vector<LockedMultiProducerSingleConsumerQueue> requests_per_cq_;
 };
 
@@ -580,12 +698,12 @@ class AllocatingRequestMatcherBase : public RequestMatcherInterface {
   AllocatingRequestMatcherBase(grpc_server* server, grpc_completion_queue* cq)
       : server_(server), cq_(cq) {
     size_t idx;
-    for (idx = 0; idx < server->cq_count; idx++) {
+    for (idx = 0; idx < server->cqs.size(); idx++) {
       if (server->cqs[idx] == cq) {
         break;
       }
     }
-    GPR_ASSERT(idx < server->cq_count);
+    GPR_ASSERT(idx < server->cqs.size());
     cq_idx_ = idx;
   }
 
@@ -620,23 +738,23 @@ class AllocatingRequestMatcherBatch : public AllocatingRequestMatcherBase {
  public:
   AllocatingRequestMatcherBatch(
       grpc_server* server, grpc_completion_queue* cq,
-      std::function<grpc_core::ServerBatchCallAllocation()> allocator)
+      std::function<ServerBatchCallAllocation()> allocator)
       : AllocatingRequestMatcherBase(server, cq),
         allocator_(std::move(allocator)) {}
   void MatchOrQueue(size_t /*start_request_queue_index*/,
                     call_data* calld) override {
-    grpc_core::ServerBatchCallAllocation call_info = allocator_();
+    ServerBatchCallAllocation call_info = allocator_();
     GPR_ASSERT(ValidateServerRequest(cq(), static_cast<void*>(call_info.tag),
                                      nullptr, nullptr) == GRPC_CALL_OK);
     requested_call* rc = new requested_call(
         static_cast<void*>(call_info.tag), cq(), call_info.call,
         call_info.initial_metadata, call_info.details);
-    gpr_atm_no_barrier_store(&calld->state, ACTIVATED);
+    calld->state.Store(CallState::ACTIVATED, grpc_core::MemoryOrder::RELAXED);
     publish_call(server(), calld, cq_idx(), rc);
   }
 
  private:
-  std::function<grpc_core::ServerBatchCallAllocation()> allocator_;
+  std::function<ServerBatchCallAllocation()> allocator_;
 };
 
 // An allocating request matcher for registered methods.
@@ -644,13 +762,13 @@ class AllocatingRequestMatcherRegistered : public AllocatingRequestMatcherBase {
  public:
   AllocatingRequestMatcherRegistered(
       grpc_server* server, grpc_completion_queue* cq, registered_method* rm,
-      std::function<grpc_core::ServerRegisteredCallAllocation()> allocator)
+      std::function<ServerRegisteredCallAllocation()> allocator)
       : AllocatingRequestMatcherBase(server, cq),
         registered_method_(rm),
         allocator_(std::move(allocator)) {}
   void MatchOrQueue(size_t /*start_request_queue_index*/,
                     call_data* calld) override {
-    grpc_core::ServerRegisteredCallAllocation call_info = allocator_();
+    ServerRegisteredCallAllocation call_info = allocator_();
     GPR_ASSERT(ValidateServerRequest(cq(), static_cast<void*>(call_info.tag),
                                      call_info.optional_payload,
                                      registered_method_) == GRPC_CALL_OK);
@@ -658,13 +776,13 @@ class AllocatingRequestMatcherRegistered : public AllocatingRequestMatcherBase {
         static_cast<void*>(call_info.tag), cq(), call_info.call,
         call_info.initial_metadata, registered_method_, call_info.deadline,
         call_info.optional_payload);
-    gpr_atm_no_barrier_store(&calld->state, ACTIVATED);
+    calld->state.Store(CallState::ACTIVATED, grpc_core::MemoryOrder::RELAXED);
     publish_call(server(), calld, cq_idx(), rc);
   }
 
  private:
   registered_method* const registered_method_;
-  std::function<grpc_core::ServerRegisteredCallAllocation()> allocator_;
+  std::function<ServerRegisteredCallAllocation()> allocator_;
 };
 
 /*
@@ -673,39 +791,10 @@ class AllocatingRequestMatcherRegistered : public AllocatingRequestMatcherBase {
 
 void server_ref(grpc_server* server) { server->internal_refcount.Ref(); }
 
-void server_delete(grpc_server* server) {
-  registered_method* rm;
-  size_t i;
-  grpc_channel_args_destroy(server->channel_args);
-  gpr_mu_destroy(&server->mu_global);
-  gpr_mu_destroy(&server->mu_call);
-  gpr_cv_destroy(&server->starting_cv);
-  while ((rm = server->registered_methods) != nullptr) {
-    server->registered_methods = rm->next;
-    delete rm;
-  }
-  delete server->unregistered_request_matcher;
-  for (i = 0; i < server->cq_count; i++) {
-    GRPC_CQ_INTERNAL_UNREF(server->cqs[i], "server");
-  }
-  gpr_free(server->cqs);
-  gpr_free(server->pollsets);
-  gpr_free(server->shutdown_tags);
-  delete server;
-}
-
 void server_unref(grpc_server* server) {
   if (GPR_UNLIKELY(server->internal_refcount.Unref())) {
-    server_delete(server);
+    delete server;
   }
-}
-
-int is_channel_orphaned(channel_data* chand) { return chand->next == chand; }
-
-void orphan_channel(channel_data* chand) {
-  chand->next->prev = chand->prev;
-  chand->prev->next = chand->next;
-  chand->next = chand->prev = chand;
 }
 
 void finish_destroy_channel(void* cd, grpc_error* /*error*/) {
@@ -716,9 +805,10 @@ void finish_destroy_channel(void* cd, grpc_error* /*error*/) {
 }
 
 void destroy_channel(channel_data* chand) {
-  if (is_channel_orphaned(chand)) return;
+  if (!chand->list_position.has_value()) return;
   GPR_ASSERT(chand->server != nullptr);
-  orphan_channel(chand);
+  chand->server->channels.erase(*chand->list_position);
+  chand->list_position.reset();
   server_ref(chand->server);
   maybe_finish_shutdown(chand->server);
   GRPC_CLOSURE_INIT(&chand->finish_destroy_channel_closure,
@@ -748,7 +838,7 @@ void publish_call(grpc_server* server, call_data* calld, size_t cq_idx,
   calld->cq_new = server->cqs[cq_idx];
   GPR_SWAP(grpc_metadata_array, *rc->initial_metadata, calld->initial_metadata);
   switch (rc->type) {
-    case BATCH_CALL:
+    case RequestedCallType::BATCH_CALL:
       GPR_ASSERT(calld->host_set);
       GPR_ASSERT(calld->path_set);
       rc->data.batch.details->host = grpc_slice_ref_internal(calld->host);
@@ -757,7 +847,7 @@ void publish_call(grpc_server* server, call_data* calld, size_t cq_idx,
           grpc_millis_to_timespec(calld->deadline, GPR_CLOCK_MONOTONIC);
       rc->data.batch.details->flags = calld->recv_initial_metadata_flags;
       break;
-    case REGISTERED_CALL:
+    case RequestedCallType::REGISTERED_CALL:
       *rc->data.registered.deadline =
           grpc_millis_to_timespec(calld->deadline, GPR_CLOCK_MONOTONIC);
       if (rc->data.registered.optional_payload) {
@@ -780,14 +870,15 @@ void publish_new_rpc(void* arg, grpc_error* error) {
   RequestMatcherInterface* rm = calld->matcher;
   grpc_server* server = rm->server();
 
-  if (error != GRPC_ERROR_NONE || gpr_atm_acq_load(&server->shutdown_flag)) {
-    gpr_atm_no_barrier_store(&calld->state, ZOMBIED);
+  if (error != GRPC_ERROR_NONE ||
+      server->shutdown_flag.load(std::memory_order_acquire)) {
+    calld->state.Store(CallState::ZOMBIED, grpc_core::MemoryOrder::RELAXED);
     GRPC_CLOSURE_INIT(
         &calld->kill_zombie_closure, kill_zombie,
         grpc_call_stack_element(grpc_call_get_call_stack(calld->call), 0),
         grpc_schedule_on_exec_ctx);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
-                            GRPC_ERROR_REF(error));
+    ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
+                 GRPC_ERROR_REF(error));
     return;
   }
 
@@ -799,12 +890,11 @@ void finish_start_new_rpc(
     grpc_server_register_method_payload_handling payload_handling) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
 
-  if (gpr_atm_acq_load(&server->shutdown_flag)) {
-    gpr_atm_no_barrier_store(&calld->state, ZOMBIED);
+  if (server->shutdown_flag.load(std::memory_order_acquire)) {
+    calld->state.Store(CallState::ZOMBIED, grpc_core::MemoryOrder::RELAXED);
     GRPC_CLOSURE_INIT(&calld->kill_zombie_closure, kill_zombie, elem,
                       grpc_schedule_on_exec_ctx);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
-                            GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure, GRPC_ERROR_NONE);
     return;
   }
 
@@ -842,8 +932,8 @@ void start_new_rpc(grpc_call_element* elem) {
     hash = GRPC_MDSTR_KV_HASH(grpc_slice_hash_internal(calld->host),
                               grpc_slice_hash_internal(calld->path));
     for (i = 0; i <= chand->registered_method_max_probes; i++) {
-      rm = &chand->registered_methods[(hash + i) %
-                                      chand->registered_method_slots];
+      rm = &(*chand->registered_methods)[(hash + i) %
+                                         chand->registered_methods->size()];
       if (rm->server_registered_method == nullptr) break;
       if (!rm->has_host) continue;
       if (rm->host != calld->host) continue;
@@ -861,8 +951,8 @@ void start_new_rpc(grpc_call_element* elem) {
     /* check for a wildcard method definition (no host set) */
     hash = GRPC_MDSTR_KV_HASH(0, grpc_slice_hash_internal(calld->path));
     for (i = 0; i <= chand->registered_method_max_probes; i++) {
-      rm = &chand->registered_methods[(hash + i) %
-                                      chand->registered_method_slots];
+      rm = &(*chand->registered_methods)[(hash + i) %
+                                         chand->registered_methods->size()];
       if (rm->server_registered_method == nullptr) break;
       if (rm->has_host) continue;
       if (rm->method != calld->path) continue;
@@ -877,7 +967,7 @@ void start_new_rpc(grpc_call_element* elem) {
       return;
     }
   }
-  finish_start_new_rpc(server, elem, server->unregistered_request_matcher,
+  finish_start_new_rpc(server, elem, server->unregistered_request_matcher.get(),
                        GRPC_SRM_PAYLOAD_NONE);
 }
 
@@ -885,22 +975,13 @@ void done_shutdown_event(void* server, grpc_cq_completion* /*completion*/) {
   server_unref(static_cast<grpc_server*>(server));
 }
 
-int num_channels(grpc_server* server) {
-  channel_data* chand;
-  int n = 0;
-  for (chand = server->root_channel_data.next;
-       chand != &server->root_channel_data; chand = chand->next) {
-    n++;
-  }
-  return n;
-}
+int num_channels(grpc_server* server) { return server->channels.size(); }
 
 void kill_pending_work_locked(grpc_server* server, grpc_error* error) {
   if (server->started) {
     server->unregistered_request_matcher->KillRequests(GRPC_ERROR_REF(error));
     server->unregistered_request_matcher->ZombifyPending();
-    for (registered_method* rm = server->registered_methods; rm;
-         rm = rm->next) {
+    for (std::unique_ptr<registered_method>& rm : server->registered_methods) {
       rm->matcher->KillRequests(GRPC_ERROR_REF(error));
       rm->matcher->ZombifyPending();
     }
@@ -910,16 +991,18 @@ void kill_pending_work_locked(grpc_server* server, grpc_error* error) {
 
 void maybe_finish_shutdown(grpc_server* server) {
   size_t i;
-  if (!gpr_atm_acq_load(&server->shutdown_flag) || server->shutdown_published) {
+  if (!server->shutdown_flag.load(std::memory_order_acquire) ||
+      server->shutdown_published) {
     return;
   }
 
-  gpr_mu_lock(&server->mu_call);
-  kill_pending_work_locked(
-      server, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
-  gpr_mu_unlock(&server->mu_call);
+  {
+    MutexLock lock(&server->mu_call);
+    kill_pending_work_locked(
+        server, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
+  }
 
-  if (server->root_channel_data.next != &server->root_channel_data ||
+  if (!server->channels.empty() ||
       server->listeners_destroyed < server->listeners.size()) {
     if (gpr_time_cmp(gpr_time_sub(gpr_now(GPR_CLOCK_REALTIME),
                                   server->last_shutdown_message_time),
@@ -935,7 +1018,7 @@ void maybe_finish_shutdown(grpc_server* server) {
     return;
   }
   server->shutdown_published = 1;
-  for (i = 0; i < server->num_shutdown_tags; i++) {
+  for (i = 0; i < server->shutdown_tags.size(); i++) {
     server_ref(server);
     grpc_cq_end_op(server->shutdown_tags[i].cq, server->shutdown_tags[i].tag,
                    GRPC_ERROR_NONE, done_shutdown_event, server,
@@ -986,7 +1069,7 @@ void server_on_recv_initial_metadata(void* ptr, grpc_error* error) {
                              calld->recv_trailing_metadata_error,
                              "continue server_recv_trailing_metadata_ready");
   }
-  grpc_core::Closure::Run(DEBUG_LOCATION, closure, error);
+  Closure::Run(DEBUG_LOCATION, closure, error);
 }
 
 void server_recv_trailing_metadata_ready(void* user_data, grpc_error* error) {
@@ -1006,8 +1089,8 @@ void server_recv_trailing_metadata_ready(void* user_data, grpc_error* error) {
   error =
       grpc_error_add_child(GRPC_ERROR_REF(error),
                            GRPC_ERROR_REF(calld->recv_initial_metadata_error));
-  grpc_core::Closure::Run(DEBUG_LOCATION,
-                          calld->original_recv_trailing_metadata_ready, error);
+  Closure::Run(DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready,
+               error);
 }
 
 void server_mutate_op(grpc_call_element* elem,
@@ -1021,7 +1104,7 @@ void server_mutate_op(grpc_call_element* elem,
     calld->on_done_recv_initial_metadata =
         op->payload->recv_initial_metadata.recv_initial_metadata_ready;
     op->payload->recv_initial_metadata.recv_initial_metadata_ready =
-        &calld->server_on_recv_initial_metadata;
+        &calld->on_recv_initial_metadata;
     op->payload->recv_initial_metadata.recv_flags =
         &calld->recv_initial_metadata_flags;
   }
@@ -1045,12 +1128,19 @@ void got_initial_metadata(void* ptr, grpc_error* error) {
   if (error == GRPC_ERROR_NONE) {
     start_new_rpc(elem);
   } else {
-    if (gpr_atm_full_cas(&calld->state, NOT_STARTED, ZOMBIED)) {
+    CallState expect_not_started = CallState::NOT_STARTED;
+    CallState expect_pending = CallState::PENDING;
+    if (calld->state.CompareExchangeStrong(
+            &expect_not_started, CallState::ZOMBIED,
+            grpc_core::MemoryOrder::ACQ_REL, grpc_core::MemoryOrder::RELAXED)) {
       GRPC_CLOSURE_INIT(&calld->kill_zombie_closure, kill_zombie, elem,
                         grpc_schedule_on_exec_ctx);
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
-                              GRPC_ERROR_NONE);
-    } else if (gpr_atm_full_cas(&calld->state, PENDING, ZOMBIED)) {
+      ExecCtx::Run(DEBUG_LOCATION, &calld->kill_zombie_closure,
+                   GRPC_ERROR_NONE);
+    } else if (calld->state.CompareExchangeStrong(
+                   &expect_pending, CallState::ZOMBIED,
+                   grpc_core::MemoryOrder::ACQ_REL,
+                   grpc_core::MemoryOrder::RELAXED)) {
       /* zombied call will be destroyed when it's removed from the pending
          queue... later */
     }
@@ -1112,63 +1202,56 @@ void server_destroy_call_elem(grpc_call_element* elem,
 
 grpc_error* server_init_channel_elem(grpc_channel_element* elem,
                                      grpc_channel_element_args* args) {
-  channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   GPR_ASSERT(args->is_first);
   GPR_ASSERT(!args->is_last);
-  chand->server = nullptr;
-  chand->channel = nullptr;
-  chand->next = chand->prev = chand;
-  chand->registered_methods = nullptr;
+
+  new (static_cast<channel_data*>(elem->channel_data)) channel_data;
   return GRPC_ERROR_NONE;
 }
 
-void server_destroy_channel_elem(grpc_channel_element* elem) {
-  size_t i;
-  channel_data* chand = static_cast<channel_data*>(elem->channel_data);
-  if (chand->registered_methods) {
-    for (i = 0; i < chand->registered_method_slots; i++) {
-      grpc_slice_unref_internal(chand->registered_methods[i].method);
-      GPR_DEBUG_ASSERT(chand->registered_methods[i].method.refcount ==
-                           &grpc_core::kNoopRefcount ||
-                       chand->registered_methods[i].method.refcount == nullptr);
-      if (chand->registered_methods[i].has_host) {
-        grpc_slice_unref_internal(chand->registered_methods[i].host);
-        GPR_DEBUG_ASSERT(chand->registered_methods[i].host.refcount ==
-                             &grpc_core::kNoopRefcount ||
-                         chand->registered_methods[i].host.refcount == nullptr);
+channel_data::~channel_data() {
+  if (registered_methods) {
+    for (const channel_registered_method& crm : *registered_methods) {
+      grpc_slice_unref_internal(crm.method);
+      GPR_DEBUG_ASSERT(crm.method.refcount == &kNoopRefcount ||
+                       crm.method.refcount == nullptr);
+      if (crm.has_host) {
+        grpc_slice_unref_internal(crm.host);
+        GPR_DEBUG_ASSERT(crm.host.refcount == &kNoopRefcount ||
+                         crm.host.refcount == nullptr);
       }
     }
-    gpr_free(chand->registered_methods);
   }
-  if (chand->server) {
-    if (chand->server->channelz_server != nullptr &&
-        chand->channelz_socket_uuid != 0) {
-      chand->server->channelz_server->RemoveChildSocket(
-          chand->channelz_socket_uuid);
+  if (server) {
+    if (server->channelz_server != nullptr && channelz_socket_uuid != 0) {
+      server->channelz_server->RemoveChildSocket(channelz_socket_uuid);
     }
-    gpr_mu_lock(&chand->server->mu_global);
-    chand->next->prev = chand->prev;
-    chand->prev->next = chand->next;
-    chand->next = chand->prev = chand;
-    maybe_finish_shutdown(chand->server);
-    gpr_mu_unlock(&chand->server->mu_global);
-    server_unref(chand->server);
+    {
+      MutexLock lock(&server->mu_global);
+      if (list_position.has_value()) {
+        server->channels.erase(*list_position);
+      }
+      maybe_finish_shutdown(server);
+    }
+    server_unref(server);
   }
+}
+
+void server_destroy_channel_elem(grpc_channel_element* elem) {
+  channel_data* chand = static_cast<channel_data*>(elem->channel_data);
+  chand->~channel_data();
 }
 
 void register_completion_queue(grpc_server* server, grpc_completion_queue* cq,
                                void* reserved) {
-  size_t i, n;
+  size_t i;
   GPR_ASSERT(!reserved);
-  for (i = 0; i < server->cq_count; i++) {
+  for (i = 0; i < server->cqs.size(); i++) {
     if (server->cqs[i] == cq) return;
   }
 
   GRPC_CQ_INTERNAL_REF(cq, "server");
-  n = server->cq_count++;
-  server->cqs = static_cast<grpc_completion_queue**>(gpr_realloc(
-      server->cqs, server->cq_count * sizeof(grpc_completion_queue*)));
-  server->cqs[n] = cq;
+  server->cqs.push_back(cq);
 }
 
 bool streq(const std::string& a, const char* b) {
@@ -1176,8 +1259,7 @@ bool streq(const std::string& a, const char* b) {
          ((b != nullptr) && !strcmp(a.c_str(), b));
 }
 
-class ConnectivityWatcher
-    : public grpc_core::AsyncConnectivityStateWatcherInterface {
+class ConnectivityWatcher : public AsyncConnectivityStateWatcherInterface {
  public:
   explicit ConnectivityWatcher(channel_data* chand) : chand_(chand) {
     GRPC_CHANNEL_INTERNAL_REF(chand_->channel, "connectivity");
@@ -1193,40 +1275,37 @@ class ConnectivityWatcher
     if (new_state != GRPC_CHANNEL_SHUTDOWN) return;
     // Shut down channel.
     grpc_server* server = chand_->server;
-    gpr_mu_lock(&server->mu_global);
+    MutexLock lock(&server->mu_global);
     destroy_channel(chand_);
-    gpr_mu_unlock(&server->mu_global);
   }
 
   channel_data* chand_;
 };
 
-void done_published_shutdown(void* done_arg, grpc_cq_completion* storage) {
-  (void)done_arg;
-  gpr_free(storage);
+void done_published_shutdown(void* /*done_arg*/, grpc_cq_completion* storage) {
+  delete storage;
 }
 
 void listener_destroy_done(void* s, grpc_error* /*error*/) {
   grpc_server* server = static_cast<grpc_server*>(s);
-  gpr_mu_lock(&server->mu_global);
+  MutexLock lock(&server->mu_global);
   server->listeners_destroyed++;
   maybe_finish_shutdown(server);
-  gpr_mu_unlock(&server->mu_global);
 }
 
 grpc_call_error queue_call_request(grpc_server* server, size_t cq_idx,
                                    requested_call* rc) {
-  if (gpr_atm_acq_load(&server->shutdown_flag)) {
+  if (server->shutdown_flag.load(std::memory_order_acquire)) {
     fail_call(server, cq_idx, rc,
               GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
     return GRPC_CALL_OK;
   }
   RequestMatcherInterface* rm;
   switch (rc->type) {
-    case BATCH_CALL:
-      rm = server->unregistered_request_matcher;
+    case RequestedCallType::BATCH_CALL:
+      rm = server->unregistered_request_matcher.get();
       break;
-    case REGISTERED_CALL:
+    case RequestedCallType::REGISTERED_CALL:
       rm = rc->data.registered.method->matcher.get();
       break;
   }
@@ -1243,16 +1322,15 @@ void fail_call(grpc_server* server, size_t cq_idx, requested_call* rc,
   grpc_cq_end_op(server->cqs[cq_idx], rc->tag, error, done_request_event, rc,
                  &rc->completion);
 }
-}  // namespace
 
-namespace grpc_core {
+}  // namespace
 
 void SetServerRegisteredMethodAllocator(
     grpc_server* server, grpc_completion_queue* cq, void* method_tag,
     std::function<ServerRegisteredCallAllocation()> allocator) {
   registered_method* rm = static_cast<registered_method*>(method_tag);
-  rm->matcher.reset(new AllocatingRequestMatcherRegistered(
-      server, cq, rm, std::move(allocator)));
+  rm->matcher = absl::make_unique<AllocatingRequestMatcherRegistered>(
+      server, cq, rm, std::move(allocator));
 }
 
 void SetServerBatchMethodAllocator(
@@ -1260,24 +1338,27 @@ void SetServerBatchMethodAllocator(
     std::function<ServerBatchCallAllocation()> allocator) {
   GPR_DEBUG_ASSERT(server->unregistered_request_matcher == nullptr);
   server->unregistered_request_matcher =
-      new AllocatingRequestMatcherBatch(server, cq, std::move(allocator));
+      absl::make_unique<AllocatingRequestMatcherBatch>(server, cq,
+                                                       std::move(allocator));
 }
 
-};  // namespace grpc_core
+}  // namespace grpc_core
 
 const grpc_channel_filter grpc_server_top_filter = {
-    server_start_transport_stream_op_batch,
+    grpc_core::server_start_transport_stream_op_batch,
     grpc_channel_next_op,
-    sizeof(call_data),
-    server_init_call_elem,
+    sizeof(grpc_core::call_data),
+    grpc_core::server_init_call_elem,
     grpc_call_stack_ignore_set_pollset_or_pollset_set,
-    server_destroy_call_elem,
-    sizeof(channel_data),
-    server_init_channel_elem,
-    server_destroy_channel_elem,
+    grpc_core::server_destroy_call_elem,
+    sizeof(grpc_core::channel_data),
+    grpc_core::server_init_channel_elem,
+    grpc_core::server_destroy_channel_elem,
     grpc_channel_next_get_info,
     "server",
 };
+
+// The following are core surface API functions.
 
 void grpc_server_register_completion_queue(grpc_server* server,
                                            grpc_completion_queue* cq,
@@ -1296,54 +1377,20 @@ void grpc_server_register_completion_queue(grpc_server* server,
        calls grpc_completion_queue_pluck() on server completion queues */
   }
 
-  register_completion_queue(server, cq, reserved);
+  grpc_core::register_completion_queue(server, cq, reserved);
 }
 
 grpc_server* grpc_server_create(const grpc_channel_args* args, void* reserved) {
   grpc_core::ExecCtx exec_ctx;
   GRPC_API_TRACE("grpc_server_create(%p, %p)", 2, (args, reserved));
 
-  grpc_server* server = new grpc_server;
-
-  gpr_mu_init(&server->mu_global);
-  gpr_mu_init(&server->mu_call);
-  gpr_cv_init(&server->starting_cv);
-
-  server->root_channel_data.next = server->root_channel_data.prev =
-      &server->root_channel_data;
-
-  server->channel_args = grpc_channel_args_copy(args);
-
-  if (grpc_channel_args_find_bool(args, GRPC_ARG_ENABLE_CHANNELZ,
-                                  GRPC_ENABLE_CHANNELZ_DEFAULT)) {
-    size_t channel_tracer_max_memory = grpc_channel_args_find_integer(
-        args, GRPC_ARG_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE,
-        {GRPC_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE_DEFAULT, 0, INT_MAX});
-    server->channelz_server =
-        grpc_core::MakeRefCounted<grpc_core::channelz::ServerNode>(
-            server, channel_tracer_max_memory);
-    server->channelz_server->AddTraceEvent(
-        grpc_core::channelz::ChannelTrace::Severity::Info,
-        grpc_slice_from_static_string("Server created"));
-  }
-
-  if (args != nullptr) {
-    grpc_resource_quota* resource_quota =
-        grpc_resource_quota_from_channel_args(args, false /* create */);
-    if (resource_quota != nullptr) {
-      server->default_resource_user =
-          grpc_resource_user_create(resource_quota, "default");
-    }
-  }
-
-  return server;
+  return new grpc_server(args);
 }
 
 void* grpc_server_register_method(
     grpc_server* server, const char* method, const char* host,
     grpc_server_register_method_payload_handling payload_handling,
     uint32_t flags) {
-  registered_method* m;
   GRPC_API_TRACE(
       "grpc_server_register_method(server=%p, method=%s, host=%s, "
       "flags=0x%08x)",
@@ -1353,8 +1400,10 @@ void* grpc_server_register_method(
             "grpc_server_register_method method string cannot be NULL");
     return nullptr;
   }
-  for (m = server->registered_methods; m; m = m->next) {
-    if (streq(m->method, method) && streq(m->host, host)) {
+  for (std::unique_ptr<grpc_core::registered_method>& m :
+       server->registered_methods) {
+    if (grpc_core::streq(m->method, method) &&
+        grpc_core::streq(m->host, host)) {
       gpr_log(GPR_ERROR, "duplicate registration for %s@%s", method,
               host ? host : "*");
       return nullptr;
@@ -1365,10 +1414,9 @@ void* grpc_server_register_method(
             flags);
     return nullptr;
   }
-  m = new registered_method(method, host, payload_handling, flags);
-  m->next = server->registered_methods;
-  server->registered_methods = m;
-  return m;
+  server->registered_methods.emplace_back(
+      new grpc_core::registered_method(method, host, payload_handling, flags));
+  return static_cast<void*>(server->registered_methods.back().get());
 }
 
 void grpc_server_start(grpc_server* server) {
@@ -1378,141 +1426,34 @@ void grpc_server_start(grpc_server* server) {
   GRPC_API_TRACE("grpc_server_start(server=%p)", 1, (server));
 
   server->started = true;
-  server->pollset_count = 0;
-  server->pollsets = static_cast<grpc_pollset**>(
-      gpr_malloc(sizeof(grpc_pollset*) * server->cq_count));
-  for (i = 0; i < server->cq_count; i++) {
+  for (i = 0; i < server->cqs.size(); i++) {
     if (grpc_cq_can_listen(server->cqs[i])) {
-      server->pollsets[server->pollset_count++] =
-          grpc_cq_pollset(server->cqs[i]);
+      server->pollsets.push_back(grpc_cq_pollset(server->cqs[i]));
     }
   }
   if (server->unregistered_request_matcher == nullptr) {
-    server->unregistered_request_matcher = new RealRequestMatcher(server);
+    server->unregistered_request_matcher =
+        absl::make_unique<grpc_core::RealRequestMatcher>(server);
   }
-  for (registered_method* rm = server->registered_methods; rm; rm = rm->next) {
+  for (std::unique_ptr<grpc_core::registered_method>& rm :
+       server->registered_methods) {
     if (rm->matcher == nullptr) {
-      rm->matcher.reset(new RealRequestMatcher(server));
+      rm->matcher = absl::make_unique<grpc_core::RealRequestMatcher>(server);
     }
   }
 
-  gpr_mu_lock(&server->mu_global);
-  server->starting = true;
-  gpr_mu_unlock(&server->mu_global);
+  {
+    grpc_core::MutexLock lock(&server->mu_global);
+    server->starting = true;
+  }
 
   for (auto& listener : server->listeners) {
-    listener.listener->Start(server, server->pollsets, server->pollset_count);
+    listener.listener->Start(server, &server->pollsets);
   }
 
-  gpr_mu_lock(&server->mu_global);
+  grpc_core::MutexLock lock(&server->mu_global);
   server->starting = false;
-  gpr_cv_signal(&server->starting_cv);
-  gpr_mu_unlock(&server->mu_global);
-}
-
-void grpc_server_get_pollsets(grpc_server* server, grpc_pollset*** pollsets,
-                              size_t* pollset_count) {
-  *pollset_count = server->pollset_count;
-  *pollsets = server->pollsets;
-}
-
-void grpc_server_setup_transport(
-    grpc_server* s, grpc_transport* transport, grpc_pollset* accepting_pollset,
-    const grpc_channel_args* args,
-    const grpc_core::RefCountedPtr<grpc_core::channelz::SocketNode>&
-        socket_node,
-    grpc_resource_user* resource_user) {
-  size_t num_registered_methods;
-  size_t alloc;
-  registered_method* rm;
-  channel_registered_method* crm;
-  grpc_channel* channel;
-  channel_data* chand;
-  uint32_t hash;
-  size_t slots;
-  uint32_t probes;
-  uint32_t max_probes = 0;
-  grpc_transport_op* op = nullptr;
-
-  channel = grpc_channel_create(nullptr, args, GRPC_SERVER_CHANNEL, transport,
-                                resource_user);
-  chand = static_cast<channel_data*>(
-      grpc_channel_stack_element(grpc_channel_get_channel_stack(channel), 0)
-          ->channel_data);
-  chand->server = s;
-  server_ref(s);
-  chand->channel = channel;
-  if (socket_node != nullptr) {
-    chand->channelz_socket_uuid = socket_node->uuid();
-    s->channelz_server->AddChildSocket(socket_node);
-  } else {
-    chand->channelz_socket_uuid = 0;
-  }
-
-  size_t cq_idx;
-  for (cq_idx = 0; cq_idx < s->cq_count; cq_idx++) {
-    if (grpc_cq_pollset(s->cqs[cq_idx]) == accepting_pollset) break;
-  }
-  if (cq_idx == s->cq_count) {
-    /* completion queue not found: pick a random one to publish new calls to */
-    cq_idx = static_cast<size_t>(rand()) % s->cq_count;
-  }
-  chand->cq_idx = cq_idx;
-
-  num_registered_methods = 0;
-  for (rm = s->registered_methods; rm; rm = rm->next) {
-    num_registered_methods++;
-  }
-  /* build a lookup table phrased in terms of mdstr's in this channels context
-     to quickly find registered methods */
-  if (num_registered_methods > 0) {
-    slots = 2 * num_registered_methods;
-    alloc = sizeof(channel_registered_method) * slots;
-    chand->registered_methods =
-        static_cast<channel_registered_method*>(gpr_zalloc(alloc));
-    for (rm = s->registered_methods; rm; rm = rm->next) {
-      grpc_core::ExternallyManagedSlice host;
-      grpc_core::ExternallyManagedSlice method(rm->method.c_str());
-      const bool has_host = !rm->host.empty();
-      if (has_host) {
-        host = grpc_core::ExternallyManagedSlice(rm->host.c_str());
-      }
-      hash = GRPC_MDSTR_KV_HASH(has_host ? host.Hash() : 0, method.Hash());
-      for (probes = 0; chand->registered_methods[(hash + probes) % slots]
-                           .server_registered_method != nullptr;
-           probes++)
-        ;
-      if (probes > max_probes) max_probes = probes;
-      crm = &chand->registered_methods[(hash + probes) % slots];
-      crm->server_registered_method = rm;
-      crm->flags = rm->flags;
-      crm->has_host = has_host;
-      if (has_host) {
-        crm->host = host;
-      }
-      crm->method = method;
-    }
-    GPR_ASSERT(slots <= UINT32_MAX);
-    chand->registered_method_slots = static_cast<uint32_t>(slots);
-    chand->registered_method_max_probes = max_probes;
-  }
-
-  gpr_mu_lock(&s->mu_global);
-  chand->next = &s->root_channel_data;
-  chand->prev = chand->next->prev;
-  chand->next->prev = chand->prev->next = chand;
-  gpr_mu_unlock(&s->mu_global);
-
-  op = grpc_make_transport_op(nullptr);
-  op->set_accept_stream = true;
-  op->set_accept_stream_fn = accept_stream;
-  op->set_accept_stream_user_data = chand;
-  op->start_connectivity_watch.reset(new ConnectivityWatcher(chand));
-  if (gpr_atm_acq_load(&s->shutdown_flag) != 0) {
-    op->disconnect_with_error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown");
-  }
-  grpc_transport_perform_op(transport, op);
+  server->starting_cv.Signal();
 }
 
 /*
@@ -1524,7 +1465,7 @@ void grpc_server_setup_transport(
     for new incoming channels).
 
   - Iterates through all channels on the server and sends shutdown msg (see
-    'channel_broadcaster_shutdown()' for details) to the clients via the
+    'ChannelBroadcaster::BroadcastShutdown' for details) to the clients via the
     transport layer. The transport layer then guarantees the following:
      -- Sends shutdown to the client (for eg: HTTP2 transport sends GOAWAY)
      -- If the server has outstanding calls that are in the process, the
@@ -1533,55 +1474,47 @@ void grpc_server_setup_transport(
  */
 void grpc_server_shutdown_and_notify(grpc_server* server,
                                      grpc_completion_queue* cq, void* tag) {
-  shutdown_tag* sdt;
-  channel_broadcaster broadcaster;
+  grpc_core::ChannelBroadcaster broadcaster;
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
 
   GRPC_API_TRACE("grpc_server_shutdown_and_notify(server=%p, cq=%p, tag=%p)", 3,
                  (server, cq, tag));
 
-  /* wait for startup to be finished: locks mu_global */
-  gpr_mu_lock(&server->mu_global);
-  while (server->starting) {
-    gpr_cv_wait(&server->starting_cv, &server->mu_global,
-                gpr_inf_future(GPR_CLOCK_MONOTONIC));
+  {
+    /* wait for startup to be finished: locks mu_global */
+    grpc_core::MutexLock lock(&server->mu_global);
+    server->starting_cv.WaitUntil(&server->mu_global,
+                                  [server] { return !server->starting; });
+
+    /* stay locked, and gather up some stuff to do */
+    GPR_ASSERT(grpc_cq_begin_op(cq, tag));
+    if (server->shutdown_published) {
+      grpc_cq_end_op(cq, tag, GRPC_ERROR_NONE,
+                     grpc_core::done_published_shutdown, nullptr,
+                     new grpc_cq_completion);
+      return;
+    }
+    server->shutdown_tags.emplace_back(tag, cq);
+    if (server->shutdown_flag.load(std::memory_order_acquire)) {
+      return;
+    }
+
+    server->last_shutdown_message_time = gpr_now(GPR_CLOCK_REALTIME);
+
+    broadcaster.FillChannelsLocked(server);
+
+    server->shutdown_flag.store(true, std::memory_order_release);
+
+    /* collect all unregistered then registered calls */
+    {
+      grpc_core::MutexLock lock(&server->mu_call);
+      grpc_core::kill_pending_work_locked(
+          server, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
+    }
+
+    grpc_core::maybe_finish_shutdown(server);
   }
-
-  /* stay locked, and gather up some stuff to do */
-  GPR_ASSERT(grpc_cq_begin_op(cq, tag));
-  if (server->shutdown_published) {
-    grpc_cq_end_op(cq, tag, GRPC_ERROR_NONE, done_published_shutdown, nullptr,
-                   static_cast<grpc_cq_completion*>(
-                       gpr_malloc(sizeof(grpc_cq_completion))));
-    gpr_mu_unlock(&server->mu_global);
-    return;
-  }
-  server->shutdown_tags = static_cast<shutdown_tag*>(
-      gpr_realloc(server->shutdown_tags,
-                  sizeof(shutdown_tag) * (server->num_shutdown_tags + 1)));
-  sdt = &server->shutdown_tags[server->num_shutdown_tags++];
-  sdt->tag = tag;
-  sdt->cq = cq;
-  if (gpr_atm_acq_load(&server->shutdown_flag)) {
-    gpr_mu_unlock(&server->mu_global);
-    return;
-  }
-
-  server->last_shutdown_message_time = gpr_now(GPR_CLOCK_REALTIME);
-
-  channel_broadcaster_init(server, &broadcaster);
-
-  gpr_atm_rel_store(&server->shutdown_flag, 1);
-
-  /* collect all unregistered then registered calls */
-  gpr_mu_lock(&server->mu_call);
-  kill_pending_work_locked(
-      server, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
-  gpr_mu_unlock(&server->mu_call);
-
-  maybe_finish_shutdown(server);
-  gpr_mu_unlock(&server->mu_global);
 
   /* Shutdown listeners */
   for (auto& listener : server->listeners) {
@@ -1592,29 +1525,29 @@ void grpc_server_shutdown_and_notify(grpc_server* server,
       server->channelz_server->RemoveChildListenSocket(
           channelz_listen_socket_node->uuid());
     }
-    GRPC_CLOSURE_INIT(&listener.destroy_done, listener_destroy_done, server,
-                      grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&listener.destroy_done, grpc_core::listener_destroy_done,
+                      server, grpc_schedule_on_exec_ctx);
     listener.listener->SetOnDestroyDone(&listener.destroy_done);
     listener.listener.reset();
   }
 
-  channel_broadcaster_shutdown(&broadcaster, true /* send_goaway */,
-                               GRPC_ERROR_NONE);
+  broadcaster.BroadcastShutdown(/*send_goaway=*/true, GRPC_ERROR_NONE);
 }
 
 void grpc_server_cancel_all_calls(grpc_server* server) {
-  channel_broadcaster broadcaster;
+  grpc_core::ChannelBroadcaster broadcaster;
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
 
   GRPC_API_TRACE("grpc_server_cancel_all_calls(server=%p)", 1, (server));
 
-  gpr_mu_lock(&server->mu_global);
-  channel_broadcaster_init(server, &broadcaster);
-  gpr_mu_unlock(&server->mu_global);
+  {
+    grpc_core::MutexLock lock(&server->mu_global);
+    broadcaster.FillChannelsLocked(server);
+  }
 
-  channel_broadcaster_shutdown(
-      &broadcaster, false /* send_goaway */,
+  broadcaster.BroadcastShutdown(
+      /*send_goaway=*/false,
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("Cancelling all calls"));
 }
 
@@ -1624,11 +1557,12 @@ void grpc_server_destroy(grpc_server* server) {
 
   GRPC_API_TRACE("grpc_server_destroy(server=%p)", 1, (server));
 
-  gpr_mu_lock(&server->mu_global);
-  GPR_ASSERT(gpr_atm_acq_load(&server->shutdown_flag) ||
-             server->listeners.empty());
-  GPR_ASSERT(server->listeners_destroyed == server->listeners.size());
-  gpr_mu_unlock(&server->mu_global);
+  {
+    grpc_core::MutexLock lock(&server->mu_global);
+    GPR_ASSERT(server->shutdown_flag.load(std::memory_order_acquire) ||
+               server->listeners.empty());
+    GPR_ASSERT(server->listeners_destroyed == server->listeners.size());
+  }
 
   if (server->default_resource_user != nullptr) {
     grpc_resource_quota_unref(
@@ -1636,57 +1570,106 @@ void grpc_server_destroy(grpc_server* server) {
     grpc_resource_user_shutdown(server->default_resource_user);
     grpc_resource_user_unref(server->default_resource_user);
   }
-  server_unref(server);
+  grpc_core::server_unref(server);
 }
 
-void grpc_server_add_listener(
-    grpc_server* server,
-    grpc_core::OrphanablePtr<grpc_core::ServerListenerInterface> listener) {
-  grpc_core::channelz::ListenSocketNode* listen_socket_node =
-      listener->channelz_listen_socket_node();
-  if (listen_socket_node != nullptr && server->channelz_server != nullptr) {
-    server->channelz_server->AddChildListenSocket(listen_socket_node->Ref());
-  }
-  server->listeners.emplace_back(std::move(listener));
+const std::vector<grpc_pollset*>& grpc_server_get_pollsets(
+    grpc_server* server) {
+  return server->pollsets;
 }
 
-namespace {
-grpc_call_error ValidateServerRequest(
-    grpc_completion_queue* cq_for_notification, void* tag,
-    grpc_byte_buffer** optional_payload, registered_method* rm) {
-  if ((rm == nullptr && optional_payload != nullptr) ||
-      ((rm != nullptr) && ((optional_payload == nullptr) !=
-                           (rm->payload_handling == GRPC_SRM_PAYLOAD_NONE)))) {
-    return GRPC_CALL_ERROR_PAYLOAD_TYPE_MISMATCH;
+void grpc_server_setup_transport(
+    grpc_server* s, grpc_transport* transport, grpc_pollset* accepting_pollset,
+    const grpc_channel_args* args,
+    const grpc_core::RefCountedPtr<grpc_core::channelz::SocketNode>&
+        socket_node,
+    grpc_resource_user* resource_user) {
+  size_t num_registered_methods;
+  grpc_core::channel_registered_method* crm;
+  grpc_channel* channel;
+  grpc_core::channel_data* chand;
+  uint32_t hash;
+  size_t slots;
+  uint32_t probes;
+  uint32_t max_probes = 0;
+  grpc_transport_op* op = nullptr;
+
+  channel = grpc_channel_create(nullptr, args, GRPC_SERVER_CHANNEL, transport,
+                                resource_user);
+  chand = static_cast<grpc_core::channel_data*>(
+      grpc_channel_stack_element(grpc_channel_get_channel_stack(channel), 0)
+          ->channel_data);
+  chand->server = s;
+  grpc_core::server_ref(s);
+  chand->channel = channel;
+  if (socket_node != nullptr) {
+    chand->channelz_socket_uuid = socket_node->uuid();
+    s->channelz_server->AddChildSocket(socket_node);
+  } else {
+    chand->channelz_socket_uuid = 0;
   }
-  if (grpc_cq_begin_op(cq_for_notification, tag) == false) {
-    return GRPC_CALL_ERROR_COMPLETION_QUEUE_SHUTDOWN;
+
+  size_t cq_idx;
+  for (cq_idx = 0; cq_idx < s->cqs.size(); cq_idx++) {
+    if (grpc_cq_pollset(s->cqs[cq_idx]) == accepting_pollset) break;
   }
-  return GRPC_CALL_OK;
-}
-grpc_call_error ValidateServerRequestAndCq(
-    size_t* cq_idx, grpc_server* server,
-    grpc_completion_queue* cq_for_notification, void* tag,
-    grpc_byte_buffer** optional_payload, registered_method* rm) {
-  size_t idx;
-  for (idx = 0; idx < server->cq_count; idx++) {
-    if (server->cqs[idx] == cq_for_notification) {
-      break;
+  if (cq_idx == s->cqs.size()) {
+    /* completion queue not found: pick a random one to publish new calls to */
+    cq_idx = static_cast<size_t>(rand()) % s->cqs.size();
+  }
+  chand->cq_idx = cq_idx;
+
+  num_registered_methods = s->registered_methods.size();
+  /* build a lookup table phrased in terms of mdstr's in this channels context
+     to quickly find registered methods */
+  if (num_registered_methods > 0) {
+    slots = 2 * num_registered_methods;
+    chand->registered_methods.reset(
+        new std::vector<grpc_core::channel_registered_method>(slots));
+    for (std::unique_ptr<grpc_core::registered_method>& rm :
+         s->registered_methods) {
+      grpc_core::ExternallyManagedSlice host;
+      grpc_core::ExternallyManagedSlice method(rm->method.c_str());
+      const bool has_host = !rm->host.empty();
+      if (has_host) {
+        host = grpc_core::ExternallyManagedSlice(rm->host.c_str());
+      }
+      hash = GRPC_MDSTR_KV_HASH(has_host ? host.Hash() : 0, method.Hash());
+      for (probes = 0; (*chand->registered_methods)[(hash + probes) % slots]
+                           .server_registered_method != nullptr;
+           probes++) {
+      }
+      if (probes > max_probes) max_probes = probes;
+      crm = &(*chand->registered_methods)[(hash + probes) % slots];
+      crm->server_registered_method = rm.get();
+      crm->flags = rm->flags;
+      crm->has_host = has_host;
+      if (has_host) {
+        crm->host = host;
+      }
+      crm->method = method;
     }
-  }
-  if (idx == server->cq_count) {
-    return GRPC_CALL_ERROR_NOT_SERVER_COMPLETION_QUEUE;
-  }
-  grpc_call_error error =
-      ValidateServerRequest(cq_for_notification, tag, optional_payload, rm);
-  if (error != GRPC_CALL_OK) {
-    return error;
+    GPR_ASSERT(slots <= UINT32_MAX);
+    chand->registered_method_max_probes = max_probes;
   }
 
-  *cq_idx = idx;
-  return GRPC_CALL_OK;
+  {
+    grpc_core::MutexLock lock(&s->mu_global);
+    s->channels.push_front(chand);
+    chand->list_position = s->channels.begin();
+  }
+
+  op = grpc_make_transport_op(nullptr);
+  op->set_accept_stream = true;
+  op->set_accept_stream_fn = grpc_core::accept_stream;
+  op->set_accept_stream_user_data = chand;
+  op->start_connectivity_watch.reset(new grpc_core::ConnectivityWatcher(chand));
+  if (s->shutdown_flag.load(std::memory_order_acquire)) {
+    op->disconnect_with_error =
+        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown");
+  }
+  grpc_transport_perform_op(transport, op);
 }
-}  // namespace
 
 grpc_call_error grpc_server_request_call(
     grpc_server* server, grpc_call** call, grpc_call_details* details,
@@ -1705,14 +1688,14 @@ grpc_call_error grpc_server_request_call(
        cq_for_notification, tag));
 
   size_t cq_idx;
-  grpc_call_error error = ValidateServerRequestAndCq(
+  grpc_call_error error = grpc_core::ValidateServerRequestAndCq(
       &cq_idx, server, cq_for_notification, tag, nullptr, nullptr);
   if (error != GRPC_CALL_OK) {
     return error;
   }
 
-  requested_call* rc = new requested_call(tag, cq_bound_to_call, call,
-                                          initial_metadata, details);
+  grpc_core::requested_call* rc = new grpc_core::requested_call(
+      tag, cq_bound_to_call, call, initial_metadata, details);
   return queue_call_request(server, cq_idx, rc);
 }
 
@@ -1720,11 +1703,12 @@ grpc_call_error grpc_server_request_registered_call(
     grpc_server* server, void* rmp, grpc_call** call, gpr_timespec* deadline,
     grpc_metadata_array* initial_metadata, grpc_byte_buffer** optional_payload,
     grpc_completion_queue* cq_bound_to_call,
-    grpc_completion_queue* cq_for_notification, void* tag) {
+    grpc_completion_queue* cq_for_notification, void* tag_new) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
   GRPC_STATS_INC_SERVER_REQUESTED_CALLS();
-  registered_method* rm = static_cast<registered_method*>(rmp);
+  grpc_core::registered_method* rm =
+      static_cast<grpc_core::registered_method*>(rmp);
   GRPC_API_TRACE(
       "grpc_server_request_registered_call("
       "server=%p, rmp=%p, call=%p, deadline=%p, initial_metadata=%p, "
@@ -1732,41 +1716,17 @@ grpc_call_error grpc_server_request_registered_call(
       "tag=%p)",
       9,
       (server, rmp, call, deadline, initial_metadata, optional_payload,
-       cq_bound_to_call, cq_for_notification, tag));
+       cq_bound_to_call, cq_for_notification, tag_new));
 
   size_t cq_idx;
   grpc_call_error error = ValidateServerRequestAndCq(
-      &cq_idx, server, cq_for_notification, tag, optional_payload, rm);
+      &cq_idx, server, cq_for_notification, tag_new, optional_payload, rm);
   if (error != GRPC_CALL_OK) {
     return error;
   }
 
-  requested_call* rc =
-      new requested_call(tag, cq_bound_to_call, call, initial_metadata, rm,
-                         deadline, optional_payload);
+  grpc_core::requested_call* rc = new grpc_core::requested_call(
+      tag_new, cq_bound_to_call, call, initial_metadata, rm, deadline,
+      optional_payload);
   return queue_call_request(server, cq_idx, rc);
-}
-
-const grpc_channel_args* grpc_server_get_channel_args(grpc_server* server) {
-  return server->channel_args;
-}
-
-grpc_resource_user* grpc_server_get_default_resource_user(grpc_server* server) {
-  return server->default_resource_user;
-}
-
-int grpc_server_has_open_connections(grpc_server* server) {
-  int r;
-  gpr_mu_lock(&server->mu_global);
-  r = server->root_channel_data.next != &server->root_channel_data;
-  gpr_mu_unlock(&server->mu_global);
-  return r;
-}
-
-grpc_core::channelz::ServerNode* grpc_server_get_channelz_node(
-    grpc_server* server) {
-  if (server == nullptr) {
-    return nullptr;
-  }
-  return server->channelz_server.get();
 }

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -36,6 +36,7 @@
 #include <grpc/support/string_util.h>
 
 #include "absl/types/optional.h"
+
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/channel/connected_channel.h"

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -41,9 +41,10 @@ class ServerListenerInterface : public Orphanable {
  public:
   virtual ~ServerListenerInterface() = default;
 
-  /// Starts listening.
-  virtual void Start(grpc_server* server, grpc_pollset** pollsets,
-                     size_t npollsets) = 0;
+  /// Starts listening. This listener may refer to the pollset object beyond
+  /// this call, so it is a pointer rather than a reference.
+  virtual void Start(grpc_server* server,
+                     const std::vector<grpc_pollset*>* pollsets) = 0;
 
   /// Returns the channelz node for the listen socket, or null if not
   /// supported.
@@ -78,12 +79,12 @@ const grpc_channel_args* grpc_server_get_channel_args(grpc_server* server);
 
 grpc_resource_user* grpc_server_get_default_resource_user(grpc_server* server);
 
-int grpc_server_has_open_connections(grpc_server* server);
+bool grpc_server_has_open_connections(grpc_server* server);
 
-/* Do not call this before grpc_server_start. Returns the pollsets and the
- * number of pollsets via 'pollsets' and 'pollset_count'. */
-void grpc_server_get_pollsets(grpc_server* server, grpc_pollset*** pollsets,
-                              size_t* pollset_count);
+// Do not call this before grpc_server_start. Returns the pollsets. The vector
+// itself is immutable, but the pollsets inside are mutable. The result is valid
+// for the lifetime of the server.
+const std::vector<grpc_pollset*>& grpc_server_get_pollsets(grpc_server* server);
 
 namespace grpc_core {
 

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -142,7 +142,7 @@ static void on_connect(void* arg, grpc_endpoint* tcp,
   grpc_slice_buffer_init(&state.outgoing_buffer);
   state.tcp = tcp;
   state.incoming_data_length = 0;
-  grpc_endpoint_add_to_pollset(tcp, server->pollset);
+  grpc_endpoint_add_to_pollset(tcp, server->pollset[0]);
   grpc_endpoint_read(tcp, &state.temp_incoming_buffer, &on_read,
                      /*urgent=*/false);
 }

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -172,7 +172,8 @@ static void test_no_op_with_start(void) {
   grpc_tcp_server* s;
   GPR_ASSERT(GRPC_ERROR_NONE == grpc_tcp_server_create(nullptr, nullptr, &s));
   LOG_TEST("test_no_op_with_start");
-  grpc_tcp_server_start(s, nullptr, 0, on_connect, nullptr);
+  std::vector<grpc_pollset*> empty_pollset;
+  grpc_tcp_server_start(s, &empty_pollset, on_connect, nullptr);
   grpc_tcp_server_unref(s);
 }
 
@@ -213,7 +214,8 @@ static void test_no_op_with_port_and_start(void) {
                  GRPC_ERROR_NONE &&
              port > 0);
 
-  grpc_tcp_server_start(s, nullptr, 0, on_connect, nullptr);
+  std::vector<grpc_pollset*> empty_pollset;
+  grpc_tcp_server_start(s, &empty_pollset, on_connect, nullptr);
 
   grpc_tcp_server_unref(s);
 }
@@ -344,7 +346,9 @@ static void test_connect(size_t num_connects,
   svr1_fd_count = grpc_tcp_server_port_fd_count(s, 1);
   GPR_ASSERT(svr1_fd_count >= 1);
 
-  grpc_tcp_server_start(s, &g_pollset, 1, on_connect, nullptr);
+  std::vector<grpc_pollset*> test_pollset;
+  test_pollset.push_back(g_pollset);
+  grpc_tcp_server_start(s, &test_pollset, on_connect, nullptr);
 
   if (dst_addrs != nullptr) {
     int ports[] = {svr_port, svr1_port};

--- a/test/core/surface/concurrent_connectivity_test.cc
+++ b/test/core/surface/concurrent_connectivity_test.cc
@@ -24,6 +24,7 @@
 
 #include <memory.h>
 #include <stdio.h>
+#include <atomic>
 
 #include <string>
 
@@ -93,19 +94,20 @@ void create_loop_destroy(void* addr) {
   }
 }
 
-struct server_thread_args {
+// Always stack-allocate or new ServerThreadArgs; never use gpr_malloc since
+// this contains C++ objects.
+struct ServerThreadArgs {
   std::string addr;
   grpc_server* server = nullptr;
   grpc_completion_queue* cq = nullptr;
-  grpc_pollset* pollset = nullptr;
+  std::vector<grpc_pollset*> pollset;
   gpr_mu* mu = nullptr;
   gpr_event ready;
-  gpr_atm stop = 0;
+  std::atomic_bool stop{false};
 };
 
 void server_thread(void* vargs) {
-  struct server_thread_args* args =
-      static_cast<struct server_thread_args*>(vargs);
+  struct ServerThreadArgs* args = static_cast<struct ServerThreadArgs*>(vargs);
   grpc_event ev;
   gpr_timespec deadline =
       grpc_timeout_milliseconds_to_deadline(SERVER_SHUTDOWN_TIMEOUT);
@@ -118,19 +120,18 @@ static void on_connect(void* vargs, grpc_endpoint* tcp,
                        grpc_pollset* /*accepting_pollset*/,
                        grpc_tcp_server_acceptor* acceptor) {
   gpr_free(acceptor);
-  struct server_thread_args* args =
-      static_cast<struct server_thread_args*>(vargs);
+  struct ServerThreadArgs* args = static_cast<struct ServerThreadArgs*>(vargs);
   grpc_endpoint_shutdown(tcp,
                          GRPC_ERROR_CREATE_FROM_STATIC_STRING("Connected"));
   grpc_endpoint_destroy(tcp);
   gpr_mu_lock(args->mu);
-  GRPC_LOG_IF_ERROR("pollset_kick", grpc_pollset_kick(args->pollset, nullptr));
+  GRPC_LOG_IF_ERROR("pollset_kick",
+                    grpc_pollset_kick(args->pollset[0], nullptr));
   gpr_mu_unlock(args->mu);
 }
 
 void bad_server_thread(void* vargs) {
-  struct server_thread_args* args =
-      static_cast<struct server_thread_args*>(vargs);
+  struct ServerThreadArgs* args = static_cast<struct ServerThreadArgs*>(vargs);
 
   grpc_core::ExecCtx exec_ctx;
   grpc_resolved_address resolved_addr;
@@ -146,18 +147,18 @@ void bad_server_thread(void* vargs) {
   GPR_ASSERT(port > 0);
   args->addr = absl::StrCat("localhost:", port);
 
-  grpc_tcp_server_start(s, &args->pollset, 1, on_connect, args);
+  grpc_tcp_server_start(s, &args->pollset, on_connect, args);
   gpr_event_set(&args->ready, (void*)1);
 
   gpr_mu_lock(args->mu);
-  while (gpr_atm_acq_load(&args->stop) == 0) {
+  while (args->stop.load(std::memory_order_acquire) == false) {
     grpc_millis deadline = grpc_core::ExecCtx::Get()->Now() + 100;
 
     grpc_pollset_worker* worker = nullptr;
     if (!GRPC_LOG_IF_ERROR(
             "pollset_work",
-            grpc_pollset_work(args->pollset, &worker, deadline))) {
-      gpr_atm_rel_store(&args->stop, 1);
+            grpc_pollset_work(args->pollset[0], &worker, deadline))) {
+      args->stop.store(true, std::memory_order_release);
     }
     gpr_mu_unlock(args->mu);
 
@@ -174,7 +175,7 @@ static void done_pollset_shutdown(void* pollset, grpc_error* /*error*/) {
 }
 
 int run_concurrent_connectivity_test() {
-  struct server_thread_args args;
+  struct ServerThreadArgs args;
 
   grpc_init();
 
@@ -225,8 +226,9 @@ int run_concurrent_connectivity_test() {
   {
     /* Third round, bogus tcp server */
     gpr_log(GPR_DEBUG, "Wave 3");
-    args.pollset = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
-    grpc_pollset_init(args.pollset, &args.mu);
+    auto* pollset = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
+    grpc_pollset_init(pollset, &args.mu);
+    args.pollset.push_back(pollset);
     gpr_event_init(&args.ready);
     grpc_core::Thread server3("grpc_wave_3_server", bad_server_thread, &args);
     server3.Start();
@@ -242,13 +244,14 @@ int run_concurrent_connectivity_test() {
       th.Join();
     }
 
-    gpr_atm_rel_store(&args.stop, 1);
+    args.stop.store(true, std::memory_order_release);
     server3.Join();
     {
       grpc_core::ExecCtx exec_ctx;
       grpc_pollset_shutdown(
-          args.pollset, GRPC_CLOSURE_CREATE(done_pollset_shutdown, args.pollset,
-                                            grpc_schedule_on_exec_ctx));
+          args.pollset[0],
+          GRPC_CLOSURE_CREATE(done_pollset_shutdown, args.pollset[0],
+                              grpc_schedule_on_exec_ctx));
     }
   }
 

--- a/test/core/util/test_tcp_server.cc
+++ b/test/core/util/test_tcp_server.cc
@@ -36,18 +36,19 @@
 
 static void on_server_destroyed(void* data, grpc_error* /*error*/) {
   test_tcp_server* server = static_cast<test_tcp_server*>(data);
-  server->shutdown = 1;
+  server->shutdown = true;
 }
 
 void test_tcp_server_init(test_tcp_server* server,
                           grpc_tcp_server_cb on_connect, void* user_data) {
   grpc_init();
-  server->tcp_server = nullptr;
   GRPC_CLOSURE_INIT(&server->shutdown_complete, on_server_destroyed, server,
                     grpc_schedule_on_exec_ctx);
-  server->shutdown = 0;
-  server->pollset = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
-  grpc_pollset_init(server->pollset, &server->mu);
+
+  grpc_pollset* pollset =
+      static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
+  grpc_pollset_init(pollset, &server->mu);
+  server->pollset.push_back(pollset);
   server->on_connect = on_connect;
   server->cb_data = user_data;
 }
@@ -71,7 +72,7 @@ void test_tcp_server_start(test_tcp_server* server, int port) {
   GPR_ASSERT(error == GRPC_ERROR_NONE);
   GPR_ASSERT(port_added == port);
 
-  grpc_tcp_server_start(server->tcp_server, &server->pollset, 1,
+  grpc_tcp_server_start(server->tcp_server, &server->pollset,
                         server->on_connect, server->cb_data);
   gpr_log(GPR_INFO, "test tcp server listening on 0.0.0.0:%d", port);
 }
@@ -83,7 +84,7 @@ void test_tcp_server_poll(test_tcp_server* server, int milliseconds) {
       grpc_timeout_milliseconds_to_deadline(milliseconds));
   gpr_mu_lock(server->mu);
   GRPC_LOG_IF_ERROR("pollset_work",
-                    grpc_pollset_work(server->pollset, &worker, deadline));
+                    grpc_pollset_work(server->pollset[0], &worker, deadline));
   gpr_mu_unlock(server->mu);
 }
 
@@ -106,10 +107,10 @@ void test_tcp_server_destroy(test_tcp_server* server) {
          gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), shutdown_deadline) < 0) {
     test_tcp_server_poll(server, 1000);
   }
-  grpc_pollset_shutdown(server->pollset,
-                        GRPC_CLOSURE_CREATE(finish_pollset, server->pollset,
+  grpc_pollset_shutdown(server->pollset[0],
+                        GRPC_CLOSURE_CREATE(finish_pollset, server->pollset[0],
                                             grpc_schedule_on_exec_ctx));
   grpc_core::ExecCtx::Get()->Flush();
-  gpr_free(server->pollset);
+  gpr_free(server->pollset[0]);
   grpc_shutdown();
 }

--- a/test/core/util/test_tcp_server.h
+++ b/test/core/util/test_tcp_server.h
@@ -19,18 +19,24 @@
 #ifndef GRPC_TEST_CORE_UTIL_TEST_TCP_SERVER_H
 #define GRPC_TEST_CORE_UTIL_TEST_TCP_SERVER_H
 
+#include <vector>
+
 #include <grpc/support/sync.h>
 #include "src/core/lib/iomgr/tcp_server.h"
 
-typedef struct test_tcp_server {
-  grpc_tcp_server* tcp_server;
+// test_tcp_server should be stack-allocated or new'ed, never gpr_malloc'ed
+// since it contains C++ objects.
+struct test_tcp_server {
+  grpc_tcp_server* tcp_server = nullptr;
   grpc_closure shutdown_complete;
-  int shutdown;
+  bool shutdown = false;
+  // mu is filled in by grpc_pollset_init and controlls the pollset.
+  // TODO: Switch this to a Mutex once pollset_init can provide a Mutex
   gpr_mu* mu;
-  grpc_pollset* pollset;
+  std::vector<grpc_pollset*> pollset;
   grpc_tcp_server_cb on_connect;
   void* cb_data;
-} test_tcp_server;
+};
 
 void test_tcp_server_init(test_tcp_server* server,
                           grpc_tcp_server_cb on_connect, void* user_data);

--- a/test/cpp/microbenchmarks/fullstack_fixtures.h
+++ b/test/cpp/microbenchmarks/fullstack_fixtures.h
@@ -178,12 +178,9 @@ class EndpointPairFixture : public BaseFixture {
       server_transport_ = grpc_create_chttp2_transport(
           server_args, endpoints.server, false /* is_client */);
 
-      grpc_pollset** pollsets;
-      size_t num_pollsets = 0;
-      grpc_server_get_pollsets(server_->c_server(), &pollsets, &num_pollsets);
-
-      for (size_t i = 0; i < num_pollsets; i++) {
-        grpc_endpoint_add_to_pollset(endpoints.server, pollsets[i]);
+      for (grpc_pollset* pollset :
+           grpc_server_get_pollsets(server_->c_server())) {
+        grpc_endpoint_add_to_pollset(endpoints.server, pollset);
       }
 
       grpc_server_setup_transport(server_->c_server(), server_transport_,

--- a/test/cpp/performance/writes_per_rpc_test.cc
+++ b/test/cpp/performance/writes_per_rpc_test.cc
@@ -75,12 +75,9 @@ class EndpointPairFixture {
       grpc_transport* transport = grpc_create_chttp2_transport(
           server_args, endpoints.server, false /* is_client */);
 
-      grpc_pollset** pollsets;
-      size_t num_pollsets = 0;
-      grpc_server_get_pollsets(server_->c_server(), &pollsets, &num_pollsets);
-
-      for (size_t i = 0; i < num_pollsets; i++) {
-        grpc_endpoint_add_to_pollset(endpoints.server, pollsets[i]);
+      for (grpc_pollset* pollset :
+           grpc_server_get_pollsets(server_->c_server())) {
+        grpc_endpoint_add_to_pollset(endpoints.server, pollset);
       }
 
       grpc_server_setup_transport(server_->c_server(), transport, nullptr,


### PR DESCRIPTION
Followup from the review comments in #22670

This converts the grpc_server and other structures in the same file to idiomatic C++ (*). This also converts the parts of grpc_tcp_server and grpc_udp_server that borrow directly from the grpc_server's structures into idiomatic C++ (but doesn't change the rest of those structures, following the 1 CL=1 concept rule).

The readability is much more "normal" now (no `->next` all over the place to create our own linked lists instead of using `std::list` or `std::vector`) and there is no performance impact.

(*) One piece of the core server that is not fully idiomatic is the map in channel_registered_methods, which is still implemented using an array (now a vector) rather than a map of some kind. This detail may be performance-sensitive so it is being pushed to a later CL after proper investigation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/22757)
<!-- Reviewable:end -->
