### PR TITLE
Remove flaky flag from bm opencensus plugin test

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -282,7 +282,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_opencensus_plugin",
     srcs = ["bm_opencensus_plugin.cc"],
-    flaky = True,  # TODO(b/151696309)
     language = "C++",
     deps = [
         ":helpers_secure",


### PR DESCRIPTION
Removed `flaky` flag from the test once #22786 fixed the flakiness. 