### PR TITLE
C++ helloworld: set min cmake version to 3.13.0

### DIFF
--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.13.0)
 
 project(HelloWorld C CXX)
 
@@ -44,7 +44,7 @@ if(GRPC_AS_SUBMODULE)
   #
   # A more robust approach to add dependency on gRPC is using
   # cmake's ExternalProject_Add (see cmake_externalproject/CMakeLists.txt).
-  
+
   # Include the gRPC's cmake build (normally grpc source code would live
   # in a git submodule called "third_party/grpc", but this example lives in
   # the same repository as gRPC sources, so we just look a few directories up)


### PR DESCRIPTION
Bump min cmake version to match what is actually needed, and what is documented in the Quick Start. Otherwise, users run into problems, e.g., see [gRPC C++ Installation Issue](https://groups.google.com/d/msg/grpc-io/OgQWa17WiuA/Luobfv3OAwAJ).

@ejona86, @jtattermusch: This PR only updates the `helloworld` example `CMakeLists.txt` file. If you'd also like me to update the top-level file let me know.

