### PR TITLE
Trust google-auth library will handle their dependency properly

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -6,7 +6,7 @@ protobuf>=3.5.0.post1
 six>=1.10
 wheel>=0.29
 futures>=2.2.0
-google-auth>=1.17.1
+google-auth>=1.17.2
 oauth2client==4.1.0
 requests>=2.14.2
 urllib3>=1.23
@@ -14,5 +14,3 @@ chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
 googleapis-common-protos==1.5.5
-# rsa 4.3 is the last version support Python 2
-rsa==4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ enum34>=1.0.4
 protobuf>=3.5.0.post1
 six>=1.10
 wheel>=0.29
-# rsa 4.3 is the last version support Python 2
-rsa==4.3

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -44,7 +44,7 @@ INSTALL_REQUIRES = (
     'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
     'grpcio-health-checking>={version}'.format(version=grpc_version.VERSION),
     'oauth2client>=1.4.7', 'protobuf>=3.6.0', 'six>=1.10',
-    'google-auth>=1.17.1', 'requests>=2.14.2')
+    'google-auth>=1.17.2', 'requests>=2.14.2')
 
 if not PY3:
     INSTALL_REQUIRES += ('futures>=2.2.0',)

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -225,7 +225,7 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 # Build/install tests
 pip_install coverage==4.4 oauth2client==4.1.0 \
             google-auth>=1.17.2 requests==2.14.2 \
-            googleapis-common-protos>=1.5.5
+            googleapis-common-protos>=1.5.5 rsa==4.0
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -222,13 +222,10 @@ pip_install_dir "$ROOT/src/python/grpcio_status"
 # Install testing
 pip_install_dir "$ROOT/src/python/grpcio_testing"
 
-# rsa 4.3 is the latest version support Python 2
-pip_install rsa==4.3
-
 # Build/install tests
 pip_install coverage==4.4 oauth2client==4.1.0 \
-            google-auth==1.17.1 requests==2.14.2 \
-            googleapis-common-protos==1.5.5
+            google-auth>=1.17.2 requests==2.14.2 \
+            googleapis-common-protos>=1.5.5
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"


### PR DESCRIPTION
Earlier today, in #23197, we pinned `rsa==4.3`. However, that might not be a good long term solution. As stated, we don't directly depend on library `rsa`, but through `google-auth`. After all, `google-auth` has a better position to prevent further breakage.

So, this PR removes `rsa` from our dependency list, and allows our CI to pick up newer `google-auth`.