### PR TITLE
Include the target name in top-level DNS error messages

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/strings/str_cat.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
@@ -370,9 +371,11 @@ void AresDnsResolver::OnResolvedLocked(grpc_error* error) {
   } else {
     GRPC_CARES_TRACE_LOG("resolver:%p dns resolution failed: %s", this,
                          grpc_error_string(error));
+    std::string error_message =
+        absl::StrCat("DNS resolution failed for service: ", name_to_resolve_);
     result_handler()->ReturnError(grpc_error_set_int(
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-            "DNS resolution failed", &error, 1),
+        GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(error_message.c_str(),
+                                                         &error, 1),
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));
     // Set retry timer.
     grpc_millis next_try = backoff_.NextAttemptTime();

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -22,6 +22,8 @@
 #include <climits>
 #include <cstring>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
@@ -195,9 +197,11 @@ void NativeDnsResolver::OnResolvedLocked(grpc_error* error) {
     gpr_log(GPR_INFO, "dns resolution failed (will retry): %s",
             grpc_error_string(error));
     // Return transient error.
+    std::string error_message =
+        absl::StrCat("DNS resolution failed for service: ", name_to_resolve_);
     result_handler()->ReturnError(grpc_error_set_int(
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-            "DNS resolution failed", &error, 1),
+        GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(error_message.c_str(),
+                                                         &error, 1),
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));
     // Set up for retry.
     grpc_millis next_try = backoff_.NextAttemptTime();


### PR DESCRIPTION
b/161158227 for context

While https://github.com/grpc/grpc/pull/22865 updated the c-ares resolver to include query types and names in the child errors of the parent error returned by the resolver, applications can only benefit from it if they are using the [error_string](https://github.com/grpc/grpc/blob/9b215e9f90410fbe6679e47b7d5ed6f3ca76bf77/include/grpc/impl/codegen/grpc_types.h#L674) field of the `recv_status_op`. For example in C++ if the application is looking at the `debug_error_string()` field on the `ClientContext`. There's a lot of consumer code that only looks at the received `grpc::Status` object though, without looking at the  `debug_error_string()`. For these users, the message from the [parent error object](https://github.com/grpc/grpc/blob/9b215e9f90410fbe6679e47b7d5ed6f3ca76bf77/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc#L375) is basically all that is visible, since this is the only part of the full `error` object that gets plumbed into the status message.


Example error message with interop client (as logged from a grpc::Status of a failed call):

```
$ bazel-bin/test/cpp/interop/interop_client --server_host=does.not.exist --server_port=443
D0715 12:47:01.569146404  321175 test_config.cc:386]         test slowdown factor: sanitizer=1, fixture=1, poller=1, total=1
I0715 12:47:01.569325528  321175 client.cc:176]              Testing these cases: large_unary

E0715 12:47:01.940762761  321175 interop_client.cc:139]      Error status code: 14 (expected: 0), message: DNS resolution failed for service: does.not.exist:443, debug string: {"created":"@1594842421.940541550","description":"Resolver transient failure","file":"src/core/ext/filters/client_channel/resolving_lb_policy.cc","file_line":214,"referenced_errors":[{"created":"@1594842421.940538573","description":"DNS resolution failed for service: does.not.exist:443","file":"src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc","file_line":378,"grpc_status":14,"referenced_errors":[{"created":"@1594842421.940414256","description":"C-ares status is not ARES_SUCCESS qtype=AAAA name=does.not.exist is_balancer=0: Domain name not found","file":"src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc","file_line":287,"referenced_errors":[{"created":"@1594842421.940392235","description":"C-ares status is not ARES_SUCCESS qtype=A name=does.not.exist is_balancer=0: Domain name not found","file":"src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc","file_line":287}]}]}]}
```

Note the: `message: DNS resolution failed for service: does.not.exist:443`