### PR TITLE
Output grpc-dotnet interop apps to specific directories

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -41,4 +41,5 @@
 
   # Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
   # Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
-  dotnet build --configuration Debug Grpc.DotNet.sln -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
+  dotnet build --configuration Debug --output ./output/InteropTestsWebsite testassets/InteropTestsWebsite/InteropTestsWebsite.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
+  dotnet build --configuration Debug --output ./output/InteropTestsClient testassets/InteropTestsClient/InteropTestsClient.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -39,4 +39,5 @@ fi
 
 # Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
 # Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
-dotnet build --configuration Debug Grpc.DotNet.sln -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
+dotnet build --configuration Debug --output ./output/InteropTestsWebsite testassets/InteropTestsWebsite/InteropTestsWebsite.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
+dotnet build --configuration Debug --output ./output/InteropTestsClient testassets/InteropTestsClient/InteropTestsClient.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -190,8 +190,8 @@ class CSharpCoreCLRLanguage:
 class AspNetCoreLanguage:
 
     def __init__(self):
-        self.client_cwd = '../grpc-dotnet/testassets/InteropTestsClient/bin/Debug/netcoreapp3.0'
-        self.server_cwd = '../grpc-dotnet/testassets/InteropTestsWebsite/bin/Debug/netcoreapp3.0'
+        self.client_cwd = '../grpc-dotnet/output/InteropTestsClient'
+        self.server_cwd = '../grpc-dotnet/output/InteropTestsWebsite'
         self.safename = str(self)
 
     def cloud_to_prod_env(self):


### PR DESCRIPTION
run_interop_tests.py includes the version in the path: `../grpc-dotnet/testassets/InteropTestsClient/bin/Debug/netcoreapp3.0`. The version in the path prevents the `FrameworkVersion` from being changed in grpc-dotnet.

For example, changing InteropTestsClient's `FrameworkVersion` to net5.0 will change the output path and break the interop tests.

This PR now builds the two interop apps explicitly, and specifies an output location without a version in it.

@jtattermusch 
