### PR TITLE
Support python rules with workspace name

### DIFF
--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -53,7 +53,7 @@ def _generate_py_impl(context):
 
     imports = []
     if out_dir.import_path:
-        imports.append("__main__/%s" % out_dir.import_path)
+        imports.append("%s/%s" % (context.workspace_name, out_dir.import_path))
 
     return [
         DefaultInfo(files = depset(direct = out_files)),

--- a/bazel/test/python_test_repo/WORKSPACE
+++ b/bazel/test/python_test_repo/WORKSPACE
@@ -3,6 +3,9 @@ local_repository(
     path = "../../..",
 )
 
+# Ensure rules don't rely on __main__ naming convention.
+workspace(name="python_test_repo")
+
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()


### PR DESCRIPTION
    Use __main__ or workspacename for py_proto_library

    All python imports currently are added to the runfiles under __main__
    which is only the default when no workspace name is provided. This
    change supports both empty workspace names, and specified workspace
    names.


@gnossen same area as #22777
@veblush
