### PR TITLE
Stop stripping .hpp files from python source packages

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -52,7 +52,7 @@ clean_non_source_files() {
   find . -type f \
     | grep -v '\.c$' | grep -v '\.cc$' | grep -v '\.cpp$' \
     | grep -v '\.h$' | grep -v '\.hh$' | grep -v '\.inc$' \
-    | grep -v '\.s$' | grep -v '\.py$' \
+    | grep -v '\.s$' | grep -v '\.py$' | grep -v '\.hpp$' \
     | while read -r file; do
       rm -f "$file" || true
     done


### PR DESCRIPTION
Fixes the python-dev distribtest failure that was originally introduced by https://github.com/grpc/grpc/pull/21905.

progress toward fixing #23461 (together with https://github.com/grpc/grpc/pull/23552 it should fix it).

I've done my experiments in https://github.com/grpc/grpc/pull/23563 and then brought the actual fix to a separate clean PR.