### PR TITLE
Convert hash to keyword arguments for ruby 2.7

### DIFF
--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -167,22 +167,22 @@ module GRPC
             if desc.request_response?
               define_method(mth_name) do |req, metadata = {}|
                 GRPC.logger.debug("calling #{@host}:#{route}")
-                request_response(route, req, marshal, unmarshal, metadata)
+                request_response(route, req, marshal, unmarshal, **metadata)
               end
             elsif desc.client_streamer?
               define_method(mth_name) do |reqs, metadata = {}|
                 GRPC.logger.debug("calling #{@host}:#{route}")
-                client_streamer(route, reqs, marshal, unmarshal, metadata)
+                client_streamer(route, reqs, marshal, unmarshal, **metadata)
               end
             elsif desc.server_streamer?
               define_method(mth_name) do |req, metadata = {}, &blk|
                 GRPC.logger.debug("calling #{@host}:#{route}")
-                server_streamer(route, req, marshal, unmarshal, metadata, &blk)
+                server_streamer(route, req, marshal, unmarshal, **metadata, &blk)
               end
             else  # is a bidi_stream
               define_method(mth_name) do |reqs, metadata = {}, &blk|
                 GRPC.logger.debug("calling #{@host}:#{route}")
-                bidi_streamer(route, reqs, marshal, unmarshal, metadata, &blk)
+                bidi_streamer(route, reqs, marshal, unmarshal, **metadata, &blk)
               end
             end
           end


### PR DESCRIPTION
Ruby 2.7 deprecated passing a hash as the last argument for a method that takes keyword params. This commit coverts the hash explicitly to keyword args using the double splat.


```
grpc-1.28.0-universal-darwin/src/ruby/lib/grpc/generic/service.rb:170: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
