### PR TITLE
PHP: better error checking in helloworld greeter_client

### DIFF
--- a/examples/php/greeter_client.php
+++ b/examples/php/greeter_client.php
@@ -34,10 +34,12 @@ function greet($name)
     $request = new Helloworld\HelloRequest();
     $request->setName($name);
     list($reply, $status) = $client->SayHello($request)->wait();
-    $message = $reply->getMessage();
-
-    return $message;
+    if ($status->code !== Grpc\STATUS_OK) {
+        echo "ERROR: ".$status->code.", ".$status->details."\n";
+        exit(1);
+    }
+    echo $reply->getMessage()."\n";
 }
 
 $name = !empty($argv[1]) ? $argv[1] : 'world';
-echo greet($name)."\n";
+greet($name);


### PR DESCRIPTION
Check the RPC return `$status` before attempting to read `$response->getMessage()`. Common use case to avoid is when the server is not ready, or has been killed. The PHP client would have ended with a `FatalError`. 