### PR TITLE
Further reduce the spam log by doing nothing if GC has error

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1126,9 +1126,8 @@ class _ChannelCallState(object):
         try:
             self.channel.close(cygrpc.StatusCode.cancelled,
                                'Channel deallocated!')
-        except (TypeError, AttributeError) as error:
-            logging.debug('Channel deallocation failed with: <%s>: %s',
-                          type(error), str(error))
+        except (TypeError, AttributeError):
+            pass
 
 
 def _run_channel_spin_thread(state):


### PR DESCRIPTION
Previous action of reducing the spam log while interpreter exiting were unsuccessful: https://github.com/grpc/grpc/pull/23201 https://github.com/grpc/grpc/pull/23351. Not only gRPC objects may get deallocated regardless of references, but also Python standard libraries (e.g., logging).

Tag b/158863508 when being imported.