### PR TITLE
increase timeout for PHP distribtests

### DIFF
--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -243,6 +243,7 @@ class PHPDistribTest(object):
             return create_jobspec(
                 self.name, ['test/distrib/php/run_distrib_test_macos.sh'],
                 environ={'EXTERNAL_GIT_ROOT': '../../../..'},
+                timeout_seconds=15 * 60,
                 use_workspace=True)
         else:
             raise Exception("Not supported yet.")


### PR DESCRIPTION
Should fix b/161704453.

I noticed that the PHP distribtest fail when they cross 10min runtime which has recently started happening.
Increasing the timeout on Mac from 10min to 15min should fix the problem.