### PR TITLE
Fix ruby protoc plugin when message is in another package

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -38,13 +38,12 @@ namespace grpc_ruby_generator {
 namespace {
 
 // Prints out the method using the ruby gRPC DSL.
-void PrintMethod(const MethodDescriptor* method, const std::string& package,
-                 Printer* out) {
-  std::string input_type = RubyTypeOf(method->input_type(), package);
+void PrintMethod(const MethodDescriptor* method, Printer* out) {
+  std::string input_type = RubyTypeOf(method->input_type());
   if (method->client_streaming()) {
     input_type = "stream(" + input_type + ")";
   }
-  std::string output_type = RubyTypeOf(method->output_type(), package);
+  std::string output_type = RubyTypeOf(method->output_type());
   if (method->server_streaming()) {
     output_type = "stream(" + output_type + ")";
   }
@@ -62,8 +61,7 @@ void PrintMethod(const MethodDescriptor* method, const std::string& package,
 }
 
 // Prints out the service using the ruby gRPC DSL.
-void PrintService(const ServiceDescriptor* service, const std::string& package,
-                  Printer* out) {
+void PrintService(const ServiceDescriptor* service, Printer* out) {
   if (service->method_count() == 0) {
     return;
   }
@@ -91,7 +89,7 @@ void PrintService(const ServiceDescriptor* service, const std::string& package,
   out->Print(pkg_vars, "self.service_name = '$service_full_name$'\n");
   out->Print("\n");
   for (int i = 0; i < service->method_count(); ++i) {
-    PrintMethod(service->method(i), package, out);
+    PrintMethod(service->method(i), out);
   }
   out->Outdent();
 
@@ -201,7 +199,7 @@ std::string GetServices(const FileDescriptor* file) {
     }
     for (int i = 0; i < file->service_count(); ++i) {
       auto service = file->service(i);
-      PrintService(service, file->package(), &out);
+      PrintService(service, &out);
     }
     for (size_t i = 0; i < modules.size(); ++i) {
       out.Outdent();

--- a/src/compiler/ruby_generator_string-inl.h
+++ b/src/compiler/ruby_generator_string-inl.h
@@ -116,10 +116,9 @@ inline std::string RubyPackage(const grpc::protobuf::FileDescriptor* file) {
 }
 
 // RubyTypeOf updates a proto type to the required ruby equivalent.
-inline std::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor,
-                              const std::string& package) {
+inline std::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor) {
   std::string proto_type = descriptor->full_name();
-  ReplacePrefix(&proto_type, package,
+  ReplacePrefix(&proto_type, descriptor->file()->package(),
                 "");                    // remove the leading package if present
   ReplacePrefix(&proto_type, ".", "");  // remove the leading . (no package)
   if (descriptor->file()->options().has_ruby_package()) {

--- a/src/compiler/ruby_generator_string-inl.h
+++ b/src/compiler/ruby_generator_string-inl.h
@@ -118,10 +118,10 @@ inline std::string RubyPackage(const grpc::protobuf::FileDescriptor* file) {
 // RubyTypeOf updates a proto type to the required ruby equivalent.
 inline std::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor) {
   std::string proto_type = descriptor->full_name();
-  ReplacePrefix(&proto_type, descriptor->file()->package(),
-                "");                    // remove the leading package if present
-  ReplacePrefix(&proto_type, ".", "");  // remove the leading . (no package)
   if (descriptor->file()->options().has_ruby_package()) {
+    // remove the leading package if present
+    ReplacePrefix(&proto_type, descriptor->file()->package(), "");
+    ReplacePrefix(&proto_type, ".", "");  // remove the leading . (no package)
     proto_type = RubyPackage(descriptor->file()) + "." + proto_type;
   }
   std::string res(proto_type);

--- a/src/ruby/spec/pb/codegen/grpc/testing/package_options_import2.proto
+++ b/src/ruby/spec/pb/codegen/grpc/testing/package_options_import2.proto
@@ -1,0 +1,23 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.foo;
+
+option ruby_package = "B::Other";
+
+message Foo {
+  message Bar { }
+}

--- a/src/ruby/spec/pb/codegen/grpc/testing/package_options_ruby_style.proto
+++ b/src/ruby/spec/pb/codegen/grpc/testing/package_options_ruby_style.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package grpc.testing;
 
 import "grpc/testing/package_options_import.proto";
+import "grpc/testing/package_options_import2.proto";
 
 // For sanity checking package definitions
 option ruby_package = "RPC::Test::New::Package::Options";
@@ -34,6 +35,7 @@ message Bar {
 service AnotherTestService {
   rpc GetTest(AnotherTestRequest) returns (AnotherTestResponse) { }
   rpc OtherTest(Thing) returns (Thing) { }
+  rpc PackageTest(grpc.testing.Thing) returns (grpc.foo.Foo.Bar) { }
   rpc FooTest(Foo) returns (Foo) { }
   rpc NestedMessageTest(Foo) returns (Bar.Baz) { }
 }

--- a/src/ruby/spec/pb/codegen/package_option_spec.rb
+++ b/src/ruby/spec/pb/codegen/package_option_spec.rb
@@ -27,7 +27,9 @@ describe 'Code Generation Options' do
   end
 
   it 'should generate and respect Ruby style package options' do
-    with_protos(%w[grpc/testing/package_options_ruby_style.proto grpc/testing/package_options_import.proto]) do
+    with_protos(['grpc/testing/package_options_ruby_style.proto',
+                 'grpc/testing/package_options_import.proto',
+                 'grpc/testing/package_options_import2.proto']) do
       expect { RPC::Test::New::Package::Options::AnotherTestService::Service }.to raise_error(NameError)
       expect(require('grpc/testing/package_options_ruby_style_services_pb')).to be_truthy
       expect { RPC::Test::New::Package::Options::AnotherTestService::Service }.to_not raise_error
@@ -38,6 +40,8 @@ describe 'Code Generation Options' do
       expect(services[:GetTest].output).to eq(RPC::Test::New::Package::Options::AnotherTestResponse)
       expect(services[:OtherTest].input).to eq(A::Other::Thing)
       expect(services[:OtherTest].output).to eq(A::Other::Thing)
+      expect(services[:PackageTest].input).to eq(A::Other::Thing)
+      expect(services[:PackageTest].output).to eq(B::Other::Foo::Bar)
       expect(services[:FooTest].input).to eq(RPC::Test::New::Package::Options::Foo)
       expect(services[:FooTest].output).to eq(RPC::Test::New::Package::Options::Foo)
       expect(services[:NestedMessageTest].input).to eq(RPC::Test::New::Package::Options::Foo)


### PR DESCRIPTION
Fixes #23490 and b/161348377.

**Summary**:

Fixes an issue where the generated code is incorrect, if the message is being imported from another proto file with a _different_ proto package, _and_ the proto has a custom `option ruby_package = "..."` value.

This is a regression introduced by #22594 in the `v1.30.x` release.

**Details**:

1. In #22594, we fixed an issue with nested message. Example, let's say we have a proto message
```
package grpc.testing;
option ruby_package = "A::Other";
message Foo {
  message Bar { }
}
```
Prior to #22594, the generated code will only have `::Bar` instead of `::Foo::Bar` because we are using only `descriptor->name()` in the code generator. So for #22594, the fix's strategy is to start with `descriptor->full_name()`, which is `grpc.testing.Foo.Bar`, and then remove `package`, which is `grpc.testing`, so we end up with `Foo.Bar`, and then we can add the `option ruby_package = "..."`, and end up with `A::Other::Foo::Bar`. This is correct.

2. However, this breaks the case if the message is in a _different_ proto package. Example, let's say we now have an imported proto file:
```
package grpc.foo;
option ruby_package = "B::Other";
message Bar {
  message Baz { }
}
```
And let's say, now, we are referring to messages in this type in our original file as the fully qualified name `grpc.foo.Bar.Baz`. 

The problem is:
- we start with `descriptor->full_name()` which is `grpc.foo.Bar.Baz`
- and then we attempt to _remove_ `package` from the beginning of it. However, `package` is the main file's package, not the imported file. So we are attempting to remove `grpc.testing` from `grpc.foo.Bar.Baz`, which didn't do anything.
- and then we add the `option ruby_package = "..."`, which is `B::Other`, so we end up with `B::Other::Grpc::Foo::Bar::Baz`, which is clearly incorrect.

2b. This scenario happens to work prior to #22594 because in the case if `option ruby_package = "..."` is defined, the `descriptor->full_name()` is discarded and we _start_ with `<ruby_package>` + `descriptor->name()`, which is what we want. However, this will break if the message is a nested message, which is precisely the point of #22594.

3. So the fix is to, instead of trying to remove `package` from `descriptor->full_name()`, we should be trying to remove `descriptor->file()->package()` (i.e. the message's _own_ package name) from `descriptor->full_name()`.


4. After the fix, I realized that the `package` parameter will no longer be needed from a few helper functions, so I removed all of those arguments.


5. Also added a test to the `spec/pb/codegen` directory to specifically test both the #22594 scenario and the #23490 scenario.


6. Some quick commands to reproduce and run tests locally (this is more for my own notes):
```
$ make grpc_ruby_plugin -j8
$ make $(pwd)/libs/opt/protobuf/libprotobuf.a -j8
$ cd src/ruby
$ CONFIG=opt rake
$ cd ../..
$ CONFIG=opt tools/run_tests/helper_scripts/run_ruby_end2end_tests.sh
```

7. This fix will likely need to be backported to the `v1.30.x` branch.