### PR TITLE
Establish mirror for all bazel dependencies

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -133,7 +133,10 @@ def grpc_deps():
             # to obtain a boringssl archive with consistent sha256
             sha256 = "a3d4de4f03cb321ef943678d72a045c9a19d26b23d6f4e313f97600c65201a27",
             strip_prefix = "boringssl-1c2769383f027befac5b75b6cedd25daf3bf4dcf",
-            url = "https://github.com/google/boringssl/archive/1c2769383f027befac5b75b6cedd25daf3bf4dcf.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/boringssl/archive/1c2769383f027befac5b75b6cedd25daf3bf4dcf.tar.gz",
+                "https://github.com/google/boringssl/archive/1c2769383f027befac5b75b6cedd25daf3bf4dcf.tar.gz",
+            ],
         )
 
     if "zlib" not in native.existing_rules():
@@ -142,7 +145,10 @@ def grpc_deps():
             build_file = "@com_github_grpc_grpc//third_party:zlib.BUILD",
             sha256 = "6d4d6640ca3121620995ee255945161821218752b551a1a180f4215f7d124d45",
             strip_prefix = "zlib-cacf7f1d4e3d44d871b605da3b647f07d718623f",
-            url = "https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
+                "https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
+            ],
         )
 
     if "com_google_protobuf" not in native.existing_rules():
@@ -150,7 +156,10 @@ def grpc_deps():
             name = "com_google_protobuf",
             sha256 = "51398b0b97b353c1c226d0ade0bae80c80380e691cba7c1a108918986784a1c7",
             strip_prefix = "protobuf-29cd005ce1fe1a8fabf11e325cb13006a6646d59",
-            url = "https://github.com/google/protobuf/archive/29cd005ce1fe1a8fabf11e325cb13006a6646d59.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/protobuf/archive/29cd005ce1fe1a8fabf11e325cb13006a6646d59.tar.gz",
+                "https://github.com/google/protobuf/archive/29cd005ce1fe1a8fabf11e325cb13006a6646d59.tar.gz",
+            ],
         )
 
     if "com_github_google_googletest" not in native.existing_rules():
@@ -158,7 +167,11 @@ def grpc_deps():
             name = "com_github_google_googletest",
             sha256 = "443d383db648ebb8e391382c0ab63263b7091d03197f304390baac10f178a468",
             strip_prefix = "googletest-c9ccac7cb7345901884aabf5d1a786cfa6e2f397",
-            url = "https://github.com/google/googletest/archive/c9ccac7cb7345901884aabf5d1a786cfa6e2f397.tar.gz",  # 2019-08-19
+            urls = [
+                # 2019-08-19
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/googletest/archive/c9ccac7cb7345901884aabf5d1a786cfa6e2f397.tar.gz",
+                "https://github.com/google/googletest/archive/c9ccac7cb7345901884aabf5d1a786cfa6e2f397.tar.gz",
+            ],
         )
 
     if "rules_cc" not in native.existing_rules():
@@ -166,7 +179,11 @@ def grpc_deps():
             name = "rules_cc",
             sha256 = "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
             strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
-            url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",  #2019-08-15
+            urls = [
+                #2019-08-15
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
+                "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz",
+            ],
         )
 
     if "com_github_gflags_gflags" not in native.existing_rules():
@@ -174,7 +191,10 @@ def grpc_deps():
             name = "com_github_gflags_gflags",
             sha256 = "63ae70ea3e05780f7547d03503a53de3a7d2d83ad1caaa443a31cb20aea28654",
             strip_prefix = "gflags-28f50e0fed19872e0fd50dd23ce2ee8cd759338e",
-            url = "https://github.com/gflags/gflags/archive/28f50e0fed19872e0fd50dd23ce2ee8cd759338e.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/gflags/gflags/archive/28f50e0fed19872e0fd50dd23ce2ee8cd759338e.tar.gz",
+                "https://github.com/gflags/gflags/archive/28f50e0fed19872e0fd50dd23ce2ee8cd759338e.tar.gz",
+            ],
         )
 
     if "com_github_google_benchmark" not in native.existing_rules():
