### PR TITLE
Moved GRPCTypes into its own grpc_objc_library.

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -66,7 +66,8 @@ Pod::Spec.new do |s|
                       "src/objective-c/GRPCClient/GRPCCall+OAuth2.h",
                       "src/objective-c/GRPCClient/GRPCCall+Tests.h",
                       "src/objective-c/GRPCClient/GRPCCallLegacy.h",
-                      "src/objective-c/GRPCClient/GRPCTypes.h"
+                      "src/objective-c/GRPCClient/GRPCTypes.h",
+                      "src/objective-c/GRPCClient/GRPCTypes.m"
     ss.dependency "gRPC-RxLibrary/Interface", version
 
     ss.ios.deployment_target = '7.0'

--- a/src/objective-c/BUILD
+++ b/src/objective-c/BUILD
@@ -64,10 +64,20 @@ grpc_objc_library(
         "GRPCClient/GRPCCall+OAuth2.h",
         "GRPCClient/GRPCCall+Tests.h",
         "GRPCClient/GRPCCallLegacy.h",
-        "GRPCClient/GRPCTypes.h",
     ],
     deps = [
-        "rx_library_headers",
+        ":grpc_objc_interface_types",
+        ":rx_library_headers",
+    ],
+)
+
+grpc_objc_library(
+    name = "grpc_objc_interface_types",
+    srcs = [
+        "GRPCClient/GRPCTypes.m",
+    ],
+    hdrs = [
+        "GRPCClient/GRPCTypes.h",
     ],
 )
 

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -25,11 +25,6 @@
 #import "GRPCTransport.h"
 #import "private/GRPCTransport+Private.h"
 
-NSString *const kGRPCHeadersKey = @"io.grpc.HeadersKey";
-NSString *const kGRPCTrailersKey = @"io.grpc.TrailersKey";
-
-NSString *const kGRPCErrorDomain = @"io.grpc";
-
 /**
  * The response dispatcher creates its own serial dispatch queue and target the queue to the
  * dispatch queue of a user provided response handler. It removes the requirement of having to use

--- a/src/objective-c/GRPCClient/GRPCTypes.h
+++ b/src/objective-c/GRPCClient/GRPCTypes.h
@@ -16,6 +16,8 @@
  *
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * gRPC error codes.
  * Note that a few of these are never produced by the gRPC libraries, but are of

--- a/src/objective-c/GRPCClient/GRPCTypes.m
+++ b/src/objective-c/GRPCClient/GRPCTypes.m
@@ -1,0 +1,24 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import "GRPCTypes.h"
+
+NSString *const kGRPCHeadersKey = @"io.grpc.HeadersKey";
+NSString *const kGRPCTrailersKey = @"io.grpc.TrailersKey";
+
+NSString *const kGRPCErrorDomain = @"io.grpc";

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -68,7 +68,8 @@
                         "src/objective-c/GRPCClient/GRPCCall+OAuth2.h",
                         "src/objective-c/GRPCClient/GRPCCall+Tests.h",
                         "src/objective-c/GRPCClient/GRPCCallLegacy.h",
-                        "src/objective-c/GRPCClient/GRPCTypes.h"
+                        "src/objective-c/GRPCClient/GRPCTypes.h",
+                        "src/objective-c/GRPCClient/GRPCTypes.m"
       ss.dependency "gRPC-RxLibrary/Interface", version
 
       ss.ios.deployment_target = '7.0'


### PR DESCRIPTION
Hi @muxi 

Moving `GRPCTypes` into its own library will help improve [build performance](https://docs.bazel.build/versions/master/best-practices.html) by reducing the number of dependencies needed by build targets that handle `NSErrors` reported by GRPC.
