### PR TITLE
Pin astroid backport to 1.28.x

### DIFF
--- a/tools/distrib/pylint_code.sh
+++ b/tools/distrib/pylint_code.sh
@@ -40,7 +40,7 @@ python3 -m virtualenv $VIRTUALENV -p $(which python3)
 PYTHON=$VIRTUALENV/bin/python
 
 $PYTHON -m pip install --upgrade pip==19.3.1
-$PYTHON -m pip install --upgrade pylint==2.2.2
+$PYTHON -m pip install --upgrade astroid==2.3.3 pylint==2.2.2
 
 EXIT=0
 for dir in "${DIRS[@]}"; do


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc/pull/22798, which fixes sanity tests.