### PR TITLE
Propagate contextvars to auxiliary threads

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -94,7 +94,7 @@ def fork_handlers_and_grpc_init():
                 _fork_state.fork_handler_registered = True
 
 
-def contextvars_supported():
+def _contextvars_supported():
     try:
         import contextvars
         return True

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -94,28 +94,6 @@ def fork_handlers_and_grpc_init():
                 _fork_state.fork_handler_registered = True
 
 
-def _contextvars_supported():
-    try:
-        import contextvars
-        return True
-    except ImportError:
-        return False
-
-
-if _contextvars_supported():
-    import contextvars
-    def _run_with_context(target):
-        ctx = contextvars.copy_context()
-        def _run(*args):
-            ctx.run(target, *args)
-        return _run
-else:
-    # NOTE(rbellevi): `contextvars` was not introduced until 3.7. On earlier
-    # interpreters, we simply do not propagate contextvars between threads.
-    def _run_with_context(target):
-        def _run(*args):
-            target(*args)
-        return _run
 
 
 class ForkManagedThread(object):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -94,8 +94,12 @@ def fork_handlers_and_grpc_init():
                 _fork_state.fork_handler_registered = True
 
 
-def _contextvars_supported():
-    return sys.version_info[0] == 3 and sys.version_info[1] >= 7
+def contextvars_supported():
+    try:
+        import contextvars
+        return True
+    except ImportError:
+        return False
 
 
 if _contextvars_supported():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
@@ -19,6 +19,7 @@ def fork_handlers_and_grpc_init():
     grpc_init()
 
 
+# TODO: Propagate contextvars.
 class ForkManagedThread(object):
     def __init__(self, target, args=()):
         self._thread = threading.Thread(target=target, args=args)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
@@ -19,10 +19,9 @@ def fork_handlers_and_grpc_init():
     grpc_init()
 
 
-# TODO: Propagate contextvars.
 class ForkManagedThread(object):
     def __init__(self, target, args=()):
-        self._thread = threading.Thread(target=target, args=args)
+        self._thread = threading.Thread(target=_tun_with_context(target), args=args)
 
     def setDaemon(self, daemonic):
         self._thread.daemon = daemonic

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
@@ -21,7 +21,7 @@ def fork_handlers_and_grpc_init():
 
 class ForkManagedThread(object):
     def __init__(self, target, args=()):
-        self._thread = threading.Thread(target=_tun_with_context(target), args=args)
+        self._thread = threading.Thread(target=_run_with_context(target), args=args)
 
     def setDaemon(self, daemonic):
         self._thread.daemon = daemonic

