### PR TITLE
setup.py: respect CC variable in latomic test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,9 +148,10 @@ ENABLE_DOCUMENTATION_BUILD = os.environ.get(
 
 def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
+    cc = os.environ.get('CC', 'cc')
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cc_test = subprocess.Popen(['cc', '-x', 'c++', '-std=c++11', '-'],
+    cc_test = subprocess.Popen([cc, '-x', 'c++', '-std=c++11', '-'],
                                stdin=PIPE,
                                stdout=PIPE,
                                stderr=PIPE)


### PR DESCRIPTION
some configurations do not provide generic cc binary.
while rest of the build calls CHOST prefixed binaries,
this check fails. fix it.

Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
