### PR TITLE
Uses sources.json from BoringSSL

### DIFF
--- a/src/boringssl/gen_build_yaml.py
+++ b/src/boringssl/gen_build_yaml.py
@@ -30,7 +30,7 @@ def map_dir(filename):
 
 
 class Grpc(object):
-    """ Adapter for boring-SSL json sources files. """
+    """Adapter for boring-SSL json sources files. """
 
     def __init__(self, sources):
         self.yaml = None

--- a/src/boringssl/gen_build_yaml.py
+++ b/src/boringssl/gen_build_yaml.py
@@ -13,24 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-import shutil
-import sys
+import json
 import os
+import sys
 import yaml
 
-sys.dont_write_bytecode = True
-
-boring_ssl_root = os.path.abspath(
+sources_path = os.path.abspath(
     os.path.join(os.path.dirname(sys.argv[0]),
-                 '../../third_party/boringssl-with-bazel/src'))
-sys.path.append(os.path.join(boring_ssl_root, 'util'))
-
-try:
-    import generate_build_files
-except ImportError:
-    print(yaml.dump({}))
-    sys.exit()
+                 '../../third_party/boringssl-with-bazel/sources.json'))
+with open(sources_path, 'r') as s:
+    sources = json.load(s)
 
 
 def map_dir(filename):
@@ -38,18 +30,19 @@ def map_dir(filename):
 
 
 class Grpc(object):
-    """Implements a "platform" in the sense of boringssl's generate_build_files.py"""
-    yaml = None
+    """ Adapter for boring-SSL json sources files. """
 
-    def WriteFiles(self, files, asm_outputs):
+    def __init__(self, sources):
+        self.yaml = None
+        self.WriteFiles(sources)
+
+    def WriteFiles(self, files):
         test_binaries = ['ssl_test', 'crypto_test']
-
         self.yaml = {
             '#':
                 'generated with src/boringssl/gen_build_yaml.py',
             'raw_boringssl_build_output_for_debugging': {
                 'files': files,
-                'asm_outputs': asm_outputs,
             },
             'libs': [
                 {
@@ -120,29 +113,5 @@ class Grpc(object):
         }
 
 
-os.chdir(os.path.dirname(sys.argv[0]))
-os.mkdir('src')
-try:
-    for f in os.listdir(boring_ssl_root):
-        os.symlink(os.path.join(boring_ssl_root, f), os.path.join('src', f))
-
-    grpc_platform = Grpc()
-    # We use a hack to run boringssl's util/generate_build_files.py as part of this script.
-    # The call will populate "grpc_platform" with boringssl's source file metadata.
-    # As a side effect this script generates err_data.c and crypto_test_data.cc (requires golang)
-    # Both of these files are already available under third_party/boringssl-with-bazel
-    # so we don't need to generate them again, but there's no option to disable that behavior.
-    # - crypto_test_data.cc is required to run boringssl_crypto_test but we already
-    #   use the copy under third_party/boringssl-with-bazel so we just delete it
-    # - err_data.c is already under third_party/boringssl-with-bazel so we just delete it
-    generate_build_files.main([grpc_platform])
-
-    print(yaml.dump(grpc_platform.yaml))
-
-finally:
-    # we don't want err_data.c and crypto_test_data.cc (see comment above)
-    if os.path.exists('err_data.c'):
-        os.remove('err_data.c')
-    if os.path.exists('crypto_test_data.cc'):
-        os.remove('crypto_test_data.cc')
-    shutil.rmtree('src')
+grpc_platform = Grpc(sources)
+print(yaml.dump(grpc_platform.yaml))


### PR DESCRIPTION
This change undoes some hackiness that relied
on specifics of the BoringSSL build system to
generate source files. With the latest github
mirror of BoringSSL exports a sources.json
that lists all source code files. This change
makes use of that file.

I ran "./tools/buildgen/generate_projects.sh" and no changes are
generated with this change.

@lidizheng @jtattermusch 
