### PR TITLE
Fix c-ares resolver to properly handle error from SplitHostPort().

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -467,8 +467,7 @@ static bool inner_resolve_as_ip_literal_locked(
     const char* name, const char* default_port,
     std::unique_ptr<grpc_core::ServerAddressList>* addrs, std::string* host,
     std::string* port, std::string* hostport) {
-  grpc_core::SplitHostPort(name, host, port);
-  if (host->empty()) {
+  if (!grpc_core::SplitHostPort(name, host, port)) {
     gpr_log(GPR_ERROR,
             "Failed to parse %s to host:port while attempting to resolve as ip "
             "literal.",


### PR DESCRIPTION
This fixes a bug introduced in #22729.