### PR TITLE
Dynamically check if expected IG is primary

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -537,7 +537,7 @@ def test_secondary_locality_gets_requests_on_primary_failure(
             (primary_instance_group,
              secondary_instance_group) = (secondary_instance_group,
                                           primary_instance_group)
-        primary_instance_names = get_instance_names(gcp, instance_group)
+        primary_instance_names = get_instance_names(gcp, primary_instance_group)
         secondary_instance_names = get_instance_names(gcp,
                                                       secondary_instance_group)
         wait_until_all_rpcs_go_to_given_backends(primary_instance_names,


### PR DESCRIPTION
In certain test environments (and even, potentially, in prod) we may not connect to a xds server in the same region as the client. This will skew the primary/secondary calculation, which will then be based off the location of the xds server and not the client itself. Currently we unconditionally expect RPCs to initially be routed only to a MIG in the same zone as the client; when the above scenario occurs, this is no longer valid.

This PR changes the secondary_locality_* tests to first verify that the MIG we expect to be primary *is* actually primary, based on where traffic is assigned. This allows the test to continue to operate by, when necessary, swapping the roles of primary/secondary MIGs and validating that failover then works as expected.