@@ -182,7 +202,10 @@ def grpc_deps():
             name = "com_github_google_benchmark",
             sha256 = "f68aec93154d010324c05bcd8c5cc53468b87af88d87acb5ddcfaa1bba044837",
             strip_prefix = "benchmark-090faecb454fbd6e6e17a75ef8146acb037118d4",
-            url = "https://github.com/google/benchmark/archive/090faecb454fbd6e6e17a75ef8146acb037118d4.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/090faecb454fbd6e6e17a75ef8146acb037118d4.tar.gz",
+                "https://github.com/google/benchmark/archive/090faecb454fbd6e6e17a75ef8146acb037118d4.tar.gz",
+            ],
         )
 
     if "com_github_cares_cares" not in native.existing_rules():
@@ -191,7 +214,10 @@ def grpc_deps():
             build_file = "@com_github_grpc_grpc//third_party:cares/cares.BUILD",
             sha256 = "e8c2751ddc70fed9dc6f999acd92e232d5846f009ee1674f8aee81f19b2b915a",
             strip_prefix = "c-ares-e982924acee7f7313b4baa4ee5ec000c5e373c30",
-            url = "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+                "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+            ],
         )
 
     if "com_google_absl" not in native.existing_rules():
@@ -199,7 +225,10 @@ def grpc_deps():
             name = "com_google_absl",
             sha256 = "f368a8476f4e2e0eccf8a7318b98dafbe30b2600f4e3cf52636e5eb145aba06a",
             strip_prefix = "abseil-cpp-df3ea785d8c30a9503321a3d35ee7d35808f190d",
-            url = "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+                "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
+            ],
         )
 
     if "bazel_toolchains" not in native.existing_rules():
@@ -209,8 +238,8 @@ def grpc_deps():
             sha256 = "0b36eef8a66f39c8dbae88e522d5bbbef49d5e66e834a982402c79962281be10",
             strip_prefix = "bazel-toolchains-1.0.1",
             urls = [
-                "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.0.1/bazel-toolchains-1.0.1.tar.gz",
                 "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1.0.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.0.1/bazel-toolchains-1.0.1.tar.gz",
             ],
         )
 
@@ -229,14 +258,20 @@ def grpc_deps():
             name = "io_opencensus_cpp",
             sha256 = "90d6fafa8b1a2ea613bf662731d3086e1c2ed286f458a95c81744df2dbae41b1",
             strip_prefix = "opencensus-cpp-c9a4da319bc669a772928ffc55af4a61be1a1176",
-            url = "https://github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
+            ],
         )
     if "upb" not in native.existing_rules():
         http_archive(
             name = "upb",
             sha256 = "e9c136e56b98c8eb48ad1c9f8df4a6348e99f9f336ee6199c4259a312c2e3598",
             strip_prefix = "upb-d8f3d6f9d415b31f3ce56d46791706c38fa311bc",
-            url = "https://github.com/protocolbuffers/upb/archive/d8f3d6f9d415b31f3ce56d46791706c38fa311bc.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/upb/archive/d8f3d6f9d415b31f3ce56d46791706c38fa311bc.tar.gz",
+                "https://github.com/protocolbuffers/upb/archive/d8f3d6f9d415b31f3ce56d46791706c38fa311bc.tar.gz",
+            ],
         )
 
     if "envoy_api" not in native.existing_rules():
@@ -244,28 +279,38 @@ def grpc_deps():
             name = "envoy_api",
             sha256 = "4ba23e0370ec358d1050c020e00cd020f03644a733aaf8fd85cc43d17b92236a",
             strip_prefix = "data-plane-api-0487bbb43c3e8b54c7332f74ba7344d8265774f7",
-            url = "https://github.com/envoyproxy/data-plane-api/archive/0487bbb43c3e8b54c7332f74ba7344d8265774f7.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/0487bbb43c3e8b54c7332f74ba7344d8265774f7.tar.gz",
+                "https://github.com/envoyproxy/data-plane-api/archive/0487bbb43c3e8b54c7332f74ba7344d8265774f7.tar.gz",
+            ],
         )
 
     if "io_bazel_rules_go" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_go",