--- a/src/python/grpcio/grpc/_cython/_cygrpc/thread.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/thread.pyx.pxi
@@ -43,7 +43,6 @@ def _run_with_context(target):
       A callable object with the same signature as `target` but with
         contextvars propagated.
     """
-    pass
 
 
 if _contextvars_supported():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/thread.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/thread.pyx.pxi
@@ -1,0 +1,60 @@
+# Copyright 2020 The gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _contextvars_supported():
+    """Determines if the contextvars module is supported.
+
+    We use a 'try it and see if it works approach' here rather than predicting
+    based on interpreter version in order to support older interpreters that
+    may have a backported module based on, e.g. `threading.local`.
+
+    Returns:
+      A bool indicating whether `contextvars` are supported in the current
+      environment.
+    """
+    try:
+        import contextvars
+        return True
+    except ImportError:
+        return False
+
+
+def _run_with_context(target):
+    """Runs a callable with contextvars propagated.
+
+    If contextvars are supported, the calling thread's context will be copied
+    and propagated. If they are not supported, this function is equivalent
+    to the identity function.
+
+    Args:
+      target: A callable object to wrap.
+    Returns:
+      A callable object with the same signature as `target` but with
+        contextvars propagated.
+    """
+    pass
+
+
+if _contextvars_supported():
+    import contextvars
+    def _run_with_context(target):
+        ctx = contextvars.copy_context()
+        def _run(*args):
+            ctx.run(target, *args)
+        return _run
+else:
+    def _run_with_context(target):
+        def _run(*args):
+            target(*args)
+        return _run

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -59,6 +59,8 @@ include "_cygrpc/iomgr.pyx.pxi"
 
 include "_cygrpc/grpc_gevent.pyx.pxi"
 
+include "_cygrpc/thread.pyx.pxi"
+
 IF UNAME_SYSNAME == "Windows":
     include "_cygrpc/fork_windows.pyx.pxi"
 ELSE:

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -227,7 +227,10 @@ class TestGevent(setuptools.Command):
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
-        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',)
+        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
+        # TODO(https://github.com/grpc/grpc/issues/22257)
+        'unit._contextvars_propagation_test.ContextVarsPropagationTest',
+    )
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -227,10 +227,7 @@ class TestGevent(setuptools.Command):
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
-        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
-        # TODO(https://github.com/grpc/grpc/issues/22257)
-        'unit._contextvars_propagation_test.ContextVarsPropagationTest',
-    )
+        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',)
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -220,6 +220,9 @@ class TestGevent(setuptools.Command):
         'unit._cython._channel_test.ChannelTest.test_negative_deadline_connectivity',
         # TODO(https://github.com/grpc/grpc/issues/15411) enable this test
         'unit._local_credentials_test.LocalCredentialsTest',
+        # TODO(https://github.com/grpc/grpc/issues/22020) LocalCredentials
+        # aren't supported with custom io managers.
+        'unit._contextvars_propagation_test',
         'testing._time_test.StrictRealTimeTest',
     )
     BANNED_WINDOWS_TESTS = (

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -35,6 +35,7 @@
   "unit._channel_connectivity_test.ChannelConnectivityTest",
   "unit._channel_ready_future_test.ChannelReadyFutureTest",
   "unit._compression_test.CompressionTest",
+  "unit._contextvars_propagation_test.ContextVarsPropagationTest",
   "unit._credentials_test.CredentialsTest",
   "unit._cython._cancel_many_calls_test.CancelManyCallsTest",
   "unit._cython._channel_test.ChannelTest",

--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -13,6 +13,7 @@ GRPCIO_TESTS_UNIT = [
     "_channel_connectivity_test.py",
     "_channel_ready_future_test.py",
     "_compression_test.py",
+    "_contextvars_propagation_test.py",
     "_credentials_test.py",
     "_dns_resolver_test.py",
     "_empty_message_test.py",

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -106,6 +106,8 @@ class ContextVarsPropagationTest(unittest.TestCase):
                 self.assertEqual(_REQUEST, response)
                 test_call_credentials.assert_called(self)
 
+    # TODO: Test simple unary-unary.
+
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -1,0 +1,112 @@
+# Copyright 2020 The gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test of propagation of contextvars between threads."""
+
+import contextlib
+import logging
+import sys
+import unittest
+
+import grpc
+
+from tests.unit import test_common
+
+_UNARY_UNARY = "/test/UnaryUnary"
+_REQUEST = b"0000"
+
+
+def _unary_unary_handler(request, context):
+    return request
+
+
+# TODO: Test for <3.7 and 3.7+.
+
+
+def contextvars_supported():
+    return sys.version_info[0] == 3 and sys.version_info[1] >= 7
+
+
+class _GenericHandler(grpc.GenericRpcHandler):
+
+    def service(self, handler_call_details):
+        if handler_call_details.method == _UNARY_UNARY:
+            return grpc.unary_unary_rpc_method_handler(_unary_unary_handler)
+        else:
+            raise NotImplementedError()
+
+
+@contextlib.contextmanager
+def _server():
+    try:
+        server = test_common.test_server()
+        target = '[::]:0'
+        port = server.add_insecure_port(target)
+        server.add_generic_rpc_handlers((_GenericHandler(),))
+        server.start()
+        yield port
+    finally:
+        server.stop(None)
+
+
+if contextvars_supported():
+    import contextvars
+
+    _EXPECTED_VALUE = 24601
+    test_var = contextvars.ContextVar("test_var", default=None)
+    test_var.set(_EXPECTED_VALUE)
+
+    class TestCallCredentials(grpc.AuthMetadataPlugin):
+
+        def __init__(self):
+            self._recorded_value = None
+
+        def __call__(self, context, callback):
+            self._recorded_value = test_var.get()
+            callback((), None)
+
+        def assert_called(self, test):
+            test.assertEqual(_EXPECTED_VALUE, self._recorded_value)
+
+else:
+
+    class TestCallCredentials(grpc.AuthMetadataPlugin):
+
+        def __call__(self, context, callback):
+            callback((), None)
+
+        def assert_called(self, test):
+            pass
+
+
+class ContextVarsPropagationTest(unittest.TestCase):
+
+    def test_propagation_to_auth_plugin(self):
+        with _server() as port:
+            target = "localhost:{}".format(port)
+            local_credentials = grpc.local_channel_credentials()
+            test_call_credentials = TestCallCredentials()
+            call_credentials = grpc.metadata_call_credentials(
+                test_call_credentials, "test call credentials")
+            composite_credentials = grpc.composite_channel_credentials(
+                local_credentials, call_credentials)
+            with grpc.secure_channel(target, composite_credentials) as channel:
+                stub = channel.unary_unary(_UNARY_UNARY)
+                response = stub(_REQUEST)
+                self.assertEqual(_REQUEST, response)
+                test_call_credentials.assert_called(self)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -85,6 +85,7 @@ if contextvars_supported():
             test.assertEqual(_EXPECTED_VALUE, self._recorded_value)
 
 else:
