### PR TITLE
Fix test filter for C++ include files

### DIFF
--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -70,6 +70,7 @@ _WHITELIST_DICT = {
     '^doc/': [],
     '^examples/': [],
     '^include/grpc\+\+/': [_CPP_TEST_SUITE],
+    '^include/grpcpp/': [_CPP_TEST_SUITE],
     '^summerofcode/': [],
     '^src/cpp/': [_CPP_TEST_SUITE],
     '^src/csharp/': [_CSHARP_TEST_SUITE],


### PR DESCRIPTION
The directory name changed, so changes to `include/grpcpp` were actually triggering all test suites, not just C++ (seen when testing #23224)
