### PR TITLE
Add TestEnvironment to tests

### DIFF
--- a/test/cpp/codegen/golden_file_test.cc
+++ b/test/cpp/codegen/golden_file_test.cc
@@ -22,6 +22,7 @@
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
 #include "test/cpp/util/test_config.h"
 
 // In some distros, gflags is in the namespace google, and in some others,
@@ -68,6 +69,7 @@ TEST(GoldenMockFileTest, TestGeneratedMockFile) {
 }
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
   if (FLAGS_generated_file_path.empty()) {

--- a/test/cpp/codegen/proto_utils_test.cc
+++ b/test/cpp/codegen/proto_utils_test.cc
@@ -23,6 +23,8 @@
 #include <grpcpp/impl/grpc_library.h>
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
+
 namespace grpc {
 
 namespace internal {
@@ -187,6 +189,7 @@ TEST_F(WriterTest, LargeBlockLargeBackup) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/qps/qps_json_driver.cc
+++ b/test/cpp/qps/qps_json_driver.cc
@@ -26,6 +26,7 @@
 #include <gflags/gflags.h>
 #include <grpc/support/log.h>
 
+#include "test/core/util/test_config.h"
 #include "test/cpp/qps/benchmark_config.h"
 #include "test/cpp/qps/driver.h"
 #include "test/cpp/qps/parse_json.h"
@@ -290,6 +291,7 @@ static bool QpsDriver() {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
 
   bool ok = grpc::testing::QpsDriver();

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -26,6 +26,7 @@
 #include <grpc/grpc.h>
 #include <grpc/support/time.h>
 
+#include "test/core/util/test_config.h"
 #include "test/cpp/qps/qps_worker.h"
 #include "test/cpp/util/test_config.h"
 #include "test/cpp/util/test_credentials_provider.h"
@@ -57,6 +58,7 @@ static void RunServer() {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
 
   signal(SIGINT, sigint_handler);


### PR DESCRIPTION
Add grpc::testing::TestEnvironment to the main of tests that failed under MSAN.

