### PR TITLE
Re-enable a check in bazel_check_workspace.py

### DIFF
--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -68,6 +68,7 @@ _GRPC_DEP_NAMES = [
 ]
 
 _GRPC_BAZEL_ONLY_DEPS = [
+    'upb',  # third_party/upb is checked in locally
     'rules_cc',
     'com_google_absl',
     'io_opencensus_cpp',

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -170,6 +170,11 @@ if len(workspace_git_hashes - git_submodule_hashes) > 0:
     print(
         "Found discrepancies between git submodules and Bazel WORKSPACE dependencies"
     )
+    print("workspace_git_hashes: %s" % workspace_git_hashes)
+    print("git_submodule_hashes: %s" % git_submodule_hashes)
+    print("workspace_git_hashes - git_submodule_hashes: %s" %
+          (workspace_git_hashes - git_submodule_hashes))
+    sys.exit(1)
 
 # Also check that we can override each dependency
 for name in _GRPC_DEP_NAMES:


### PR DESCRIPTION
One of the checks was disabled by mistake in https://github.com/grpc/grpc/pull/15070/files#diff-8868fe52c73c7da816d2ba37363125a7L139

After adding back the check, I got two failures that will need to be fixed (upb and protobuf).

- upb is easy
- for protobuf, bazel dependency and the submodule are currently out of sync due to some bazel cherrypicks in https://github.com/grpc/grpc/pull/21590/commits. We will need to update the submodule to protobuf 3.11.4 to fix this.