### PR TITLE
Lower log level to INFO from ERROR from keepalive watchdog firing

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2890,7 +2890,7 @@ static void keepalive_watchdog_fired_locked(void* arg, grpc_error* error) {
   grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(arg);
   if (t->keepalive_state == GRPC_CHTTP2_KEEPALIVE_STATE_PINGING) {
     if (error == GRPC_ERROR_NONE) {
-      gpr_log(GPR_ERROR, "%s: Keepalive watchdog fired. Closing transport.",
+      gpr_log(GPR_INFO, "%s: Keepalive watchdog fired. Closing transport.",
               t->peer_string);
       t->keepalive_state = GRPC_CHTTP2_KEEPALIVE_STATE_DYING;
       close_transport_locked(


### PR DESCRIPTION
Internal bug - b/128976496
Reasoning being that each occurrence of an ERROR log should REQUIRE a bug being filed in the respective project. 
A keepalive is something that indicates a problem but not necessarily deserves a bug being filed. It might deserves a bug being filed if it happens too often but if it happens rarely simply reconnecting seems like a good enough approach. This falls more in line with WARNING as the log level. Unfortunately, we don't have that at the moment, so using INFO.