### PR TITLE
Add a consistency check on version and core_version

### DIFF
--- a/tools/run_tests/sanity/check_version.sh
+++ b/tools/run_tests/sanity/check_version.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+
+buildfile=BUILD
+yamlfile=build_handwritten.yaml
+status=0
+
+function check_key() {
+    key=$1
+    build=$(grep "^$key =" < $buildfile | awk -F\" '{print $2}')
+    yaml=$(grep "^ *${key}:" < $yamlfile | head -1 | awk '{print $2}')
+
+    if [ x"$build" = x ] ; then
+        echo $key not defined in $buildfile
+        status=1
+    fi
+
+    if [ x"$yaml" = x ] ; then
+        echo $key not defined in $yamlfile
+        status=1
+    fi
+
+    if [ x"$build" != x -a x"$yaml" != x -a "$build" != "$yaml" ] ; then
+        echo $key mismatch between $buildfile "($build)" and $yamlfile "($yaml)"
+        status=1
+    fi
+}
+
+check_key core_version
+check_key version
+
+exit $status

--- a/tools/run_tests/sanity/check_version.sh
+++ b/tools/run_tests/sanity/check_version.sh
@@ -21,23 +21,23 @@ buildfile=BUILD
 yamlfile=build_handwritten.yaml
 status=0
 
-function check_key() {
+check_key () {
     key=$1
     build=$(grep "^$key =" < $buildfile | awk -F\" '{print $2}')
     yaml=$(grep "^ *${key}:" < $yamlfile | head -1 | awk '{print $2}')
 
     if [ x"$build" = x ] ; then
-        echo $key not defined in $buildfile
+        echo "$key not defined in $buildfile"
         status=1
     fi
 
     if [ x"$yaml" = x ] ; then
-        echo $key not defined in $yamlfile
+        echo "$key not defined in $yamlfile"
         status=1
     fi
 
-    if [ x"$build" != x -a x"$yaml" != x -a "$build" != "$yaml" ] ; then
-        echo $key mismatch between $buildfile "($build)" and $yamlfile "($yaml)"
+    if [ x"$build" != x"$yaml" ] ; then
+        echo "$key mismatch between $buildfile ($build) and $yamlfile ($yaml)"
         status=1
     fi
 }

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -11,6 +11,7 @@
 - script: tools/run_tests/sanity/check_submodules.sh
 - script: tools/run_tests/sanity/check_test_filtering.py
 - script: tools/run_tests/sanity/check_tracer_sanity.py
+- script: tools/run_tests/sanity/check_version.sh
 - script: tools/run_tests/sanity/core_banned_functions.py
 - script: tools/run_tests/sanity/core_untyped_structs.sh
 - script: tools/run_tests/sanity/cpp_banned_constructs.sh


### PR DESCRIPTION
Fixes chance of misconfiguring versions between BUILD and build_handwritten.yaml as introduced in #22991 and fixed in #23576

Although there will eventually be a single source-of-truth for information and build_handwritten.yaml will be deprecated, we need a consistency check in the meanwhile.
