### PR TITLE
xds: Put channel in TRANSIENT_FAILURE when CDS resource is removed.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
@@ -342,20 +342,15 @@ class EdsLb::EndpointWatcher : public XdsClient::EndpointWatcherInterface {
   }
 
   void OnResourceDoesNotExist() override {
-    gpr_log(GPR_ERROR, "[edslb %p] EDS resource does not exist",
-            eds_policy_.get());
-    // Go into TRANSIENT_FAILURE if we have not yet created the child
-    // policy (i.e., we have not yet received data from xds).  Otherwise,
-    // we keep running with the data we had previously.
-    // TODO(roth): Once traffic splitting is implemented, this should be
-    // fixed to report TRANSIENT_FAILURE unconditionally.
-    if (eds_policy_->child_policy_ == nullptr) {
-      eds_policy_->channel_control_helper()->UpdateState(
-          GRPC_CHANNEL_TRANSIENT_FAILURE,
-          absl::make_unique<TransientFailurePicker>(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                  "EDS resource does not exist")));
-    }
+    gpr_log(
+        GPR_ERROR,
+        "[edslb %p] EDS resource does not exist -- reporting TRANSIENT_FAILURE",
+        eds_policy_.get());
+    eds_policy_->channel_control_helper()->UpdateState(
+        GRPC_CHANNEL_TRANSIENT_FAILURE,
+        absl::make_unique<TransientFailurePicker>(
+            GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+                "EDS resource does not exist")));
   }
 
  private:


### PR DESCRIPTION
I've also changed the EDS policy to do the same thing, but in practice that code path will never get triggered, because the SotW variant of the xDS protocol (which is the only variant we currently support) does not actually have a way to delete the EDS resource without deleting the CDS resource.  But this will be possible when we eventually add support for the incremental variant of the xDS protocol, so it seems better to handle this case correctly now, so that we don't forget about it later.

I won't merge this until WeightedClusters support is merged.