### PR TITLE
Servers should always prefer sending status over RST_STREAM

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -336,7 +336,6 @@ GRPCAPI grpc_call_error grpc_call_cancel(grpc_call* call, void* reserved);
     Can be called multiple times, from any thread.
     If a status has not been received for the call, set it to the status code
     and description passed in.
-    If called on the server, this status would also be sent to the client.
     Note that \a description doesn't need be a static string. It
     doesn't need to be alive after the call to grpc_call_cancel_with_status
     completes. */

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -336,12 +336,10 @@ GRPCAPI grpc_call_error grpc_call_cancel(grpc_call* call, void* reserved);
     Can be called multiple times, from any thread.
     If a status has not been received for the call, set it to the status code
     and description passed in.
-    Importantly, this function does not send status nor description to the
-    remote endpoint.
-    Note that \a description doesn't need be a static string.
-    It doesn't need to be alive after the call to
-    grpc_call_cancel_with_status completes.
-    */
+    If called on the server, this status would also be sent to the client.
+    Note that \a description doesn't need be a static string. It
+    doesn't need to be alive after the call to grpc_call_cancel_with_status
+    completes. */
 GRPCAPI grpc_call_error grpc_call_cancel_with_status(grpc_call* call,
                                                      grpc_status_code status,
                                                      const char* description,

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2083,6 +2083,7 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
     if (!s->write_closed) {
       close_from_api(t, s, due_to_error);
     }
+    GRPC_ERROR_UNREF(due_to_error);
     return;
   }
 

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2082,8 +2082,9 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
     // already be closed for both reading and writing.
     if (!s->write_closed) {
       close_from_api(t, s, due_to_error);
+    } else {
+      GRPC_ERROR_UNREF(due_to_error);
     }
-    GRPC_ERROR_UNREF(due_to_error);
     return;
   }
 

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2080,7 +2080,7 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
     // The server should always send trailers on cancellation. If it has already
     // sent trailers, there is no action to be taken here since the stream would
     // already be closed for both reading and writing.
-    if (!s->sent_trailing_metadata) {
+    if (!s->write_closed) {
       close_from_api(t, s, due_to_error);
     }
     return;

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -615,7 +615,6 @@ struct grpc_chttp2_stream {
   int64_t received_bytes = 0;
 
   bool sent_initial_metadata = false;
-  bool sent_trailing_metadata = false;
 
   grpc_core::PolymorphicManualConstructor<
       grpc_core::chttp2::StreamFlowControlBase,

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -611,7 +611,6 @@ class StreamWriteContext {
       *s_->sent_trailing_metadata_op = true;
       s_->sent_trailing_metadata_op = nullptr;
     }
-    s_->sent_trailing_metadata = true;
     s_->eos_sent = true;
 
     if (!t_->is_client && !s_->read_closed) {


### PR DESCRIPTION
After #19545 is merged, we'll also be able to add a test that messages are not dropped on server cancellations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/23757)
<!-- Reviewable:end -->
