### PR TITLE
Raises an exception when port binding failed

### DIFF
--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -61,6 +61,9 @@ STATUS_CODE_TO_CYGRPC_STATUS_CODE = {
 
 MAXIMUM_WAIT_TIMEOUT = 0.1
 
+_ERROR_MESSAGE_PORT_BINDING_FAILED = 'Failed to bind to address %s; set ' \
+    'GRPC_VERBOSITY=debug environment variable to see detailed error message.'
+
 
 def encode(s):
     if isinstance(s, bytes):
@@ -144,3 +147,22 @@ def wait(wait_fn, wait_complete_fn, timeout=None, spin_cb=None):
                 return True
             _wait_once(wait_fn, remaining, spin_cb)
     return False
+
+
+def validate_port_binding_result(address, port):
+    """Validates if the port binding succeed.
+
+    If the port returned by Core is 0, the binding is failed. However, in that
+    case, the Core API doesn't return a detailed failing reason. The best we
+    can do is raising an exception to prevent further confusion.
+
+    Args:
+        address: The address string to be bound.
+        port: An int returned by core
+    """
+    if port == 0:
+        # The Core API doesn't return a failure message. The best we can do
+        # is raising an exception to prevent further confusion.
+        raise RuntimeError(_ERROR_MESSAGE_PORT_BINDING_FAILED % address)
+    else:
+        return port

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -958,27 +958,14 @@ class _Server(grpc.Server):
         _add_generic_handlers(self._state, generic_rpc_handlers)
 
     def add_insecure_port(self, address):
-        port = _add_insecure_port(self._state, _common.encode(address))
-        if port == 0:
-            # The Core API doesn't return a failure message. The best we can do
-            # is raising an exception to prevent further confusion.
-            raise RuntimeError('Failed to bind to address %s; set '
-                               'GRPC_VERBOSITY=debug env to see detailed error '
-                               'message.' % address)
-        else:
-            return port
+        return _common.validate_port_binding_result(
+            address, _add_insecure_port(self._state, _common.encode(address)))
 
     def add_secure_port(self, address, server_credentials):
-        port = _add_secure_port(self._state, _common.encode(address),
-                                server_credentials)
-        if port == 0:
-            # The Core API doesn't return a failure message. The best we can do
-            # is raising an exception to prevent further confusion.
-            raise RuntimeError('Failed to bind to address %s; set '
-                               'GRPC_VERBOSITY=debug env to see detailed error '
-                               'message.' % address)
-        else:
-            return port
+        return _common.validate_port_binding_result(
+            address,
+            _add_secure_port(self._state, _common.encode(address),
+                             server_credentials))
 
     def start(self):
         _start(self._state)

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -958,11 +958,27 @@ class _Server(grpc.Server):
         _add_generic_handlers(self._state, generic_rpc_handlers)
 
     def add_insecure_port(self, address):
-        return _add_insecure_port(self._state, _common.encode(address))
+        port = _add_insecure_port(self._state, _common.encode(address))
+        if port == 0:
+            # The Core API doesn't return a failure message. The best we can do
+            # is raising an exception to prevent further confusion.
+            raise RuntimeError('Failed to bind to address %s; set '
+                               'GRPC_VERBOSITY=debug env to see detailed error '
+                               'message.' % address)
+        else:
+            return port
 
     def add_secure_port(self, address, server_credentials):
-        return _add_secure_port(self._state, _common.encode(address),
+        port = _add_secure_port(self._state, _common.encode(address),
                                 server_credentials)
+        if port == 0:
+            # The Core API doesn't return a failure message. The best we can do
+            # is raising an exception to prevent further confusion.
+            raise RuntimeError('Failed to bind to address %s; set '
+                               'GRPC_VERBOSITY=debug env to see detailed error '
+                               'message.' % address)
+        else:
+            return port
 
     def start(self):
         _start(self._state)

--- a/src/python/grpcio/grpc/experimental/aio/_server.py
+++ b/src/python/grpcio/grpc/experimental/aio/_server.py
@@ -80,7 +80,15 @@ class Server(_base_server.Server):
         Returns:
           An integer port on which the server will accept RPC requests.
         """
-        return self._server.add_insecure_port(_common.encode(address))
+        port = self._server.add_insecure_port(_common.encode(address))
+        if port == 0:
+            # The Core API doesn't return a failure message. The best we can do
+            # is raising an exception to prevent further confusion.
+            raise RuntimeError('Failed to bind to address %s; set '
+                               'GRPC_VERBOSITY=debug env to see detailed error '
+                               'message.' % address)
+        else:
+            return port
 
     def add_secure_port(self, address: str,
                         server_credentials: grpc.ServerCredentials) -> int:
@@ -97,8 +105,16 @@ class Server(_base_server.Server):
         Returns:
           An integer port on which the server will accept RPC requests.
         """
-        return self._server.add_secure_port(_common.encode(address),
+        port = self._server.add_secure_port(_common.encode(address),
                                             server_credentials)
+        if port == 0:
+            # The Core API doesn't return a failure message. The best we can do
+            # is raising an exception to prevent further confusion.
+            raise RuntimeError('Failed to bind to address %s; set '
+                               'GRPC_VERBOSITY=debug env to see detailed error '
+                               'message.' % address)
+        else:
+            return port
 
     async def start(self) -> None:
         """Starts this Server.

--- a/src/python/grpcio/grpc/experimental/aio/_server.py
+++ b/src/python/grpcio/grpc/experimental/aio/_server.py
@@ -80,15 +80,8 @@ class Server(_base_server.Server):
         Returns:
           An integer port on which the server will accept RPC requests.
         """
-        port = self._server.add_insecure_port(_common.encode(address))
-        if port == 0:
-            # The Core API doesn't return a failure message. The best we can do
-            # is raising an exception to prevent further confusion.
-            raise RuntimeError('Failed to bind to address %s; set '
-                               'GRPC_VERBOSITY=debug env to see detailed error '
-                               'message.' % address)
-        else:
-            return port
+        return _common.validate_port_binding_result(
+            address, self._server.add_insecure_port(_common.encode(address)))
 
     def add_secure_port(self, address: str,
                         server_credentials: grpc.ServerCredentials) -> int:
@@ -105,16 +98,10 @@ class Server(_base_server.Server):
         Returns:
           An integer port on which the server will accept RPC requests.
         """
-        port = self._server.add_secure_port(_common.encode(address),
-                                            server_credentials)
-        if port == 0:
-            # The Core API doesn't return a failure message. The best we can do
-            # is raising an exception to prevent further confusion.
-            raise RuntimeError('Failed to bind to address %s; set '
-                               'GRPC_VERBOSITY=debug env to see detailed error '
-                               'message.' % address)
-        else:
-            return port
+        return _common.validate_port_binding_result(
+            address,
+            self._server.add_secure_port(_common.encode(address),
+                                         server_credentials))
 
     async def start(self) -> None:
         """Starts this Server.

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -227,7 +227,10 @@ class TestGevent(setuptools.Command):
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
-        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',)
+        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
+        # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
+        'unit._server_test.ServerTest.test_failed_port_binding_exception',
+    )
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -18,6 +18,8 @@ import logging
 
 import grpc
 
+from tests.unit.framework.common import get_socket
+
 
 class _ActualGenericRpcHandler(grpc.GenericRpcHandler):
 
@@ -46,6 +48,17 @@ class ServerTest(unittest.TestCase):
             ])
         self.assertIn('grpc.GenericRpcHandler',
                       str(exception_context.exception))
