### PR TITLE
json_run_localhost: print ports bounds by benchmark_service servers.

### DIFF
--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -82,7 +82,8 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &port_num);
     }
 
     register_service(builder.get(), &async_service_);
@@ -105,6 +106,11 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     ApplyConfigToBuilder(config, builder.get());
 
     server_ = builder->BuildAndStart();
+    if (server_ == nullptr) {
+      gpr_log(GPR_ERROR, "Server: Fail to BuildAndStart(port=%d)", port_num);
+    } else {
+      gpr_log(GPR_INFO, "Server: BuildAndStart(port=%d)", port_num);
+    }
 
     auto process_rpc_bound =
         std::bind(process_rpc, config.payload_config(), std::placeholders::_1,

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -104,7 +104,8 @@ class CallbackServer final : public grpc::testing::Server {
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &port_num);
     }
 
     ApplyConfigToBuilder(config, builder.get());
@@ -112,6 +113,11 @@ class CallbackServer final : public grpc::testing::Server {
     builder->RegisterService(&service_);
 
     impl_ = builder->BuildAndStart();
+    if (impl_ == nullptr) {
+      gpr_log(GPR_ERROR, "Server: Fail to BuildAndStart(port=%d)", port_num);
+    } else {
+      gpr_log(GPR_INFO, "Server: BuildAndStart(port=%d)", port_num);
+    }
   }
 
   std::shared_ptr<Channel> InProcessChannel(

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -162,7 +162,8 @@ class SynchronousServer final : public grpc::testing::Server {
     if (port_num >= 0) {
       std::string server_address = grpc_core::JoinHostPort("::", port_num);
       builder->AddListeningPort(server_address.c_str(),
-                                Server::CreateServerCredentials(config));
+                                Server::CreateServerCredentials(config),
+                                &port_num);
     }
 
     ApplyConfigToBuilder(config, builder.get());
@@ -170,6 +171,11 @@ class SynchronousServer final : public grpc::testing::Server {
     builder->RegisterService(&service_);
 
     impl_ = builder->BuildAndStart();
+    if (impl_ == nullptr) {
+      gpr_log(GPR_ERROR, "Server: Fail to BuildAndStart(port=%d)", port_num);
+    } else {
+      gpr_log(GPR_INFO, "Server: BuildAndStart(port=%d)", port_num);
+    }
   }
 
   std::shared_ptr<Channel> InProcessChannel(


### PR DESCRIPTION
no fixes, just add logging to prove which failures are caused by a port conflict.
