### PR TITLE
PHP: AbstractCall remove decode method

### DIFF
--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -114,9 +114,7 @@ abstract class AbstractCall
     protected function _serializeMessage($data)
     {
         // Proto3 implementation
-        if (method_exists($data, 'encode')) {
-            return $data->encode();
-        } elseif (method_exists($data, 'serializeToString')) {
+       if (method_exists($data, 'serializeToString')) {
             return $data->serializeToString();
         }
 
@@ -141,12 +139,7 @@ abstract class AbstractCall
         if (is_array($this->deserialize)) {
             list($className, $deserializeFunc) = $this->deserialize;
             $obj = new $className();
-            if (method_exists($obj, $deserializeFunc)) {
-                $obj->$deserializeFunc($value);
-            } else {
-                $obj->mergeFromString($value);
-            }
-
+            $obj->mergeFromString($value);
             return $obj;
         }
 

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -114,12 +114,7 @@ abstract class AbstractCall
     protected function _serializeMessage($data)
     {
         // Proto3 implementation
-       if (method_exists($data, 'serializeToString')) {
-            return $data->serializeToString();
-        }
-
-        // Protobuf-PHP implementation
-        return $data->serialize();
+        return $data->serializeToString();
     }
 
     /**

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -129,17 +129,10 @@ abstract class AbstractCall
         if ($value === null) {
             return;
         }
-
-        // Proto3 implementation
-        if (is_array($this->deserialize)) {
-            list($className, $deserializeFunc) = $this->deserialize;
-            $obj = new $className();
-            $obj->mergeFromString($value);
-            return $obj;
-        }
-
-        // Protobuf-PHP implementation
-        return call_user_func($this->deserialize, $value);
+        list($className, $deserializeFunc) = $this->deserialize;
+        $obj = new $className();
+        $obj->mergeFromString($value);
+        return $obj;
     }
 
     /**


### PR DESCRIPTION
remove method_exists($data, 'encode')) and method_exists($obj, $deserializeFunc)




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@stanley-cheung 
