### PR TITLE
Replace most uses of gpr_asprintf() with absl calls.

### DIFF
--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -22,6 +22,8 @@
 
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -241,11 +243,10 @@ void HttpConnectHandshaker::OnReadDone(void* arg, grpc_error* error) {
   // Make sure we got a 2xx response.
   if (handshaker->http_response_.status < 200 ||
       handshaker->http_response_.status >= 300) {
-    char* msg;
-    gpr_asprintf(&msg, "HTTP proxy returned response code %d",
-                 handshaker->http_response_.status);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("HTTP proxy returned response code ",
+                     handshaker->http_response_.status)
+            .c_str());
     handshaker->HandshakeFailedLocked(error);
     goto done;
   }

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -176,13 +178,13 @@ class HttpProxyMapper : public ProxyMapperInterface {
       /* Use base64 encoding for user credentials as stated in RFC 7617 */
       char* encoded_user_cred =
           grpc_base64_encode(user_cred, strlen(user_cred), 0, 0);
-      char* header;
-      gpr_asprintf(&header, "Proxy-Authorization:Basic %s", encoded_user_cred);
+      std::string header =
+          absl::StrCat("Proxy-Authorization:Basic ", encoded_user_cred);
       gpr_free(encoded_user_cred);
       args_to_add[1] = grpc_channel_arg_string_create(
-          (char*)GRPC_ARG_HTTP_CONNECT_HEADERS, header);
+          const_cast<char*>(GRPC_ARG_HTTP_CONNECT_HEADERS),
+          const_cast<char*>(header.c_str()));
       *new_args = grpc_channel_args_copy_and_add(args, args_to_add, 2);
-      gpr_free(header);
     } else {
       *new_args = grpc_channel_args_copy_and_add(args, args_to_add, 1);
     }

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -390,23 +390,21 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
     if (subchannel == nullptr) {
       // Subchannel could not be created.
       if (GRPC_TRACE_FLAG_ENABLED(*tracer_)) {
-        char* address_uri = grpc_sockaddr_to_uri(&addresses[i].address());
         gpr_log(GPR_INFO,
                 "[%s %p] could not create subchannel for address uri %s, "
                 "ignoring",
-                tracer_->name(), policy_, address_uri);
-        gpr_free(address_uri);
+                tracer_->name(), policy_,
+                grpc_sockaddr_to_uri(&addresses[i].address()).c_str());
       }
       continue;
     }
     if (GRPC_TRACE_FLAG_ENABLED(*tracer_)) {
-      char* address_uri = grpc_sockaddr_to_uri(&addresses[i].address());
       gpr_log(GPR_INFO,
               "[%s %p] subchannel list %p index %" PRIuPTR
               ": Created subchannel %p for address uri %s",
               tracer_->name(), policy_, this, subchannels_.size(),
-              subchannel.get(), address_uri);
-      gpr_free(address_uri);
+              subchannel.get(),
+              grpc_sockaddr_to_uri(&addresses[i].address()).c_str());
     }
     subchannels_.emplace_back(this, addresses[i], std::move(subchannel));
   }

--- a/src/core/ext/filters/client_channel/lb_policy_registry.cc
+++ b/src/core/ext/filters/client_channel/lb_policy_registry.cc
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/strings/str_format.h"
 
 #include "src/core/lib/gpr/string.h"
 
@@ -168,11 +169,9 @@ LoadBalancingPolicyRegistry::ParseLoadBalancingConfig(const Json& json,
   LoadBalancingPolicyFactory* factory =
       g_state->GetLoadBalancingPolicyFactory(policy->first.c_str());
   if (factory == nullptr) {
-    char* msg;
-    gpr_asprintf(&msg, "Factory not found for policy \"%s\"",
-                 policy->first.c_str());
-    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat("Factory not found for policy \"%s\"", policy->first)
+            .c_str());
     return nullptr;
   }
   // Parse load balancing config via factory.

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
@@ -23,6 +23,8 @@
 #include <ares.h>
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h"
 
 #include <grpc/support/alloc.h>
@@ -155,11 +157,10 @@ grpc_error* grpc_ares_ev_driver_create_locked(
   grpc_ares_test_only_inject_config((*ev_driver)->channel);
   GRPC_CARES_TRACE_LOG("request:%p grpc_ares_ev_driver_create_locked", request);
   if (status != ARES_SUCCESS) {
-    char* err_msg;
-    gpr_asprintf(&err_msg, "Failed to init ares channel. C-ares error: %s",
-                 ares_strerror(status));
-    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(err_msg);
-    gpr_free(err_msg);
+    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Failed to init ares channel. C-ares error: ",
+                     ares_strerror(status))
+            .c_str());
     gpr_free(*ev_driver);
     return err;
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
@@ -20,6 +20,8 @@
 #include "src/core/lib/iomgr/port.h"
 #if GRPC_ARES == 1 && defined(GRPC_UV)
 
+#include "absl/strings/str_format.h"
+
 #include <ares.h>
 #include <uv.h>
 
