### PR TITLE
Update Python default test suite in run_tests.py

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -862,7 +862,12 @@ class PythonLanguage(object):
 
         if args.compiler == 'default':
             if os.name == 'nt':
-                return (python38_config,)
+                if args.iomgr_platform == 'gevent':
+                    # TODO(https://github.com/grpc/grpc/issues/23784) allow
+                    # gevent to run on later version once issue solved.
+                    return (python36_config,)
+                else:
+                    return (python38_config,)
             else:
                 if args.iomgr_platform == 'asyncio':
                     return (python36_config, python38_config)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -862,25 +862,23 @@ class PythonLanguage(object):
 
         if args.compiler == 'default':
             if os.name == 'nt':
-                return (python36_config,)
+                return (python38_config,)
             else:
                 if args.iomgr_platform == 'asyncio':
-                    return (python36_config,)
+                    return (python36_config, python38_config)
                 elif os.uname()[0] == 'Darwin':
                     # NOTE(rbellevi): Testing takes significantly longer on
                     # MacOS, so we restrict the number of interpreter versions
                     # tested.
                     return (
                         python27_config,
-                        python36_config,
-                        python37_config,
+                        python38_config,
                     )
                 else:
                     return (
                         python27_config,
                         python35_config,
-                        python36_config,
-                        python37_config,
+                        python38_config,
                     )
         elif args.compiler == 'python2.7':
             return (python27_config,)


### PR DESCRIPTION
Issue https://github.com/grpc/grpc/issues/23617 exposes our lack of testing for 3.8.

This PR intended to include 38 in our `run_tests.py` tests across platforms. Also, this PR reduces the total number of tested Python versions. Hoping the length of our test won't be affected too much.