### PR TITLE
Construct/destruct ExecCtx between init/shutdown only

### DIFF
--- a/test/core/util/port_server_client.cc
+++ b/test/core/util/port_server_client.cc
@@ -63,56 +63,57 @@ void grpc_free_port_using_server(int port) {
   grpc_httpcli_response rsp;
   freereq pr;
   char* path;
-  grpc_core::ExecCtx exec_ctx;
   grpc_closure* shutdown_closure;
 
   grpc_init();
+  {
+    grpc_core::ExecCtx exec_ctx;
 
-  pr = {};
-  memset(&req, 0, sizeof(req));
-  rsp = {};
+    pr = {};
+    memset(&req, 0, sizeof(req));
+    rsp = {};
 
-  grpc_pollset* pollset =
-      static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
-  grpc_pollset_init(pollset, &pr.mu);
-  pr.pops = grpc_polling_entity_create_from_pollset(pollset);
-  shutdown_closure = GRPC_CLOSURE_CREATE(destroy_pops_and_shutdown, &pr.pops,
-                                         grpc_schedule_on_exec_ctx);
+    grpc_pollset* pollset =
+        static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
+    grpc_pollset_init(pollset, &pr.mu);
+    pr.pops = grpc_polling_entity_create_from_pollset(pollset);
+    shutdown_closure = GRPC_CLOSURE_CREATE(destroy_pops_and_shutdown, &pr.pops,
+                                           grpc_schedule_on_exec_ctx);
 
-  req.host = const_cast<char*>(GRPC_PORT_SERVER_ADDRESS);
-  gpr_asprintf(&path, "/drop/%d", port);
-  req.http.path = path;
+    req.host = const_cast<char*>(GRPC_PORT_SERVER_ADDRESS);
+    gpr_asprintf(&path, "/drop/%d", port);
+    req.http.path = path;
 
-  grpc_httpcli_context_init(&context);
-  grpc_resource_quota* resource_quota =
-      grpc_resource_quota_create("port_server_client/free");
-  grpc_httpcli_get(&context, &pr.pops, resource_quota, &req,
-                   grpc_core::ExecCtx::Get()->Now() + 30 * GPR_MS_PER_SEC,
-                   GRPC_CLOSURE_CREATE(freed_port_from_server, &pr,
-                                       grpc_schedule_on_exec_ctx),
-                   &rsp);
-  grpc_resource_quota_unref_internal(resource_quota);
-  grpc_core::ExecCtx::Get()->Flush();
-  gpr_mu_lock(pr.mu);
-  while (!pr.done) {
-    grpc_pollset_worker* worker = nullptr;
-    if (!GRPC_LOG_IF_ERROR(
-            "pollset_work",
-            grpc_pollset_work(
-                grpc_polling_entity_pollset(&pr.pops), &worker,
-                grpc_core::ExecCtx::Get()->Now() + GPR_MS_PER_SEC))) {
-      pr.done = 1;
+    grpc_httpcli_context_init(&context);
+    grpc_resource_quota* resource_quota =
+        grpc_resource_quota_create("port_server_client/free");
+    grpc_httpcli_get(&context, &pr.pops, resource_quota, &req,
+                     grpc_core::ExecCtx::Get()->Now() + 30 * GPR_MS_PER_SEC,
+                     GRPC_CLOSURE_CREATE(freed_port_from_server, &pr,
+                                         grpc_schedule_on_exec_ctx),
+                     &rsp);
+    grpc_resource_quota_unref_internal(resource_quota);
+    grpc_core::ExecCtx::Get()->Flush();
+    gpr_mu_lock(pr.mu);
+    while (!pr.done) {
+      grpc_pollset_worker* worker = nullptr;
+      if (!GRPC_LOG_IF_ERROR(
+              "pollset_work",
+              grpc_pollset_work(
+                  grpc_polling_entity_pollset(&pr.pops), &worker,
+                  grpc_core::ExecCtx::Get()->Now() + GPR_MS_PER_SEC))) {
+        pr.done = 1;
+      }
     }
+    gpr_mu_unlock(pr.mu);
+
+    grpc_httpcli_context_destroy(&context);
+    grpc_pollset_shutdown(grpc_polling_entity_pollset(&pr.pops),
+                          shutdown_closure);
+
+    gpr_free(path);
+    grpc_http_response_destroy(&rsp);
   }
-  gpr_mu_unlock(pr.mu);
-
-  grpc_httpcli_context_destroy(&context);
-  grpc_pollset_shutdown(grpc_polling_entity_pollset(&pr.pops),
-                        shutdown_closure);
-
-  gpr_free(path);
-  grpc_http_response_destroy(&rsp);
-
   grpc_shutdown();
 }
 


### PR DESCRIPTION
ExecCtx and its TLS'es are only valid from init-to-shutdown. This was already fixed on "pick_port" but needed to be fixed on "free_port" also.
