### PR TITLE
Disable TLS 1.3 in the C-core.

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1894,8 +1894,11 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 #else
   ssl_context = SSL_CTX_new(TLSv1_2_method());
 #endif
+  // TODO(mattstev): Re-enable TLS 1.3 by using |options.min_tls_version| and
+  // |options.max_tls_version|, rather than hardcoding in TLS 1.2 as the min and
+  // max.
   result = tsi_set_min_and_max_tls_versions(
-      ssl_context, options->min_tls_version, options->max_tls_version);
+      ssl_context, tsi_tls_version::TSI_TLS1_2, tsi_tls_version::TSI_TLS1_2);
   if (result != TSI_OK) return result;
   if (ssl_context == nullptr) {
     gpr_log(GPR_ERROR, "Could not create ssl context.");
@@ -2061,9 +2064,12 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 #else
       impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
 #endif
+      // TODO(mattstev): Re-enable TLS 1.3 by using |options.min_tls_version|
+      // and |options.max_tls_version|, rather than hardcoding in TLS 1.2 as the
+      // min and max.
       result = tsi_set_min_and_max_tls_versions(impl->ssl_contexts[i],
-                                                options->min_tls_version,
-                                                options->max_tls_version);
+                                                tsi_tls_version::TSI_TLS1_2,
+                                                tsi_tls_version::TSI_TLS1_2);
       if (result != TSI_OK) return result;
       if (impl->ssl_contexts[i] == nullptr) {
         gpr_log(GPR_ERROR, "Could not create ssl context.");

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -969,7 +969,7 @@ void ssl_tsi_test_extract_cert_chain() {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
-  const size_t number_tls_versions = 2;
+  const size_t number_tls_versions = 1;
   const tsi_tls_version tls_versions[] = {tsi_tls_version::TSI_TLS1_2};
   for (size_t i = 0; i < number_tls_versions; i++) {
     // Set the TLS version to be used in the tests.

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -970,8 +970,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
   const size_t number_tls_versions = 2;
-  const tsi_tls_version tls_versions[] = {tsi_tls_version::TSI_TLS1_2,
-                                          tsi_tls_version::TSI_TLS1_3};
+  const tsi_tls_version tls_versions[] = {tsi_tls_version::TSI_TLS1_2};
   for (size_t i = 0; i < number_tls_versions; i++) {
     // Set the TLS version to be used in the tests.
     test_tls_version = tls_versions[i];


### PR DESCRIPTION
This PR is a minimal change needed to disable TLS 1.3 in the gRPC C-core. This PR leaves all of the plumbing and fixes that were necessary for TLS 1.3, and disables it by ignoring any min/max TLS version that was selected by the SSL options. Note that setting the min/max TLS version is not currently user visible (it was to be made visible in PR #23527).

TLS 1.3 was enabled in PR #23165 (and an additional test case was added in #23413).
