### PR TITLE
PHP: avoid destroy channel more than once

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -50,7 +50,7 @@ extern HashTable grpc_persistent_list;
 extern HashTable grpc_target_upper_bound_map;
 
 void free_grpc_channel_wrapper(grpc_channel_wrapper* channel, bool free_channel) {
-  if (free_channel) {
+  if (free_channel && channel->wrapped) {
     grpc_channel_destroy(channel->wrapped);
     channel->wrapped = NULL;
   }

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -159,6 +159,7 @@ void destroy_grpc_channels() {
     wrapped_channel.wrapper = le->channel;
     grpc_channel_wrapper *channel = wrapped_channel.wrapper;
     grpc_channel_destroy(channel->wrapped);
+    channel->wrapped = NULL;
   PHP_GRPC_HASH_FOREACH_END()
 }
 


### PR DESCRIPTION
This is a fix of #23477.
To verify this fix without fpm, we could change node-server to its IP address and add the following lines in echo/client.php. 

diff --git a/examples/php/echo/client.php b/examples/php/echo/client.php
index b482992871..c5db7bd6e0 100644
--- a/examples/php/echo/client.php
+++ b/examples/php/echo/client.php
@@ -19,7 +19,8 @@
 
 require dirname(__FILE__).'/vendor/autoload.php';
 
-$client = new Grpc\Gateway\Testing\EchoServiceClient('node-server:9090', [
+
+$client = new Grpc\Gateway\Testing\EchoServiceClient('172.17.0.3:9090', [
     'credentials' => Grpc\ChannelCredentials::createInsecure(),
 ]);
 
@@ -43,3 +44,14 @@ $responses = $client->ServerStreamingEcho($stream_request)->responses();
 foreach ($responses as $response) {
     echo $response->getMessage()."\n";
 }
+
+
+$client->close();
+
+$ret = 0;
+$out = [];
+exec("uname", $out, $ret);
+var_dump($out, $ret);


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
