### PR TITLE
Add an overall deadline option to interop soak tests to prevent test runner timeouts

### DIFF
--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -97,7 +97,7 @@ DEFINE_int32(soak_max_failures, 0,
 DEFINE_int32(soak_per_iteration_max_acceptable_latency_ms, 0,
              "The number of milliseconds a single iteration in the two soak "
              "tests (rpc_soak and channel_soak) should take.");
-DEFINE_int32(soak_overall_deadline_seconds, 0,
+DEFINE_int32(soak_overall_timeout_seconds, 0,
              "The overall number of seconds after which a soak test should "
              "stop and fail, if the desired number of iterations have not yet "
              "completed.");
@@ -270,12 +270,12 @@ int main(int argc, char** argv) {
       std::bind(&grpc::testing::InteropClient::DoChannelSoakTest, &client,
                 FLAGS_soak_iterations, FLAGS_soak_max_failures,
                 FLAGS_soak_per_iteration_max_acceptable_latency_ms,
-                FLAGS_soak_overall_deadline_seconds);
+                FLAGS_soak_overall_timeout_seconds);
   actions["rpc_soak"] =
       std::bind(&grpc::testing::InteropClient::DoRpcSoakTest, &client,
                 FLAGS_soak_iterations, FLAGS_soak_max_failures,
                 FLAGS_soak_per_iteration_max_acceptable_latency_ms,
-                FLAGS_soak_overall_deadline_seconds);
+                FLAGS_soak_overall_timeout_seconds);
   actions["long_lived_channel"] =
       std::bind(&grpc::testing::InteropClient::DoLongLivedChannelTest, &client,
                 FLAGS_soak_iterations, FLAGS_iteration_interval);

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -96,7 +96,11 @@ DEFINE_int32(soak_max_failures, 0,
              "per-iteration max acceptable latency).");
 DEFINE_int32(soak_per_iteration_max_acceptable_latency_ms, 0,
              "The number of milliseconds a single iteration in the two soak "
-             "tests (rpc_soak and channel_soak) is allowed to take.");
+             "tests (rpc_soak and channel_soak) should take.");
+DEFINE_int32(soak_overall_deadline_seconds, 0,
+             "The overall number of seconds after which a soak test should "
+             "stop and fail, if the desired number of iterations have not yet "
+             "completed.");
 DEFINE_int32(iteration_interval, 10,
              "The interval in seconds between rpcs. This is used by "
              "long_connection test");
