### PR TITLE
Fix bazel out directory when using external repo

### DIFF
--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -230,7 +230,12 @@ def get_out_dir(protos, context):
             path = out_dir,
             import_path = out_dir[out_dir.find(_VIRTUAL_IMPORTS) + 1:],
         )
-    return struct(path = context.genfiles_dir.path, import_path = None)
+
+    out_dir = context.genfiles_dir.path
+    ws_root = context.label.workspace_root
+    if ws_root:
+        out_dir = out_dir + "/" + ws_root
+    return struct(path = out_dir, import_path = None)
 
 def is_in_virtual_imports(source_file, virtual_folder = _VIRTUAL_IMPORTS):
     """Determines if source_file is virtual (is placed in _virtual_imports


### PR DESCRIPTION
When using proto/grpc bazel target from an external repository, the grpc code gen would output the files in the base genfile directory but bazel is expecting them inside the workspace root sub directory for the external repository.

The bazel build would error similar to
```
ERROR: /private/var/tmp/_bazel_jfish/f4236b85e6327668fc7bcd1f6c552a62/external/envoy_api_canonical/envoy/api/v2/BUILD:7:18: output 'external/envoy_api_canonical/envoy/api/v2/cds_pb2_grpc.py' was not created
```

When inspect the genfile directory it wrote to:
```
envoy/api/v2/cds_pb2_grpc.py
```

Therefore when using external workspace, add the workspace root prefix (e.g. `external/envoy_api_canonical`), so the file is where expected.