### PR TITLE
Increase PHP/Ruby xDS test timeout

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_php.cfg
+++ b/tools/internal_ci/linux/grpc_xds_php.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_php.sh"
-timeout_mins: 90
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_xds_ruby.cfg
+++ b/tools/internal_ci/linux/grpc_xds_ruby.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_ruby.sh"
-timeout_mins: 90
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
The PHP / Ruby xDS tests seem to be running just fine - but it gets killed after 5400 seconds.

https://source.cloud.google.com/results/invocations/ce1ad3ba-ec0e-4305-be61-822179b3b585/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_xds_php/log

https://source.cloud.google.com/results/invocations/63336250-9f5d-4e7c-90ff-f86d8e00fe24/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_xds_ruby/log

So trying to increase the timeout to make sure at least they get to run to completion.

cc @ericgribkoff 