### PR TITLE
Inproc transport server should end all RPC ops after sending status

### DIFF
--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -812,6 +812,24 @@ void op_state_machine_locked(inproc_stream* s, grpc_error* error) {
           "op_state_machine %p has trailing md but not yet waiting for it", s);
     }
   }
+  if (!s->t->is_client && s->trailing_md_sent &&
+      (s->recv_trailing_md_op != nullptr)) {
+    // In this case, we don't care to receive the write-close from the client
+    // because we have already sent status and the RPC is over as far as we
+    // are concerned.
+    INPROC_LOG(GPR_INFO, "op_state_machine %p scheduling trailing-md-ready %p",
+               s, new_err);
+    grpc_core::ExecCtx::Run(
+        DEBUG_LOCATION,
+        s->recv_trailing_md_op->payload->recv_trailing_metadata
+            .recv_trailing_metadata_ready,
+        GRPC_ERROR_REF(new_err));
+    complete_if_batch_end_locked(
+        s, new_err, s->recv_trailing_md_op,
+        "op_state_machine scheduling recv-trailing-md-on-complete");
+    s->trailing_md_recvd = true;
+    s->recv_trailing_md_op = nullptr;
+  }
   if (s->trailing_md_recvd && s->recv_message_op) {
     // No further message will come on this stream, so finish off the
     // recv_message_op

--- a/test/core/end2end/tests/server_finishes_request.cc
+++ b/test/core/end2end/tests/server_finishes_request.cc
@@ -151,7 +151,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
   op++;
   op->op = GRPC_OP_SEND_STATUS_FROM_SERVER;
   op->data.send_status_from_server.trailing_metadata_count = 0;
-  op->data.send_status_from_server.status = GRPC_STATUS_UNIMPLEMENTED;
+  op->data.send_status_from_server.status = GRPC_STATUS_OK;
   grpc_slice status_details = grpc_slice_from_static_string("xyz");
   op->data.send_status_from_server.status_details = &status_details;
   op->flags = 0;
@@ -170,10 +170,10 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
   CQ_EXPECT_COMPLETION(cqv, tag(1), 1);
   cq_verify(cqv);
 
-  GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
+  GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo"));
-  GPR_ASSERT(was_cancelled == 1);
+  GPR_ASSERT(was_cancelled == 0);
 
   grpc_slice_unref(details);
   grpc_metadata_array_destroy(&initial_metadata_recv);


### PR DESCRIPTION
There was a bug in the inproc transport by which the server could send status but then would keep waiting for other outstanding RPC ops (like receiving a client WritesDone). This was not seen in testing because the core end2end tests would eventually fail with a deadline exceeded and then mark the cancellation bit, which was expected to be marked anyway because of the unintuitive cancellation behavior being fixed by #22991. This PR exposes that by making the server_finishes_request end2end test return an OK status and by making the inproc transport properly terminate outstanding RPC ops.

I have validated that the changes in the test commit fail without the changes in the source commit, so the test is a valid repro case now.
