### PR TITLE
DO NOT MERGE: Test upgrade to protobuf 4.0.0-rc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ endif # HAS_PKG_CONFIG
 PERFTOOLS_CHECK_CMD = $(CC) $(CPPFLAGS) $(CFLAGS) -o $(TMPOUT) test/build/perftools.c -lprofiler $(LDFLAGS)
 
 PROTOC_CHECK_CMD = which protoc > /dev/null
-PROTOC_CHECK_VERSION_CMD = protoc --version | grep -q libprotoc.3
+PROTOC_CHECK_VERSION_CMD = protoc --version | grep -q libprotoc.4
 DTRACE_CHECK_CMD = which dtrace > /dev/null
 SYSTEMTAP_HEADERS_CHECK_CMD = $(CC) $(CPPFLAGS) $(CFLAGS) -o $(TMPOUT) test/build/systemtap.c $(LDFLAGS)
 

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -159,11 +159,10 @@ def grpc_deps():
     if "com_google_protobuf" not in native.existing_rules():
         http_archive(
             name = "com_google_protobuf",
-            sha256 = "efaf69303e01caccc2447064fc1832dfd23c0c130df0dc5fc98a13185bb7d1a7",
-            strip_prefix = "protobuf-678da4f76eb9168c9965afc2149944a66cd48546",
+            sha256 = "adb0da9aa2b94cb2a63e23bd69a309a00064d24d190ddd1d9c859280926b15d1",
+            strip_prefix = "protobuf-ed35458e7d000aa5c5abe457f6e51f303860286d",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/protobuf/archive/678da4f76eb9168c9965afc2149944a66cd48546.tar.gz",
-                "https://github.com/google/protobuf/archive/678da4f76eb9168c9965afc2149944a66cd48546.tar.gz",
+                "https://github.com/google/protobuf/archive/ed35458e7d000aa5c5abe457f6e51f303860286d.tar.gz",
             ],
         )
 

--- a/examples/cpp/compression/Makefile
+++ b/examples/cpp/compression/Makefile
@@ -60,7 +60,7 @@ clean:
 # They are by no means necessary to actually compile a grpc-enabled software.
 
 PROTOC_CMD = which $(PROTOC)
-PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.3
+PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.4
 PLUGIN_CHECK_CMD = which $(GRPC_CPP_PLUGIN)
 HAS_PROTOC = $(shell $(PROTOC_CMD) > /dev/null && echo true || echo false)
 ifeq ($(HAS_PROTOC),true)

--- a/examples/cpp/helloworld/Makefile
+++ b/examples/cpp/helloworld/Makefile
@@ -71,7 +71,7 @@ clean:
 # They are by no means necessary to actually compile a grpc-enabled software.
 
 PROTOC_CMD = which $(PROTOC)
-PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.3
+PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.4
 PLUGIN_CHECK_CMD = which $(GRPC_CPP_PLUGIN)
 HAS_PROTOC = $(shell $(PROTOC_CMD) > /dev/null && echo true || echo false)
 ifeq ($(HAS_PROTOC),true)

--- a/examples/cpp/load_balancing/Makefile
+++ b/examples/cpp/load_balancing/Makefile
@@ -60,7 +60,7 @@ clean:
 # They are by no means necessary to actually compile a grpc-enabled software.
 
 PROTOC_CMD = which $(PROTOC)
-PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.3
+PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.4
 PLUGIN_CHECK_CMD = which $(GRPC_CPP_PLUGIN)
 HAS_PROTOC = $(shell $(PROTOC_CMD) > /dev/null && echo true || echo false)
 ifeq ($(HAS_PROTOC),true)

--- a/examples/cpp/metadata/Makefile
+++ b/examples/cpp/metadata/Makefile
@@ -48,7 +48,7 @@ GRPC_CPP_PLUGIN_PATH ?= `which $(GRPC_CPP_PLUGIN)`
  # The following is to test your system and ensure a smoother experience.
 # They are by no means necessary to actually compile a grpc-enabled software.
  PROTOC_CMD = which $(PROTOC)
-PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.3
+PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.4
 PLUGIN_CHECK_CMD = which $(GRPC_CPP_PLUGIN)
 HAS_PROTOC = $(shell $(PROTOC_CMD) > /dev/null && echo true || echo false)
 ifeq ($(HAS_PROTOC),true)

--- a/examples/cpp/route_guide/Makefile
+++ b/examples/cpp/route_guide/Makefile
@@ -60,7 +60,7 @@ clean:
 # They are by no means necessary to actually compile a grpc-enabled software.
 
 PROTOC_CMD = which $(PROTOC)
-PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.3
+PROTOC_CHECK_CMD = $(PROTOC) --version | grep -q libprotoc.4
 PLUGIN_CHECK_CMD = which $(GRPC_CPP_PLUGIN)
 HAS_PROTOC = $(shell $(PROTOC_CMD) > /dev/null && echo true || echo false)
 ifeq ($(HAS_PROTOC),true)

--- a/gRPC-ProtoRPC.podspec
+++ b/gRPC-ProtoRPC.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = "src/objective-c/ProtoRPC"
     ss.dependency "#{s.name}/Legacy-Header", version
     ss.dependency 'gRPC/Interface', version
-    ss.dependency 'Protobuf', '~> 3.0'
+    ss.dependency 'Protobuf', '>= 4.0.0-rc1'
 
     ss.source_files = "src/objective-c/ProtoRPC/ProtoMethod.{h,m}",
                       "src/objective-c/ProtoRPC/ProtoRPC.{h,m}",
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
     ss.dependency "#{s.name}/Legacy-Header", version
     ss.dependency 'gRPC/GRPCCore', version
     ss.dependency 'gRPC-RxLibrary', version
-    ss.dependency 'Protobuf', '~> 3.0'
+    ss.dependency 'Protobuf', '>= 4.0.0-rc1'
 
     ss.source_files = "src/objective-c/ProtoRPC/ProtoRPCLegacy.m",
                       "src/objective-c/ProtoRPC/ProtoServiceLegacy.m"

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 3.12'
+  s.add_dependency 'google-protobuf', '>= 4.0.0.rc.1'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
   s.add_development_dependency 'bundler',            '>= 1.9'

--- a/src/cpp/Protobuf-C++.podspec
+++ b/src/cpp/Protobuf-C++.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Protobuf-C++'
-  s.version  = '3.12.2'
+  s.version  = '4.0.0-rc1'
   s.summary  = 'Protocol Buffers v3 runtime library for C++.'
   s.homepage = 'https://github.com/google/protobuf'
   s.license  = '3-Clause BSD License'

--- a/src/csharp/build/dependencies.props
+++ b/src/csharp/build/dependencies.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <GrpcCsharpVersion>2.31.0-dev</GrpcCsharpVersion>
-    <GoogleProtobufVersion>3.12.2</GoogleProtobufVersion>
+    <GoogleProtobufVersion>4.0.0-rc1</GoogleProtobufVersion>
   </PropertyGroup>
 </Project>

--- a/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
@@ -100,7 +100,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = plugin
 
   # Restrict the protoc version to the one supported by this plugin.
-  s.dependency '!ProtoCompiler', '3.12.2'
+  s.dependency '!ProtoCompiler', '4.0.0-rc1'
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'

--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -102,7 +102,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = plugin
 
   # Restrict the protoc version to the one supported by this plugin.
-  s.dependency '!ProtoCompiler', '3.12.2'
+  s.dependency '!ProtoCompiler', '4.0.0-rc1'
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   # exclamation mark ensures that other "regular" pods will be able to find it as it'll be installed
   # before them.
   s.name     = '!ProtoCompiler'
-  v = '3.12.2'
+  v = '4.0.0-rc1'
   s.version  = v
   s.summary  = 'The Protobuf Compiler (protoc) generates Objective-C files from .proto files'
   s.description = <<-DESC
@@ -108,7 +108,7 @@ Pod::Spec.new do |s|
                      'google/**/*.proto' # Well-known protobuf types
 
   # Restrict the protobuf runtime version to the one supported by this version of protoc.
-  s.dependency 'Protobuf', '~> 3.0'
+  s.dependency 'Protobuf', '>= 4.0.0-rc1'
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -446,7 +446,7 @@
   PERFTOOLS_CHECK_CMD = $(CC) $(CPPFLAGS) $(CFLAGS) -o $(TMPOUT) test/build/perftools.c -lprofiler $(LDFLAGS)
 
   PROTOC_CHECK_CMD = which protoc > /dev/null
-  PROTOC_CHECK_VERSION_CMD = protoc --version | grep -q libprotoc.3
+  PROTOC_CHECK_VERSION_CMD = protoc --version | grep -q libprotoc.4
   DTRACE_CHECK_CMD = which dtrace > /dev/null
   SYSTEMTAP_HEADERS_CHECK_CMD = $(CC) $(CPPFLAGS) $(CFLAGS) -o $(TMPOUT) test/build/systemtap.c $(LDFLAGS)
 

--- a/templates/gRPC-ProtoRPC.podspec.template
+++ b/templates/gRPC-ProtoRPC.podspec.template
@@ -56,7 +56,7 @@
       ss.header_mappings_dir = "src/objective-c/ProtoRPC"
       ss.dependency "#{s.name}/Legacy-Header", version
       ss.dependency 'gRPC/Interface', version
