### PR TITLE
Fixed typo

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -96,7 +96,7 @@ composer package as well. Add this to your project's `composer.json` file.
 
 ```json
     "require": {
-        "grpc/grpc": "~v1.30.0"
+        "grpc/grpc": "~1.30.0"
     }
 ```
 


### PR DESCRIPTION
Version **constraints** cannot contain a `v`.