### PR TITLE
Fixed port conflict of json_run_localhost

### DIFF
--- a/test/cpp/qps/json_run_localhost.cc
+++ b/test/cpp/qps/json_run_localhost.cc
@@ -88,12 +88,16 @@ int main(int argc, char** argv) {
   bool first = true;
 
   for (int i = 0; i < kNumWorkers; i++) {
-    const auto port = grpc_pick_unused_port_or_die();
+    const auto driver_port = grpc_pick_unused_port_or_die();
+    // ServerPort can be used or not later depending on the type of worker
+    // but we like to issue all ports required here to avoid port conflict.
+    const auto server_port = grpc_pick_unused_port_or_die();
     std::vector<std::string> args = {bin_dir + "/qps_worker", "-driver_port",
-                                     as_string(port)};
+                                     as_string(driver_port), "-server_port",
+                                     as_string(server_port)};
     g_workers[i] = new SubProcess(args);
     if (!first) env << ",";
-    env << "localhost:" << port;
+    env << "localhost:" << driver_port;
     first = false;
   }
 

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -292,10 +292,11 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
   server_ = builder->BuildAndStart();
   if (server_ == nullptr) {
     gpr_log(GPR_ERROR,
-            "QpsWorker: Fail to BuildAndStart(port=%d) (server_port=%d)",
+            "QpsWorker: Fail to BuildAndStart(driver_port=%d, server_port=%d)",
             driver_port, server_port);
   } else {
-    gpr_log(GPR_INFO, "QpsWorker: BuildAndStart(port=%d) (server_port=%d)",
+    gpr_log(GPR_INFO,
+            "QpsWorker: BuildAndStart(driver_port=%d, server_port=%d) done",
             driver_port, server_port);
   }
 }

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -280,6 +280,7 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
   gpr_atm_rel_store(&done_, static_cast<gpr_atm>(0));
 
   std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
+  builder->AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
   if (driver_port >= 0) {
     std::string server_address = grpc_core::JoinHostPort("::", driver_port);
     builder->AddListeningPort(
@@ -291,11 +292,10 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
   server_ = builder->BuildAndStart();
   if (server_ == nullptr) {
     gpr_log(GPR_ERROR,
-            "QpsWorker: Fail to BuildAndStart(driver_port=%d, server_port=%d)",
+            "QpsWorker: Fail to BuildAndStart(port=%d) (server_port=%d)",
             driver_port, server_port);
   } else {
-    gpr_log(GPR_INFO,
-            "QpsWorker: BuildAndStart(driver_port=%d, server_port=%d) done",
+    gpr_log(GPR_INFO, "QpsWorker: BuildAndStart(port=%d) (server_port=%d)",
             driver_port, server_port);
   }
 }

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -82,7 +82,8 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &port_num);
     }
 
     register_service(builder.get(), &async_service_);
@@ -105,6 +106,11 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     ApplyConfigToBuilder(config, builder.get());
 
     server_ = builder->BuildAndStart();
+    if (server_ == nullptr) {
+      gpr_log(GPR_ERROR, "Server: Fail to BuildAndStart(port=%d)", port_num);
+    } else {
+      gpr_log(GPR_INFO, "Server: BuildAndStart(port=%d)", port_num);
+    }
 
     auto process_rpc_bound =
         std::bind(process_rpc, config.payload_config(), std::placeholders::_1,

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -104,7 +104,8 @@ class CallbackServer final : public grpc::testing::Server {
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &port_num);
     }
 
     ApplyConfigToBuilder(config, builder.get());
@@ -112,6 +113,11 @@ class CallbackServer final : public grpc::testing::Server {
     builder->RegisterService(&service_);
 
     impl_ = builder->BuildAndStart();
+    if (impl_ == nullptr) {
+      gpr_log(GPR_ERROR, "Server: Fail to BuildAndStart(port=%d)", port_num);
+    } else {
+      gpr_log(GPR_INFO, "Server: BuildAndStart(port=%d)", port_num);
+    }
   }
 
   std::shared_ptr<Channel> InProcessChannel(

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -162,7 +162,8 @@ class SynchronousServer final : public grpc::testing::Server {
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &port_num);
     }
 
     ApplyConfigToBuilder(config, builder.get());
@@ -170,6 +171,11 @@ class SynchronousServer final : public grpc::testing::Server {
     builder->RegisterService(&service_);
 
     impl_ = builder->BuildAndStart();
+    if (impl_ == nullptr) {
+      gpr_log(GPR_ERROR, "Server: Fail to BuildAndStart(port=%d)", port_num);
+    } else {
+      gpr_log(GPR_INFO, "Server: BuildAndStart(port=%d)", port_num);
+    }
   }
 
   std::shared_ptr<Channel> InProcessChannel(


### PR DESCRIPTION
This makes the json_run_localhost assign ports to workers more robustly to avoid port conflict with a small change.

Json_run_localhost works like this;

- json_run_localhost
  - spawning QpsWorker1 as a server (bind `driver_port` and `server_port`)
  - spawning QpsWorker2 as a client (bind `driver_port`) which connects to the server worker via `server_port`.
  - spawning the Driver which connects to QpsWorkers via `driver_port`

Previously the `driver_port` of QpsWorkers were chosen by json_run_localhost but the `server_port` of Server Workers were picked pu by itself so chances are that they're using the same value for  `driver_port` and `server_port`.

This change makes json_run_localhost pick up the all ports in advance although some QpsWorkers don't use `server_port` because they will be clients. At lease, this guarantees that all ports used here will be unique. (This doesn't prevent port conflict from multiple json_run_localhosts runnin on the same space) 

In addition to this, logs printing out the port are added to trace this problem easily in future and the driver port is changed not to be reused with others.

This will supersede #23178.

