### PR TITLE
Fix PHP build by adding re2 dependencies

### DIFF
--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -224,6 +224,7 @@ php_config_m4:
   - grpc
   - address_sorting
   - boringssl
+  - re2
   - z
   headers:
   - src/php/ext/grpc/byte_buffer.h

--- a/config.m4
+++ b/config.m4
@@ -894,6 +894,29 @@ if test "$PHP_GRPC" != "no"; then
     third_party/boringssl-with-bazel/src/ssl/tls13_server.cc \
     third_party/boringssl-with-bazel/src/ssl/tls_method.cc \
     third_party/boringssl-with-bazel/src/ssl/tls_record.cc \
+    third_party/re2/re2/bitstate.cc \
+    third_party/re2/re2/compile.cc \
+    third_party/re2/re2/dfa.cc \
+    third_party/re2/re2/filtered_re2.cc \
+    third_party/re2/re2/mimics_pcre.cc \
+    third_party/re2/re2/nfa.cc \
+    third_party/re2/re2/onepass.cc \
+    third_party/re2/re2/parse.cc \
+    third_party/re2/re2/perl_groups.cc \
+    third_party/re2/re2/prefilter.cc \
+    third_party/re2/re2/prefilter_tree.cc \
+    third_party/re2/re2/prog.cc \
+    third_party/re2/re2/re2.cc \
+    third_party/re2/re2/regexp.cc \
+    third_party/re2/re2/set.cc \
+    third_party/re2/re2/simplify.cc \
+    third_party/re2/re2/stringpiece.cc \
+    third_party/re2/re2/tostring.cc \
+    third_party/re2/re2/unicode_casefold.cc \
+    third_party/re2/re2/unicode_groups.cc \
+    third_party/re2/util/pcre.cc \
+    third_party/re2/util/rune.cc \
+    third_party/re2/util/strutil.cc \
     third_party/upb/upb/decode.c \
     third_party/upb/upb/def.c \
     third_party/upb/upb/encode.c \
@@ -1068,5 +1091,7 @@ if test "$PHP_GRPC" != "no"; then
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl-with-bazel/src/crypto/x509)
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl-with-bazel/src/crypto/x509v3)
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl-with-bazel/src/ssl)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/re2/re2)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/re2/util)
   PHP_ADD_BUILD_DIR($ext_builddir/third_party/upb/upb)
 fi

--- a/config.w32
+++ b/config.w32
@@ -862,6 +862,29 @@ if (PHP_GRPC != "no") {
     "third_party\\boringssl-with-bazel\\src\\ssl\\tls13_server.cc " +
     "third_party\\boringssl-with-bazel\\src\\ssl\\tls_method.cc " +
     "third_party\\boringssl-with-bazel\\src\\ssl\\tls_record.cc " +
+    "third_party\\re2\\re2\\bitstate.cc " +
+    "third_party\\re2\\re2\\compile.cc " +
+    "third_party\\re2\\re2\\dfa.cc " +
+    "third_party\\re2\\re2\\filtered_re2.cc " +
+    "third_party\\re2\\re2\\mimics_pcre.cc " +
+    "third_party\\re2\\re2\\nfa.cc " +
+    "third_party\\re2\\re2\\onepass.cc " +
+    "third_party\\re2\\re2\\parse.cc " +
+    "third_party\\re2\\re2\\perl_groups.cc " +
+    "third_party\\re2\\re2\\prefilter.cc " +
+    "third_party\\re2\\re2\\prefilter_tree.cc " +
+    "third_party\\re2\\re2\\prog.cc " +
+    "third_party\\re2\\re2\\re2.cc " +
+    "third_party\\re2\\re2\\regexp.cc " +
+    "third_party\\re2\\re2\\set.cc " +
+    "third_party\\re2\\re2\\simplify.cc " +
+    "third_party\\re2\\re2\\stringpiece.cc " +
+    "third_party\\re2\\re2\\tostring.cc " +
+    "third_party\\re2\\re2\\unicode_casefold.cc " +
+    "third_party\\re2\\re2\\unicode_groups.cc " +
+    "third_party\\re2\\util\\pcre.cc " +
+    "third_party\\re2\\util\\rune.cc " +
+    "third_party\\re2\\util\\strutil.cc " +
     "third_party\\upb\\upb\\decode.c " +
     "third_party\\upb\\upb\\def.c " +
     "third_party\\upb\\upb\\encode.c " +
@@ -1107,6 +1130,9 @@ if (PHP_GRPC != "no") {
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\boringssl-with-bazel\\src\\crypto\\x509");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\boringssl-with-bazel\\src\\crypto\\x509v3");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\boringssl-with-bazel\\src\\ssl");
+  FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\re2");
+  FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\re2\\re2");
+  FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\re2\\util");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\upb");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\upb\\upb");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\third_party\\zlib");

--- a/package.xml
+++ b/package.xml
@@ -1717,6 +1717,55 @@
     <file baseinstalldir="/" name="third_party/boringssl-with-bazel/src/third_party/fiat/curve25519_64.h" role="src" />
     <file baseinstalldir="/" name="third_party/boringssl-with-bazel/src/third_party/fiat/p256_32.h" role="src" />
     <file baseinstalldir="/" name="third_party/boringssl-with-bazel/src/third_party/fiat/p256_64.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/bitmap256.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/bitstate.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/compile.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/dfa.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/filtered_re2.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/filtered_re2.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/mimics_pcre.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/nfa.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/onepass.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/parse.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/perl_groups.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/pod_array.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/prefilter.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/prefilter.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/prefilter_tree.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/prefilter_tree.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/prog.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/prog.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/re2.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/re2.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/regexp.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/regexp.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/set.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/set.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/simplify.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/sparse_array.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/sparse_set.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/stringpiece.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/stringpiece.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/tostring.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/unicode_casefold.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/unicode_casefold.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/unicode_groups.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/unicode_groups.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/re2/walker-inl.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/benchmark.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/flags.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/logging.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/malloc_counter.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/mix.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/mutex.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/pcre.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/pcre.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/rune.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/strutil.cc" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/strutil.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/test.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/utf.h" role="src" />
+    <file baseinstalldir="/" name="third_party/re2/util/util.h" role="src" />
     <file baseinstalldir="/" name="third_party/upb/upb/decode.c" role="src" />
     <file baseinstalldir="/" name="third_party/upb/upb/decode.h" role="src" />
     <file baseinstalldir="/" name="third_party/upb/upb/def.c" role="src" />


### PR DESCRIPTION
The PHP extension build has been broken since #21941 is merged (see details of investigation in #23307). #21941 is going to be reverted in #23524 soon so I was trying to make sure the PHP extension will build successfully. I ran into a new issue where apparently `re2` was recently added as a dependency - so I need to add those to the PHP extension build as well.

This PR, together with #23524, should fix the PHP build. I am going to run more tests.

`build_handwritten.yaml` is the only manual change in this PR. The other 3 files are updated by `generate_projects.sh`.

cc @srini100 