### PR TITLE
Set timeout to PHP/Ruby xDS test

### DIFF
--- a/src/php/tests/interop/xds_client.php
+++ b/src/php/tests/interop/xds_client.php
@@ -98,6 +98,7 @@ class ClientThread extends Thread {
         // Autoloaded classes do not get inherited in threads.
         // Hence we need to do this.
         require_once($this->autoload_path_);
+        $TIMEOUT_US = 30 * 1e6; // 30 seconds
 
         $stub = new Grpc\Testing\TestServiceClient($this->server_address_, [
             'credentials' => Grpc\ChannelCredentials::createInsecure()
@@ -121,7 +122,8 @@ class ClientThread extends Thread {
                 usleep($sleep_us);
             }
             list($response, $status)
-                = $stub->UnaryCall($request)->wait();
+                = $stub->UnaryCall($request, [],
+                                   ['timeout' => $TIMEOUT_US])->wait();
             if ($status->code == Grpc\STATUS_OK) {
                 $this->results[] = $response->getHostname();
             } else {

--- a/src/ruby/pb/test/xds_client.rb
+++ b/src/ruby/pb/test/xds_client.rb
@@ -122,7 +122,8 @@ def run_test_loop(stub, target_seconds_between_rpcs, fail_on_failed_rpcs)
       sleep(sleep_seconds)
     end
     begin
-      resp = stub.unary_call(req)
+      deadline = GRPC::Core::TimeConsts::from_relative_time(30) # 30 seconds
+      resp = stub.unary_call(req, deadline: deadline)
       remote_peer = resp.hostname
     rescue GRPC::BadStatus => e
       remote_peer = ""


### PR DESCRIPTION
Follow up on #23139.

We saw these logs from the PHP / Ruby xDS test:

```
php xds: warning, rpc takes too long to finish. Deficit 938297.8ms.If you consistently see this, the qps is too high.
```

```
ruby xds: warning, rpc takes too long to finish. Deficit = 937971.0ms. If you consistently see this, the qps is too high.
```

These are both from the `backends_restart` test (there might be others). 

https://source.cloud.google.com/results/invocations/b754ceb5-548d-4775-9be3-c52cc95fbc9f/targets/github%2Fgrpc%2Freports%2Fbackends_restart/artifacts

https://source.cloud.google.com/results/invocations/516f6df6-d4e0-4f68-9934-9e1ca440657e/targets/github%2Fgrpc%2Freports%2Fbackends_restart/artifacts


This PR adds a timeout to the client RPC so we don't spend 15.5 minutes waiting on one.