### PR TITLE
Fix C# distrib test

### DIFF
--- a/test/distrib/csharp/DistribTest/DistribTest.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTest.csproj
@@ -100,7 +100,7 @@
     <Reference Include="Google.Apis.Auth.PlatformServices">
       <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Protobuf, Version=3.12.2, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+    <Reference Include="Google.Protobuf">
       <HintPath>..\packages\Google.Protobuf.3.12.2\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Somewhat counterintuitively, in the classic .csproj files, the assembly versions are 4-part and not 3-part:

Original state a while ago:
https://github.com/grpc/grpc/blob/2725ae4f86a46f45c5c243f3f23237e4335a3693/test/distrib/csharp/DistribTest/DistribTest.csproj#L103

A recent change that has changed the assembly version to 3-part (which has broken stuff)
https://github.com/grpc/grpc/pull/22998/files#diff-c4197c35bcaaa6ebc0c25c214c8ba74cL103

As a resolution, I'm actually removing the assembly version specifier (it's not strictly necessary and makes stuff more confusing).

