### PR TITLE
Fix bm opencensus plugin test

### DIFF
--- a/test/cpp/microbenchmarks/bm_opencensus_plugin.cc
+++ b/test/cpp/microbenchmarks/bm_opencensus_plugin.cc
@@ -28,6 +28,7 @@
 #include "opencensus/stats/stats.h"
 #include "src/cpp/ext/filters/census/grpc_plugin.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
+#include "test/core/util/test_config.h"
 #include "test/cpp/microbenchmarks/helpers.h"
 
 using ::grpc::RegisterOpenCensusPlugin;
@@ -86,6 +87,8 @@ class EchoServerThread final {
 };
 
 static void BM_E2eLatencyCensusDisabled(benchmark::State& state) {
+  grpc::testing::TestEnvironment env(0, {});
+
   EchoServerThread server;
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub =
       grpc::testing::EchoTestService::NewStub(grpc::CreateChannel(
@@ -101,11 +104,7 @@ static void BM_E2eLatencyCensusDisabled(benchmark::State& state) {
 BENCHMARK(BM_E2eLatencyCensusDisabled);
 
 static void BM_E2eLatencyCensusEnabled(benchmark::State& state) {
-  // Avoid a data race between registering plugin and shutdown of previous
-  // test (order-dependent) by doing an init/shutdown so that any previous
-  // shutdowns are fully complete first.
-  grpc_init();
-  grpc_shutdown_blocking();
+  grpc::testing::TestEnvironment env(0, {});
 
   // Now start the test by registering the plugin (once in the execution)
   RegisterOnce();


### PR DESCRIPTION
Used `TestEnvironment` to make sure that gRPC stuff is fully shutdown before starting the new test. 