### PR TITLE
Return blank span if no call is active.

### DIFF
--- a/src/cpp/ext/filters/census/grpc_plugin.cc
+++ b/src/cpp/ext/filters/census/grpc_plugin.cc
@@ -57,6 +57,8 @@ void RegisterOpenCensusPlugin() {
 
 ::opencensus::trace::Span GetSpanFromServerContext(
     grpc::ServerContext* context) {
+  if (context == nullptr) return opencensus::trace::Span::BlankSpan();
+
   return reinterpret_cast<const grpc::CensusContext*>(context->census_context())
       ->Span();
 }

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -367,7 +367,7 @@ std::string ServerContextBase::peer() const {
 }
 
 const struct census_context* ServerContextBase::census_context() const {
-  return grpc_census_call_get_context(call_);
+  return call_ == nullptr ? nullptr : grpc_census_call_get_context(call_);
 }
 
 void ServerContextBase::SetLoadReportingCosts(


### PR DESCRIPTION
Otherwise unit tests of gRPC servers that call GetSpanFromServerContext
segfault.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
