### PR TITLE
Add TestEnvironment to tests

### DIFF
--- a/test/cpp/qps/inproc_sync_unary_ping_pong_test.cc
+++ b/test/cpp/qps/inproc_sync_unary_ping_pong_test.cc
@@ -20,6 +20,7 @@
 
 #include <grpc/support/log.h>
 
+#include "test/core/util/test_config.h"
 #include "test/cpp/qps/benchmark_config.h"
 #include "test/cpp/qps/driver.h"
 #include "test/cpp/qps/report.h"
@@ -58,6 +59,7 @@ static void RunSynchronousUnaryPingPong() {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
 
   grpc::testing::RunSynchronousUnaryPingPong();

--- a/test/cpp/qps/qps_interarrival_test.cc
+++ b/test/cpp/qps/qps_interarrival_test.cc
@@ -22,6 +22,7 @@
 // Use the C histogram rather than C++ to avoid depending on proto
 #include "test/core/util/histogram.h"
 
+#include "test/core/util/test_config.h"
 #include "test/cpp/qps/interarrival.h"
 #include "test/cpp/util/test_config.h"
 
@@ -52,6 +53,7 @@ static void RunTest(RandomDistInterface&& r, int threads,
 using grpc::testing::ExpDist;
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
 
   RunTest(ExpDist(10.0), 5, std::string("Exponential(10)"));

--- a/test/cpp/qps/qps_openloop_test.cc
+++ b/test/cpp/qps/qps_openloop_test.cc
@@ -62,6 +62,7 @@ static void RunQPS() {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
 
   grpc::testing::RunQPS();


### PR DESCRIPTION
Add grpc::testing::TestEnvironment to the main of tests that failed under MSAN.