@@ -43,14 +45,13 @@ class GrpcPolledFdLibuv : public GrpcPolledFd {
  public:
   GrpcPolledFdLibuv(ares_socket_t as,
                     std::shared_ptr<WorkSerializer> work_serializer)
-      : as_(as), work_serializer_(std::move(work_serializer)) {
-    gpr_asprintf(&name_, "c-ares socket: %" PRIdPTR, (intptr_t)as);
+      : name_(absl::StrFormat("c-ares socket: %" PRIdPTR, (intptr_t)as)),
+        as_(as),
+        work_serializer_(std::move(work_serializer)) {
     handle_ = new uv_poll_t();
     uv_poll_init_socket(uv_default_loop(), handle_, as);
     handle_->data = this;
   }
-
-  ~GrpcPolledFdLibuv() { gpr_free(name_); }
 
   void RegisterForOnReadableLocked(grpc_closure* read_closure) override {
     GPR_ASSERT(read_closure_ == nullptr);
@@ -98,9 +99,10 @@ class GrpcPolledFdLibuv : public GrpcPolledFd {
 
   ares_socket_t GetWrappedAresSocketLocked() override { return as_; }
 
-  const char* GetName() override { return name_; }
+  const char* GetName() override { return name_.c_str(); }
 
-  char* name_;
+  // TODO(apolcyn): Data members should be private.
+  std::string name_;
   ares_socket_t as_;
   uv_poll_t* handle_;
   grpc_closure* read_closure_ = nullptr;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -20,6 +20,8 @@
 #include "src/core/lib/iomgr/port.h"
 #if GRPC_ARES == 1 && defined(GRPC_WINDOWS_SOCKET_ARES_EV_DRIVER)
 
+#include "absl/strings/str_format.h"
+
 #include <ares.h>
 
 #include <grpc/support/alloc.h>
@@ -100,14 +102,14 @@ class GrpcPolledFdWindows {
   GrpcPolledFdWindows(ares_socket_t as,
                       std::shared_ptr<WorkSerializer> work_serializer,
                       int address_family, int socket_type)
-      : work_serializer_(std::move(work_serializer)),
+      : name_(absl::StrFormat("c-ares socket: %" PRIdPTR, as)),
+        work_serializer_(std::move(work_serializer)),
         read_buf_(grpc_empty_slice()),
         write_buf_(grpc_empty_slice()),
         tcp_write_state_(WRITE_IDLE),
         gotten_into_driver_list_(false),
         address_family_(address_family),
         socket_type_(socket_type) {
-    gpr_asprintf(&name_, "c-ares socket: %" PRIdPTR, as);
     // Closure Initialization
     GRPC_CLOSURE_INIT(&outer_read_closure_,
                       &GrpcPolledFdWindows::OnIocpReadable, this,
@@ -118,7 +120,7 @@ class GrpcPolledFdWindows {
     GRPC_CLOSURE_INIT(&on_tcp_connect_locked_,
                       &GrpcPolledFdWindows::OnTcpConnect, this,
                       grpc_schedule_on_exec_ctx);
-    winsocket_ = grpc_winsocket_create(as, name_);
+    winsocket_ = grpc_winsocket_create(as, name_.c_str());
   }
 
   ~GrpcPolledFdWindows() {
@@ -127,7 +129,6 @@ class GrpcPolledFdWindows {
     GPR_ASSERT(read_closure_ == nullptr);
     GPR_ASSERT(write_closure_ == nullptr);
     grpc_winsocket_destroy(winsocket_);
-    gpr_free(name_);
   }
 
   void ScheduleAndNullReadClosure(grpc_error* error) {
@@ -260,7 +261,7 @@ class GrpcPolledFdWindows {
     return grpc_winsocket_wrapped_socket(winsocket_);
   }
 
-  const char* GetName() { return name_; }
+  const char* GetName() { return name_.c_str(); }
 
   ares_ssize_t RecvFrom(WSAErrorContext* wsa_error_ctx, void* data,
                         ares_socket_t data_len, int flags,
@@ -657,6 +658,7 @@ class GrpcPolledFdWindows {
   bool gotten_into_driver_list() const { return gotten_into_driver_list_; }
   void set_gotten_into_driver_list() { gotten_into_driver_list_ = true; }
 
+ private:
   std::shared_ptr<WorkSerializer> work_serializer_;
   char recv_from_source_addr_[200];
   ares_socklen_t recv_from_source_addr_len_;
@@ -670,7 +672,7 @@ class GrpcPolledFdWindows {
   grpc_winsocket* winsocket_;
   // tcp_write_state_ is only used on TCP GrpcPolledFds
   WriteState tcp_write_state_;
-  char* name_ = nullptr;
+  std::string name_;
   bool gotten_into_driver_list_;
   int address_family_;
   int socket_type_;

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/alloc.h>
@@ -353,13 +354,11 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const Json& json,
         error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
             "field:loadBalancingPolicy error:Unknown lb policy"));
       } else if (requires_config) {
-        char* error_msg;
-        gpr_asprintf(&error_msg,
-                     "field:loadBalancingPolicy error:%s requires a config. "
-                     "Please use loadBalancingConfig instead.",
-                     lb_policy_name.c_str());
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg));
-        gpr_free(error_msg);
+        error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+            absl::StrCat("field:loadBalancingPolicy error:", lb_policy_name,
+                         " requires a config. Please use loadBalancingConfig "
+                         "instead.")
+                .c_str()));
       }
     }
   }

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -872,7 +872,7 @@ grpc_arg Subchannel::CreateSubchannelAddressArg(
     const grpc_resolved_address* addr) {
   return grpc_channel_arg_string_create(
       (char*)GRPC_ARG_SUBCHANNEL_ADDRESS,
-      addr->len > 0 ? grpc_sockaddr_to_uri(addr) : gpr_strdup(""));
+      gpr_strdup(addr->len > 0 ? grpc_sockaddr_to_uri(addr).c_str() : ""));
 }
 
 const char* Subchannel::GetUriFromSubchannelAddressArg(

--- a/src/core/ext/filters/client_channel/xds/xds_client_stats.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client_stats.h
@@ -24,9 +24,9 @@
 #include <map>
 #include <string>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
-
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/atomic.h"
 #include "src/core/lib/gprpp/memory.h"
@@ -80,21 +80,20 @@ class XdsLocalityName : public RefCounted<XdsLocalityName> {
   const std::string& zone() const { return zone_; }
   const std::string& sub_zone() const { return sub_zone_; }
 
-  const char* AsHumanReadableString() {
-    if (human_readable_string_ == nullptr) {
-      char* tmp;
-      gpr_asprintf(&tmp, "{region=\"%s\", zone=\"%s\", sub_zone=\"%s\"}",
-                   region_.c_str(), zone_.c_str(), sub_zone_.c_str());
-      human_readable_string_.reset(tmp);
+  const std::string& AsHumanReadableString() {
+    if (human_readable_string_.empty()) {
+      human_readable_string_ =
+          absl::StrFormat("{region=\"%s\", zone=\"%s\", sub_zone=\"%s\"}",
+                          region_, zone_, sub_zone_);
     }
-    return human_readable_string_.get();
+    return human_readable_string_;
   }
 
  private:
   std::string region_;
   std::string zone_;
   std::string sub_zone_;
-  UniquePtr<char> human_readable_string_;
+  std::string human_readable_string_;
 };
 
 // Drop stats for an xds cluster.

--- a/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
@@ -23,11 +23,12 @@
 #include <assert.h>
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/compression.h>
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "absl/strings/str_format.h"
 #include "src/core/ext/filters/message_size/message_size_filter.h"
@@ -258,14 +259,12 @@ void CallData::FinishRecvMessage() {
   grpc_slice_buffer_init(&decompressed_slices);
   if (grpc_msg_decompress(algorithm_, &recv_slices_, &decompressed_slices) ==
       0) {
-    char* msg;
-    gpr_asprintf(
-        &msg,
-        "Unexpected error decompressing data for algorithm with enum value %d",
-        algorithm_);
     GPR_DEBUG_ASSERT(error_ == GRPC_ERROR_NONE);
-    error_ = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error_ = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Unexpected error decompressing data for algorithm with "
+                     "enum value ",
+                     algorithm_)
+            .c_str());
     grpc_slice_buffer_destroy_internal(&decompressed_slices);
   } else {
     uint32_t recv_flags =

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.h
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <string>
+
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/cpp/common/channel_filter.h"
 
@@ -54,9 +56,8 @@ class ServerLoadReportingCallData : public CallData {
 
  private:
   // From the peer_string_ in calld, extracts the client IP string (owned by
-  // caller), e.g., "01020a0b". Upon failure, set the output pointer to null and
-  // size to zero.
-  void GetCensusSafeClientIpString(char** client_ip_string, size_t* size);
+  // caller), e.g., "01020a0b". Upon failure, returns empty string.
+  std::string GetCensusSafeClientIpString();
 
   // Concatenates the client IP address and the load reporting token, then
   // stores the result into the call data.

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -24,14 +24,14 @@
 #include <limits.h>
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
-
-#include "absl/strings/str_format.h"
 
 #include "src/core/ext/filters/http/server/http_server_filter.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.cc
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.cc
@@ -24,8 +24,9 @@
 
 #ifdef GPR_SUPPORT_CHANNELS_FROM_FD
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
@@ -40,14 +41,11 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server* server,
   GPR_ASSERT(reserved == nullptr);
 
   grpc_core::ExecCtx exec_ctx;
-  char* name;
-  gpr_asprintf(&name, "fd:%d", fd);
 
+  std::string name = absl::StrCat("fd:", fd);
   grpc_endpoint* server_endpoint =
-      grpc_tcp_create(grpc_fd_create(fd, name, true),
-                      grpc_server_get_channel_args(server), name);
-
-  gpr_free(name);
+      grpc_tcp_create(grpc_fd_create(fd, name.c_str(), true),
+                      grpc_server_get_channel_args(server), name.c_str());
 
   const grpc_channel_args* server_args = grpc_server_get_channel_args(server);
   grpc_transport* transport = grpc_create_chttp2_transport(

--- a/src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc
+++ b/src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc
@@ -22,9 +22,10 @@
 
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/transport/chttp2/server/chttp2_server.h"
 
@@ -56,12 +57,10 @@ int grpc_server_add_secure_http2_port(grpc_server* server, const char* addr,
   }
   sc = creds->create_security_connector();
   if (sc == nullptr) {
-    char* msg;
-    gpr_asprintf(&msg,
-                 "Unable to create secure server with credentials of type %s.",
-                 creds->type());
-    err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Unable to create secure server with credentials of type ",
+                     creds->type())
+            .c_str());
     goto done;
   }
   // Create channel args.

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -23,9 +23,10 @@
 
 #include <string.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 void grpc_chttp2_goaway_parser_init(grpc_chttp2_goaway_parser* p) {
   p->debug_data = nullptr;
@@ -39,11 +40,8 @@ grpc_error* grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
                                                   uint32_t length,
                                                   uint8_t /*flags*/) {
   if (length < 8) {
-    char* msg;
-    gpr_asprintf(&msg, "goaway frame too short (%d bytes)", length);
-    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return err;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat("goaway frame too short (%d bytes)", length).c_str());
   }
 
   gpr_free(p->debug_data);

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -23,9 +23,10 @@
 
 #include <string.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 static bool g_disable_ping_ack = false;
 
@@ -58,11 +59,9 @@ grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,
                                                 uint32_t length,
                                                 uint8_t flags) {
   if (flags & 0xfe || length != 8) {
-    char* msg;
-    gpr_asprintf(&msg, "invalid ping: length=%d, flags=%02x", length, flags);
-    grpc_error* error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return error;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat("invalid ping: length=%d, flags=%02x", length, flags)
+            .c_str());
   }
   parser->byte = 0;
   parser->is_ack = flags;

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -21,9 +21,11 @@
 #include "src/core/ext/transport/chttp2/transport/frame_rst_stream.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
 #include "src/core/lib/gprpp/memory.h"
@@ -69,12 +71,10 @@ void grpc_chttp2_add_rst_stream_to_next_write(
 grpc_error* grpc_chttp2_rst_stream_parser_begin_frame(
     grpc_chttp2_rst_stream_parser* parser, uint32_t length, uint8_t flags) {
   if (length != 4) {
-    char* msg;
-    gpr_asprintf(&msg, "invalid rst_stream: length=%d, flags=%02x", length,
-                 flags);
-    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return err;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat("invalid rst_stream: length=%d, flags=%02x", length,
+                        flags)
+            .c_str());
   }
   parser->byte = 0;
   return GRPC_ERROR_NONE;
@@ -106,13 +106,12 @@ grpc_error* grpc_chttp2_rst_stream_parser_parse(void* parser,
                       ((static_cast<uint32_t>(p->reason_bytes[3])));
     grpc_error* error = GRPC_ERROR_NONE;
     if (reason != GRPC_HTTP2_NO_ERROR || s->metadata_buffer[1].size == 0) {
-      char* message;
-      gpr_asprintf(&message, "Received RST_STREAM with error code %d", reason);
       error = grpc_error_set_int(
-          grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
-                             GRPC_ERROR_STR_GRPC_MESSAGE,
-                             grpc_slice_from_moved_string(
-                                 grpc_core::UniquePtr<char>(message))),
+          grpc_error_set_str(
+              GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
+              GRPC_ERROR_STR_GRPC_MESSAGE,
+              grpc_slice_from_cpp_string(absl::StrCat(
+                  "Received RST_STREAM with error code ", reason))),
           GRPC_ERROR_INT_HTTP2_ERROR, static_cast<intptr_t>(reason));
     }
     grpc_chttp2_mark_stream_closed(t, s, true, true, error);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -23,9 +23,10 @@
 
 #include <string.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/ext/transport/chttp2/transport/frame.h"
@@ -117,7 +118,6 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
       static_cast<grpc_chttp2_settings_parser*>(p);
   const uint8_t* cur = GRPC_SLICE_START_PTR(slice);
   const uint8_t* end = GRPC_SLICE_END_PTR(slice);
-  char* msg;
   grpc_chttp2_setting_id id;
 
   if (parser->is_ack) {
@@ -208,11 +208,10 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
                     t->last_new_stream_id, sp->error_value,
                     grpc_slice_from_static_string("HTTP2 settings error"),
                     &t->qbuf);
-                gpr_asprintf(&msg, "invalid value %u passed for %s",
-                             parser->value, sp->name);
-                grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-                gpr_free(msg);
-                return err;
+                return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+                    absl::StrFormat("invalid value %u passed for %s",
+                                    parser->value, sp->name)
+                        .c_str());
             }
           }
           if (id == GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE &&

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -21,9 +21,11 @@
 #include "src/core/ext/transport/chttp2/transport/frame_window_update.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 grpc_slice grpc_chttp2_window_update_create(
     uint32_t id, uint32_t window_update, grpc_transport_one_way_stats* stats) {
@@ -54,12 +56,10 @@ grpc_slice grpc_chttp2_window_update_create(
 grpc_error* grpc_chttp2_window_update_parser_begin_frame(
     grpc_chttp2_window_update_parser* parser, uint32_t length, uint8_t flags) {
   if (flags || length != 4) {
-    char* msg;
-    gpr_asprintf(&msg, "invalid window update: length=%d, flags=%02x", length,
-                 flags);
-    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return err;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat("invalid window update: length=%d, flags=%02x", length,
+                        flags)
+            .c_str());
   }
   parser->byte = 0;
   parser->amount = 0;
@@ -91,11 +91,8 @@ grpc_error* grpc_chttp2_window_update_parser_parse(void* parser,
     // top bit is reserved and must be ignored.
     uint32_t received_update = p->amount & 0x7fffffffu;
     if (received_update == 0) {
-      char* msg;
-      gpr_asprintf(&msg, "invalid window update bytes: %d", p->amount);
-      grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-      gpr_free(msg);
-      return err;
+      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrCat("invalid window update bytes: ", p->amount).c_str());
     }
     GPR_ASSERT(is_last);
 

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -25,9 +25,11 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/transport/chttp2/transport/bin_encoder.h"
 #include "src/core/lib/debug/stats.h"
@@ -1087,10 +1089,8 @@ static grpc_error* still_parse_error(grpc_chttp2_hpack_parser* p,
 static grpc_error* parse_illegal_op(grpc_chttp2_hpack_parser* p,
                                     const uint8_t* cur, const uint8_t* end) {
   GPR_ASSERT(cur != end);
-  char* msg;
-  gpr_asprintf(&msg, "Illegal hpack op code %d", *cur);
-  grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-  gpr_free(msg);
+  grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+      absl::StrCat("Illegal hpack op code ", *cur).c_str());
   return parse_error(p, cur, end, err);
 }
 
@@ -1173,7 +1173,6 @@ static grpc_error* parse_value4(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
   uint8_t c;
   uint32_t cur_value;
   uint32_t add_value;
-  char* msg;
 
   if (cur == end) {
     p->state = parse_value4;
@@ -1200,12 +1199,12 @@ static grpc_error* parse_value4(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
   }
 
 error:
-  gpr_asprintf(&msg,
-               "integer overflow in hpack integer decoding: have 0x%08x, "
-               "got byte 0x%02x on byte 5",
-               *p->parsing.value, *cur);
-  grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-  gpr_free(msg);
+  grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+      absl::StrFormat(
+          "integer overflow in hpack integer decoding: have 0x%08x, "
+          "got byte 0x%02x on byte 5",
+          *p->parsing.value, *cur)
+          .c_str());
   return parse_error(p, cur, end, err);
 }
 
@@ -1227,13 +1226,12 @@ static grpc_error* parse_value5up(grpc_chttp2_hpack_parser* p,
     return parse_next(p, cur + 1, end);
   }
 
-  char* msg;
-  gpr_asprintf(&msg,
-               "integer overflow in hpack integer decoding: have 0x%08x, "
-               "got byte 0x%02x sometime after byte 5",
-               *p->parsing.value, *cur);
-  grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-  gpr_free(msg);
+  grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+      absl::StrFormat(
+          "integer overflow in hpack integer decoding: have 0x%08x, "
+          "got byte 0x%02x sometime after byte 5",
+          *p->parsing.value, *cur)
+          .c_str());
   return parse_error(p, cur, end, err);
 }
 
@@ -1389,11 +1387,10 @@ static grpc_error* finish_str(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
     case B64_BYTE2:
       bits = p->base64_buffer;
       if (bits & 0xffff) {
-        char* msg;
-        gpr_asprintf(&msg, "trailing bits in base64 encoding: 0x%04x",
-                     bits & 0xffff);
-        grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-        gpr_free(msg);
+        grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+            absl::StrFormat("trailing bits in base64 encoding: 0x%04x",
+                            bits & 0xffff)
+                .c_str());
         return parse_error(p, cur, end, err);
       }
       decoded[0] = static_cast<uint8_t>(bits >> 16);
@@ -1402,11 +1399,10 @@ static grpc_error* finish_str(grpc_chttp2_hpack_parser* p, const uint8_t* cur,
     case B64_BYTE3:
       bits = p->base64_buffer;
       if (bits & 0xff) {
-        char* msg;
-        gpr_asprintf(&msg, "trailing bits in base64 encoding: 0x%02x",
-                     bits & 0xff);
-        grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-        gpr_free(msg);
+        grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+            absl::StrFormat("trailing bits in base64 encoding: 0x%02x",
+                            bits & 0xff)
+                .c_str());
         return parse_error(p, cur, end, err);
       }
       decoded[0] = static_cast<uint8_t>(bits >> 16);

--- a/src/core/ext/transport/chttp2/transport/hpack_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_table.cc
@@ -23,9 +23,10 @@
 #include <assert.h>
 #include <string.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/murmur_hash.h"
@@ -119,13 +120,11 @@ grpc_error* grpc_chttp2_hptbl_set_current_table_size(grpc_chttp2_hptbl* tbl,
     return GRPC_ERROR_NONE;
   }
   if (bytes > tbl->max_bytes) {
-    char* msg;
-    gpr_asprintf(&msg,
-                 "Attempt to make hpack table %d bytes when max is %d bytes",
-                 bytes, tbl->max_bytes);
-    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return err;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat(
+            "Attempt to make hpack table %d bytes when max is %d bytes", bytes,
+            tbl->max_bytes)
+            .c_str());
   }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace)) {
     gpr_log(GPR_INFO, "Update hpack parser table size to %d", bytes);
@@ -153,15 +152,12 @@ grpc_error* grpc_chttp2_hptbl_add(grpc_chttp2_hptbl* tbl, grpc_mdelem md) {
                       GRPC_CHTTP2_HPACK_ENTRY_OVERHEAD;
 
   if (tbl->current_table_bytes > tbl->max_bytes) {
-    char* msg;
-    gpr_asprintf(
-        &msg,
-        "HPACK max table size reduced to %d but not reflected by hpack "
-        "stream (still at %d)",
-        tbl->max_bytes, tbl->current_table_bytes);
-    grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return err;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat(
+            "HPACK max table size reduced to %d but not reflected by hpack "
+            "stream (still at %d)",
+            tbl->max_bytes, tbl->current_table_bytes)
+            .c_str());
   }
 
   /* we can't add elements bigger than the max table size */

--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -146,14 +146,12 @@ const char* severity_string(ChannelTrace::Severity severity) {
 
 Json ChannelTrace::TraceEvent::RenderTraceEvent() const {
   char* description = grpc_slice_to_c_string(data_);
-  char* ts_str = gpr_format_timespec(timestamp_);
   Json::Object object = {
       {"description", description},
       {"severity", severity_string(severity_)},
-      {"timestamp", ts_str},
+      {"timestamp", gpr_format_timespec(timestamp_)},
   };
   gpr_free(description);
-  gpr_free(ts_str);
   if (referenced_entity_ != nullptr) {
     const bool is_channel =
         (referenced_entity_->type() == BaseNode::EntityType::kTopLevelChannel ||
@@ -171,11 +169,9 @@ Json ChannelTrace::RenderJson() const {
   if (max_event_memory_ == 0) {
     return Json();  // JSON null
   }
-  char* ts_str = gpr_format_timespec(time_created_);
   Json::Object object = {
-      {"creationTimestamp", ts_str},
+      {"creationTimestamp", gpr_format_timespec(time_created_)},
   };
-  gpr_free(ts_str);
   if (num_events_logged_ > 0) {
     object["numEventsLogged"] = std::to_string(num_events_logged_);
   }

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -156,9 +156,7 @@ void CallCountingHelper::PopulateCallCounts(Json::Object* object) {
     gpr_timespec ts = gpr_convert_clock_type(
         gpr_cycle_counter_to_time(data.last_call_started_cycle),
         GPR_CLOCK_REALTIME);
-    char* ts_str = gpr_format_timespec(ts);
-    (*object)["lastCallStartedTimestamp"] = ts_str;
-    gpr_free(ts_str);
+    (*object)["lastCallStartedTimestamp"] = gpr_format_timespec(ts);
   }
   if (data.calls_succeeded != 0) {
     (*object)["callsSucceeded"] = std::to_string(data.calls_succeeded);
@@ -456,9 +454,7 @@ Json SocketNode::RenderJson() {
       ts = gpr_convert_clock_type(
           gpr_cycle_counter_to_time(last_local_stream_created_cycle),
           GPR_CLOCK_REALTIME);
-      char* ts_str = gpr_format_timespec(ts);
-      data["lastLocalStreamCreatedTimestamp"] = ts_str;
-      gpr_free(ts_str);
+      data["lastLocalStreamCreatedTimestamp"] = gpr_format_timespec(ts);
     }
     gpr_cycle_counter last_remote_stream_created_cycle =
         last_remote_stream_created_cycle_.Load(MemoryOrder::RELAXED);
@@ -466,9 +462,7 @@ Json SocketNode::RenderJson() {
       ts = gpr_convert_clock_type(
           gpr_cycle_counter_to_time(last_remote_stream_created_cycle),
           GPR_CLOCK_REALTIME);
-      char* ts_str = gpr_format_timespec(ts);
-      data["lastRemoteStreamCreatedTimestamp"] = ts_str;
-      gpr_free(ts_str);
+      data["lastRemoteStreamCreatedTimestamp"] = gpr_format_timespec(ts);
     }
   }
   int64_t streams_succeeded = streams_succeeded_.Load(MemoryOrder::RELAXED);
@@ -486,9 +480,7 @@ Json SocketNode::RenderJson() {
         gpr_cycle_counter_to_time(
             last_message_sent_cycle_.Load(MemoryOrder::RELAXED)),
         GPR_CLOCK_REALTIME);
-    char* ts_str = gpr_format_timespec(ts);
-    data["lastMessageSentTimestamp"] = ts_str;
-    gpr_free(ts_str);
+    data["lastMessageSentTimestamp"] = gpr_format_timespec(ts);
   }
   int64_t messages_received = messages_received_.Load(MemoryOrder::RELAXED);
   if (messages_received != 0) {
@@ -497,9 +489,7 @@ Json SocketNode::RenderJson() {
         gpr_cycle_counter_to_time(
             last_message_received_cycle_.Load(MemoryOrder::RELAXED)),
         GPR_CLOCK_REALTIME);
-    char* ts_str = gpr_format_timespec(ts);
-    data["lastMessageReceivedTimestamp"] = ts_str;
-    gpr_free(ts_str);
+    data["lastMessageReceivedTimestamp"] = gpr_format_timespec(ts);
   }
   int64_t keepalives_sent = keepalives_sent_.Load(MemoryOrder::RELAXED);
   if (keepalives_sent != 0) {

--- a/src/core/lib/gpr/log_linux.cc
+++ b/src/core/lib/gpr/log_linux.cc
@@ -30,7 +30,6 @@
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <inttypes.h>
 #include <stdarg.h>
@@ -39,6 +38,8 @@
 #include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
+#include <string>
+#include "absl/strings/str_format.h"
 
 static long sys_gettid(void) { return syscall(__NR_gettid); }
 
@@ -63,7 +64,6 @@ void gpr_log(const char* file, int line, gpr_log_severity severity,
 
 void gpr_default_log(gpr_log_func_args* args) {
   const char* final_slash;
-  char* prefix;
   const char* display_file;
   char time_buffer[64];
   time_t timer;
@@ -86,12 +86,10 @@ void gpr_default_log(gpr_log_func_args* args) {
     strcpy(time_buffer, "error:strftime");
   }
 
-  gpr_asprintf(&prefix, "%s%s.%09" PRId32 " %7ld %s:%d]",
-               gpr_log_severity_string(args->severity), time_buffer,
-               now.tv_nsec, tid, display_file, args->line);
-
-  fprintf(stderr, "%-60s %s\n", prefix, args->message);
-  gpr_free(prefix);
+  std::string prefix = absl::StrFormat(
+      "%s%s.%09" PRId32 " %7ld %s:%d]", gpr_log_severity_string(args->severity),
+      time_buffer, now.tv_nsec, tid, display_file, args->line);
+  fprintf(stderr, "%-60s %s\n", prefix.c_str(), args->message);
 }
 
 #endif /* GPR_LINUX_LOG */

--- a/src/core/lib/gpr/log_posix.cc
+++ b/src/core/lib/gpr/log_posix.cc
@@ -22,7 +22,6 @@
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <inttypes.h>
 #include <pthread.h>
@@ -30,6 +29,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <string>
+#include "absl/strings/str_format.h"
 
 static intptr_t sys_gettid(void) { return (intptr_t)pthread_self(); }
 
@@ -83,13 +84,10 @@ void gpr_default_log(gpr_log_func_args* args) {
     strcpy(time_buffer, "error:strftime");
   }
 
-  char* prefix;
-  gpr_asprintf(&prefix, "%s%s.%09d %7" PRIdPTR " %s:%d]",
-               gpr_log_severity_string(args->severity), time_buffer,
-               (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
-
-  fprintf(stderr, "%-70s %s\n", prefix, args->message);
-  gpr_free(prefix);
+  std::string prefix = absl::StrFormat(
+      "%s%s.%09d %7" PRIdPTR " %s:%d]", gpr_log_severity_string(args->severity),
+      time_buffer, (int)(now.tv_nsec), sys_gettid(), display_file, args->line);
+  fprintf(stderr, "%-70s %s\n", prefix.c_str(), args->message);
 }
 
 #endif /* defined(GPR_POSIX_LOG) */

--- a/src/core/lib/gpr/string.cc
+++ b/src/core/lib/gpr/string.cc
@@ -28,6 +28,8 @@
 #include <string.h>
 #include <time.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -50,12 +52,7 @@ char* gpr_strdup(const char* src) {
   return dst;
 }
 
-struct dump_out {
-  size_t capacity;
-  size_t length;
-  char* data;
-};
-char* gpr_format_timespec(gpr_timespec tm) {
+std::string gpr_format_timespec(gpr_timespec tm) {
   char time_buffer[35];
   char ns_buffer[11];  // '.' + 9 digits of precision
   struct tm* tm_info = localtime((const time_t*)&tm.tv_sec);
@@ -76,10 +73,14 @@ char* gpr_format_timespec(gpr_timespec tm) {
       break;
     }
   }
-  char* full_time_str;
-  gpr_asprintf(&full_time_str, "%s%sZ", time_buffer, ns_buffer);
-  return full_time_str;
+  return absl::StrCat(time_buffer, ns_buffer, "Z");
 }
+
+struct dump_out {
+  size_t capacity;
+  size_t length;
+  char* data;
+};
 
 static dump_out dump_out_create(void) {
   dump_out r = {0, 0, nullptr};

--- a/src/core/lib/gpr/string.h
+++ b/src/core/lib/gpr/string.h
@@ -26,6 +26,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include <string>
+
 /* String utility functions */
 
 /* Flags for gpr_dump function. */
@@ -88,13 +90,13 @@ char* gpr_strjoin_sep(const char** strs, size_t nstrs, const char* sep,
 void gpr_string_split(const char* input, const char* sep, char*** strs,
                       size_t* nstrs);
 
-/* Returns an allocated string that represents tm according to RFC-3339, and,
+/* Returns a string that represents tm according to RFC-3339, and,
    more specifically, follows:
    https://developers.google.com/protocol-buffers/docs/proto3#json
 
    Uses RFC 3339, where generated output will always be Z-normalized and uses
    0, 3, 6 or 9 fractional digits. */
-char* gpr_format_timespec(gpr_timespec);
+std::string gpr_format_timespec(gpr_timespec);
 
 /** Case insensitive string comparison... return <0 if lower(a)<lower(b), ==0 if
     lower(a)==lower(b), >0 if lower(a)>lower(b) */

--- a/src/core/lib/gprpp/global_config_env.cc
+++ b/src/core/lib/gprpp/global_config_env.cc
@@ -30,6 +30,10 @@
 #include <ctype.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 namespace grpc_core {
 
 namespace {
@@ -42,12 +46,10 @@ GlobalConfigEnvErrorFunctionType g_global_config_env_error_func =
     DefaultGlobalConfigEnvErrorFunction;
 
 void LogParsingError(const char* name, const char* value) {
-  char* error_message;
-  gpr_asprintf(&error_message,
-               "Illegal value '%s' specified for environment variable '%s'",
-               value, name);
-  (*g_global_config_env_error_func)(error_message);
-  gpr_free(error_message);
+  std::string error_message = absl::StrFormat(
+      "Illegal value '%s' specified for environment variable '%s'", value,
+      name);
+  (*g_global_config_env_error_func)(error_message.c_str());
 }
 
 }  // namespace

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -22,6 +22,7 @@
 
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/alloc.h>
@@ -95,11 +96,10 @@ class grpc_httpcli_ssl_channel_security_connector final
     /* Check the peer name. */
     if (secure_peer_name_ != nullptr &&
         !tsi_ssl_peer_matches_name(&peer, secure_peer_name_)) {
-      char* msg;
-      gpr_asprintf(&msg, "Peer name %s is not in peer certificate",
-                   secure_peer_name_);
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-      gpr_free(msg);
+      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrCat("Peer name ", secure_peer_name_,
+                       " is not in peer certificate")
+              .c_str());
     }
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
     tsi_peer_destruct(&peer);

--- a/src/core/lib/iomgr/endpoint_pair_posix.cc
+++ b/src/core/lib/iomgr/endpoint_pair_posix.cc
@@ -32,9 +32,12 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/tcp_posix.h"
 
@@ -53,19 +56,16 @@ grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(const char* name,
                                                    grpc_channel_args* args) {
   int sv[2];
   grpc_endpoint_pair p;
-  char* final_name;
   create_sockets(sv);
 
   grpc_core::ExecCtx exec_ctx;
 
-  gpr_asprintf(&final_name, "%s:client", name);
-  p.client = grpc_tcp_create(grpc_fd_create(sv[1], final_name, false), args,
-                             "socketpair-server");
-  gpr_free(final_name);
-  gpr_asprintf(&final_name, "%s:server", name);
-  p.server = grpc_tcp_create(grpc_fd_create(sv[0], final_name, false), args,
-                             "socketpair-client");
-  gpr_free(final_name);
+  std::string final_name = absl::StrCat(name, ":client");
+  p.client = grpc_tcp_create(grpc_fd_create(sv[1], final_name.c_str(), false),
+                             args, "socketpair-server");
+  final_name = absl::StrCat(name, ":server");
+  p.server = grpc_tcp_create(grpc_fd_create(sv[0], final_name.c_str(), false),
+                             args, "socketpair-client");
 
   return p;
 }

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -38,14 +38,15 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <string>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/gpr/string.h"
@@ -351,16 +352,14 @@ static grpc_fd* fd_create(int fd, const char* name, bool track_err) {
 
   new_fd->freelist_next = nullptr;
 
-  char* fd_name;
-  gpr_asprintf(&fd_name, "%s fd=%d", name, fd);
-  grpc_iomgr_register_object(&new_fd->iomgr_object, fd_name);
+  std::string fd_name = absl::StrCat(name, " fd=", fd);
+  grpc_iomgr_register_object(&new_fd->iomgr_object, fd_name.c_str());
   fork_fd_list_add_grpc_fd(new_fd);
 #ifndef NDEBUG
   if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_fd_refcount)) {
-    gpr_log(GPR_DEBUG, "FD %d %p create %s", fd, new_fd, fd_name);
+    gpr_log(GPR_DEBUG, "FD %d %p create %s", fd, new_fd, fd_name.c_str());
   }
 #endif
-  gpr_free(fd_name);
 
   struct epoll_event ev;
   ev.events = static_cast<uint32_t>(EPOLLIN | EPOLLOUT | EPOLLET);

--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -38,10 +38,14 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#include <grpc/support/alloc.h>
-#include <grpc/support/string_util.h>
+#include <string>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
+#include <grpc/support/alloc.h>
+
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/gpr/spinlock.h"
 #include "src/core/lib/gpr/tls.h"
@@ -124,11 +128,10 @@ static const char* pollable_type_string(pollable_type t) {
   return "<invalid>";
 }
 
-static char* pollable_desc(pollable* p) {
-  char* out;
-  gpr_asprintf(&out, "type=%s epfd=%d wakeup=%d", pollable_type_string(p->type),
-               p->epfd, p->wakeup.read_fd);
-  return out;
+static std::string pollable_desc(pollable* p) {
+  return absl::StrFormat("type=%s epfd=%d wakeup=%d",
+                         pollable_type_string(p->type), p->epfd,
+                         p->wakeup.read_fd);
 }
 
 /// Shared empty pollable - used by pollset to poll on until the first fd is
@@ -170,15 +173,13 @@ struct grpc_fd {
     write_closure.InitEvent();
     error_closure.InitEvent();
 
-    char* fd_name;
-    gpr_asprintf(&fd_name, "%s fd=%d", name, fd);
-    grpc_iomgr_register_object(&iomgr_object, fd_name);
+    std::string fd_name = absl::StrCat(name, " fd=", fd);
+    grpc_iomgr_register_object(&iomgr_object, fd_name.c_str());
 #ifndef NDEBUG
     if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_fd_refcount)) {
-      gpr_log(GPR_DEBUG, "FD %d %p create %s", fd, this, fd_name);
+      gpr_log(GPR_DEBUG, "FD %d %p create %s", fd, this, fd_name.c_str());
     }
 #endif
-    gpr_free(fd_name);
   }
 
   // This is really the dtor, but the poller threads waking up from
@@ -934,9 +935,8 @@ static grpc_error* pollable_epoll(pollable* p, grpc_millis deadline) {
   int timeout = poll_deadline_to_millis_timeout(deadline);
 
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
-    char* desc = pollable_desc(p);
-    gpr_log(GPR_INFO, "POLLABLE:%p[%s] poll for %dms", p, desc, timeout);
-    gpr_free(desc);
+    gpr_log(GPR_INFO, "POLLABLE:%p[%s] poll for %dms", p,
+            pollable_desc(p).c_str(), timeout);
   }
 
   if (timeout != 0) {

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -32,9 +32,12 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/gpr/murmur_hash.h"
@@ -381,10 +384,8 @@ static grpc_fd* fd_create(int fd, const char* name, bool track_err) {
   r->released = 0;
   gpr_atm_no_barrier_store(&r->pollhup, 0);
 
-  char* name2;
-  gpr_asprintf(&name2, "%s fd=%d", name, fd);
-  grpc_iomgr_register_object(&r->iomgr_object, name2);
-  gpr_free(name2);
+  std::string name2 = absl::StrCat(name, " fd=", fd);
+  grpc_iomgr_register_object(&r->iomgr_object, name2.c_str());
   fork_fd_list_add_grpc_fd(r);
   return r;
 }

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -29,6 +29,10 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/log_windows.h>
@@ -65,18 +69,14 @@ static grpc_error* windows_blocking_resolve_address(
   std::string port;
   grpc_core::SplitHostPort(name, &host, &port);
   if (host.empty()) {
-    char* msg;
-    gpr_asprintf(&msg, "unparseable host:port: '%s'", name);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrFormat("unparseable host:port: '%s'", name).c_str());
     goto done;
   }
   if (port.empty()) {
     if (default_port == NULL) {
-      char* msg;
-      gpr_asprintf(&msg, "no port in name '%s'", name);
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-      gpr_free(msg);
+      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrFormat("no port in name '%s'", name).c_str());
       goto done;
     }
     port = default_port;

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -25,10 +25,13 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/combiner.h"
@@ -118,7 +121,7 @@ struct grpc_resource_user {
   grpc_resource_user_link links[GRPC_RULIST_COUNT];
 
   /* The name of this resource user, for debugging/tracing */
-  char* name;
+  std::string name;
 };
 
 struct grpc_resource_quota {
@@ -181,7 +184,7 @@ struct grpc_resource_quota {
   /* Roots of all resource user lists */
   grpc_resource_user* roots[GRPC_RULIST_COUNT];
 
-  char* name;
+  std::string name;
 };
 
 static void ru_unref_by(grpc_resource_user* resource_user, gpr_atm amount);
@@ -349,13 +352,13 @@ static bool rq_alloc(grpc_resource_quota* resource_quota) {
         gpr_log(GPR_INFO,
                 "RQ %s %s: grant alloc %" PRId64
                 " bytes; rq_free_pool -> %" PRId64,
-                resource_quota->name, resource_user->name, amt,
+                resource_quota->name.c_str(), resource_user->name.c_str(), amt,
                 resource_quota->free_pool);
       }
     } else if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace) &&
                resource_user->free_pool >= 0) {
       gpr_log(GPR_INFO, "RQ %s %s: discard already satisfied alloc request",
-              resource_quota->name, resource_user->name);
+              resource_quota->name.c_str(), resource_user->name.c_str());
     }
     if (resource_user->free_pool >= 0) {
       resource_user->allocating = false;
@@ -388,7 +391,7 @@ static bool rq_reclaim_from_per_user_free_pool(
         gpr_log(GPR_INFO,
                 "RQ %s %s: reclaim_from_per_user_free_pool %" PRId64
                 " bytes; rq_free_pool -> %" PRId64,
-                resource_quota->name, resource_user->name, amt,
+                resource_quota->name.c_str(), resource_user->name.c_str(), amt,
                 resource_quota->free_pool);
       }
       gpr_mu_unlock(&resource_user->mu);
@@ -398,7 +401,7 @@ static bool rq_reclaim_from_per_user_free_pool(
         gpr_log(GPR_INFO,
                 "RQ %s %s: failed to reclaim_from_per_user_free_pool; "
                 "free_pool = %" PRId64 "; rq_free_pool = %" PRId64,
-                resource_quota->name, resource_user->name,
+                resource_quota->name.c_str(), resource_user->name.c_str(),
                 resource_user->free_pool, resource_quota->free_pool);
       }
       gpr_mu_unlock(&resource_user->mu);
@@ -415,8 +418,9 @@ static bool rq_reclaim(grpc_resource_quota* resource_quota, bool destructive) {
   grpc_resource_user* resource_user = rulist_pop_head(resource_quota, list);
   if (resource_user == nullptr) return false;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-    gpr_log(GPR_INFO, "RQ %s %s: initiate %s reclamation", resource_quota->name,
-            resource_user->name, destructive ? "destructive" : "benign");
+    gpr_log(GPR_INFO, "RQ %s %s: initiate %s reclamation",
+            resource_quota->name.c_str(), resource_user->name.c_str(),
+            destructive ? "destructive" : "benign");
   }
   resource_quota->reclaiming = true;
   grpc_resource_quota_ref_internal(resource_quota);
@@ -585,8 +589,7 @@ static void ru_destroy(void* ru, grpc_error* /*error*/) {
   }
   grpc_resource_quota_unref_internal(resource_user->resource_quota);
   gpr_mu_destroy(&resource_user->mu);
-  gpr_free(resource_user->name);
-  gpr_free(resource_user);
+  delete resource_user;
 }
 
 static void ru_alloc_slices(
@@ -640,8 +643,7 @@ static void rq_reclamation_done(void* rq, grpc_error* /*error*/) {
 
 /* Public API */
 grpc_resource_quota* grpc_resource_quota_create(const char* name) {
-  grpc_resource_quota* resource_quota =
-      static_cast<grpc_resource_quota*>(gpr_malloc(sizeof(*resource_quota)));
+  grpc_resource_quota* resource_quota = new grpc_resource_quota;
   gpr_ref_init(&resource_quota->refs, 1);
   resource_quota->combiner = grpc_combiner_create();
   resource_quota->free_pool = INT64_MAX;
@@ -655,10 +657,10 @@ grpc_resource_quota* grpc_resource_quota_create(const char* name) {
   resource_quota->reclaiming = false;
   gpr_atm_no_barrier_store(&resource_quota->memory_usage_estimation, 0);
   if (name != nullptr) {
-    resource_quota->name = gpr_strdup(name);
+    resource_quota->name = name;
   } else {
-    gpr_asprintf(&resource_quota->name, "anonymous_pool_%" PRIxPTR,
-                 (intptr_t)resource_quota);
+    resource_quota->name =
+        absl::StrCat("anonymous_pool_", (intptr_t)resource_quota);
   }
   GRPC_CLOSURE_INIT(&resource_quota->rq_step_closure, rq_step, resource_quota,
                     nullptr);
@@ -675,9 +677,8 @@ void grpc_resource_quota_unref_internal(grpc_resource_quota* resource_quota) {
     // No outstanding thread quota
     GPR_ASSERT(resource_quota->num_threads_allocated == 0);
     GRPC_COMBINER_UNREF(resource_quota->combiner, "resource_quota");
-    gpr_free(resource_quota->name);
     gpr_mu_destroy(&resource_quota->thread_count_mu);
-    gpr_free(resource_quota);
+    delete resource_quota;
   }
 }
 
@@ -774,8 +775,7 @@ const grpc_arg_pointer_vtable* grpc_resource_quota_arg_vtable(void) {
 
 grpc_resource_user* grpc_resource_user_create(
     grpc_resource_quota* resource_quota, const char* name) {
-  grpc_resource_user* resource_user =
-      static_cast<grpc_resource_user*>(gpr_malloc(sizeof(*resource_user)));
+  grpc_resource_user* resource_user = new grpc_resource_user;
   resource_user->resource_quota =
       grpc_resource_quota_ref_internal(resource_quota);
   GRPC_CLOSURE_INIT(&resource_user->allocate_closure, &ru_allocate,
@@ -805,10 +805,10 @@ grpc_resource_user* grpc_resource_user_create(
     resource_user->links[i].next = resource_user->links[i].prev = nullptr;
   }
   if (name != nullptr) {
-    resource_user->name = gpr_strdup(name);
+    resource_user->name = name;
   } else {
-    gpr_asprintf(&resource_user->name, "anonymous_resource_user_%" PRIxPTR,
-                 (intptr_t)resource_user);
+    resource_user->name =
+        absl::StrCat("anonymous_resource_user_", (intptr_t)resource_user);
   }
   return resource_user;
 }
@@ -890,8 +890,8 @@ static bool resource_user_alloc_locked(grpc_resource_user* resource_user,
   resource_user->free_pool -= static_cast<int64_t>(size);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
     gpr_log(GPR_INFO, "RQ %s %s: alloc %" PRIdPTR "; free_pool -> %" PRId64,
-            resource_user->resource_quota->name, resource_user->name, size,
-            resource_user->free_pool);
+            resource_user->resource_quota->name.c_str(),
+            resource_user->name.c_str(), size, resource_user->free_pool);
   }
   if (GPR_LIKELY(resource_user->free_pool >= 0)) return true;
   // Slow path: We need to wait for the free pool to refill.
@@ -951,8 +951,8 @@ void grpc_resource_user_free(grpc_resource_user* resource_user, size_t size) {
   resource_user->free_pool += static_cast<int64_t>(size);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
     gpr_log(GPR_INFO, "RQ %s %s: free %" PRIdPTR "; free_pool -> %" PRId64,
-            resource_user->resource_quota->name, resource_user->name, size,
-            resource_user->free_pool);
+            resource_user->resource_quota->name.c_str(),
+            resource_user->name.c_str(), size, resource_user->free_pool);
   }
   bool is_bigger_than_zero = resource_user->free_pool > 0;
   if (is_bigger_than_zero && was_zero_or_negative &&
@@ -977,7 +977,8 @@ void grpc_resource_user_post_reclaimer(grpc_resource_user* resource_user,
 void grpc_resource_user_finish_reclamation(grpc_resource_user* resource_user) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
     gpr_log(GPR_INFO, "RQ %s %s: reclamation complete",
-            resource_user->resource_quota->name, resource_user->name);
+            resource_user->resource_quota->name.c_str(),
+            resource_user->name.c_str());
   }
   resource_user->resource_quota->combiner->Run(
       &resource_user->resource_quota->rq_reclamation_done_closure,

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -24,11 +24,13 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/host_port.h"
@@ -212,8 +214,8 @@ void grpc_string_to_sockaddr(grpc_resolved_address* out, char* addr, int port) {
   grpc_sockaddr_set_port(out, port);
 }
 
-char* grpc_sockaddr_to_uri(const grpc_resolved_address* resolved_addr) {
-  if (resolved_addr->len == 0) return nullptr;
+std::string grpc_sockaddr_to_uri(const grpc_resolved_address* resolved_addr) {
+  if (resolved_addr->len == 0) return "";
   grpc_resolved_address addr_normalized;
   if (grpc_sockaddr_is_v4mapped(resolved_addr, &addr_normalized)) {
     resolved_addr = &addr_normalized;
@@ -224,9 +226,9 @@ char* grpc_sockaddr_to_uri(const grpc_resolved_address* resolved_addr) {
   }
   std::string path =
       grpc_sockaddr_to_string(resolved_addr, false /* normalize */);
-  char* uri_str = nullptr;
+  std::string uri_str;
   if (scheme != nullptr) {
-    gpr_asprintf(&uri_str, "%s:%s", scheme, path.c_str());
+    uri_str = absl::StrCat(scheme, ":", path);
   }
   return uri_str;
 }

--- a/src/core/lib/iomgr/sockaddr_utils.h
+++ b/src/core/lib/iomgr/sockaddr_utils.h
@@ -69,7 +69,7 @@ std::string grpc_sockaddr_to_string(const grpc_resolved_address* addr,
 void grpc_string_to_sockaddr(grpc_resolved_address* out, char* addr, int port);
 
 /* Returns the URI string corresponding to \a addr */
-char* grpc_sockaddr_to_uri(const grpc_resolved_address* addr);
+std::string grpc_sockaddr_to_uri(const grpc_resolved_address* addr);
 
 /* Returns the URI scheme corresponding to \a addr */
 const char* grpc_sockaddr_get_uri_scheme(const grpc_resolved_address* addr);

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -27,10 +27,11 @@
 // must be included after winsock2.h
 #include <mswsock.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/log_windows.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/iomgr/iocp_windows.h"
 #include "src/core/lib/iomgr/iomgr_internal.h"
@@ -42,14 +43,12 @@
 static DWORD s_wsa_socket_flags;
 
 grpc_winsocket* grpc_winsocket_create(SOCKET socket, const char* name) {
-  char* final_name;
   grpc_winsocket* r = (grpc_winsocket*)gpr_malloc(sizeof(grpc_winsocket));
   memset(r, 0, sizeof(grpc_winsocket));
   r->socket = socket;
   gpr_mu_init(&r->state_mu);
-  gpr_asprintf(&final_name, "%s:socket=0x%p", name, r);
-  grpc_iomgr_register_object(&r->iomgr_object, final_name);
-  gpr_free(final_name);
+  grpc_iomgr_register_object(
+      &r->iomgr_object, absl::StrFormat("%s:socket=0x%p", name, r).c_str());
   grpc_iocp_add_socket(r);
   return r;
 }

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -46,7 +46,7 @@
 
 extern grpc_core::TraceFlag grpc_tcp_trace;
 
-typedef struct CFStreamConnect {
+struct CFStreamConnect {
   gpr_mu mu;
   gpr_refcount refcount;
 
@@ -65,9 +65,9 @@ typedef struct CFStreamConnect {
   grpc_closure* closure;
   grpc_endpoint** endpoint;
   int refs;
-  char* addr_name;
+  std::string addr_name;
   grpc_resource_quota* resource_quota;
-} CFStreamConnect;
+};
 
 static void CFStreamConnectCleanup(CFStreamConnect* connect) {
   grpc_resource_quota_unref_internal(connect->resource_quota);
@@ -75,8 +75,7 @@ static void CFStreamConnectCleanup(CFStreamConnect* connect) {
   CFRelease(connect->read_stream);
   CFRelease(connect->write_stream);
   gpr_mu_destroy(&connect->mu);
-  gpr_free(connect->addr_name);
-  gpr_free(connect);
+  delete connect;
 }
 
 static void OnAlarm(void* arg, grpc_error* error) {
@@ -130,8 +129,9 @@ static void OnOpen(void* arg, grpc_error* error) {
       }
       if (error == GRPC_ERROR_NONE) {
         *endpoint = grpc_cfstream_endpoint_create(
-            connect->read_stream, connect->write_stream, connect->addr_name,
-            connect->resource_quota, connect->stream_handle);
+            connect->read_stream, connect->write_stream,
+            connect->addr_name.c_str(), connect->resource_quota,
+            connect->stream_handle);
       }
     } else {
       GRPC_ERROR_REF(error);
@@ -157,9 +157,7 @@ static void CFStreamClientConnect(grpc_closure* closure, grpc_endpoint** ep,
                                   const grpc_channel_args* channel_args,
                                   const grpc_resolved_address* resolved_addr,
                                   grpc_millis deadline) {
-  CFStreamConnect* connect;
-
-  connect = (CFStreamConnect*)gpr_zalloc(sizeof(CFStreamConnect));
+  CFStreamConnect* connect = new CFStreamConnect();
   connect->closure = closure;
   connect->endpoint = ep;
   connect->addr_name = grpc_sockaddr_to_uri(resolved_addr);
@@ -170,7 +168,7 @@ static void CFStreamClientConnect(grpc_closure* closure, grpc_endpoint** ep,
 
   if (grpc_tcp_trace.enabled()) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT: %p, %s: asynchronously connecting",
-            connect, connect->addr_name);
+            connect, connect->addr_name.c_str());
   }
 
   grpc_resource_quota* resource_quota = grpc_resource_quota_create(NULL);

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -29,9 +29,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/channel/channel_args.h"
@@ -57,11 +58,12 @@ struct async_connect {
   int refs;
   grpc_closure write_closure;
   grpc_pollset_set* interested_parties;
-  char* addr_str;
+  std::string addr_str;
   grpc_endpoint** ep;
   grpc_closure* closure;
   grpc_channel_args* channel_args;
 };
+
 static grpc_error* prepare_socket(const grpc_resolved_address* addr, int fd,
                                   const grpc_channel_args* channel_args) {
   grpc_error* err = GRPC_ERROR_NONE;
@@ -102,8 +104,8 @@ static void tc_on_alarm(void* acp, grpc_error* error) {
   async_connect* ac = static_cast<async_connect*>(acp);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     const char* str = grpc_error_string(error);
-    gpr_log(GPR_INFO, "CLIENT_CONNECT: %s: on_alarm: error=%s", ac->addr_str,
-            str);
+    gpr_log(GPR_INFO, "CLIENT_CONNECT: %s: on_alarm: error=%s",
+            ac->addr_str.c_str(), str);
   }
   gpr_mu_lock(&ac->mu);
   if (ac->fd != nullptr) {
@@ -114,9 +116,8 @@ static void tc_on_alarm(void* acp, grpc_error* error) {
   gpr_mu_unlock(&ac->mu);
   if (done) {
     gpr_mu_destroy(&ac->mu);
-    gpr_free(ac->addr_str);
     grpc_channel_args_destroy(ac->channel_args);
-    gpr_free(ac);
+    delete ac;
   }
 }
 
@@ -139,8 +140,8 @@ static void on_writable(void* acp, grpc_error* error) {
 
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     const char* str = grpc_error_string(error);
-    gpr_log(GPR_INFO, "CLIENT_CONNECT: %s: on_writable: error=%s", ac->addr_str,
-            str);
+    gpr_log(GPR_INFO, "CLIENT_CONNECT: %s: on_writable: error=%s",
+            ac->addr_str.c_str(), str);
   }
 
   gpr_mu_lock(&ac->mu);
@@ -172,7 +173,8 @@ static void on_writable(void* acp, grpc_error* error) {
   switch (so_error) {
     case 0:
       grpc_pollset_set_del_fd(ac->interested_parties, fd);
-      *ep = grpc_tcp_client_create_from_fd(fd, ac->channel_args, ac->addr_str);
+      *ep = grpc_tcp_client_create_from_fd(fd, ac->channel_args,
+                                           ac->addr_str.c_str());
       fd = nullptr;
       break;
     case ENOBUFS:
@@ -214,19 +216,17 @@ finish:
   done = (--ac->refs == 0);
   // Create a copy of the data from "ac" to be accessed after the unlock, as
   // "ac" and its contents may be deallocated by the time they are read.
-  const grpc_slice addr_str_slice = grpc_slice_from_copied_string(ac->addr_str);
+  const grpc_slice addr_str_slice = grpc_slice_from_cpp_string(ac->addr_str);
   gpr_mu_unlock(&ac->mu);
   if (error != GRPC_ERROR_NONE) {
-    char* error_descr;
     grpc_slice str;
     bool ret = grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &str);
     GPR_ASSERT(ret);
-    char* desc = grpc_slice_to_c_string(str);
-    gpr_asprintf(&error_descr, "Failed to connect to remote host: %s", desc);
-    error = grpc_error_set_str(error, GRPC_ERROR_STR_DESCRIPTION,
-                               grpc_slice_from_copied_string(error_descr));
-    gpr_free(error_descr);
-    gpr_free(desc);
+    std::string description = absl::StrCat("Failed to connect to remote host: ",
+                                           grpc_core::StringViewFromSlice(str));
+    error =
+        grpc_error_set_str(error, GRPC_ERROR_STR_DESCRIPTION,
+                           grpc_slice_from_cpp_string(std::move(description)));
     error = grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
                                addr_str_slice /* takes ownership */);
   } else {
@@ -236,9 +236,8 @@ finish:
     // This is safe even outside the lock, because "done", the sentinel, is
     // populated *inside* the lock.
     gpr_mu_destroy(&ac->mu);
-    gpr_free(ac->addr_str);
     grpc_channel_args_destroy(ac->channel_args);
-    gpr_free(ac);
+    delete ac;
   }
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
 }
@@ -279,33 +278,25 @@ void grpc_tcp_client_create_from_prepared_fd(
     const grpc_channel_args* channel_args, const grpc_resolved_address* addr,
     grpc_millis deadline, grpc_endpoint** ep) {
   int err;
-  async_connect* ac;
   do {
     err = connect(fd, reinterpret_cast<const grpc_sockaddr*>(addr->addr),
                   addr->len);
   } while (err < 0 && errno == EINTR);
 
-  char* name;
-  char* addr_str;
-  addr_str = grpc_sockaddr_to_uri(addr);
-  gpr_asprintf(&name, "tcp-client:%s", addr_str);
-  grpc_fd* fdobj = grpc_fd_create(fd, name, true);
-  gpr_free(name);
-  gpr_free(addr_str);
+  std::string name = absl::StrCat("tcp-client:", grpc_sockaddr_to_uri(addr));
+  grpc_fd* fdobj = grpc_fd_create(fd, name.c_str(), true);
 
   if (err >= 0) {
-    char* addr_str = grpc_sockaddr_to_uri(addr);
-    *ep = grpc_tcp_client_create_from_fd(fdobj, channel_args, addr_str);
-    gpr_free(addr_str);
+    *ep = grpc_tcp_client_create_from_fd(fdobj, channel_args,
+                                         grpc_sockaddr_to_uri(addr).c_str());
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
     return;
   }
   if (errno != EWOULDBLOCK && errno != EINPROGRESS) {
     grpc_error* error = GRPC_OS_ERROR(errno, "connect");
-    char* addr_str = grpc_sockaddr_to_uri(addr);
-    error = grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
-                               grpc_slice_from_copied_string(addr_str));
-    gpr_free(addr_str);
+    error = grpc_error_set_str(
+        error, GRPC_ERROR_STR_TARGET_ADDRESS,
+        grpc_slice_from_cpp_string(grpc_sockaddr_to_uri(addr)));
     grpc_fd_orphan(fdobj, nullptr, nullptr, "tcp_client_connect_error");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
     return;
@@ -313,7 +304,7 @@ void grpc_tcp_client_create_from_prepared_fd(
 
   grpc_pollset_set_add_fd(interested_parties, fdobj);
 
-  ac = static_cast<async_connect*>(gpr_malloc(sizeof(async_connect)));
+  async_connect* ac = new async_connect();
   ac->closure = closure;
   ac->ep = ep;
   ac->fd = fdobj;
@@ -327,7 +318,7 @@ void grpc_tcp_client_create_from_prepared_fd(
 
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_INFO, "CLIENT_CONNECT: %s: asynchronously connecting fd %p",
-            ac->addr_str, fdobj);
+            ac->addr_str.c_str(), fdobj);
   }
 
   gpr_mu_lock(&ac->mu);

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -39,6 +39,7 @@
 #include "src/core/lib/iomgr/tcp_client.h"
 #include "src/core/lib/iomgr/tcp_windows.h"
 #include "src/core/lib/iomgr/timer.h"
+#include "src/core/lib/slice/slice_internal.h"
 
 struct async_connect {
   grpc_closure* on_done;
@@ -46,12 +47,13 @@ struct async_connect {
   grpc_winsocket* socket;
   grpc_timer alarm;
   grpc_closure on_alarm;
-  char* addr_name;
+  std::string addr_name;
   int refs;
   grpc_closure on_connect;
   grpc_endpoint** endpoint;
   grpc_channel_args* channel_args;
 };
+
 static void async_connect_unlock_and_cleanup(async_connect* ac,
                                              grpc_winsocket* socket) {
   int done = (--ac->refs == 0);
@@ -59,8 +61,7 @@ static void async_connect_unlock_and_cleanup(async_connect* ac,
   if (done) {
     grpc_channel_args_destroy(ac->channel_args);
     gpr_mu_destroy(&ac->mu);
-    gpr_free(ac->addr_name);
-    gpr_free(ac);
+    delete ac;
   }
   if (socket != NULL) grpc_winsocket_destroy(socket);
 }
@@ -105,7 +106,7 @@ static void on_connect(void* acp, grpc_error* error) {
         error = GRPC_WSA_ERROR(WSAGetLastError(), "ConnectEx");
         closesocket(socket->socket);
       } else {
-        *ep = grpc_tcp_create(socket, ac->channel_args, ac->addr_name);
+        *ep = grpc_tcp_create(socket, ac->channel_args, ac->addr_name.c_str());
         socket = NULL;
       }
     } else {
@@ -131,13 +132,13 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   int status;
   grpc_resolved_address addr6_v4mapped;
   grpc_resolved_address local_address;
-  async_connect* ac;
   grpc_winsocket* socket = NULL;
   LPFN_CONNECTEX ConnectEx;
   GUID guid = WSAID_CONNECTEX;
   DWORD ioctl_num_bytes;
   grpc_winsocket_callback_info* info;
   grpc_error* error = GRPC_ERROR_NONE;
+  async_connect* ac = NULL;
 
   *endpoint = NULL;
 
@@ -194,7 +195,7 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
     }
   }
 
-  ac = (async_connect*)gpr_malloc(sizeof(async_connect));
+  ac = new async_connect();
   ac->on_done = on_done;
   ac->socket = socket;
   gpr_mu_init(&ac->mu);
@@ -211,13 +212,12 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
 
 failure:
   GPR_ASSERT(error != GRPC_ERROR_NONE);
-  char* target_uri = grpc_sockaddr_to_uri(addr);
+  std::string target_uri = grpc_sockaddr_to_uri(addr);
   grpc_error* final_error =
       grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                              "Failed to connect", &error, 1),
                          GRPC_ERROR_STR_TARGET_ADDRESS,
-                         grpc_slice_from_copied_string(
-                             target_uri == nullptr ? "NULL" : target_uri));
+                         grpc_slice_from_cpp_string(std::move(target_uri)));
   GRPC_ERROR_UNREF(error);
   if (socket != NULL) {
     grpc_winsocket_destroy(socket);

--- a/src/core/lib/iomgr/tcp_custom.cc
+++ b/src/core/lib/iomgr/tcp_custom.cc
@@ -345,7 +345,7 @@ static grpc_endpoint_vtable vtable = {endpoint_read,
 
 grpc_endpoint* custom_tcp_endpoint_create(grpc_custom_socket* socket,
                                           grpc_resource_quota* resource_quota,
-                                          char* peer_string) {
+                                          const char* peer_string) {
   custom_tcp_endpoint* tcp =
       (custom_tcp_endpoint*)gpr_malloc(sizeof(custom_tcp_endpoint));
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;

--- a/src/core/lib/iomgr/tcp_custom.h
+++ b/src/core/lib/iomgr/tcp_custom.h
@@ -79,6 +79,6 @@ void grpc_custom_close_server_callback(grpc_tcp_listener* listener);
 
 grpc_endpoint* custom_tcp_endpoint_create(grpc_custom_socket* socket,
                                           grpc_resource_quota* resource_quota,
-                                          char* peer_string);
+                                          const char* peer_string);
 
 #endif /* GRPC_CORE_LIB_IOMGR_TCP_CUSTOM_H */

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -216,10 +216,9 @@ static void finish_accept(grpc_tcp_listener* sp, grpc_custom_socket* socket) {
       (grpc_tcp_server_acceptor*)gpr_malloc(sizeof(*acceptor));
   grpc_endpoint* ep = nullptr;
   grpc_resolved_address peer_name;
-  char* peer_name_string;
+  std::string peer_name_string;
   grpc_error* err;
 
-  peer_name_string = nullptr;
   memset(&peer_name, 0, sizeof(grpc_resolved_address));
   peer_name.len = GRPC_MAX_SOCKADDR_SIZE;
   err = grpc_custom_socket_vtable->getpeername(
@@ -231,21 +230,16 @@ static void finish_accept(grpc_tcp_listener* sp, grpc_custom_socket* socket) {
     GRPC_ERROR_UNREF(err);
   }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
-    if (peer_name_string) {
-      gpr_log(GPR_INFO, "SERVER_CONNECT: %p accepted connection: %s",
-              sp->server, peer_name_string);
-    } else {
-      gpr_log(GPR_INFO, "SERVER_CONNECT: %p accepted connection", sp->server);
-    }
+    gpr_log(GPR_INFO, "SERVER_CONNECT: %p accepted connection: %s", sp->server,
+            peer_name_string.c_str());
   }
   ep = custom_tcp_endpoint_create(socket, sp->server->resource_quota,
-                                  peer_name_string);
+                                  peer_name_string.c_str());
   acceptor->from_server = sp->server;
   acceptor->port_index = sp->port_index;
   acceptor->fd_index = 0;
   acceptor->external_connection = false;
   sp->server->on_accept_cb(sp->server->on_accept_cb_arg, ep, nullptr, acceptor);
-  gpr_free(peer_name_string);
 }
 
 static void custom_accept_callback(grpc_custom_socket* socket,

--- a/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
@@ -31,9 +31,10 @@
 
 #include <string>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/sockaddr.h"
@@ -145,14 +146,8 @@ grpc_error* grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     }
     if ((err = grpc_tcp_server_add_addr(s, &addr, port_index, fd_index, &dsmode,
                                         &new_sp)) != GRPC_ERROR_NONE) {
-      char* err_str = nullptr;
-      grpc_error* root_err;
-      if (gpr_asprintf(&err_str, "Failed to add listener: %s",
-                       addr_str.c_str()) < 0) {
-        err_str = gpr_strdup("Failed to add listener");
-      }
-      root_err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(err_str);
-      gpr_free(err_str);
+      grpc_error* root_err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrCat("Failed to add listener: ", addr_str).c_str());
       err = grpc_error_add_child(root_err, err);
       break;
     } else {

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -22,12 +22,15 @@
 
 #include <inttypes.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include "src/core/lib/iomgr/timer.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/debug/trace.h"
@@ -706,38 +709,36 @@ static grpc_timer_check_result timer_check(grpc_millis* next) {
 
   // tracing
   if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {
-    char* next_str;
+    std::string next_str;
     if (next == nullptr) {
-      next_str = gpr_strdup("NULL");
+      next_str = "NULL";
     } else {
-      gpr_asprintf(&next_str, "%" PRId64, *next);
+      next_str = absl::StrCat(*next);
     }
 #if GPR_ARCH_64
     gpr_log(GPR_INFO,
             "TIMER CHECK BEGIN: now=%" PRId64 " next=%s tls_min=%" PRId64
             " glob_min=%" PRId64,
-            now, next_str, min_timer,
+            now, next_str.c_str(), min_timer,
             static_cast<grpc_millis>(gpr_atm_no_barrier_load(
                 (gpr_atm*)(&g_shared_mutables.min_timer))));
 #else
     gpr_log(GPR_INFO, "TIMER CHECK BEGIN: now=%" PRId64 " next=%s min=%" PRId64,
-            now, next_str, min_timer);
+            now, next_str.c_str(), min_timer);
 #endif
-    gpr_free(next_str);
   }
   // actual code
   grpc_timer_check_result r =
       run_some_expired_timers(now, next, shutdown_error);
   // tracing
   if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {
-    char* next_str;
+    std::string next_str;
     if (next == nullptr) {
-      next_str = gpr_strdup("NULL");
+      next_str = "NULL";
     } else {
-      gpr_asprintf(&next_str, "%" PRId64, *next);
+      next_str = absl::StrCat(*next);
     }
-    gpr_log(GPR_INFO, "TIMER CHECK END: r=%d; next=%s", r, next_str);
-    gpr_free(next_str);
+    gpr_log(GPR_INFO, "TIMER CHECK END: r=%d; next=%s", r, next_str.c_str());
   }
   return r;
 }

--- a/src/core/lib/iomgr/udp_server.cc
+++ b/src/core/lib/iomgr/udp_server.cc
@@ -44,7 +44,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <string>
+
 #include "absl/container/inlined_vector.h"
+#include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
@@ -148,13 +151,11 @@ GrpcUdpListener::GrpcUdpListener(grpc_udp_server* server, int fd,
       server_(server),
       orphan_notified_(false),
       already_shutdown_(false) {
-  char* name;
   std::string addr_str = grpc_sockaddr_to_string(addr, true);
-  gpr_asprintf(&name, "udp-server-listener:%s", addr_str.c_str());
-  emfd_ = grpc_fd_create(fd, name, true);
+  std::string name = absl::StrCat("udp-server-listener:", addr_str);
+  emfd_ = grpc_fd_create(fd, name.c_str(), true);
   memcpy(&addr_, addr, sizeof(grpc_resolved_address));
   GPR_ASSERT(emfd_);
-  gpr_free(name);
   gpr_mu_init(&mutex_);
 }
 

--- a/src/core/lib/iomgr/unix_sockets_posix.h
+++ b/src/core/lib/iomgr/unix_sockets_posix.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <string>
+
 #include "src/core/lib/iomgr/port.h"
 
 #include <grpc/support/string_util.h>
@@ -37,7 +39,7 @@ int grpc_is_unix_socket(const grpc_resolved_address* resolved_addr);
 void grpc_unlink_if_unix_domain_socket(
     const grpc_resolved_address* resolved_addr);
 
-char* grpc_sockaddr_to_uri_unix_if_possible(
+std::string grpc_sockaddr_to_uri_unix_if_possible(
     const grpc_resolved_address* resolved_addr);
 
 #endif /* GRPC_CORE_LIB_IOMGR_UNIX_SOCKETS_POSIX_H */

--- a/src/core/lib/iomgr/unix_sockets_posix_noop.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix_noop.cc
@@ -22,6 +22,8 @@
 
 #ifndef GRPC_HAVE_UNIX_SOCKET
 
+#include <string>
+
 #include <grpc/support/log.h>
 
 void grpc_create_socketpair_if_unix(int sv[2]) {
@@ -42,8 +44,9 @@ int grpc_is_unix_socket(const grpc_resolved_address* addr) { return false; }
 
 void grpc_unlink_if_unix_domain_socket(const grpc_resolved_address* addr) {}
 
-char* grpc_sockaddr_to_uri_unix_if_possible(const grpc_resolved_address* addr) {
-  return NULL;
+std::string grpc_sockaddr_to_uri_unix_if_possible(
+    const grpc_resolved_address* addr) {
+  return "";
 }
 
 #endif

--- a/src/core/lib/security/credentials/credentials.h
+++ b/src/core/lib/security/credentials/credentials.h
@@ -23,6 +23,8 @@
 
 #include <string.h>
 
+#include <string>
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/sync.h>
@@ -79,13 +81,13 @@ typedef enum {
 /* --- Google utils --- */
 
 /* It is the caller's responsibility to gpr_free the result if not NULL. */
-char* grpc_get_well_known_google_credentials_file_path(void);
+std::string grpc_get_well_known_google_credentials_file_path(void);
 
 /* Implementation function for the different platforms. */
-char* grpc_get_well_known_google_credentials_file_path_impl(void);
+std::string grpc_get_well_known_google_credentials_file_path_impl(void);
 
 /* Override for testing only. Not thread-safe */
-typedef char* (*grpc_well_known_credentials_path_getter)(void);
+typedef std::string (*grpc_well_known_credentials_path_getter)(void);
 void grpc_override_well_known_credentials_path_getter(
     grpc_well_known_credentials_path_getter getter);
 

--- a/src/core/lib/security/credentials/google_default/credentials_generic.cc
+++ b/src/core/lib/security/credentials/google_default/credentials_generic.cc
@@ -20,22 +20,24 @@
 
 #include "src/core/lib/security/credentials/google_default/google_default_credentials.h"
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/env.h"
-#include "src/core/lib/gpr/string.h"
 
-char* grpc_get_well_known_google_credentials_file_path_impl(void) {
-  char* result = nullptr;
+std::string grpc_get_well_known_google_credentials_file_path_impl(void) {
   char* base = gpr_getenv(GRPC_GOOGLE_CREDENTIALS_PATH_ENV_VAR);
   if (base == nullptr) {
     gpr_log(GPR_ERROR, "Could not get " GRPC_GOOGLE_CREDENTIALS_PATH_ENV_VAR
                        " environment variable.");
-    return nullptr;
+    return "";
   }
-  gpr_asprintf(&result, "%s/%s", base, GRPC_GOOGLE_CREDENTIALS_PATH_SUFFIX);
+  std::string result =
+      absl::StrCat(base, "/", GRPC_GOOGLE_CREDENTIALS_PATH_SUFFIX);
   gpr_free(base);
   return result;
 }

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -24,6 +24,8 @@
 #include <string.h>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 
 #include <grpc/grpc_security.h>
@@ -33,7 +35,6 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
-#include "absl/strings/str_format.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/error.h"
@@ -136,7 +137,6 @@ grpc_oauth2_token_fetcher_credentials_parse_server_response(
     const grpc_http_response* response, grpc_mdelem* token_md,
     grpc_millis* token_lifetime) {
   char* null_terminated_body = nullptr;
-  char* new_access_token = nullptr;
   grpc_credentials_status status = GRPC_CREDENTIALS_OK;
   Json json;
 
@@ -202,12 +202,12 @@ grpc_oauth2_token_fetcher_credentials_parse_server_response(
       goto end;
     }
     expires_in = it->second.string_value().c_str();
-    gpr_asprintf(&new_access_token, "%s %s", token_type, access_token);
     *token_lifetime = strtol(expires_in, nullptr, 10) * GPR_MS_PER_SEC;
     if (!GRPC_MDISNULL(*token_md)) GRPC_MDELEM_UNREF(*token_md);
     *token_md = grpc_mdelem_from_slices(
         grpc_core::ExternallyManagedSlice(GRPC_AUTHORIZATION_METADATA_KEY),
-        grpc_core::UnmanagedMemorySlice(new_access_token));
+        grpc_slice_from_cpp_string(
+            absl::StrCat(token_type, " ", access_token)));
     status = GRPC_CREDENTIALS_OK;
   }
 
@@ -216,8 +216,7 @@ end:
     GRPC_MDELEM_UNREF(*token_md);
     *token_md = GRPC_MDNULL;
   }
-  if (null_terminated_body != nullptr) gpr_free(null_terminated_body);
-  if (new_access_token != nullptr) gpr_free(new_access_token);
+  gpr_free(null_terminated_body);
   return status;
 }
 
@@ -442,10 +441,9 @@ void grpc_google_refresh_token_credentials::fetch_oauth2(
       const_cast<char*>("Content-Type"),
       const_cast<char*>("application/x-www-form-urlencoded")};
   grpc_httpcli_request request;
-  char* body = nullptr;
-  gpr_asprintf(&body, GRPC_REFRESH_TOKEN_POST_BODY_FORMAT_STRING,
-               refresh_token_.client_id, refresh_token_.client_secret,
-               refresh_token_.refresh_token);
+  std::string body = absl::StrFormat(
+      GRPC_REFRESH_TOKEN_POST_BODY_FORMAT_STRING, refresh_token_.client_id,
+      refresh_token_.client_secret, refresh_token_.refresh_token);
   memset(&request, 0, sizeof(grpc_httpcli_request));
   request.host = (char*)GRPC_GOOGLE_OAUTH2_SERVICE_HOST;
   request.http.path = (char*)GRPC_GOOGLE_OAUTH2_SERVICE_TOKEN_PATH;
@@ -457,13 +455,12 @@ void grpc_google_refresh_token_credentials::fetch_oauth2(
      extreme memory pressure. */
   grpc_resource_quota* resource_quota =
       grpc_resource_quota_create("oauth2_credentials_refresh");
-  grpc_httpcli_post(httpcli_context, pollent, resource_quota, &request, body,
-                    strlen(body), deadline,
+  grpc_httpcli_post(httpcli_context, pollent, resource_quota, &request,
+                    body.c_str(), body.size(), deadline,
                     GRPC_CLOSURE_INIT(&http_post_cb_closure_, response_cb,
                                       metadata_req, grpc_schedule_on_exec_ctx),
                     &metadata_req->response);
   grpc_resource_quota_unref_internal(resource_quota);
-  gpr_free(body);
 }
 
 grpc_google_refresh_token_credentials::grpc_google_refresh_token_credentials(
@@ -487,16 +484,15 @@ std::string grpc_google_refresh_token_credentials::debug_string() {
                          grpc_oauth2_token_fetcher_credentials::debug_string());
 }
 
-static char* create_loggable_refresh_token(grpc_auth_refresh_token* token) {
+static std::string create_loggable_refresh_token(
+    grpc_auth_refresh_token* token) {
   if (strcmp(token->type, GRPC_AUTH_JSON_TYPE_INVALID) == 0) {
-    return gpr_strdup("<Invalid json token>");
+    return "<Invalid json token>";
   }
-  char* loggable_token = nullptr;
-  gpr_asprintf(&loggable_token,
-               "{\n type: %s\n client_id: %s\n client_secret: "
-               "<redacted>\n refresh_token: <redacted>\n}",
-               token->type, token->client_id);
-  return loggable_token;
+  return absl::StrFormat(
+      "{\n type: %s\n client_id: %s\n client_secret: "
+      "<redacted>\n refresh_token: <redacted>\n}",
+      token->type, token->client_id);
 }
 
 grpc_call_credentials* grpc_google_refresh_token_credentials_create(
@@ -504,12 +500,10 @@ grpc_call_credentials* grpc_google_refresh_token_credentials_create(
   grpc_auth_refresh_token token =
       grpc_auth_refresh_token_create_from_string(json_refresh_token);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_api_trace)) {
-    char* loggable_token = create_loggable_refresh_token(&token);
     gpr_log(GPR_INFO,
             "grpc_refresh_token_credentials_create(json_refresh_token=%s, "
             "reserved=%p)",
-            loggable_token, reserved);
-    gpr_free(loggable_token);
+            create_loggable_refresh_token(&token).c_str(), reserved);
   }
   GPR_ASSERT(reserved == nullptr);
   return grpc_refresh_token_credentials_create_from_auth_refresh_token(token)
@@ -744,13 +738,10 @@ void grpc_access_token_credentials::cancel_get_request_metadata(
 grpc_access_token_credentials::grpc_access_token_credentials(
     const char* access_token)
     : grpc_call_credentials(GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) {
-  char* token_md_value;
-  gpr_asprintf(&token_md_value, "Bearer %s", access_token);
   grpc_core::ExecCtx exec_ctx;
   access_token_md_ = grpc_mdelem_from_slices(
       grpc_core::ExternallyManagedSlice(GRPC_AUTHORIZATION_METADATA_KEY),
-      grpc_core::UnmanagedMemorySlice(token_md_value));
-  gpr_free(token_md_value);
+      grpc_slice_from_cpp_string(absl::StrCat("Bearer ", access_token)));
 }
 
 std::string grpc_access_token_credentials::debug_string() {

--- a/src/core/lib/security/credentials/plugin/plugin_credentials.cc
+++ b/src/core/lib/security/credentials/plugin/plugin_credentials.cc
@@ -22,10 +22,11 @@
 
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/slice/slice_internal.h"
@@ -86,11 +87,10 @@ static grpc_error* process_plugin_result(
     size_t num_md, grpc_status_code status, const char* error_details) {
   grpc_error* error = GRPC_ERROR_NONE;
   if (status != GRPC_STATUS_OK) {
-    char* msg;
-    gpr_asprintf(&msg, "Getting metadata from plugin failed with error: %s",
-                 error_details);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Getting metadata from plugin failed with error: ",
+                     error_details)
+            .c_str());
   } else {
     bool seen_illegal_header = false;
     for (size_t i = 0; i < num_md; ++i) {

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -22,6 +22,8 @@
 
 #include <stdbool.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -227,11 +229,10 @@ static void fake_check_peer(
   prop_name = peer.properties[0].name;
   if (prop_name == nullptr ||
       strcmp(prop_name, TSI_CERTIFICATE_TYPE_PEER_PROPERTY)) {
-    char* msg;
-    gpr_asprintf(&msg, "Unexpected property in fake peer: %s.",
-                 prop_name == nullptr ? "<EMPTY>" : prop_name);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Unexpected property in fake peer: ",
+                     prop_name == nullptr ? "<EMPTY>" : prop_name)
+            .c_str());
     goto end;
   }
   if (strncmp(peer.properties[0].value.data, TSI_FAKE_CERTIFICATE_TYPE,
@@ -243,11 +244,10 @@ static void fake_check_peer(
   prop_name = peer.properties[1].name;
   if (prop_name == nullptr ||
       strcmp(prop_name, TSI_SECURITY_LEVEL_PEER_PROPERTY) != 0) {
-    char* msg;
-    gpr_asprintf(&msg, "Unexpected property in fake peer: %s.",
-                 prop_name == nullptr ? "<EMPTY>" : prop_name);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Unexpected property in fake peer: ",
+                     prop_name == nullptr ? "<EMPTY>" : prop_name)
+            .c_str());
     goto end;
   }
   if (strncmp(peer.properties[1].value.data, TSI_FAKE_SECURITY_LEVEL,

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -22,11 +22,12 @@
 
 #include <stdbool.h>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/transport/chttp2/alpn/alpn.h"
 #include "src/core/lib/channel/handshaker.h"
@@ -53,11 +54,9 @@ grpc_error* ssl_check_peer(
   }
   /* Check the peer name if specified. */
   if (peer_name != nullptr && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    char* msg;
-    gpr_asprintf(&msg, "Peer name %s is not in peer certificate", peer_name);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return error;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Peer name ", peer_name, " is not in peer certificate")
+            .c_str());
   }
   *auth_context =
       grpc_ssl_peer_to_auth_context(peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
@@ -163,11 +162,10 @@ class grpc_ssl_channel_security_connector final
             verify_options_->verify_peer_callback_userdata);
         gpr_free(peer_pem);
         if (callback_status) {
-          char* msg;
-          gpr_asprintf(&msg, "Verify peer callback returned a failure (%d)",
-                       callback_status);
-          error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-          gpr_free(msg);
+          error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+              absl::StrFormat("Verify peer callback returned a failure (%d)",
+                              callback_status)
+                  .c_str());
         }
       }
     }

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -20,12 +20,13 @@
 
 #include "src/core/lib/security/security_connector/ssl_utils.h"
 
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
-
-#include <vector>
 
 #include "src/core/ext/transport/chttp2/alpn/alpn.h"
 #include "src/core/lib/channel/channel_args.h"
@@ -170,12 +171,9 @@ grpc_error* grpc_ssl_check_peer_name(absl::string_view peer_name,
                                      const tsi_peer* peer) {
   /* Check the peer name if specified. */
   if (!peer_name.empty() && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    char* msg;
-    gpr_asprintf(&msg, "Peer name %s is not in peer certificate",
-                 peer_name.data());
-    grpc_error* error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
-    return error;
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Peer name ", peer_name, " is not in peer certificate")
+            .c_str());
   }
   return GRPC_ERROR_NONE;
 }

--- a/src/core/lib/security/util/json_util.cc
+++ b/src/core/lib/security/util/json_util.cc
@@ -18,13 +18,15 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "src/core/lib/iomgr/error.h"
-#include "src/core/lib/security/util/json_util.h"
-
 #include <string.h>
+
+#include "absl/strings/str_cat.h"
 
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+
+#include "src/core/lib/iomgr/error.h"
+#include "src/core/lib/security/util/json_util.h"
 
 const char* grpc_json_get_string_property(const grpc_core::Json& json,
                                           const char* prop_name,
@@ -39,21 +41,18 @@ const char* grpc_json_get_string_property(const grpc_core::Json& json,
   auto it = json.object_value().find(prop_name);
   if (it == json.object_value().end()) {
     if (error != nullptr) {
-      char* error_msg;
-      gpr_asprintf(&error_msg, "Property %s not found in JSON object.",
-                   prop_name);
-      *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg);
-      gpr_free(error_msg);
+      *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrCat("Property ", prop_name, " not found in JSON object.")
+              .c_str());
     }
     return nullptr;
   }
   if (it->second.type() != grpc_core::Json::Type::STRING) {
     if (error != nullptr) {
-      char* error_msg;
-      gpr_asprintf(&error_msg, "Property %s in JSON object is not a string.",
-                   prop_name);
-      *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg);
-      gpr_free(error_msg);
+      *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrCat("Property ", prop_name,
+                       " n JSON object is not a string.")
+              .c_str());
     }
     return nullptr;
   }

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -156,7 +156,7 @@ class NewWithLenSliceRefcount {
 /** grpc_slice_from_moved_(string|buffer) ref count .*/
 class MovedStringSliceRefCount {
  public:
-  MovedStringSliceRefCount(grpc_core::UniquePtr<char>&& str)
+  explicit MovedStringSliceRefCount(grpc_core::UniquePtr<char>&& str)
       : base_(grpc_slice_refcount::Type::REGULAR, &refs_, Destroy, this,
               &base_),
         str_(std::move(str)) {}
@@ -171,6 +171,26 @@ class MovedStringSliceRefCount {
   grpc_slice_refcount base_;
   grpc_core::RefCount refs_;
   grpc_core::UniquePtr<char> str_;
+};
+
+// grpc_slice_from_cpp_string() ref count.
+class MovedCppStringSliceRefCount {
+ public:
+  explicit MovedCppStringSliceRefCount(std::string&& str)
+      : base_(grpc_slice_refcount::Type::REGULAR, &refs_, Destroy, this,
+              &base_),
+        str_(std::move(str)) {}
+
+  grpc_slice_refcount* base_refcount() { return &base_; }
+
+ private:
+  static void Destroy(void* arg) {
+    delete static_cast<MovedCppStringSliceRefCount*>(arg);
+  }
+
+  grpc_slice_refcount base_;
+  grpc_core::RefCount refs_;
+  std::string str_;
 };
 
 }  // namespace grpc_core
@@ -230,6 +250,23 @@ grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
 grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p) {
   const size_t len = strlen(p.get());
   return grpc_slice_from_moved_buffer(std::move(p), len);
+}
+
+grpc_slice grpc_slice_from_cpp_string(std::string str) {
+  grpc_slice slice;
+  if (str.size() <= sizeof(slice.data.inlined.bytes)) {
+    slice.refcount = nullptr;
+    slice.data.inlined.length = str.size();
+    memcpy(GRPC_SLICE_START_PTR(slice), str.data(), str.size());
+  } else {
+    slice.data.refcounted.bytes =
+        reinterpret_cast<uint8_t*>(const_cast<char*>(str.data()));
+    slice.data.refcounted.length = str.size();
+    slice.refcount =
+        (new grpc_core::MovedCppStringSliceRefCount(std::move(str)))
+            ->base_refcount();
+  }
+  return slice;
 }
 
 namespace {

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -338,6 +338,7 @@ inline uint32_t grpc_slice_hash_internal(const grpc_slice& s) {
 grpc_slice grpc_slice_from_moved_buffer(grpc_core::UniquePtr<char> p,
                                         size_t len);
 grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p);
+grpc_slice grpc_slice_from_cpp_string(std::string str);
 
 // Returns the memory used by this slice, not counting the slice structure
 // itself. This means that inlined and slices from static strings will return

--- a/src/core/lib/uri/uri_parser.cc
+++ b/src/core/lib/uri/uri_parser.cc
@@ -22,10 +22,13 @@
 
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/slice/percent_encoding.h"
@@ -37,22 +40,12 @@
 
 static grpc_uri* bad_uri(const char* uri_text, size_t pos, const char* section,
                          bool suppress_errors) {
-  char* line_prefix;
-  size_t pfx_len;
-
   if (!suppress_errors) {
-    gpr_asprintf(&line_prefix, "bad uri.%s: '", section);
-    pfx_len = strlen(line_prefix) + pos;
-    gpr_log(GPR_ERROR, "%s%s'", line_prefix, uri_text);
-    gpr_free(line_prefix);
-
-    line_prefix = static_cast<char*>(gpr_malloc(pfx_len + 1));
-    memset(line_prefix, ' ', pfx_len);
-    line_prefix[pfx_len] = 0;
-    gpr_log(GPR_ERROR, "%s^ here", line_prefix);
-    gpr_free(line_prefix);
+    std::string line_prefix = absl::StrFormat("bad uri.%s: '", section);
+    gpr_log(GPR_ERROR, "%s%s'", line_prefix.c_str(), uri_text);
+    size_t pfx_len = line_prefix.size() + pos;
+    gpr_log(GPR_ERROR, "%s^ here", std::string(pfx_len, ' ').c_str());
   }
-
   return nullptr;
 }
 

--- a/test/core/client_channel/parse_address_with_named_scope_id_test.cc
+++ b/test/core/client_channel/parse_address_with_named_scope_id_test.cc
@@ -26,9 +26,10 @@
 #include <sys/un.h>
 #endif
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/gprpp/memory.h"
@@ -108,18 +109,17 @@ int main(int argc, char** argv) {
     }
   }
   GPR_ASSERT(strlen(arbitrary_interface_name) > 0);
-  char* target = nullptr;
-  gpr_asprintf(&target, "ipv6:[fe80::1234%%%s]:12345",
-               arbitrary_interface_name);
+  std::string target =
+      absl::StrFormat("ipv6:[fe80::1234%%%s]:12345", arbitrary_interface_name);
   struct sockaddr_in6 result_from_getaddrinfo =
-      resolve_with_gettaddrinfo(target);
+      resolve_with_gettaddrinfo(target.c_str());
   // Run the test
   gpr_log(GPR_DEBUG,
           "Run test_grpc_parse_ipv6_parity_with_getaddrinfo with target: %s",
-          target);
-  test_grpc_parse_ipv6_parity_with_getaddrinfo(target, result_from_getaddrinfo);
+          target.c_str());
+  test_grpc_parse_ipv6_parity_with_getaddrinfo(target.c_str(),
+                                               result_from_getaddrinfo);
   // Cleanup
-  gpr_free(target);
   gpr_free(arbitrary_interface_name);
   grpc_shutdown();
 }

--- a/test/core/client_channel/resolvers/fake_resolver_test.cc
+++ b/test/core/client_channel/resolvers/fake_resolver_test.cc
@@ -18,9 +18,12 @@
 
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/ext/filters/client_channel/parse_address.h"
 #include "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"
@@ -85,13 +88,12 @@ static grpc_core::OrphanablePtr<grpc_core::Resolver> build_fake_resolver(
 static grpc_core::Resolver::Result create_new_resolver_result() {
   static size_t test_counter = 0;
   const size_t num_addresses = 2;
-  char* uri_string;
   // Create address list.
   grpc_core::Resolver::Result result;
   for (size_t i = 0; i < num_addresses; ++i) {
-    gpr_asprintf(&uri_string, "ipv4:127.0.0.1:100%" PRIuPTR,
-                 test_counter * num_addresses + i);
-    grpc_uri* uri = grpc_uri_parse(uri_string, true);
+    std::string uri_string = absl::StrFormat("ipv4:127.0.0.1:100%" PRIuPTR,
+                                             test_counter * num_addresses + i);
+    grpc_uri* uri = grpc_uri_parse(uri_string.c_str(), true);
     grpc_resolved_address address;
     GPR_ASSERT(grpc_parse_uri(uri, &address));
     absl::InlinedVector<grpc_arg, 2> args_to_add;
@@ -99,7 +101,6 @@ static grpc_core::Resolver::Result create_new_resolver_result() {
         address.addr, address.len,
         grpc_channel_args_copy_and_add(nullptr, nullptr, 0));
     grpc_uri_destroy(uri);
-    gpr_free(uri_string);
   }
   ++test_counter;
   return result;

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -66,9 +66,8 @@ static void log_resolved_addrs(const char* label, const char* hostname) {
     return;
   }
   for (size_t i = 0; i < res->naddrs; ++i) {
-    char* addr_str = grpc_sockaddr_to_uri(&res->addrs[i]);
-    gpr_log(GPR_INFO, "%s: %s", label, addr_str);
-    gpr_free(addr_str);
+    gpr_log(GPR_INFO, "%s: %s", label,
+            grpc_sockaddr_to_uri(&res->addrs[i]).c_str());
   }
   grpc_resolved_addresses_destroy(res);
 }

--- a/test/core/end2end/fixtures/h2_uds.cc
+++ b/test/core/end2end/fixtures/h2_uds.cc
@@ -22,9 +22,12 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/ext/filters/client_channel/client_channel.h"
@@ -37,22 +40,20 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-typedef struct fullstack_fixture_data {
-  char* localaddr;
-} fullstack_fixture_data;
+struct fullstack_fixture_data {
+  std::string localaddr;
+};
 
 static int unique = 1;
 
 static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
     grpc_channel_args* /*client_args*/, grpc_channel_args* /*server_args*/) {
+  fullstack_fixture_data* ffd = new fullstack_fixture_data;
+  ffd->localaddr = absl::StrFormat("unix:/tmp/grpc_fullstack_test.%d.%d",
+                                   getpid(), unique++);
+
   grpc_end2end_test_fixture f;
-  fullstack_fixture_data* ffd = static_cast<fullstack_fixture_data*>(
-      gpr_malloc(sizeof(fullstack_fixture_data)));
   memset(&f, 0, sizeof(f));
-
-  gpr_asprintf(&ffd->localaddr, "unix:/tmp/grpc_fullstack_test.%d.%d", getpid(),
-               unique++);
-
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(nullptr);
   f.shutdown_cq = grpc_completion_queue_create_for_pluck(nullptr);
@@ -64,8 +65,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
                                   grpc_channel_args* client_args) {
   fullstack_fixture_data* ffd =
       static_cast<fullstack_fixture_data*>(f->fixture_data);
-  f->client =
-      grpc_insecure_channel_create(ffd->localaddr, client_args, nullptr);
+  f->client = grpc_insecure_channel_create(ffd->localaddr.c_str(), client_args,
+                                           nullptr);
 }
 
 void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
@@ -77,15 +78,15 @@ void chttp2_init_server_fullstack(grpc_end2end_test_fixture* f,
   }
   f->server = grpc_server_create(server_args, nullptr);
   grpc_server_register_completion_queue(f->server, f->cq, nullptr);
-  GPR_ASSERT(grpc_server_add_insecure_http2_port(f->server, ffd->localaddr));
+  GPR_ASSERT(
+      grpc_server_add_insecure_http2_port(f->server, ffd->localaddr.c_str()));
   grpc_server_start(f->server);
 }
 
 void chttp2_tear_down_fullstack(grpc_end2end_test_fixture* f) {
   fullstack_fixture_data* ffd =
       static_cast<fullstack_fixture_data*>(f->fixture_data);
-  gpr_free(ffd->localaddr);
-  gpr_free(ffd);
+  delete ffd;
 }
 
 /* All test configurations */

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -22,12 +22,13 @@
 
 #include <string.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/atm.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/channel/channel_args.h"
@@ -492,11 +493,10 @@ static void on_read_request_done_locked(void* arg, grpc_error* error) {
   }
   // Make sure we got a CONNECT request.
   if (strcmp(conn->http_request.method, "CONNECT") != 0) {
-    char* msg;
-    gpr_asprintf(&msg, "HTTP proxy got request method %s",
-                 conn->http_request.method);
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);
-    gpr_free(msg);
+    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("HTTP proxy got request method ",
+                     conn->http_request.method)
+            .c_str());
     proxy_connection_failed(conn, SETUP_FAILED, "HTTP proxy read request",
                             GRPC_ERROR_REF(error));
     GRPC_ERROR_UNREF(error);

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -23,11 +23,16 @@
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/socket_utils.h"
 
+#include <string.h>
+
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
-#include <string.h>
+
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"
 #include "src/core/ext/filters/client_channel/server_address.h"
 #include "src/core/lib/iomgr/resolve_address.h"
@@ -185,7 +190,7 @@ int main(int argc, char** argv) {
   int port1 = grpc_pick_unused_port_or_die();
   int port2 = grpc_pick_unused_port_or_die();
 
-  char* addr;
+  std::string addr;
 
   grpc_channel_args client_args;
   grpc_arg arg_array[2];
@@ -242,10 +247,9 @@ int main(int argc, char** argv) {
 
   /* bring a server up on the first port */
   grpc_server* server1 = grpc_server_create(nullptr, nullptr);
-  gpr_asprintf(&addr, "127.0.0.1:%d", port1);
-  grpc_server_add_insecure_http2_port(server1, addr);
+  addr = absl::StrCat("127.0.0.1:", port1);
+  grpc_server_add_insecure_http2_port(server1, addr.c_str());
   grpc_server_register_completion_queue(server1, cq, nullptr);
-  gpr_free(addr);
   grpc_server_start(server1);
 
   /* request a call to the server */
@@ -319,10 +323,9 @@ int main(int argc, char** argv) {
   /* and bring up second server */
   set_resolve_port(port2);
   grpc_server* server2 = grpc_server_create(nullptr, nullptr);
-  gpr_asprintf(&addr, "127.0.0.1:%d", port2);
-  grpc_server_add_insecure_http2_port(server2, addr);
+  addr = absl::StrCat("127.0.0.1:", port2);
+  grpc_server_add_insecure_http2_port(server2, addr.c_str());
   grpc_server_register_completion_queue(server2, cq, nullptr);
-  gpr_free(addr);
   grpc_server_start(server2);
 
   /* request a call to the server */

--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -21,12 +21,15 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/byte_buffer_reader.h>
 #include <grpc/compression.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/channel/channel_args.h"
@@ -246,12 +249,10 @@ static void request_for_disabled_algorithm(
 
   const char* algo_name = nullptr;
   GPR_ASSERT(grpc_compression_algorithm_name(algorithm_to_disable, &algo_name));
-  char* expected_details = nullptr;
-  gpr_asprintf(&expected_details, "Compression algorithm '%s' is disabled.",
-               algo_name);
+  std::string expected_details =
+      absl::StrFormat("Compression algorithm '%s' is disabled.", algo_name);
   /* and we expect a specific reason for it */
-  GPR_ASSERT(0 == grpc_slice_str_cmp(details, expected_details));
-  gpr_free(expected_details);
+  GPR_ASSERT(0 == grpc_slice_str_cmp(details, expected_details.c_str()));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo"));
 
   grpc_slice_unref(details);

--- a/test/core/end2end/tests/high_initial_seqno.cc
+++ b/test/core/end2end/tests/high_initial_seqno.cc
@@ -21,11 +21,14 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/gpr/string.h"
@@ -205,7 +208,6 @@ static void test_invoke_10_simple_requests(grpc_end2end_test_config config,
   grpc_end2end_test_fixture f;
   grpc_arg client_arg;
   grpc_channel_args client_args;
-  char* name;
 
   client_arg.type = GRPC_ARG_INTEGER;
   client_arg.key = const_cast<char*>(GRPC_ARG_HTTP2_INITIAL_SEQUENCE_NUMBER);
@@ -214,16 +216,15 @@ static void test_invoke_10_simple_requests(grpc_end2end_test_config config,
   client_args.num_args = 1;
   client_args.args = &client_arg;
 
-  gpr_asprintf(&name, "test_invoke_requests first_seqno=%d",
-               initial_sequence_number);
-  f = begin_test(config, name, &client_args, nullptr);
+  std::string name = absl::StrCat("test_invoke_requests first_seqno=",
+                                  initial_sequence_number);
+  f = begin_test(config, name.c_str(), &client_args, nullptr);
   for (i = 0; i < 10; i++) {
     simple_request_body(config, f);
     gpr_log(GPR_INFO, "Running test: Passed simple request %d", i);
   }
   end_test(&f);
   config.tear_down_data(&f);
-  gpr_free(name);
 }
 
 void high_initial_seqno(grpc_end2end_test_config config) {

--- a/test/core/end2end/tests/hpack_size.cc
+++ b/test/core/end2end/tests/hpack_size.cc
@@ -21,11 +21,14 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/gpr/string.h"
@@ -355,7 +358,6 @@ static void test_size(grpc_end2end_test_config config, int encode_size,
   grpc_channel_args server_args;
   grpc_arg client_arg;
   grpc_channel_args client_args;
-  char* name;
 
   server_arg.type = GRPC_ARG_INTEGER;
   server_arg.key = const_cast<char*>(GRPC_ARG_HTTP2_HPACK_TABLE_SIZE_DECODER);
@@ -369,15 +371,16 @@ static void test_size(grpc_end2end_test_config config, int encode_size,
   client_args.num_args = 1;
   client_args.args = &client_arg;
 
-  gpr_asprintf(&name, "test_size:e=%d:d=%d", encode_size, decode_size);
-  f = begin_test(config, name, encode_size != 4096 ? &client_args : nullptr,
+  std::string name =
+      absl::StrFormat("test_size:e=%d:d=%d", encode_size, decode_size);
+  f = begin_test(config, name.c_str(),
+                 encode_size != 4096 ? &client_args : nullptr,
                  decode_size != 4096 ? &server_args : nullptr);
   for (i = 0; i < 4 * GPR_ARRAY_SIZE(hobbits); i++) {
     simple_request_body(config, f, i);
   }
   end_test(&f);
   config.tear_down_data(&f);
-  gpr_free(name);
 }
 
 void hpack_size(grpc_end2end_test_config config) {

--- a/test/core/end2end/tests/invoke_large_request.cc
+++ b/test/core/end2end/tests/invoke_large_request.cc
@@ -21,10 +21,13 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/gpr/useful.h"
@@ -90,10 +93,9 @@ static grpc_slice large_slice(void) {
 
 static void test_invoke_large_request(grpc_end2end_test_config config,
                                       int max_frame_size, int lookahead_bytes) {
-  char* name;
-  gpr_asprintf(&name,
-               "test_invoke_large_request:max_frame_size=%d:lookahead_bytes=%d",
-               max_frame_size, lookahead_bytes);
+  std::string name = absl::StrFormat(
+      "test_invoke_large_request:max_frame_size=%d:lookahead_bytes=%d",
+      max_frame_size, lookahead_bytes);
 
   grpc_arg args[2];
   args[0].type = GRPC_ARG_INTEGER;
@@ -105,8 +107,7 @@ static void test_invoke_large_request(grpc_end2end_test_config config,
   grpc_channel_args channel_args = {GPR_ARRAY_SIZE(args), args};
 
   grpc_end2end_test_fixture f =
-      begin_test(config, name, &channel_args, &channel_args);
-  gpr_free(name);
+      begin_test(config, name.c_str(), &channel_args, &channel_args);
 
   grpc_slice request_payload_slice = large_slice();
   grpc_slice response_payload_slice = large_slice();

--- a/test/core/end2end/tests/no_logging.cc
+++ b/test/core/end2end/tests/no_logging.cc
@@ -21,11 +21,14 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/error.h"
@@ -38,11 +41,9 @@ static void* tag(intptr_t t) { return (void*)t; }
 void gpr_default_log(gpr_log_func_args* args);
 
 static void test_no_log(gpr_log_func_args* args) {
-  char* message = nullptr;
-  gpr_asprintf(&message, "Unwanted log: %s", args->message);
-  args->message = message;
+  std::string message = absl::StrCat("Unwanted log: ", args->message);
+  args->message = message.c_str();
   gpr_default_log(args);
-  gpr_free(message);
   abort();
 }
 

--- a/test/core/end2end/tests/retry_cancellation.cc
+++ b/test/core/end2end/tests/retry_cancellation.cc
@@ -21,11 +21,14 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/channel/channel_args.h"
@@ -138,10 +141,9 @@ static void test_retry_cancellation(grpc_end2end_test_config config,
       "  } ]\n"
       "}");
   grpc_channel_args client_args = {1, &arg};
-  char* name;
-  gpr_asprintf(&name, "retry_cancellation/%s", mode.name);
-  grpc_end2end_test_fixture f = begin_test(config, name, &client_args, nullptr);
-  gpr_free(name);
+  std::string name = absl::StrCat("retry_cancellation/%s", mode.name);
+  grpc_end2end_test_fixture f =
+      begin_test(config, name.c_str(), &client_args, nullptr);
 
   cq_verifier* cqv = cq_verifier_create(f.cq);
 

--- a/test/core/end2end/tests/stream_compression_compressed_payload.cc
+++ b/test/core/end2end/tests/stream_compression_compressed_payload.cc
@@ -21,12 +21,15 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/byte_buffer_reader.h>
 #include <grpc/compression.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/channel/channel_args.h"
@@ -231,12 +234,10 @@ static void request_for_disabled_algorithm(
 
   const char* algo_name = nullptr;
   GPR_ASSERT(grpc_compression_algorithm_name(algorithm_to_disable, &algo_name));
-  char* expected_details = nullptr;
-  gpr_asprintf(&expected_details, "Compression algorithm '%s' is disabled.",
-               algo_name);
+  std::string expected_details =
+      absl::StrCat("Compression algorithm '", algo_name, "' is disabled.");
   /* and we expect a specific reason for it */
-  GPR_ASSERT(0 == grpc_slice_str_cmp(details, expected_details));
-  gpr_free(expected_details);
+  GPR_ASSERT(0 == grpc_slice_str_cmp(details, expected_details.c_str()));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo"));
 
   grpc_slice_unref(details);

--- a/test/core/fling/fling_stream_test.cc
+++ b/test/core/fling/fling_stream_test.cc
@@ -19,10 +19,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <grpc/support/alloc.h>
-#include <grpc/support/string_util.h>
+#include <string>
 
-#include "src/core/lib/gpr/string.h"
+#include "absl/strings/str_cat.h"
+
 #include "src/core/lib/gprpp/host_port.h"
 #include "test/core/util/port.h"
 #include "test/core/util/subprocess.h"
@@ -43,18 +43,19 @@ int main(int /*argc*/, char** argv) {
     strcpy(root, ".");
   }
   /* start the server */
-  gpr_asprintf(&args[0], "%s/fling_server%s", root,
-               gpr_subprocess_binary_extension());
+  std::string command =
+      absl::StrCat(root, "/fling_server", gpr_subprocess_binary_extension());
+  args[0] = const_cast<char*>(command.c_str());
   args[1] = const_cast<char*>("--bind");
   std::string joined = grpc_core::JoinHostPort("::", port);
   args[2] = const_cast<char*>(joined.c_str());
   args[3] = const_cast<char*>("--no-secure");
   svr = gpr_subprocess_create(4, (const char**)args);
-  gpr_free(args[0]);
 
   /* start the client */
-  gpr_asprintf(&args[0], "%s/fling_client%s", root,
-               gpr_subprocess_binary_extension());
+  command =
+      absl::StrCat(root, "/fling_client", gpr_subprocess_binary_extension());
+  args[0] = const_cast<char*>(command.c_str());
   args[1] = const_cast<char*>("--target");
   joined = grpc_core::JoinHostPort("127.0.0.1", port);
   args[2] = const_cast<char*>(joined.c_str());
@@ -62,7 +63,6 @@ int main(int /*argc*/, char** argv) {
   args[4] = const_cast<char*>("--no-secure");
   args[5] = nullptr;
   cli = gpr_subprocess_create(6, (const char**)args);
-  gpr_free(args[0]);
 
   /* wait for completion */
   printf("waiting for client\n");

--- a/test/core/fling/fling_test.cc
+++ b/test/core/fling/fling_test.cc
@@ -19,12 +19,13 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <grpc/support/alloc.h>
-#include <grpc/support/string_util.h>
+#include <string>
 
-#include "src/core/lib/gpr/string.h"
+#include "absl/strings/str_cat.h"
+
+#include <grpc/support/alloc.h>
+
 #include "src/core/lib/gprpp/host_port.h"
-#include "src/core/lib/gprpp/memory.h"
 #include "test/core/util/port.h"
 #include "test/core/util/subprocess.h"
 
@@ -44,18 +45,19 @@ int main(int /*argc*/, const char** argv) {
     strcpy(root, ".");
   }
   /* start the server */
-  gpr_asprintf(&args[0], "%s/fling_server%s", root,
-               gpr_subprocess_binary_extension());
+  std::string command =
+      absl::StrCat(root, "/fling_server", gpr_subprocess_binary_extension());
+  args[0] = const_cast<char*>(command.c_str());
   args[1] = const_cast<char*>("--bind");
   std::string joined = grpc_core::JoinHostPort("::", port);
   args[2] = const_cast<char*>(joined.c_str());
   args[3] = const_cast<char*>("--no-secure");
   svr = gpr_subprocess_create(4, (const char**)args);
-  gpr_free(args[0]);
 
   /* start the client */
-  gpr_asprintf(&args[0], "%s/fling_client%s", root,
-               gpr_subprocess_binary_extension());
+  command =
+      absl::StrCat(root, "/fling_client", gpr_subprocess_binary_extension());
+  args[0] = const_cast<char*>(command.c_str());
   args[1] = const_cast<char*>("--target");
   joined = grpc_core::JoinHostPort("127.0.0.1", port);
   args[2] = const_cast<char*>(joined.c_str());
@@ -63,7 +65,6 @@ int main(int /*argc*/, const char** argv) {
   args[4] = const_cast<char*>("--no-secure");
   args[5] = nullptr;
   cli = gpr_subprocess_create(6, (const char**)args);
-  gpr_free(args[0]);
 
   /* wait for completion */
   printf("waiting for client\n");

--- a/test/core/handshake/client_ssl.cc
+++ b/test/core/handshake/client_ssl.cc
@@ -29,11 +29,14 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/load_file.h"
@@ -256,8 +259,7 @@ static bool client_ssl_test(char* server_alpn_preferred) {
 
   // Establish a channel pointing at the TLS server. Since the gRPC runtime is
   // lazy, this won't necessarily establish a connection yet.
-  char* target;
-  gpr_asprintf(&target, "127.0.0.1:%d", port);
+  std::string target = absl::StrCat("127.0.0.1:", port);
   grpc_arg ssl_name_override = {
       GRPC_ARG_STRING,
       const_cast<char*>(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG),
@@ -265,10 +267,9 @@ static bool client_ssl_test(char* server_alpn_preferred) {
   grpc_channel_args grpc_args;
   grpc_args.num_args = 1;
   grpc_args.args = &ssl_name_override;
-  grpc_channel* channel =
-      grpc_secure_channel_create(ssl_creds, target, &grpc_args, nullptr);
+  grpc_channel* channel = grpc_secure_channel_create(ssl_creds, target.c_str(),
+                                                     &grpc_args, nullptr);
   GPR_ASSERT(channel);
-  gpr_free(target);
 
   // Initially the channel will be idle, the
   // grpc_channel_check_connectivity_state triggers an attempt to connect.

--- a/test/core/handshake/server_ssl_common.cc
+++ b/test/core/handshake/server_ssl_common.cc
@@ -25,11 +25,14 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/gprpp/sync.h"
@@ -117,11 +120,10 @@ void server_thread(void* arg) {
       ca_cert, &pem_key_cert_pair, 1, 0, nullptr);
 
   // Start server listening on local port.
-  char* addr;
-  gpr_asprintf(&addr, "127.0.0.1:%d", port);
+  std::string addr = absl::StrCat("127.0.0.1:", port);
   grpc_server* server = grpc_server_create(nullptr, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(server, addr, ssl_creds));
-  free(addr);
+  GPR_ASSERT(
+      grpc_server_add_secure_http2_port(server, addr.c_str(), ssl_creds));
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
 

--- a/test/core/handshake/verify_peer_options.cc
+++ b/test/core/handshake/verify_peer_options.cc
@@ -29,11 +29,14 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/load_file.h"
@@ -69,11 +72,10 @@ static void server_thread(void* arg) {
       ca_cert, &pem_key_cert_pair, 1, 0, nullptr);
 
   // Start server listening on local port.
-  char* addr;
-  gpr_asprintf(&addr, "127.0.0.1:%d", port);
+  std::string addr = absl::StrCat("127.0.0.1:", port);
   grpc_server* server = grpc_server_create(nullptr, nullptr);
-  GPR_ASSERT(grpc_server_add_secure_http2_port(server, addr, ssl_creds));
-  free(addr);
+  GPR_ASSERT(
+      grpc_server_add_secure_http2_port(server, addr.c_str(), ssl_creds));
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
 
@@ -144,8 +146,7 @@ static bool verify_peer_options_test(verify_peer_options* verify_options) {
 
   // Establish a channel pointing at the TLS server. Since the gRPC runtime is
   // lazy, this won't necessarily establish a connection yet.
-  char* target;
-  gpr_asprintf(&target, "127.0.0.1:%d", port);
+  std::string target = absl::StrCat("127.0.0.1:", port);
   grpc_arg ssl_name_override = {
       GRPC_ARG_STRING,
       const_cast<char*>(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG),
@@ -153,10 +154,9 @@ static bool verify_peer_options_test(verify_peer_options* verify_options) {
   grpc_channel_args grpc_args;
   grpc_args.num_args = 1;
   grpc_args.args = &ssl_name_override;
-  grpc_channel* channel =
-      grpc_secure_channel_create(ssl_creds, target, &grpc_args, nullptr);
+  grpc_channel* channel = grpc_secure_channel_create(ssl_creds, target.c_str(),
+                                                     &grpc_args, nullptr);
   GPR_ASSERT(channel);
-  gpr_free(target);
 
   // Initially the channel will be idle, the
   // grpc_channel_check_connectivity_state triggers an attempt to connect.

--- a/test/core/http/parser_test.cc
+++ b/test/core/http/parser_test.cc
@@ -21,10 +21,13 @@
 #include <stdarg.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/useful.h"
 #include "test/core/util/slice_splitter.h"
@@ -216,7 +219,6 @@ int main(int argc, char** argv) {
   size_t i;
   const grpc_slice_split_mode split_modes[] = {GRPC_SLICE_SPLIT_IDENTITY,
                                                GRPC_SLICE_SPLIT_ONE_BYTE};
-  char *tmp1, *tmp2;
 
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
@@ -293,14 +295,14 @@ int main(int argc, char** argv) {
     test_request_fails(split_modes[i], "GET / HTTP/1.2\r\n");
     test_request_fails(split_modes[i], "GET / HTTP/1.0\n");
 
-    tmp1 =
+    char* tmp1 =
         static_cast<char*>(gpr_malloc(2 * GRPC_HTTP_PARSER_MAX_HEADER_LENGTH));
     memset(tmp1, 'a', 2 * GRPC_HTTP_PARSER_MAX_HEADER_LENGTH - 1);
     tmp1[2 * GRPC_HTTP_PARSER_MAX_HEADER_LENGTH - 1] = 0;
-    gpr_asprintf(&tmp2, "HTTP/1.0 200 OK\r\nxyz: %s\r\n\r\n", tmp1);
-    test_fails(split_modes[i], tmp2);
+    std::string tmp2 =
+        absl::StrFormat("HTTP/1.0 200 OK\r\nxyz: %s\r\n\r\n", tmp1);
     gpr_free(tmp1);
-    gpr_free(tmp2);
+    test_fails(split_modes[i], tmp2.c_str());
   }
 
   grpc_shutdown();

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -22,10 +22,13 @@
 #include <string.h>
 #include <sys/un.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
@@ -200,19 +203,15 @@ static void test_named_and_numeric_scope_ids(void) {
   GPR_ASSERT(strlen(arbitrary_interface_name) > 0);
   // Test resolution of an ipv6 address with a named scope ID
   gpr_log(GPR_DEBUG, "test resolution with a named scope ID");
-  char* target_with_named_scope_id = nullptr;
-  gpr_asprintf(&target_with_named_scope_id, "fe80::1234%%%s",
-               arbitrary_interface_name);
-  resolve_address_must_succeed(target_with_named_scope_id);
-  gpr_free(target_with_named_scope_id);
+  std::string target_with_named_scope_id =
+      absl::StrFormat("fe80::1234%%%s", arbitrary_interface_name);
+  resolve_address_must_succeed(target_with_named_scope_id.c_str());
   gpr_free(arbitrary_interface_name);
   // Test resolution of an ipv6 address with a numeric scope ID
   gpr_log(GPR_DEBUG, "test resolution with a numeric scope ID");
-  char* target_with_numeric_scope_id = nullptr;
-  gpr_asprintf(&target_with_numeric_scope_id, "fe80::1234%%%d",
-               interface_index);
-  resolve_address_must_succeed(target_with_numeric_scope_id);
-  gpr_free(target_with_numeric_scope_id);
+  std::string target_with_numeric_scope_id =
+      absl::StrFormat("fe80::1234%%%d", interface_index);
+  resolve_address_must_succeed(target_with_numeric_scope_id.c_str());
 }
 
 int main(int argc, char** argv) {

--- a/test/core/iomgr/sockaddr_utils_test.cc
+++ b/test/core/iomgr/sockaddr_utils_test.cc
@@ -182,12 +182,9 @@ static void expect_sockaddr_str(const char* expected,
 
 static void expect_sockaddr_uri(const char* expected,
                                 grpc_resolved_address* addr) {
-  char* str;
   gpr_log(GPR_INFO, "  expect_sockaddr_uri(%s)", expected);
-  str = grpc_sockaddr_to_uri(addr);
-  GPR_ASSERT(str != nullptr);
-  GPR_ASSERT(strcmp(expected, str) == 0);
-  gpr_free(str);
+  std::string actual = grpc_sockaddr_to_uri(addr);
+  GPR_ASSERT(actual == expected);
 }
 
 static void test_sockaddr_to_string(void) {
@@ -235,7 +232,7 @@ static void test_sockaddr_to_string(void) {
   dummy_addr->sa_family = 123;
   expect_sockaddr_str("(sockaddr family=123)", &dummy, 0);
   expect_sockaddr_str("(sockaddr family=123)", &dummy, 1);
-  GPR_ASSERT(grpc_sockaddr_to_uri(&dummy) == nullptr);
+  GPR_ASSERT(grpc_sockaddr_to_uri(&dummy).empty());
 }
 
 static void test_sockaddr_set_get_port(void) {

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -24,6 +24,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
@@ -670,16 +675,14 @@ static void test_compute_engine_creds_failure(void) {
 static void validate_refresh_token_http_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size) {
   /* The content of the assertion is tested extensively in json_token_test. */
-  char* expected_body = nullptr;
   GPR_ASSERT(body != nullptr);
   GPR_ASSERT(body_size != 0);
-  gpr_asprintf(&expected_body, GRPC_REFRESH_TOKEN_POST_BODY_FORMAT_STRING,
-               "32555999999.apps.googleusercontent.com",
-               "EmssLNjJy1332hD4KFsecret",
-               "1/Blahblasj424jladJDSGNf-u4Sua3HDA2ngjd42");
-  GPR_ASSERT(strlen(expected_body) == body_size);
-  GPR_ASSERT(memcmp(expected_body, body, body_size) == 0);
-  gpr_free(expected_body);
+  std::string expected_body = absl::StrFormat(
+      GRPC_REFRESH_TOKEN_POST_BODY_FORMAT_STRING,
+      "32555999999.apps.googleusercontent.com", "EmssLNjJy1332hD4KFsecret",
+      "1/Blahblasj424jladJDSGNf-u4Sua3HDA2ngjd42");
+  GPR_ASSERT(expected_body.size() == body_size);
+  GPR_ASSERT(memcmp(expected_body.data(), body, body_size) == 0);
   GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
   GPR_ASSERT(strcmp(request->host, GRPC_GOOGLE_OAUTH2_SERVICE_HOST) == 0);
   GPR_ASSERT(
@@ -891,9 +894,9 @@ static void validate_sts_token_http_request(const grpc_httpcli_request* request,
   GPR_ASSERT(body != nullptr);
   GPR_ASSERT(body_size != 0);
   GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
-  char* get_url_equivalent;
-  gpr_asprintf(&get_url_equivalent, "%s?%s", test_sts_endpoint_url, body);
-  grpc_uri* url = grpc_uri_parse(get_url_equivalent, false);
+  std::string get_url_equivalent =
+      absl::StrFormat("%s?%s", test_sts_endpoint_url, body);
+  grpc_uri* url = grpc_uri_parse(get_url_equivalent.c_str(), false);
   GPR_ASSERT(strcmp(grpc_uri_get_query_arg(url, "resource"), "resource") == 0);
   GPR_ASSERT(strcmp(grpc_uri_get_query_arg(url, "audience"), "audience") == 0);
   GPR_ASSERT(strcmp(grpc_uri_get_query_arg(url, "scope"), "scope") == 0);
@@ -913,7 +916,6 @@ static void validate_sts_token_http_request(const grpc_httpcli_request* request,
     GPR_ASSERT(grpc_uri_get_query_arg(url, "actor_token_type") == nullptr);
   }
   grpc_uri_destroy(url);
-  gpr_free(get_url_equivalent);
 
   // Check the rest of the request.
   GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
@@ -1268,9 +1270,8 @@ static void test_jwt_creds_success(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
-  char* expected_md_value;
-  gpr_asprintf(&expected_md_value, "Bearer %s", test_signed_jwt);
-  expected_md emd[] = {{"authorization", expected_md_value}};
+  std::string expected_md_value = absl::StrCat("Bearer ", test_signed_jwt);
+  expected_md emd[] = {{"authorization", expected_md_value.c_str()}};
   grpc_call_credentials* creds =
       grpc_service_account_jwt_access_credentials_create(
           json_key_string, grpc_max_auth_token_lifetime(), nullptr);
@@ -1304,7 +1305,6 @@ static void test_jwt_creds_success(void) {
 
   creds->Unref();
   gpr_free(json_key_string);
-  gpr_free(expected_md_value);
   grpc_jwt_encode_and_sign_set_override(nullptr);
 }
 
@@ -1409,7 +1409,7 @@ static int default_creds_metadata_server_detection_httpcli_get_success_override(
   return 1;
 }
 
-static char* null_well_known_creds_path_getter(void) { return nullptr; }
+static std::string null_well_known_creds_path_getter(void) { return ""; }
 
 static bool test_gce_tenancy_checker(void) {
   g_test_gce_tenancy_checker_called = true;
@@ -1636,13 +1636,10 @@ static void test_metadata_plugin_failure(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
-  char* expected_error;
-  gpr_asprintf(&expected_error,
-               "Getting metadata from plugin failed with error: %s",
-               plugin_error_details);
+  std::string expected_error = absl::StrCat(
+      "Getting metadata from plugin failed with error: ", plugin_error_details);
   request_metadata_state* md_state = make_request_metadata_state(
-      GRPC_ERROR_CREATE_FROM_COPIED_STRING(expected_error), nullptr, 0);
-  gpr_free(expected_error);
+      GRPC_ERROR_CREATE_FROM_COPIED_STRING(expected_error.c_str()), nullptr, 0);
 
   plugin.state = &state;
   plugin.get_metadata = plugin_get_metadata_failure;
@@ -1662,7 +1659,6 @@ static void test_metadata_plugin_failure(void) {
 }
 
 static void test_get_well_known_google_credentials_file_path(void) {
-  char* path;
   char* home = gpr_getenv("HOME");
   bool restore_home_env = false;
 #if defined(GRPC_BAZEL_BUILD) && \
@@ -1673,15 +1669,13 @@ static void test_get_well_known_google_credentials_file_path(void) {
   gpr_setenv("HOME", "/fake/home/for/bazel");
 #endif /* defined(GRPC_BAZEL_BUILD) && (defined(GPR_POSIX_ENV) || \
           defined(GPR_LINUX_ENV)) */
-  path = grpc_get_well_known_google_credentials_file_path();
-  GPR_ASSERT(path != nullptr);
-  gpr_free(path);
+  std::string path = grpc_get_well_known_google_credentials_file_path();
+  GPR_ASSERT(!path.empty());
 #if defined(GPR_POSIX_ENV) || defined(GPR_LINUX_ENV)
   restore_home_env = true;
   gpr_unsetenv("HOME");
   path = grpc_get_well_known_google_credentials_file_path();
-  GPR_ASSERT(path == nullptr);
-  gpr_free(path);
+  GPR_ASSERT(path.empty());
 #endif /* GPR_POSIX_ENV || GPR_LINUX_ENV */
   if (restore_home_env) {
     if (home) {

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -16,11 +16,14 @@
  *
  */
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/iomgr/resolve_address.h"
@@ -72,26 +75,26 @@ void test_request_call_on_no_server_cq(void) {
 // GRPC_ARG_ALLOW_REUSEPORT isn't supported for custom servers
 #ifndef GRPC_UV
 void test_bind_server_twice(void) {
-  grpc_arg a;
-  a.type = GRPC_ARG_INTEGER;
-  a.key = const_cast<char*>(GRPC_ARG_ALLOW_REUSEPORT);
-  a.value.integer = 0;
+  grpc_arg a = grpc_channel_arg_integer_create(
+      const_cast<char*>(GRPC_ARG_ALLOW_REUSEPORT), 0);
   grpc_channel_args args = {1, &a};
 
-  char* addr;
   grpc_server* server1 = grpc_server_create(&args, nullptr);
   grpc_server* server2 = grpc_server_create(&args, nullptr);
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   int port = grpc_pick_unused_port_or_die();
-  gpr_asprintf(&addr, "[::]:%d", port);
+  std::string addr = absl::StrCat("[::]:", port);
   grpc_server_register_completion_queue(server1, cq, nullptr);
   grpc_server_register_completion_queue(server2, cq, nullptr);
-  GPR_ASSERT(0 == grpc_server_add_secure_http2_port(server2, addr, nullptr));
-  GPR_ASSERT(port == grpc_server_add_insecure_http2_port(server1, addr));
-  GPR_ASSERT(0 == grpc_server_add_insecure_http2_port(server2, addr));
+  GPR_ASSERT(0 ==
+             grpc_server_add_secure_http2_port(server2, addr.c_str(), nullptr));
+  GPR_ASSERT(port ==
+             grpc_server_add_insecure_http2_port(server1, addr.c_str()));
+  GPR_ASSERT(0 == grpc_server_add_insecure_http2_port(server2, addr.c_str()));
   grpc_server_credentials* fake_creds =
       grpc_fake_transport_security_server_credentials_create();
-  GPR_ASSERT(0 == grpc_server_add_secure_http2_port(server2, addr, fake_creds));
+  GPR_ASSERT(0 == grpc_server_add_secure_http2_port(server2, addr.c_str(),
+                                                    fake_creds));
   grpc_server_credentials_release(fake_creds);
   grpc_server_shutdown_and_notify(server1, cq, nullptr);
   grpc_server_shutdown_and_notify(server2, cq, nullptr);
@@ -100,7 +103,6 @@ void test_bind_server_twice(void) {
   grpc_server_destroy(server1);
   grpc_server_destroy(server2);
   grpc_completion_queue_destroy(cq);
-  gpr_free(addr);
 }
 #endif
 

--- a/test/core/transport/chttp2/hpack_table_test.cc
+++ b/test/core/transport/chttp2/hpack_table_test.cc
@@ -21,13 +21,17 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/slice/slice_internal.h"
 #include "test/core/util/test_config.h"
 
 #define LOG_TEST(x) gpr_log(GPR_INFO, "%s", x)
@@ -117,8 +121,6 @@ static void test_static_lookup(void) {
 static void test_many_additions(void) {
   grpc_chttp2_hptbl tbl;
   int i;
-  char* key;
-  char* value;
 
   LOG_TEST("test_many_additions");
 
@@ -126,21 +128,19 @@ static void test_many_additions(void) {
 
   for (i = 0; i < 100000; i++) {
     grpc_mdelem elem;
-    gpr_asprintf(&key, "K:%d", i);
-    gpr_asprintf(&value, "VALUE:%d", i);
-    elem = grpc_mdelem_from_slices(grpc_slice_from_copied_string(key),
-                                   grpc_slice_from_copied_string(value));
+    std::string key = absl::StrCat("K:", i);
+    std::string value = absl::StrCat("VALUE:", i);
+    elem = grpc_mdelem_from_slices(grpc_slice_from_cpp_string(key),
+                                   grpc_slice_from_cpp_string(value));
     GPR_ASSERT(grpc_chttp2_hptbl_add(&tbl, elem) == GRPC_ERROR_NONE);
     GRPC_MDELEM_UNREF(elem);
-    assert_index(&tbl, 1 + GRPC_CHTTP2_LAST_STATIC_ENTRY, key, value);
-    gpr_free(key);
-    gpr_free(value);
+    assert_index(&tbl, 1 + GRPC_CHTTP2_LAST_STATIC_ENTRY, key.c_str(),
+                 value.c_str());
     if (i) {
-      gpr_asprintf(&key, "K:%d", i - 1);
-      gpr_asprintf(&value, "VALUE:%d", i - 1);
-      assert_index(&tbl, 2 + GRPC_CHTTP2_LAST_STATIC_ENTRY, key, value);
-      gpr_free(key);
-      gpr_free(value);
+      std::string key = absl::StrCat("K:", i - 1);
+      std::string value = absl::StrCat("VALUE:", i - 1);
+      assert_index(&tbl, 2 + GRPC_CHTTP2_LAST_STATIC_ENTRY, key.c_str(),
+                   value.c_str());
     }
   }
 

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -16,16 +16,18 @@
  *
  */
 
-#include <grpc/grpc.h>
-#include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
-
 #include <functional>
 #include <memory>
+#include <string>
 #include <thread>
 
 #include <gtest/gtest.h>
+
+#include "absl/strings/str_cat.h"
+
+#include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
 
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/error.h"
@@ -220,15 +222,14 @@ class Client {
 TEST(SettingsTimeout, Basic) {
   // Construct server address string.
   const int server_port = grpc_pick_unused_port_or_die();
-  char* server_address_string;
-  gpr_asprintf(&server_address_string, "localhost:%d", server_port);
+  std::string server_address_string = absl::StrCat("localhost:", server_port);
   // Start server.
-  gpr_log(GPR_INFO, "starting server on %s", server_address_string);
-  ServerThread server_thread(server_address_string);
+  gpr_log(GPR_INFO, "starting server on %s", server_address_string.c_str());
+  ServerThread server_thread(server_address_string.c_str());
   server_thread.Start();
   // Create client and connect to server.
   gpr_log(GPR_INFO, "starting client connect");
-  Client client(server_address_string);
+  Client client(server_address_string.c_str());
   client.Connect();
   // Client read.  Should fail due to server dropping connection.
   gpr_log(GPR_INFO, "starting client read");
@@ -240,7 +241,6 @@ TEST(SettingsTimeout, Basic) {
   gpr_log(GPR_INFO, "shutting down server");
   server_thread.Shutdown();
   // Clean up.
-  gpr_free(server_address_string);
 }
 
 }  // namespace

--- a/test/core/transport/timeout_encoding_test.cc
+++ b/test/core/transport/timeout_encoding_test.cc
@@ -21,9 +21,12 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 
 #include "src/core/lib/gpr/murmur_hash.h"
 #include "src/core/lib/gpr/string.h"
@@ -84,24 +87,18 @@ void decode_suite(char ext, grpc_millis (*answer)(int64_t x)) {
   long test_vals[] = {1,       12,       123,       1234,     12345,   123456,
                       1234567, 12345678, 123456789, 98765432, 9876543, 987654,
                       98765,   9876,     987,       98,       9};
-  unsigned i;
-  char* input;
-  for (i = 0; i < GPR_ARRAY_SIZE(test_vals); i++) {
-    gpr_asprintf(&input, "%ld%c", test_vals[i], ext);
-    assert_decodes_as(input, answer(test_vals[i]));
-    gpr_free(input);
+  for (unsigned i = 0; i < GPR_ARRAY_SIZE(test_vals); i++) {
+    std::string input = absl::StrFormat("%ld%c", test_vals[i], ext);
+    assert_decodes_as(input.c_str(), answer(test_vals[i]));
 
-    gpr_asprintf(&input, "   %ld%c", test_vals[i], ext);
-    assert_decodes_as(input, answer(test_vals[i]));
-    gpr_free(input);
+    input = absl::StrFormat("   %ld%c", test_vals[i], ext);
+    assert_decodes_as(input.c_str(), answer(test_vals[i]));
 
-    gpr_asprintf(&input, "%ld %c", test_vals[i], ext);
-    assert_decodes_as(input, answer(test_vals[i]));
-    gpr_free(input);
+    input = absl::StrFormat("%ld %c", test_vals[i], ext);
+    assert_decodes_as(input.c_str(), answer(test_vals[i]));
 
-    gpr_asprintf(&input, "%ld %c  ", test_vals[i], ext);
-    assert_decodes_as(input, answer(test_vals[i]));
-    gpr_free(input);
+    input = absl::StrFormat("%ld %c  ", test_vals[i], ext);
+    assert_decodes_as(input.c_str(), answer(test_vals[i]));
   }
 }
 

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -31,6 +31,8 @@
 #include <set>
 #include <thread>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
@@ -337,9 +339,7 @@ class FakeTcpServer {
       : process_read_cb_(process_read_cb) {
     port_ = grpc_pick_unused_port_or_die();
     accept_socket_ = socket(AF_INET6, SOCK_STREAM, 0);
-    char* addr_str;
-    GPR_ASSERT(gpr_asprintf(&addr_str, "[::]:%d", port_));
-    address_ = grpc_core::UniquePtr<char>(addr_str);
+    address_ = absl::StrCat("[::]:", port_);
     GPR_ASSERT(accept_socket_ != -1);
     if (accept_socket_ == -1) {
       gpr_log(GPR_ERROR, "Failed to create socket: %d", errno);
@@ -388,7 +388,7 @@ class FakeTcpServer {
             "thread complete");
   }
 
-  const char* address() { return address_.get(); }
+  const char* address() { return address_.c_str(); }
 
   static ProcessReadResult CloseSocketUponReceivingBytesFromPeer(
       int bytes_received_size, int read_error, int s) {
@@ -479,7 +479,7 @@ class FakeTcpServer {
   int accept_socket_;
   int port_;
   gpr_event stop_ev_;
-  grpc_core::UniquePtr<char> address_;
+  std::string address_;
   std::unique_ptr<std::thread> run_server_loop_thd_;
   std::function<ProcessReadResult(int, int, int)> process_read_cb_;
 };

--- a/test/core/tsi/transport_security_test.cc
+++ b/test/core/tsi/transport_security_test.cc
@@ -20,6 +20,10 @@
 
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -291,16 +295,13 @@ static tsi_peer peer_from_cert_name_test_entry(
   return peer;
 }
 
-char* cert_name_test_entry_to_string(const cert_name_test_entry* entry) {
-  char* s;
-  gpr_asprintf(&s,
-               "{ success = %s, host_name = %s, common_name = %s, dns_names = "
-               "%s, ip_names = %s}",
-               entry->expected ? "true" : "false", entry->host_name,
-               entry->common_name,
-               entry->dns_names != nullptr ? entry->dns_names : "",
-               entry->ip_names != nullptr ? entry->ip_names : "");
-  return s;
+std::string cert_name_test_entry_to_string(const cert_name_test_entry* entry) {
+  return absl::StrFormat(
+      "{ success = %s, host_name = %s, common_name = %s, dns_names = "
+      "%s, ip_names = %s}",
+      entry->expected ? "true" : "false", entry->host_name, entry->common_name,
+      entry->dns_names != nullptr ? entry->dns_names : "",
+      entry->ip_names != nullptr ? entry->ip_names : "");
 }
 
 static void test_peer_matches_name(void) {
@@ -310,9 +311,7 @@ static void test_peer_matches_name(void) {
     tsi_peer peer = peer_from_cert_name_test_entry(entry);
     int result = tsi_ssl_peer_matches_name(&peer, entry->host_name);
     if (result != entry->expected) {
-      char* entry_str = cert_name_test_entry_to_string(entry);
-      gpr_log(GPR_ERROR, "%s", entry_str);
-      gpr_free(entry_str);
+      gpr_log(GPR_ERROR, "%s", cert_name_test_entry_to_string(entry).c_str());
       GPR_ASSERT(0); /* Unexpected result. */
     }
     tsi_peer_destruct(&peer);

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -22,9 +22,13 @@
    headers. Therefore, sockaddr.h must always be included first */
 #include "src/core/lib/iomgr/sockaddr.h"
 
-#include "test/core/util/mock_endpoint.h"
-
 #include <inttypes.h>
+
+#include <string>
+
+#include "absl/strings/str_format.h"
+
+#include "test/core/util/mock_endpoint.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
@@ -123,10 +127,8 @@ grpc_endpoint* grpc_mock_endpoint_create(void (*on_write)(grpc_slice slice),
                                          grpc_resource_quota* resource_quota) {
   mock_endpoint* m = static_cast<mock_endpoint*>(gpr_malloc(sizeof(*m)));
   m->base.vtable = &vtable;
-  char* name;
-  gpr_asprintf(&name, "mock_endpoint_%" PRIxPTR, (intptr_t)m);
-  m->resource_user = grpc_resource_user_create(resource_quota, name);
-  gpr_free(name);
+  std::string name = absl::StrFormat("mock_endpoint_%" PRIxPTR, (intptr_t)m);
+  m->resource_user = grpc_resource_user_create(resource_quota, name.c_str());
   grpc_slice_buffer_init(&m->read_buffer);
   gpr_mu_init(&m->mu);
   m->on_write = on_write;

--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -27,6 +27,10 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include <string>
+
+#include "absl/strings/str_format.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 #include "src/core/lib/iomgr/sockaddr.h"
@@ -185,11 +189,9 @@ static void half_init(half* m, passthru_endpoint* parent,
   m->parent = parent;
   grpc_slice_buffer_init(&m->read_buffer);
   m->on_read = nullptr;
-  char* name;
-  gpr_asprintf(&name, "passthru_endpoint_%s_%" PRIxPTR, half_name,
-               (intptr_t)parent);
-  m->resource_user = grpc_resource_user_create(resource_quota, name);
-  gpr_free(name);
+  std::string name = absl::StrFormat("passthru_endpoint_%s_%" PRIxPTR,
+                                     half_name, (intptr_t)parent);
+  m->resource_user = grpc_resource_user_create(resource_quota, name.c_str());
 }
 
 void grpc_passthru_endpoint_create(grpc_endpoint** client,

--- a/test/cpp/client/client_channel_stress_test.cc
+++ b/test/cpp/client/client_channel_stress_test.cc
@@ -21,12 +21,14 @@
 #include <mutex>
 #include <random>
 #include <sstream>
+#include <string>
 #include <thread>
+
+#include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -221,9 +223,8 @@ class ClientChannelStressTest {
       const std::vector<AddressData>& address_data) {
     grpc_core::ServerAddressList addresses;
     for (const auto& addr : address_data) {
-      char* lb_uri_str;
-      gpr_asprintf(&lb_uri_str, "ipv4:127.0.0.1:%d", addr.port);
-      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str, true);
+      std::string lb_uri_str = absl::StrCat("ipv4:127.0.0.1:", addr.port);
+      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str.c_str(), true);
       GPR_ASSERT(lb_uri != nullptr);
       grpc_resolved_address address;
       GPR_ASSERT(grpc_parse_uri(lb_uri, &address));
@@ -233,7 +234,6 @@ class ClientChannelStressTest {
           grpc_channel_args_copy_and_add(nullptr, &arg, 1);
       addresses.emplace_back(address.addr, address.len, args);
       grpc_uri_destroy(lb_uri);
-      gpr_free(lb_uri_str);
     }
     return addresses;
   }

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -21,13 +21,15 @@
 #include <mutex>
 #include <random>
 #include <set>
+#include <string>
 #include <thread>
+
+#include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/atm.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -186,16 +188,14 @@ class FakeResolverResponseGeneratorWrapper {
       const char* service_config_json = nullptr) {
     grpc_core::Resolver::Result result;
     for (const int& port : ports) {
-      char* lb_uri_str;
-      gpr_asprintf(&lb_uri_str, "ipv4:127.0.0.1:%d", port);
-      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str, true);
+      std::string lb_uri_str = absl::StrCat("ipv4:127.0.0.1:", port);
+      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str.c_str(), true);
       GPR_ASSERT(lb_uri != nullptr);
       grpc_resolved_address address;
       GPR_ASSERT(grpc_parse_uri(lb_uri, &address));
       result.addresses.emplace_back(address.addr, address.len,
                                     nullptr /* args */);
       grpc_uri_destroy(lb_uri);
-      gpr_free(lb_uri_str);
     }
     if (service_config_json != nullptr) {
       result.service_config = grpc_core::ServiceConfig::Create(

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -21,13 +21,15 @@
 #include <mutex>
 #include <random>
 #include <set>
+#include <string>
 #include <thread>
+
+#include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/atm.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -167,16 +169,14 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
   grpc_core::Resolver::Result BuildFakeResults(const std::vector<int>& ports) {
     grpc_core::Resolver::Result result;
     for (const int& port : ports) {
-      char* lb_uri_str;
-      gpr_asprintf(&lb_uri_str, "ipv4:127.0.0.1:%d", port);
-      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str, true);
+      std::string lb_uri_str = absl::StrCat("ipv4:127.0.0.1:", port);
+      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str.c_str(), true);
       GPR_ASSERT(lb_uri != nullptr);
       grpc_resolved_address address;
       GPR_ASSERT(grpc_parse_uri(lb_uri, &address));
       result.addresses.emplace_back(address.addr, address.len,
                                     nullptr /* args */);
       grpc_uri_destroy(lb_uri);
-      gpr_free(lb_uri_str);
     }
     return result;
   }

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -26,10 +26,11 @@
 #include <thread>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
@@ -1378,15 +1379,13 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
       const std::vector<int>& ports) {
     grpc_core::ServerAddressList addresses;
     for (int port : ports) {
-      char* lb_uri_str;
-      gpr_asprintf(&lb_uri_str, "ipv4:127.0.0.1:%d", port);
-      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str, true);
+      std::string lb_uri_str = absl::StrCat("ipv4:127.0.0.1:", port);
+      grpc_uri* lb_uri = grpc_uri_parse(lb_uri_str.c_str(), true);
       GPR_ASSERT(lb_uri != nullptr);
       grpc_resolved_address address;
       GPR_ASSERT(grpc_parse_uri(lb_uri, &address));
       addresses.emplace_back(address.addr, address.len, nullptr);
       grpc_uri_destroy(lb_uri);
-      gpr_free(lb_uri_str);
     }
     return addresses;
   }


### PR DESCRIPTION
There are still some uses of `gpr_asprintf()` remaining, which will take a little more work to remove.  But this gets rid of most of the low-hanging fruit.

Note that this also adds `grpc_slice_from_cpp_string()`, which takes ownership of a `std::string` for the slice storage.