### PR TITLE
Fix client_lb_end2end_test flake

### DIFF
--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -243,7 +243,7 @@ int grpc_is_initialized(void) {
 void grpc_maybe_wait_for_async_shutdown(void) {
   gpr_once_init(&g_basic_init, do_basic_init);
   grpc_core::MutexLock lock(&g_init_mu);
-  while (g_shutting_down) {
+  while (g_shutting_down || g_initializations > 0) {
     gpr_cv_wait(g_shutting_down_cv, &g_init_mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
   }

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -50,6 +50,7 @@
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/tcp_client.h"
 #include "src/core/lib/security/credentials/fake/fake_credentials.h"
+#include "src/core/lib/surface/init.h"
 #include "src/cpp/client/secure_credentials.h"
 #include "src/cpp/server/secure_server_credentials.h"
 
@@ -239,6 +240,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
     servers_.clear();
     creds_.reset();
     grpc_shutdown_blocking();
+    grpc_maybe_wait_for_async_shutdown();
   }
 
   void CreateServers(size_t num_servers,


### PR DESCRIPTION
#### The cause of the flake
When a test case completes, `grpc_shutdown_blocking()` does not wait for the  grpc clean-up to be done. A following test case may start and invokes `grpc_init()` before all the entities in the previous case invoke `grpc_shutdown()`. In that case, the lb policy registry is not cleaned-up, and [registering another lb policy factory](https://github.com/grpc/grpc/blob/master/test/cpp/end2end/client_lb_end2end_test.cc#L1642) at this time will trigger duplicated registration assertion.

#### The solution
Use `grpc_maybe_wait_for_async_shutdown()` after each test case to guarantee the clean-up is complete.