+
+    def test_failed_port_binding_exception(self):
+        address, _, __ = get_socket()
+        server = grpc.server(None)
+
+        with self.assertRaises(RuntimeError):
+            server.add_insecure_port(address)
+
+        with self.assertRaises(RuntimeError):
+            server.add_secure_port(address,
+                                   grpc.ssl_server_credentials(((b'', b''),)))
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -51,7 +51,7 @@ class ServerTest(unittest.TestCase):
 
     def test_failed_port_binding_exception(self):
         address, _, __ = get_socket()
-        server = grpc.server(None)
+        server = grpc.server(None, options=(('grpc.so_reuseport', 0),))
 
         with self.assertRaises(RuntimeError):
             server.add_insecure_port(address)

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -466,7 +466,7 @@ class TestServer(AioTestBase):
 
     async def test_port_binding_exception(self):
         address, _, __ = get_socket()
-        server = aio.server()
+        server = aio.server(options=(('grpc.so_reuseport', 0),))
 
         with self.assertRaises(RuntimeError):
             server.add_insecure_port(address)

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -21,7 +21,7 @@ import unittest
 import grpc
 from grpc.experimental import aio
 
-from tests.unit.framework.common import test_constants
+from tests.unit.framework.common import get_socket, test_constants
 from tests_aio.unit._test_base import AioTestBase
 
 _SIMPLE_UNARY_UNARY = '/test/SimpleUnaryUnary'
@@ -463,6 +463,17 @@ class TestServer(AioTestBase):
         await call.done_writing()
 
         self.assertEqual(grpc.StatusCode.INTERNAL, await call.code())
+
+    async def test_port_binding_exception(self):
+        address, _, __ = get_socket()
+        server = aio.server()
+
+        with self.assertRaises(RuntimeError):
+            server.add_insecure_port(address)
+
+        with self.assertRaises(RuntimeError):
+            server.add_secure_port(address,
+                                   grpc.ssl_server_credentials(((b'', b''),)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/23315

This PR adds a logic to raise a Runtime exception if the port binding Core API returns 0. According to [the comment](https://github.com/grpc/grpc/blob/e20136f944ec0a2bd2f13defde499538032def6f/include/grpc/grpc.h#L420), 0 indicates binding failure. However, there is no way for wrapper layer to get the detailed error log. So, this PR also try to guide users to turn on tracing for debugging.

```c
/** Add a HTTP2 over plaintext over tcp listener.
    Returns bound port number on success, 0 on failure.
    REQUIRES: server not started */
GRPCAPI int grpc_server_add_insecure_http2_port(grpc_server* server,
                                                const char* addr);
```

Testing turns out to be quite tricky. Address `localhost` translates into both v4 and v6, which creates weird behavior like, gRPC binds to v4 while Python socket binds to v6. Also, gevent seems also modified the standard socket binding behavior. So, I disabled this test for gevent + Windows combination.