### PR TITLE
Add config to run additional PHP tests per PR

### DIFF
--- a/tools/internal_ci/linux/grpc_php_run_extratests.sh
+++ b/tools/internal_ci/linux/grpc_php_run_extratests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,29 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
+
+# change to grpc repo root
 cd $(dirname $0)/../../..
 
-ALL_IMAGES=( grpc-ext grpc-src alpine centos7 php5 php-src php-future php-zts
-             fork-support )
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-if [[ "$1" == "--cmds" ]]; then
-  for arg in "${ALL_IMAGES[@]}"
-  do
-    echo "docker build -t grpc-php/$arg -f ./src/php/docker/$arg/Dockerfile ."
-  done
-  exit 0
-fi
-
-if [[ $# -eq 0 ]]; then
-  lst=("${ALL_IMAGES[@]}")
-else
-  lst=("$@")
-fi
-
-set -x
-for arg in "${lst[@]}"
-do
-  docker build -t grpc-php/"$arg" -f ./src/php/docker/"$arg"/Dockerfile .
-  docker run -it --rm grpc-php/"$arg"
-done
+tools/run_tests/run_php_extratests.py

--- a/tools/internal_ci/linux/pull_request/grpc_extratests_php.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_extratests_php.cfg
@@ -1,0 +1,25 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_php_run_extratests.sh"
+timeout_mins: 60
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/tools/run_tests/run_php_extratests.py
+++ b/tools/run_tests/run_php_extratests.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run additional PHP tests"""
+
+from __future__ import print_function
+
+import os
+import sys
+
+import python_utils.jobset as jobset
+import python_utils.report_utils as report_utils
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../..'))
+os.chdir(_ROOT)
+
+_DEFAULT_RUNTESTS_TIMEOUT = 1 * 60 * 60
+
+# Number of jobs assigned to each job instance
+_DEFAULT_NUM_JOBS = 2
+
+# Name of the top-level umbrella report that includes all the test invocations
+_REPORT_NAME = 'toplevel_php_extratests_invocations'
+
+
+def _safe_report_name(name):
+    """Reports with '+' in target name won't show correctly in ResultStore"""
+    return name.replace('+', 'p')
+
+
+def _report_filename(name):
+    """Generates report file name with directory structure that leads to better presentation by internal CI"""
+    # 'sponge_log.xml' suffix must be there for results to get recognized by kokoro.
+    return '%s/%s' % (_safe_report_name(name), 'sponge_log.xml')
+
+
+def _job_logfilename(shortname):
+    """Generate location for log file that will match the sponge_log.xml from the top-level report."""
+    # 'sponge_log.log' suffix must be there for log to get recognized as "target log"
+    # for the corresponding 'sponge_log.xml' report.
+    # the shortname_for_multi_target component must be set to match the sponge_log.xml location
+    # because the top-level render_junit_xml_report is called with multi_target=True
+    return '%s/%s/%s' % (_REPORT_NAME, shortname, 'sponge_log.log')
+
+
+def _create_php_docker_job(docker_image_shortname):
+    shortname = 'run_php_docker_test_%s' % docker_image_shortname
+    return jobset.JobSpec(cmdline=[
+        'src/php/bin/build_all_docker_images.sh', docker_image_shortname
+    ],
+                          shortname=shortname,
+                          timeout_seconds=_DEFAULT_RUNTESTS_TIMEOUT,
+                          logfilename=_job_logfilename(shortname))
+
+
+if __name__ == "__main__":
+    jobs = []
+    jobs.append(_create_php_docker_job('grpc-ext'))
+    jobs.append(_create_php_docker_job('php-zts'))
+
+    print('Will run these tests:')
+    for job in jobs:
+        print('  %s: "%s"' % (job.shortname, ' '.join(job.cmdline)))
+    print('')
+
+    jobset.message('START', 'Running additional PHP tests', do_newline=True)
+    num_failures, resultset = jobset.run(jobs,
+                                         newline_on_success=True,
+                                         travis=True,
+                                         maxjobs=_DEFAULT_NUM_JOBS)
+
+    report_utils.render_junit_xml_report(resultset,
+                                         _report_filename(_REPORT_NAME),
+                                         suite_name=_REPORT_NAME,
+                                         multi_target=True)
+    if num_failures == 0:
+        jobset.message('SUCCESS',
+                       'All PHP tests finished successfully.',
+                       do_newline=True)
+    else:
+        jobset.message('FAILED', 'Some PHP tests have failed.', do_newline=True)
+        sys.exit(1)


### PR DESCRIPTION
For #23307

In #21941 , there was a core change related to `upb`, and later we discovered (via the xDS tests breakage) that that change broke the `pecl install` build of the PHP extension. That breakage wasn't discovered early primarily because we build the PHP extension slightly differently in the PR tests vs in the xDS tests, which are only run in `master`. In the PR tests, c-core was compiled and installed first and then the PHP extension was built in a 'thin' way. See [here](https://github.com/grpc/grpc/blob/master/tools/run_tests/helper_scripts/build_php.sh#L30-L37). But in the xDS tests, the pecl extension was built fully as if an end user would have used it (i.e. tgz archive, and then `pecl install`). See [here](https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh#L49-L51).

So in order to make sure we test this `pecl install` way, in PR, I'd like to have a new entry point Kokoro config to run additional tests for PHP. This PR adds the config and entry point script for it. There's a corresponding internal CL to add the corresponding Kokoro config.

We already have a series of docker images [here](https://github.com/grpc/grpc/blob/master/src/php/bin/build_all_docker_images.sh) that will build the grpc PHP extension the `pecl install` way and test our grpc PHP extension against a variety of different PHP runtimes. So I'd like to hook those up to be run every pull request.

The concern (why that script was never hooked up before) was that right now we have 9 such PHP docker images and the script wasn't optimized much at all so the script takes an hour or so to run. In order to not draw too much resources to each PR test run, I only run 2 such docker images for now, which would finish around 5-10 minutes, and still should be able to catch a class of errors/breakages as the c-core is being updated.

In the future, there are probably a few things we can do to `tools/internal_ci/linux/grpc_php_run_extratests.sh` to run the rest of the docker images. And as a follow up I can see how to hook up the proper log file, etc.