### PR TITLE
Fix build_one_example.sh script build issue.

### DIFF
--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -49,6 +49,7 @@ if [ "$SCHEME" == "tvOS-sample" ]; then
     -derivedDataPath Build/Build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \ 
     | $TEST_PATH/verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v "^$" -
@@ -61,6 +62,7 @@ else
     -derivedDataPath Build/Build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
     | $TEST_PATH/verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v "^$" -

--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -49,7 +49,7 @@ if [ "$SCHEME" == "tvOS-sample" ]; then
     -derivedDataPath Build/Build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGNING_ALLOWED=NO \ 
+    CODE_SIGNING_ALLOWED=NO \
     | $TEST_PATH/verbose_time.sh \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v "^$" -


### PR DESCRIPTION
`An empty identity is not valid when signing a binary for the product type 'Application'` shows up when running `build_one_example.sh`. Need to add `CODE_SIGNING_ALLOWED=NO` in the script.