### PR TITLE
Suppress exceptions from the __del__ of channel object

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1123,10 +1123,12 @@ class _ChannelCallState(object):
         self.managed_calls = 0
 
     def __del__(self):
-        if hasattr(self,
-                   'channel') and self.channel and cygrpc and cygrpc.StatusCode:
+        try:
             self.channel.close(cygrpc.StatusCode.cancelled,
                                'Channel deallocated!')
+        except (TypeError, AttributeError) as error:
+            logging.debug('Channel deallocation failed with: <%s>: %s',
+                          type(error), str(error))
 
 
 def _run_channel_spin_thread(state):


### PR DESCRIPTION
Another report from https://github.com/grpc/grpc/pull/22855 observed spam exception during the GC of Channel object. This PR silences the `__del__` function from `TypeError` and `AttributeError`, which covers the exceptions raised from unexpected object deletion order.