### PR TITLE
Remove reference to building from source in Python xDS Example

### DIFF
--- a/examples/python/xds/README.md
+++ b/examples/python/xds/README.md
@@ -3,11 +3,8 @@ gRPC Hostname Example
 
 The hostname example is a Hello World server whose response includes its
 hostname. It also supports health and reflection services. This makes it a good
-server to test infrastructure, like load balancing.
-
-The example requires grpc to already be built. You are strongly encouraged
-to check out a git release tag, since there will already be a build of gRPC
-available.
+server to test infrastructure, like load balancing .This example depends on a
+gRPC version of 1.28.1 or newer.
 
 ### Run the example
 

--- a/examples/python/xds/README.md
+++ b/examples/python/xds/README.md
@@ -3,10 +3,10 @@ gRPC Hostname Example
 
 The hostname example is a Hello World server whose response includes its
 hostname. It also supports health and reflection services. This makes it a good
-server to test infrastructure, like load balancing .This example depends on a
+server to test infrastructure, like load balancing. This example depends on a
 gRPC version of 1.28.1 or newer.
 
-### Run the example
+### Run the Server
 
 1. Navigate to this directory:
 
@@ -23,7 +23,9 @@ pip install -r requirements.txt
 python server.py
 ```
 
-3. Verify the Server
+### Run the Client
+
+1. Set up xDS configuration.
 
 After configuring your xDS server to track the gRPC server we just started,
 create a bootstrap file as desribed in [gRFC A27](https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md):
@@ -45,23 +47,28 @@ create a bootstrap file as desribed in [gRFC A27](https://github.com/grpc/propos
 }
 ```
 
-Then point the `GRPC_XDS_BOOTSTRAP` environment variable at the bootstrap file:
+2. Point the `GRPC_XDS_BOOTSTRAP` environment variable at the bootstrap file:
 
 ```
 export GRPC_XDS_BOOTSTRAP=/etc/xds-bootstrap.json
 ```
 
-Finally, run your client:
+3. Run the client:
 
 ```
-python client.py xds:///my-backend
+python client.py xds-experimental:///my-backend
 ```
 
-Alternatively, `grpcurl` can be used to test your server. If you don't have it,
+### Verifying Configuration with a CLI Tool
+
+Alternatively, `grpcurl` can be used to verify your server. If you don't have it,
 install [`grpcurl`](https://github.com/fullstorydev/grpcurl/releases). This will allow
 you to manually test the service.
 
-Exercise your server's application-layer service:
+Be sure to set up the bootstrap file and `GRPC_XDS_BOOTSTRAP` as in the previous
+section.
+
+1. Verify the server's application-layer service:
 
 ```sh
 > grpcurl --plaintext -d '{"name": "you"}' localhost:50051
@@ -70,7 +77,7 @@ Exercise your server's application-layer service:
 }
 ```
 
-Make sure that all of your server's services are available via reflection:
+2. Verify that all services are available via reflection:
 
 ```sh
 > grpcurl --plaintext localhost:50051 list
@@ -79,7 +86,7 @@ grpc.reflection.v1alpha.ServerReflection
 helloworld.Greeter
 ```
 
-Make sure that your services are reporting healthy:
+3. Verify that all services are reporting healthy:
 
 ```sh
 > grpcurl --plaintext -d '{"service": "helloworld.Greeter"}' localhost:50051

--- a/examples/python/xds/requirements.txt
+++ b/examples/python/xds/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.28.0
+grpcio>=1.28.1
 protobuf
 grpcio-reflection
 grpcio-health-checking


### PR DESCRIPTION
Now that there are binary artifacts available, we should recommend those over building from source.

Thanks to @jtattermusch for catching this.