### PR TITLE
tools/dockerfile: Run Java build twice to reduce flakiness

### DIFF
--- a/templates/tools/dockerfile/java_build_interop.sh.include
+++ b/templates/tools/dockerfile/java_build_interop.sh.include
@@ -22,7 +22,9 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 cp -r /var/local/jenkins/service_account $HOME || true
 
 pushd /tmp/grpc-java
-./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true
+# make two attempts; downloads can fail. See https://github.com/grpc/grpc/issues/18892
+./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true || ${'\\'}
+    ./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true
 
 mkdir -p /var/local/git/grpc-java/
 cp -r --parents -t /var/local/git/grpc-java/ ${'\\'}

--- a/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
@@ -22,7 +22,9 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 cp -r /var/local/jenkins/service_account $HOME || true
 
 pushd /tmp/grpc-java
-./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true
+# make two attempts; downloads can fail. See https://github.com/grpc/grpc/issues/18892
+./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true || \
+    ./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true
 
 mkdir -p /var/local/git/grpc-java/
 cp -r --parents -t /var/local/git/grpc-java/ \


### PR DESCRIPTION
Downloads fail from time to time because Gradle does not retry certain
types of network failures
(https://github.com/gradle/gradle/issues/8264).

Retrying twice should reduce the flake rate below noticeable without
increasing the size of the interop image created for each new release
for historical testing.

Fixes #18892

-----

I'm doing this version in favor of https://github.com/grpc/grpc/pull/22902 to avoid increasing the size of the release interop images, which have a long lifetime.