### PR TITLE
Remove flaky flag from ChannelzChannelTest::LastCallStartedTime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2196,6 +2196,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/channelz_registry_test || ( echo test channelz_registry_test failed ; exit 1 )
 	$(E) "[RUN]     Testing channelz_service_test"
 	$(Q) $(BINDIR)/$(CONFIG)/channelz_service_test || ( echo test channelz_service_test failed ; exit 1 )
+	$(E) "[RUN]     Testing channelz_test"
+	$(Q) $(BINDIR)/$(CONFIG)/channelz_test || ( echo test channelz_test failed ; exit 1 )
 	$(E) "[RUN]     Testing cli_call_test"
 	$(Q) $(BINDIR)/$(CONFIG)/cli_call_test || ( echo test cli_call_test failed ; exit 1 )
 	$(E) "[RUN]     Testing client_callback_end2end_test"

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5434,7 +5434,6 @@ targets:
 - name: channelz_test
   gtest: true
   build: test
-  run: false
   language: c++
   headers:
   - test/cpp/util/channel_trace_proto_helper.h

--- a/test/core/channel/BUILD
+++ b/test/core/channel/BUILD
@@ -87,7 +87,6 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
-    flaky = True,  # TODO(b/151792070)
     language = "C++",
     deps = [
         "//:gpr",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4064,6 +4064,30 @@
     "flaky": false, 
     "gtest": true, 
     "language": "c++", 
+    "name": "channelz_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": true, 
+    "language": "c++", 
     "name": "cli_call_test", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
Remove the flaky flag from ChannelzChannelTest::LastCallStartedTime once it #22655 fixed the flakiness.