+
     def set_up_expected_context():
         pass
 

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import logging
+import os
 import sys
 import unittest
 
@@ -98,6 +99,8 @@ else:
             pass
 
 
+# TODO(https://github.com/grpc/grpc/issues/22257)
+@unittest.skipIf(os.name == "nt", "LocalCredentials not supported on Windows.")
 class ContextVarsPropagationTest(unittest.TestCase):
 
     def test_propagation_to_auth_plugin(self):

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -106,7 +106,7 @@ class ContextVarsPropagationTest(unittest.TestCase):
             # NOTE(rbellevi): We use a literal IPV6 address because 'localhost'
             # is not recognized as a local address by the LocalCredentials
             # implementation on Windows.
-            target = "[::]:{}".format(port)
+            target = "[::1]:{}".format(port)
             local_credentials = grpc.local_channel_credentials()
             test_call_credentials = TestCallCredentials()
             call_credentials = grpc.metadata_call_credentials(

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -103,10 +103,7 @@ class ContextVarsPropagationTest(unittest.TestCase):
     def test_propagation_to_auth_plugin(self):
         set_up_expected_context()
         with _server() as port:
-            # NOTE(rbellevi): We use a literal IPV6 address because 'localhost'
-            # is not recognized as a local address by the LocalCredentials
-            # implementation on Windows.
-            target = "[::1]:{}".format(port)
+            target = "localhost:{}".format(port)
             local_credentials = grpc.local_channel_credentials()
             test_call_credentials = TestCallCredentials()
             call_credentials = grpc.metadata_call_credentials(

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -34,7 +34,11 @@ def _unary_unary_handler(request, context):
 
 
 def contextvars_supported():
-    return sys.version_info[0] == 3 and sys.version_info[1] >= 7
+    try:
+        import contextvars
+        return True
+    except ImportError:
+        return False
 
 
 class _GenericHandler(grpc.GenericRpcHandler):

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -112,7 +112,7 @@ class ContextVarsPropagationTest(unittest.TestCase):
                 local_credentials, call_credentials)
             with grpc.secure_channel(target, composite_credentials) as channel:
                 stub = channel.unary_unary(_UNARY_UNARY)
-                response = stub(_REQUEST)
+                response = stub(_REQUEST, wait_for_ready=True)
                 self.assertEqual(_REQUEST, response)
                 test_call_credentials.assert_called(self)
 

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -103,7 +103,10 @@ class ContextVarsPropagationTest(unittest.TestCase):
     def test_propagation_to_auth_plugin(self):
         set_up_expected_context()
         with _server() as port:
-            target = "localhost:{}".format(port)
+            # NOTE(rbellevi): We use a literal IPV6 address because 'localhost'
+            # is not recognized as a local address by the LocalCredentials
+            # implementation on Windows.
+            target = "[::]:{}".format(port)
             local_credentials = grpc.local_channel_credentials()
             test_call_credentials = TestCallCredentials()
             call_credentials = grpc.metadata_call_credentials(

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test of propagation of contextvars between threads."""
+"""Test of propagation of contextvars to AuthMetadataPlugin threads.."""
 
 import contextlib
 import logging
@@ -28,9 +28,6 @@ _REQUEST = b"0000"
 
 def _unary_unary_handler(request, context):
     return request
-
-
-# TODO: Test for <3.7 and 3.7+.
 
 
 def contextvars_supported():
@@ -109,8 +106,6 @@ class ContextVarsPropagationTest(unittest.TestCase):
                 response = stub(_REQUEST)
                 self.assertEqual(_REQUEST, response)
                 test_call_credentials.assert_called(self)
-
-    # TODO: Test simple unary-unary.
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -72,13 +72,10 @@ if contextvars_supported():
 
     class TestCallCredentials(grpc.AuthMetadataPlugin):
 
-        def __init__(self):
-            self._recorded_value = None
-            self._invoked = False
-
         def __call__(self, context, callback):
-            self._recorded_value = test_var.get()
-            self._invoked = True
+            if test_var.get() != _EXPECTED_VALUE:
+                raise AssertionError("{} != {}".format(test_var.get(),
+                                                       _EXPECTED_VALUE))
             callback((), None)
 
         def assert_called(self, test):
@@ -94,9 +91,6 @@ else:
 
         def __call__(self, context, callback):
             callback((), None)
-
-        def assert_called(self, test):
-            pass
 
 
 # TODO(https://github.com/grpc/grpc/issues/22257)
@@ -117,7 +111,6 @@ class ContextVarsPropagationTest(unittest.TestCase):
                 stub = channel.unary_unary(_UNARY_UNARY)
                 response = stub(_REQUEST, wait_for_ready=True)
                 self.assertEqual(_REQUEST, response)
-                test_call_credentials.assert_called(self)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change was spurred by a problem encountered by a user from the opentelemetry project. The user was attempting to monkeypatch the `requests` library to collect statistics about messages sent. Periodically, their code sent a load report to a backend using gRPC Python. However, they used an `AuthMetadataPlugin` which also used the `requests` library. This caused a recursion -- reporting load triggered an auth refresh triggered more load triggered another load report...

The project makes great use of the `contextvars` module, introduced in 3.7. They even wrote an API-compatible backport that functions with interpreter versions as far back as `3.4`. Their initial solution was to add metadata to the `contextvars` context before reporting load with gRPC and then to exclude load reports marked with this metadata in their `requests` monkeypatch. However, they found that since `AuthMetadataPlugin`s may be executed on a new thread, their `contextvars` context was not propagated, defeating their solution.

This PR enables their solution by propagating `contextvars` context if and only if it is possible to do so. In all other cases, this PR is a no-op.

There may be some other scenarios besides auth where it is desirable to propagate this context, but our threading model makes it complicated to do so. We can cross that bridge when there's a river under it (i.e., when there's demand for it).

**This PR requires a cherrypick!**