### PR TITLE
tools/dockerfile: Cache Java downloads to reduce flakiness

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile.include
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile.include
@@ -17,8 +17,16 @@
 RUN echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list && ${'\\'}
     echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until && ${'\\'}
     apt-get update && ${'\\'}
+    apt-get install -y --no-install-recommends curl && ${'\\'}
     apt-get install -y --no-install-recommends -t jessie-backports openjdk-8-jdk-headless && ${'\\'}
     apt-get clean
+
+# Trigger download of as many artifacts as possible, to reduce download
+# flakiness rate. https://github.com/grpc/grpc/issues/18892
+RUN curl -L https://github.com/grpc/grpc-java/archive/master.tar.gz | tar xzp && ${'\\'}
+    cd grpc-java-master && ${'\\'}
+    ./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true && ${'\\'}
+    rm -r "$(pwd)"
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile
@@ -18,8 +18,16 @@ FROM debian:jessie
 RUN echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list && \
     echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until && \
     apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
     apt-get install -y --no-install-recommends -t jessie-backports openjdk-8-jdk-headless && \
     apt-get clean
+
+# Trigger download of as many artifacts as possible, to reduce download
+# flakiness rate. https://github.com/grpc/grpc/issues/18892
+RUN curl -L https://github.com/grpc/grpc-java/archive/master.tar.gz | tar xzp && \
+    cd grpc-java-master && \
+    ./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true && \
+    rm -r "$(pwd)"
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Pre-running the build will save artifacts in ~/.gradle which can be
reused for the real build. This reduces our reliance on build-time
downloads which hopefully reduces flakiness rate.

This increases the container size by ~300 MB.

Fixes #18892