### PR TITLE
Update check_include_guards.py

### DIFF
--- a/tools/distrib/check_include_guards.py
+++ b/tools/distrib/check_include_guards.py
@@ -63,14 +63,14 @@ class GuardValidator(object):
             '...\n') + ('#endif /* {2} */'
                         if c_core_header else '#endif  // {2}')
         if not match_txt:
-            print(invalid_guards_msg_template.format(fpath, regexp.pattern,
-                                                     build_valid_guard(fpath)))
+            print(
+                invalid_guards_msg_template.format(fpath, regexp.pattern,
+                                                   build_valid_guard(fpath)))
             return fcontents
 
-        print((
-            '{}: Wrong preprocessor guards (RE {}):'
-            '\n\tFound {}, expected {}').format(fpath, regexp.pattern,
-                                                match_txt, correct))
+        print(('{}: Wrong preprocessor guards (RE {}):'
+               '\n\tFound {}, expected {}').format(fpath, regexp.pattern,
+                                                   match_txt, correct))
         if fix:
             print('Fixing {}...\n'.format(fpath))
             fixed_fcontents = re.sub(match_txt, correct, fcontents)

--- a/tools/distrib/check_include_guards.py
+++ b/tools/distrib/check_include_guards.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import argparse
 import os
 import os.path
@@ -62,22 +63,22 @@ class GuardValidator(object):
             '...\n') + ('#endif /* {2} */'
                         if c_core_header else '#endif  // {2}')
         if not match_txt:
-            print invalid_guards_msg_template.format(fpath, regexp.pattern,
-                                                     build_valid_guard(fpath))
+            print(invalid_guards_msg_template.format(fpath, regexp.pattern,
+                                                     build_valid_guard(fpath)))
             return fcontents
 
-        print(
+        print((
             '{}: Wrong preprocessor guards (RE {}):'
             '\n\tFound {}, expected {}').format(fpath, regexp.pattern,
-                                                match_txt, correct)
+                                                match_txt, correct))
         if fix:
-            print 'Fixing {}...\n'.format(fpath)
+            print('Fixing {}...\n'.format(fpath))
             fixed_fcontents = re.sub(match_txt, correct, fcontents)
             if fixed_fcontents:
                 self.failed = False
             return fixed_fcontents
         else:
-            print
+            print()
         return fcontents
 
     def check(self, fpath, fix):
@@ -89,7 +90,7 @@ class GuardValidator(object):
 
         match = self.ifndef_re.search(fcontents)
         if not match:
-            print 'something drastically wrong with: %s' % fpath
+            print('something drastically wrong with: %s' % fpath)
             return False  # failed
         if match.lastindex is None:
             # No ifndef. Request manual addition with hints


### PR DESCRIPTION
Fix the Py3 checker issue during import. Use print() instead of print and add "from __future__ import print_function" for py2 and py3 compatibility.

Assign the review of this pull request to markdroth@, since he is the last person who changes this file.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
