### PR TITLE
ALTS peer attributes plumbing

### DIFF
--- a/include/grpcpp/security/alts_context.h
+++ b/include/grpcpp/security/alts_context.h
@@ -22,6 +22,7 @@
 #include <grpc/grpc_security_constants.h>
 #include <grpcpp/security/auth_context.h>
 
+#include <map>
 #include <memory>
 
 struct grpc_gcp_AltsContext;
@@ -50,15 +51,16 @@ class AltsContext {
   std::string local_service_account() const;
   grpc_security_level security_level() const;
   RpcProtocolVersions peer_rpc_versions() const;
+  const std::map<std::string, std::string>& peer_attributes() const;
 
  private:
-  // TODO(ZhenLian): Also plumb field peer_attributes when it is in use
   std::string application_protocol_;
   std::string record_protocol_;
   std::string peer_service_account_;
   std::string local_service_account_;
   grpc_security_level security_level_ = GRPC_SECURITY_NONE;
   RpcProtocolVersions peer_rpc_versions_ = {{0, 0}, {0, 0}};
+  std::map<std::string, std::string> peer_attributes_map_;
 };
 
 }  // namespace experimental

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -334,6 +334,28 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
                                                  local_service_account);
   grpc_gcp_AltsContext_set_peer_rpc_versions(
       context, const_cast<grpc_gcp_RpcProtocolVersions*>(peer_rpc_version));
+  grpc_gcp_Identity* peer_identity = const_cast<grpc_gcp_Identity*>(identity);
+  if (peer_identity == nullptr) {
+    gpr_log(GPR_ERROR, "Null peer identity in ALTS context.");
+    return TSI_FAILED_PRECONDITION;
+  }
+  if (grpc_gcp_Identity_has_attributes(identity)) {
+    size_t iter = UPB_MAP_BEGIN;
+    grpc_gcp_Identity_AttributesEntry* peer_attributes_entry =
+        grpc_gcp_Identity_attributes_nextmutable(peer_identity, &iter);
+    while (peer_attributes_entry != nullptr) {
+      upb_strview key = grpc_gcp_Identity_AttributesEntry_key(
+          const_cast<grpc_gcp_Identity_AttributesEntry*>(
+              peer_attributes_entry));
+      upb_strview val = grpc_gcp_Identity_AttributesEntry_value(
+          const_cast<grpc_gcp_Identity_AttributesEntry*>(
+              peer_attributes_entry));
+      grpc_gcp_AltsContext_peer_attributes_set(context, key, val,
+                                               context_arena.ptr());
+      peer_attributes_entry =
+          grpc_gcp_Identity_attributes_nextmutable(peer_identity, &iter);
+    }
+  }
   size_t serialized_ctx_length;
   char* serialized_ctx = grpc_gcp_AltsContext_serialize(
       context, context_arena.ptr(), &serialized_ctx_length);

--- a/src/cpp/common/alts_context.cc
+++ b/src/cpp/common/alts_context.cc
@@ -80,6 +80,21 @@ AltsContext::AltsContext(const grpc_gcp_AltsContext* ctx) {
     security_level_ = static_cast<grpc_security_level>(
         grpc_gcp_AltsContext_security_level(ctx));
   }
