### PR TITLE
Include algorithm for std::find

### DIFF
--- a/src/compiler/python_generator_helpers.h
+++ b/src/compiler/python_generator_helpers.h
@@ -19,6 +19,7 @@
 #ifndef GRPC_INTERNAL_COMPILER_PYTHON_GENERATOR_HELPERS_H
 #define GRPC_INTERNAL_COMPILER_PYTHON_GENERATOR_HELPERS_H
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
python_generator_helpers.h uses std::find, but does not include the STL header where it is declared.  In certain configurations, this will lead to a build error like this:

`In file included from /tmp/grpc/src/compiler/protobuf_plugin.h:24:0,
                 from /tmp/grpc/src/compiler/cpp_plugin.h:29,
                 from /tmp/grpc/src/compiler/cpp_plugin.cc:21:
/tmp/grpc/src/compiler/python_generator_helpers.h: In function ‘void grpc_python_generator::{anonymous}::Split(const string&, char, std::vector<std::__cxx11::basic_string<char> >*)’:
/tmp/grpc/src/compiler/python_generator_helpers.h:143:50: error: no matching function for call to ‘find(__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> >&, std::__cxx11::basic_string<char>::const_iterator, char&)’
     auto next = std::find(current, s.end(), delim);`

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
