### PR TITLE
Fix C# distribtest

### DIFF
--- a/test/distrib/csharp/DistribTest/DistribTest.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTest.csproj
@@ -100,8 +100,8 @@
     <Reference Include="Google.Apis.Auth.PlatformServices">
       <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Protobuf, Version=3.12.2, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.12.2\lib\net45\Google.Protobuf.dll</HintPath>
+    <Reference Include="Google.Protobuf, Version=3.11.2.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.11.2\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Grpc" Version="__GRPC_NUGET_VERSION__" />
     <PackageReference Include="Grpc.Auth" Version="__GRPC_NUGET_VERSION__" />
     <PackageReference Include="Grpc.Tools" Version="__GRPC_NUGET_VERSION__" />
-    <PackageReference Include="Google.Protobuf" Version="3.12.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/distrib/csharp/DistribTest/packages.config
+++ b/test/distrib/csharp/DistribTest/packages.config
@@ -8,7 +8,7 @@
   <package id="Grpc.Core" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
   <package id="Grpc.Core.Api" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
   <package id="Grpc.Tools" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
-  <package id="Google.Protobuf" version="3.12.2" targetFramework="net45" />
+  <package id="Google.Protobuf" version="3.11.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net45" />
   <package id="System.Memory" version="4.5.3" targetFramework="net45" />


### PR DESCRIPTION
When updating the `third_party/protobuf` dependency, I accidentally updated these 3 files under the `test/distrib/csharp/DistribTest` directory which I shouldn't have, causing breakage to the master/windows/grpc_distribtests.

https://fusion.corp.google.com/runanalysis/info/prod%3Agrpc%2Fcore%2Fmaster%2Fwindows%2Fgrpc_distribtests/prod%3Agrpc%2Fcore%2Fmaster%2Fwindows%2Fgrpc_distribtests/KOKORO/30c61d03-fcf0-4b42-a612-4eb82571c86c/1591067749721/build%20%2311636/Targets