### PR TITLE
Removed sort_keys=True in yaml.gen.py

### DIFF
--- a/src/abseil-cpp/preprocessed_builds.yaml.gen.py
+++ b/src/abseil-cpp/preprocessed_builds.yaml.gen.py
@@ -206,7 +206,7 @@ def main():
   builds = generate_builds("absl")
   os.chdir(previous_dir)
   with open(OUTPUT_PATH, 'w') as outfile:
-    outfile.write(yaml.dump(builds, indent=2, sort_keys=True))
+    outfile.write(yaml.dump(builds, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removed `sort_keys=True` from the script because sort_keys is True by default. This is needed to run the script on the system with pyyaml < 5.1 like Kokoro machine.

```
Traceback (most recent call last):
  File "src/abseil-cpp/preprocessed_builds.yaml.gen.py", line 213, in <module>
    main()
  File "src/abseil-cpp/preprocessed_builds.yaml.gen.py", line 209, in main
    outfile.write(yaml.dump(builds, indent=2, sort_keys=True))
  File "/usr/local/lib/python3.4/dist-packages/yaml/__init__.py", line 200, in dump
    return dump_all([data], stream, Dumper=Dumper, **kwds)
TypeError: dump_all() got an unexpected keyword argument 'sort_keys'
```

This is follow up PR of #23319