### PR TITLE
Make plugins embed zlib

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_protoc.sh
+++ b/tools/run_tests/artifacts/build_artifact_protoc.sh
@@ -13,15 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use devtoolset environment that has GCC 4.8 before set -ex
-# shellcheck disable=SC1091
-source scl_source enable devtoolset-2
-
 set -ex
 
 cd "$(dirname "$0")/../../.."
 
-make plugins
+EMBED_ZLIB=true PROTOBUF_CONFIG_OPTS=--with-zlib=no make plugins
 
 mkdir -p "${ARTIFACTS_OUT}"
 cp bins/opt/protobuf/protoc bins/opt/*_plugin "${ARTIFACTS_OUT}"/


### PR DESCRIPTION
Fixed the problem that generated protoc binaries have a dependency toward zlib. This problem was caused by #23352.

#### distribtest.csharp_linux_x64_alpine_dotnetcli
```
...
+ dotnet build DistribTestDotNet.csproj
Microsoft (R) Build Engine version 16.2.32702+c4012a063 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 67.76 ms for /var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj.
/root/.nuget/packages/grpc.tools/2.31.0-dev202006302329/tools/linux_x64/protoc : error : error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory [/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj]
/root/.nuget/packages/grpc.tools/2.31.0-dev202006302329/tools/linux_x64/protoc : error : error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory [/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj]

Build FAILED.
```

[grpc_build_artifacts_multiplatform](https://sponge.corp.google.com/invocation?id=39af2965-8f7d-4007-acfe-379dfb70b1f4&searchFor=): fixed `distribtest.csharp_linux_x64_alpine_dotnetcli`