### PR TITLE
Member variable should not be a reference; causing crash when used in destructor.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -171,7 +171,7 @@ class WeightedTargetLb : public LoadBalancingPolicy {
     // The owning LB policy.
     RefCountedPtr<WeightedTargetLb> weighted_target_policy_;
 
-    const std::string& name_;
+    const std::string name_;
 
     uint32_t weight_;
 
@@ -290,9 +290,8 @@ void WeightedTargetLb::UpdateLocked(UpdateArgs args) {
     const std::string& name = p.first;
     auto it = targets_.find(name);
     if (it == targets_.end()) {
-      it = targets_.emplace(std::make_pair(name, nullptr)).first;
-      it->second = MakeOrphanable<WeightedChild>(
-          Ref(DEBUG_LOCATION, "WeightedChild"), it->first);
+      targets_.emplace(name, MakeOrphanable<WeightedChild>(
+                                 Ref(DEBUG_LOCATION, "WeightedChild"), name));
     }
   }
   // Update all children.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/23610)
<!-- Reviewable:end -->
