### PR TITLE
Remove unused variable (fixes builder error)

### DIFF
--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -1404,7 +1404,6 @@ TEST_F(SingleBalancerTest, ServiceNameFromLbPolicyConfig) {
       "}";
 
   SetNextResolutionAllBalancers(kServiceConfigWithTarget);
-  const size_t kNumRpcsPerAddress = 1;
   ScheduleResponseForBalancer(
       0, BalancerServiceImpl::BuildResponseForBackends(GetBackendPorts(), {}),
       0);


### PR DESCRIPTION
Seen at import with -Werror,-Wunused-variable