-            urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
             sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
+                "https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
+            ],
         )
 
     if "build_bazel_rules_apple" not in native.existing_rules():
         http_archive(
             name = "build_bazel_rules_apple",
-            url = "https://github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
             strip_prefix = "rules_apple-b869b0d3868d78a1d4ffd866ccb304fb68aa12c3",
             sha256 = "bdc8e66e70b8a75da23b79f1f8c6207356df07d041d96d2189add7ee0780cf4e",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
+                "https://github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
+            ],
         )
 
     if "build_bazel_apple_support" not in native.existing_rules():
         http_archive(
             name = "build_bazel_apple_support",
             urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/apple_support/releases/download/0.7.1/apple_support.0.7.1.tar.gz",
                 "https://github.com/bazelbuild/apple_support/releases/download/0.7.1/apple_support.0.7.1.tar.gz",
             ],
             sha256 = "122ebf7fe7d1c8e938af6aeaee0efe788a3a2449ece5a8d6a428cb18d6f88033",
@@ -277,7 +322,10 @@ def grpc_deps():
             build_file = "@com_github_grpc_grpc//third_party:libuv.BUILD",
             sha256 = "dfb4fe1ff0b47340978490a14bf253475159ecfcbad46ab2a350c78f9ce3360f",
             strip_prefix = "libuv-15ae750151ac9341e5945eb38f8982d59fb99201",
-            url = "https://github.com/libuv/libuv/archive/15ae750151ac9341e5945eb38f8982d59fb99201.tar.gz",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/libuv/libuv/archive/15ae750151ac9341e5945eb38f8982d59fb99201.tar.gz",
+                "https://github.com/libuv/libuv/archive/15ae750151ac9341e5945eb38f8982d59fb99201.tar.gz",
+            ],
         )
 
     grpc_python_deps()
@@ -301,7 +349,10 @@ def grpc_test_only_deps():
             name = "com_github_twisted_twisted",
             sha256 = "ca17699d0d62eafc5c28daf2c7d0a18e62ae77b4137300b6c7d7868b39b06139",
             strip_prefix = "twisted-twisted-17.5.0",
-            url = "https://github.com/twisted/twisted/archive/twisted-17.5.0.zip",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/twisted/twisted/archive/twisted-17.5.0.zip",
+                "https://github.com/twisted/twisted/archive/twisted-17.5.0.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:twisted.BUILD",
         )
 
@@ -310,7 +361,10 @@ def grpc_test_only_deps():
             name = "com_github_yaml_pyyaml",
             sha256 = "6b4314b1b2051ddb9d4fcd1634e1fa9c1bb4012954273c9ff3ef689f6ec6c93e",
             strip_prefix = "pyyaml-3.12",
-            url = "https://github.com/yaml/pyyaml/archive/3.12.zip",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/yaml/pyyaml/archive/3.12.zip",
+                "https://github.com/yaml/pyyaml/archive/3.12.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:yaml.BUILD",
         )
 
@@ -319,7 +373,10 @@ def grpc_test_only_deps():
             name = "com_github_twisted_incremental",
             sha256 = "f0ca93359ee70243ff7fbf2d904a6291810bd88cb80ed4aca6fa77f318a41a36",
             strip_prefix = "incremental-incremental-17.5.0",
-            url = "https://github.com/twisted/incremental/archive/incremental-17.5.0.zip",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/twisted/incremental/archive/incremental-17.5.0.zip",
+                "https://github.com/twisted/incremental/archive/incremental-17.5.0.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:incremental.BUILD",
         )
 
@@ -328,7 +385,10 @@ def grpc_test_only_deps():
             name = "com_github_zopefoundation_zope_interface",
             sha256 = "e9579fc6149294339897be3aa9ecd8a29217c0b013fe6f44fcdae00e3204198a",
             strip_prefix = "zope.interface-4.4.3",
