### PR TITLE
packages.grpc.io: Use search.maven.org instead of mvnrepository.com

### DIFF
--- a/tools/package_hosting/home.xsl
+++ b/tools/package_hosting/home.xsl
@@ -45,7 +45,7 @@
     <li><a href="https://github.com/grpc/grpc/blob/master/src/csharp">C#</a>: NuGet package <code>Grpc</code></li>
     <li><a href="https://github.com/grpc/grpc-dart">Dart</a>: pub package <code>grpc</code></li>
     <li><a href="https://github.com/grpc/grpc-go">Go</a>: <code>go get google.golang.org/grpc</code></li>
-    <li><a href="https://github.com/grpc/grpc-java">Java</a>: Use JARs from <a href="https://mvnrepository.com/artifact/io.grpc">gRPC Maven Central Repository</a></li>
+    <li><a href="https://github.com/grpc/grpc-java">Java</a>: Use JARs from <a href="https://search.maven.org/search?q=g:io.grpc">gRPC Maven Central Repository</a></li>
     <li><a href="https://github.com/grpc/grpc-kotlin">Kotlin</a>: Use JARs from <a href="https://mvnrepository.com/artifact/io.grpc">gRPC Maven Central Repository</a></li>
     <li><a href="https://github.com/grpc/grpc-node">Node</a>: <code>npm install grpc</code></li>
     <li><a href="https://github.com/grpc/grpc/blob/master/src/objective-c">Objective-C</a>: Add <code>gRPC-ProtoRPC</code> dependency to podspec</li>


### PR DESCRIPTION
It is unafficiated with Maven Central. Just link to the normal site. This is
approximately the same link the grpc-java README uses.

Technically, https://repo.maven.apache.org/maven2/io/grpc/ is potentially even
better, since that is by Apache instead of Sonatype and is the _actual_
repository, but the difference probably doesn't matter to most people.

CC @chalin