@@ -265,11 +269,13 @@ int main(int argc, char** argv) {
   actions["channel_soak"] =
       std::bind(&grpc::testing::InteropClient::DoChannelSoakTest, &client,
                 FLAGS_soak_iterations, FLAGS_soak_max_failures,
-                FLAGS_soak_per_iteration_max_acceptable_latency_ms);
+                FLAGS_soak_per_iteration_max_acceptable_latency_ms,
+                FLAGS_soak_overall_deadline_seconds);
   actions["rpc_soak"] =
       std::bind(&grpc::testing::InteropClient::DoRpcSoakTest, &client,
                 FLAGS_soak_iterations, FLAGS_soak_max_failures,
-                FLAGS_soak_per_iteration_max_acceptable_latency_ms);
+                FLAGS_soak_per_iteration_max_acceptable_latency_ms,
+                FLAGS_soak_overall_deadline_seconds);
   actions["long_lived_channel"] =
       std::bind(&grpc::testing::InteropClient::DoLongLivedChannelTest, &client,
                 FLAGS_soak_iterations, FLAGS_iteration_interval);

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -1107,14 +1107,14 @@ void InteropClient::PerformSoakTest(
     const bool reset_channel_per_iteration, const int32_t soak_iterations,
     const int32_t max_failures,
     const int32_t max_acceptable_per_iteration_latency_ms,
-    const int32_t overall_deadline_seconds) {
+    const int32_t overall_timeout_seconds) {
   std::vector<std::tuple<bool, int32_t, std::string>> results;
   grpc_histogram* latencies_ms_histogram = grpc_histogram_create(
       1 /* resolution */,
       500 * 1e3 /* largest bucket; 500 seconds is unlikely */);
   gpr_timespec overall_deadline = gpr_time_add(
       gpr_now(GPR_CLOCK_MONOTONIC),
-      gpr_time_from_seconds(overall_deadline_seconds, GPR_TIMESPAN));
+      gpr_time_from_seconds(overall_timeout_seconds, GPR_TIMESPAN));
   int32_t iterations_ran = 0;
   for (int i = 0;
        i < soak_iterations &&
@@ -1159,7 +1159,7 @@ void InteropClient::PerformSoakTest(
         "Some or all of the iterations that did run were unexpectedly slow. "
         "See breakdown above for which iterations succeeded, failed, and "
         "why for more info.",
-        overall_deadline_seconds, iterations_ran, soak_iterations,
+        overall_timeout_seconds, iterations_ran, soak_iterations,
         total_failures, max_failures, latency_ms_median, latency_ms_90th,
         latency_ms_worst);
     GPR_ASSERT(0);
@@ -1192,12 +1192,12 @@ void InteropClient::PerformSoakTest(
 bool InteropClient::DoRpcSoakTest(
     int32_t soak_iterations, int32_t max_failures,
     int64_t max_acceptable_per_iteration_latency_ms,
-    int32_t overall_deadline_seconds) {
+    int32_t overall_timeout_seconds) {
   gpr_log(GPR_DEBUG, "Sending %d RPCs...", soak_iterations);
   GPR_ASSERT(soak_iterations > 0);
   PerformSoakTest(false /* reset channel per iteration */, soak_iterations,
                   max_failures, max_acceptable_per_iteration_latency_ms,
-                  overall_deadline_seconds);
+                  overall_timeout_seconds);
   gpr_log(GPR_DEBUG, "rpc_soak test done.");
   return true;
 }
@@ -1205,13 +1205,13 @@ bool InteropClient::DoRpcSoakTest(
 bool InteropClient::DoChannelSoakTest(
     int32_t soak_iterations, int32_t max_failures,
     int64_t max_acceptable_per_iteration_latency_ms,
-    int32_t overall_deadline_seconds) {
+    int32_t overall_timeout_seconds) {
   gpr_log(GPR_DEBUG, "Sending %d RPCs, tearing down the channel each time...",
           soak_iterations);
   GPR_ASSERT(soak_iterations > 0);
   PerformSoakTest(true /* reset channel per iteration */, soak_iterations,
                   max_failures, max_acceptable_per_iteration_latency_ms,
-                  overall_deadline_seconds);
+                  overall_timeout_seconds);
   gpr_log(GPR_DEBUG, "channel_soak test done.");
   return true;
 }

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -77,9 +77,11 @@ class InteropClient {
   // but at some point in the future, might be codified and implemented in all
   // languages
   bool DoChannelSoakTest(int32_t soak_iterations, int32_t max_failures,
-                         int64_t max_acceptable_per_iteration_latency_ms);
+                         int64_t max_acceptable_per_iteration_latency_ms,
+                         int32_t overall_deadline_seconds);
   bool DoRpcSoakTest(int32_t soak_iterations, int32_t max_failures,
-                     int64_t max_acceptable_per_iteration_latency_ms);
+                     int64_t max_acceptable_per_iteration_latency_ms,
+                     int32_t overall_deadline_seconds);
   bool DoLongLivedChannelTest(int32_t soak_iterations,
                               int32_t iteration_interval);
 
