### PR TITLE
Removed GRPC_USE_ABSL

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -28,13 +28,6 @@
  */
 
 /*
- * Defines GRPC_USE_ABSL to use Abseil Common Libraries (C++)
- */
-#ifndef GRPC_USE_ABSL
-#define GRPC_USE_ABSL 1
-#endif
-
-/*
  * Defines GPR_ABSEIL_SYNC to use synchronization features from Abseil
  */
 #ifndef GPR_ABSEIL_SYNC


### PR DESCRIPTION
Removed `GRPC_USE_ABSL` since abseil got integrated completely and this doesn't do anything now.