### PR TITLE
Make grpc_shutdown_blocking blocking

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -86,7 +86,10 @@ GRPCAPI void grpc_shutdown(void);
     https://github.com/grpc/grpc/issues/15334 */
 GRPCAPI int grpc_is_initialized(void);
 
-/** EXPERIMENTAL. Blocking shut down grpc library.
+/** EXPERIMENTAL. Blocking shut down grpc library. If the shutdown is the last
+    call, it will perform the clean-up and return; otherwise it will block until
+    the clean-up process is complete.
+
     This is only for wrapped language to use now. */
 GRPCAPI void grpc_shutdown_blocking(void);
 

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -65,6 +65,8 @@ static int g_initializations;
 static gpr_cv* g_shutting_down_cv;
 static bool g_shutting_down;
 
+void grpc_maybe_wait_for_async_shutdown_locked(void);
+
 static void do_basic_init(void) {
   gpr_log_verbosity_init();
   gpr_mu_init(&g_init_mu);


### PR DESCRIPTION
Make `grpc_shutdown_blocking` block until the gRPC shutdown process (`grpc_shutdown_internal_locked`) has completed.