### PR TITLE
Explicitly fake the status for when we cancel the streams 

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2095,6 +2095,7 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
   }
   if (due_to_error != GRPC_ERROR_NONE && !s->seen_error) {
     s->seen_error = true;
+    grpc_chttp2_fake_status(t, s, GRPC_ERROR_REF(due_to_error));
   }
   grpc_chttp2_mark_stream_closed(t, s, 1, 1, due_to_error);
 }

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2095,6 +2095,10 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
   }
   if (due_to_error != GRPC_ERROR_NONE && !s->seen_error) {
     s->seen_error = true;
+    /* We are setting the fake status here instead of in
+     * grpc_chttp2_mark_stream_closed to handle the case where the stream is
+     * read and write closed, but not all callbacks have been made possibly due
+     * to pending data. */
     grpc_chttp2_fake_status(t, s, GRPC_ERROR_REF(due_to_error));
   }
   grpc_chttp2_mark_stream_closed(t, s, 1, 1, due_to_error);


### PR DESCRIPTION
Explicitly fake the status for when we cancel the streams. (Explanation in the issue.)

Fix #23559

Edit :
The updated method of doing this is to simply do this in grpc_chttp2_mark_stream_closed. So, if there are future paths where we call grpc_chttp2_mark_stream_closed when the stream is both read and write closed, we would cover that case. The current cases of grpc_chttp2_mark_stream_closed with an error seem to be called when the stream is either read or write open (other than grpc_chttp2_cancel_stream ofcourse, which can be called even after the stream is read and write closed). 

@sheenaqotj and I looked over call sites of grpc_chttp2_mark_stream_closed and made sure that this change seems ok logically.