### PR TITLE
Allow XDS bootstrap contents to be specified as a channel argument

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -360,6 +360,10 @@ typedef struct {
  * The default is 15 seconds. */
 #define GRPC_ARG_XDS_RESOURCE_DOES_NOT_EXIST_TIMEOUT_MS \
   "grpc.xds_resource_does_not_exist_timeout_ms"
+/* The contents of the XDS bootstrap. This will be used instead of the
+ * file at the environment variable GRPC_XDS_BOOTSTRAP if present. */
+#define GRPC_ARG_XDS_BOOTSTRAP \
+  "grpc.xds_bootstrap"
 /** If non-zero, grpc server's cronet compression workaround will be enabled */
 #define GRPC_ARG_WORKAROUND_CRONET_COMPRESSION \
   "grpc.workaround.cronet_compression"

--- a/src/core/ext/filters/client_channel/xds/xds_bootstrap.h
+++ b/src/core/ext/filters/client_channel/xds/xds_bootstrap.h
@@ -58,7 +58,14 @@ class XdsBootstrap {
   };
 
   // If *error is not GRPC_ERROR_NONE after returning, then there was an
-  // error reading the file.
+  // error parsing the string.
+  static std::unique_ptr<XdsBootstrap> ReadFromString(absl::string_view contents_str_view, 
+                                                      XdsClient* client,
+                                                      TraceFlag* tracer,
+                                                      grpc_error** error);
+
+  // If *error is not GRPC_ERROR_NONE after returning, then there was an
+  // error reading/parsing the file.
   static std::unique_ptr<XdsBootstrap> ReadFromFile(XdsClient* client,
                                                     TraceFlag* tracer,
                                                     grpc_error** error);


### PR DESCRIPTION
This provides a way for the XDS bootstrap information (normally populated from the file at environment variable GRPC_XDS_BOOTSTRAP) to be specified as a channel argument.

The motivator for this is to have XDS servers that serve information for specific services, instead of a single XDS tier that must have information for all services a client could talk to.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
