### PR TITLE
Backport: Trust google-auth library will handle their dependency properly

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -6,7 +6,7 @@ protobuf>=3.5.0.post1
 six>=1.10
 wheel>=0.29
 futures>=2.2.0
-google-auth>=1.0.0
+google-auth>=1.17.2
 oauth2client==4.1.0
 requests>=2.14.2
 urllib3>=1.23

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -43,8 +43,8 @@ INSTALL_REQUIRES = (
     'grpcio-status>={version}'.format(version=grpc_version.VERSION),
     'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
     'grpcio-health-checking>={version}'.format(version=grpc_version.VERSION),
-    'oauth2client>=1.4.7', 'protobuf>=3.6.0', 'six>=1.10', 'google-auth>=1.0.0',
-    'requests>=2.14.2')
+    'oauth2client>=1.4.7', 'protobuf>=3.6.0', 'six>=1.10',
+    'google-auth>=1.17.2', 'requests>=2.14.2')
 
 if not PY3:
     INSTALL_REQUIRES += ('futures>=2.2.0',)

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -224,8 +224,8 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 
 # Build/install tests
 pip_install coverage==4.4 oauth2client==4.1.0 \
-            google-auth==1.0.0 requests==2.14.2 \
-            googleapis-common-protos==1.5.5
+            google-auth>=1.17.2 requests==2.14.2 \
+            googleapis-common-protos>=1.5.5
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -225,7 +225,7 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 # Build/install tests
 pip_install coverage==4.4 oauth2client==4.1.0 \
             google-auth>=1.17.2 requests==2.14.2 \
-            googleapis-common-protos>=1.5.5
+            googleapis-common-protos>=1.5.5 rsa==4.0
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"


### PR DESCRIPTION
Original PR #23200.
Fixes: https://github.com/grpc/grpc/pull/23264