-            url = "https://github.com/zopefoundation/zope.interface/archive/4.4.3.zip",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/zopefoundation/zope.interface/archive/4.4.3.zip",
+                "https://github.com/zopefoundation/zope.interface/archive/4.4.3.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:zope_interface.BUILD",
         )
 
@@ -337,6 +397,9 @@ def grpc_test_only_deps():
             name = "com_github_twisted_constantly",
             sha256 = "2702cd322161a579d2c0dbf94af4e57712eedc7bd7bbbdc554a230544f7d346c",
             strip_prefix = "constantly-15.1.0",
-            url = "https://github.com/twisted/constantly/archive/15.1.0.zip",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/twisted/constantly/archive/15.1.0.zip",
+                "https://github.com/twisted/constantly/archive/15.1.0.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:constantly.BUILD",
         )

--- a/bazel/update_mirror.sh
+++ b/bazel/update_mirror.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Script to upload github archives for bazel dependencies to GCS, creating a reliable mirror link.
 # Archives are copied to "grpc-bazel-mirror" GCS bucket (https://console.cloud.google.com/storage/browser/grpc-bazel-mirror?project=grpc-testing)
 # and will by downloadable with the https://storage.googleapis.com/grpc-bazel-mirror/ prefix.
+#
+# This script should be run each time bazel dependencies are updated.
 
 set -e
 

--- a/bazel/update_mirror.sh
+++ b/bazel/update_mirror.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Script to upload github archives for bazel dependencies to GCS, creating a reliable mirror link.
+# Archives are copied to "grpc-bazel-mirror" GCS bucket (https://console.cloud.google.com/storage/browser/grpc-bazel-mirror?project=grpc-testing)
+# and will by downloadable with the https://storage.googleapis.com/grpc-bazel-mirror/ prefix.
+
+set -e
+
+cd $(dirname $0)/..
+
+# Create a temp directory to hold the versioned tarball,
+# and clean it up when the script exits.
+tmpdir="$(mktemp -d)"
+function cleanup {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+function upload {
+  local file="$1"
+
+  echo "Downloading https://${file}"
+  curl -L --fail --output "${tmpdir}/archive" "https://${file}"
+
+  echo "Uploading https://${file} to https://storage.googleapis.com/grpc-bazel-mirror/${file}"
+  gsutil cp -n "${tmpdir}/archive" "gs://grpc-bazel-mirror/${file}"  # "-n" will skip existing files
+
+  rm -rf "${tmpdir}/archive"
+}
+
+# How to check that all mirror URLs work:
+# 1. clean $HOME/.cache/bazel
+# 2. bazel clean --expunge
+# 3. bazel sync (failed downloads will print warnings)
+
+# A specific link can be upload manually by running e.g.
+# upload "github.com/google/boringssl/archive/1c2769383f027befac5b75b6cedd25daf3bf4dcf.tar.gz"
+
+# Collect the github archives to mirror from grpc_deps.bzl
+grep -o '"https://github.com/[^"]*"' bazel/grpc_deps.bzl | sed 's/^"https:\/\///' | sed 's/"$//' | while read -r line ; do
+    echo "Updating mirror for ${line}"
+    upload "${line}"
+done

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -109,7 +109,12 @@ class BazelEvalState(object):
         if args['name'] in _GRPC_BAZEL_ONLY_DEPS:
             self.names_and_urls[args['name']] = 'dont care'
             return
-        self.names_and_urls[args['name']] = args['url']
+        url = args.get('url', None)
+        if not url:
+            # we will only be looking for git commit hashes, so concatenating
+            # the urls is fine.
+            url = ' '.join(args['urls'])
+        self.names_and_urls[args['name']] = url
 
     def git_repository(self, **args):
         assert self.names_and_urls.get(args['name']) is None


### PR DESCRIPTION
This should be fixing https://github.com/grpc/grpc/issues/22392 (and also internal b/151773507).
Both are caused by http_archive failing to download from github from time to time.

Also including a script that makes it easy to keep the mirror up-to-date after we update our dependencies.