### PR TITLE
Backport pylint sanity check fix to 1.30.x

### DIFF
--- a/tools/distrib/pylint_code.sh
+++ b/tools/distrib/pylint_code.sh
@@ -40,7 +40,9 @@ python3 -m virtualenv $VIRTUALENV -p $(which python3)
 PYTHON=$VIRTUALENV/bin/python
 
 $PYTHON -m pip install --upgrade pip==19.3.1
-$PYTHON -m pip install --upgrade astroid==2.3.3 pylint==2.2.2
+
+# TODO(https://github.com/grpc/grpc/issues/23394): Update Pylint.
+$PYTHON -m pip install --upgrade astroid==2.3.3 pylint==2.2.2 "isort>=4.3.0,<5.0.0"
 
 EXIT=0
 for dir in "${DIRS[@]}"; do


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/23395 to 1.30.x

This is to allow merging https://github.com/grpc/grpc/pull/23399