### PR TITLE
Update manylinux2010 docker images

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
@@ -27,5 +27,4 @@ RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
 RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
 RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
 RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
-RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
 RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
@@ -27,5 +27,4 @@ RUN /opt/python/cp27-cp27mu/bin/pip install --upgrade cython
 RUN /opt/python/cp35-cp35m/bin/pip install --upgrade cython
 RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
 RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
-RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
 RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython


### PR DESCRIPTION
It may look like a simple CL to remove redundant lines from the docker script but it's more about upgrading the underlying manylinux2010 image to try out devtoolset-8 on i686. ([ref](https://github.com/pypa/manylinux/pull/565))