### PR TITLE
Use pure virtual functions at FlowControl

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2149,7 +2149,6 @@ libs:
   - include/grpcpp/impl/server_initializer_impl.h
   - include/grpcpp/impl/service_type.h
   - include/grpcpp/resource_quota.h
-  - include/grpcpp/resource_quota_impl.h
   - include/grpcpp/security/auth_context.h
   - include/grpcpp/security/auth_metadata_processor.h
   - include/grpcpp/security/auth_metadata_processor_impl.h
@@ -2543,7 +2542,6 @@ libs:
   - include/grpcpp/impl/server_initializer_impl.h
   - include/grpcpp/impl/service_type.h
   - include/grpcpp/resource_quota.h
-  - include/grpcpp/resource_quota_impl.h
   - include/grpcpp/security/auth_context.h
   - include/grpcpp/security/auth_metadata_processor.h
   - include/grpcpp/security/auth_metadata_processor_impl.h

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -333,8 +333,7 @@ class TransportFlowControl final : public TransportFlowControlBase {
 };
 
 // Fat interface with all methods a stream flow control implementation needs
-// to support. gRPC C Core does not support pure virtual functions, so instead
-// we abort in any methods which require implementation in the base class.
+// to support.
 class StreamFlowControlBase {
  public:
   StreamFlowControlBase() {}
@@ -347,19 +346,19 @@ class StreamFlowControlBase {
 
   // Using the protected members, returns an Action for this stream to be
   // taken by the tranport.
-  virtual FlowControlAction MakeAction() { abort(); }
+  virtual FlowControlAction MakeAction() = 0;
 
   // Bookkeeping for when data is sent on this stream.
-  virtual void SentData(int64_t /* outgoing_frame_size */) { abort(); }
+  virtual void SentData(int64_t /* outgoing_frame_size */) = 0;
 
   // Bookkeeping and error checking for when data is received by this stream.
-  virtual grpc_error* RecvData(int64_t /* incoming_frame_size */) { abort(); }
+  virtual grpc_error* RecvData(int64_t /* incoming_frame_size */) = 0;
 
   // Called to check if this stream needs to send a WINDOW_UPDATE frame.
-  virtual uint32_t MaybeSendUpdate() { abort(); }
+  virtual uint32_t MaybeSendUpdate() = 0;
 
   // Bookkeeping for receiving a WINDOW_UPDATE from for this stream.
-  virtual void RecvUpdate(uint32_t /* size */) { abort(); }
+  virtual void RecvUpdate(uint32_t /* size */) = 0;
 
   // Bookkeeping for when a call pulls bytes out of the transport. At this
   // point we consider the data 'used' and can thus let out peer know we are

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -140,8 +140,7 @@ class FlowControlTrace {
 };
 
 // Fat interface with all methods a flow control implementation needs to
-// support. gRPC C Core does not support pure virtual functions, so instead
-// we abort in any methods which require implementation in the base class.
+// support.
 class TransportFlowControlBase {
  public:
   TransportFlowControlBase() {}
@@ -149,30 +148,30 @@ class TransportFlowControlBase {
 
   // Is flow control enabled? This is needed in other codepaths like the checks
   // in parsing and in writing.
-  virtual bool flow_control_enabled() const { abort(); }
+  virtual bool flow_control_enabled() const = 0;
 
   // Called to check if the transport needs to send a WINDOW_UPDATE frame
-  virtual uint32_t MaybeSendUpdate(bool /* writing_anyway */) { abort(); }
+  virtual uint32_t MaybeSendUpdate(bool /* writing_anyway */) = 0;
 
   // Using the protected members, returns and Action to be taken by the
   // tranport.
-  virtual FlowControlAction MakeAction() { abort(); }
+  virtual FlowControlAction MakeAction() = 0;
 
   // Using the protected members, returns and Action to be taken by the
   // tranport. Also checks for updates to our BDP estimate and acts
   // accordingly.
-  virtual FlowControlAction PeriodicUpdate() { abort(); }
+  virtual FlowControlAction PeriodicUpdate() = 0;
 
   // Called to do bookkeeping when a stream owned by this transport sends
   // data on the wire
-  virtual void StreamSentData(int64_t /* size */) { abort(); }
+  virtual void StreamSentData(int64_t /* size */) = 0;
 
   // Called to do bookkeeping when a stream owned by this transport receives
   // data from the wire. Also does error checking for frame size.
-  virtual grpc_error* RecvData(int64_t /* incoming_frame_size */) { abort(); }
+  virtual grpc_error* RecvData(int64_t /* incoming_frame_size */) = 0;
 
   // Called to do bookkeeping when we receive a WINDOW_UPDATE frame.
-  virtual void RecvUpdate(uint32_t /* size */) { abort(); }
+  virtual void RecvUpdate(uint32_t /* size */) = 0;
 
   // Returns the BdpEstimator held by this object. Caller is responsible for
   // checking for nullptr. TODO(ncteisen): consider fully encapsulating all


### PR DESCRIPTION
Since gRPC Core is allowed to use pure virtual functions, clean up code to use them properly for better readability.