### PR TITLE
Fix build in c++2a mode

### DIFF
--- a/src/core/lib/gprpp/atomic.h
+++ b/src/core/lib/gprpp/atomic.h
@@ -28,12 +28,12 @@
 namespace grpc_core {
 
 enum class MemoryOrder {
-  RELAXED = std::memory_order_relaxed,
-  CONSUME = std::memory_order_consume,
-  ACQUIRE = std::memory_order_acquire,
-  RELEASE = std::memory_order_release,
-  ACQ_REL = std::memory_order_acq_rel,
-  SEQ_CST = std::memory_order_seq_cst
+  RELAXED = static_cast<int>(std::memory_order_relaxed),
+  CONSUME = static_cast<int>(std::memory_order_consume),
+  ACQUIRE = static_cast<int>(std::memory_order_acquire),
+  RELEASE = static_cast<int>(std::memory_order_release),
+  ACQ_REL = static_cast<int>(std::memory_order_acq_rel),
+  SEQ_CST = static_cast<int>(std::memory_order_seq_cst)
 };
 
 template <typename T>


### PR DESCRIPTION
This is dup of #21750 to work around the EasyCLA problem which made the original PR stuck forever.