### PR TITLE
Fix a message indicating the protobuf version CMakeLists.txt

### DIFF
--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -101,7 +101,7 @@ else()
   # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
   set(protobuf_MODULE_COMPATIBLE TRUE)
   find_package(Protobuf CONFIG REQUIRED)
-  message(STATUS "Using protobuf ${protobuf_VERSION}")
+  message(STATUS "Using protobuf ${Protobuf_VERSION}")
 
   set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
   set(_REFLECTION gRPC::grpc++_reflection)


### PR DESCRIPTION
In hello_world cpp example,
a variable name has been wrong and an expected output has not been printed in CMake logs.

Current:
```
-- Using protobuf
```

With this fix:
```
-- Using protobuf 3.11.2.0
```

@donnadionne