### PR TITLE
do not write unnecessary (and incorrect) new lines in binary output for the grpc_cli

### DIFF
--- a/test/cpp/util/grpc_cli.cc
+++ b/test/cpp/util/grpc_cli.cc
@@ -68,10 +68,10 @@ DEFINE_string(outfile, "", "Output file (default is stdout)");
 static bool SimplePrint(const grpc::string& outfile,
                         const grpc::string& output) {
   if (outfile.empty()) {
-    std::cout << output << std::endl;
+    std::cout << output << std::flush;
   } else {
     std::ofstream output_file(outfile, std::ios::app | std::ios::binary);
-    output_file << output << std::endl;
+    output_file << output << std::flush;
     output_file.close();
   }
   return true;


### PR DESCRIPTION
Currently the grpc_cli does not round-trip when using stdout or files:

`bazel build //test/cpp/util:grpc_cli && echo 'name: "my-name"' | bazel-bin/test/cpp/util/grpc_cli tobinary --proto_path examples/protos/ helloworld.proto helloworld.HelloRequest -outfile tmp.pb && grpc_cli totext --infile tmp.pb --proto_path examples/protos/ helloworld.proto helloworld.HelloRequest`

and 

`bazel build //test/cpp/util:grpc_cli && echo 'name: "my-name"' | bazel-bin/test/cpp/util/grpc_cli tobinary --proto_path examples/protos/ helloworld.proto helloworld.HelloRequest | grpc_cli totext --proto_path examples/protos/ helloworld.proto helloworld.HelloRequest`

both fail with:

```
Failed to deserialize proto.
Failed to deserialize the message.
```

This PR fixes this to correctly output:
```
name: "my-name"
```



<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
