### PR TITLE
Fix C++ cleanup in Grpc.Tools

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -100,6 +100,7 @@
           Condition=" '@(Protobuf)' != '' "
           DependsOnTargets=" Protobuf_BeforeCompile;
                              Protobuf_ResolvePlatform;
+                             _Protobuf_SetProtoRoot;
                              _Protobuf_SelectFiles;
                              Protobuf_PrepareCompile;
                              _Protobuf_AugmentLanguageCompile;
@@ -115,27 +116,33 @@
           DependsOnTargets="Protobuf_Compile"
           Condition=" '$(Language)' == 'C#' " />
 
-  <Target Name="_Protobuf_SelectFiles">
+  <Target Name="_Protobuf_SetProtoRoot">
     <!-- Guess .proto root for the files. Whenever the root is set for a file explicitly,
          leave it as is. Otherwise, for files under the project directory, set the root
          to "." for the project's directory, as it is the current when compiling; for the
-         files outside of project directory, use each .proto file's directory as the root. -->
+         files outside of project directory, use each .proto file's directory as the root 
+		 or Protobuf_ProtoRoot if set. -->
     <FindUnderPath Path="$(MSBuildProjectDirectory)"
                    Files="@(Protobuf->WithMetadataValue('ProtoRoot',''))">
       <Output TaskParameter="InPath" ItemName="_Protobuf_NoRootInProject"/>
       <Output TaskParameter="OutOfPath" ItemName="_Protobuf_NoRootElsewhere"/>
     </FindUnderPath>
+	
+    <ItemGroup>
+      <Protobuf>
+		<!-- In-project files will have ProtoRoot='.'. -->
+        <ProtoRoot Condition=" '%(ProtoRoot)' == '' and '@(_Protobuf_NoRootInProject)' != '' ">.</ProtoRoot>
+		<!-- Out-of-project files will have respective ProtoRoot='%(RelativeDir)'. -->
+        <ProtoRoot Condition=" '%(ProtoRoot)' == '' and '@(_Protobuf_NoRootElsewhere)' != '' ">%(RelativeDir)</ProtoRoot>
+      </Protobuf>
+    </ItemGroup>
+  </Target>
+
+  <!-- Select files that should be compiled. -->
+  <Target Name="_Protobuf_SelectFiles">
     <ItemGroup>
       <!-- Files with explicit metadata. -->
-      <Protobuf_Compile Include="@(Protobuf->HasMetadata('ProtoRoot'))" />
-      <!-- In-project files will have ProtoRoot='.'. -->
-      <Protobuf_Compile Include="@(_Protobuf_NoRootInProject)">
-        <ProtoRoot>.</ProtoRoot>
-      </Protobuf_Compile>
-      <!-- Out-of-project files will have respective ProtoRoot='%(RelativeDir)'. -->
-      <Protobuf_Compile Include="@(_Protobuf_NoRootElsewhere)">
-        <ProtoRoot>%(RelativeDir)</ProtoRoot>
-      </Protobuf_Compile>
+      <Protobuf_Compile Include="@(Protobuf)" />
       <!-- Remove files not for compile. -->
       <Protobuf_Compile Remove="@(Protobuf_Compile)" Condition=" '%(ProtoCompile)' != 'true' " />
       <!-- Ensure invariant Source=%(Identity). -->
@@ -329,6 +336,7 @@
   <Target Name="Protobuf_Clean"
           Condition=" '@(Protobuf)' != '' "
           DependsOnTargets=" Protobuf_BeforeClean;
+                             _Protobuf_SetProtoRoot;
                              Protobuf_PrepareClean;
                              _Protobuf_CoreClean;
                              Protobuf_AfterClean" />

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -100,7 +100,6 @@
           Condition=" '@(Protobuf)' != '' "
           DependsOnTargets=" Protobuf_BeforeCompile;
                              Protobuf_ResolvePlatform;
-                             _Protobuf_SetProtoRoot;
                              _Protobuf_SelectFiles;
                              Protobuf_PrepareCompile;
                              _Protobuf_AugmentLanguageCompile;
@@ -141,7 +140,8 @@
   </Target>
 
   <!-- Select files that should be compiled. -->
-  <Target Name="_Protobuf_SelectFiles">
+  <Target Name="_Protobuf_SelectFiles"
+          DependsOnTargets=" _Protobuf_SetProtoRoot">
     <ItemGroup>
       <!-- Files with explicit metadata. -->
       <Protobuf_Compile Include="@(Protobuf_Rooted)" />

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -120,21 +120,23 @@
     <!-- Guess .proto root for the files. Whenever the root is set for a file explicitly,
          leave it as is. Otherwise, for files under the project directory, set the root
          to "." for the project's directory, as it is the current when compiling; for the
