### PR TITLE
Robust driver_port handling

### DIFF
--- a/test/cpp/qps/qps_worker.h
+++ b/test/cpp/qps/qps_worker.h
@@ -39,7 +39,8 @@ extern std::vector<grpc::testing::Server*>* g_inproc_servers;
 class QpsWorker {
  public:
   explicit QpsWorker(int driver_port, int server_port,
-                     const grpc::string& credential_type);
+                     const grpc::string& credential_type,
+                     const grpc::string& driver_port_result_path = "");
   ~QpsWorker();
 
   bool Done() const;

--- a/test/cpp/qps/server.h
+++ b/test/cpp/qps/server.h
@@ -43,11 +43,7 @@ class Server {
   explicit Server(const ServerConfig& config)
       : timer_(new UsageTimer), last_reset_poll_count_(0) {
     cores_ = gpr_cpu_num_cores();
-    if (config.port()) {  // positive for a fixed port, negative for inproc
-      port_ = config.port();
-    } else {  // zero for dynamic port
-      port_ = grpc_pick_unused_port_or_die();
-    }
+    port_ = config.port();
   }
   virtual ~Server() {}
 
@@ -119,6 +115,8 @@ class Server {
       const ChannelArguments& args) = 0;
 
  protected:
+  void SetPort(int port) { port_ = port; }
+
   static void ApplyConfigToBuilder(const ServerConfig& config,
                                    ServerBuilder* builder) {
     if (config.resource_quota_size() > 0) {

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -100,11 +100,13 @@ class CallbackServer final : public grpc::testing::Server {
     std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
 
     auto port_num = port();
+    int selected_port = 0;
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &selected_port);
     }
 
     ApplyConfigToBuilder(config, builder.get());
@@ -112,6 +114,11 @@ class CallbackServer final : public grpc::testing::Server {
     builder->RegisterService(&service_);
 
     impl_ = builder->BuildAndStart();
+
+    // Update the port when the port is given by system
+    if (port_num == 0) {
+      SetPort(selected_port);
+    }
   }
 
   std::shared_ptr<Channel> InProcessChannel(

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -158,11 +158,13 @@ class SynchronousServer final : public grpc::testing::Server {
     std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
 
     auto port_num = port();
+    int selected_port = 0;
     // Negative port number means inproc server, so no listen port needed
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &selected_port);
     }
 
     ApplyConfigToBuilder(config, builder.get());
@@ -170,6 +172,9 @@ class SynchronousServer final : public grpc::testing::Server {
     builder->RegisterService(&service_);
 
     impl_ = builder->BuildAndStart();
+
+    // Update the port when the port is given by system
+    SetPort(selected_port);
   }
 
   std::shared_ptr<Channel> InProcessChannel(

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -34,6 +34,9 @@ DEFINE_int32(driver_port, 0, "Port for communication with driver");
 DEFINE_int32(server_port, 0, "Port for operation as a server");
 DEFINE_string(credential_type, grpc::testing::kInsecureCredentialsType,
               "Credential type for communication with driver");
+DEFINE_string(
+    driver_port_result_path, "",
+    "Path for the file to have a driver port. (Useful when driver_port is 0)");
 
 static bool got_sigint = false;
 
@@ -45,7 +48,8 @@ namespace testing {
 std::vector<grpc::testing::Server*>* g_inproc_servers = nullptr;
 
 static void RunServer() {
-  QpsWorker worker(FLAGS_driver_port, FLAGS_server_port, FLAGS_credential_type);
+  QpsWorker worker(FLAGS_driver_port, FLAGS_server_port, FLAGS_credential_type,
+                   FLAGS_driver_port_result_path);
 
   while (!got_sigint && !worker.Done()) {
     gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -34,9 +34,12 @@ DEFINE_int32(driver_port, 0, "Port for communication with driver");
 DEFINE_int32(server_port, 0, "Port for operation as a server");
 DEFINE_string(credential_type, grpc::testing::kInsecureCredentialsType,
               "Credential type for communication with driver");
-DEFINE_string(
-    driver_port_result_path, "",
-    "Path for the file to have a driver port. (Useful when driver_port is 0)");
+DEFINE_string(driver_port_result_path, "",
+              "Path for the file to have a driver port once it starts to "
+              "listen with the port. It is for external runners to know "
+              "the real port when driver_port is specified 0 meaning that "
+              "the port will be determined later."
+              "This path must be accessible from the worker.");
 
 static bool got_sigint = false;
 


### PR DESCRIPTION
To establish the connection between a test-driver and workers, port should be randomly determined because there could be multiple drivers and workers on the same machine. To address this problem, previously

1. The driver decides the port by calling `grpc_pick_unused_port`.
2. The driver spawns the worker with the port chosen above.
3. The spawned worker starts the server on the port.
4. The driver connects to the port.

This works most times but chances are the given port is being used by other processes because `grpc_pick_unused_port` doesn't guarantee that it is free at the 3rd step. Also this hasn't been noticable because gRPC enables `SO_REUSEPORT` by default, which may result in different workers having the same port.

This can be addressed in such a way:

1. The driver spawns the worker without the port
2. The spawned worker starts the server on the port which it randomly picks.
3. The spawned worker let the driver know the port.
4. The driver connects to the port.

This makes whole process stable. Challenge here is that how spawned workers pass the port to the driver. In this PR, temporary file is used.

1. The driver spawns the worker with the temporary file path.
2. The spawned worker starts the server on the port which it randomly picks.
3. The spawned writes the port to the temporary file.
4. Once the driver read the port from the file, it connects to the port.

In addition to this, QpsWorker disables `SO_REUSEPORT` in order to notice when it accidentally shares the port with others.