### PR TITLE
Store ref to the ExternalConnectivityWatcher in external_watchers_ map.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -171,22 +171,14 @@ class ChannelData {
                                       grpc_connectivity_state* state,
                                       grpc_closure* on_complete,
                                       grpc_closure* watcher_timer_init) {
-    auto watcher = new ExternalConnectivityWatcher(
-        this, pollent, state, on_complete, watcher_timer_init);
-    {
-      MutexLock lock(&external_watchers_mu_);
-      // Store a ref to the watcher in the external_watchers_ map.
-      watcher->AddWatcherToExternalWatchersMapLocked(&external_watchers_,
-                                                     on_complete);
-    }
-    // Pass the ref from creating the object to Start().
-    watcher->Start();
+    new ExternalConnectivityWatcher(this, pollent, state, on_complete,
+                                    watcher_timer_init);
   }
 
   void RemoveExternalConnectivityWatcher(grpc_closure* on_complete,
                                          bool cancel) {
     ExternalConnectivityWatcher::RemoveWatcherFromExternalWatchersMap(
-        &external_watchers_mu_, &external_watchers_, on_complete, cancel);
+        this, on_complete, cancel);
   }
 
   int NumExternalConnectivityWatchers() const {
@@ -217,23 +209,10 @@ class ChannelData {
 
     ~ExternalConnectivityWatcher();
 
-    // Adds the watcher to the external_watchers_ map. Synchronized by
-    // external_watchers_mu_
-    void AddWatcherToExternalWatchersMapLocked(
-        std::map<grpc_closure*, RefCountedPtr<ExternalConnectivityWatcher>>*
-            external_watchers,
-        grpc_closure* on_complete);
-
     // Removes the watcher from the external_watchers_ map.
-    static void RemoveWatcherFromExternalWatchersMap(
-        Mutex* external_watchers_mu,
-        std::map<grpc_closure*, RefCountedPtr<ExternalConnectivityWatcher>>*
-            external_watchers,
-        grpc_closure* on_complete, bool cancel);
-
-    // Starts the watch. Consumes the ref from the creation of the
-    // ExternalConnectivityWatcher object.
-    void Start();
+    static void RemoveWatcherFromExternalWatchersMap(ChannelData* chand,
+                                                     grpc_closure* on_complete,
+                                                     bool cancel);
 
     void Notify(grpc_connectivity_state state) override;
 
@@ -1181,6 +1160,21 @@ ChannelData::ExternalConnectivityWatcher::ExternalConnectivityWatcher(
   grpc_polling_entity_add_to_pollset_set(&pollent_,
                                          chand_->interested_parties_);
   GRPC_CHANNEL_STACK_REF(chand_->owning_stack_, "ExternalConnectivityWatcher");
+  {
+    MutexLock lock(&chand_->external_watchers_mu_);
+    // Will be deleted when the watch is complete.
+    GPR_ASSERT(chand->external_watchers_[on_complete] == nullptr);
+    // Store a ref to the watcher in the external_watchers_ map.
+    chand->external_watchers_[on_complete] =
+        Ref(DEBUG_LOCATION, "AddWatcherToExternalWatchersMapLocked");
+  }
+  // Pass the ref from creating the object to Start().
+  chand_->work_serializer_->Run(
+      [this]() {
+        // The ref is passed to AddWatcherLocked().
+        AddWatcherLocked();
+      },
+      DEBUG_LOCATION);
 }
 
 ChannelData::ExternalConnectivityWatcher::~ExternalConnectivityWatcher() {
@@ -1191,45 +1185,21 @@ ChannelData::ExternalConnectivityWatcher::~ExternalConnectivityWatcher() {
 }
 
 void ChannelData::ExternalConnectivityWatcher::
-    AddWatcherToExternalWatchersMapLocked(
-        std::map<grpc_closure*, RefCountedPtr<ExternalConnectivityWatcher>>*
-            external_watchers,
-        grpc_closure* on_complete) {
-  // Will be deleted when the watch is complete.
-  GPR_ASSERT((*external_watchers)[on_complete] == nullptr);
-  (*external_watchers)[on_complete] =
-      Ref(DEBUG_LOCATION, "AddWatcherToExternalWatchersMapLocked");
-}
-
-void ChannelData::ExternalConnectivityWatcher::
-    RemoveWatcherFromExternalWatchersMap(
-        Mutex* external_watchers_mu,
-        std::map<grpc_closure*, RefCountedPtr<ExternalConnectivityWatcher>>*
-            external_watchers,
-        grpc_closure* on_complete, bool cancel) {
+    RemoveWatcherFromExternalWatchersMap(ChannelData* chand,
+                                         grpc_closure* on_complete,
+                                         bool cancel) {
   RefCountedPtr<ExternalConnectivityWatcher> watcher;
   {
-    MutexLock lock(external_watchers_mu);
-    auto it = (*external_watchers).find(on_complete);
-    if (it != (*external_watchers).end()) {
+    MutexLock lock(&chand->external_watchers_mu_);
+    auto it = chand->external_watchers_.find(on_complete);
+    if (it != chand->external_watchers_.end()) {
       watcher = std::move(it->second);
-      (*external_watchers).erase(it);
+      chand->external_watchers_.erase(it);
     }
   }
   // watcher->Cancel() will hop into the WorkSerializer, so we have to unlock
   // the mutex before calling it.
   if (watcher != nullptr && cancel) watcher->Cancel();
-}
-
-void ChannelData::ExternalConnectivityWatcher::Start() {
-  // No need to take a ref since Start() consumes the ref from the
-  // creation of the object.
-  chand_->work_serializer_->Run(
-      [this]() {
-        // The ref is passed to AddWatcherLocked().
-        AddWatcherLocked();
-      },
-      DEBUG_LOCATION);
 }
 
 void ChannelData::ExternalConnectivityWatcher::Notify(

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1216,9 +1216,9 @@ void ChannelData::ExternalConnectivityWatcher::
       (*external_watchers).erase(it);
     }
   }
-  if (watcher != nullptr && cancel) {
-    watcher->Cancel();
-  }
+  // watcher->Cancel() will hop into the WorkSerializer, so we have to unlock
+  // the mutex before calling it.
+  if (watcher != nullptr && cancel) watcher->Cancel();
 }
 
 void ChannelData::ExternalConnectivityWatcher::Start() {

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -177,7 +177,9 @@ class ChannelData {
       MutexLock lock(&external_watchers_mu_);
       // Will be deleted when the watch is complete.
       GPR_ASSERT(external_watchers_[on_complete] == nullptr);
-      // Pass a ref to the external_watchers_ map.
+      // Pass a ref to the external_watchers_ map. We are taking an additional
+      // ref on the watcher so that we can maintain lifetime guarantees when
+      // watcher->Start() is called after the critical section.
       external_watchers_[on_complete] = watcher;
     }
     watcher->Start();


### PR DESCRIPTION
Fixes b/issues/160704724 and b/160697391. This started occurring after #23365, but I think the issue could have cropped up even before the PR. 

This PR basically adds a ref to the ExternalConnectivityWatcher in the map to maintain lifetime guarantees.
