### PR TITLE
[Aio] Allows poller to bound to ephemeral loops in multiple threads

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -171,19 +171,16 @@ async def generator_to_async_generator(object gen, object loop, object thread_po
 
 if PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
     def get_working_loop():
-        """Returns a running event loop."""
-        return asyncio.get_running_loop()
+        """Returns a running event loop.
+
+        Due to a defect of asyncio.get_event_loop, its returned event loop might
+        not be set as the default event loop for the main thread.
+        """
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.get_event_loop()
 else:
     def get_working_loop():
-        """Returns a running event loop.
-        
-        Due to a defect of asyncio.get_event_loop, its returned event loop might
-        not be set as the default event loop for the main thread. So, we will
-        raise RuntimeError if the returned event loop is not running.
-        """
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            return loop
-        else:
-            raise RuntimeError('No running event loop detected. This function '
-                             + 'must be called from inside of a running event loop.')
+        """Returns a running event loop."""
+        return asyncio.get_event_loop()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -49,6 +49,12 @@ cdef class BaseCompletionQueue:
 
     cdef grpc_completion_queue* c_ptr(self)
 
+
+cdef class _EventLoopBound:
+    cdef readonly object loop
+    cdef readonly object read_socket
+
+
 cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef bint _shutdown
     cdef cpp_event_queue _queue
@@ -57,7 +63,7 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef int _write_fd
     cdef object _read_socket
     cdef object _write_socket
-    cdef object _loop
+    cdef dict _loops
 
     cdef void _poll(self) nogil
     cdef shutdown(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -52,18 +52,18 @@ cdef class BaseCompletionQueue:
 
 cdef class _BoundEventLoop:
     cdef readonly object loop
-    cdef readonly object read_socket
+    cdef readonly object read_socket  # socket.socket
 
 
 cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef bint _shutdown
     cdef cpp_event_queue _queue
     cdef mutex _queue_mutex
-    cdef object _poller_thread
+    cdef object _poller_thread  # threading.Thread
     cdef int _write_fd
-    cdef object _read_socket
-    cdef object _write_socket
-    cdef dict _loops
+    cdef object _read_socket    # socket.socket
+    cdef object _write_socket   # socket.socket
+    cdef dict _loops            # Mapping[asyncio.AbstractLoop, _BoundEventLoop]
 
     cdef void _poll(self) nogil
     cdef shutdown(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -50,7 +50,7 @@ cdef class BaseCompletionQueue:
     cdef grpc_completion_queue* c_ptr(self)
 
 
-cdef class _EventLoopBound:
+cdef class _BoundEventLoop:
     cdef readonly object loop
     cdef readonly object read_socket
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
@@ -38,7 +38,7 @@ cdef class BaseCompletionQueue:
         return self._cq
 
 
-cdef class _EventLoopBound:
+cdef class _BoundEventLoop:
 
     def __cinit__(self, object loop, object read_socket, object handler):
         self.loop = loop
@@ -73,11 +73,11 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
 
         self._queue = cpp_event_queue()
 
-    def bound_loop(self, object loop):
+    def bind_loop(self, object loop):
         if loop in self._loops:
             return
         else:
-            self._loops[loop] = _EventLoopBound(loop, self._read_socket, self._handle_events)
+            self._loops[loop] = _BoundEventLoop(loop, self._read_socket, self._handle_events)
 
     cdef void _poll(self) nogil:
         cdef grpc_event event

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
@@ -38,11 +38,25 @@ cdef class BaseCompletionQueue:
         return self._cq
 
 
+cdef class _EventLoopBound:
+
+    def __cinit__(self, object loop, object read_socket, object handler):
+        self.loop = loop
+        self.read_socket = read_socket
+        reader_function = functools.partial(
+            handler,
+            loop
+        )
+        self.loop.add_reader(self.read_socket, reader_function)
+
+    def close(self):
+        if self.loop:
+            self.loop.remove_reader(self.read_socket)
+
+
 cdef class PollerCompletionQueue(BaseCompletionQueue):
 
     def __cinit__(self):
-        
-        self._loop = get_working_loop()
         self._cq = grpc_completion_queue_create_for_next(NULL)
         self._shutdown = False
         self._poller_thread = threading.Thread(target=self._poll_wrapper, daemon=True)
@@ -50,9 +64,20 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
 
         self._read_socket, self._write_socket = socket.socketpair()
         self._write_fd = self._write_socket.fileno()
-        self._loop.add_reader(self._read_socket, self._handle_events)
+        self._loops = {}
+
+        # The read socket might be read by multiple threads. But only one of them will
+        # read the 1 byte sent by the poller thread. This setting is essential to allow
+        # multiple loops in multiple threads bound to the same poller.
+        self._read_socket.setblocking(False)
 
         self._queue = cpp_event_queue()
+
+    def bound_loop(self, object loop):
+        if loop in self._loops:
+            return
+        else:
+            self._loops[loop] = _EventLoopBound(loop, self._read_socket, self._handle_events)
 
     cdef void _poll(self) nogil:
         cdef grpc_event event
@@ -79,14 +104,21 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
             self._poll()
 
     cdef shutdown(self):
-        self._loop.remove_reader(self._read_socket)
+        # Removes the socket hook from loops
+        for loop in self._loops:
+            self._loops.get(loop).close()
+
         # TODO(https://github.com/grpc/grpc/issues/22365) perform graceful shutdown
         grpc_completion_queue_shutdown(self._cq)
         while not self._shutdown:
             self._poller_thread.join(timeout=_POLL_AWAKE_INTERVAL_S)
         grpc_completion_queue_destroy(self._cq)
 
-    def _handle_events(self):
+        # Clean up socket resources
+        self._read_socket.close()
+        self._write_socket.close()
+
+    def _handle_events(self, object context_loop):
         cdef bytes data = self._read_socket.recv(1)
         cdef grpc_event event
         cdef CallbackContext *context
@@ -103,7 +135,7 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
 
             context = <CallbackContext *>event.tag
             loop = <object>context.loop
-            if loop is self._loop:
+            if loop is context_loop:
                 # Executes callbacks: complete the future
                 CallbackWrapper.functor_run(
                     <grpc_experimental_completion_queue_functor *>event.tag,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
@@ -111,10 +111,10 @@ cdef _actual_aio_shutdown():
         raise ValueError('Unsupported engine type [%s]' % _global_aio_state.engine)
 
 
-cdef _per_loop_initialization():
+cdef _initialize_per_loop():
     cdef object loop = get_working_loop()
     if _global_aio_state.engine is AsyncIOEngine.POLLER:
-        _global_aio_state.cq.bound_loop(loop)
+        _global_aio_state.cq.bind_loop(loop)
 
 
 cpdef init_grpc_aio():
@@ -127,7 +127,7 @@ cpdef init_grpc_aio():
         _global_aio_state.refcount += 1
         if _global_aio_state.refcount == 1:
             _actual_aio_initialization()
-        _per_loop_initialization()
+        _initialize_per_loop()
 
 
 cpdef shutdown_grpc_aio():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi
@@ -111,6 +111,12 @@ cdef _actual_aio_shutdown():
         raise ValueError('Unsupported engine type [%s]' % _global_aio_state.engine)
 
 
+cdef _per_loop_initialization():
+    cdef object loop = get_working_loop()
+    if _global_aio_state.engine is AsyncIOEngine.POLLER:
+        _global_aio_state.cq.bound_loop(loop)
+
+
 cpdef init_grpc_aio():
     """Initializes the gRPC AsyncIO module.
 
@@ -121,6 +127,7 @@ cpdef init_grpc_aio():
         _global_aio_state.refcount += 1
         if _global_aio_state.refcount == 1:
             _actual_aio_initialization()
+        _per_loop_initialization()
 
 
 cpdef shutdown_grpc_aio():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -1000,3 +1000,6 @@ cdef class AioServer:
     cdef thread_pool(self):
         """Access the thread pool instance."""
         return self._thread_pool
+
+    def is_running(self):
+        return self._status == AIO_SERVER_STATUS_RUNNING

--- a/src/python/grpcio/grpc/experimental/aio/_server.py
+++ b/src/python/grpcio/grpc/experimental/aio/_server.py
@@ -162,10 +162,11 @@ class Server(_base_server.Server):
         be safe to slightly extend the underlying Cython object's life span.
         """
         if hasattr(self, '_server'):
-            cygrpc.schedule_coro_threadsafe(
-                self._server.shutdown(None),
-                self._loop,
-            )
+            if self._server.is_running():
+                cygrpc.schedule_coro_threadsafe(
+                    self._server.shutdown(None),
+                    self._loop,
+                )
 
 
 def server(migration_thread_pool: Optional[Executor] = None,


### PR DESCRIPTION
Originated: https://github.com/googleapis/gapic-generator-python/issues/491

Recap: An update from `pytest-asyncio` caused the `gapic-generator-python` tests to deadlock. The update enforces renewing event loops between each test file. Before this PR, the gRPC AsyncIO poller binds to an event loop to consume Core's events and assumes the event loop will be alive until all gRPC logic finishes. So, the update closes the poller-bound event loop and left no one consuming Core's events.

A temporary fix is available in https://github.com/googleapis/gapic-generator-python/pull/493. This PR meant to solve similar issues for good.

This PR alters the poller binding mechanism to be invoked from only once to per loop. Each time an gRPC AsyncIo object is created the init function will check if there is a new event loop. If so, the event loop will listen to the socket that communicating between Core and Cython.

An interesting finding is that we are prone to the thundering herd problem now. A Core event wakes up all bound event loop (technically their threads). The performance might suffer slightly if there are multiple event loop. This trade off is acceptable to me, since the GIL does damage to the multi-loop-multi-thread application's performance much worse than this PR.