### PR TITLE
[9/n] remove hard-coded credential

### DIFF
--- a/test/core/fling/BUILD
+++ b/test/core/fling/BUILD
@@ -52,6 +52,9 @@ grpc_cc_test(
     data = [
         ":fling_client",
         ":fling_server",
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
     ],
     tags = ["no_windows"],
     deps = [
@@ -68,6 +71,9 @@ grpc_cc_test(
     data = [
         ":fling_client",
         ":fling_server",
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
     ],
     tags = ["no_windows"],
     deps = [


### PR DESCRIPTION
This is 9th part of the PR to clean up the test credentials used in C Core(more specifically, in `test/core/end2end/...`).
The ultimate goal is to remove the dependencies on `test/core/end2end/data/ssl_test_data.h`, which contains strings of hard-coded certificates.