### PR TITLE
grpc_artifact_centos6 update

### DIFF
--- a/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC artifacts.
+# Updated: 2020-06-16
 
 ##################
 # Base

--- a/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC artifacts.
+# Updated: 2020-06-16
 
 ##################
 # Base

--- a/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
@@ -32,7 +32,7 @@ RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.6
-RUN /bin/bash -l -c "rvm install ruby-2.6"
+RUN /bin/bash -l -c "rvm install ruby-2.6 --32"
 RUN /bin/bash -l -c "rvm use --default ruby-2.6"
 RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"


### PR DESCRIPTION
Updated our main docker images, `grpc_artifact_centos6_*` to use the latest `manylinux2010` images which upgraded gcc7 to gcc8 for i686, which fixes one of compiler errors allowing us to use absl `variant`.

Added "Updated: 2020-06-16" comment to the docker file deliberately to get it updated even when there is no change in the file but want it to get updated base docker image or the latest packages. We can use this pattern for further updates. 

* [grpc_build_artifacts_multiplatform](https://sponge.corp.google.com/d4cc0163-e3b7-4ce7-9627-22f6467177c7): passed