### PR TITLE
Revert "Fix client_lb_end2end_test flake"

### DIFF
--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -243,7 +243,7 @@ int grpc_is_initialized(void) {
 void grpc_maybe_wait_for_async_shutdown(void) {
   gpr_once_init(&g_basic_init, do_basic_init);
   grpc_core::MutexLock lock(&g_init_mu);
-  while (g_shutting_down || g_initializations > 0) {
+  while (g_shutting_down) {
     gpr_cv_wait(g_shutting_down_cv, &g_init_mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
   }

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -50,7 +50,6 @@
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/tcp_client.h"
 #include "src/core/lib/security/credentials/fake/fake_credentials.h"
-#include "src/core/lib/surface/init.h"
 #include "src/cpp/client/secure_credentials.h"
 #include "src/cpp/server/secure_server_credentials.h"
 
@@ -240,7 +239,6 @@ class ClientLbEnd2endTest : public ::testing::Test {
     servers_.clear();
     creds_.reset();
     grpc_shutdown_blocking();
-    grpc_maybe_wait_for_async_shutdown();
   }
 
   void CreateServers(size_t num_servers,


### PR DESCRIPTION
Reverts grpc/grpc#22778

Unfortunately the fix is making `//test/core/tsi/alts/handshaker:alts_concurrent_connectivity_test ` (and possibly other tests) significantly flaky

Repro:
`bazel --bazelrc=tools/remote_build/manual.bazelrc test --config=msan //test/core/tsi/alts/handshaker:alts_concurrent_connectivity_test@poller=poll --runs_per_test 500 --test_timeout 120`

Bisected down to the PR
```
INFO: Streaming build results to: https://source.cloud.google.com/results/invocations/30cb73fc-d0c7-40a3-bb57-f7e42371bfb9
INFO: Build completed, 1 test FAILED, 501 total actions
4f9425086b4b3249bed7301830cde52d8361bf83 is the first bad commit
commit 4f9425086b4b3249bed7301830cde52d8361bf83
Author: Muxi Yan <mxyan@google.com>
Date:   Fri Apr 24 16:15:43 2020 -0700

    Fix client_lb_end2end_test flake

 src/core/lib/surface/init.cc               | 2 +-
 test/cpp/end2end/client_lb_end2end_test.cc | 2 ++
 2 files changed, 3 insertions(+), 1 deletion(-)
```