### PR TITLE
Add --fail_on_failed_rpc flag to xds tests

### DIFF
--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -25,6 +25,9 @@ The code for the xDS test client can be at:
 
 Clients should accept these arguments:
 
+*   --fail_on_failed_rpcs=BOOL
+    *   If true, the client should exit with a non-zero return code if any RPCs
+        fail. Default is false.
 *   --num_channels=CHANNELS
     *   The number of channels to create to the server.
 *   --qps=QPS
@@ -88,6 +91,7 @@ Client parameters:
 
 1.  --num_channels=1
 1.  --qps=10
+1.  --fail_on_failed_rpc=true
 
 Load balancer configuration:
 
@@ -106,6 +110,7 @@ Client parameters:
 
 1.  --num_channels=1
 1.  --qps=10
+1.  --fail_on_failed_rpc=true
 
 Load balancer configuration:
 
@@ -220,6 +225,7 @@ Client parameters:
 
 1.  --num_channels=1
 1.  --qps=10
+1.  --fail_on_failed_rpc=true
 
 Load balancer configuration:
 
@@ -268,6 +274,7 @@ Client parameters:
 
 1.  --num_channels=1
 1.  --qps=10
+1.  --fail_on_failed_rpc=true
 
 Load balancer configuration:
 

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -38,10 +38,11 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/test_config.h"
 
+DEFINE_bool(fail_on_failed_rpc, false, "Fail client if any RPCs fail.");
 DEFINE_int32(num_channels, 1, "Number of channels.");
 DEFINE_bool(print_response, false, "Write RPC response to stdout.");
 DEFINE_int32(qps, 1, "Qps per channel.");
-DEFINE_int32(rpc_timeout_sec, 10, "Per RPC timeout seconds.");
+DEFINE_int32(rpc_timeout_sec, 30, "Per RPC timeout seconds.");
 DEFINE_string(server, "localhost:50051", "Address of server.");
 DEFINE_int32(stats_port, 50052,
              "Port to expose peer distribution stats service.");
@@ -155,14 +156,19 @@ class TestClient {
         }
       }
 
-      if (FLAGS_print_response) {
-        if (call->status.ok()) {
+      if (!call->status.ok()) {
+        if (FLAGS_print_response || FLAGS_fail_on_failed_rpc) {
+          std::cout << "RPC failed: " << call->status.error_code() << ": "
+                    << call->status.error_message() << std::endl;
+        }
+        if (FLAGS_fail_on_failed_rpc) {
+          abort();
+        }
+      } else {
+        if (FLAGS_print_response) {
           std::cout << "Greeting: Hello world, this is "
                     << call->response.hostname() << ", from "
                     << call->context.peer() << std::endl;
-        } else {
-          std::cout << "RPC failed: " << call->status.error_code() << ": "
-                    << call->status.error_message() << std::endl;
         }
       }
 

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -56,4 +56,4 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,cds_lb,eds_lb,priority_l
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \
-    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds-experimental:///{server_uri} --stats_port={stats_port} --qps={qps}'
+    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds-experimental:///{server_uri} --stats_port={stats_port} --qps={qps} {fail_on_failed_rpc}'


### PR DESCRIPTION
Ensure that tests which should work without any failed RPCs (e.g., round-robin) will fail with an error message if an unexpected RPC failure occurs.