### PR TITLE
Prevent another exception spam in _ChannelCallState.__del__

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1123,7 +1123,8 @@ class _ChannelCallState(object):
         self.managed_calls = 0
 
     def __del__(self):
-        if hasattr(self, 'channel') and self.channel:
+        if hasattr(self,
+                   'channel') and self.channel and cygrpc and cygrpc.StatusCode:
             self.channel.close(cygrpc.StatusCode.cancelled,
                                'Channel deallocated!')
 


### PR DESCRIPTION
As title.

This issue originated from google3 (b/158863508), where the GC might behave slightly different than OSS. In theory, this function should hold reference against `cygrpc` and `cygrpc.StatusCode`. It's surprising that the dependencies of `_ChannelCallState.__del__` being deallocated earlier than itself.

Overall, Python's GC is working fine in the runtime. Indeterministic behaviors only observed during interpreter shutdowns. The google3 issue is no exception. I have manually tested that this corner case is fixed by this PR.

If there is another spam, we should consider suppress the exception instead of patching up corner cases. (Error suppression considered harmful for project's debuggability.)