### PR TITLE
Include re2 in source wheel && solve the missing --all complain

### DIFF
--- a/PYTHON-MANIFEST.in
+++ b/PYTHON-MANIFEST.in
@@ -8,6 +8,7 @@ graft third_party/abseil-cpp/absl
 graft third_party/address_sorting
 graft third_party/boringssl-with-bazel
 graft third_party/cares
+graft third_party/re2
 graft third_party/upb
 graft third_party/zlib
 include src/python/grpcio/_parallel_compile_patch.py

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -298,7 +298,9 @@ class Clean(setuptools.Command):
     """Command to clean build artifacts."""
 
     description = 'Clean build artifacts.'
-    user_options = []
+    user_options = [
+        ('all', 'a', 'a phony flag to allow our script to continue'),
+    ]
 
     _FILE_PATTERNS = (
         'python_build',
@@ -311,7 +313,7 @@ class Clean(setuptools.Command):
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../.."))
 
     def initialize_options(self):
-        pass
+        self.all = False
 
     def finalize_options(self):
         pass


### PR DESCRIPTION
Related: https://github.com/grpc/grpc/issues/23461 https://github.com/grpc/grpc/pull/22987

Error log: https://source.cloud.google.com/results/invocations/be9ce4b7-f2f8-4f63-8ee9-975c12915e4a/targets/github%2Fgrpc/tests

With help from Jan, I find the source installation or `python_dev` distribtest is failing due to missing a third_party dependency. This PR adds that into our MANIFEST. Manually tested with `debian:jessie` Docker image, and the fix worked.

Let's see if the full suite of distribtests is happy:
* ~~http://sponge/cc49b479-005c-46cd-8f96-90423adf034f~~ Failed due to Kokoro unable to start a child job
* ~~http://sponge/0ef14d0b-dc09-4775-9c79-3c1320f69a79~~ Failed due to upb error???
* http://sponge/562a4bbb-74e8-482c-a9cf-377912d63c68

CC @jtattermusch 