### PR TITLE
Revert "Revert a change to XdsTest/ClientLoadReportingWithDropTest"

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -3959,7 +3959,7 @@ class ClientLoadReportingWithDropTest : public XdsEnd2endTest {
 TEST_P(ClientLoadReportingWithDropTest, Vanilla) {
   SetNextResolution({});
   SetNextResolutionForLbChannelAllBalancers();
-  const size_t kNumRpcs = 3000;
+  const size_t kNumRpcs = 5000;
   const uint32_t kDropPerMillionForLb = 100000;
   const uint32_t kDropPerMillionForThrottle = 200000;
   const double kDropRateForLb = kDropPerMillionForLb / 1000000.0;


### PR DESCRIPTION
Reverts grpc/grpc#22785.

grpc_sanity tests started to fail after #22785 was merged. Probably it's the cause (let's see what the tests say)