### PR TITLE
Fix clang compiler warning on implicit conversion from 'long' to 'dou…

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -58,7 +58,7 @@ static grpc_millis timespan_to_millis_round_down(gpr_timespec ts) {
   double x = GPR_MS_PER_SEC * static_cast<double>(ts.tv_sec) +
              static_cast<double>(ts.tv_nsec) / GPR_NS_PER_MS;
   if (x < 0) return 0;
-  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
+  if (x > static_cast<double>(GRPC_MILLIS_INF_FUTURE)) return GRPC_MILLIS_INF_FUTURE;
   return static_cast<grpc_millis>(x);
 }
 
@@ -72,7 +72,7 @@ static grpc_millis timespan_to_millis_round_up(gpr_timespec ts) {
              static_cast<double>(GPR_NS_PER_SEC - 1) /
                  static_cast<double>(GPR_NS_PER_SEC);
   if (x < 0) return 0;
-  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
+  if (x > static_cast<double>(GRPC_MILLIS_INF_FUTURE)) return GRPC_MILLIS_INF_FUTURE;
   return static_cast<grpc_millis>(x);
 }
 


### PR DESCRIPTION
Adding a static cast to fix clang (10.0.0) warning about implicit conversion from long to double. 

```
INFO: From Compiling src/core/lib/iomgr/exec_ctx.cc:
src/core/lib/iomgr/exec_ctx.cc:61:11: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-int-float-conversion]
  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
        ~ ^~~~~~~~~~~~~~~~~~~~~~
./src/core/lib/iomgr/exec_ctx.h:39:32: note: expanded from macro 'GRPC_MILLIS_INF_FUTURE'
#define GRPC_MILLIS_INF_FUTURE INT64_MAX
                               ^~~~~~~~~
/usr/include/stdint.h:124:22: note: expanded from macro 'INT64_MAX'
# define INT64_MAX              (__INT64_C(9223372036854775807))
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/stdint.h:106:24: note: expanded from macro '__INT64_C'
#  define __INT64_C(c)  c ## L
                        ^~~~~~
<scratch space>:315:1: note: expanded from here
9223372036854775807L
^~~~~~~~~~~~~~~~~~~~
src/core/lib/iomgr/exec_ctx.cc:75:11: warning: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Wimplicit-int-float-conversion]
  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
        ~ ^~~~~~~~~~~~~~~~~~~~~~
./src/core/lib/iomgr/exec_ctx.h:39:32: note: expanded from macro 'GRPC_MILLIS_INF_FUTURE'
#define GRPC_MILLIS_INF_FUTURE INT64_MAX
                               ^~~~~~~~~
/usr/include/stdint.h:124:22: note: expanded from macro 'INT64_MAX'
# define INT64_MAX              (__INT64_C(9223372036854775807))
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/stdint.h:106:24: note: expanded from macro '__INT64_C'
#  define __INT64_C(c)  c ## L
                        ^~~~~~
<scratch space>:317:1: note: expanded from here
9223372036854775807L
^~~~~~~~~~~~~~~~~~~~
2 warnings generated.

```



<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
