### PR TITLE
Fix sorting of gRPCLB addresses when resolved via DNS

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -181,6 +181,12 @@ void grpc_ares_complete_request_locked(grpc_ares_request* r) {
     // TODO(apolcyn): allow c-ares to return a service config
     // with no addresses along side it
   }
+  if (r->balancer_addresses_out != nullptr) {
+    ServerAddressList* balancer_addresses = r->balancer_addresses_out->get();
+    if (balancer_addresses != nullptr) {
+      grpc_cares_wrapper_address_sorting_sort(r, balancer_addresses);
+    }
+  }
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, r->on_done, r->error);
 }
 

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -44,6 +44,8 @@ def _resolver_test_cases(resolver_component_data):
                 target_name,
             'arg_names_and_values': [
                 ('target_name', target_name),
+                ('do_ordered_address_comparison',
+                 test_case['do_ordered_address_comparison']),
                 ('expected_addrs',
                  _build_expected_addrs_cmd_arg(test_case['expected_addrs'])),
                 ('expected_chosen_service_config',

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -122,6 +122,7 @@ test_runner_log('Run test with target: %s' % 'no-srv-ipv4-single-target.resolver
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'no-srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '5.5.5.5:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -138,6 +139,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-single-target.resolver-te
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -154,6 +156,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-multi-target.resolver-tes
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -170,6 +173,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv6-single-target.resolver-te
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '[2607:f8b0:400a:801::1001]:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -186,6 +190,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv6-multi-target.resolver-tes
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -202,6 +207,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-simple-service-config.res
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}',
   '--expected_service_config_error', '',
@@ -218,6 +224,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-no-srv-simple-service-config.
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}',
   '--expected_service_config_error', '',
@@ -234,6 +241,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-no-config-for-cpp.resolver-te
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -250,6 +258,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-cpp-config-has-zero-percentag
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -266,6 +275,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-second-language-is-cpp.resolv
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService"}],"waitForReady":true}]}',
   '--expected_service_config_error', '',
@@ -282,6 +292,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-config-with-percentages.resol
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}',
   '--expected_service_config_error', '',
@@ -298,6 +309,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-target-has-backend-and-ba
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:1234,True;1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -314,6 +326,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv6-target-has-backend-and-ba
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -330,6 +343,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-config-causing-fallback-to-tc
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-config-causing-fallback-to-tcp.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThree","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFour","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFive","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSix","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSeven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEight","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooNine","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEleven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThirteen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFourteen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFifteen","service":"SimpleService"}],"waitForReady":true}]}',
   '--expected_service_config_error', '',
@@ -346,6 +360,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-single-target-srv-disable
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-single-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '2.3.4.5:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -362,6 +377,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-multi-target-srv-disabled
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-multi-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '9.2.3.5:443,False;9.2.3.6:443,False;9.2.3.7:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -378,6 +394,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv6-single-target-srv-disable
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv6-single-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '[2600::1001]:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -394,6 +411,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv6-multi-target-srv-disabled
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv6-multi-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '[2600::1002]:443,False;[2600::1003]:443,False;[2600::1004]:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -410,6 +428,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-simple-service-config-srv
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-simple-service-config-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '5.5.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}',
   '--expected_service_config_error', '',
