### PR TITLE
Incrementally Improve setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -383,6 +383,7 @@ COMMAND_CLASS = {
     'build_py': commands.BuildPy,
     'build_ext': commands.BuildExt,
     'gather': commands.Gather,
+    'clean': commands.Clean,
 }
 
 # Ensure that package data is copied over before any commands have been run:

--- a/src/python/grpcio/_parallel_compile_patch.py
+++ b/src/python/grpcio/_parallel_compile_patch.py
@@ -22,7 +22,10 @@ import os
 
 try:
     BUILD_EXT_COMPILER_JOBS = int(
-        os.environ.get('GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS', '1'))
+        os.environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'])
+except KeyError:
+    import multiprocessing
+    BUILD_EXT_COMPILER_JOBS = multiprocessing.cpu_count()
 except ValueError:
     BUILD_EXT_COMPILER_JOBS = 1
 

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -221,7 +221,7 @@ class BuildExt(build_ext.build_ext):
                 return False
             # TODO(lidiz) Remove the generated a.out for success tests.
             cc_test = subprocess.Popen([
-                distutils.ccompiler.executable_filename, '-x', 'c',
+                self.compiler.compiler[0], '-x', 'c',
                 '-std=c++11', '-'
             ],
                                        stdin=subprocess.PIPE,

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -300,13 +300,13 @@ class Clean(setuptools.Command):
     description = 'Clean build artifacts.'
     user_options = []
 
-    _FILE_PATTERNS = [
+    _FILE_PATTERNS = (
         'python_build',
         'src/python/grpcio/__pycache__/',
         'src/python/grpcio/grpc/_cython/cygrpc.cpp',
         'src/python/grpcio/grpc/_cython/*.so',
         'src/python/grpcio/grpcio.egg-info/',
-    ]
+    )
     _CURRENT_DIRECTORY = os.path.normpath(
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../.."))
 

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -220,10 +220,7 @@ class BuildExt(build_ext.build_ext):
             if platform.system() != 'Windows':
                 return False
             # TODO(lidiz) Remove the generated a.out for success tests.
-            cc_test = subprocess.Popen([
-                self.compiler.compiler[0], '-x', 'c',
-                '-std=c++11', '-'
-            ],
+            cc_test = subprocess.Popen(['cc', '-x', 'c', '-std=c++11', '-'],
                                        stdin=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE)

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Provides distutils command classes for the GRPC Python setup process."""
 
+from __future__ import print_function
+
 import distutils
 import glob
 import os
@@ -218,7 +220,10 @@ class BuildExt(build_ext.build_ext):
             if platform.system() != 'Windows':
                 return False
             # TODO(lidiz) Remove the generated a.out for success tests.
-            cc_test = subprocess.Popen(['cc', '-x', 'c', '-std=c++11', '-'],
+            cc_test = subprocess.Popen([
+                distutils.ccompiler.executable_filename, '-x', 'c',
+                '-std=c++11', '-'
+            ],
                                        stdin=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE)
@@ -290,3 +295,41 @@ class Gather(setuptools.Command):
                 self.distribution.install_requires)
         if self.test and self.distribution.tests_require:
             self.distribution.fetch_build_eggs(self.distribution.tests_require)
+
+
+class Clean(setuptools.Command):
+    """Command to clean build artifacts."""
+
+    description = 'Clean build artifacts.'
+    user_options = []
+
+    _FILE_PATTERNS = [
+        'python_build',
+        'src/python/grpcio/__pycache__/',
+        'src/python/grpcio/grpc/_cython/cygrpc.cpp',
+        'src/python/grpcio/grpc/_cython/*.so',
+        'src/python/grpcio/grpcio.egg-info/',
+    ]
+    _CURRENT_DIRECTORY = os.path.normpath(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../.."))
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        for path_spec in self._FILE_PATTERNS:
+            this_glob = os.path.normpath(
+                os.path.join(Clean._CURRENT_DIRECTORY, path_spec))
+            abs_paths = glob.glob(this_glob)
+            for path in abs_paths:
+                if not str(path).startswith(Clean._CURRENT_DIRECTORY):
+                    raise ValueError(
+                        "Cowardly refusing to delete {}.".format(path))
+                print("Removing {}".format(os.path.relpath(path)))
+                if os.path.isfile(path):
+                    os.remove(str(path))
+                else:
+                    shutil.rmtree(str(path))

--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -21,7 +21,7 @@ BASEDIR=$(dirname "$0")
 BASEDIR=$(realpath "$BASEDIR")/../..
 
 (cd "$BASEDIR";
-  pip install cython;
+  pip install --upgrade cython;
   python setup.py install;
   pushd tools/distrib/python/grpcio_tools;
     ../make_grpcio_tools.py

--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 echo "It's recommended that you run this script from a virtual environment."
 

--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "It's recommended that you run this script from a virtual environment."
+
+set -e
+
+BASEDIR=$(dirname "$0")
+BASEDIR=$(realpath "$BASEDIR")/../..
+
+(cd "$BASEDIR";
+  pip install cython;
+  python setup.py install;
+  pushd tools/distrib/python/grpcio_tools;
+    ../make_grpcio_tools.py
+    GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
+  popd;
+  pushd src/python;
+    for PACKAGE in ./grpcio_*; do
+      pushd "${PACKAGE}";
+        python setup.py preprocess;
+        python setup.py install;
+      popd;
+    done
+  popd;
+)


### PR DESCRIPTION
`setup.py` is, ironically, currently the least user friendly way to build gRPC Python. This PR addresses a few small usability issues. In particular, we:
 - Ensure that `python setup.py clean` *actually cleans* the build artifacts
 - Set build parallelism to the max by default
 - Provide a script that puts the user's environment in a state where they can easily run tests directly.

The holy grail would be completely incremental builds of the C extension, but judging by what I've read, that would take quite a bit of effort.

Another potential area for improvement is parallelizing the `grpcio-tools` build.