### PR TITLE
Avoid unused param warning

### DIFF
--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -278,7 +278,7 @@ int TlsChannelSecurityConnector::cmp(
 
 bool TlsChannelSecurityConnector::check_call_host(
     absl::string_view host, grpc_auth_context* auth_context,
-    grpc_closure* on_call_host_checked, grpc_error** error) {
+    grpc_closure* /*on_call_host_checked*/, grpc_error** error) {
   return grpc_ssl_check_call_host(host, target_name_.c_str(),
                                   overridden_target_name_.c_str(), auth_context,
                                   error);


### PR DESCRIPTION
on a TLS closure