+  if (grpc_gcp_AltsContext_has_peer_attributes(ctx)) {
+    size_t iter = UPB_MAP_BEGIN;
+    const grpc_gcp_AltsContext_PeerAttributesEntry* peer_attributes_entry =
+        grpc_gcp_AltsContext_peer_attributes_next(ctx, &iter);
+    while (peer_attributes_entry != nullptr) {
+      upb_strview key =
+          grpc_gcp_AltsContext_PeerAttributesEntry_key(peer_attributes_entry);
+      upb_strview val =
+          grpc_gcp_AltsContext_PeerAttributesEntry_value(peer_attributes_entry);
+      peer_attributes_map_[std::string(key.data, key.size)] =
+          std::string(val.data, val.size);
+      peer_attributes_entry =
+          grpc_gcp_AltsContext_peer_attributes_next(ctx, &iter);
+    }
+  }
 }
 
 std::string AltsContext::application_protocol() const {
@@ -102,6 +117,10 @@ grpc_security_level AltsContext::security_level() const {
 
 AltsContext::RpcProtocolVersions AltsContext::peer_rpc_versions() const {
   return peer_rpc_versions_;
+}
+
+const std::map<std::string, std::string>& AltsContext::peer_attributes() const {
+  return peer_attributes_map_;
 }
 
 }  // namespace experimental

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -53,6 +53,8 @@
   "test application protocol"
 #define ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL "test record protocol"
 #define ALTS_TSI_HANDSHAKER_TEST_MAX_FRAME_SIZE 256 * 1024
+#define ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_KEY "peer"
+#define ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_VALUE "attributes"
 
 using grpc_core::internal::alts_handshaker_client_check_fields_for_testing;
 using grpc_core::internal::alts_handshaker_client_get_handshaker_for_testing;
@@ -148,6 +150,11 @@ static grpc_byte_buffer* generate_handshaker_response(
       result = grpc_gcp_HandshakerResp_mutable_result(resp, arena.ptr());
       peer_identity =
           grpc_gcp_HandshakerResult_mutable_peer_identity(result, arena.ptr());
+      grpc_gcp_Identity_attributes_set(
+          peer_identity,
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_KEY),
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_VALUE),
+          arena.ptr());
       grpc_gcp_Identity_set_service_account(
           peer_identity,
           upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY));
@@ -177,6 +184,11 @@ static grpc_byte_buffer* generate_handshaker_response(
       result = grpc_gcp_HandshakerResp_mutable_result(resp, arena.ptr());
       peer_identity =
           grpc_gcp_HandshakerResult_mutable_peer_identity(result, arena.ptr());
+      grpc_gcp_Identity_attributes_set(
+          peer_identity,
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_KEY),
+          upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_VALUE),
+          arena.ptr());
       grpc_gcp_Identity_set_service_account(
           peer_identity,
           upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY));
@@ -328,6 +340,25 @@ static void on_client_next_success_cb(tsi_result status, void* user_data,
                     peer_account.size) == 0);
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY, local_account.data,
                     local_account.size) == 0);
+  size_t iter = UPB_MAP_BEGIN;
+  grpc_gcp_AltsContext_PeerAttributesEntry* peer_attributes_entry =
+      grpc_gcp_AltsContext_peer_attributes_nextmutable(ctx, &iter);
+  GPR_ASSERT(peer_attributes_entry != nullptr);
+  while (peer_attributes_entry != nullptr) {
+    upb_strview key = grpc_gcp_AltsContext_PeerAttributesEntry_key(
+        const_cast<grpc_gcp_AltsContext_PeerAttributesEntry*>(
+            peer_attributes_entry));
+    upb_strview val = grpc_gcp_AltsContext_PeerAttributesEntry_value(
+        const_cast<grpc_gcp_AltsContext_PeerAttributesEntry*>(
+            peer_attributes_entry));
+    GPR_ASSERT(upb_strview_eql(
+        key, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_KEY)));
+    GPR_ASSERT(upb_strview_eql(
+        val,
+        upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_VALUE)));
+    peer_attributes_entry =
+        grpc_gcp_AltsContext_peer_attributes_nextmutable(ctx, &iter);
+  }
   /* Validate security level. */
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_SECURITY_LEVEL,
                     peer.properties[4].value.data,
@@ -402,6 +433,25 @@ static void on_server_next_success_cb(tsi_result status, void* user_data,
                     peer_account.size) == 0);
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY, local_account.data,
                     local_account.size) == 0);
