### PR TITLE
Update SPIFFE ID check

### DIFF
--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -257,7 +257,8 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
       transport_security_type);
   const char* spiffe_data = nullptr;
   size_t spiffe_length = 0;
-  int spiffe_id_count = 0;
+  int uri_count = 0;
+  bool has_spiffe_id = false;
   for (i = 0; i < peer->property_count; i++) {
     const tsi_peer_property* prop = &peer->properties[i];
     if (prop->name == nullptr) continue;
@@ -290,11 +291,12 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
           ctx.get(), GRPC_TRANSPORT_SECURITY_LEVEL_PROPERTY_NAME,
           prop->value.data, prop->value.length);
     } else if (strcmp(prop->name, TSI_X509_URI_PEER_PROPERTY) == 0) {
+      uri_count++;
       absl::string_view spiffe_id(prop->value.data, prop->value.length);
       if (IsSpiffeId(spiffe_id)) {
         spiffe_data = prop->value.data;
         spiffe_length = prop->value.length;
-        spiffe_id_count += 1;
+        has_spiffe_id = true;
       }
     }
   }
@@ -302,16 +304,17 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
     GPR_ASSERT(grpc_auth_context_set_peer_identity_property_name(
                    ctx.get(), peer_identity_property_name) == 1);
   }
-  // SPIFFE ID should be unique. If we find more than one SPIFFE IDs, we log
-  // the error without returning the error.
-  if (spiffe_id_count > 1) {
-    gpr_log(GPR_INFO, "Invalid SPIFFE ID: SPIFFE ID should be unique.");
-  }
-  if (spiffe_id_count == 1) {
-    GPR_ASSERT(spiffe_length > 0);
-    GPR_ASSERT(spiffe_data != nullptr);
-    grpc_auth_context_add_property(ctx.get(), GRPC_PEER_SPIFFE_ID_PROPERTY_NAME,
-                                   spiffe_data, spiffe_length);
+  // A valid SPIFFE certificate can only have exact one URI SAN field.
+  if (has_spiffe_id) {
+    if (uri_count == 1) {
+      GPR_ASSERT(spiffe_length > 0);
+      GPR_ASSERT(spiffe_data != nullptr);
+      grpc_auth_context_add_property(ctx.get(),
+                                     GRPC_PEER_SPIFFE_ID_PROPERTY_NAME,
+                                     spiffe_data, spiffe_length);
+    } else {
+      gpr_log(GPR_INFO, "Invalid SPIFFE ID: multiple URI SANs.");
+    }
   }
   return ctx;
 }

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -895,6 +895,7 @@ void ssl_tsi_test_extract_x509_subject_names() {
   GPR_ASSERT(check_subject_alt_name(&peer, "foo.test.domain.com") == 1);
   GPR_ASSERT(check_subject_alt_name(&peer, "bar.test.domain.com") == 1);
   // Check URI
+  // Note that a valid SPIFFE certificate should only have one URI.
   GPR_ASSERT(check_subject_alt_name(&peer, "spiffe://foo.com/bar/baz") == 1);
   GPR_ASSERT(
       check_subject_alt_name(&peer, "https://foo.test.domain.com/test") == 1);


### PR DESCRIPTION
The SPIFFE certificate only allows one URI field, according to [SPIFFE standards](https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md). An X.509 SVID MUST contain exactly one URI SAN.

This PR fix previous implementation. In previous implementation, if there are multiple URIs, but only one spiffe id, it will be accepted.