### PR TITLE
Fix environment for protobuf compilation

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -141,6 +141,7 @@ def generate_cc_impl(ctx):
         outputs = out_files,
         executable = ctx.executable._protoc,
         arguments = arguments,
+        use_default_shell_env = True,
     )
 
     return struct(files = depset(out_files))


### PR DESCRIPTION
Add use_default_shell_env = True to protoc invocation to mirror what the protobuf cc_proto_library & co are doing
Fixes a failure in invocing protoc when it is build in a non-default environment (e.g. with a custom LD_LIBRARY_PATH)

See also https://github.com/bazelbuild/bazel/pull/11860

Fixes #23682

@markdroth @c-mita 
