### PR TITLE
Use the wrapper version of bazel in the script

### DIFF
--- a/src/abseil-cpp/preprocessed_builds.yaml.gen.py
+++ b/src/abseil-cpp/preprocessed_builds.yaml.gen.py
@@ -69,8 +69,11 @@ def parse_bazel_rule(elem, package):
 
 def read_bazel_build(package):
   """Runs bazel query on given package file and returns all cc rules."""
+  # Use a wrapper version of bazel in gRPC not to use system-wide bazel
+  # to avoid bazel conflict when running on Kokoro.
+  BAZEL_BIN = "../../tools/bazel"
   result = subprocess.check_output(
-      ["bazel", "query", package + ":all", "--output", "xml"])
+      [BAZEL_BIN, "query", package + ":all", "--output", "xml"])
   root = ET.fromstring(result)
   return [
       parse_bazel_rule(elem, package)


### PR DESCRIPTION
Changed to use a wrapped version of bazel in the abseil script to avoid the following error on Kokoro.

#### [Log](https://source.cloud.google.com/results/invocations/0cf244b9-c6ff-4c72-8cc7-9f356fdc5929/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_build_abseil-cpp_at_head/log) / [internal dashboard](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod%3Agrpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_build_abseil-cpp_at_head)
```
+ src/abseil-cpp/preprocessed_builds.yaml.gen.py
FATAL: corrupt installation: file '/home/kbuilder/.cache/bazel/_bazel_kbuilder/install/4cfcf40fe067e89c8f5c38e156f8d8ca/_embedded_binaries/A-server.jar' is missing or modified.
Please remove '/home/kbuilder/.cache/bazel/_bazel_kbuilder/install/4cfcf40fe067e89c8f5c38e156f8d8ca' and try again.
    raise CalledProcessError(retcode, process.args, output=output)
subprocess.CalledProcessError: Command '['bazel', 'query', '//absl:all', '--output', 'xml']' returned non-zero exit status 36
```

