### PR TITLE
Sync unary call after shutdown: Add a repro and fix for #19090 

### DIFF
--- a/src/csharp/Grpc.Core.Tests/CallAfterShutdownTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CallAfterShutdownTest.cs
@@ -1,0 +1,48 @@
+#region Copyright notice and license
+
+// Copyright 2020 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    public class CallAfterShutdownTest
+    {
+        Method<string, string> dummyUnaryMethod = new Method<string, string>(MethodType.Unary, "fooservice", "dummyMethod", Marshallers.StringMarshaller, Marshallers.StringMarshaller);
+
+        [Test]
+        public void StartBlockingUnaryCallAfterChannelShutdown()
+        {
+            // create a channel and immediately shut it down.
+            var channel = new Channel("127.0.0.1", 1000, ChannelCredentials.Insecure);
+            channel.ShutdownAsync().Wait();  // also shuts down GrpcEnvironment
+
+            Assert.Throws(typeof(ObjectDisposedException), () => Calls.BlockingUnaryCall(new CallInvocationDetails<string, string>(channel, dummyUnaryMethod, new CallOptions()), "THE REQUEST"));
+        }
+
+        [Test]
+        public void StartAsyncUnaryCallAfterChannelShutdown()
+        {
+            // create a channel and immediately shut it down.
+            var channel = new Channel("127.0.0.1", 1000, ChannelCredentials.Insecure);
+            channel.ShutdownAsync().Wait();  // also shuts down GrpcEnvironment
+
+            Assert.Throws(typeof(ObjectDisposedException), () => Calls.AsyncUnaryCall(new CallInvocationDetails<string, string>(channel, dummyUnaryMethod, new CallOptions()), "THE REQUEST"));
+        }
+    }
+}

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -22,6 +22,7 @@
     "Grpc.Core.Tests.AppDomainUnloadTest",
     "Grpc.Core.Tests.AuthContextTest",
     "Grpc.Core.Tests.AuthPropertyTest",
+    "Grpc.Core.Tests.CallAfterShutdownTest",
     "Grpc.Core.Tests.CallCancellationTest",
     "Grpc.Core.Tests.CallCredentialsTest",
     "Grpc.Core.Tests.CallOptionsTest",


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/19090

The bug is actually quite an oddity, because one should not try to start calls on a channel that was already shutdown, nevertheless it's wrong for grpc to crash when that happens.
The problem only affected blocking unary calls, because they need to create/destroy a pluckable completion queue (which is what crashes when run after grpc environment is shutdown).
