### PR TITLE
Fix php build from source

### DIFF
--- a/src/php/docker/grpc-src/Dockerfile
+++ b/src/php/docker/grpc-src/Dockerfile
@@ -32,13 +32,13 @@ WORKDIR /github/grpc
 
 COPY . .
 
-RUN make && make install
+RUN make shared_c static_c
 
 
 WORKDIR /github/grpc/src/php/ext/grpc
 
 RUN phpize && \
-  ./configure --enable-tests && \
+  GRPC_LIB_SUBDIR=libs/opt ./configure --enable-grpc=/github/grpc --enable-tests && \
   make && \
   make install
 

--- a/templates/src/php/docker/grpc-src/Dockerfile.template
+++ b/templates/src/php/docker/grpc-src/Dockerfile.template
@@ -31,13 +31,13 @@
 
   COPY . .
 
-  RUN make && make install
+  RUN make shared_c static_c
 
 
   WORKDIR /github/grpc/src/php/ext/grpc
 
   RUN phpize && ${'\\'}
-    ./configure --enable-tests && ${'\\'}
+    GRPC_LIB_SUBDIR=libs/opt ./configure --enable-grpc=/github/grpc --enable-tests && ${'\\'}
     make && ${'\\'}
     make install
 


### PR DESCRIPTION
A similar fix to #23412, specifically https://github.com/grpc/grpc/pull/23412/files#diff-4099b6d08c78f83a44ad7e3583aa60fa, now that `make install` has gone away.

With this PR, plus #23526, plus #23524, I verified that I can run `src/php/bin/build_all_docker_images.sh` to completion successfully.