### PR TITLE
Add abseil compiler options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6601,6 +6601,7 @@ LIBGRPC_ABSEIL_SRC = \
 
 LIBGRPC_ABSEIL_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC_ABSEIL_SRC))))
 
+$(LIBGRPC_ABSEIL_OBJS): CPPFLAGS += -g -maes -msse4 -Ithird_party/abseil-cpp
 
 $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a:  $(LIBGRPC_ABSEIL_OBJS) 
 	$(E) "[AR]      Creating $@"

--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -195,6 +195,8 @@ configs:
     test_environ:
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:suppressions=test/core/util/ubsan_suppressions.txt
 defaults:
+  abseil:
+    CPPFLAGS: -g -maes -msse4 -Ithird_party/abseil-cpp
   ares:
     CFLAGS: -g
     CPPFLAGS: -Ithird_party/cares -Ithird_party/cares/cares -fvisibility=hidden -D_GNU_SOURCE

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -1491,6 +1491,7 @@
       "name": "grpc_abseil",
       "build": "private",
       "language": "c",
+      "defaults": "abseil",
       "src": sorted(used_abseil_srcs),
       "hdr": sorted(used_abseil_hdrs),
       "secure": False,


### PR DESCRIPTION
GCC up to 4.8 and Clang up to 3.7 had a problem incapable of compiling certain target in Abseil with the following error.

```
In file included from third_party/abseil-cpp/absl/random/internal/randen_hwaes.cc:260:0:
/usr/lib/gcc/x86_64-linux-gnu/4.8/include/wmmintrin.h:34:3: error: #error "AES/PCLMUL instructions not enabled"
 # error "AES/PCLMUL instructions not enabled"
```

This is because `wmmintrin.h` had intrinsic functions available on certain Intel CPUs. To address this problem, abseil needs `-maes` and `-msse4.1` options. ([ref](https://github.com/abseil/abseil-cpp/blob/e96ae2203b80d5ae2e0b7abe0c77b722b224b16d/absl/copts/GENERATED_AbseilCopts.cmake#L210)) This doesn't mean that this code only runs on cpus with this intruction-set support. This is just about a compilation and Abseil will detect the cpu on runtime and use either a slow module or a fast module using the instruction depending on the cpu.

[grpc_build_artifacts_multiplatform](https://sponge.corp.google.com/invocation?id=e136ae39-7f18-4fcd-9d43-b6d98deac1a3&searchFor=): passed except existing breakages by upb.