### PR TITLE
Added call to grpc::testing::TestEnvironment in transports tests

### DIFF
--- a/test/core/transport/byte_stream_test.cc
+++ b/test/core/transport/byte_stream_test.cc
@@ -246,8 +246,8 @@ TEST(CachingByteStream, SharedCache) {
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();

--- a/test/core/transport/connectivity_state_test.cc
+++ b/test/core/transport/connectivity_state_test.cc
@@ -233,8 +233,8 @@ TEST(StateTracker, DoNotNotifyShutdownAtDestructionIfAlreadyInShutdown) {
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
   grpc_core::testing::grpc_tracer_enable_flag(
       &grpc_core::grpc_connectivity_state_trace);

--- a/test/core/transport/static_metadata_test.cc
+++ b/test/core/transport/static_metadata_test.cc
@@ -42,9 +42,9 @@ TEST(StaticMetadataTest, ReadAllStaticElements) {
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
-  grpc::testing::TestEnvironment env(argc, argv);
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/transport/status_conversion_test.cc
+++ b/test/core/transport/status_conversion_test.cc
@@ -162,8 +162,6 @@ static void test_http2_status_to_grpc_status() {
 }
 
 int main(int argc, char** argv) {
-  int i;
-
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
 
@@ -173,7 +171,7 @@ int main(int argc, char** argv) {
   test_http2_status_to_grpc_status();
 
   /* check all status values can be converted */
-  for (i = 0; i <= 999; i++) {
+  for (int i = 0; i <= 999; i++) {
     grpc_http2_status_to_grpc_status(i);
   }
 

--- a/test/core/transport/status_metadata_test.cc
+++ b/test/core/transport/status_metadata_test.cc
@@ -17,10 +17,10 @@
  */
 
 #include "src/core/lib/transport/status_metadata.h"
+#include "src/core/lib/transport/static_metadata.h"
+#include "test/core/util/test_config.h"
 
 #include <gtest/gtest.h>
-
-#include "src/core/lib/transport/static_metadata.h"
 
 namespace {
 
@@ -56,6 +56,7 @@ TEST(GetStatusCodeFromMetadata, Unparseable) {
 }  // namespace
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
   int ret = RUN_ALL_TESTS();


### PR DESCRIPTION
This is to make some of tests more robust by using grpc::testing::TestEnvironment which waits until gRPC is fully shutdown at the end of the test, which MSAN test particularly is interested in when running with Abseil.

Without this, #23372 cannot pass the MSAN tests.