### PR TITLE
Avoid attribute error in __del__ of _ChannelCallState

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1123,7 +1123,9 @@ class _ChannelCallState(object):
         self.managed_calls = 0
 
     def __del__(self):
-        self.channel.close(cygrpc.StatusCode.cancelled, 'Channel deallocated!')
+        if hasattr(self, 'channel') and self.channel:
+            self.channel.close(cygrpc.StatusCode.cancelled,
+                               'Channel deallocated!')
 
 
 def _run_channel_spin_thread(state):


### PR DESCRIPTION
This PR fixes a reported crash that in the the `__del__` of `_ChannelCallState`, the `self.channel` attribute becomes `None`, and caused `AttributeError`.

During the deallocation, `Channel` is deallocated before `_ChannelCallState`, which caused this issue.