### PR TITLE
Add configurable client to Python xDS Example

### DIFF
--- a/examples/python/xds/README.md
+++ b/examples/python/xds/README.md
@@ -60,9 +60,8 @@ Finally, run your client:
 python client.py xds-experimental:///my-backend
 ```
 
-Alternatively, but you can use it as a sanity check if
-you'd like. If you don't have it, install
-[`grpcurl`](https://github.com/fullstorydev/grpcurl/releases). This will allow
+Alternatively, `grpcurl` can be used to test your server. If you don't have it,
+install [`grpcurl`](https://github.com/fullstorydev/grpcurl/releases). This will allow
 you to manually test the service.
 
 Exercise your server's application-layer service:

--- a/examples/python/xds/README.md
+++ b/examples/python/xds/README.md
@@ -28,7 +28,39 @@ python server.py
 
 3. Verify the Server
 
-This step is not strictly necessary, but you can use it as a sanity check if
+After configuring your xDS server to track the gRPC server we just started,
+create a bootstrap file as desribed in [gRFC A27](https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md):
+
+```
+{
+  xds_servers": [
+    {
+      "server_uri": <string containing URI of xds server>,
+      "channel_creds": [
+        {
+          "type": <string containing channel cred type>,
+          "config": <JSON object containing config for the type>
+        }
+      ]
+    }
+  ],
+  "node": <JSON form of Node proto>
+}
+```
+
+Then point the `GRPC_XDS_BOOTSTRAP` environment variable at the bootstrap file:
+
+```
+export GRPC_XDS_BOOTSTRAP=/etc/xds-bootstrap.json
+```
+
+Finally, run your client:
+
+```
+python client.py xds-experimental:///my-backend
+```
+
+Alternatively, but you can use it as a sanity check if
 you'd like. If you don't have it, install
 [`grpcurl`](https://github.com/fullstorydev/grpcurl/releases). This will allow
 you to manually test the service.

--- a/examples/python/xds/client.py
+++ b/examples/python/xds/client.py
@@ -24,6 +24,7 @@ import helloworld_pb2_grpc
 
 _DESCRIPTION = "Get a greeting from a server."
 
+
 def run(server_address):
     with grpc.insecure_channel(server_address) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)

--- a/examples/python/xds/client.py
+++ b/examples/python/xds/client.py
@@ -1,0 +1,41 @@
+# Copyright 2020 The gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python implementation of the GRPC helloworld.Greeter client."""
+
+from __future__ import print_function
+import logging
+import argparse
+
+import grpc
+
+import helloworld_pb2
+import helloworld_pb2_grpc
+
+_DESCRIPTION = "Get a greeting from a server."
+
+def run(server_address):
+    with grpc.insecure_channel(server_address) as channel:
+        stub = helloworld_pb2_grpc.GreeterStub(channel)
+        response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
+    print("Greeter client received: " + response.message)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=_DESCRIPTION)
+    parser.add_argument("server",
+                        default=None,
+                        help="The address of the server.")
+    args = parser.parse_args()
+    logging.basicConfig()
+    run(args.server)


### PR DESCRIPTION
Include a configurable greeter client in the Python xDS example.

I've hard-forked the greeter client from the helloworld example so as not to clutter what should be the simplest example with command line parsing code.