### PR TITLE
Remove proto_server_reflection_plugin_impl.h from build_autogenerated.yaml

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2568,7 +2568,6 @@ libs:
   public_headers:
   - include/grpc++/ext/proto_server_reflection_plugin.h
   - include/grpcpp/ext/proto_server_reflection_plugin.h
-  - include/grpcpp/ext/proto_server_reflection_plugin_impl.h
   headers:
   - src/cpp/ext/proto_server_reflection.h
   src:


### PR DESCRIPTION
Follow up of: https://github.com/grpc/grpc/pull/23471

build.autoregenerated.yaml should not have proto_server_reflection_plugin_impl.h as it is deleted. Removing it here in this PR.