### PR TITLE
Include the target_uri in target uri is not valid error messages

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -28,6 +28,7 @@
 
 #include <set>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/alloc.h>
@@ -1683,8 +1684,9 @@ ChannelData::ChannelData(grpc_channel_element_args* args, grpc_error** error)
                       ? new_args
                       : grpc_channel_args_copy(args->channel_args);
   if (!ResolverRegistry::IsValidTarget(target_uri_.get())) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("the target uri is not valid.");
+    std::string error_message =
+        absl::StrCat("the target uri is not valid: ", target_uri_.get());
+    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_message.c_str());
     return;
   }
   *error = GRPC_ERROR_NONE;


### PR DESCRIPTION
Noticed that the error message here could be improved while looking at something where the target uri was being set incorrectly

This is also something towards https://github.com/grpc/grpc/issues/22883. Though this doesn't affect RPC status messages, it does improve the GPR_ERROR logs that are emitted upon channel creation failure: https://github.com/grpc/grpc/blob/86aa3579dfe8dbc9bc6258b894fa699e98752c75/src/core/lib/surface/channel.cc#L77
