### PR TITLE
Fix HTTP/2 error to gRPC status mapping upon receiving a GOAWAY.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1067,12 +1067,14 @@ void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
   if (t->goaway_error != GRPC_ERROR_NONE) {
     GRPC_ERROR_UNREF(t->goaway_error);
   }
+  // Note: We do not set GRPC_ERROR_INT_GRPC_STATUS on this error,
+  // because without that attribute, grpc_error_get_status() will use
+  // grpc_http2_error_to_grpc_status() to set the status from the
+  // GRPC_ERROR_INT_HTTP2_ERROR attribute.
   t->goaway_error = grpc_error_set_str(
       grpc_error_set_int(
-          grpc_error_set_int(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING("GOAWAY received"),
-              GRPC_ERROR_INT_HTTP2_ERROR, static_cast<intptr_t>(goaway_error)),
-          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE),
+          GRPC_ERROR_CREATE_FROM_STATIC_STRING("GOAWAY received"),
+          GRPC_ERROR_INT_HTTP2_ERROR, static_cast<intptr_t>(goaway_error)),
       GRPC_ERROR_STR_RAW_BYTES, goaway_text);
 
   GRPC_CHTTP2_IF_TRACING(

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -106,6 +106,10 @@ grpc_error* grpc_chttp2_rst_stream_parser_parse(void* parser,
                       ((static_cast<uint32_t>(p->reason_bytes[3])));
     grpc_error* error = GRPC_ERROR_NONE;
     if (reason != GRPC_HTTP2_NO_ERROR || s->metadata_buffer[1].size == 0) {
+      // Note: We do not set GRPC_ERROR_INT_GRPC_STATUS on this error,
+      // because without that attribute, grpc_error_get_status() will use
+      // grpc_http2_error_to_grpc_status() to set the status from the
+      // GRPC_ERROR_INT_HTTP2_ERROR attribute.
       error = grpc_error_set_int(
           grpc_error_set_str(
               GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),


### PR DESCRIPTION
I broke this in #18222, but it turns out that the code was correct as-is, because it adheres to the defined mapping in https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#errors.  This reverts that part of the change and adds comments so that we don't accidentally break this again in the future.