### PR TITLE
Add bazel "counters" config (to enable switching microbenchmark build to bazel)

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -88,3 +88,10 @@ build:basicprof --copt=-DGRPC_TIMERS_RDTSC
 build:python_single_threaded_unary_stream --test_env="GRPC_SINGLE_THREADED_UNARY_STREAM=true"
 
 build:python_poller_engine --test_env="GRPC_ASYNCIO_ENGINE=poller"
+
+# "counters" config is based on a legacy config provided by the Makefile (see definition in build_handwritten.yaml).
+# It is only used in microbenchmarks.
+# TODO(jtattermusch): get rid of the "counters" config when possible
+build:counters --compilation_mode=opt
+build:counters --copt=-Wframe-larger-than=16384
+build:counters --copt=-DGPR_LOW_LEVEL_COUNTERS


### PR DESCRIPTION
Needs to be merged before https://github.com/grpc/grpc/pull/23813 to make the "microbenchmark diff" tests there pass.

The issue is that the "diff" tests build both on the PR and on upstream/master, but the "counters" config is not on master yet.