### PR TITLE
Fix keyword arguments warning for ruby 2.7

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -172,7 +172,7 @@ module GRPC
       i = @interceptors.pop
       return yield unless i
 
-      i.send(type, args) do
+      i.send(type, **args) do
         if @interceptors.any?
           intercept!(type, args) do
             yield


### PR DESCRIPTION
Fixes keyword argument warning that is being emitted from ruby `interceptors.rb`

```
Line 175: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

@donnadionne
