### PR TITLE
Increase size of a test to match internal guidance

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -236,6 +236,7 @@ grpc_cc_library(
 
 grpc_cc_test(
     name = "bm_fullstack_unary_ping_pong",
+    size = "large",
     srcs = [
         "bm_fullstack_unary_ping_pong.cc",
     ],


### PR DESCRIPTION
As found by an internal flake detector.
