### PR TITLE
Backport of #23765 to v1.30.x branch

### DIFF
--- a/src/compiler/ruby_generator_string-inl.h
+++ b/src/compiler/ruby_generator_string-inl.h
@@ -124,7 +124,7 @@ inline grpc::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor) {
     ReplacePrefix(&proto_type, ".", "");  // remove the leading . (no package)
     proto_type = RubyPackage(descriptor->file()) + "." + proto_type;
   }
-  grpc::string res(proto_type);
+  grpc::string res("." + proto_type);
   if (res.find('.') == grpc::string::npos) {
     return res;
   } else {

--- a/src/ruby/bin/math_services_pb.rb
+++ b/src/ruby/bin/math_services_pb.rb
@@ -31,19 +31,19 @@ module Math
 
       # Div divides DivArgs.dividend by DivArgs.divisor and returns the quotient
       # and remainder.
-      rpc :Div, DivArgs, DivReply
+      rpc :Div, ::Math::DivArgs, ::Math::DivReply
       # DivMany accepts an arbitrary number of division args from the client stream
       # and sends back the results in the reply stream.  The stream continues until
       # the client closes its end; the server does the same after sending all the
       # replies.  The stream ends immediately if either end aborts.
-      rpc :DivMany, stream(DivArgs), stream(DivReply)
+      rpc :DivMany, stream(::Math::DivArgs), stream(::Math::DivReply)
       # Fib generates numbers in the Fibonacci sequence.  If FibArgs.limit > 0, Fib
       # generates up to limit numbers; otherwise it continues until the call is
       # canceled.  Unlike Fib above, Fib has no final FibReply.
-      rpc :Fib, FibArgs, stream(Num)
+      rpc :Fib, ::Math::FibArgs, stream(::Math::Num)
       # Sum sums a stream of numbers, returning the final result once the stream
       # is closed.
-      rpc :Sum, stream(Num), Num
+      rpc :Sum, stream(::Math::Num), ::Math::Num
     end
 
     Stub = Service.rpc_stub_class

--- a/src/ruby/end2end/package_with_underscore_checker.rb
+++ b/src/ruby/end2end/package_with_underscore_checker.rb
@@ -43,8 +43,8 @@ def main
   end
 
   correct_modularized_rpc = 'rpc :TestOne, ' \
-                            'Grpc::Testing::PackageWithUnderscore::Data::Request, ' \
-                            'Grpc::Testing::PackageWithUnderscore::Data::Response'
+                            '::Grpc::Testing::PackageWithUnderscore::Data::Request, ' \
+                            '::Grpc::Testing::PackageWithUnderscore::Data::Response'
 
   return if got.include?(correct_modularized_rpc)
 

--- a/src/ruby/pb/grpc/health/v1/health_services_pb.rb
+++ b/src/ruby/pb/grpc/health/v1/health_services_pb.rb
@@ -36,7 +36,7 @@ module Grpc
 
           # If the requested service is unknown, the call will fail with status
           # NOT_FOUND.
-          rpc :Check, HealthCheckRequest, HealthCheckResponse
+          rpc :Check, ::Grpc::Health::V1::HealthCheckRequest, ::Grpc::Health::V1::HealthCheckResponse
           # Performs a watch for the serving status of the requested service.
           # The server will immediately send back a message indicating the current
           # serving status.  It will then subsequently send a new message whenever
@@ -52,7 +52,7 @@ module Grpc
           # should assume this method is not supported and should not retry the
           # call.  If the call terminates with any other status (including OK),
           # clients should retry the call with appropriate exponential backoff.
-          rpc :Watch, HealthCheckRequest, stream(HealthCheckResponse)
+          rpc :Watch, ::Grpc::Health::V1::HealthCheckRequest, stream(::Grpc::Health::V1::HealthCheckResponse)
         end
 
         Stub = Service.rpc_stub_class

--- a/src/ruby/pb/src/proto/grpc/testing/test_services_pb.rb
+++ b/src/ruby/pb/src/proto/grpc/testing/test_services_pb.rb
@@ -36,31 +36,31 @@ module Grpc
         self.service_name = 'grpc.testing.TestService'
 
         # One empty request followed by one empty response.
-        rpc :EmptyCall, Empty, Empty
+        rpc :EmptyCall, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
         # One request followed by one response.
-        rpc :UnaryCall, SimpleRequest, SimpleResponse
+        rpc :UnaryCall, ::Grpc::Testing::SimpleRequest, ::Grpc::Testing::SimpleResponse
         # One request followed by one response. Response has cache control
         # headers set such that a caching HTTP proxy (such as GFE) can
         # satisfy subsequent requests.
-        rpc :CacheableUnaryCall, SimpleRequest, SimpleResponse
+        rpc :CacheableUnaryCall, ::Grpc::Testing::SimpleRequest, ::Grpc::Testing::SimpleResponse
         # One request followed by a sequence of responses (streamed download).
         # The server returns the payload with client desired type and sizes.
-        rpc :StreamingOutputCall, StreamingOutputCallRequest, stream(StreamingOutputCallResponse)
+        rpc :StreamingOutputCall, ::Grpc::Testing::StreamingOutputCallRequest, stream(::Grpc::Testing::StreamingOutputCallResponse)
         # A sequence of requests followed by one response (streamed upload).
         # The server returns the aggregated size of client payload as the result.
-        rpc :StreamingInputCall, stream(StreamingInputCallRequest), StreamingInputCallResponse
+        rpc :StreamingInputCall, stream(::Grpc::Testing::StreamingInputCallRequest), ::Grpc::Testing::StreamingInputCallResponse
         # A sequence of requests with each request served by the server immediately.
         # As one request could lead to multiple responses, this interface
         # demonstrates the idea of full duplexing.
-        rpc :FullDuplexCall, stream(StreamingOutputCallRequest), stream(StreamingOutputCallResponse)
+        rpc :FullDuplexCall, stream(::Grpc::Testing::StreamingOutputCallRequest), stream(::Grpc::Testing::StreamingOutputCallResponse)
         # A sequence of requests followed by a sequence of responses.
         # The server buffers all the client requests and then serves them in order. A
         # stream of responses are returned to the client when the server starts with
         # first request.
-        rpc :HalfDuplexCall, stream(StreamingOutputCallRequest), stream(StreamingOutputCallResponse)
+        rpc :HalfDuplexCall, stream(::Grpc::Testing::StreamingOutputCallRequest), stream(::Grpc::Testing::StreamingOutputCallResponse)
         # The test server will not implement this method. It will be used
         # to test the behavior when clients call unimplemented methods.
-        rpc :UnimplementedCall, Empty, Empty
+        rpc :UnimplementedCall, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
       end
 
       Stub = Service.rpc_stub_class
@@ -77,7 +77,7 @@ module Grpc
         self.service_name = 'grpc.testing.UnimplementedService'
 
         # A call that no server should implement
-        rpc :UnimplementedCall, Empty, Empty
+        rpc :UnimplementedCall, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
       end
 
       Stub = Service.rpc_stub_class
@@ -92,8 +92,8 @@ module Grpc
         self.unmarshal_class_method = :decode
         self.service_name = 'grpc.testing.ReconnectService'
 
-        rpc :Start, ReconnectParams, Empty
-        rpc :Stop, Empty, ReconnectInfo
+        rpc :Start, ::Grpc::Testing::ReconnectParams, ::Grpc::Testing::Empty
+        rpc :Stop, ::Grpc::Testing::Empty, ::Grpc::Testing::ReconnectInfo
       end
 
       Stub = Service.rpc_stub_class
@@ -109,7 +109,23 @@ module Grpc
         self.service_name = 'grpc.testing.LoadBalancerStatsService'
 
         # Gets the backend distribution for RPCs sent by a test client.
-        rpc :GetClientStats, LoadBalancerStatsRequest, LoadBalancerStatsResponse
+        rpc :GetClientStats, ::Grpc::Testing::LoadBalancerStatsRequest, ::Grpc::Testing::LoadBalancerStatsResponse
+      end
+
+      Stub = Service.rpc_stub_class
+    end
+    module XdsUpdateHealthService
+      # A service to remotely control health status of an xDS test server.
+      class Service
+
+        include GRPC::GenericService
+
+        self.marshal_class_method = :encode
+        self.unmarshal_class_method = :decode
+        self.service_name = 'grpc.testing.XdsUpdateHealthService'
+
+        rpc :SetServing, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
+        rpc :SetNotServing, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
       end
 
       Stub = Service.rpc_stub_class

--- a/src/ruby/qps/src/proto/grpc/testing/benchmark_service_services_pb.rb
+++ b/src/ruby/qps/src/proto/grpc/testing/benchmark_service_services_pb.rb
@@ -34,20 +34,20 @@ module Grpc
 
         # One request followed by one response.
         # The server returns the client payload as-is.
-        rpc :UnaryCall, SimpleRequest, SimpleResponse
+        rpc :UnaryCall, ::Grpc::Testing::SimpleRequest, ::Grpc::Testing::SimpleResponse
         # Repeated sequence of one request followed by one response.
         # Should be called streaming ping-pong
         # The server returns the client payload as-is on each response
-        rpc :StreamingCall, stream(SimpleRequest), stream(SimpleResponse)
+        rpc :StreamingCall, stream(::Grpc::Testing::SimpleRequest), stream(::Grpc::Testing::SimpleResponse)
         # Single-sided unbounded streaming from client to server
         # The server returns the client payload as-is once the client does WritesDone
-        rpc :StreamingFromClient, stream(SimpleRequest), SimpleResponse
+        rpc :StreamingFromClient, stream(::Grpc::Testing::SimpleRequest), ::Grpc::Testing::SimpleResponse
         # Single-sided unbounded streaming from server to client
         # The server repeatedly returns the client payload as-is
-        rpc :StreamingFromServer, SimpleRequest, stream(SimpleResponse)
+        rpc :StreamingFromServer, ::Grpc::Testing::SimpleRequest, stream(::Grpc::Testing::SimpleResponse)
         # Two-sided unbounded streaming between server to client
         # Both sides send the content of their own choice to the other
-        rpc :StreamingBothWays, stream(SimpleRequest), stream(SimpleResponse)
+        rpc :StreamingBothWays, stream(::Grpc::Testing::SimpleRequest), stream(::Grpc::Testing::SimpleResponse)
       end
 
       Stub = Service.rpc_stub_class

--- a/src/ruby/qps/src/proto/grpc/testing/report_qps_scenario_service_services_pb.rb
+++ b/src/ruby/qps/src/proto/grpc/testing/report_qps_scenario_service_services_pb.rb
@@ -33,7 +33,7 @@ module Grpc
         self.service_name = 'grpc.testing.ReportQpsScenarioService'
 
         # Report results of a QPS test benchmark scenario.
-        rpc :ReportScenario, ScenarioResult, Void
+        rpc :ReportScenario, ::Grpc::Testing::ScenarioResult, ::Grpc::Testing::Void
       end
 
       Stub = Service.rpc_stub_class

--- a/src/ruby/qps/src/proto/grpc/testing/worker_service_services_pb.rb
+++ b/src/ruby/qps/src/proto/grpc/testing/worker_service_services_pb.rb
@@ -38,18 +38,18 @@ module Grpc
         # stats. Closing the stream will initiate shutdown of the test server
         # and once the shutdown has finished, the OK status is sent to terminate
         # this RPC.
-        rpc :RunServer, stream(ServerArgs), stream(ServerStatus)
+        rpc :RunServer, stream(::Grpc::Testing::ServerArgs), stream(::Grpc::Testing::ServerStatus)
         # Start client with specified workload.
         # First request sent specifies the ClientConfig followed by ClientStatus
         # response. After that, a "Mark" can be sent anytime to request the latest
         # stats. Closing the stream will initiate shutdown of the test client
         # and once the shutdown has finished, the OK status is sent to terminate
         # this RPC.
-        rpc :RunClient, stream(ClientArgs), stream(ClientStatus)
+        rpc :RunClient, stream(::Grpc::Testing::ClientArgs), stream(::Grpc::Testing::ClientStatus)
         # Just return the core count - unary call
-        rpc :CoreCount, CoreRequest, CoreResponse
+        rpc :CoreCount, ::Grpc::Testing::CoreRequest, ::Grpc::Testing::CoreResponse
         # Quit this worker
-        rpc :QuitWorker, Void, Void
+        rpc :QuitWorker, ::Grpc::Testing::Void, ::Grpc::Testing::Void
       end
 
       Stub = Service.rpc_stub_class

--- a/src/ruby/spec/pb/codegen/grpc/testing/same_package_service_name.proto
+++ b/src/ruby/spec/pb/codegen/grpc/testing/same_package_service_name.proto
@@ -1,0 +1,27 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package same_name;
+
+service SameName {
+  rpc Health(Request) returns (Status);
+}
+
+message Status {
+  string msg = 1;
+}
+
+message Request {}

--- a/src/ruby/spec/pb/codegen/grpc/testing/same_ruby_package_service_name.proto
+++ b/src/ruby/spec/pb/codegen/grpc/testing/same_ruby_package_service_name.proto
@@ -1,0 +1,29 @@
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package other_name;
+
+option ruby_package = "SameName2";
+
+service SameName2 {
+  rpc Health(Request) returns (Status);
+}
+
+message Status {
+  string msg = 1;
+}
+
+message Request {}

--- a/src/ruby/spec/pb/codegen/package_option_spec.rb
+++ b/src/ruby/spec/pb/codegen/package_option_spec.rb
@@ -48,6 +48,26 @@ describe 'Code Generation Options' do
       expect(services[:NestedMessageTest].output).to eq(RPC::Test::New::Package::Options::Bar::Baz)
     end
   end
+
+  it 'should generate when package and service has same name' do
+    with_protos(['grpc/testing/same_package_service_name.proto']) do
+      expect { SameName::SameName::Service }.to raise_error(NameError)
+      expect(require('grpc/testing/same_package_service_name_services_pb')).to be_truthy
+      expect { SameName::SameName::Service }.to_not raise_error
+      expect { SameName::Request }.to_not raise_error
+      expect { SameName::Status }.to_not raise_error
+    end
+  end
+
+  it 'should generate when ruby_package and service has same name' do
+    with_protos(['grpc/testing/same_ruby_package_service_name.proto']) do
+      expect { SameName2::SameName2::Service }.to raise_error(NameError)
+      expect(require('grpc/testing/same_ruby_package_service_name_services_pb')).to be_truthy
+      expect { SameName2::SameName2::Service }.to_not raise_error
+      expect { SameName2::Request }.to_not raise_error
+      expect { SameName2::Status }.to_not raise_error
+    end
+  end
 end
 
 def with_protos(file_paths)


### PR DESCRIPTION
This PR is to backport the #23765 fix to the `v1.30.x` branch.

The main fix is to add this `"."` in front of the fully qualified proto message name, so that it will be converted into an absolute path starting with `::` as the Ruby package name. See [this comment](https://github.com/grpc/grpc/issues/23746#issue-673815291) and [this comment](https://github.com/grpc/grpc/issues/23746#issuecomment-671536078) for the rationale for the fix.

There are new tests added in the PR.

We also ran the `src/ruby/pb/generate_proto_ruby.sh` script to re-generate some generated files that will be updated by this protoc plugin change. NOTE that, only 6 files are re-generated after running that script in this PR (for `v1.30.x`), as opposed to _8_ files being updated in the `v1.31.x` branch and `master` branch respectively, likely because there are some additional new changes to the corresponding .proto files _after_ version 1.30.