### PR TITLE
Add --verbose to dart pub get command

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_dart/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_dart/build_interop.sh.template
@@ -16,7 +16,7 @@
   # limitations under the License.
   #
   # Builds Dart interop server and client in a base image.
-  set -e
+  set -ex
 
   mkdir -p /var/local/git
   git clone /var/local/jenkins/grpc-dart /var/local/git/grpc-dart
@@ -25,4 +25,4 @@
   cp -r /var/local/jenkins/service_account $HOME || true
 
   cd /var/local/git/grpc-dart/interop
-  /usr/lib/dart/bin/pub get
+  /usr/lib/dart/bin/pub get --verbose

--- a/tools/dockerfile/interoptest/grpc_interop_dart/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_dart/build_interop.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # Builds Dart interop server and client in a base image.
-set -e
+set -ex
 
 mkdir -p /var/local/git
 git clone /var/local/jenkins/grpc-dart /var/local/git/grpc-dart
@@ -23,4 +23,4 @@ git clone /var/local/jenkins/grpc-dart /var/local/git/grpc-dart
 cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc-dart/interop
-/usr/lib/dart/bin/pub get
+/usr/lib/dart/bin/pub get --verbose


### PR DESCRIPTION
Attempt to understand #23055 better. The current [flake failure](https://source.cloud.google.com/results/invocations/24f1555d-7ec9-4bde-835a-d161ebc217f7/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_interop_tocloud/log) doesn't give much idea why the `pub get` command failed.

Locally, running `pub get` in the `grpc-dart/interop` directory repeatedly in the `google/dart:2.7` base docker image cannot reproduce the error.