### PR TITLE
Resolve the user warning generated by our setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A setup module for the GRPC Python package."""
+
+# setuptools need to be imported before distutils. Otherwise it might lead to
+# undesirable behaviors or errors.
+import setuptools
+
 from distutils import cygwinccompiler
 from distutils import extension as _extension
 from distutils import util
@@ -25,7 +30,6 @@ import shutil
 import sys
 import sysconfig
 
-import setuptools
 from setuptools.command import egg_info
 
 import subprocess


### PR DESCRIPTION
Happen to find out that our `setup.py` generates a UserWarning now:

> UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.

See `setuptools` source code: https://github.com/pypa/setuptools/blob/a4945970acae9c654715871a08803d67d9bd3527/setuptools/distutils_patch.py#L18