### PR TITLE
Renamed com_github_google_googletest to com_google_googletest

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -63,7 +63,7 @@ def grpc_deps():
 
     native.bind(
         name = "gtest",
-        actual = "@com_github_google_googletest//:gtest",
+        actual = "@com_google_googletest//:gtest",
     )
 
     native.bind(
@@ -162,9 +162,9 @@ def grpc_deps():
             ],
         )
 
-    if "com_github_google_googletest" not in native.existing_rules():
+    if "com_google_googletest" not in native.existing_rules():
         http_archive(
-            name = "com_github_google_googletest",
+            name = "com_google_googletest",
             sha256 = "443d383db648ebb8e391382c0ab63263b7091d03197f304390baac10f178a468",
             strip_prefix = "googletest-c9ccac7cb7345901884aabf5d1a786cfa6e2f397",
             urls = [

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -46,7 +46,7 @@ _GRPC_DEP_NAMES = [
     'boringssl',
     'zlib',
     'com_google_protobuf',
-    'com_github_google_googletest',
+    'com_google_googletest',
     'rules_cc',
     'com_github_gflags_gflags',
     'com_github_google_benchmark',


### PR DESCRIPTION
Renamed `com_github_google_googletest` to `com_google_googletest` to follow the conventional bazel name of gtest. Internal code search shows that `com_google_googletest` is majority and it's important to have the common name for users to use both gRPC and other libraries naming it as `com_google_googletest`.