### PR TITLE
Fix-forward: Stop using mutex for non-polling engine marker

### DIFF
--- a/src/core/lib/iomgr/iomgr.cc
+++ b/src/core/lib/iomgr/iomgr.cc
@@ -31,6 +31,7 @@
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/gprpp/atomic.h"
 #include "src/core/lib/gprpp/global_config.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/buffer_list.h"
@@ -50,7 +51,7 @@ static gpr_cv g_rcv;
 static int g_shutdown;
 static grpc_iomgr_object g_root_object;
 static bool g_grpc_abort_on_leaks;
-static bool g_iomgr_non_polling;
+static grpc_core::Atomic<bool> g_iomgr_non_polling{false};
 
 void grpc_iomgr_init() {
   grpc_core::ExecCtx exec_ctx;
@@ -195,14 +196,9 @@ void grpc_iomgr_unregister_object(grpc_iomgr_object* obj) {
 bool grpc_iomgr_abort_on_leaks(void) { return g_grpc_abort_on_leaks; }
 
 bool grpc_iomgr_non_polling() {
-  gpr_mu_lock(&g_mu);
-  bool ret = g_iomgr_non_polling;
-  gpr_mu_unlock(&g_mu);
-  return ret;
+  return g_iomgr_non_polling.Load(grpc_core::MemoryOrder::SEQ_CST);
 }
 
 void grpc_iomgr_mark_non_polling_internal() {
-  gpr_mu_lock(&g_mu);
-  g_iomgr_non_polling = true;
-  gpr_mu_unlock(&g_mu);
+  g_iomgr_non_polling.Store(true, grpc_core::MemoryOrder::SEQ_CST);
 }


### PR DESCRIPTION
Fix-forward for #23433 . Can instead add this to a roll-forward if the roll-back merges. I went with SEQ_CST which is the strongest atomic so that it has the minimum possible difference relative to the lock-based approach and it's not performance-sensitive; RELAXED would probably work but why bother? (A lock is really more like ACQ_REL but some platforms don't allow ACQ_REL on load or store)
