### PR TITLE
Add verbose logs for details around ruby call creds user callback invocation

### DIFF
--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -56,6 +56,28 @@ typedef struct callback_params {
 
 static VALUE grpc_rb_call_credentials_callback(VALUE callback_args) {
   VALUE result = rb_hash_new();
+  if (gpr_should_log(GPR_LOG_SEVERITY_DEBUG)) {
+    VALUE callback_args_as_str =
+        rb_funcall(callback_args, rb_intern("to_s"), 0);
+    VALUE callback_source_info = rb_funcall(rb_ary_entry(callback_args, 0),
+                                            rb_intern("source_location"), 0);
+    if (callback_source_info != Qnil) {
+      VALUE source_filename = rb_ary_entry(callback_source_info, 0);
+      VALUE source_line_number = rb_funcall(
+          rb_ary_entry(callback_source_info, 1), rb_intern("to_s"), 0);
+      gpr_log(GPR_DEBUG,
+              "GRPC_RUBY: grpc_rb_call_credentials invoking user callback "
+              "(source_filename:%s line_number:%s) with arguments:%s",
+              StringValueCStr(source_filename),
+              StringValueCStr(source_line_number),
+              StringValueCStr(callback_args_as_str));
+    } else {
+      gpr_log(GPR_DEBUG,
+              "GRPC_RUBY: grpc_rb_call_credentials invoking user callback "
+              "(failed to get source filename ane line) with arguments:%s",
+              StringValueCStr(callback_args_as_str));
+    }
+  }
   VALUE metadata = rb_funcall(rb_ary_entry(callback_args, 0), rb_intern("call"),
                               1, rb_ary_entry(callback_args, 1));
   rb_hash_aset(result, rb_str_new2("metadata"), metadata);


### PR DESCRIPTION
Now, when `GRPC_VERBOSITY=DEBUG` is set, the ruby call creds code will dump source file and line number of where the user callback is defined, and also the arguments.

Example log:
```
D0626 11:23:23.105811665  514109 rb_call_credentials.c:68]   GRPC_RUBY: grpc_rb_call_credentials invoking user callback (source_filename:/<redacted>/grpc/src/ruby/spec/generic/client_stub_spec.rb line_number:263) with arguments:[#<Proc:0x0055e80587ee50@<redacted>/grpc/src/ruby/spec/generic/client_stub_spec.rb:263>, {:jwt_aud_uri=>"https://foo.test.google.fr"}]
```

This is motivated mainly for internal bug b/153688681

cc @igorpeshansky 