### PR TITLE
Fix PHP xDS test

### DIFF
--- a/tools/dockerfile/test/php73_zts_stretch_x64/Dockerfile
+++ b/tools/dockerfile/test/php73_zts_stretch_x64/Dockerfile
@@ -16,22 +16,14 @@ FROM php:7.3-zts-stretch
 
 RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake build-essential git libtool curl \
+  zlib1g-dev \
   python-all-dev \
   python3-all-dev \
   python-setuptools
 
 WORKDIR /tmp
 
-RUN git clone https://github.com/grpc/grpc
 RUN git clone https://github.com/krakjoe/pthreads
-
-RUN cd grpc && \
-  git submodule update --init --recursive && \
-  make && \
-  make install && \
-  cd third_party/protobuf && \
-  make install && \
-  ldconfig
 
 RUN cd pthreads && \
   phpize && \
@@ -47,4 +39,7 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
-WORKDIR /var/local/git/grpc
+RUN mkdir /var/local/jenkins
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -46,12 +46,9 @@ touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
     "$PROTO_SOURCE_DIR"/messages.proto \
     "$PROTO_SOURCE_DIR"/empty.proto
 
-# Compile the PHP extension.
-(cd src/php/ext/grpc && \
-  phpize && \
-  ./configure && \
-  make && \
-  make install)
+# Generate and compile the PHP extension.
+(pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {})
 
 # Prepare generated PHP code.
 export CC=/usr/bin/gcc


### PR DESCRIPTION
Fixes #23123 

The PHP xDS test is set up like this:
 - There's a base dockerfile `tools/dockerfile/test/php73_zts_stretch_x64/Dockerfile`.
 - We run the xds tests inside this docker container.

We shouldn't be compiling c-core as part of the docker image, because the dockerfile is snapshoted. Unless the _content_ of the Dockerfile changes, the docker image will not be re-built.

So what we _should_ do is to compile the PHP extension (including c-core) during the test every time, to make sure we are running the latest c-core code.

Green build after the fix: https://g3c.corp.google.com/results/invocations/cc14a8ac-4adf-44e2-a53c-31167d650e4f/targets