@@ -137,7 +139,8 @@ class InteropClient {
   void PerformSoakTest(const bool reset_channel_per_iteration,
                        const int32_t soak_iterations,
                        const int32_t max_failures,
-                       const int32_t max_acceptable_per_iteration_latency_ms);
+                       const int32_t max_acceptable_per_iteration_latency_ms,
+                       const int32_t overall_deadline_seconds);
 
   ServiceStub serviceStub_;
   /// If true, abort() is not called for transient failures

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -78,10 +78,10 @@ class InteropClient {
   // languages
   bool DoChannelSoakTest(int32_t soak_iterations, int32_t max_failures,
                          int64_t max_acceptable_per_iteration_latency_ms,
-                         int32_t overall_deadline_seconds);
+                         int32_t overall_timeout_seconds);
   bool DoRpcSoakTest(int32_t soak_iterations, int32_t max_failures,
                      int64_t max_acceptable_per_iteration_latency_ms,
-                     int32_t overall_deadline_seconds);
+                     int32_t overall_timeout_seconds);
   bool DoLongLivedChannelTest(int32_t soak_iterations,
                               int32_t iteration_interval);
 
@@ -140,7 +140,7 @@ class InteropClient {
                        const int32_t soak_iterations,
                        const int32_t max_failures,
                        const int32_t max_acceptable_per_iteration_latency_ms,
-                       const int32_t overall_deadline_seconds);
+                       const int32_t overall_timeout_seconds);
 
   ServiceStub serviceStub_;
   /// If true, abort() is not called for transient failures


### PR DESCRIPTION
I've still seen a couple of recent failure modes of this test where failure mode caused every RPC to be so slow that the test didn't complete all desired soak iteration and the test runner timed out the process.

In that case, relevant debug data that's normally displayed in the test's summary log is lost, which makes it hard to debug. I plan to use this flag to set it to something e.g. 1 or 2 minute less than the test runner's overall deadline on the process.

Example log output on failure:

```
D0608 18:39:12.652534387   70283 interop_client.cc:1139]     soak iteration: 1245 elapsed_ms: 2 succeeded
D0608 18:39:12.652539105   70283 interop_client.cc:1139]     soak iteration: 1246 elapsed_ms: 2 succeeded
D0608 18:39:12.652543805   70283 interop_client.cc:1139]     soak iteration: 1247 elapsed_ms: 2 succeeded
D0608 18:39:12.652548598   70283 interop_client.cc:1139]     soak iteration: 1248 elapsed_ms: 3 succeeded
D0608 18:39:12.652553146   70283 interop_client.cc:1139]     soak iteration: 1249 elapsed_ms: 3 succeeded
D0608 18:39:12.652557796   70283 interop_client.cc:1139]     soak iteration: 1250 elapsed_ms: 3 succeeded
D0608 18:39:12.652562287   70283 interop_client.cc:1139]     soak iteration: 1251 elapsed_ms: 3 succeeded
D0608 18:39:12.652566970   70283 interop_client.cc:1139]     soak iteration: 1252 elapsed_ms: 5 succeeded
D0608 18:39:12.652571574   70283 interop_client.cc:1139]     soak iteration: 1253 elapsed_ms: 5 succeeded
D0608 18:39:12.652576126   70283 interop_client.cc:1139]     soak iteration: 1254 elapsed_ms: 3 succeeded
D0608 18:39:12.652580984   70283 interop_client.cc:1139]     soak iteration: 1255 elapsed_ms: 3 succeeded
D0608 18:39:12.652585717   70283 interop_client.cc:1139]     soak iteration: 1256 elapsed_ms: 3 succeeded
D0608 18:39:12.652591680   70283 interop_client.cc:1139]     soak iteration: 1257 elapsed_ms: 3 succeeded
E0608 18:39:12.652609013   70283 interop_client.cc:1151]     soak test consumed all 4 seconds of time and quit early, only having ran 1258 out of desired 2100 iterations. total_failures: 0. max_failures_threshold: 5. median_soak_iteration_latency: 3.066102 ms. 90th_soak_iteration_latency: 3.918983 ms. worst_soak_iteration_latency: 5.000000 ms. Some or all of the iterations that did run were unexpectedly slow. See breakdown above for which iterations succeeded, failed, and why for more info.
E0608 18:39:12.652621330   70283 interop_client.cc:1165]     assertion failed: 0



*******************************
Caught signal SIGABRT
```
