### PR TITLE
Add error for non-virtual-dtor and fix a few other warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,7 @@ CXXFLAGS += -stdlib=libc++
 LDFLAGS += -framework CoreFoundation
 endif
 CFLAGS += -g
+CXXFLAGS += -Werror=non-virtual-dtor
 CPPFLAGS += -g -Wall -Wextra -DOSATOMIC_USE_INLINED=1 -Ithird_party/abseil-cpp -Ithird_party/upb -Isrc/core/ext/upb-generated
 COREFLAGS += -fno-exceptions
 LDFLAGS += -g

--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -214,6 +214,7 @@ defaults:
     COREFLAGS: -fno-exceptions
     CPPFLAGS: -g -Wall -Wextra -DOSATOMIC_USE_INLINED=1 -Ithird_party/abseil-cpp -Ithird_party/upb
       -Isrc/core/ext/upb-generated
+    CXXFLAGS: -Werror=non-virtual-dtor
     LDFLAGS: -g
   zlib:
     CFLAGS: -fvisibility=hidden

--- a/include/grpcpp/impl/codegen/client_callback_impl.h
+++ b/include/grpcpp/impl/codegen/client_callback_impl.h
@@ -105,6 +105,8 @@ class CallbackUnaryCallImpl {
 // Base class for public API classes.
 class ClientReactor {
  public:
+  virtual ~ClientReactor() = default;
+
   /// Called by the library when all operations associated with this RPC have
   /// completed and all Holds have been removed. OnDone provides the RPC status
   /// outcome for both successful and failed RPCs. If it is never called on an

--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -58,7 +58,9 @@ static grpc_millis timespan_to_millis_round_down(gpr_timespec ts) {
   double x = GPR_MS_PER_SEC * static_cast<double>(ts.tv_sec) +
              static_cast<double>(ts.tv_nsec) / GPR_NS_PER_MS;
   if (x < 0) return 0;
-  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
+  if (x > static_cast<double>(GRPC_MILLIS_INF_FUTURE)) {
+    return GRPC_MILLIS_INF_FUTURE;
+  }
   return static_cast<grpc_millis>(x);
 }
 
@@ -72,7 +74,9 @@ static grpc_millis timespan_to_millis_round_up(gpr_timespec ts) {
              static_cast<double>(GPR_NS_PER_SEC - 1) /
                  static_cast<double>(GPR_NS_PER_SEC);
   if (x < 0) return 0;
-  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
+  if (x > static_cast<double>(GRPC_MILLIS_INF_FUTURE)) {
+    return GRPC_MILLIS_INF_FUTURE;
+  }
   return static_cast<grpc_millis>(x);
 }
 

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -107,7 +107,6 @@ static double SystemTime(const ClientStats& s) { return s.time_system(); }
 static double UserTime(const ClientStats& s) { return s.time_user(); }
 static double CliPollCount(const ClientStats& s) { return s.cq_poll_count(); }
 static double SvrPollCount(const ServerStats& s) { return s.cq_poll_count(); }
-static double ServerWallTime(const ServerStats& s) { return s.time_elapsed(); }
 static double ServerSystemTime(const ServerStats& s) { return s.time_system(); }
 static double ServerUserTime(const ServerStats& s) { return s.time_user(); }
 static double ServerTotalCpuTime(const ServerStats& s) {

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -7,8 +7,10 @@ build --define=use_fast_cpp_protos=true
 
 build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
+build:opt --copt=-Werror=non-virtual-dtor
 
 build:dbg --compilation_mode=dbg
+build:opt --copt=-Werror=non-virtual-dtor
 
 build:windows_opt --compilation_mode=opt
 build:windows_dbg --compilation_mode=dbg
@@ -17,6 +19,7 @@ build:asan --strip=never
 build:asan --copt=-fsanitize=address
 build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
+build:asan --copt=-Werror=non-virtual-dtor
 build:asan --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:asan --copt=-DGRPC_ASAN
 build:asan --copt=-DADDRESS_SANITIZER  # used by absl
@@ -51,6 +54,7 @@ build:msan --copt=-O0
 build:msan --copt=-fsanitize-memory-track-origins
 build:msan --copt=-fsanitize-memory-use-after-dtor
 build:msan --copt=-fno-omit-frame-pointer
+build:msan --copt=-Werror=non-virtual-dtor
 build:msan --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:msan --copt=-DMEMORY_SANITIZER  # used by absl
 build:msan --linkopt=-fsanitize=memory
@@ -59,6 +63,7 @@ build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
 build:tsan --strip=never
 build:tsan --copt=-fsanitize=thread
 build:tsan --copt=-fno-omit-frame-pointer
+build:tsan --copt=-Werror=non-virtual-dtor
 build:tsan --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:tsan --copt=-DGRPC_TSAN
 # TODO(jtattermusch): ideally we would set --copt=-DTHREAD_SANITIZER (used by absl)
@@ -69,6 +74,7 @@ build:tsan --action_env=TSAN_OPTIONS=suppressions=test/core/util/tsan_suppressio
 build:ubsan --strip=never
 build:ubsan --copt=-fsanitize=undefined
 build:ubsan --copt=-fno-omit-frame-pointer
+build:ubsan --copt=-Werror=non-virtual-dtor
 build:ubsan --copt=-DGRPC_UBSAN
 build:ubsan --copt=-DNDEBUG
 build:ubsan --copt=-DUNDEFINED_BEHAVIOR_SANITIZER  # used by absl


### PR DESCRIPTION
This warning was previously added in #16667 but fell out when build.yaml was split into hand-written and auto-generated portions; we also used to have Werror at the time. Adding these back in all builds possible.