### PR TITLE
Fix comments in time.h

### DIFF
--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -32,9 +32,15 @@ extern "C" {
 
 /** Time constants. */
 GPRAPI gpr_timespec
-gpr_time_0(gpr_clock_type type); /** The zero time interval. */
-GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type); /** The far future */
-GPRAPI gpr_timespec gpr_inf_past(gpr_clock_type type);   /** The far past. */
+
+/** The zero time interval. */
+gpr_time_0(gpr_clock_type type);
+
+/** The far future */
+GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type);
+
+/** The far past. */
+GPRAPI gpr_timespec gpr_inf_past(gpr_clock_type type);
 
 #define GPR_MS_PER_SEC 1000
 #define GPR_US_PER_SEC 1000000
@@ -60,8 +66,10 @@ GPRAPI int gpr_time_cmp(gpr_timespec a, gpr_timespec b);
 GPRAPI gpr_timespec gpr_time_max(gpr_timespec a, gpr_timespec b);
 GPRAPI gpr_timespec gpr_time_min(gpr_timespec a, gpr_timespec b);
 
-/** Add and subtract times.  Calculations saturate at infinities. */
+/** Add times.  Calculations saturate at infinities. */
 GPRAPI gpr_timespec gpr_time_add(gpr_timespec a, gpr_timespec b);
+
+/** Subtract times.  Calculations saturate at infinities. */
 GPRAPI gpr_timespec gpr_time_sub(gpr_timespec a, gpr_timespec b);
 
 /** Return a timespec representing a given number of time units. INT64_MIN is


### PR DESCRIPTION
Small change that fixes comments in time.h that don't seem to survive the doc generation properly. i.e. the current same-line comments cause [docs](https://grpc.github.io/grpc/core/time_8h.html#ab2f44f83d25f050f8d607b2bd65e46a4) to say that `gpr_inf_past()` is "The far future."

Also added separate comments for `gpr_time_add()` and `gpr_time_sub()` since they get separated in the doc.

@nicolasnoble
