### PR TITLE
Make channel/rpc soak interop tests easier to debug

### DIFF
--- a/src/android/test/interop/app/CMakeLists.txt
+++ b/src/android/test/interop/app/CMakeLists.txt
@@ -110,7 +110,9 @@ add_library(grpc-interop
   SHARED
   src/main/cpp/grpc-interop.cc
   ${GRPC_SRC_DIR}/test/cpp/interop/interop_client.h
-  ${GRPC_SRC_DIR}/test/cpp/interop/interop_client.cc)
+  ${GRPC_SRC_DIR}/test/cpp/interop/interop_client.cc
+  ${GRPC_SRC_DIR}/test/core/util/histogram.h
+  ${GRPC_SRC_DIR}/test/core/util/histogram.cc)
 
 target_link_libraries(grpc-interop
   messages_proto_lib

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -94,7 +94,7 @@ DEFINE_int32(soak_max_failures, 0,
              "The number of iterations in soak tests that are allowed to fail "
              "(either due to non-OK status code or exceeding the "
              "per-iteration max acceptable latency).");
-DEFINE_int64(soak_per_iteration_max_acceptable_latency_ms, 0,
+DEFINE_int32(soak_per_iteration_max_acceptable_latency_ms, 0,
              "The number of milliseconds a single iteration in the two soak "
              "tests (rpc_soak and channel_soak) is allowed to take.");
 DEFINE_int32(iteration_interval, 10,

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -88,8 +88,15 @@ DEFINE_bool(do_not_abort_on_transient_failures, false,
             "test is retried in case of transient failures (and currently the "
             "interop tests are not retried even if this flag is set to true)");
 DEFINE_int32(soak_iterations, 1000,
-             "number of iterations to use for the two soak tests; rpc_soak and "
-             "channel_soak");
+             "The number of iterations to use for the two soak tests; rpc_soak "
+             "and channel_soak.");
+DEFINE_int32(soak_max_failures, 0,
+             "The number of iterations in soak tests that are allowed to fail "
+             "(either due to non-OK status code or exceeding the "
+             "per-iteration max acceptable latency).");
+DEFINE_int64(soak_per_iteration_max_acceptable_latency_ms, 0,
+             "The number of milliseconds a single iteration in the two soak "
+             "tests (rpc_soak and channel_soak) is allowed to take.");
 DEFINE_int32(iteration_interval, 10,
              "The interval in seconds between rpcs. This is used by "
              "long_connection test");
@@ -257,9 +264,12 @@ int main(int argc, char** argv) {
       std::bind(&grpc::testing::InteropClient::DoCacheableUnary, &client);
   actions["channel_soak"] =
       std::bind(&grpc::testing::InteropClient::DoChannelSoakTest, &client,
-                FLAGS_soak_iterations);
-  actions["rpc_soak"] = std::bind(&grpc::testing::InteropClient::DoRpcSoakTest,
-                                  &client, FLAGS_soak_iterations);
+                FLAGS_soak_iterations, FLAGS_soak_max_failures,
+                FLAGS_soak_per_iteration_max_acceptable_latency_ms);
+  actions["rpc_soak"] =
+      std::bind(&grpc::testing::InteropClient::DoRpcSoakTest, &client,
+                FLAGS_soak_iterations, FLAGS_soak_max_failures,
+                FLAGS_soak_per_iteration_max_acceptable_latency_ms);
   actions["long_lived_channel"] =
       std::bind(&grpc::testing::InteropClient::DoLongLivedChannelTest, &client,
                 FLAGS_soak_iterations, FLAGS_iteration_interval);

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -23,6 +23,7 @@
 
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/proto/grpc/testing/messages.pb.h"
 #include "src/proto/grpc/testing/test.grpc.pb.h"
 
@@ -76,8 +77,10 @@ class InteropClient {
   // not implemented cross-language. They are considered experimental for now,
   // but at some point in the future, might be codified and implemented in all
   // languages
-  bool DoChannelSoakTest(int32_t soak_iterations);
-  bool DoRpcSoakTest(int32_t soak_iterations);
+  bool DoChannelSoakTest(int32_t soak_iterations, int32_t max_failures,
+                         int64_t max_acceptable_per_iteration_latency_ms);
+  bool DoRpcSoakTest(int32_t soak_iterations, int32_t max_failures,
+                     int64_t max_acceptable_per_iteration_latency_ms);
   bool DoLongLivedChannelTest(int32_t soak_iterations,
                               int32_t iteration_interval);
 
@@ -127,6 +130,15 @@ class InteropClient {
   bool AssertStatusCode(const Status& s, StatusCode expected_code,
                         const grpc::string& optional_debug_string);
   bool TransientFailureOrAbort();
+
+  std::tuple<bool, grpc_millis, std::string> PerformOneSoakTestIteration(
+      const bool reset_channel,
+      const int64_t max_acceptable_per_iteration_latency_ms);
+
+  void PerformSoakTest(const bool reset_channel_per_iteration,
+                       const int32_t soak_iterations,
+                       const int32_t max_failures,
+                       const int64_t max_acceptable_per_iteration_latency_ms);
 
   ServiceStub serviceStub_;
   /// If true, abort() is not called for transient failures

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -23,7 +23,6 @@
 
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
-#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/proto/grpc/testing/messages.pb.h"
 #include "src/proto/grpc/testing/test.grpc.pb.h"
 
@@ -131,14 +130,14 @@ class InteropClient {
                         const grpc::string& optional_debug_string);
   bool TransientFailureOrAbort();
 
-  std::tuple<bool, grpc_millis, std::string> PerformOneSoakTestIteration(
+  std::tuple<bool, int32_t, std::string> PerformOneSoakTestIteration(
       const bool reset_channel,
-      const int64_t max_acceptable_per_iteration_latency_ms);
+      const int32_t max_acceptable_per_iteration_latency_ms);
 
   void PerformSoakTest(const bool reset_channel_per_iteration,
                        const int32_t soak_iterations,
                        const int32_t max_failures,
-                       const int64_t max_acceptable_per_iteration_latency_ms);
+                       const int32_t max_acceptable_per_iteration_latency_ms);
 
   ServiceStub serviceStub_;
   /// If true, abort() is not called for transient failures


### PR DESCRIPTION
Add "max acceptable failures" and "max acceptable latency per iteration ms" options.

This test is ran continuously in an external test runner.

Currently, if there's ever a failure, it manifests as a timeout of the entire test, which can be hard to debug.

I plan to use these options to instead make it so that the test itself never times out, but sometimes fails if X number of iterations of these tests result in failures and/or latency higher than a threshold Y, which should result in more information upon failures.

