### PR TITLE
Add TLS 1.2 and 1.3 specific tests to h2_tls fixture.

### DIFF
--- a/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
@@ -264,6 +264,8 @@ struct grpc_tls_credentials_options
   grpc_tls_server_verification_option server_verification_option() const {
     return server_verification_option_;
   }
+  grpc_tls_version min_tls_version() const { return min_tls_version_; }
+  grpc_tls_version max_tls_version() const { return max_tls_version_; }
   grpc_tls_key_materials_config* key_materials_config() const {
     return key_materials_config_.get();
   }
@@ -284,6 +286,12 @@ struct grpc_tls_credentials_options
       const grpc_tls_server_verification_option server_verification_option) {
     server_verification_option_ = server_verification_option;
   }
+  void set_min_tls_version(grpc_tls_version min_tls_version) {
+    min_tls_version_ = min_tls_version;
+  }
+  void set_max_tls_version(grpc_tls_version max_tls_version) {
+    max_tls_version_ = max_tls_version;
+  }
   void set_key_materials_config(
       grpc_core::RefCountedPtr<grpc_tls_key_materials_config> config) {
     key_materials_config_ = std::move(config);
@@ -302,6 +310,8 @@ struct grpc_tls_credentials_options
   grpc_ssl_client_certificate_request_type cert_request_type_;
   grpc_tls_server_verification_option server_verification_option_ =
       GRPC_TLS_SERVER_VERIFICATION;
+  grpc_tls_version min_tls_version_ = grpc_tls_version::TLS1_2;
+  grpc_tls_version max_tls_version_ = grpc_tls_version::TLS1_3;
   grpc_core::RefCountedPtr<grpc_tls_key_materials_config> key_materials_config_;
   grpc_core::RefCountedPtr<grpc_tls_credential_reload_config>
       credential_reload_config_;

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -391,8 +391,8 @@ void grpc_shallow_peer_destruct(tsi_peer* peer) {
 
 grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
     tsi_ssl_pem_key_cert_pair* pem_key_cert_pair, const char* pem_root_certs,
-    bool skip_server_certificate_verification,
-    tsi_ssl_session_cache* ssl_session_cache,
+    bool skip_server_certificate_verification, tsi_tls_version min_tls_version,
+    tsi_tls_version max_tls_version, tsi_ssl_session_cache* ssl_session_cache,
     tsi_ssl_client_handshaker_factory** handshaker_factory) {
   const char* root_certs;
   const tsi_ssl_root_certs_store* root_store;
@@ -424,6 +424,8 @@ grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
   options.session_cache = ssl_session_cache;
   options.skip_server_certificate_verification =
       skip_server_certificate_verification;
+  options.min_tls_version = min_tls_version;
+  options.max_tls_version = max_tls_version;
   const tsi_result result =
       tsi_create_ssl_client_handshaker_factory_with_options(&options,
                                                             handshaker_factory);
@@ -440,6 +442,7 @@ grpc_security_status grpc_ssl_tsi_server_handshaker_factory_init(
     tsi_ssl_pem_key_cert_pair* pem_key_cert_pairs, size_t num_key_cert_pairs,
     const char* pem_root_certs,
     grpc_ssl_client_certificate_request_type client_certificate_request,
+    tsi_tls_version min_tls_version, tsi_tls_version max_tls_version,
     tsi_ssl_server_handshaker_factory** handshaker_factory) {
   size_t num_alpn_protocols = 0;
   const char** alpn_protocol_strings =
@@ -453,6 +456,8 @@ grpc_security_status grpc_ssl_tsi_server_handshaker_factory_init(
   options.cipher_suites = grpc_get_ssl_cipher_suites();
   options.alpn_protocols = alpn_protocol_strings;
   options.num_alpn_protocols = static_cast<uint16_t>(num_alpn_protocols);
+  options.min_tls_version = min_tls_version;
+  options.max_tls_version = max_tls_version;
   const tsi_result result =
       tsi_create_ssl_server_handshaker_factory_with_options(&options,
                                                             handshaker_factory);

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -89,14 +89,15 @@ const char** grpc_fill_alpn_protocol_strings(size_t* num_alpn_protocols);
 /* Initialize TSI SSL server/client handshaker factory. */
 grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
     tsi_ssl_pem_key_cert_pair* key_cert_pair, const char* pem_root_certs,
-    bool skip_server_certificate_verification,
-    tsi_ssl_session_cache* ssl_session_cache,
+    bool skip_server_certificate_verification, tsi_tls_version min_tls_version,
+    tsi_tls_version max_tls_version, tsi_ssl_session_cache* ssl_session_cache,
     tsi_ssl_client_handshaker_factory** handshaker_factory);
 
 grpc_security_status grpc_ssl_tsi_server_handshaker_factory_init(
     tsi_ssl_pem_key_cert_pair* key_cert_pairs, size_t num_key_cert_pairs,
     const char* pem_root_certs,
     grpc_ssl_client_certificate_request_type client_certificate_request,
+    tsi_tls_version min_tls_version, tsi_tls_version max_tls_version,
     tsi_ssl_server_handshaker_factory** handshaker_factory);
 
 /* Exposed for testing only. */

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -334,8 +334,10 @@ grpc_security_status TlsChannelSecurityConnector::ReplaceHandshakerFactory(
       key_materials_config_->pem_key_cert_pair_list());
   grpc_security_status status = grpc_ssl_tsi_client_handshaker_factory_init(
       pem_key_cert_pair, key_materials_config_->pem_root_certs(),
-      skip_server_certificate_verification, ssl_session_cache,
-      &client_handshaker_factory_);
+      skip_server_certificate_verification,
+      grpc_get_tsi_tls_version(creds->options().min_tls_version()),
+      grpc_get_tsi_tls_version(creds->options().max_tls_version()),
+      ssl_session_cache, &client_handshaker_factory_);
   /* Free memory. */
   grpc_tsi_ssl_pem_key_cert_pairs_destroy(pem_key_cert_pair, 1);
   return status;
@@ -544,7 +546,10 @@ grpc_security_status TlsServerSecurityConnector::ReplaceHandshakerFactory() {
   grpc_security_status status = grpc_ssl_tsi_server_handshaker_factory_init(
       pem_key_cert_pairs, num_key_cert_pairs,
       key_materials_config_->pem_root_certs(),
-      creds->options().cert_request_type(), &server_handshaker_factory_);
+      creds->options().cert_request_type(),
+      grpc_get_tsi_tls_version(creds->options().min_tls_version()),
+      grpc_get_tsi_tls_version(creds->options().max_tls_version()),
+      &server_handshaker_factory_);
   /* Free memory. */
   grpc_tsi_ssl_pem_key_cert_pairs_destroy(pem_key_cert_pairs,
                                           num_key_cert_pairs);


### PR DESCRIPTION
This is a follow-up to PR #23165 
