### PR TITLE
Revert "[7/n] Avoid using hardcoded test credentials"

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -74,11 +74,6 @@ grpc_cc_library(
         "create_test_channel.h",
         "test_credentials_provider.h",
     ],
-    data = [
-        "//src/core/tsi/test_creds:ca.pem",
-        "//src/core/tsi/test_creds:server1.key",
-        "//src/core/tsi/test_creds:server1.pem",
-    ],
     external_deps = [
         "gflags",
         "protobuf",

--- a/test/cpp/util/test_credentials_provider.h
+++ b/test/cpp/util/test_credentials_provider.h
@@ -19,11 +19,11 @@
 #ifndef GRPC_TEST_CPP_UTIL_TEST_CREDENTIALS_PROVIDER_H
 #define GRPC_TEST_CPP_UTIL_TEST_CREDENTIALS_PROVIDER_H
 
+#include <memory>
+
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/support/channel_arguments.h>
-
-#include <memory>
 
 namespace grpc {
 namespace testing {


### PR DESCRIPTION
Reverts grpc/grpc#22695

Looks like the PR has likely broken ObjC tests?
They started failing right after this PR got merged:
https://source.cloud.google.com/results/invocations/5025cbbb-ee58-4e7a-b606-3d7308c75a7a/targets/github%2Fgrpc%2Frun_tests%2Fobjc_macos_opt_native%2Fmac-test-basictests/tests
https://source.cloud.google.com/results/invocations/7fdb8649-a656-4f35-a95b-11dee9d89855/targets
https://source.cloud.google.com/results/invocations/e02117bc-d854-469d-b041-a082c9c3c4b3/targets