-      ss.dependency 'Protobuf', '~> 3.0'
+      ss.dependency 'Protobuf', '>= 4.0.0-rc1'
 
       ss.source_files = "src/objective-c/ProtoRPC/ProtoMethod.{h,m}",
                         "src/objective-c/ProtoRPC/ProtoRPC.{h,m}",
@@ -69,7 +69,7 @@
       ss.dependency "#{s.name}/Legacy-Header", version
       ss.dependency 'gRPC/GRPCCore', version
       ss.dependency 'gRPC-RxLibrary', version
-      ss.dependency 'Protobuf', '~> 3.0'
+      ss.dependency 'Protobuf', '>= 4.0.0-rc1'
 
       ss.source_files = "src/objective-c/ProtoRPC/ProtoRPCLegacy.m",
                         "src/objective-c/ProtoRPC/ProtoServiceLegacy.m"

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -34,7 +34,7 @@
     s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
     s.platform      = Gem::Platform::RUBY
 
-    s.add_dependency 'google-protobuf', '~> 3.12'
+    s.add_dependency 'google-protobuf', '>= 4.0.0.rc.1'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
     s.add_development_dependency 'bundler',            '>= 1.9'

--- a/templates/src/csharp/build/dependencies.props.template
+++ b/templates/src/csharp/build/dependencies.props.template
@@ -4,6 +4,6 @@
   <Project>
     <PropertyGroup>
       <GrpcCsharpVersion>${settings.csharp_version}</GrpcCsharpVersion>
-      <GoogleProtobufVersion>3.12.2</GoogleProtobufVersion>
+      <GoogleProtobufVersion>4.0.0-rc1</GoogleProtobufVersion>
     </PropertyGroup>
   </Project>

--- a/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
@@ -102,7 +102,7 @@
     s.preserve_paths = plugin
 
     # Restrict the protoc version to the one supported by this plugin.
-    s.dependency '!ProtoCompiler', '3.12.2'
+    s.dependency '!ProtoCompiler', '4.0.0-rc1'
     # For the Protobuf dependency not to complain:
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.9'

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -104,7 +104,7 @@
     s.preserve_paths = plugin
 
     # Restrict the protoc version to the one supported by this plugin.
-    s.dependency '!ProtoCompiler', '3.12.2'
+    s.dependency '!ProtoCompiler', '4.0.0-rc1'
     # For the Protobuf dependency not to complain:
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.9'

--- a/tools/distrib/check_protobuf_pod_version.sh
+++ b/tools/distrib/check_protobuf_pod_version.sh
@@ -20,7 +20,7 @@ cd `dirname $0`/../..
 # get the version of protobuf in /third_party/protobuf
 pushd third_party/protobuf
 
-version1=$(git describe --tags | cut -f 1 -d'-')
+version1=$(git describe --tags | cut -f 1)
 v1=${version1:1}
 
 popd

--- a/tools/distrib/python/grpcio_tools/protoc_lib_deps.py
+++ b/tools/distrib/python/grpcio_tools/protoc_lib_deps.py
@@ -20,4 +20,4 @@ PROTO_FILES=['google/protobuf/wrappers.proto', 'google/protobuf/type.proto', 'go
 CC_INCLUDE='third_party/protobuf/src'
 PROTO_INCLUDE='third_party/protobuf/src'
 
-PROTOBUF_SUBMODULE_VERSION="678da4f76eb9168c9965afc2149944a66cd48546"
+PROTOBUF_SUBMODULE_VERSION="ed35458e7d000aa5c5abe457f6e51f303860286d"

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -36,7 +36,7 @@ cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  80ed4d0bbf65d57cc267dfc63bd2584557f11f9b third_party/googleapis (common-protos-1_3_1-915-g80ed4d0bb)
  c9ccac7cb7345901884aabf5d1a786cfa6e2f397 third_party/googletest (6e2f397)
  15ae750151ac9341e5945eb38f8982d59fb99201 third_party/libuv (v1.34.0)
- 678da4f76eb9168c9965afc2149944a66cd48546 third_party/protobuf (v3.12.2)
+ ed35458e7d000aa5c5abe457f6e51f303860286d third_party/protobuf (v4.0.0-rc1)
  0f2bc6c0fdac9113e3863ea6e30e5b2bd33e3b40 third_party/protoc-gen-validate (v0.0.10)
  aecba11114cf1fac5497aeb844b6966106de3eb6 third_party/re2 (heads/master)
  e8cd3a4bb307e2c810cffff99f93e96e6d7fee85 third_party/udpa (heads/master)


### PR DESCRIPTION
Protobuf just released version [`4.0.0-rc1`](https://github.com/protocolbuffers/protobuf/releases). This PR is to attempt to run our tests early to identify potential issues.

There is no language package uploaded for this release candidate yet.

This is a Draft PR - DO NOT MERGE please.