### PR TITLE
Don't drop message on WriteAndFinish with non-ok status

### DIFF
--- a/include/grpcpp/impl/codegen/server_callback_handlers.h
+++ b/include/grpcpp/impl/codegen/server_callback_handlers.h
@@ -579,11 +579,8 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
     void WriteAndFinish(const ResponseType* resp, ::grpc::WriteOptions options,
                         ::grpc::Status s) override {
       // This combines the write into the finish callback
-      // Don't send any message if the status is bad
-      if (s.ok()) {
-        // TODO(vjpai): don't assert
-        GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
-      }
+      // TODO(vjpai): don't assert
+      GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
       Finish(std::move(s));
     }
 
@@ -784,11 +781,8 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
 
     void WriteAndFinish(const ResponseType* resp, ::grpc::WriteOptions options,
                         ::grpc::Status s) override {
-      // Don't send any message if the status is bad
-      if (s.ok()) {
-        // TODO(vjpai): don't assert
-        GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
-      }
+      // TODO(vjpai): don't assert
+      GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
       Finish(std::move(s));
     }
 


### PR DESCRIPTION
This makes the callback API match the async API in behavior. We continue to drop the message on non-OK status for unary RPCs or for client-streaming RPCs (matching the async API in both cases). This is orthogonal to the long-standing issue about whether or not to drop messages at the transport layer for non-OK status.