### PR TITLE
Fix for helloworld external project example

### DIFF
--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -54,7 +54,8 @@ ExternalProject_Add(c-ares
 # Builds protobuf project from the git submodule.
 ExternalProject_Add(protobuf
   PREFIX protobuf
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../third_party/protobuf/cmake"
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../third_party/protobuf"
+  SOURCE_SUBDIR cmake
   CMAKE_CACHE_ARGS
         -Dprotobuf_BUILD_TESTS:BOOL=OFF
         -Dprotobuf_WITH_ZLIB:BOOL=OFF


### PR DESCRIPTION
Fixes #22037 : Fix cmake file for helloworld external project example
- Downloads protobuf dependency in the correct directory




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
