### PR TITLE
Expose Peer SPIFFE Identity

### DIFF
--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -32,6 +32,7 @@ extern "C" {
 #define GRPC_X509_PEM_CERT_CHAIN_PROPERTY_NAME "x509_pem_cert_chain"
 #define GRPC_SSL_SESSION_REUSED_PROPERTY "ssl_session_reused"
 #define GRPC_TRANSPORT_SECURITY_LEVEL_PROPERTY_NAME "security_level"
+#define GRPC_PEER_SPIFFE_ID_PROPERTY_NAME "peer_spiffe_id"
 
 /** Environment variable that points to the default SSL roots file. This file
    must be a PEM encoded file with all the roots such as the one that can be

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -256,7 +256,7 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
       ctx.get(), GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
       transport_security_type);
   const char* spiffe_data = nullptr;
-  size_t spiffe_length;
+  size_t spiffe_length = 0;
   int spiffe_id_count = 0;
   for (i = 0; i < peer->property_count; i++) {
     const tsi_peer_property* prop = &peer->properties[i];
@@ -352,6 +352,9 @@ tsi_peer grpc_shallow_peer_from_ssl_auth_context(
                  0) {
         add_shallow_auth_property_to_peer(&peer, prop,
                                           TSI_X509_PEM_CERT_CHAIN_PROPERTY);
+      } else if (strcmp(prop->name, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME) == 0) {
+        add_shallow_auth_property_to_peer(&peer, prop,
+                                          TSI_X509_URI_PEER_PROPERTY);
       }
     }
   }

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 
+#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/grpc_security.h>

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -33,15 +33,15 @@
 #include <sys/socket.h>
 #endif
 
-#include "absl/strings/match.h"
-#include "absl/strings/string_view.h"
-
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/thd_id.h>
+
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
 
 extern "C" {
 #include <openssl/bio.h>
@@ -378,6 +378,12 @@ static tsi_result add_subject_alt_names_properties_to_peer(
           TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY,
           reinterpret_cast<const char*>(name), static_cast<size_t>(name_size),
           &peer->properties[peer->property_count++]);
+      if (subject_alt_name->type == GEN_URI) {
+        result = tsi_construct_string_peer_property(
+            TSI_X509_URI_PEER_PROPERTY, reinterpret_cast<const char*>(name),
+            static_cast<size_t>(name_size),
+            &peer->properties[peer->property_count++]);
+      }
       OPENSSL_free(name);
     } else if (subject_alt_name->type == GEN_IPADD) {
       char ntop_buf[INET6_ADDRSTRLEN];

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -346,12 +346,9 @@ static tsi_result add_pem_certificate(X509* cert, tsi_peer_property* property) {
 /* Gets the subject SANs from an X509 cert as a tsi_peer_property. */
 static tsi_result add_subject_alt_names_properties_to_peer(
     tsi_peer* peer, GENERAL_NAMES* subject_alt_names,
-    size_t subject_alt_name_count) {
+    size_t subject_alt_name_count, int* current_insert_index) {
   size_t i;
   tsi_result result = TSI_OK;
-
-  /* Reset for DNS entries filtering. */
-  peer->property_count -= subject_alt_name_count;
 
   for (i = 0; i < subject_alt_name_count; i++) {
     GENERAL_NAME* subject_alt_name =
@@ -377,13 +374,7 @@ static tsi_result add_subject_alt_names_properties_to_peer(
       result = tsi_construct_string_peer_property(
           TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY,
           reinterpret_cast<const char*>(name), static_cast<size_t>(name_size),
-          &peer->properties[peer->property_count++]);
-      if (subject_alt_name->type == GEN_URI) {
-        result = tsi_construct_string_peer_property(
-            TSI_X509_URI_PEER_PROPERTY, reinterpret_cast<const char*>(name),
-            static_cast<size_t>(name_size),
-            &peer->properties[peer->property_count++]);
-      }
+          &peer->properties[(*current_insert_index)++]);
       OPENSSL_free(name);
     } else if (subject_alt_name->type == GEN_IPADD) {
       char ntop_buf[INET6_ADDRSTRLEN];
@@ -408,7 +399,24 @@ static tsi_result add_subject_alt_names_properties_to_peer(
 
       result = tsi_construct_string_peer_property_from_cstring(
           TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY, name,
-          &peer->properties[peer->property_count++]);
+          &peer->properties[(*current_insert_index)++]);
+    }
+    if (result != TSI_OK) break;
+    if (subject_alt_name->type == GEN_URI) {
+      unsigned char* name = nullptr;
+      int name_size;
+      name_size = ASN1_STRING_to_UTF8(
+          &name, subject_alt_name->d.uniformResourceIdentifier);
+      if (name_size < 0) {
+        gpr_log(GPR_ERROR, "Could not get utf8 from asn1 string.");
+        result = TSI_INTERNAL_ERROR;
+        break;
+      }
+      result = tsi_construct_string_peer_property(
+          TSI_X509_URI_PEER_PROPERTY, reinterpret_cast<const char*>(name),
+          static_cast<size_t>(name_size),
+          &peer->properties[(*current_insert_index)++]);
+      OPENSSL_free(name);
     }
     if (result != TSI_OK) break;
   }
@@ -431,26 +439,35 @@ static tsi_result peer_from_x509(X509* cert, int include_certificate_type,
   property_count = (include_certificate_type ? static_cast<size_t>(1) : 0) +
                    2 /* common name, certificate */ +
                    static_cast<size_t>(subject_alt_name_count);
+  for (int i = 0; i < subject_alt_name_count; i++) {
+    GENERAL_NAME* subject_alt_name =
+        sk_GENERAL_NAME_value(subject_alt_names, TSI_SIZE_AS_SIZE(i));
+    if (subject_alt_name->type == GEN_URI) {
+      property_count += 1;
+    }
+  }
   result = tsi_construct_peer(property_count, peer);
   if (result != TSI_OK) return result;
+  int current_insert_index = 0;
   do {
     if (include_certificate_type) {
       result = tsi_construct_string_peer_property_from_cstring(
           TSI_CERTIFICATE_TYPE_PEER_PROPERTY, TSI_X509_CERTIFICATE_TYPE,
-          &peer->properties[0]);
+          &peer->properties[current_insert_index++]);
       if (result != TSI_OK) break;
     }
     result = peer_property_from_x509_common_name(
-        cert, &peer->properties[include_certificate_type ? 1 : 0]);
+        cert, &peer->properties[current_insert_index++]);
     if (result != TSI_OK) break;
 
-    result = add_pem_certificate(
-        cert, &peer->properties[include_certificate_type ? 2 : 1]);
+    result =
+        add_pem_certificate(cert, &peer->properties[current_insert_index++]);
     if (result != TSI_OK) break;
 
     if (subject_alt_name_count != 0) {
       result = add_subject_alt_names_properties_to_peer(
-          peer, subject_alt_names, static_cast<size_t>(subject_alt_name_count));
+          peer, subject_alt_names, static_cast<size_t>(subject_alt_name_count),
+          &current_insert_index);
       if (result != TSI_OK) break;
     }
   } while (0);
