### PR TITLE
Allow configuring default service configs in grpc_cli via --default_service_config

### DIFF
--- a/test/cpp/util/grpc_cli.cc
+++ b/test/cpp/util/grpc_cli.cc
@@ -51,6 +51,9 @@
        --decode=grpc.testing.SimpleResponse \
        src/proto/grpc/testing/messages.proto \
        < output.bin > output.txt
+   10. --default_service_config, optional default service config to use
+       on the channel. Note that this may be ignored if the name resolver
+       returns a service config.
 */
 
 #include <fstream>

--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -57,6 +57,11 @@ DEFINE_string(proto_path, ".", "Path to look for the proto file.");
 DEFINE_string(protofiles, "", "Name of the proto file.");
 DEFINE_bool(binary_input, false, "Input in binary format");
 DEFINE_bool(binary_output, false, "Output in binary format");
+DEFINE_string(
+    default_service_config, "",
+    "Default service config to use on the channel, if non-empty. Note "
+    "that this will be ignored if the name resolver returns a service "
+    "config.");
 DEFINE_bool(json_input, false, "Input in json format");
 DEFINE_bool(json_output, false, "Output in json format");
 DEFINE_string(infile, "", "Input file (default is stdin)");
@@ -216,6 +221,10 @@ std::shared_ptr<grpc::Channel> CreateCliChannel(
   grpc::ChannelArguments args;
   if (!cred.GetSslTargetNameOverride().empty()) {
     args.SetSslTargetNameOverride(cred.GetSslTargetNameOverride());
+  }
+  if (!FLAGS_default_service_config.empty()) {
+    args.SetString(GRPC_ARG_SERVICE_CONFIG,
+                   FLAGS_default_service_config.c_str());
   }
   return ::grpc::CreateCustomChannel(server_address, cred.GetCredentials(),
                                      args);


### PR DESCRIPTION
b/157764059 for context, this does part 1) of that bug

This is needed in order for grpc_cli to be useful for certain services which can only be reached if a service config is used (e.g. grpclb-load-balanced services).