### PR TITLE
Add TestEnvironment to tests

### DIFF
--- a/test/cpp/util/byte_buffer_test.cc
+++ b/test/cpp/util/byte_buffer_test.cc
@@ -27,6 +27,8 @@
 #include <grpcpp/support/slice.h>
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
+
 namespace grpc {
 
 static internal::GrpcLibraryInitializer g_gli_initializer;
@@ -125,6 +127,7 @@ TEST_F(ByteBufferTest, SerializationMakesCopy) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;

--- a/test/cpp/util/error_details_test.cc
+++ b/test/cpp/util/error_details_test.cc
@@ -21,6 +21,7 @@
 
 #include "src/proto/grpc/status/status.pb.h"
 #include "src/proto/grpc/testing/echo_messages.pb.h"
+#include "test/core/util/test_config.h"
 
 namespace grpc {
 namespace {
@@ -118,6 +119,7 @@ TEST(SetTest, ValidScopeErrorCode) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/util/string_ref_test.cc
+++ b/test/cpp/util/string_ref_test.cc
@@ -22,6 +22,8 @@
 
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
+
 namespace grpc {
 namespace {
 
@@ -197,6 +199,7 @@ TEST_F(StringRefTest, ComparisonOperators) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/util/time_test.cc
+++ b/test/cpp/util/time_test.cc
@@ -20,6 +20,8 @@
 #include <grpcpp/support/time.h>
 #include <gtest/gtest.h>
 
+#include "test/core/util/test_config.h"
+
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::system_clock;
@@ -64,6 +66,7 @@ TEST_F(TimeTest, InfFuture) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Add grpc::testing::TestEnvironment to the main of tests that failed under MSAN.

