### PR TITLE
Revert "Switch C++ interop tests build to cmake"

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile.template
@@ -19,7 +19,6 @@
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../cxx_deps.include"/>
-  <%include file="../../cmake_jessie_backports.include"/>
   <%include file="../../run_tests_addons.include"/>
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
@@ -70,15 +70,6 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 # C++ dependencies
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
-#=================
-# Use cmake 3.6 from jessie-backports
-# should only be used for images based on debian jessie.
-
-RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
-RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
-
 
 RUN mkdir /var/local/jenkins
 

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/build_interop.sh
@@ -32,9 +32,8 @@ cd /var/local/git/grpc
 mkdir -p /usr/local/share/grpc
 cp etc/roots.pem /usr/local/share/grpc/roots.pem
 
-# build C++ interop client, interop server and http2 interop client
-mkdir -p cmake/build
-cd cmake/build
-cmake -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release ../..
+# build C++ interop client & server
 make interop_client interop_server -j4
+
+# build C++ http2 client
 make http2_client -j4

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -97,16 +97,16 @@ class CXXLanguage:
         self.safename = 'cxx'
 
     def client_cmd(self, args):
-        return ['cmake/build/interop_client'] + args
+        return ['bins/opt/interop_client'] + args
 
     def client_cmd_http2interop(self, args):
-        return ['cmake/build/http2_client'] + args
+        return ['bins/opt/http2_client'] + args
 
     def cloud_to_prod_env(self):
         return {}
 
     def server_cmd(self, args):
-        return ['cmake/build/interop_server'] + args
+        return ['bins/opt/interop_server'] + args
 
     def global_env(self):
         return {}


### PR DESCRIPTION
Reverts grpc/grpc#23703

The macos/grpc_interop_toprod tests failed after this PR merged. Feel free to close this revert PR if the fix is easy. 