### PR TITLE
Trying to fix `ruby requirements` error

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -37,11 +37,10 @@ fi
 if [ "${PREPARE_BUILD_INSTALL_DEPS_RUBY}" == "true" ]
 then
   brew update
-  # special case for https://github.com/grpc/grpc/issues/23027
+  # special case fix for https://github.com/grpc/grpc/issues/23027
   rm -f /usr/local/bin/gpg
   rm -f /usr/local/bin/gpgconf
   rm -f /usr/local/bin/gpgsm
-  brew upgrade gnupg
   # end https://github.com/grpc/grpc/issues/23027
   brew cleanup
   set +ex

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -36,11 +36,17 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_RUBY}" == "true" ]
 then
-  set +ex  # rvm script is very verbose and exits with errorcode
-  # Advice from https://github.com/Homebrew/homebrew-cask/issues/8629#issuecomment-68641176
-  brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
-  set -e  # rvm commands are very verbose
+  brew update
+  # special case for https://github.com/grpc/grpc/issues/23027
+  rm -f /usr/local/bin/gpg
+  rm -f /usr/local/bin/gpgconf
+  rm -f /usr/local/bin/gpgsm
+  brew upgrade gnupg
+  # end https://github.com/grpc/grpc/issues/23027
+  brew cleanup
+  set +ex
   source $HOME/.rvm/scripts/rvm
+  set -ex
   for RUBY_VERSION in 2.5.0 2.7.0; do
     rvm --debug requirements "ruby-${RUBY_VERSION}"
     time rvm install "$RUBY_VERSION"
@@ -51,7 +57,6 @@ then
   time gem install cocoapods --version 1.3.1 --no-document
   rvm osx-ssl-certs status all
   rvm osx-ssl-certs update all
-  set -ex
 fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_OBJC}" == "true" ]


### PR DESCRIPTION
Trying to fix #23027

---

There was an error `Error: No available formula with the name "brew-cask"`

Reference: https://github.com/Homebrew/homebrew-cask/issues/75135#issuecomment-570974489, https://github.com/Homebrew/homebrew-cask/issues/57875#issuecomment-457020885, or maybe https://github.com/rvm/rvm/issues/3995#issuecomment-295192675

[Edit:] The above seems to be a minor error, is under a `set +e` and hence is skipped


---
**Investigations**

The script seems to be failing on this particular [command](https://github.com/grpc/grpc/blob/master/tools/internal_ci/helper_scripts/prepare_build_macos_rc#L45), originally coming from #17750:
```
rvm --debug requirements ruby-2.5.0
```
eventually with this error `Requirements installation failed with status: 1.`.

The [last green build](https://g3c.corp.google.com/results/invocations/42909503-dab9-42bb-8274-486f05e1b91a/targets/grpc%2Fcore%2Fpull_request%2Fmacos%2Fgrpc_build_artifacts;config=default/log) has these lines:
```
==> Upgrading 4 dependents:
libevent 2.1.8 -> 2.1.11_1, sqlite 3.26.0_1 -> 3.31.1, tmux 2.8 -> 3.1b, wget 1.20.1_3 -> 1.20.3_2
```

Now the failures have these lines:
```
==> Upgrading 5 dependents:
gnupg 2.2.12 -> 2.2.20, libevent 2.1.8 -> 2.1.11_1, sqlite 3.26.0_1 -> 3.31.1, tmux 2.8 -> 3.1b, wget 1.20.1_3 -> 1.20.3_2
```

And then later
```
==> Installing gnupg
==> Pouring gnupg-2.2.20.high_sierra.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/gpg
Target /usr/local/bin/gpg
already exists. You may want to remove it:
  rm '/usr/local/bin/gpg'

To force the link and overwrite all conflicting files:
  brew link --overwrite gnupg

To list all files that would be deleted:
  brew link --overwrite --dry-run gnupg

Possible conflicting files are:
/usr/local/bin/gpg -> /usr/local/bin/gpg2
/usr/local/bin/gpgconf -> /usr/local/gnupg-2.2/bin/gpgconf
/usr/local/bin/gpgsm -> /usr/local/gnupg-2.2/bin/gpgsm
```

So looks like somehow an additional dependency about this `gnupg` package is being pulled in recently, causing the error.

The investigation from [this comment on](https://github.com/grpc/grpc/issues/17729#issuecomment-455217052) is extremely similar to the issue here.

---

One thing to note is that the `rvm --debug requirements ruby-2.5.0` command [used to be](https://github.com/grpc/grpc/pull/22195/files#diff-035a14c04ab4a7d5b15c576e6398058b) under a `set +ex` before, so it doesn't error out the whole script. After this recent change (#22195) in Mar 2, the command is now under a `set -e`.

In other words, the command `rvm requirements ruby-2.5.0` _did_ pass under a `set -e` between Mar 2 and May 20.



**Fix attempt 1**: putting `rvm requirements ruby-2.5.0` under a `set +e`

This will make the build green. But the `brew link gnupg` error is still there. We just ignored it. Ignoring the error doesn't seem to affect the rest of the build (e.g. `rvm install 2.5.0`). But, this doesn't exactly feel like the right solution.

**Fix attempt 2**: just remove the `rvm requirements ruby-2.5.0` command

Just removing the `rvm requirements ruby-2.5.0` command did _not_ help. Even though we went on to do `rvm install 2.5.0` directly, `rvm` eventually decides to do `rvm requirements ruby-2.5.0` anyways, which still leads back to the error with `gnupg`.

So the problem is still with `brew link gnupg`.
Another question: what happened between May 20 6:35pm PDT and 8:17pm PDT?

**Fix attempt 3**: do something special to deal with the error associated with `brew upgrade gnupg`

Since these Kokoro MacOS workers are images anyways, we can probably just do something special just to deal with the `gnupg` error. Every run starts fresh anyways. This is borrowed from Alex's attempts in #23048.