### PR TITLE
Fix access of root certs on MacOS

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -100,7 +100,8 @@ def grpc_cc_library(
                       "//:grpc_allow_exceptions": ["GRPC_ALLOW_EXCEPTIONS=1"],
                       "//:grpc_disallow_exceptions": ["GRPC_ALLOW_EXCEPTIONS=0"],
                       "//conditions:default": [],
-                  }),
+                  }) +
+                  if_mac(["INSTALL_PREFIX=/usr/local"]),
         hdrs = hdrs + public_hdrs,
         deps = deps + _get_external_deps(external_deps),
         copts = copts,

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -43,8 +43,10 @@
 #ifndef INSTALL_PREFIX
 static const char* installed_roots_path = "/usr/share/grpc/roots.pem";
 #else
+#define QUOTE(x) #x
+#define EXPAND_AND_QUOTE(x) QUOTE(x)
 static const char* installed_roots_path =
-    INSTALL_PREFIX "/share/grpc/roots.pem";
+    EXPAND_AND_QUOTE(INSTALL_PREFIX) "/share/grpc/roots.pem";
 #endif
 
 #ifndef TSI_OPENSSL_ALPN_SUPPORT


### PR DESCRIPTION
gRPC (and importantly, the gRPC CLI) looks for the root certificates at
`INSTALL_PREFIX /share/grpc/roots.pem` on MacOS, since pulling the
certificates from the system is still not supported: [1].

The default installation prefix ("/usr") is a problem since that
directory is subject to "System Integrity Protection" on MacOS ([2]),
which means manually adding the file is a convoluted process: [3].
`/usr/local` is excepted from this, however, so it is much simpler to
manually add the `roots.pem` file to `/usr/local/share/grpc`.

[1]: https://github.com/grpc/grpc/pull/16246.  Note that this PR was
closed without merging for being stale.
[2]: https://support.apple.com/en-us/HT204899
[3]: https://apple.stackexchange.com/questions/208478/how-do-i-disable-system-integrity-protection-sip-aka-rootless-on-macos-os-x

Commit description by James Duncan <james@camus.energy>.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
