### PR TITLE
Ruby: encode gRPC error details in UTF-8

### DIFF
--- a/src/ruby/ext/grpc/rb_byte_buffer.c
+++ b/src/ruby/ext/grpc/rb_byte_buffer.c
@@ -17,6 +17,7 @@
  */
 
 #include <ruby/ruby.h>
+#include <ruby/encoding.h>
 
 #include "rb_byte_buffer.h"
 #include "rb_grpc_imports.generated.h"
@@ -61,4 +62,14 @@ VALUE grpc_rb_slice_to_ruby_string(grpc_slice slice) {
   }
   return rb_str_new((char*)GRPC_SLICE_START_PTR(slice),
                     GRPC_SLICE_LENGTH(slice));
+}
+
+VALUE grpc_rb_slice_to_utf8_ruby_string(grpc_slice slice) {
+  if (GRPC_SLICE_START_PTR(slice) == NULL) {
+    rb_raise(rb_eRuntimeError,
+             "attempt to convert uninitialized grpc_slice to ruby string");
+  }
+  return rb_enc_str_new((char*)GRPC_SLICE_START_PTR(slice),
+                        GRPC_SLICE_LENGTH(slice),
+                        rb_utf8_encoding());
 }

--- a/src/ruby/ext/grpc/rb_byte_buffer.h
+++ b/src/ruby/ext/grpc/rb_byte_buffer.h
@@ -32,4 +32,7 @@ VALUE grpc_rb_byte_buffer_to_s(grpc_byte_buffer* buffer);
 /* Converts a grpc_slice to a ruby string */
 VALUE grpc_rb_slice_to_ruby_string(grpc_slice slice);
 
+/* Converts a grpc_slice to a UTF-8 ruby string */
+VALUE grpc_rb_slice_to_utf8_ruby_string(grpc_slice slice);
+
 #endif /* GRPC_RB_BYTE_BUFFER_H_ */

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -783,7 +783,7 @@ static VALUE grpc_run_batch_stack_build_result(run_batch_stack* st) {
                 grpc_rb_sStatus, UINT2NUM(st->recv_status),
                 (GRPC_SLICE_START_PTR(st->recv_status_details) == NULL
                      ? Qnil
-                     : grpc_rb_slice_to_ruby_string(st->recv_status_details)),
+                     : grpc_rb_slice_to_utf8_ruby_string(st->recv_status_details)),
                 grpc_rb_md_ary_to_h(&st->recv_trailing_metadata),
                 st->recv_status_debug_error_string == NULL
                     ? Qnil

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -236,6 +236,21 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
         th.join
       end
 
+      it 'should raise an error with UTF-8 encoded error messages' do
+        server_port = create_test_server
+        host = "localhost:#{server_port}"
+        th = run_request_response(@sent_msg, @resp, @fail, details: "エラー")
+        stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
+        error = nil
+        begin
+          get_response(stub)
+        rescue GRPC::BadStatus
+          error = $!
+        end
+        expect(error&.details).to eq("エラー")
+        th.join
+      end
+
       it 'should receive UNAVAILABLE if call credentials plugin fails' do
         server_port = create_secure_test_server
         server_started_notifier = GRPC::Notifier.new
@@ -1040,7 +1055,8 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
   def run_request_response(expected_input, resp, status,
                            expected_metadata: {},
                            server_initial_md: {},
-                           server_trailing_md: {})
+                           server_trailing_md: {},
+                           details: nil)
     wanted_metadata = expected_metadata.clone
     wakey_thread do |notifier|
       c = expect_server_to_be_invoked(
@@ -1050,7 +1066,7 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
         expect(c.metadata[k.to_s]).to eq(v)
       end
       c.remote_send(resp)
-      c.send_status(status, status == @pass ? 'OK' : 'NOK', true,
+      c.send_status(status, details || (status == @pass ? 'OK' : 'NOK'), true,
                     metadata: server_trailing_md)
       close_active_server_call(c)
     end


### PR DESCRIPTION
Error messages are considered encoded in UTF-8:

> The value portion of **Status-Message** is conceptually a Unicode string description of the error, physically encoded as UTF-8 followed by percent-encoding.
> https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md

However, in the current implementation, the gRPC client generates Ruby strings with default encoding (ASCII-8BIT for non-ascii strings). This is inconvenient for error collection and investigation; in our configuration, the error messages are shown as a series of question marks.

This pull request uses `rb_enc_new_str` instead of `rb_new_str` for generating Ruby `String` from `grpc_slice` when handling gRPC error statuses.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