@@ -459,6 +476,8 @@ static tsi_result peer_from_x509(X509* cert, int include_certificate_type,
     sk_GENERAL_NAME_pop_free(subject_alt_names, GENERAL_NAME_free);
   }
   if (result != TSI_OK) tsi_peer_destruct(peer);
+
+  GPR_ASSERT((int)peer->property_count == current_insert_index);
   return result;
 }
 

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -22,7 +22,6 @@
 #include <grpc/support/port_platform.h>
 
 #include "absl/strings/string_view.h"
-
 #include "src/core/tsi/transport_security_interface.h"
 
 extern "C" {
@@ -43,6 +42,8 @@ extern "C" {
 #define TSI_X509_PEM_CERT_CHAIN_PROPERTY "x509_pem_cert_chain"
 
 #define TSI_SSL_ALPN_SELECTED_PROTOCOL "ssl_alpn_selected_protocol"
+
+#define TSI_X509_URI_PEER_PROPERTY "x509_uri"
 
 /* --- tsi_ssl_root_certs_store object ---
 

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -16,19 +16,19 @@
  *
  */
 
-#include <stdio.h>
-#include <string.h>
+#include "src/core/lib/security/security_connector/security_connector.h"
 
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/tmpfile.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/security/context/security_context.h"
-#include "src/core/lib/security/security_connector/security_connector.h"
 #include "src/core/lib/security/security_connector/ssl_utils.h"
 #include "src/core/lib/slice/slice_string_helpers.h"
 #include "src/core/tsi/ssl_transport_security.h"
@@ -217,6 +217,35 @@ static int check_x509_pem_cert_chain(const grpc_auth_context* ctx,
   }
   if (grpc_auth_property_iterator_next(&it) != nullptr) {
     gpr_log(GPR_ERROR, "Expected only one property for pem cert chain.");
+    return 0;
+  }
+  return 1;
+}
+
+static int check_spiffe_id(const grpc_auth_context* ctx,
+                           const char* expected_spiffe_id,
+                           bool expect_spiffe_id) {
+  grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(
+      ctx, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME);
+  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
+  if (prop == nullptr && !expect_spiffe_id) {
+    return 1;
+  }
+  if (prop != nullptr && !expect_spiffe_id) {
+    gpr_log(GPR_ERROR, "SPIFFE ID not expected, but got %s.", prop->value);
+    return 0;
+  }
+  if (prop == nullptr && expect_spiffe_id) {
+    gpr_log(GPR_ERROR, "SPIFFE ID expected, but got nullptr.");
+    return 0;
+  }
+  if (strncmp(prop->value, expected_spiffe_id, prop->value_length) != 0) {
+    gpr_log(GPR_ERROR, "Expected SPIFFE ID %s but got %s.", expected_spiffe_id,
+            prop->value);
+    return 0;
+  }
+  if (grpc_auth_property_iterator_next(&it) != nullptr) {
+    gpr_log(GPR_ERROR, "Expected only one property for SPIFFE ID.");
     return 0;
   }
   return 1;
@@ -415,6 +444,71 @@ static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
   ctx.reset(DEBUG_LOCATION, "test");
 }
 
+static void test_spiffe_id_peer_to_auth_context(void) {
+  // Invalid SPIFFE IDs should not be plumbed.
+  std::string long_id(2050, 'x');
+  std::string long_domain(256, 'x');
+  tsi_peer invalid_peer;
+  std::vector<std::string> invalid_spiffe_id = {
+      "",
+      "spi://",
+      "sfiffe://domain/wl",
+      "spiffe://domain",
+      "spiffe://domain/",
+      long_id,
+      "spiffe://" + long_domain + "/wl"};
+  size_t i;
+  GPR_ASSERT(tsi_construct_peer(invalid_spiffe_id.size(), &invalid_peer) ==
+             TSI_OK);
+  for (i = 0; i < invalid_spiffe_id.size(); i++) {
+    GPR_ASSERT(tsi_construct_string_peer_property_from_cstring(
+                   TSI_X509_URI_PEER_PROPERTY, invalid_spiffe_id[i].c_str(),
+                   &invalid_peer.properties[i]) == TSI_OK);
+  }
+  grpc_core::RefCountedPtr<grpc_auth_context> invalid_ctx =
+      grpc_ssl_peer_to_auth_context(&invalid_peer,
+                                    GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  GPR_ASSERT(invalid_ctx != nullptr);
+  GPR_ASSERT(check_spiffe_id(invalid_ctx.get(), "", false));
+  tsi_peer_destruct(&invalid_peer);
+  invalid_ctx.reset(DEBUG_LOCATION, "test");
+  // A valid SPIFFE ID with other URI fields should be plumbed.
+  tsi_peer valid_peer;
+  std::vector<std::string> valid_spiffe_id = {"spiffe://foo.bar.com/wl",
+                                              "https://xyz"};
+  GPR_ASSERT(tsi_construct_peer(valid_spiffe_id.size(), &valid_peer) == TSI_OK);
+  for (i = 0; i < valid_spiffe_id.size(); i++) {
+    GPR_ASSERT(tsi_construct_string_peer_property_from_cstring(
+                   TSI_X509_URI_PEER_PROPERTY, valid_spiffe_id[i].c_str(),
+                   &valid_peer.properties[i]) == TSI_OK);
+  }
+  grpc_core::RefCountedPtr<grpc_auth_context> valid_ctx =
+      grpc_ssl_peer_to_auth_context(&valid_peer,
+                                    GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  GPR_ASSERT(valid_ctx != nullptr);
+  GPR_ASSERT(check_spiffe_id(valid_ctx.get(), "spiffe://foo.bar.com/wl", true));
+  tsi_peer_destruct(&valid_peer);
+  valid_ctx.reset(DEBUG_LOCATION, "test");
+  // Multiple SPIFFE IDs should not be plumbed.
+  tsi_peer multiple_peer;
+  std::vector<std::string> multiple_spiffe_id = {
+      "spiffe://foo.bar.com/wl", "https://xyz", "spiffe://foo.bar.com/wl2"};
+  GPR_ASSERT(tsi_construct_peer(multiple_spiffe_id.size(), &multiple_peer) ==
+             TSI_OK);
+  for (i = 0; i < multiple_spiffe_id.size(); i++) {
+    GPR_ASSERT(tsi_construct_string_peer_property_from_cstring(
+                   TSI_X509_URI_PEER_PROPERTY, multiple_spiffe_id[i].c_str(),
+                   &multiple_peer.properties[i]) == TSI_OK);
+  }
+  grpc_core::RefCountedPtr<grpc_auth_context> multiple_ctx =
+      grpc_ssl_peer_to_auth_context(&multiple_peer,
+                                    GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  GPR_ASSERT(multiple_ctx != nullptr);
+  GPR_ASSERT(check_spiffe_id(multiple_ctx.get(), "", false));
+  tsi_peer_destruct(&multiple_peer);
+  multiple_ctx.reset(DEBUG_LOCATION, "test");
+}
+
 static const char* roots_for_override_api = "roots for override api";
 
 static grpc_ssl_roots_override_result override_roots_success(
@@ -562,6 +656,7 @@ int main(int argc, char** argv) {
   test_cn_and_one_san_ssl_peer_to_auth_context();
   test_cn_and_multiple_sans_ssl_peer_to_auth_context();
   test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context();
+  test_spiffe_id_peer_to_auth_context();
   test_ipv6_address_san();
   test_default_ssl_roots();
   test_peer_alpn_check();

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -469,7 +469,7 @@ static void test_spiffe_id_peer_to_auth_context(void) {
       grpc_ssl_peer_to_auth_context(&invalid_peer,
                                     GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(invalid_ctx != nullptr);
-  GPR_ASSERT(check_spiffe_id(invalid_ctx.get(), "", false));
+  GPR_ASSERT(check_spiffe_id(invalid_ctx.get(), nullptr, false));
   tsi_peer_destruct(&invalid_peer);
   invalid_ctx.reset(DEBUG_LOCATION, "test");
   // A valid SPIFFE ID with other URI fields should be plumbed.
@@ -504,7 +504,7 @@ static void test_spiffe_id_peer_to_auth_context(void) {
       grpc_ssl_peer_to_auth_context(&multiple_peer,
                                     GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(multiple_ctx != nullptr);
-  GPR_ASSERT(check_spiffe_id(multiple_ctx.get(), "", false));
+  GPR_ASSERT(check_spiffe_id(multiple_ctx.get(), nullptr, false));
   tsi_peer_destruct(&multiple_peer);
   multiple_ctx.reset(DEBUG_LOCATION, "test");
 }


### PR DESCRIPTION
This PR exposes SPIFFE ID, if any, from the tsi_peer layer to the auth_context layer.
Users could use 

```
context->auth_context()->FindPropertyValues(GRPC_PEER_SPIFFE_ID_PROPERTY_NAME);
```
to get the SPIFFE ID. 
Note that although FindPropertyValues returns a vector of strings, we do the check to guarantee there is always one SPIFFE ID. This means that if a peer certificate contains two valid SPIFFE IDs, we won't get any SPIFFE ID information from context.