### PR TITLE
Add TestEnvironment to tests

### DIFF
--- a/test/cpp/codegen/codegen_test_full.cc
+++ b/test/cpp/codegen/codegen_test_full.cc
@@ -20,6 +20,8 @@
 #include <grpcpp/completion_queue.h>
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
+
 namespace grpc {
 namespace {
 
@@ -37,6 +39,7 @@ TEST_F(CodegenTestFull, Init) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/codegen/codegen_test_minimal.cc
+++ b/test/cpp/codegen/codegen_test_minimal.cc
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
+
 namespace grpc {
 namespace {
 
@@ -29,6 +31,7 @@ TEST_F(CodegenTestMinimal, Build) {}
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/end2end/server_load_reporting_end2end_test.cc
+++ b/test/cpp/end2end/server_load_reporting_end2end_test.cc
@@ -33,6 +33,7 @@
 #include "src/proto/grpc/lb/v1/load_reporter.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
 
 namespace grpc {
 namespace testing {
@@ -185,6 +186,7 @@ TEST_F(ServerLoadReportingEnd2endTest, BasicReport) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/qps/secure_sync_unary_ping_pong_test.cc
+++ b/test/cpp/qps/secure_sync_unary_ping_pong_test.cc
@@ -20,6 +20,7 @@
 
 #include <grpc/support/log.h>
 
+#include "test/core/util/test_config.h"
 #include "test/cpp/qps/benchmark_config.h"
 #include "test/cpp/qps/driver.h"
 #include "test/cpp/qps/report.h"
@@ -65,9 +66,9 @@ static void RunSynchronousUnaryPingPong() {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
 
   grpc::testing::RunSynchronousUnaryPingPong();
-
   return 0;
 }


### PR DESCRIPTION
Add `grpc::testing::TestEnvironment` to the main of tests that failed under MSAN.