### PR TITLE
Make status_code_and_message interop test robust

### DIFF
--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -88,6 +88,18 @@ py_library(
     ],
 )
 
+py_binary(
+    name = "server_bin",
+    srcs = ["server.py"],
+    main = "server.py",
+    python_version = "PY3",
+    deps = [
+        ":server",
+        ":service",
+        "//src/proto/grpc/testing:test_py_pb2_grpc",
+    ],
+)
+
 py2and3_test(
     name = "_insecure_intraop_test",
     size = "small",

--- a/src/python/grpcio_tests/tests/interop/methods.py
+++ b/src/python/grpcio_tests/tests/interop/methods.py
@@ -301,6 +301,10 @@ def _status_code_and_message(stub):
             payload=messages_pb2.Payload(body=b'\x00'),
             response_status=messages_pb2.EchoStatus(code=code, message=details))
         pipe.add(request)  # sends the initial request.
+    try:
+        next(response_iterator)
+    except grpc.RpcError as rpc_error:
+        assert rpc_error.code() == status
     # Dropping out of with block closes the pipe
     _validate_status_code_and_details(response_iterator, status, details)
 

--- a/src/python/grpcio_tests/tests_aio/interop/methods.py
+++ b/src/python/grpcio_tests/tests_aio/interop/methods.py
@@ -271,6 +271,10 @@ async def _status_code_and_message(stub: test_pb2_grpc.TestServiceStub):
                                                 message=details))
     await call.write(request)  # sends the initial request.
     await call.done_writing()
+    try:
+        await call.read()
+    except aio.AioRpcError as rpc_error:
+        assert rpc_error.code() == status
     await _validate_status_code_and_details(call, status, details)
 
 


### PR DESCRIPTION
Fixes the interop breakage in https://github.com/grpc/grpc/pull/19545.

It's unclear why only Python clients are infected. Most likely, the culprit is the test implementation instead of overall architecture.

This PR tries to drain bi-di streaming RPC before trying to get the final status code.