### PR TITLE
use Microsoft.NETFramework.ReferenceAssemblies for Grpc.Tools

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/Grpc.Tools.Tests.csproj
+++ b/src/csharp/Grpc.Tools.Tests/Grpc.Tools.Tests.csproj
@@ -37,36 +37,4 @@
     <PackageReference Include="Microsoft.Build.Framework; Microsoft.Build.Utilities.Core" Version="15.6.*" />
   </ItemGroup>
 
-  <!-- Groups below is a hack to allow the test to run under Mono Framework build.
-       ========================================================================== -->
-
-  <!-- Mono unfortunately comes with broken Microsoft.Build.* assemblies installed in
-       the GAC, but fortunately searches for runtime assemblies in a different order
-       than Windows CLR host: the GAC assemblies have the lowest search priority, (see
-       https://www.mono-project.com/docs/advanced/assemblies-and-the-gac/), not the
-       highest as is in Windows (documented at
-       https://docs.microsoft.com/dotnet/framework/deployment/how-the-runtime-locates-assemblies).
-       To run the tests under Mono, we need correct assemblies in the same directory as
-       the test executable. Correct versions are in the MSBuild directory under Mono. -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' and '$(OS)' != 'Windows_NT' ">
-    <None Include="$(_MSBuildAssemblyPath)/Microsoft.Build.Framework.dll;
-                   $(_MSBuildAssemblyPath)/Microsoft.Build.Utilities.v4.0.dll;
-                   $(_MSBuildAssemblyPath)/Microsoft.Build.Utilities.Core.dll"
-          CopyToOutputDirectory="Always" Visible="false" />
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' and '$(OS)' != 'Windows_NT' ">
-    <!-- The None items are included into assembly candidate resolution by default, and
-         we do not want that, as they are not valid as reference assemblies (the version of
-         Microsoft.Build.Utilities.v4.0 is a pure facade for Microsoft.Build.Utilities.Core,
-         and does not define any types at all). Exclude them from assembly resolution. See
-         https://github.com/Microsoft/msbuild/blob/50639058f/documentation/wiki/ResolveAssemblyReference.md -->
-    <AssemblySearchPaths>{HintPathFromItem};{TargetFrameworkDirectory};{RawFileName}</AssemblySearchPaths>
-    <!-- Mono knows better where its MSBuild is. -->
-    <_MSBuildAssemblyPath Condition=" '$(MSBuildRuntimeType)' != 'Core' "
-                          >$(MSBuildToolsPath)</_MSBuildAssemblyPath>
-    <!-- Under dotnet, make the best guess we can. -->
-    <_MSBuildAssemblyPath Condition=" '$(MSBuildRuntimeType)' == 'Core' "
-                          >$(FrameworkPathOverride)/../msbuild/$(MSBuildToolsVersion)/bin</_MSBuildAssemblyPath>
-  </PropertyGroup>
-
 </Project>

--- a/src/csharp/Grpc.Tools.Tests/Grpc.Tools.Tests.csproj
+++ b/src/csharp/Grpc.Tools.Tests/Grpc.Tools.Tests.csproj
@@ -7,14 +7,13 @@
 
   <Import Project="..\Grpc.Core\SourceLink.csproj.include" />
 
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Core' ">
-    <!-- Use Mono reference assemblies in SDK build: https://github.com/dotnet/sdk/issues/335.
-         This is a different approach than used in Grpc.Core/Common.csproj.include because
-         the workaround used there doesn't seem to be working for Microsoft.Build.* assemblies -->
-    <FrameworkPathOverride Condition="Exists('/usr/lib/mono/4.5-api')">/usr/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="Exists('/usr/local/lib/mono/4.5-api')">/usr/local/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="Exists('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api')">/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api</FrameworkPathOverride>
-  </PropertyGroup>
+  <!-- Needed for the net45 build to work on Unix. See https://github.com/dotnet/designs/pull/33 -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Grpc.Tools\Grpc.Tools.csproj" />

--- a/src/csharp/Grpc.Tools.Tests/MsBuildAssemblyHelper.cs
+++ b/src/csharp/Grpc.Tools.Tests/MsBuildAssemblyHelper.cs
@@ -1,0 +1,63 @@
+#region Copyright notice and license
+
+// Copyright 2018 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Reflection;
+using NUnitLite;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Grpc.Tools.Tests
+{
+    static class MsBuildAssemblyHelper
+    {
+        [DllImport("__Internal")]
+	    extern static void mono_set_assemblies_path(string path);
+
+        public static void TweakAssemblyPathIfOnMono()
+        {
+            // Below is a hack to allow the tests to run under Mono Framework build.
+            // Mono unfortunately comes with broken Microsoft.Build.* assemblies installed in
+            // the GAC, so we need to tweak the assembly search path to make sure the right
+            // msbuild assemblies are loaded (and the tests work).
+#if NET45
+            // only run this under .NET framework; under mono
+            bool isMono = Type.GetType("Mono.Runtime") != null;
+            if (isMono)
+            {
+               var mscorlibDir = Path.GetDirectoryName(typeof(Array).Assembly.Location);
+               // Construct the location of MsBuild assemblies from the location of mscorlib assembly.
+               var msbuildToolPath = Path.Combine(mscorlibDir, "..", "msbuild", "Current", "bin");
+
+               // To make sure we've constructed the right path, make sure the assemblies we're interested
+               // in are there.
+               foreach(var assemblyName in new [] {"Microsoft.Build.Framework.dll", "Microsoft.Build.Utilities.v4.0.dll", "Microsoft.Build.Utilities.Core.dll"})
+               {
+                   if (!File.Exists(Path.Combine(msbuildToolPath, assemblyName)))
+                   {
+                       throw new InvalidOperationException($"Could not locate assembly {assemblyName} under {msbuildToolPath}");
+                   }
+               }
+               // Normally the assembly search path can be changed by MONO_PATH environment variable, but it needs to be done
+               // before the process starts. The following internal method allows us to do the same thing.
+               mono_set_assemblies_path(msbuildToolPath);
+            }
+#endif
+        }
+    }
+}

--- a/src/csharp/Grpc.Tools.Tests/MsBuildAssemblyHelper.cs
+++ b/src/csharp/Grpc.Tools.Tests/MsBuildAssemblyHelper.cs
@@ -44,6 +44,14 @@ namespace Grpc.Tools.Tests
                // Construct the location of MsBuild assemblies from the location of mscorlib assembly.
                var msbuildToolPath = Path.Combine(mscorlibDir, "..", "msbuild", "Current", "bin");
 
+               if (!Directory.Exists(msbuildToolPath))
+               {
+                   // with older versions of mono for Mac (e.g. mono 5.16.0 which is currently
+                   // installed on the kokoro mac workers) the "Current" symlink doesn't exist
+                   // so also try specifying the msbuild version explicitly
+                   msbuildToolPath = Path.Combine(mscorlibDir, "..", "msbuild", "15.0", "bin");
+               }
+
                // To make sure we've constructed the right path, make sure the assemblies we're interested
                // in are there.
                foreach(var assemblyName in new [] {"Microsoft.Build.Framework.dll", "Microsoft.Build.Utilities.v4.0.dll", "Microsoft.Build.Utilities.Core.dll"})

--- a/src/csharp/Grpc.Tools.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Tools.Tests/NUnitMain.cs
@@ -23,7 +23,10 @@ namespace Grpc.Tools.Tests
 {
     static class NUnitMain
     {
-        public static int Main(string[] args) =>
-            new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
-    };
+        public static int Main(string[] args)
+        {
+            MsBuildAssemblyHelper.TweakAssemblyPathIfOnMono();
+            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
+        }
+    }
 }

--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -7,14 +7,13 @@
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' and '$(MSBuildRuntimeType)' == 'Core' ">
-    <!-- Use Mono reference assemblies in SDK build: https://github.com/dotnet/sdk/issues/335.
-         This is a different approach than used in Grpc.Core/Common.csproj.include because
-         the workaround used there doesn't seem to be working for Microsoft.Build.* assemblies -->
-    <FrameworkPathOverride Condition="Exists('/usr/lib/mono/4.5-api')">/usr/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="Exists('/usr/local/lib/mono/4.5-api')">/usr/local/lib/mono/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="Exists('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api')">/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/4.5-api</FrameworkPathOverride>
-  </PropertyGroup>
+  <!-- Needed for the net45 build to work on Unix. See https://github.com/dotnet/designs/pull/33 -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
   <PropertyGroup Label="Asset root folders. TODO(kkm): Change with package separation.">
     <!-- TODO(kkm): Rework whole section when splitting packages.  -->


### PR DESCRIPTION
The main motivation is to make everything buildable using dotnet SDK even if mono is not installed.
- remove some ugly msbuild hacks
- one additional hack was needed to make Grpc.Tools.Tests work under mono, but I moved it from the .csproj file into a C# tweak. The hack is still a bit ugly but IMHO it's better to have the hack contained in a single C# file, rather than making the .csproj build messy and preventing us it from building with pure dotnet SDK.