### PR TITLE
[Aio] Support tuple and aio.Metadata interaction

### DIFF
--- a/src/python/grpcio/grpc/experimental/aio/_metadata.py
+++ b/src/python/grpcio/grpc/experimental/aio/_metadata.py
@@ -101,10 +101,18 @@ class Metadata(abc.Mapping):
         return key in self._metadata
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, self.__class__):
-            return NotImplemented  # pytype: disable=bad-return-type
+        if isinstance(other, self.__class__):
+            return self._metadata == other._metadata
+        if isinstance(other, tuple):
+            return tuple(self) == other
+        return NotImplemented  # pytype: disable=bad-return-type
 
-        return self._metadata == other._metadata
+    def __add__(self, other: Any) -> bool:
+        if isinstance(other, self.__class__):
+            return Metadata(*(tuple(self) + tuple(other)))
+        if isinstance(other, tuple):
+            return Metadata(*(tuple(self) + other))
+        return NotImplemented  # pytype: disable=bad-return-type
 
     def __repr__(self) -> str:
         view = tuple(self)

--- a/src/python/grpcio/grpc/experimental/aio/_metadata.py
+++ b/src/python/grpcio/grpc/experimental/aio/_metadata.py
@@ -107,7 +107,7 @@ class Metadata(abc.Mapping):
             return tuple(self) == other
         return NotImplemented  # pytype: disable=bad-return-type
 
-    def __add__(self, other: Any) -> bool:
+    def __add__(self, other: Any) -> Metadata:
         if isinstance(other, self.__class__):
             return Metadata(*(tuple(self) + tuple(other)))
         if isinstance(other, tuple):

--- a/src/python/grpcio/grpc/experimental/aio/_metadata.py
+++ b/src/python/grpcio/grpc/experimental/aio/_metadata.py
@@ -107,7 +107,7 @@ class Metadata(abc.Mapping):
             return tuple(self) == other
         return NotImplemented  # pytype: disable=bad-return-type
 
-    def __add__(self, other: Any) -> Metadata:
+    def __add__(self, other: Any) -> 'Metadata':
         if isinstance(other, self.__class__):
             return Metadata(*(tuple(self) + tuple(other)))
         if isinstance(other, tuple):

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -281,6 +281,16 @@ class TestMetadata(AioTestBase):
         self.assertEqual(_TRAILING_METADATA, await call.trailing_metadata())
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 
+    async def test_compatibility_with_tuple(self):
+        metadata_obj = aio.Metadata(('key', 42), ('key-2', 'value'))
+        self.assertEqual(metadata_obj, tuple(metadata_obj))
+        self.assertEqual(tuple(metadata_obj), metadata_obj)
+
+        expected_sum = tuple(metadata_obj) + (('third', 3),)
+        self.assertEqual(expected_sum, metadata_obj + (('third', 3),))
+        self.assertEqual(expected_sum, metadata_obj + aio.Metadata(
+            ('third', 3)))
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/metadata_test.py
@@ -282,14 +282,14 @@ class TestMetadata(AioTestBase):
         self.assertEqual(grpc.StatusCode.OK, await call.code())
 
     async def test_compatibility_with_tuple(self):
-        metadata_obj = aio.Metadata(('key', 42), ('key-2', 'value'))
+        metadata_obj = aio.Metadata(('key', '42'), ('key-2', 'value'))
         self.assertEqual(metadata_obj, tuple(metadata_obj))
         self.assertEqual(tuple(metadata_obj), metadata_obj)
 
-        expected_sum = tuple(metadata_obj) + (('third', 3),)
-        self.assertEqual(expected_sum, metadata_obj + (('third', 3),))
+        expected_sum = tuple(metadata_obj) + (('third', '3'),)
+        self.assertEqual(expected_sum, metadata_obj + (('third', '3'),))
         self.assertEqual(expected_sum, metadata_obj + aio.Metadata(
-            ('third', 3)))
+            ('third', '3')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc/issues/23554

`aio.Metadata` is introduced to ease the modification of gRPC metadata. In the past, we only accept tuple-in-tuple data structure, so many unit tests implicitly expect it to have tuple interfaces. This PR tries to make `aio.Metadata` compatible with `tuple`. Suggestions are welcomed.