### PR TITLE
Fix ruby 2.7 keyword arguments deprecation

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -172,7 +172,7 @@ module GRPC
       i = @interceptors.pop
       return yield unless i
 
-      i.send(type, args) do
+      i.send(type, **args) do
         if @interceptors.any?
           intercept!(type, args) do
             yield


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc/pull/22915

```
grpc-1.30.0-universal-darwin/src/ruby/lib/grpc/generic/interceptors.rb:175: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
