### PR TITLE
Use grpc health checks for PHP and Ruby xDS tests

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -65,6 +65,5 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_routing_lb,cds_lb,ed
   --source_image=projects/grpc-testing/global/images/xds-test-server \
   --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
   --gcp_suffix=$(date '+%s') \
-  --only_stable_gcp_apis \
   --verbose \
   --client_cmd='php -d extension=grpc.so -d extension=pthreads.so src/php/tests/interop/xds_client.php --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps}'

--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -55,6 +55,5 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_routing_lb,cds_lb,ed
     --source_image=projects/grpc-testing/global/images/xds-test-server \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
-    --only_stable_gcp_apis \
     --verbose \
     --client_cmd='ruby src/ruby/pb/test/xds_client.rb --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps}'

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -186,8 +186,12 @@ argp.add_argument('--log_client_output',
                   help='Log captured client output',
                   default=False,
                   action='store_true')
+# TODO(ericgribkoff) Remove this flag once all test environments are verified to
+# have access to the alpha compute APIs.
 argp.add_argument('--only_stable_gcp_apis',
-                  help='Do not use alpha compute APIs',
+                  help='Do not use alpha compute APIs. Some tests may be '
+                  'incompatible with this option (gRPC health checks are '
+                  'currently alpha and required for simulating server failure',
                   default=False,
                   action='store_true')
 args = argp.parse_args()


### PR DESCRIPTION
The test suite now dynamically updates the server's health status (via
the gRPC health service) to simulate failing backends; this requires
grpc health checks, which means the --use_stable_apis flag is no longer
compatible with these checks (it should probably be removed, but will
leave that for a follow-up).


