### PR TITLE
CEL evaluation argument utilility

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1855,9 +1855,11 @@ grpc_cc_library(
     name = "grpc_authorization_engine",
     srcs = [
         "src/core/lib/security/authorization/authorization_engine.cc",
+        "src/core/lib/security/authorization/evaluate_args.cc",
     ],
     hdrs = [
         "src/core/lib/security/authorization/authorization_engine.h",
+        "src/core/lib/security/authorization/evaluate_args.h",
         "src/core/lib/security/authorization/mock_cel/activation.h",
         "src/core/lib/security/authorization/mock_cel/cel_value.h",
     ],
@@ -1866,6 +1868,7 @@ grpc_cc_library(
         "envoy_ads_upb",
         "google_api_upb",
         "grpc_base",
+        "grpc_secure",
     ],
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8411,6 +8411,7 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(authorization_engine_test
   src/core/lib/security/authorization/authorization_engine.cc
+  src/core/lib/security/authorization/evaluate_args.cc
   test/core/security/authorization_engine_test.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc

--- a/Makefile
+++ b/Makefile
@@ -11652,6 +11652,7 @@ endif
 
 AUTHORIZATION_ENGINE_TEST_SRC = \
     src/core/lib/security/authorization/authorization_engine.cc \
+    src/core/lib/security/authorization/evaluate_args.cc \
     test/core/security/authorization_engine_test.cc \
 
 AUTHORIZATION_ENGINE_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(AUTHORIZATION_ENGINE_TEST_SRC))))
@@ -11684,6 +11685,8 @@ endif
 endif
 
 $(OBJDIR)/$(CONFIG)/src/core/lib/security/authorization/authorization_engine.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
+
+$(OBJDIR)/$(CONFIG)/src/core/lib/security/authorization/evaluate_args.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
 
 $(OBJDIR)/$(CONFIG)/test/core/security/authorization_engine_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4771,10 +4771,12 @@ targets:
   language: c++
   headers:
   - src/core/lib/security/authorization/authorization_engine.h
+  - src/core/lib/security/authorization/evaluate_args.h
   - src/core/lib/security/authorization/mock_cel/activation.h
   - src/core/lib/security/authorization/mock_cel/cel_value.h
   src:
   - src/core/lib/security/authorization/authorization_engine.cc
+  - src/core/lib/security/authorization/evaluate_args.cc
   - test/core/security/authorization_engine_test.cc
   deps:
   - grpc_test_util

