### PR TITLE
docs: use lowercase in TROUBLESHOOTING guide

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,7 +10,7 @@ that gets printed to stderr.
 
 ## GRPC_VERBOSITY
 
-`GRPC_VERBOSITY` is used to set the minimum level of log messages printed by gRPC (supported values are `DEBUG`, `INFO` and `ERROR`). If this environment variable is unset, only `ERROR` logs will be printed.
+`GRPC_VERBOSITY` is used to set the minimum level of log messages printed by gRPC (supported values are `debug`, `info` and `error`). If this environment variable is unset, only `error` logs will be printed.
 
 ## GRPC_TRACE
 


### PR DESCRIPTION
We use the lowercase version in the steps right below. I assume they are interchangeable.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
