### PR TITLE
Fix flaky test:ios-test-cronettests

### DIFF
--- a/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/CronetTests.xcscheme
+++ b/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/CronetTests.xcscheme
@@ -44,8 +44,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Cronet"
@@ -66,8 +64,13 @@
             ReferencedContainer = "container:Tests.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "grpc_cfstream"
+            value = "0"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Cronet"


### PR DESCRIPTION
Endless loop may happen when running **CoreCronetEnd2EndTests.testNegativeDeadline** because of the known bug from Apple when CFStream streams dispatch events to dispatch queues. To solve this issue, we are going to disable **CFStream** in CronetTests and use **tcp sockets** instead.