--- a/src/core/lib/security/authorization/evaluate_args.cc
+++ b/src/core/lib/security/authorization/evaluate_args.cc
@@ -1,0 +1,110 @@
+//
+//
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/lib/security/authorization/evaluate_args.h"
+
+#include "src/core/lib/slice/slice_utils.h"
+
+namespace grpc_core {
+
+absl::string_view EvaluateArgs::GetPath() const {
+  absl::string_view path;
+  if (metadata_ != nullptr && metadata_->idx.named.path != nullptr) {
+    grpc_linked_mdelem* elem = metadata_->idx.named.path;
+    const grpc_slice& val = GRPC_MDVALUE(elem->md);
+    path = StringViewFromSlice(val);
+  }
+  return path;
+}
+
+absl::string_view EvaluateArgs::GetHost() const {
+  absl::string_view host;
+  if (metadata_ != nullptr && metadata_->idx.named.host != nullptr) {
+    grpc_linked_mdelem* elem = metadata_->idx.named.host;
+    const grpc_slice& val = GRPC_MDVALUE(elem->md);
+    host = StringViewFromSlice(val);
+  }
+  return host;
+}
+
+absl::string_view EvaluateArgs::GetMethod() const {
+  absl::string_view method;
+  if (metadata_ != nullptr && metadata_->idx.named.method != nullptr) {
+    grpc_linked_mdelem* elem = metadata_->idx.named.method;
+    const grpc_slice& val = GRPC_MDVALUE(elem->md);
+    method = StringViewFromSlice(val);
+  }
+  return method;
+}
+
+std::multimap<absl::string_view, absl::string_view> EvaluateArgs::GetHeaders()
+    const {
+  std::multimap<absl::string_view, absl::string_view> headers;
+  if (metadata_ == nullptr) {
+    return headers;
+  }
+  for (grpc_linked_mdelem* elem = metadata_->list.head; elem != nullptr;
+       elem = elem->next) {
+    const grpc_slice& key = GRPC_MDKEY(elem->md);
+    const grpc_slice& val = GRPC_MDVALUE(elem->md);
+    headers.emplace(StringViewFromSlice(key), StringViewFromSlice(val));
+  }
+  return headers;
+}
+
+absl::string_view EvaluateArgs::GetSpiffeId() const {
+  absl::string_view spiffe_id;
+  if (auth_context_ == nullptr) {
+    return spiffe_id;
+  }
+  grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(
+      auth_context_, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME);
+  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
+  if (prop == nullptr) return spiffe_id;
+  if (strncmp(prop->value, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME,
+              prop->value_length) != 0) {
+    return spiffe_id;
+  }
+  if (grpc_auth_property_iterator_next(&it) != nullptr) return spiffe_id;
+  spiffe_id = absl::string_view(
+      reinterpret_cast<const char*>(prop->value, prop->value_length));
+  return spiffe_id;
+}
+
+absl::string_view EvaluateArgs::GetCertServerName() const {
+  absl::string_view name;
+  if (auth_context_ == nullptr) {
+    return name;
+  }
+  grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(
+      auth_context_, GRPC_X509_CN_PROPERTY_NAME);
+  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
+  if (prop == nullptr) return name;
+  if (strncmp(prop->value, GRPC_X509_CN_PROPERTY_NAME, prop->value_length) !=
+      0) {
+    return name;
+  }
+  if (grpc_auth_property_iterator_next(&it) != nullptr) return name;
+  name = absl::string_view(
+      reinterpret_cast<const char*>(prop->value, prop->value_length));
+  return name;
+}
+
+}  // namespace grpc_core

--- a/src/core/lib/security/authorization/evaluate_args.h
+++ b/src/core/lib/security/authorization/evaluate_args.h
@@ -1,0 +1,54 @@
+//
+//
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#ifndef GRPC_CORE_LIB_SECURITY_AUTHORIZATION_EVALUATE_ARGS_H
+#define GRPC_CORE_LIB_SECURITY_AUTHORIZATION_EVALUATE_ARGS_H
+
+#include <grpc/support/port_platform.h>
+
+#include <map>
+
+#include "src/core/lib/iomgr/endpoint.h"
+#include "src/core/lib/security/context/security_context.h"
+#include "src/core/lib/transport/metadata_batch.h"
+
+namespace grpc_core {
+
+class EvaluateArgs {
+ public:
+  EvaluateArgs(grpc_metadata_batch* metadata, grpc_auth_context* auth_context,
+               grpc_endpoint* endpoint);
+
+  absl::string_view GetPath() const;
+  absl::string_view GetHost() const;
+  absl::string_view GetMethod() const;
+  std::multimap<absl::string_view, absl::string_view> GetHeaders() const;
+  absl::string_view GetSpiffeId() const;
+  absl::string_view GetCertServerName() const;
+
+  // TODO: Add a getter function for source.principal
+
+ private:
+  grpc_metadata_batch* metadata_;
+  grpc_auth_context* auth_context_;
+  grpc_endpoint* endpoint_;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_CORE_LIB_SECURITY_AUTHORIZATION_EVALUATE_ARGS_H


### PR DESCRIPTION
This pr contains an implementation of EvaluateArgs, which holds grpc related structures that contain values necessary for the auth engine evaluation, and methods that extract values from metadata batch and auth_context.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@ashithasantosh 
