### PR TITLE
Add a distrib test for source-only ruby packages on linux

### DIFF
--- a/test/distrib/ruby/run_distrib_test.sh
+++ b/test/distrib/ruby/run_distrib_test.sh
@@ -17,12 +17,26 @@ set -ex
 
 cd "$(dirname "$0")"
 
-ARCH=$1
-PLATFORM=$2
+function die {
+  echo "$1"
+  exit 1
+}
+
+ARCH="$1"
+PLATFORM="$2"
+PACKAGE_TYPE="$3"
+echo "$EXTERNAL_GIT_ROOT"
+GRPC_VERSION="$(ruby -e 'require ENV["EXTERNAL_GIT_ROOT"] + "/src/ruby/lib/grpc/version.rb"; puts GRPC::VERSION')"
+if [[ "$PACKAGE_TYPE" == "source" ]]; then
+  GEM_NAME="grpc-${GRPC_VERSION}.gem"
+else
+  [[ "$PACKAGE_TYPE" == "binary" ]] || die "unexpeced package type: $PACKAGE_TYPE"
+  GEM_NAME="grpc-${GRPC_VERSION}-${ARCH}-${PLATFORM}.gem"
+fi
 # Create an indexed local gem source with gRPC gems to test
 GEM_SOURCE=../../../gem_source
 mkdir -p "${GEM_SOURCE}/gems"
-cp "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*"$ARCH-$PLATFORM".gem "${GEM_SOURCE}/gems"
+cp "${EXTERNAL_GIT_ROOT}/input_artifacts/${GEM_NAME}" "${GEM_SOURCE}/gems"
 # TODO: rewrite the following line to be shellcheck-compliant
 # shellcheck disable=SC2010
 if [[ "$(ls "${GEM_SOURCE}/gems" | grep -c grpc)" != 1 ]]; then
@@ -36,10 +50,10 @@ bundle install
 
 bundle exec ./distribtest.rb
 
+[[ "$PACKAGE_TYPE" == "source" ]] && exit 0
 # Attempt to repro https://github.com/google/protobuf/issues/4210.
-# TODO: This sanity check only works for linux-based distrib tests and for
-# binary gRPC packages. It will need to be ran conditionally if this test script is
-# used for other types of distrib tests.
+# This sanity check only works for linux-based distrib tests and for
+# binary gRPC packages.
 INSTALLATION_DIR="$(gem env | grep '\- INSTALLATION DIRECTORY' | awk '{ print $4 }')"
 if [[ "$(find "$INSTALLATION_DIR" -name 'grpc_c.so' | wc -l)" == 0 ]]; then
   echo "Sanity check failed. The gRPC package is not installed in $INSTALLATION_DIR."

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -183,9 +183,18 @@ class PythonDistribTest(object):
 class RubyDistribTest(object):
     """Tests Ruby package"""
 
-    def __init__(self, platform, arch, docker_suffix, ruby_version=None):
-        self.name = 'ruby_%s_%s_%s_version_%s' % (platform, arch, docker_suffix,
-                                                  ruby_version or 'unspecified')
+    def __init__(self,
+                 platform,
+                 arch,
+                 docker_suffix,
+                 ruby_version=None,
+                 source=False):
+        self.package_type = 'binary'
+        if source:
+            self.package_type = 'source'
+        self.name = 'ruby_%s_%s_%s_version_%s_package_type_%s' % (
+            platform, arch, docker_suffix, ruby_version or
+            'unspecified', self.package_type)
         self.platform = platform
         self.arch = arch
         self.docker_suffix = docker_suffix
@@ -210,8 +219,8 @@ class RubyDistribTest(object):
         return create_docker_jobspec(
             self.name,
             dockerfile_name,
-            'test/distrib/ruby/run_distrib_test.sh %s %s' %
-            (arch_to_gem_arch[self.arch], self.platform),
+            'test/distrib/ruby/run_distrib_test.sh %s %s %s' %
+            (arch_to_gem_arch[self.arch], self.platform, self.package_type),
             copy_rel_path='test/distrib')
 
     def __str__(self):
@@ -341,6 +350,11 @@ def targets():
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_5'),
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_6'),
         RubyDistribTest('linux', 'x64', 'jessie', ruby_version='ruby_2_7'),
+        RubyDistribTest('linux',
+                        'x64',
+                        'jessie',
+                        ruby_version='ruby_2_3',
+                        source=True),
         RubyDistribTest('linux', 'x64', 'centos6'),
         RubyDistribTest('linux', 'x64', 'centos7'),
         RubyDistribTest('linux', 'x64', 'fedora23'),


### PR DESCRIPTION
This is a followup to the idea mentioned in https://github.com/grpc/grpc/issues/23593#issuecomment-664256161

Passing artifact/package/distrib build in https://g3c.corp.google.com/results/invocations/4b3a7f3d-da43-470f-ba9a-31a862ddf44e/targets