### PR TITLE
doc/compression.md: Make it clear compression is per-RPC

### DIFF
--- a/doc/compression.md
+++ b/doc/compression.md
@@ -76,8 +76,8 @@ of _compression levels_ (such as "low", "medium", "high").
 Levels map to concrete algorithms and/or their settings (such as "low" mapping
 to "gzip -3" and "high" mapping to "gzip -9") automatically depending on what a
 peer is known to support. A server is always aware of what its clients support,
-as clients disclose it in their Message-Accept-Encoding header as part of their
-initial call. A client doesn't a priori (presently) know which algorithms a
+as clients disclose it in the Message-Accept-Encoding header as part of the
+RPC. A client doesn't a priori (presently) know which algorithms a
 server supports. This issue can be addressed with an initial negotiation of
 capabilities or an automatic retry mechanism. These features will be implemented
 in the future. Currently however, compression levels are only supported at the


### PR DESCRIPTION
"initial call" should not be understood as "initial call on the connection" but
"initial call of the RPC". All the data necessary for understanding client's
compression abilities is provided per-RPC, so no connection-level state should
be used. Using such state would break the use of proxies.