### PR TITLE
Make tools/bazel wrapper more reliable when downloading

### DIFF
--- a/bazel/update_mirror.sh
+++ b/bazel/update_mirror.sh
@@ -51,6 +51,11 @@ function upload {
 # A specific link can be upload manually by running e.g.
 # upload "github.com/google/boringssl/archive/1c2769383f027befac5b75b6cedd25daf3bf4dcf.tar.gz"
 
+# bazel binaries used by the tools/bazel wrapper script
+upload github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-linux-x86_64
+upload github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-darwin-x86_64
+upload github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-windows-x86_64.exe
+
 # Collect the github archives to mirror from grpc_deps.bzl
 grep -o '"https://github.com/[^"]*"' bazel/grpc_deps.bzl | sed 's/^"https:\/\///' | sed 's/"$//' | while read -r line ; do
     echo "Updating mirror for ${line}"

--- a/tools/bazel
+++ b/tools/bazel
@@ -63,7 +63,7 @@ esac
 filename="bazel-$VERSION-$suffix"
 
 if [ ! -x "$filename" ] ; then
-  curl -L "$BASEURL/$VERSION/$filename" > "$filename"
+  curl --fail -L "$BASEURL/$VERSION/$filename" > "$filename"
   chmod a+x "$filename"
 fi
 

--- a/tools/bazel
+++ b/tools/bazel
@@ -43,7 +43,9 @@ fi
 VERSION=1.0.0
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
-BASEURL=https://github.com/bazelbuild/bazel/releases/download/
+# update tools/update_mirror.sh to populate the mirror with new bazel archives
+BASEURL_MIRROR="https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/bazel/releases/download"
+BASEURL="https://github.com/bazelbuild/bazel/releases/download"
 pushd "$(dirname "$0")" >/dev/null
 TOOLDIR=$(pwd)
 
@@ -63,7 +65,9 @@ esac
 filename="bazel-$VERSION-$suffix"
 
 if [ ! -x "$filename" ] ; then
-  curl --fail -L "$BASEURL/$VERSION/$filename" > "$filename"
+  # first try to download using mirror, fallback to download from github
+  echo "Downloading bazel, will try URLs: ${BASEURL_MIRROR}/${VERSION}/${filename} ${BASEURL}/${VERSION}/${filename}" >&2
+  curl --fail -L --output "${filename}" "${BASEURL_MIRROR}/${VERSION}/${filename}" || curl --fail -L --output "${filename}" "${BASEURL}/${VERSION}/${filename}"
   chmod a+x "$filename"
 fi
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/22775

- use curl's `--fail` to actually stop if there's a download problem
- establish mirror for bazel download links, to make the bazel downloads much more robust.