### PR TITLE
Remove XdsClient from channel args to fix subchannel sharing.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/lrs.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/lrs.cc
@@ -254,9 +254,11 @@ void LrsLb::UpdateLocked(UpdateArgs args) {
         config_->eds_service_name(), config_->locality_name());
     MaybeUpdatePickerLocked();
   }
+  // Remove XdsClient from channel args, so that its presence doesn't
+  // prevent us from sharing subchannels between channels.
+  grpc_channel_args* new_args = XdsClient::RemoveFromChannelArgs(*args.args);
   // Update child policy.
-  UpdateChildPolicyLocked(std::move(args.addresses), args.args);
-  args.args = nullptr;  // Ownership passed to UpdateChildPolicyLocked().
+  UpdateChildPolicyLocked(std::move(args.addresses), new_args);
 }
 
 void LrsLb::MaybeUpdatePickerLocked() {

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -2387,4 +2387,10 @@ RefCountedPtr<XdsClient> XdsClient::GetFromChannelArgs(
   return nullptr;
 }
 
+grpc_channel_args* XdsClient::RemoveFromChannelArgs(
+    const grpc_channel_args& args) {
+  const char* arg_name = GRPC_ARG_XDS_CLIENT;
+  return grpc_channel_args_copy_and_remove(&args, &arg_name, 1);
+}
+
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -142,6 +142,8 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
   grpc_arg MakeChannelArg() const;
   static RefCountedPtr<XdsClient> GetFromChannelArgs(
       const grpc_channel_args& args);
+  static grpc_channel_args* RemoveFromChannelArgs(
+      const grpc_channel_args& args);
 
  private:
   // Contains a channel to the xds server and all the data related to the


### PR DESCRIPTION
Each channel has its own XdsClient, which is added to channel args.  The channel args then form the key used in the subchannel pool.  This means that each channel winds up using a different key for the same address, which inhibits subchannel sharing.  Removing the XdsClient from channel args before we get down to the leaf LB policy fixes this problem.