### PR TITLE
doc: adding the fourth enum for health check proto docs

### DIFF
--- a/doc/health-checking.md
+++ b/doc/health-checking.md
@@ -37,6 +37,7 @@ message HealthCheckResponse {
     UNKNOWN = 0;
     SERVING = 1;
     NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
   }
   ServingStatus status = 1;
 }


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt



This is a simple PR to fix the `GRPC Health Check Protocol` markdown file by adding the fourth enum to make it sync with the proto file in the code base.

Related Issue: https://github.com/grpc/grpc/issues/23033