### PR TITLE
Revert "Include source address in tcp posix async connect errors"

### DIFF
--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -91,8 +91,6 @@ static const char* error_str_name(grpc_error_strs key) {
       return "description";
     case GRPC_ERROR_STR_OS_ERROR:
       return "os_error";
-    case GRPC_ERROR_STR_SOURCE_ADDRESS:
-      return "source_address";
     case GRPC_ERROR_STR_TARGET_ADDRESS:
       return "target_address";
     case GRPC_ERROR_STR_SYSCALL:

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -88,8 +88,6 @@ typedef enum {
   GRPC_ERROR_STR_OS_ERROR,
   /// syscall that generated this error
   GRPC_ERROR_STR_SYSCALL,
-  /// source address of the socket associated with this error
-  GRPC_ERROR_STR_SOURCE_ADDRESS,
   /// peer that we were trying to communicate when this error occurred
   GRPC_ERROR_STR_TARGET_ADDRESS,
   /// grpc status message associated with this error

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -294,14 +294,11 @@ static char* extract_source_ip(int fd) {
   resolved_address.len = sizeof(resolved_address.addr);
   char* out = nullptr;
   if (getsockname(fd, reinterpret_cast<grpc_sockaddr*>(&resolved_address.addr),
-                  &resolved_address.len) != -1) {
-    std::string result =
-        grpc_sockaddr_to_string(&resolved_address, false /* normalize */);
-    out = gpr_strdup(result.c_str());
-  } else {
+                  &resolved_address.len) == -1 ||
+      grpc_sockaddr_to_string(&out, &resolved_address, false /* normalize */) ==
+          -1) {
     gpr_log(GPR_INFO,
-            "source address will be missing from logs and errors. gotsockname "
-            "errno: %d",
+            "source address will be missing from logs and errors. errno: %d",
             errno);
     out = gpr_strdup("source_address_extraction_failed");
   }


### PR DESCRIPTION
Reverts #22802

@muxi pointed out that this is making client_lb_end2end_test's flakey on a TSAN issue:

```
I0512 17:49:48.166977706      69 subchannel.cc:1033]         Connect failed: {"created":"@1589305788.166486030","description":"Failed to connect to remote host: Connection refused","errno":111,"file":"src/core/lib/iomgr/tcp_client_posix.cc","file_line":204,"os_error":"Connection refused","source_address":"[::ffff:127.0.0.1]:46276","syscall":"connect","target_address":"ipv4:127.0.0.1:16254"}
==================
WARNING: ThreadSanitizer: data race (pid=17)
  Write of size 8 at 0x7b0800007440 by thread T14:
    #0 free /tmp/clang-build/src/compiler-rt/lib/tsan/rtl/tsan_interceptors.cpp:706:3 (client_lb_end2end_test+0x49e108)
    #1 gpr_free /proc/self/cwd/src/core/lib/gpr/alloc.cc:52:3 (liblibgpr_Ubase.so+0x9e9d)
    #2 tc_on_alarm(void*, grpc_error*) /proc/self/cwd/src/core/lib/iomgr/tcp_client_posix.cc:120:5 (liblibgrpc_Ubase_Uc.so+0x13bd83)
    #3 exec_ctx_run(grpc_closure*, grpc_error*) /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:40:3 (liblibgrpc_Ubase_Uc.so+0x11df87)
    #4 grpc_core::ExecCtx::Flush() /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:153:9 (liblibgrpc_Ubase_Uc.so+0x11dcce)
    #5 run_some_timers() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:134:30 (liblibgrpc_Ubase_Uc.so+0x15fb37)
    #6 timer_main_loop() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:237:9 (liblibgrpc_Ubase_Uc.so+0x15f753)
    #7 timer_thread(void*) /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:284:3 (liblibgrpc_Ubase_Uc.so+0x15f64a)
    #8 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:140:27 (liblibgpr_Ubase.so+0x17c0e)
    #9 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:110:25 (liblibgpr_Ubase.so+0x17a08)

  Previous read of size 8 at 0x7b0800007440 by thread T15:
    #0 strlen /tmp/clang-build/src/compiler-rt/lib/tsan/../sanitizer_common/sanitizer_common_interceptors.inc:362:3 (client_lb_end2end_test+0x4a6e0d)
    #1 grpc_slice_from_copied_string /proc/self/cwd/src/core/lib/slice/slice.cc:210:50 (liblibgrpc_Ubase_Uc.so+0x177327)
    #2 on_writable(void*, grpc_error*) /proc/self/cwd/src/core/lib/iomgr/tcp_client_posix.cc:239:9 (liblibgrpc_Ubase_Uc.so+0x13b90f)
    #3 exec_ctx_run(grpc_closure*, grpc_error*) /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:40:3 (liblibgrpc_Ubase_Uc.so+0x11df87)
    #4 grpc_core::ExecCtx::Flush() /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:153:9 (liblibgrpc_Ubase_Uc.so+0x11dcce)
    #5 run_some_timers() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:134:30 (liblibgrpc_Ubase_Uc.so+0x15fb37)
    #6 timer_main_loop() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:237:9 (liblibgrpc_Ubase_Uc.so+0x15f753)
    #7 timer_thread(void*) /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:284:3 (liblibgrpc_Ubase_Uc.so+0x15f64a)
    #8 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:140:27 (liblibgpr_Ubase.so+0x17c0e)
    #9 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:110:25 (liblibgpr_Ubase.so+0x17a08)

  Thread T14 'grpc_global_tim' (tid=68, running) created by main thread at:
    #0 pthread_create /tmp/clang-build/src/compiler-rt/lib/tsan/rtl/tsan_interceptors.cpp:967:3 (client_lb_end2end_test+0x49f39b)
    #1 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:109:10 (liblibgpr_Ubase.so+0x17570)
    #2 grpc_core::Thread::Thread(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:186:15 (liblibgpr_Ubase.so+0x16e36)
    #3 start_timer_thread_and_unlock() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:92:13 (liblibgrpc_Ubase_Uc.so+0x15f583)
    #4 start_threads() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:293:5 (liblibgrpc_Ubase_Uc.so+0x15efc2)
    #5 grpc_timer_manager_init() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:311:3 (liblibgrpc_Ubase_Uc.so+0x15ef3e)
    #6 grpc_iomgr_start() /proc/self/cwd/src/core/lib/iomgr/iomgr.cc:69:27 (liblibgrpc_Ubase_Uc.so+0x126e05)
    #7 grpc_init /proc/self/cwd/src/core/lib/surface/init.cc:162:5 (liblibgrpc.so+0x47aa)
    #8 grpc::internal::GrpcLibrary::init() /proc/self/cwd/include/grpcpp/impl/grpc_library.h:34:26 (liblibgrpc++.so+0x3b254)
    #9 grpc::GrpcLibraryCodegen::GrpcLibraryCodegen(bool) /proc/self/cwd/external/com_github_grpc_grpc/include/grpcpp/impl/codegen/grpc_library.h:45:15 (libsrc_Sproto_Sgrpc_Stesting_Slibecho_Uproto.so+0xa8a15)
    #10 grpc_impl::ChannelCredentials::ChannelCredentials() /proc/self/cwd/src/cpp/client/credentials_cc.cc:25:21 (liblibgrpc++_Ubase.so+0xdf1b4)
    #11 grpc_impl::SecureChannelCredentials::SecureChannelCredentials(grpc_channel_credentials*) /proc/self/cwd/src/cpp/client/secure_credentials.cc:44:27 (liblibgrpc++.so+0x33c8b)
    #12 grpc::testing::(anonymous namespace)::ClientLbEnd2endTest::ClientLbEnd2endTest() /proc/self/cwd/test/cpp/end2end/client_lb_end2end_test.cc:217:20 (client_lb_end2end_test+0x50fed7)
    #13 grpc::testing::(anonymous namespace)::ClientLbEnd2endTest_PickFirstBackOffMinReconnect_Test::ClientLbEnd2endTest_PickFirstBackOffMinReconnect_Test() /proc/self/cwd/test/cpp/end2end/client_lb_end2end_test.cc:583:1 (client_lb_end2end_test+0x51d68f)
    #14 testing::internal::TestFactoryImpl<grpc::testing::(anonymous namespace)::ClientLbEnd2endTest_PickFirstBackOffMinReconnect_Test>::CreateTest() /proc/self/cwd/external/com_github_google_googletest/googletest/include/gtest/internal/gtest-internal.h:460:44 (client_lb_end2end_test+0x51d5f3)
    #15 testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:2439:10 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0x124a0c)
    #16 testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:2475:14 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0x107687)
    #17 testing::TestInfo::Run() /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:2680:22 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0xe7ee5)
    #18 testing::TestSuite::Run() /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:2822:28 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0xe8a1a)
    #19 testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:5342:44 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0xfc2db)
    #20 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:2439:10 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0x12afdc)
    #21 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:2475:14 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0x10af67)
    #22 testing::UnitTest::Run() /proc/self/cwd/external/com_github_google_googletest/googletest/src/gtest.cc:4930:10 (libexternal_Scom_Ugithub_Ugoogle_Ugoogletest_Slibgtest.so+0xfbb0e)
    #23 RUN_ALL_TESTS() /proc/self/cwd/external/com_github_google_googletest/googletest/include/gtest/gtest.h:2472:46 (client_lb_end2end_test+0x544617)
    #24 main /proc/self/cwd/test/cpp/end2end/client_lb_end2end_test.cc:1809:23 (client_lb_end2end_test+0x50fb64)

  Thread T15 'grpc_global_tim' (tid=69, finished) created by thread T14 at:
    #0 pthread_create /tmp/clang-build/src/compiler-rt/lib/tsan/rtl/tsan_interceptors.cpp:967:3 (client_lb_end2end_test+0x49f39b)
    #1 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:109:10 (liblibgpr_Ubase.so+0x17570)
    #2 grpc_core::Thread::Thread(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:186:15 (liblibgpr_Ubase.so+0x16e36)
    #3 start_timer_thread_and_unlock() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:92:13 (liblibgrpc_Ubase_Uc.so+0x15f583)
    #4 run_some_timers() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:118:5 (liblibgrpc_Ubase_Uc.so+0x15fa22)
    #5 timer_main_loop() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:237:9 (liblibgrpc_Ubase_Uc.so+0x15f753)
    #6 timer_thread(void*) /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:284:3 (liblibgrpc_Ubase_Uc.so+0x15f64a)
    #7 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:140:27 (liblibgpr_Ubase.so+0x17c0e)
    #8 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:110:25 (liblibgpr_Ubase.so+0x17a08)

SUMMARY: ThreadSanitizer: data race /proc/self/cwd/src/core/lib/gpr/alloc.cc:52:3 in gpr_free
```

https://source.cloud.google.com/results/invocations/e392d9dc-1929-40c6-a920-cd48617c46ba/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fbazel_rbe%2Fgrpc_bazel_rbe_tsan/log
