### PR TITLE
Re-enable TLS 1.3 in the C-core.

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1894,11 +1894,8 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 #else
   ssl_context = SSL_CTX_new(TLSv1_2_method());
 #endif
-  // TODO(mattstev): Re-enable TLS 1.3 by using |options.min_tls_version| and
-  // |options.max_tls_version|, rather than hardcoding in TLS 1.2 as the min and
-  // max.
   result = tsi_set_min_and_max_tls_versions(
-      ssl_context, tsi_tls_version::TSI_TLS1_2, tsi_tls_version::TSI_TLS1_2);
+      ssl_context, options->min_tls_version, options->max_tls_version);
   if (result != TSI_OK) return result;
   if (ssl_context == nullptr) {
     gpr_log(GPR_ERROR, "Could not create ssl context.");
@@ -2064,12 +2061,9 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 #else
       impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
 #endif
-      // TODO(mattstev): Re-enable TLS 1.3 by using |options.min_tls_version|
-      // and |options.max_tls_version|, rather than hardcoding in TLS 1.2 as the
-      // min and max.
       result = tsi_set_min_and_max_tls_versions(impl->ssl_contexts[i],
-                                                tsi_tls_version::TSI_TLS1_2,
-                                                tsi_tls_version::TSI_TLS1_2);
+                                                options->min_tls_version,
+                                                options->max_tls_version);
       if (result != TSI_OK) return result;
       if (impl->ssl_contexts[i] == nullptr) {
         gpr_log(GPR_ERROR, "Could not create ssl context.");

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -969,8 +969,9 @@ void ssl_tsi_test_extract_cert_chain() {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
-  const size_t number_tls_versions = 1;
-  const tsi_tls_version tls_versions[] = {tsi_tls_version::TSI_TLS1_2};
+  const size_t number_tls_versions = 2;
+  const tsi_tls_version tls_versions[] = {tsi_tls_version::TSI_TLS1_2,
+                                          tsi_tls_version::TSI_TLS1_3};
   for (size_t i = 0; i < number_tls_versions; i++) {
     // Set the TLS version to be used in the tests.
     test_tls_version = tls_versions[i];


### PR DESCRIPTION
This was disabled in PR #23608. In PR #23636, the issue that forced us to disable TLS 1.3 was resolved (thanks @yashykt for the quick fix!).

I'm sending another PR rather than rolling back PR #23608 because it was back-ported to the last release and wanted to avoid any confusion.

I also did some testing: with the fix in PR #23636 and TLS 1.3, neither the client nor the server send anything until both the client and server have completed the handshake. This is what we were hoping for.

