### PR TITLE
Simplify running of C# RouteGuide example

### DIFF
--- a/examples/csharp/RouteGuide/RouteGuide/RouteGuide.csproj
+++ b/examples/csharp/RouteGuide/RouteGuide/RouteGuide.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="route_guide_db.json" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="route_guide_db.json" />
   </ItemGroup>
 
 </Project>

--- a/examples/csharp/RouteGuide/RouteGuide/RouteGuideUtil.cs
+++ b/examples/csharp/RouteGuide/RouteGuide/RouteGuideUtil.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -28,7 +29,7 @@ namespace Routeguide
     /// </summary>
     public static class RouteGuideUtil
     {
-        public const string DefaultFeaturesFile = "route_guide_db.json";
+        public const string DefaultFeaturesResourceName = "RouteGuide.route_guide_db.json";
 
         private const double CoordFactor = 1e7;
 
@@ -90,12 +91,12 @@ namespace Routeguide
         }
 
         /// <summary>
-        /// Parses features from a JSON file.
+        /// Parses features from an embedded resource.
         /// </summary>
-        public static List<Feature> ParseFeatures(string filename)
+        public static List<Feature> LoadFeatures()
         {
             var features = new List<Feature>();
-            var jsonFeatures = JsonConvert.DeserializeObject<List<JsonFeature>>(File.ReadAllText(filename));
+            var jsonFeatures = JsonConvert.DeserializeObject<List<JsonFeature>>(ReadFeaturesFromResource());
 
             foreach(var jsonFeature in jsonFeatures)
             {
@@ -106,6 +107,19 @@ namespace Routeguide
                 });
             }
             return features;
+        }
+
+        private static string ReadFeaturesFromResource()
+        {
+            var stream = typeof(RouteGuideUtil).GetTypeInfo().Assembly.GetManifestResourceStream(DefaultFeaturesResourceName);
+            if (stream == null)
+            {
+                throw new IOException(string.Format("Error loading the embedded resource \"{0}\"", DefaultFeaturesResourceName));
+            }
+            using (var streamReader = new StreamReader(stream))
+            {
+                return streamReader.ReadToEnd();
+            }
         }
 
 #pragma warning disable 0649  // Suppresses "Field 'x' is never assigned to".

--- a/examples/csharp/RouteGuide/RouteGuideClient/Program.cs
+++ b/examples/csharp/RouteGuide/RouteGuideClient/Program.cs
@@ -228,7 +228,7 @@ namespace Routeguide
             client.ListFeatures(400000000, -750000000, 420000000, -730000000).Wait();
 
             // Record a few randomly selected points from the features file.
-            client.RecordRoute(RouteGuideUtil.ParseFeatures(RouteGuideUtil.DefaultFeaturesFile), 10).Wait();
+            client.RecordRoute(RouteGuideUtil.LoadFeatures(), 10).Wait();
 
             // Send and receive some notes.
             client.RouteChat().Wait();

--- a/examples/csharp/RouteGuide/RouteGuideServer/Program.cs
+++ b/examples/csharp/RouteGuide/RouteGuideServer/Program.cs
@@ -27,7 +27,7 @@ namespace Routeguide
         {
             const int Port = 50052;
 
-            var features = RouteGuideUtil.ParseFeatures(RouteGuideUtil.DefaultFeaturesFile);
+            var features = RouteGuideUtil.LoadFeatures();
 
             Server server = new Server
             {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/22157

currently one needs to do 
```
cd RouteGuideServer/bin/Debug/netcoreapp2.1
dotnet exec RouteGuideServer.dll
```
instead of just simple `dotnet run` to run the example.
It's because the way we load the .json file with resources.

After this PR is merged and released, we can update the routeguide example on grpc.io to just say `dotnet run`