### PR TITLE
Update PHP artifact test

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -286,7 +286,7 @@ class PHPArtifact:
     def build_jobspec(self):
         return create_docker_jobspec(
             self.name,
-            'tools/dockerfile/grpc_artifact_centos6_{}'.format(self.arch),
+            'tools/dockerfile/test/php73_zts_stretch_{}'.format(self.arch),
             'tools/run_tests/artifacts/build_artifact_php.sh')
 
 

--- a/tools/run_tests/artifacts/build_artifact_php.sh
+++ b/tools/run_tests/artifacts/build_artifact_php.sh
@@ -19,11 +19,14 @@ cd "$(dirname "$0")/../../.."
 
 mkdir -p "${ARTIFACTS_OUT}"
 
-# build the PHP extension archive (this just zips all the files up)
+# Build the PHP extension archive (this just zips all the files up)
 pear package
-# test installing the PHP extension via pecl install
+# Note: the extension compiled by this step is not being used in any
+# way, i.e. they are not the pacakge being distributed.
+# This is done here to get an early signal for compiling the PHP
+# extension in some form.
 find . -name "grpc-*.tgz" | cut -b3- | xargs pecl install
-# verified that the grpc extension is installed
+# Verified that the grpc extension is built properly.
 php -d extension=grpc.so --re grpc | head -1
 
 cp -r grpc-*.tgz "${ARTIFACTS_OUT}"/

--- a/tools/run_tests/artifacts/build_artifact_php.sh
+++ b/tools/run_tests/artifacts/build_artifact_php.sh
@@ -19,6 +19,11 @@ cd "$(dirname "$0")/../../.."
 
 mkdir -p "${ARTIFACTS_OUT}"
 
+# build the PHP extension archive (this just zips all the files up)
 pear package
+# test installing the PHP extension via pecl install
+find . -name "grpc-*.tgz" | cut -b3- | xargs pecl install
+# verified that the grpc extension is installed
+php -d extension=grpc.so --re grpc | head -1
 
 cp -r grpc-*.tgz "${ARTIFACTS_OUT}"/


### PR DESCRIPTION
Background 1: there had been a few recent breakages to the PHP extension (e.g. #23307, #23526), only to be discovered after a PR is merged to `master`. So let's try to add the PHP extension build to part of the ~49 tests suite that we ran per pull request.

Background 2: There are 2 parts to building and compiling the PHP extension. First is to run `pear package` - but this only zips up all the relevant files into a `tgz` archive and does nothing else. Second step is to run `pecl install <said>.tgz` - this steps compiles the source files into the `grpc.so` extension.

The first step is included in the [artifacts](https://github.com/grpc/grpc/blob/master/tools/run_tests/artifacts/build_artifact_php.sh#L22) test, while the second step is included in the [distribtest](https://github.com/grpc/grpc/blob/master/test/distrib/php/run_distrib_test.sh#L22-L23).

However, only the first step is being regularly run per pull request, in the "Artifact Build Linux" kokoro test suite. The second step is only run at `master` as "Distribution Tests Linux" are only run as "standalone subset" per pull request. There are also the `grpc_build_artifact_multiplatform` job that will execute the "artifact -> package -> distribtest" in 3 stages, but that's only run before each release.


So the fix here is to also do the second step, `pecl install` in the "Artifact Build Linux" kokoro test suite, as one can argue that doing only `pear package` to zip up all the files in a .tgz archive is rather pointless. This should weed out a big category of breakages that potentially affect PHP. 