### PR TITLE
Update docgen.py

### DIFF
--- a/tools/distrib/python/docgen.py
+++ b/tools/distrib/python/docgen.py
@@ -91,7 +91,7 @@ else:
     subprocess.check_call(['git', 'checkout', '-b', doc_branch], cwd=repo_dir)
     subprocess.check_call([
         'git', 'remote', 'add', 'ssh-origin',
-        'git@github.com:%s/grpc.git' % (args.repo_owner)
+        'git@github.com:%s/grpc.git' % args.repo_owner
     ],
                           cwd=repo_dir)
     print('Updating documentation...')


### PR DESCRIPTION
Fix a RexAnalyzer error during the import, and update in github as well. 

Parentheses around a single item in Python has no effect: (foo) is exactly equivalent to foo. In many cases this is harmless, but it can suggest a subtle bug when used in string formatting.  A '%'-formatted string with a single format specifier can be formatted using a single value or a one element tuple: 'hello %s' % name or 'hello %s' % (name,). Consequently, a line like error_msg = 'Cannot process %s' % (data) may leave code reviewers and future readers unsure if there is a subtle bug if data is a tuple. 

Since the args.repo_owner here is a single string, drop the parentheses is better.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
