### PR TITLE
Stablize metadata flags test

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -102,7 +102,7 @@ class _GenericHandler(grpc.GenericRpcHandler):
 
 def create_dummy_channel():
     """Creating dummy channels is a workaround for retries"""
-    host, port, sock = get_socket()
+    host, port, sock = get_socket(sock_options=(socket.SO_REUSEADDR,))
     sock.close()
     return grpc.insecure_channel('{}:{}'.format(host, port))
 
@@ -207,7 +207,7 @@ class MetadataFlagsTest(unittest.TestCase):
         unhandled_exceptions = queue.Queue()
 
         # We just need an unused TCP port
-        host, port, sock = get_socket()
+        host, port, sock = get_socket(sock_options=(socket.SO_REUSEADDR,))
         sock.close()
 
         addr = '{}:{}'.format(host, port)


### PR DESCRIPTION
`_metadata_flags_test.py` still flakes around 1 % in our dashboard.

This PR applies the same fix as https://github.com/grpc/grpc/pull/23007 to `_metadata_flags_test.py`. Hopefully, the last bit of flake will go away.

We still need to close the socket, otherwise the channel will stuck at CONNECTING state.