### PR TITLE
Fix pagination in ServerNode::RenderServerSockets.

### DIFF
--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -310,27 +310,26 @@ void ServerNode::RemoveChildListenSocket(intptr_t child_uuid) {
 
 std::string ServerNode::RenderServerSockets(intptr_t start_socket_id,
                                             intptr_t max_results) {
+  GPR_ASSERT(start_socket_id >= 0);
+  GPR_ASSERT(max_results >= 0);
   // If user does not set max_results, we choose 500.
   size_t pagination_limit = max_results == 0 ? 500 : max_results;
   Json::Object object;
   {
     MutexLock lock(&child_mu_);
     size_t sockets_rendered = 0;
-    if (!child_sockets_.empty()) {
-      // Create list of socket refs.
-      Json::Array array;
-      const size_t limit = GPR_MIN(child_sockets_.size(), pagination_limit);
-      for (auto it = child_sockets_.lower_bound(start_socket_id);
-           it != child_sockets_.end() && sockets_rendered < limit;
-           ++it, ++sockets_rendered) {
-        array.emplace_back(Json::Object{
-            {"socketId", std::to_string(it->first)},
-            {"name", it->second->name()},
-        });
-      }
-      object["socketRef"] = std::move(array);
+    // Create list of socket refs.
+    Json::Array array;
+    auto it = child_sockets_.lower_bound(start_socket_id);
+    for (; it != child_sockets_.end() && sockets_rendered < pagination_limit;
+         ++it, ++sockets_rendered) {
+      array.emplace_back(Json::Object{
+          {"socketId", std::to_string(it->first)},
+          {"name", it->second->name()},
+      });
     }
-    if (sockets_rendered == child_sockets_.size()) object["end"] = true;
+    object["socketRef"] = std::move(array);
+    if (it == child_sockets_.end()) object["end"] = true;
   }
   Json json = std::move(object);
   return json.Dump();

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -208,10 +208,12 @@ char* grpc_channelz_get_server(intptr_t server_id) {
 char* grpc_channelz_get_server_sockets(intptr_t server_id,
                                        intptr_t start_socket_id,
                                        intptr_t max_results) {
+  // Validate inputs before handing them of to the renderer.
   grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode> base_node =
       grpc_core::channelz::ChannelzRegistry::Get(server_id);
   if (base_node == nullptr ||
-      base_node->type() != grpc_core::channelz::BaseNode::EntityType::kServer) {
+      base_node->type() != grpc_core::channelz::BaseNode::EntityType::kServer ||
+      start_socket_id < 0 || max_results < 0) {
     return nullptr;
   }
   // This cast is ok since we have just checked to make sure base_node is


### PR DESCRIPTION
Make sure we set "end" to true once we hit the end of child_sockets_.
Validate arguments passed to grpc_channelz_get_server_sockets() before calling ServerNode::RenderServerSockets.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yang-g
