### PR TITLE
Generate grpc cc library using built-in shell environment

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -141,6 +141,7 @@ def generate_cc_impl(ctx):
         outputs = out_files,
         executable = ctx.executable._protoc,
         arguments = arguments,
+        use_default_shell_env = True,
     )
 
     return struct(files = depset(out_files))


### PR DESCRIPTION
This commit updates the implementation of `cc_grpc_library` to use the built-in shell environment. It aligns the implementation with the `proto_gen` rule for protocol buffers.

Migrated from bazelbuild/bazel#11260




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