-         files outside of project directory, use each .proto file's directory as the root 
-		 or Protobuf_ProtoRoot if set. -->
+         files outside of project directory, use each .proto file's directory as the root. -->
     <FindUnderPath Path="$(MSBuildProjectDirectory)"
                    Files="@(Protobuf->WithMetadataValue('ProtoRoot',''))">
       <Output TaskParameter="InPath" ItemName="_Protobuf_NoRootInProject"/>
       <Output TaskParameter="OutOfPath" ItemName="_Protobuf_NoRootElsewhere"/>
     </FindUnderPath>
-	
     <ItemGroup>
-      <Protobuf>
-		<!-- In-project files will have ProtoRoot='.'. -->
-        <ProtoRoot Condition=" '%(ProtoRoot)' == '' and '@(_Protobuf_NoRootInProject)' != '' ">.</ProtoRoot>
-		<!-- Out-of-project files will have respective ProtoRoot='%(RelativeDir)'. -->
-        <ProtoRoot Condition=" '%(ProtoRoot)' == '' and '@(_Protobuf_NoRootElsewhere)' != '' ">%(RelativeDir)</ProtoRoot>
-      </Protobuf>
+      <!-- Files with explicit metadata. -->
+      <Protobuf_Rooted Include="@(Protobuf->HasMetadata('ProtoRoot'))" />
+      <!-- In-project files will have ProtoRoot='.'. -->
+      <Protobuf_Rooted Include="@(_Protobuf_NoRootInProject)">
+        <ProtoRoot>.</ProtoRoot>
+      </Protobuf_Rooted>
+      <!-- Out-of-project files will have respective ProtoRoot='%(RelativeDir)'. -->
+      <Protobuf_Rooted Include="@(_Protobuf_NoRootElsewhere)">
+        <ProtoRoot>%(RelativeDir)</ProtoRoot>
+      </Protobuf_Rooted>
     </ItemGroup>
   </Target>
 
@@ -142,7 +144,7 @@
   <Target Name="_Protobuf_SelectFiles">
     <ItemGroup>
       <!-- Files with explicit metadata. -->
-      <Protobuf_Compile Include="@(Protobuf)" />
+      <Protobuf_Compile Include="@(Protobuf_Rooted)" />
       <!-- Remove files not for compile. -->
       <Protobuf_Compile Remove="@(Protobuf_Compile)" Condition=" '%(ProtoCompile)' != 'true' " />
       <!-- Ensure invariant Source=%(Identity). -->
@@ -354,15 +356,15 @@
        Protobuf_ExpectedOutputs with all possible output. An option is to include
        all existing outputs using Include with a wildcard, if you know where to look.
 
-       Note this is like Protobuf_PrepareCompile, but uses @(Protobuf) regardless
+       Note this is like Protobuf_PrepareCompile, but uses @(Protobuf_Rooted) regardless
        of the Compile metadata, to remove all possible outputs. Plugins should err
        on the side of overextending the Protobuf_ExpectedOutputs here.
 
        All ExpectedOutputs will be removed. -->
-  <Target Name="Protobuf_PrepareClean" Condition=" '@(Protobuf)' != '' ">
+  <Target Name="Protobuf_PrepareClean" Condition=" '@(Protobuf_Rooted)' != '' ">
     <!-- Predict expected names. -->
     <ProtoCompilerOutputs Condition=" '$(Language)' == 'C#' "
-                          Protobuf="@(Protobuf)"
+                          Protobuf="@(Protobuf_Rooted)"
                           Generator="$(Protobuf_Generator)">
       <Output TaskParameter="PossibleOutputs" ItemName="Protobuf_ExpectedOutputs" />
     </ProtoCompilerOutputs>


### PR DESCRIPTION
The result of `Protobuf_ExpectedOutputs` in `Protobuf_PrepareClean` and `Protobuf_PrepareCompile` is different for out-of-path protos if no `ProtoRoot` was given.

This is, because `_Protobuf_SelectFiles` is setting `ProtoRoot=%(RelativeDir)` when building, but this is not set when cleaning up.

This PR extracts the logic of settings the `ProtoRoot` from `_Protobuf_SelectFiles` into `_Protobuf_SetProtoRoot` and ensures, that the same files are expected for creation and cleanup. Since we are not filling a new item group but updating an existing one, we had to use update logic instead of include logic. Otherwise we would end up with `Protobuf` having the same item twice, once without `ProtoRoot` and once with the set `ProtoRoot`.

CC @jtattermusch @kkm000 