### PR TITLE
Disable GPR_ABSEIL_SYNC on Apple platforms

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -31,8 +31,14 @@
  * Defines GPR_ABSEIL_SYNC to use synchronization features from Abseil
  */
 #ifndef GPR_ABSEIL_SYNC
+#if defined(__APPLE__)
+// This is disabled on Apple platforms because macos/grpc_basictests_c_cpp
+// fails with this. https://github.com/grpc/grpc/issues/23661
+#define GPR_ABSEIL_SYNC 0
+#else
 #define GPR_ABSEIL_SYNC 1
 #endif
+#endif  // GPR_ABSEIL_SYNC
 
 /* Get windows.h included everywhere (we need it) */
 #if defined(_WIN64) || defined(WIN64) || defined(_WIN32) || defined(WIN32)


### PR DESCRIPTION
This is about to fix the weird behavior of "Basic Tests C/C++ MacOS" on OSX. It's not still clear why this test is failing with Abseil lock enabled on Apple. I suspect that it has a problem with thread-local-storage which has been untamed on OSX throughout gRPC code. While working to investigate and fix the problem, this is going to be disabled by default on Apple platforms.

Fixes #23661