### PR TITLE
Add option to pass in custom target to helloworld example for PHP/Ruby

### DIFF
--- a/examples/php/greeter_client.php
+++ b/examples/php/greeter_client.php
@@ -17,24 +17,28 @@
  *
  */
 
-// php:generate protoc --proto_path=./../protos   --php_out=./   --grpc_out=./ --plugin=protoc-gen-grpc=./../../bins/opt/grpc_php_plugin ./../protos/helloworld.proto
+// To generate the necessary proto classes:
+// $ protoc --proto_path=../protos --php_out=. --grpc_out=.
+//   --plugin=protoc-gen-grpc=../../bins/opt/grpc_php_plugin
+//   ../protos/helloworld.proto
 
 require dirname(__FILE__).'/vendor/autoload.php';
 
-function greet($name)
+function greet($hostname, $name)
 {
-    $client = new Helloworld\GreeterClient('localhost:50051', [
+    $client = new Helloworld\GreeterClient($hostname, [
         'credentials' => Grpc\ChannelCredentials::createInsecure(),
     ]);
     $request = new Helloworld\HelloRequest();
     $request->setName($name);
-    list($reply, $status) = $client->SayHello($request)->wait();
+    list($response, $status) = $client->SayHello($request)->wait();
     if ($status->code !== Grpc\STATUS_OK) {
-        echo "ERROR: ".$status->code.", ".$status->details."\n";
+        echo "ERROR: " . $status->code . ", " . $status->details . PHP_EOL;
         exit(1);
     }
-    echo $reply->getMessage()."\n";
+    echo $response->getMessage() . PHP_EOL;
 }
 
 $name = !empty($argv[1]) ? $argv[1] : 'world';
-greet($name);
+$hostname = !empty($argv[2]) ? $argv[2] : 'localhost:50051';
+greet($hostname, $name);

--- a/examples/php/greeter_proto_gen.sh
+++ b/examples/php/greeter_proto_gen.sh
@@ -13,5 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-protoc --proto_path=./../protos   --php_out=./   --grpc_out=./   --plugin=protoc-gen-grpc=./../../bins/opt/grpc_php_plugin   ./../protos/helloworld.proto
-
+protoc --proto_path=../protos --php_out=. --grpc_out=. --plugin=protoc-gen-grpc=../../bins/opt/grpc_php_plugin ../protos/helloworld.proto

--- a/examples/ruby/greeter_client.rb
+++ b/examples/ruby/greeter_client.rb
@@ -26,8 +26,9 @@ require 'grpc'
 require 'helloworld_services_pb'
 
 def main
-  stub = Helloworld::Greeter::Stub.new('localhost:50051', :this_channel_is_insecure)
   user = ARGV.size > 0 ?  ARGV[0] : 'world'
+  hostname = ARGV.size > 1 ?  ARGV[1] : 'localhost:50051'
+  stub = Helloworld::Greeter::Stub.new(hostname, :this_channel_is_insecure)
   message = stub.say_hello(Helloworld::HelloRequest.new(name: user)).message
   p "Greeting: #{message}"
 end


### PR DESCRIPTION
This is to prepare for xDS user guide. User can now pass in the target as the 2nd command line parameter (spec: b/147371230) to the helloworld greeter_client script for both PHP and Ruby. This will allow us to pass in an entirely different server endpoint like `xds:///<hostname>` to the greeter client.

Ruby:
```
$ ruby greeter_client.rb John localhost:50051
"Greeting: Hello John" 
```

PHP:
```
$ php greeter_client.php John localhost:50051
Hello John
```