### PR TITLE
Increase the deadline of the keepalive_timeout test call to a minute

### DIFF
--- a/test/core/end2end/tests/keepalive_timeout.cc
+++ b/test/core/end2end/tests/keepalive_timeout.cc
@@ -276,7 +276,7 @@ static void test_read_delays_keepalive(grpc_end2end_test_config config) {
   grpc_slice response_payload_slice =
       grpc_slice_from_copied_string("hello you");
 
-  gpr_timespec deadline = five_seconds_from_now();
+  gpr_timespec deadline = n_seconds_from_now(60);
   c = grpc_channel_create_call(f.client, nullptr, GRPC_PROPAGATE_DEFAULTS, f.cq,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);


### PR DESCRIPTION
Fix for internal bug b/153365725