@@ -426,6 +445,7 @@ test_runner_log('Run test with target: %s' % 'srv-ipv4-simple-service-config-txt
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'srv-ipv4-simple-service-config-txt-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -442,6 +462,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-cpp-config-has-zero-percentag
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-cpp-config-has-zero-percentage-txt-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -458,6 +479,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-second-language-is-cpp-txt-di
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-second-language-is-cpp-txt-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -474,6 +496,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-svc_cfg_bad_json.resolver-tes
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-svc_cfg_bad_json.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', 'JSON parse error',
@@ -490,6 +513,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-svc_cfg_bad_client_language.r
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-svc_cfg_bad_client_language.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', 'field:clientLanguage error:should be of type array',
@@ -506,6 +530,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-svc_cfg_bad_percentage.resolv
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-svc_cfg_bad_percentage.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', 'field:percentage error:should be of type number',
@@ -522,6 +547,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-svc_cfg_bad_wait_for_ready.re
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-svc_cfg_bad_wait_for_ready.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', 'field:waitForReady error:Type should be true/false',
@@ -538,6 +564,7 @@ test_runner_log('Run test with target: %s' % 'no-srv-ipv4-single-target-inject-b
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'no-srv-ipv4-single-target-inject-broken-nameservers.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '5.5.5.5:443,False',
   '--expected_chosen_service_config', '',
   '--expected_service_config_error', '',
@@ -554,6 +581,7 @@ test_runner_log('Run test with target: %s' % 'ipv4-config-causing-fallback-to-tc
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,
   '--target_name', 'ipv4-config-causing-fallback-to-tcp-inject-broken-nameservers.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":["round_robin"]}',
   '--expected_service_config_error', 'field:loadBalancingPolicy error:type should be string',
@@ -561,6 +589,23 @@ current_test_subprocess = subprocess.Popen([
   '--enable_srv_queries', 'True',
   '--enable_txt_queries', 'True',
   '--inject_broken_nameserver_list', 'True',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'load-balanced-name-with-dualstack-balancer.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'load-balanced-name-with-dualstack-balancer.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'True',
+  '--expected_addrs', '[::1]:1234,True;[2002::1111]:1234,True',
+  '--expected_chosen_service_config', '',
+  '--expected_service_config_error', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
+  '--inject_broken_nameserver_list', 'False',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -3,6 +3,7 @@ resolver_component_tests:
 # Tests for which we enable SRV queries
 - expected_addrs:
   - {address: '5.5.5.5:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -15,6 +16,7 @@ resolver_component_tests:
     - {TTL: '2100', data: 5.5.5.5, type: A}
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -31,6 +33,7 @@ resolver_component_tests:
   - {address: '1.2.3.5:1234', is_balancer: true}
   - {address: '1.2.3.6:1234', is_balancer: true}
   - {address: '1.2.3.7:1234', is_balancer: true}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -47,6 +50,7 @@ resolver_component_tests:
     - {TTL: '2100', data: 1.2.3.7, type: A}
 - expected_addrs:
   - {address: '[2607:f8b0:400a:801::1001]:1234', is_balancer: true}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -63,6 +67,7 @@ resolver_component_tests:
   - {address: '[2607:f8b0:400a:801::1002]:1234', is_balancer: true}
   - {address: '[2607:f8b0:400a:801::1003]:1234', is_balancer: true}
   - {address: '[2607:f8b0:400a:801::1004]:1234', is_balancer: true}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -79,6 +84,7 @@ resolver_component_tests:
     - {TTL: '2100', data: '2607:f8b0:400a:801::1004', type: AAAA}
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}'
   expected_service_config_error: null
   expected_lb_policy: round_robin
@@ -96,6 +102,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}'
   expected_service_config_error: null
   expected_lb_policy: round_robin
@@ -111,6 +118,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -126,6 +134,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -141,6 +150,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService"}],"waitForReady":true}]}'
   expected_service_config_error: null
   expected_lb_policy: round_robin
@@ -156,6 +166,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}'
   expected_service_config_error: null
   expected_lb_policy: round_robin
@@ -172,6 +183,7 @@ resolver_component_tests:
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -189,6 +201,7 @@ resolver_component_tests:
 - expected_addrs:
   - {address: '[2607:f8b0:400a:801::1002]:1234', is_balancer: true}
   - {address: '[2607:f8b0:400a:801::1002]:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -205,6 +218,7 @@ resolver_component_tests:
     - {TTL: '2100', data: '2607:f8b0:400a:801::1002', type: AAAA}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThree","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFour","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFive","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSix","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSeven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEight","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooNine","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEleven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThirteen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFourteen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFifteen","service":"SimpleService"}],"waitForReady":true}]}'
   expected_service_config_error: null
   expected_lb_policy: null
@@ -221,6 +235,7 @@ resolver_component_tests:
 # Tests for which we don't enable SRV queries
 - expected_addrs:
   - {address: '2.3.4.5:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -239,6 +254,7 @@ resolver_component_tests:
   - {address: '9.2.3.5:443', is_balancer: false}
   - {address: '9.2.3.6:443', is_balancer: false}
   - {address: '9.2.3.7:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -259,6 +275,7 @@ resolver_component_tests:
     - {TTL: '2100', data: 9.2.3.7, type: A}
 - expected_addrs:
   - {address: '[2600::1001]:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -277,6 +294,7 @@ resolver_component_tests:
   - {address: '[2600::1002]:443', is_balancer: false}
   - {address: '[2600::1003]:443', is_balancer: false}
   - {address: '[2600::1004]:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -297,6 +315,7 @@ resolver_component_tests:
     - {TTL: '2100', data: '2600::1004', type: AAAA}
 - expected_addrs:
   - {address: '5.5.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}'
   expected_service_config_error: null
   expected_lb_policy: round_robin
@@ -316,6 +335,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -333,6 +353,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -348,6 +369,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -363,6 +385,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: 'JSON parse error'
   expected_lb_policy: null
@@ -378,6 +401,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: 'field:clientLanguage error:should be of type array'
   expected_lb_policy: null
@@ -393,6 +417,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: 'field:percentage error:should be of type number'
   expected_lb_policy: null
@@ -408,6 +433,7 @@ resolver_component_tests:
       type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: 'field:waitForReady error:Type should be true/false'
   expected_lb_policy: null
@@ -420,10 +446,11 @@ resolver_component_tests:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-svc_cfg_bad_wait_for_ready:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"methodConfig":[{"name":[{"method":"Foo","service":"CppService"}],"waitForReady":"true"}]}}]',
-      type: TXT}      
+      type: TXT}
 # Tests for which we also exercise the resolver's ability to skip past a broken DNS server in its nameserver list
 - expected_addrs:
   - {address: '5.5.5.5:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: null
   expected_service_config_error: null
   expected_lb_policy: null
@@ -436,6 +463,7 @@ resolver_component_tests:
     - {TTL: '2100', data: 5.5.5.5, type: A}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
   expected_chosen_service_config: '{"loadBalancingPolicy":["round_robin"]}'
   expected_service_config_error: 'field:loadBalancingPolicy error:type should be string'
   expected_lb_policy: null
@@ -449,3 +477,26 @@ resolver_component_tests:
     _grpc_config.ipv4-config-causing-fallback-to-tcp-inject-broken-nameservers:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":["round_robin"]}}]',
       type: TXT}
+# This tests that gRPCLB addresses are sorted properly per RFC 6724. Note
+# that the only assumption that this makes is that the machine that the
+# test runs on has a functioning IPv6 loopback (which by the RFC should
+# always be preferred). Note too that the ordering of the AAAA records
+# listed under the dualstack-balancer name is important in order to
+# actually test this sorting.
+- expected_addrs:
+  - {address: '[::1]:1234', is_balancer: true}
+  - {address: '[2002::1111]:1234', is_balancer: true}
+  do_ordered_address_comparison: true
+  expected_chosen_service_config: null
+  expected_service_config_error: null
+  expected_lb_policy: null
+  enable_srv_queries: true
+  enable_txt_queries: true
+  inject_broken_nameserver_list: false
+  record_to_resolve: load-balanced-name-with-dualstack-balancer
+  records:
+    _grpclb._tcp.load-balanced-name-with-dualstack-balancer:
+    - {TTL: '2100', data: 0 0 1234 dualstack-balancer, type: SRV}
+    dualstack-balancer:
+    - {TTL: '2100', data: '2002::1111', type: AAAA}
+    - {TTL: '2100', data: '::1', type: AAAA}


### PR DESCRIPTION
b/152920055 for context

Confirmed when the sorting code here is removed, the added test here fails (the one generated from the new config in the yaml file), due to the addresses not being in expected order.