### PR TITLE
PHP: add interop test case of compression

### DIFF
--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -117,6 +117,53 @@ function performLargeUnary($stub, $fillUsername = false,
 }
 
 /**
+ * Run the client_compressed_unary test.
+ *
+ * @param $stub Stub object that has service methods
+ */
+function clientCompressedUnary($stub)
+{
+    $request_len = 271828;
+    $response_len = 314159;
+    $falseBoolValue = new Grpc\Testing\BoolValue(['value' => false]);
+    $trueBoolValue = new Grpc\Testing\BoolValue(['value' => true]);
+    // 1. Probing for compression-checks support
+    $payload = new Grpc\Testing\Payload([
+        'body' => str_repeat("\0", $request_len),
+    ]);
+    $request = new Grpc\Testing\SimpleRequest([
+        'payload' => $payload,
+        'response_size' => $response_len,
+        'expect_compressed' => $trueBoolValue, // lie
+    ]);
+    list($result, $status) = $stub->UnaryCall($request, [], [])->wait();
+    hardAssert(
+        $status->code === GRPC\STATUS_INVALID_ARGUMENT,
+        'Received unexpected UnaryCall status code: ' .
+            $status->code
+    );
+    // 2. with/without compressed message
+    foreach ([true, false] as $compression) {
+        $request->setExpectCompressed($compression ? $trueBoolValue : $falseBoolValue);
+        $metadata = $compression ? [
+            'grpc-internal-encoding-request' => ['gzip'],
+        ] : [];
+        list($result, $status) = $stub->UnaryCall($request, $metadata, [])->wait();
+        hardAssertIfStatusOk($status);
+        hardAssert($result !== null, 'Call returned a null response');
+        $payload = $result->getPayload();
+        hardAssert(
+            strlen($payload->getBody()) === $response_len,
+            'Payload had the wrong length'
+        );
+        hardAssert(
+            $payload->getBody() === str_repeat("\0", $response_len),
+            'Payload had the wrong content'
+        );
+    }
+}
+
+/**
  * Run the service account credentials auth test.
  *
  * @param $stub Stub object that has service methods
@@ -672,6 +719,9 @@ function interop_main($args, $stub = false)
             break;
         case 'per_rpc_creds':
             perRpcCreds($stub, $args);
+            break;
+        case 'client_compressed_unary':
+            clientCompressedUnary($stub);
             break;
         default:
             echo "Unsupported test case $test_case\n";

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -499,7 +499,7 @@ class PHPLanguage:
         return {}
 
     def unimplemented_test_cases(self):
-        return _SKIP_COMPRESSION + \
+        return _SKIP_SERVER_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_SPECIAL_STATUS_MESSAGE + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
@@ -528,7 +528,7 @@ class PHP7Language:
         return {}
 
     def unimplemented_test_cases(self):
-        return _SKIP_COMPRESSION + \
+        return _SKIP_SERVER_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_SPECIAL_STATUS_MESSAGE + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \


### PR DESCRIPTION
Add support in PHP interop test client to run the `client_compressed_unary` and `client_compressed_streaming` test case.