### PR TITLE
use https instead of ssh for google/re2 repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/google/boringssl.git
 [submodule "third_party/re2"]
 	path = third_party/re2
-	url = git://github.com/google/re2.git
+	url = https://github.com/google/re2.git
 [submodule "third_party/cares/cares"]
 	path = third_party/cares/cares
 	url = https://github.com/c-ares/c-ares.git


### PR DESCRIPTION
re2 is the only submodule which uses ssh instead of https. As ssh always requires key configuration, https is the better choice is you simply want to clone the repo.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
