### PR TITLE
Added call to grpc::testing::TestEnvironment in tests

### DIFF
--- a/test/core/compression/compression_test.cc
+++ b/test/core/compression/compression_test.cc
@@ -335,7 +335,8 @@ static void test_channel_args_compression_algorithm_states(void) {
   grpc_channel_args_destroy(ch_args);
 }
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
   test_compression_algorithm_parse();
   test_compression_algorithm_name();
@@ -344,6 +345,5 @@ int main(int /*argc*/, char** /*argv*/) {
   test_channel_args_set_compression_algorithm();
   test_channel_args_compression_algorithm_states();
   grpc_shutdown();
-
   return 0;
 }

--- a/test/core/security/grpc_tls_credentials_options_test.cc
+++ b/test/core/security/grpc_tls_credentials_options_test.cc
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 
 #include "src/core/lib/iomgr/load_file.h"
+#include "test/core/util/test_config.h"
 
 #define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
 #define SERVER_CERT_PATH "src/core/tsi/test_creds/server1.pem"
@@ -92,6 +93,7 @@ TEST(GrpcTlsCredentialsOptionsTest, ErrorDetails) {
 }  // namespace testing
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
   int ret = RUN_ALL_TESTS();


### PR DESCRIPTION
This is to make some of tests more robust by using grpc::testing::TestEnvironment which waits until gRPC is fully shutdown at the end of the test, which MSAN test particularly is interested in when running with Abseil.

Without this, #23372 cannot pass the MSAN tests.