+  size_t iter = UPB_MAP_BEGIN;
+  grpc_gcp_AltsContext_PeerAttributesEntry* peer_attributes_entry =
+      grpc_gcp_AltsContext_peer_attributes_nextmutable(ctx, &iter);
+  GPR_ASSERT(peer_attributes_entry != nullptr);
+  while (peer_attributes_entry != nullptr) {
+    upb_strview key = grpc_gcp_AltsContext_PeerAttributesEntry_key(
+        const_cast<grpc_gcp_AltsContext_PeerAttributesEntry*>(
+            peer_attributes_entry));
+    upb_strview val = grpc_gcp_AltsContext_PeerAttributesEntry_value(
+        const_cast<grpc_gcp_AltsContext_PeerAttributesEntry*>(
+            peer_attributes_entry));
+    GPR_ASSERT(upb_strview_eql(
+        key, upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_KEY)));
+    GPR_ASSERT(upb_strview_eql(
+        val,
+        upb_strview_makez(ALTS_TSI_HANDSHAKER_TEST_PEER_ATTRIBUTES_VALUE)));
+    peer_attributes_entry =
+        grpc_gcp_AltsContext_peer_attributes_nextmutable(ctx, &iter);
+  }
   /* Check security level. */
   GPR_ASSERT(memcmp(ALTS_TSI_HANDSHAKER_TEST_SECURITY_LEVEL,
                     peer.properties[4].value.data,

--- a/test/cpp/common/alts_util_test.cc
+++ b/test/cpp/common/alts_util_test.cc
@@ -83,6 +83,8 @@ TEST(AltsUtilTest, AuthContextWithGoodAltsContextWithoutRpcVersions) {
   std::string expected_rp("record protocol");
   std::string expected_peer("peer");
   std::string expected_local("local");
+  std::string expected_peer_atrributes_key("peer");
+  std::string expected_peer_atrributes_value("attributes");
   grpc_security_level expected_sl = GRPC_INTEGRITY_ONLY;
   upb::Arena context_arena;
   grpc_gcp_AltsContext* context = grpc_gcp_AltsContext_new(context_arena.ptr());
@@ -96,6 +98,13 @@ TEST(AltsUtilTest, AuthContextWithGoodAltsContextWithoutRpcVersions) {
   grpc_gcp_AltsContext_set_local_service_account(
       context,
       upb_strview_make(expected_local.data(), expected_local.length()));
+  grpc_gcp_AltsContext_peer_attributes_set(
+      context,
+      upb_strview_make(expected_peer_atrributes_key.data(),
+                       expected_peer_atrributes_key.length()),
+      upb_strview_make(expected_peer_atrributes_value.data(),
+                       expected_peer_atrributes_value.length()),
+      context_arena.ptr());
   size_t serialized_ctx_length;
   char* serialized_ctx = grpc_gcp_AltsContext_serialize(
       context, context_arena.ptr(), &serialized_ctx_length);
@@ -117,6 +126,8 @@ TEST(AltsUtilTest, AuthContextWithGoodAltsContextWithoutRpcVersions) {
   EXPECT_EQ(0, rpc_protocol_versions.max_rpc_version.minor_version);
   EXPECT_EQ(0, rpc_protocol_versions.min_rpc_version.major_version);
   EXPECT_EQ(0, rpc_protocol_versions.min_rpc_version.minor_version);
+  EXPECT_EQ(expected_peer_atrributes_value,
+            alts_context->peer_attributes().at(expected_peer_atrributes_key));
 }
 
 TEST(AltsUtilTest, AuthContextWithGoodAltsContext) {

--- a/test/cpp/common/alts_util_test.cc
+++ b/test/cpp/common/alts_util_test.cc
@@ -26,6 +26,7 @@
 #include "src/core/tsi/alts/handshaker/alts_tsi_handshaker.h"
 #include "src/cpp/common/secure_auth_context.h"
 #include "src/proto/grpc/gcp/altscontext.upb.h"
+#include "test/core/util/test_config.h"
 #include "test/cpp/util/string_ref_helper.h"
 
 namespace grpc {
@@ -211,6 +212,7 @@ TEST(AltsUtilTest, AltsClientAuthzCheck) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This is based on the work of https://github.com/grpc/grpc/pull/23441.
Finished Peer Attributes Plumbing for ALTS Context. Now the user has the ability to interact with the peer attributes map from the resulting ALTS Context. Specific changes involved using upb to take the peer attribute entries from the Handshaker response and copy them over to place them in Peer Identity entries and later convert that to a map that the user can more easily interact with.
