### PR TITLE
Stop trying to handle SIGSEGV in Test Runner

### DIFF
--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -183,7 +183,6 @@ class Runner(object):
                 pass
 
         try_set_handler('SIGINT', sigint_handler)
-        try_set_handler('SIGSEGV', fault_handler)
         try_set_handler('SIGBUS', fault_handler)
         try_set_handler('SIGABRT', fault_handler)
         try_set_handler('SIGFPE', fault_handler)


### PR DESCRIPTION
In https://github.com/grpc/grpc/pull/23157, @markdroth ran into timed out gevent tests with no clear indication of the problem. Way back in 2015, https://github.com/grpc/grpc/pull/4281 introduced a catch-all handler for deadly signals in the test runner, including `SIGSEGV`:

```python
def fault_handler(signal_number, frame):
  stdout_pipe.write_bypass(
      'Received fault signal {}\nstdout:\n{}\n\nstderr:{}\n'
      .format(signal_number, stdout_pipe.output, stderr_pipe.output))
  os._exit(1)
```

This handler has largely gone unnoticed since then. Within the sync stack, segfaults have been handled basically as expected, with this handler thrown into the mix. In the gevent stack, however, this setup never worked.

CPython's system for dealing with signals is a bit odd. It guarantees that user-defined signal handlers will always run on the main thread. As such, the native handler supplied to `sigaction` does not execute any Python code -- it simply [increments a global counter](https://github.com/python/cpython/blob/10772ec1505a4583d662c051e577eb2d4fb6e755/Modules/signalmodule.c#L247) of signals encountered in the process. The main thread is expected to periodically run [`PyErr_CheckSignals`](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_CheckSignals), which checks the global signal counters and runs the user-defined signal handlers.

Gevent creates multiple threads. It puts an event loop on the main thread. On the other, it runs gRPC Core code. In @markdroth's PR, a null pointer dereference occurred in Core, triggering a `SIGSEGV`. This initiated the CPython native signal handler (which does nothing of substance) and resets the instruction pointer to the null pointer dereference -- causing yet another `SIGSEGV`. So the thread that should have been running gRPC Core code instead consumed a full core generating and clearing `SIGSEGV`.

Meanwhile, the main thread running the gevent event loop waited for the auxiliary thread in `futex_wait`, apparently not periodically calling `PyErr_CheckSignals`. So the process ended up deadlocked with no indication of the segfault. Nasty.

This PR removes the `SIGSEGV` handler and lets the shell's handler deal with it, which will work correctly in the case of gevent and supply just as much information for the sync stack.