### PR TITLE
Add protobuf as an "extras" dependency to grpcio package

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -2,7 +2,7 @@
 coverage>=4.0
 cython>=0.29.8
 enum34>=1.0.4
-protobuf>=3.5.0.post1
+protobuf>=3.5.0.post1, < 4.0dev
 six>=1.10
 wheel>=0.29
 futures>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 coverage>=4.0
 cython>=0.29.8
 enum34>=1.0.4
-protobuf>=3.5.0.post1
+protobuf>=3.5.0.post1, < 4.0dev
 six>=1.10
 wheel>=0.29
 # rsa 4.3 is the last version support Python 2

--- a/setup.py
+++ b/setup.py
@@ -355,6 +355,9 @@ INSTALL_REQUIRES = (
     "futures>=2.2.0; python_version<'3.2'",
     "enum34>=1.0.4; python_version<'3.4'",
 )
+EXTRAS_REQUIRES = {
+    "protobuf": "protobuf>=3.5.0.post1",
+}
 
 SETUP_REQUIRES = INSTALL_REQUIRES + (
     'Sphinx~=1.8.1',
@@ -417,6 +420,7 @@ setuptools.setup(
     package_dir=PACKAGE_DIRECTORIES,
     package_data=PACKAGE_DATA,
     install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRES,
     setup_requires=SETUP_REQUIRES,
     cmdclass=COMMAND_CLASS,
 )

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,7 @@ INSTALL_REQUIRES = (
     "enum34>=1.0.4; python_version<'3.4'",
 )
 EXTRAS_REQUIRES = {
-    "protobuf": "protobuf>=3.5.0.post1",
+    'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
 }
 
 SETUP_REQUIRES = INSTALL_REQUIRES + (

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,7 @@ INSTALL_REQUIRES = (
     "enum34>=1.0.4; python_version<'3.4'",
 )
 EXTRAS_REQUIRES = {
-    'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
+    'protobuf': 'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
 }
 
 SETUP_REQUIRES = INSTALL_REQUIRES + (

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -219,7 +219,7 @@ setuptools.setup(
     ext_modules=extension_modules(),
     packages=setuptools.find_packages('.'),
     install_requires=[
-        'protobuf>=3.5.0.post1',
+        'protobuf>=3.5.0.post1, < 4.0dev',
         'grpcio>={version}'.format(version=grpc_version.VERSION),
     ],
     package_data=package_data(),


### PR DESCRIPTION
This PR allows installation like `pip install grpcio[protobuf]`. It adds an extra dependency to the `grpcio` package, other than that, no logic will be changed. We can promote this way of installation in our tutorial.

https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies