### PR TITLE
Ensuring each action is only generated once in service config, even

### DIFF
--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -2068,10 +2068,14 @@ grpc_error* XdsClient::CreateServiceConfig(
       "    { \"xds_routing_experimental\":{\n"
       "      \"actions\":{\n");
   std::vector<std::string> actions_vector;
+  std::set<std::string> actions_set;
   for (size_t i = 0; i < rds_update.routes.size(); ++i) {
     auto route = rds_update.routes[i];
-    actions_vector.push_back(
-        CreateServiceConfigActionCluster(route.cluster_name.c_str()));
+    if (actions_set.find(route.cluster_name) == actions_set.end()) {
+      actions_vector.push_back(
+          CreateServiceConfigActionCluster(route.cluster_name.c_str()));
+      actions_set.emplace(route.cluster_name);
+    }
   }
   config_parts.push_back(absl::StrJoin(actions_vector, ",\n"));
   config_parts.push_back(

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2576,6 +2576,9 @@ TEST_P(LdsTest, XdsRoutingPathMatching) {
   auto* route2 = new_route_config.mutable_virtual_hosts(0)->add_routes();
   route2->mutable_match()->set_path("/grpc.testing.EchoTest2Service/Echo2");
   route2->mutable_route()->set_cluster(kNewCluster2Name);
+  auto* route3 = new_route_config.mutable_virtual_hosts(0)->add_routes();
+  route3->mutable_match()->set_path("/grpc.testing.EchoTest3Service/Echo3");
+  route3->mutable_route()->set_cluster(kDefaultResourceName);
   auto* default_route = new_route_config.mutable_virtual_hosts(0)->add_routes();
   default_route->mutable_match()->set_prefix("");
   default_route->mutable_route()->set_cluster(kDefaultResourceName);


### PR DESCRIPTION
if the same one is referred to multiple times by routes.

Added this test case in existing test case.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
