### PR TITLE
test proto: add field rpcs_by_method to LoadBalancerStatsResponse

### DIFF
--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -211,6 +211,6 @@ message LoadBalancerStatsResponse {
   map<string, int32> rpcs_by_peer = 1;
   // The number of RPCs that failed to record a remote peer.
   int32 num_failures = 2;
-  // The number of completed RPCs for each type (UnaryCall or EmptyCall).
-  map<string, RpcsByPeer> rpcs_by_type = 3;
+  // The number of completed RPCs for each method (UnaryCall or EmptyCall).
+  map<string, RpcsByPeer> rpcs_by_method = 3;
 }

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -202,8 +202,15 @@ message LoadBalancerStatsRequest {
 }
 
 message LoadBalancerStatsResponse {
+  message RpcsByPeer {
+    // The number of completed RPCs for each peer.
+    map<string, int32> rpcs_by_peer = 1;
+  }
+
   // The number of completed RPCs for each peer.
   map<string, int32> rpcs_by_peer = 1;
   // The number of RPCs that failed to record a remote peer.
   int32 num_failures = 2;
+  // The number of completed RPCs for each type (UnaryCall or EmptyCall).
+  map<string, RpcsByPeer> rpcs_by_type = 3;
 }


### PR DESCRIPTION
So xds interop client can report rpcs_by_peer for each type of RPC, instead of just count by peer.
