### PR TITLE
Add per-address attribute mechanism that does not affect subchannel uniqueness.

### DIFF
--- a/src/core/ext/filters/client_channel/server_address.cc
+++ b/src/core/ext/filters/client_channel/server_address.cc
@@ -26,23 +26,56 @@ namespace grpc_core {
 // ServerAddress
 //
 
-ServerAddress::ServerAddress(const grpc_resolved_address& address,
-                             grpc_channel_args* args)
-    : address_(address), args_(args) {}
+ServerAddress::ServerAddress(
+    const grpc_resolved_address& address, grpc_channel_args* args,
+    std::map<const char*, std::unique_ptr<AttributeInterface>> attributes)
+    : address_(address), args_(args), attributes_(std::move(attributes)) {}
 
-ServerAddress::ServerAddress(const void* address, size_t address_len,
-                             grpc_channel_args* args)
-    : args_(args) {
+ServerAddress::ServerAddress(
+    const void* address, size_t address_len, grpc_channel_args* args,
+    std::map<const char*, std::unique_ptr<AttributeInterface>> attributes)
+    : args_(args), attributes_(std::move(attributes)) {
   memcpy(address_.addr, address, address_len);
   address_.len = static_cast<socklen_t>(address_len);
 }
+
+namespace {
+
+int CompareAttributes(
+    const std::map<const char*,
+                   std::unique_ptr<ServerAddress::AttributeInterface>>&
+        attributes1,
+    const std::map<const char*,
+                   std::unique_ptr<ServerAddress::AttributeInterface>>&
+        attributes2) {
+  auto it2 = attributes2.begin();
+  for (auto it1 = attributes1.begin(); it1 != attributes1.end(); ++it1) {
+    // attributes2 has fewer elements than attributes1
+    if (it2 == attributes2.end()) return -1;
+    // compare keys
+    int retval = strcmp(it1->first, it2->first);
+    if (retval != 0) return retval;
+    // compare values
+    retval = it1->second->Cmp(it2->second.get());
+    if (retval != 0) return retval;
+    ++it2;
+  }
+  // attributes1 has fewer elements than attributes2
+  if (it2 != attributes2.end()) return 1;
+  // equal
+  return 0;
+}
+
+}  // namespace
 
 int ServerAddress::Cmp(const ServerAddress& other) const {
   if (address_.len > other.address_.len) return 1;
   if (address_.len < other.address_.len) return -1;
   int retval = memcmp(address_.addr, other.address_.addr, address_.len);
   if (retval != 0) return retval;
-  return grpc_channel_args_compare(args_, other.args_);
+  retval = grpc_channel_args_compare(args_, other.args_);
+  if (retval != 0) return retval;
+  return CompareAttributes(attributes_, other.attributes_);
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/server_address.h
+++ b/src/core/ext/filters/client_channel/server_address.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <map>
+
 #include "absl/container/inlined_vector.h"
 
 #include "src/core/lib/channel/channel_args.h"
@@ -37,26 +39,54 @@ namespace grpc_core {
 // args when a subchannel is created for this address.
 class ServerAddress {
  public:
+  // Base clas for resolver-supplied attributes.
+  // Unlike channel args, these attributes don't affect subchannel
+  // uniqueness or behavior.  They are for use by LB policies only.
+  class AttributeInterface {
+   public:
+    virtual ~AttributeInterface();
+
+    // Creates a copy of the attribute.
+    virtual std::unique_ptr<AttributeInterface> Copy() const = 0;
+
+    // Compares this attribute with another.
+    virtual int Cmp(const AttributeInterface* other) const = 0;
+  };
+
   // Takes ownership of args.
-  ServerAddress(const grpc_resolved_address& address, grpc_channel_args* args);
+  ServerAddress(const grpc_resolved_address& address, grpc_channel_args* args,
+                std::map<const char*, std::unique_ptr<AttributeInterface>>
+                    attributes = {});
   ServerAddress(const void* address, size_t address_len,
-                grpc_channel_args* args);
+                grpc_channel_args* args,
+                std::map<const char*, std::unique_ptr<AttributeInterface>>
+                    attributes = {});
 
   ~ServerAddress() { grpc_channel_args_destroy(args_); }
 
   // Copyable.
   ServerAddress(const ServerAddress& other)
-      : address_(other.address_), args_(grpc_channel_args_copy(other.args_)) {}
+      : address_(other.address_), args_(grpc_channel_args_copy(other.args_)) {
+    for (const auto& p : other.attributes_) {
+      attributes_[p.first] = p.second->Copy();
+    }
+  }
   ServerAddress& operator=(const ServerAddress& other) {
     address_ = other.address_;
     grpc_channel_args_destroy(args_);
     args_ = grpc_channel_args_copy(other.args_);
+    attributes_.clear();
+    for (const auto& p : other.attributes_) {
+      attributes_[p.first] = p.second->Copy();
+    }
     return *this;
   }
 
   // Movable.
   ServerAddress(ServerAddress&& other)
-      : address_(other.address_), args_(other.args_) {
+      : address_(other.address_),
+        args_(other.args_),
+        attributes_(std::move(other.attributes_)) {
     other.args_ = nullptr;
   }
   ServerAddress& operator=(ServerAddress&& other) {
@@ -64,6 +94,7 @@ class ServerAddress {
     grpc_channel_args_destroy(args_);
     args_ = other.args_;
     other.args_ = nullptr;
+    attributes_ = std::move(other.attributes_);
     return *this;
   }
 
@@ -74,9 +105,16 @@ class ServerAddress {
   const grpc_resolved_address& address() const { return address_; }
   const grpc_channel_args* args() const { return args_; }
 
+  const AttributeInterface* GetAttribute(const char* key) const {
+    auto it = attributes_.find(key);
+    if (it == attributes_.end()) return nullptr;
+    return it->second.get();
+  }
+
  private:
   grpc_resolved_address address_;
   grpc_channel_args* args_;
+  std::map<const char*, std::unique_ptr<AttributeInterface>> attributes_;
 };
 
 //


### PR DESCRIPTION
This will allow encoding per-address parameters like xDS-supplied endpoint weights that may be used by LB policies but that are not used by the subchannel or taken into account when determining the key of the subchannel pool.

@ejona86 @dfawley as an FYI.  The impetus for this is [a user that wants to implement xDS-supplied endpoint weights](https://groups.google.com/g/grpc-io/c/wf-IvQiBt80/m/HIZ_vpjFAwAJ).