### PR TITLE
Stablize Python's channel_ready_test

### DIFF
--- a/src/python/grpcio_tests/tests_aio/unit/channel_ready_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_ready_test.py
@@ -32,8 +32,8 @@ class TestChannelReady(AioTestBase):
 
     async def setUp(self):
         address, self._port, self._socket = get_socket(listen=False)
-        self._channel = aio.insecure_channel(f"{address}:{self._port}")
         self._socket.close()
+        self._channel = aio.insecure_channel(f"{address}:{self._port}")
 
     async def tearDown(self):
         await self._channel.close()

--- a/src/python/grpcio_tests/tests_aio/unit/channel_ready_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/channel_ready_test.py
@@ -16,6 +16,7 @@
 import asyncio
 import gc
 import logging
+import socket
 import time
 import unittest
 
@@ -31,9 +32,10 @@ from tests_aio.unit._test_server import start_test_server
 class TestChannelReady(AioTestBase):
 
     async def setUp(self):
-        address, self._port, self._socket = get_socket(listen=False)
-        self._socket.close()
+        address, self._port, self._socket = get_socket(
+            listen=False, sock_options=(socket.SO_REUSEADDR,))
         self._channel = aio.insecure_channel(f"{address}:{self._port}")
+        self._socket.close()
 
     async def tearDown(self):
         await self._channel.close()


### PR DESCRIPTION
Related: #22399

Not sure if this PR can fix the flake above. A channel connects to an empty TCP port, but succeeds occasionally. I still cannot reproduce it locally (1k runs with or without cpu load). Based on previous fix for connectivity-related flake, closing the picked TCP socket object might yield a more stable result.