### PR TITLE
Disable GPR_ABSEIL_SYNC on Apple platforms

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -34,7 +34,6 @@
 #if defined(__APPLE__)
 // This is disabled on Apple platforms because macos/grpc_basictests_c_cpp
 // fails with this. https://github.com/grpc/grpc/issues/23661
-#define GPR_ABSEIL_SYNC 0
 #else
 #define GPR_ABSEIL_SYNC 1
 #endif


### PR DESCRIPTION
Fix for the a bug of #23687. `GPR_ABSEIL_SYNC` needs not to be defined to disable it.
