### PR TITLE
Create stub version of CEL Activation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1861,6 +1861,8 @@ grpc_cc_library(
     ],
     hdrs = [
         "src/core/lib/security/authorization/authorization_engine.h",
+        "src/core/lib/security/authorization/mock_cel/activation.h",
+        "src/core/lib/security/authorization/mock_cel/cel_value.h",
     ],
     language = "c++",
     deps = [

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4779,6 +4779,8 @@ targets:
   language: c++
   headers:
   - src/core/lib/security/authorization/authorization_engine.h
+  - src/core/lib/security/authorization/mock_cel/activation.h
+  - src/core/lib/security/authorization/mock_cel/cel_value.h
   src:
   - src/core/lib/security/authorization/authorization_engine.cc
   - test/core/security/authorization_engine_test.cc

--- a/src/core/lib/security/authorization/mock_cel/activation.h
+++ b/src/core/lib/security/authorization/mock_cel/activation.h
@@ -1,0 +1,61 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_CORE_LIB_SECURITY_AUTHORIZATION_MOCK_CEL_ACTIVATION_H
+#define GRPC_CORE_LIB_SECURITY_AUTHORIZATION_MOCK_CEL_ACTIVATION_H
+
+#include <grpc/support/port_platform.h>
+
+#include "absl/strings/string_view.h"
+
+#include "src/core/lib/security/authorization/mock_cel/cel_value.h"
+
+namespace google {
+namespace api {
+namespace expr {
+namespace runtime {
+
+// Base class for an activation. This is a temporary stub implementation of CEL
+// APIs. Once gRPC imports the CEL library, this class will be removed.
+class BaseActivation {
+ public:
+  BaseActivation() = default;
+
+  // Non-copyable/non-assignable
+  BaseActivation(const BaseActivation&) = delete;
+  BaseActivation& operator=(const BaseActivation&) = delete;
+};
+
+// Instance of Activation class is used by evaluator.
+// It provides binding between references used in expressions
+// and actual values. This is a temporary stub implementation of CEL APIs.
+// Once gRPC imports the CEL library, this class will be removed.
+class Activation : public BaseActivation {
+ public:
+  Activation() = default;
+
+  // Non-copyable/non-assignable
+  Activation(const Activation&) = delete;
+  Activation& operator=(const Activation&) = delete;
+
+  // Insert value into Activation.
+  void InsertValue(absl::string_view name, const CelValue& value) {}
+};
+
+}  // namespace runtime
+}  // namespace expr
+}  // namespace api
+}  // namespace google
+
+#endif  // GRPC_CORE_LIB_SECURITY_AUTHORIZATION_MOCK_CEL_ACTIVATION_H

--- a/src/core/lib/security/authorization/mock_cel/cel_value.h
+++ b/src/core/lib/security/authorization/mock_cel/cel_value.h
@@ -1,0 +1,83 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_CORE_LIB_SECURITY_AUTHORIZATION_MOCK_CEL_CEL_VALUE_H
+#define GRPC_CORE_LIB_SECURITY_AUTHORIZATION_MOCK_CEL_CEL_VALUE_H
+
+// CelValue is a holder, capable of storing all kinds of data
+// supported by CEL.
+// CelValue defines explicitly typed/named getters/setters.
+// When storing pointers to objects, CelValue does not accept ownership
+// to them and does not control their lifecycle. Instead objects are expected
+// to be either external to expression evaluation, and controlled beyond the
+// scope or to be allocated and associated with some allocation/ownership
+// controller (Arena).
+// Usage examples:
+// (a) For primitive types:
+//    CelValue value = CelValue::CreateInt64(1);
+// (b) For string:
+//    std::string* msg("test");
+//    CelValue value = CelValue::CreateString(msg);
+
+#include <grpc/support/port_platform.h>
+
+#include "absl/strings/string_view.h"
+
+namespace google {
+namespace api {
+namespace expr {
+namespace runtime {
+
+// Break cyclic depdendencies for container types.
+class CelMap;
+
+// This is a temporary stub implementation of CEL APIs.
+// Once gRPC imports the CEL library, this class will be removed.
+class CelValue {
+ public:
+  // Default constructor.
+  // Creates CelValue with null data type.
+  CelValue() : CelValue(nullptr) {}
+
+  // We will use factory methods instead of public constructors
+  // The reason for this is the high risk of implicit type conversions
+  // between bool/int/pointer types.
+  // We rely on copy elision to avoid extra copying.
+  static CelValue CreateNull() { return CelValue(nullptr); }
+
+  static CelValue CreateInt64(int64_t value) { return CreateNull(); }
+
+  static CelValue CreateUint64(uint64_t value) { return CreateNull(); }
+
+  static CelValue CreateStringView(absl::string_view value) {
+    return CreateNull();
+  }
+
+  static CelValue CreateString(const std::string* str) { return CreateNull(); }
+
+  static CelValue CreateMap(const CelMap* value) { return CreateNull(); }
+
+ private:
+  // Constructs CelValue wrapping value supplied as argument.
+  // Value type T should be supported by specification of ValueHolder.
+  template <class T>
+  explicit CelValue(T value) {}
+};
+
+}  // namespace runtime
+}  // namespace expr
+}  // namespace api
+}  // namespace google
+
+#endif  // GRPC_CORE_LIB_SECURITY_AUTHORIZATION_MOCK_CEL_CEL_VALUE_H


### PR DESCRIPTION
This pull request implements a stub version of the CEL Activation class. The Activation class herein has the same public API as the version in CEL, but all of its member functions return empty or default values. This stub is intended to aid in building and testing a CEL Evaluation Engine for authorization. 


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->
