### PR TITLE
PHP: ignore-valgrind-undef-errors from php7.3

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -29,7 +29,8 @@ for arg in "$@"
 do
   if [[ "$arg" == "--skip-persistent-channel-tests" ]]; then
     SKIP_PERSISTENT_CHANNEL_TESTS=true
-    break
+  elif [[ "$arg" == "--ignore-valgrind-undef-errors" ]]; then
+    VALGRIND_UNDEF_VALUE_ERRORS="--undef-value-errors=no"
   fi
 done
 
@@ -43,6 +44,7 @@ export USE_ZEND_ALLOC=0
 # Detect whether valgrind is executable
 if [ -x "$(command -v valgrind)" ]; then
   $(which valgrind) --error-exitcode=10 --leak-check=yes \
+    $VALGRIND_UNDEF_VALUE_ERRORS \
     $(which php) $extension_dir -d max_execution_time=300 \
     ../tests/MemoryLeakTest/MemoryLeakTest.php
 fi

--- a/src/php/docker/php-future/Dockerfile
+++ b/src/php/docker/php-future/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7.4.0RC1-buster
+FROM php:7.4.5-buster
 
 RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \
-  wget zlib1g-dev
+  valgrind wget zlib1g-dev
 
 ARG MAKEFLAGS=-j8
 
@@ -36,4 +36,4 @@ RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}
 
 
-CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests", "--ignore-valgrind-undef-errors"]

--- a/templates/src/php/docker/php-future/Dockerfile.template
+++ b/templates/src/php/docker/php-future/Dockerfile.template
@@ -14,11 +14,11 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM php:7.4.0RC1-buster
+  FROM php:7.4.5-buster
 
   RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
     autoconf automake git libtool pkg-config ${'\\'}
-    wget zlib1g-dev
+    valgrind wget zlib1g-dev
 
   ARG MAKEFLAGS=-j8
 
@@ -29,4 +29,4 @@
 
   <%include file="../pecl_ext_build_src.include" />
 
-  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests", "--ignore-valgrind-undef-errors"]


### PR DESCRIPTION
In PHP 7.3/7.4, our valgrind tests are giving a bunch of these errors (like 335 of them), all on the same PHP internal function

```
Conditional jump or move depends on uninitialised value(s)
==29==    at 0x62DE72: zend_string_equal_val (in /usr/local/bin/php)
```

Some research like https://bugs.php.net/bug.php?id=76445 indicated that we need to suppress those. 