### PR TITLE
PHP: grpc_completion_queue_shutdown() called twice

### DIFF
--- a/src/php/ext/grpc/completion_queue.c
+++ b/src/php/ext/grpc/completion_queue.c
@@ -25,6 +25,5 @@ void grpc_php_init_completion_queue(TSRMLS_D) {
 }
 
 void grpc_php_shutdown_completion_queue(TSRMLS_D) {
-  grpc_completion_queue_shutdown(completion_queue);
   grpc_completion_queue_destroy(completion_queue);
 }


### PR DESCRIPTION
`grpc_completion_queue_destroy()` calls `grpc_completion_queue_shutdown()` itself. So perhaps we don't need both calls?