### PR TITLE
Re-generate PHP API reference html files using 1.31.0 branch

### DIFF
--- a/php/_abstract_call_8php.html
+++ b/php/_abstract_call_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -88,7 +88,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_base_stub_8php.html
+++ b/php/_base_stub_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_bidi_streaming_call_8php.html
+++ b/php/_bidi_streaming_call_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_call_8php.html
+++ b/php/_call_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_call_credentials_8php.html
+++ b/php/_call_credentials_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_call_invoker_8php.html
+++ b/php/_call_invoker_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_channel_8php.html
+++ b/php/_channel_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_channel_credentials_8php.html
+++ b/php/_channel_credentials_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_client_streaming_call_8php.html
+++ b/php/_client_streaming_call_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_constants_8php.html
+++ b/php/_constants_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -83,7 +83,6 @@ Namespaces</h2></td></tr>
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="var-members"></a>
 Variables</h2></td></tr>
 <tr class="memitem:aba15b4f16d9a94dae1458b6f89aa5b1e"><td class="memItemLeft" align="right" valign="top">const&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="namespace_grpc.html#aba15b4f16d9a94dae1458b6f89aa5b1e">Grpc::CALL_OK</a></td></tr>
-<tr class="memdesc:aba15b4f16d9a94dae1458b6f89aa5b1e"><td class="mdescLeft">&#160;</td><td class="mdescRight">everything went ok  <a href="namespace_grpc.html#aba15b4f16d9a94dae1458b6f89aa5b1e">More...</a><br /></td></tr>
 <tr class="separator:aba15b4f16d9a94dae1458b6f89aa5b1e"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a6f12e0a446b5933efeb43bb0f33f2de4"><td class="memItemLeft" align="right" valign="top">const&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="namespace_grpc.html#a6f12e0a446b5933efeb43bb0f33f2de4">Grpc::CALL_ERROR</a></td></tr>
 <tr class="memdesc:a6f12e0a446b5933efeb43bb0f33f2de4"><td class="mdescLeft">&#160;</td><td class="mdescRight">something failed, we don't know what  <a href="namespace_grpc.html#a6f12e0a446b5933efeb43bb0f33f2de4">More...</a><br /></td></tr>
@@ -209,7 +208,7 @@ Variables</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_default_call_invoker_8php.html
+++ b/php/_default_call_invoker_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_interceptor_8php.html
+++ b/php/_interceptor_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_p_r_o_t_o_c_o_l-_h_t_t_p2_8md.html
+++ b/php/_p_r_o_t_o_c_o_l-_h_t_t_p2_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_p_r_o_t_o_c_o_l-_w_e_b_8md.html
+++ b/php/_p_r_o_t_o_c_o_l-_w_e_b_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_r_e_a_d_m_e_8md.html
+++ b/php/_r_e_a_d_m_e_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_rpc_server_8php.html
+++ b/php/_rpc_server_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -88,7 +88,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_server_8php.html
+++ b/php/_server_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_server_credentials_8php.html
+++ b/php/_server_credentials_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_server_streaming_call_8php.html
+++ b/php/_server_streaming_call_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_timeval_8php.html
+++ b/php/_timeval_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/_unary_call_8php.html
+++ b/php/_unary_call_8php.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -89,7 +89,7 @@ Namespaces</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/annotated.html
+++ b/php/annotated.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -91,7 +91,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/binary-logging_8md.html
+++ b/php/binary-logging_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/c-style-guide_8md.html
+++ b/php/c-style-guide_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_abstract_call.html
+++ b/php/class_grpc_1_1_abstract_call.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -432,7 +432,7 @@ Protected Attributes</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_base_stub.html
+++ b/php/class_grpc_1_1_base_stub.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -562,7 +562,7 @@ Protected Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_bidi_streaming_call.html
+++ b/php/class_grpc_1_1_bidi_streaming_call.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -261,7 +261,7 @@ Additional Inherited Members</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_call.html
+++ b/php/class_grpc_1_1_call.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -81,18 +81,18 @@ Public Member Functions</h2></td></tr>
 <tr class="memitem:a1e427a3545ad6116b06788ac453a8503"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#a1e427a3545ad6116b06788ac453a8503">__construct</a> ($channel_obj, $method, $deadline_obj, $host_override=&quot;&quot;)</td></tr>
 <tr class="memdesc:a1e427a3545ad6116b06788ac453a8503"><td class="mdescLeft">&#160;</td><td class="mdescRight">Constructs a new instance of the <a class="el" href="class_grpc_1_1_call.html" title="class Call">Call</a> class.  <a href="class_grpc_1_1_call.html#a1e427a3545ad6116b06788ac453a8503">More...</a><br /></td></tr>
 <tr class="separator:a1e427a3545ad6116b06788ac453a8503"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:a0026968f6868365e3ba910f5b30416c5"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#a0026968f6868365e3ba910f5b30416c5">startBatch</a> ($array)</td></tr>
-<tr class="memdesc:a0026968f6868365e3ba910f5b30416c5"><td class="mdescLeft">&#160;</td><td class="mdescRight">Start a batch of RPC actions.  <a href="class_grpc_1_1_call.html#a0026968f6868365e3ba910f5b30416c5">More...</a><br /></td></tr>
-<tr class="separator:a0026968f6868365e3ba910f5b30416c5"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:ab6aa5fa913c3175b4c029e372112a777"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#ab6aa5fa913c3175b4c029e372112a777">getPeer</a> ()</td></tr>
-<tr class="memdesc:ab6aa5fa913c3175b4c029e372112a777"><td class="mdescLeft">&#160;</td><td class="mdescRight">Get the endpoint this call/stream is connected to.  <a href="class_grpc_1_1_call.html#ab6aa5fa913c3175b4c029e372112a777">More...</a><br /></td></tr>
-<tr class="separator:ab6aa5fa913c3175b4c029e372112a777"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:afc7c962d3288c3483ea4ce6ed1cfe9f7"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#afc7c962d3288c3483ea4ce6ed1cfe9f7">cancel</a> ()</td></tr>
 <tr class="memdesc:afc7c962d3288c3483ea4ce6ed1cfe9f7"><td class="mdescLeft">&#160;</td><td class="mdescRight">Cancel the call.  <a href="class_grpc_1_1_call.html#afc7c962d3288c3483ea4ce6ed1cfe9f7">More...</a><br /></td></tr>
 <tr class="separator:afc7c962d3288c3483ea4ce6ed1cfe9f7"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a0026968f6868365e3ba910f5b30416c5"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#a0026968f6868365e3ba910f5b30416c5">startBatch</a> ($array)</td></tr>
+<tr class="memdesc:a0026968f6868365e3ba910f5b30416c5"><td class="mdescLeft">&#160;</td><td class="mdescRight">Start a batch of RPC actions.  <a href="class_grpc_1_1_call.html#a0026968f6868365e3ba910f5b30416c5">More...</a><br /></td></tr>
+<tr class="separator:a0026968f6868365e3ba910f5b30416c5"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a547de08c2c0712561250ff01c32a9b90"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#a547de08c2c0712561250ff01c32a9b90">setCredentials</a> ($creds_obj)</td></tr>
 <tr class="memdesc:a547de08c2c0712561250ff01c32a9b90"><td class="mdescLeft">&#160;</td><td class="mdescRight">Set the <a class="el" href="class_grpc_1_1_call_credentials.html" title="class CallCredentials">CallCredentials</a> for this call.  <a href="class_grpc_1_1_call.html#a547de08c2c0712561250ff01c32a9b90">More...</a><br /></td></tr>
 <tr class="separator:a547de08c2c0712561250ff01c32a9b90"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:ab6aa5fa913c3175b4c029e372112a777"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call.html#ab6aa5fa913c3175b4c029e372112a777">getPeer</a> ()</td></tr>
+<tr class="memdesc:ab6aa5fa913c3175b4c029e372112a777"><td class="mdescLeft">&#160;</td><td class="mdescRight">Get the endpoint this call/stream is connected to.  <a href="class_grpc_1_1_call.html#ab6aa5fa913c3175b4c029e372112a777">More...</a><br /></td></tr>
+<tr class="separator:ab6aa5fa913c3175b4c029e372112a777"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>
 <div class="textblock"><p>class <a class="el" href="class_grpc_1_1_call.html" title="class Call">Call</a> </p>
@@ -250,7 +250,7 @@ Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_call_credentials.html
+++ b/php/class_grpc_1_1_call_credentials.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -78,12 +78,12 @@ $(function() {
 <table class="memberdecls">
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="pub-static-methods"></a>
 Static Public Member Functions</h2></td></tr>
-<tr class="memitem:a3fba3eaacbc05e4f8aff03d77e591eaf"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call_credentials.html#a3fba3eaacbc05e4f8aff03d77e591eaf">createComposite</a> ($cred1_obj, $cred2_obj)</td></tr>
-<tr class="memdesc:a3fba3eaacbc05e4f8aff03d77e591eaf"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create composite credentials from two existing credentials.  <a href="class_grpc_1_1_call_credentials.html#a3fba3eaacbc05e4f8aff03d77e591eaf">More...</a><br /></td></tr>
-<tr class="separator:a3fba3eaacbc05e4f8aff03d77e591eaf"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a1a1bbc0082e41f40873d9c3a97574bed"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call_credentials.html#a1a1bbc0082e41f40873d9c3a97574bed">createFromPlugin</a> ($fci)</td></tr>
 <tr class="memdesc:a1a1bbc0082e41f40873d9c3a97574bed"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create a call credentials object from the plugin API.  <a href="class_grpc_1_1_call_credentials.html#a1a1bbc0082e41f40873d9c3a97574bed">More...</a><br /></td></tr>
 <tr class="separator:a1a1bbc0082e41f40873d9c3a97574bed"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a3fba3eaacbc05e4f8aff03d77e591eaf"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_call_credentials.html#a3fba3eaacbc05e4f8aff03d77e591eaf">createComposite</a> ($cred1_obj, $cred2_obj)</td></tr>
+<tr class="memdesc:a3fba3eaacbc05e4f8aff03d77e591eaf"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create composite credentials from two existing credentials.  <a href="class_grpc_1_1_call_credentials.html#a3fba3eaacbc05e4f8aff03d77e591eaf">More...</a><br /></td></tr>
+<tr class="separator:a3fba3eaacbc05e4f8aff03d77e591eaf"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>
 <div class="textblock"><p>class <a class="el" href="class_grpc_1_1_call_credentials.html" title="class CallCredentials">CallCredentials</a> </p>
@@ -176,7 +176,7 @@ Static Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_channel.html
+++ b/php/class_grpc_1_1_channel.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -81,12 +81,12 @@ Public Member Functions</h2></td></tr>
 <tr class="memitem:aa9cf4f79b071b277c297cbd2da31aff2"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel.html#aa9cf4f79b071b277c297cbd2da31aff2">__construct</a> ($target, $args_array)</td></tr>
 <tr class="memdesc:aa9cf4f79b071b277c297cbd2da31aff2"><td class="mdescLeft">&#160;</td><td class="mdescRight">Construct an instance of the <a class="el" href="class_grpc_1_1_channel.html" title="class Channel">Channel</a> class.  <a href="class_grpc_1_1_channel.html#aa9cf4f79b071b277c297cbd2da31aff2">More...</a><br /></td></tr>
 <tr class="separator:aa9cf4f79b071b277c297cbd2da31aff2"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:afce31d39c37f42d29cae7c5fbd5279d9"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel.html#afce31d39c37f42d29cae7c5fbd5279d9">getTarget</a> ()</td></tr>
-<tr class="memdesc:afce31d39c37f42d29cae7c5fbd5279d9"><td class="mdescLeft">&#160;</td><td class="mdescRight">Get the endpoint this call/stream is connected to.  <a href="class_grpc_1_1_channel.html#afce31d39c37f42d29cae7c5fbd5279d9">More...</a><br /></td></tr>
-<tr class="separator:afce31d39c37f42d29cae7c5fbd5279d9"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a64f6c766e8d06e6d78c01c37de28f8d7"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel.html#a64f6c766e8d06e6d78c01c37de28f8d7">getConnectivityState</a> ($try_to_connect)</td></tr>
 <tr class="memdesc:a64f6c766e8d06e6d78c01c37de28f8d7"><td class="mdescLeft">&#160;</td><td class="mdescRight">Get the connectivity state of the channel.  <a href="class_grpc_1_1_channel.html#a64f6c766e8d06e6d78c01c37de28f8d7">More...</a><br /></td></tr>
 <tr class="separator:a64f6c766e8d06e6d78c01c37de28f8d7"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:afce31d39c37f42d29cae7c5fbd5279d9"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel.html#afce31d39c37f42d29cae7c5fbd5279d9">getTarget</a> ()</td></tr>
+<tr class="memdesc:afce31d39c37f42d29cae7c5fbd5279d9"><td class="mdescLeft">&#160;</td><td class="mdescRight">Get the endpoint this call/stream is connected to.  <a href="class_grpc_1_1_channel.html#afce31d39c37f42d29cae7c5fbd5279d9">More...</a><br /></td></tr>
+<tr class="separator:afce31d39c37f42d29cae7c5fbd5279d9"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a2ef0546000edb6aba1f8e0233a75b10d"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel.html#a2ef0546000edb6aba1f8e0233a75b10d">watchConnectivityState</a> ($last_state, $deadline_obj)</td></tr>
 <tr class="memdesc:a2ef0546000edb6aba1f8e0233a75b10d"><td class="mdescLeft">&#160;</td><td class="mdescRight">Watch the connectivity state of the channel until it changed.  <a href="class_grpc_1_1_channel.html#a2ef0546000edb6aba1f8e0233a75b10d">More...</a><br /></td></tr>
 <tr class="separator:a2ef0546000edb6aba1f8e0233a75b10d"><td class="memSeparator" colspan="2">&#160;</td></tr>
@@ -250,7 +250,7 @@ Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_channel_credentials.html
+++ b/php/class_grpc_1_1_channel_credentials.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -78,27 +78,27 @@ $(function() {
 <table class="memberdecls">
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="pub-static-methods"></a>
 Static Public Member Functions</h2></td></tr>
-<tr class="memitem:aa36260c02be6eb2f7d141dcbc508ddcf"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#aa36260c02be6eb2f7d141dcbc508ddcf">setDefaultRootsPem</a> ($pem_roots)</td></tr>
-<tr class="memdesc:aa36260c02be6eb2f7d141dcbc508ddcf"><td class="mdescLeft">&#160;</td><td class="mdescRight">Set default roots pem.  <a href="class_grpc_1_1_channel_credentials.html#aa36260c02be6eb2f7d141dcbc508ddcf">More...</a><br /></td></tr>
-<tr class="separator:aa36260c02be6eb2f7d141dcbc508ddcf"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:af9f1e5522ce2767c297e46847ef5fff4"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#af9f1e5522ce2767c297e46847ef5fff4">isDefaultRootsPemSet</a> ()</td></tr>
-<tr class="memdesc:af9f1e5522ce2767c297e46847ef5fff4"><td class="mdescLeft">&#160;</td><td class="mdescRight">if default roots pem is set  <a href="class_grpc_1_1_channel_credentials.html#af9f1e5522ce2767c297e46847ef5fff4">More...</a><br /></td></tr>
-<tr class="separator:af9f1e5522ce2767c297e46847ef5fff4"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:aeb985b18bdb11939991e988f717c801a"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#aeb985b18bdb11939991e988f717c801a">invalidateDefaultRootsPem</a> ()</td></tr>
-<tr class="memdesc:aeb985b18bdb11939991e988f717c801a"><td class="mdescLeft">&#160;</td><td class="mdescRight">free default roots pem, if it is set  <a href="class_grpc_1_1_channel_credentials.html#aeb985b18bdb11939991e988f717c801a">More...</a><br /></td></tr>
-<tr class="separator:aeb985b18bdb11939991e988f717c801a"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:ae6cfccd4ab1f09fc3e326e4cc98c0507"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#ae6cfccd4ab1f09fc3e326e4cc98c0507">createDefault</a> ()</td></tr>
 <tr class="memdesc:ae6cfccd4ab1f09fc3e326e4cc98c0507"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create a default channel credentials object.  <a href="class_grpc_1_1_channel_credentials.html#ae6cfccd4ab1f09fc3e326e4cc98c0507">More...</a><br /></td></tr>
 <tr class="separator:ae6cfccd4ab1f09fc3e326e4cc98c0507"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:af9f1e5522ce2767c297e46847ef5fff4"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#af9f1e5522ce2767c297e46847ef5fff4">isDefaultRootsPemSet</a> ()</td></tr>
+<tr class="memdesc:af9f1e5522ce2767c297e46847ef5fff4"><td class="mdescLeft">&#160;</td><td class="mdescRight">if default roots pem is set  <a href="class_grpc_1_1_channel_credentials.html#af9f1e5522ce2767c297e46847ef5fff4">More...</a><br /></td></tr>
+<tr class="separator:af9f1e5522ce2767c297e46847ef5fff4"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:aa36260c02be6eb2f7d141dcbc508ddcf"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#aa36260c02be6eb2f7d141dcbc508ddcf">setDefaultRootsPem</a> ($pem_roots)</td></tr>
+<tr class="memdesc:aa36260c02be6eb2f7d141dcbc508ddcf"><td class="mdescLeft">&#160;</td><td class="mdescRight">Set default roots pem.  <a href="class_grpc_1_1_channel_credentials.html#aa36260c02be6eb2f7d141dcbc508ddcf">More...</a><br /></td></tr>
+<tr class="separator:aa36260c02be6eb2f7d141dcbc508ddcf"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a5f8365f36d4b11101039e86811571203"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#a5f8365f36d4b11101039e86811571203">createSsl</a> ($pem_root_certs=&quot;&quot;, $private_key=&quot;&quot;, $cert_chain=&quot;&quot;)</td></tr>
 <tr class="memdesc:a5f8365f36d4b11101039e86811571203"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create SSL credentials.  <a href="class_grpc_1_1_channel_credentials.html#a5f8365f36d4b11101039e86811571203">More...</a><br /></td></tr>
 <tr class="separator:a5f8365f36d4b11101039e86811571203"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:ab86aca4055799eaa2eed315fa2446944"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#ab86aca4055799eaa2eed315fa2446944">createComposite</a> ($cred1_obj, $cred2_obj)</td></tr>
-<tr class="memdesc:ab86aca4055799eaa2eed315fa2446944"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create composite credentials from two existing credentials.  <a href="class_grpc_1_1_channel_credentials.html#ab86aca4055799eaa2eed315fa2446944">More...</a><br /></td></tr>
-<tr class="separator:ab86aca4055799eaa2eed315fa2446944"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:ab8ca6b64ea261b0c9344878b2348f320"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#ab8ca6b64ea261b0c9344878b2348f320">createInsecure</a> ()</td></tr>
 <tr class="memdesc:ab8ca6b64ea261b0c9344878b2348f320"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create insecure channel credentials.  <a href="class_grpc_1_1_channel_credentials.html#ab8ca6b64ea261b0c9344878b2348f320">More...</a><br /></td></tr>
 <tr class="separator:ab8ca6b64ea261b0c9344878b2348f320"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:ab86aca4055799eaa2eed315fa2446944"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#ab86aca4055799eaa2eed315fa2446944">createComposite</a> ($cred1_obj, $cred2_obj)</td></tr>
+<tr class="memdesc:ab86aca4055799eaa2eed315fa2446944"><td class="mdescLeft">&#160;</td><td class="mdescRight">Create composite credentials from two existing credentials.  <a href="class_grpc_1_1_channel_credentials.html#ab86aca4055799eaa2eed315fa2446944">More...</a><br /></td></tr>
+<tr class="separator:ab86aca4055799eaa2eed315fa2446944"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:aeb985b18bdb11939991e988f717c801a"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_channel_credentials.html#aeb985b18bdb11939991e988f717c801a">invalidateDefaultRootsPem</a> ()</td></tr>
+<tr class="memdesc:aeb985b18bdb11939991e988f717c801a"><td class="mdescLeft">&#160;</td><td class="mdescRight">free default roots pem, if it is set  <a href="class_grpc_1_1_channel_credentials.html#aeb985b18bdb11939991e988f717c801a">More...</a><br /></td></tr>
+<tr class="separator:aeb985b18bdb11939991e988f717c801a"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>
 <div class="textblock"><p>class <a class="el" href="class_grpc_1_1_channel_credentials.html" title="class ChannelCredentials">ChannelCredentials</a> </p>
@@ -355,7 +355,7 @@ Static Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_client_streaming_call.html
+++ b/php/class_grpc_1_1_client_streaming_call.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -216,7 +216,7 @@ Additional Inherited Members</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_default_call_invoker.html
+++ b/php/class_grpc_1_1_default_call_invoker.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -297,7 +297,7 @@ Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_interceptor.html
+++ b/php/class_grpc_1_1_interceptor.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -346,7 +346,7 @@ Static Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_rpc_server.html
+++ b/php/class_grpc_1_1_rpc_server.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -83,21 +83,21 @@ Public Member Functions</h2></td></tr>
 <tr class="memitem:a6376eda9f614e1c61715ebc0ae3ca746"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_rpc_server.html#a6376eda9f614e1c61715ebc0ae3ca746">run</a> ()</td></tr>
 <tr class="separator:a6376eda9f614e1c61715ebc0ae3ca746"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="inherit_header pub_methods_class_grpc_1_1_server"><td colspan="2" onclick="javascript:toggleInherit('pub_methods_class_grpc_1_1_server')"><img src="closed.png" alt="-"/>&#160;Public Member Functions inherited from <a class="el" href="class_grpc_1_1_server.html">Grpc\Server</a></td></tr>
-<tr class="memitem:a109c078b8e6718a1ed777f60cb4bc958 inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">__construct</a> ($args_array)</td></tr>
-<tr class="memdesc:a109c078b8e6718a1ed777f60cb4bc958 inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Constructs a new instance of the <a class="el" href="class_grpc_1_1_server.html" title="class Server">Server</a> class.  <a href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">More...</a><br /></td></tr>
-<tr class="separator:a109c078b8e6718a1ed777f60cb4bc958 inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a90ada396f37c675d70b43d4f96afe334 inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a90ada396f37c675d70b43d4f96afe334">requestCall</a> ()</td></tr>
 <tr class="memdesc:a90ada396f37c675d70b43d4f96afe334 inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Request a call on a server.  <a href="class_grpc_1_1_server.html#a90ada396f37c675d70b43d4f96afe334">More...</a><br /></td></tr>
 <tr class="separator:a90ada396f37c675d70b43d4f96afe334 inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a109c078b8e6718a1ed777f60cb4bc958 inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">__construct</a> ($args_array)</td></tr>
+<tr class="memdesc:a109c078b8e6718a1ed777f60cb4bc958 inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Constructs a new instance of the <a class="el" href="class_grpc_1_1_server.html" title="class Server">Server</a> class.  <a href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">More...</a><br /></td></tr>
+<tr class="separator:a109c078b8e6718a1ed777f60cb4bc958 inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a5b20e4fe60663ff1cdb7e30f1995e31b inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a5b20e4fe60663ff1cdb7e30f1995e31b">addHttp2Port</a> ($addr)</td></tr>
 <tr class="memdesc:a5b20e4fe60663ff1cdb7e30f1995e31b inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Add a http2 over tcp listener.  <a href="class_grpc_1_1_server.html#a5b20e4fe60663ff1cdb7e30f1995e31b">More...</a><br /></td></tr>
 <tr class="separator:a5b20e4fe60663ff1cdb7e30f1995e31b inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:a3b3120398662e298719de06716909dcd inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">addSecureHttp2Port</a> ($addr)</td></tr>
-<tr class="memdesc:a3b3120398662e298719de06716909dcd inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Add a secure http2 over tcp listener.  <a href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">More...</a><br /></td></tr>
-<tr class="separator:a3b3120398662e298719de06716909dcd inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a3c2935d3be77ea9902eaf2e20e3422b5 inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a3c2935d3be77ea9902eaf2e20e3422b5">start</a> ()</td></tr>
 <tr class="memdesc:a3c2935d3be77ea9902eaf2e20e3422b5 inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Start a server - tells all listeners to start listening.  <a href="class_grpc_1_1_server.html#a3c2935d3be77ea9902eaf2e20e3422b5">More...</a><br /></td></tr>
 <tr class="separator:a3c2935d3be77ea9902eaf2e20e3422b5 inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a3b3120398662e298719de06716909dcd inherit pub_methods_class_grpc_1_1_server"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">addSecureHttp2Port</a> ($addr)</td></tr>
+<tr class="memdesc:a3b3120398662e298719de06716909dcd inherit pub_methods_class_grpc_1_1_server"><td class="mdescLeft">&#160;</td><td class="mdescRight">Add a secure http2 over tcp listener.  <a href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">More...</a><br /></td></tr>
+<tr class="separator:a3b3120398662e298719de06716909dcd inherit pub_methods_class_grpc_1_1_server"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table><table class="memberdecls">
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="pro-methods"></a>
 Protected Member Functions</h2></td></tr>
@@ -232,7 +232,7 @@ Protected Attributes</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_server.html
+++ b/php/class_grpc_1_1_server.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -78,21 +78,21 @@ $(function() {
 <table class="memberdecls">
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="pub-methods"></a>
 Public Member Functions</h2></td></tr>
-<tr class="memitem:a109c078b8e6718a1ed777f60cb4bc958"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">__construct</a> ($args_array)</td></tr>
-<tr class="memdesc:a109c078b8e6718a1ed777f60cb4bc958"><td class="mdescLeft">&#160;</td><td class="mdescRight">Constructs a new instance of the <a class="el" href="class_grpc_1_1_server.html" title="class Server">Server</a> class.  <a href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">More...</a><br /></td></tr>
-<tr class="separator:a109c078b8e6718a1ed777f60cb4bc958"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a90ada396f37c675d70b43d4f96afe334"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a90ada396f37c675d70b43d4f96afe334">requestCall</a> ()</td></tr>
 <tr class="memdesc:a90ada396f37c675d70b43d4f96afe334"><td class="mdescLeft">&#160;</td><td class="mdescRight">Request a call on a server.  <a href="class_grpc_1_1_server.html#a90ada396f37c675d70b43d4f96afe334">More...</a><br /></td></tr>
 <tr class="separator:a90ada396f37c675d70b43d4f96afe334"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a109c078b8e6718a1ed777f60cb4bc958"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">__construct</a> ($args_array)</td></tr>
+<tr class="memdesc:a109c078b8e6718a1ed777f60cb4bc958"><td class="mdescLeft">&#160;</td><td class="mdescRight">Constructs a new instance of the <a class="el" href="class_grpc_1_1_server.html" title="class Server">Server</a> class.  <a href="class_grpc_1_1_server.html#a109c078b8e6718a1ed777f60cb4bc958">More...</a><br /></td></tr>
+<tr class="separator:a109c078b8e6718a1ed777f60cb4bc958"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a5b20e4fe60663ff1cdb7e30f1995e31b"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a5b20e4fe60663ff1cdb7e30f1995e31b">addHttp2Port</a> ($addr)</td></tr>
 <tr class="memdesc:a5b20e4fe60663ff1cdb7e30f1995e31b"><td class="mdescLeft">&#160;</td><td class="mdescRight">Add a http2 over tcp listener.  <a href="class_grpc_1_1_server.html#a5b20e4fe60663ff1cdb7e30f1995e31b">More...</a><br /></td></tr>
 <tr class="separator:a5b20e4fe60663ff1cdb7e30f1995e31b"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:a3b3120398662e298719de06716909dcd"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">addSecureHttp2Port</a> ($addr)</td></tr>
-<tr class="memdesc:a3b3120398662e298719de06716909dcd"><td class="mdescLeft">&#160;</td><td class="mdescRight">Add a secure http2 over tcp listener.  <a href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">More...</a><br /></td></tr>
-<tr class="separator:a3b3120398662e298719de06716909dcd"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a3c2935d3be77ea9902eaf2e20e3422b5"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a3c2935d3be77ea9902eaf2e20e3422b5">start</a> ()</td></tr>
 <tr class="memdesc:a3c2935d3be77ea9902eaf2e20e3422b5"><td class="mdescLeft">&#160;</td><td class="mdescRight">Start a server - tells all listeners to start listening.  <a href="class_grpc_1_1_server.html#a3c2935d3be77ea9902eaf2e20e3422b5">More...</a><br /></td></tr>
 <tr class="separator:a3c2935d3be77ea9902eaf2e20e3422b5"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a3b3120398662e298719de06716909dcd"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">addSecureHttp2Port</a> ($addr)</td></tr>
+<tr class="memdesc:a3b3120398662e298719de06716909dcd"><td class="mdescLeft">&#160;</td><td class="mdescRight">Add a secure http2 over tcp listener.  <a href="class_grpc_1_1_server.html#a3b3120398662e298719de06716909dcd">More...</a><br /></td></tr>
+<tr class="separator:a3b3120398662e298719de06716909dcd"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>
 <div class="textblock"><p>class <a class="el" href="class_grpc_1_1_server.html" title="class Server">Server</a> </p>
@@ -226,7 +226,7 @@ Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_server_credentials.html
+++ b/php/class_grpc_1_1_server_credentials.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -145,7 +145,7 @@ Static Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_server_streaming_call.html
+++ b/php/class_grpc_1_1_server_streaming_call.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -233,7 +233,7 @@ Additional Inherited Members</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_timeval.html
+++ b/php/class_grpc_1_1_timeval.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -82,36 +82,36 @@ Public Member Functions</h2></td></tr>
 <tr class="memitem:a0923f66b9d8b0250737922c2114cf1df"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a0923f66b9d8b0250737922c2114cf1df">__construct</a> ($microseconds)</td></tr>
 <tr class="memdesc:a0923f66b9d8b0250737922c2114cf1df"><td class="mdescLeft">&#160;</td><td class="mdescRight">Constructs a new instance of the <a class="el" href="class_grpc_1_1_timeval.html" title="class Timeval">Timeval</a> class.  <a href="class_grpc_1_1_timeval.html#a0923f66b9d8b0250737922c2114cf1df">More...</a><br /></td></tr>
 <tr class="separator:a0923f66b9d8b0250737922c2114cf1df"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:ac99ca9206e9fe2f7d8b5777aa91922c7"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ac99ca9206e9fe2f7d8b5777aa91922c7">add</a> ($other_obj)</td></tr>
-<tr class="memdesc:ac99ca9206e9fe2f7d8b5777aa91922c7"><td class="mdescLeft">&#160;</td><td class="mdescRight">Adds another <a class="el" href="class_grpc_1_1_timeval.html" title="class Timeval">Timeval</a> to this one and returns the sum.  <a href="class_grpc_1_1_timeval.html#ac99ca9206e9fe2f7d8b5777aa91922c7">More...</a><br /></td></tr>
-<tr class="separator:ac99ca9206e9fe2f7d8b5777aa91922c7"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:ac9ad3de83213183bc51f9ff9c0036f7c"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ac9ad3de83213183bc51f9ff9c0036f7c">subtract</a> ($other_obj)</td></tr>
-<tr class="memdesc:ac9ad3de83213183bc51f9ff9c0036f7c"><td class="mdescLeft">&#160;</td><td class="mdescRight">Subtracts another <a class="el" href="class_grpc_1_1_timeval.html" title="class Timeval">Timeval</a> from this one and returns the difference.  <a href="class_grpc_1_1_timeval.html#ac9ad3de83213183bc51f9ff9c0036f7c">More...</a><br /></td></tr>
-<tr class="separator:ac9ad3de83213183bc51f9ff9c0036f7c"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:aad3080f912ffb1cac40a65ddb42940d2"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#aad3080f912ffb1cac40a65ddb42940d2">sleepUntil</a> ()</td></tr>
 <tr class="memdesc:aad3080f912ffb1cac40a65ddb42940d2"><td class="mdescLeft">&#160;</td><td class="mdescRight">Sleep until this time, interpreted as an absolute timeout.  <a href="class_grpc_1_1_timeval.html#aad3080f912ffb1cac40a65ddb42940d2">More...</a><br /></td></tr>
 <tr class="separator:aad3080f912ffb1cac40a65ddb42940d2"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:ac9ad3de83213183bc51f9ff9c0036f7c"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ac9ad3de83213183bc51f9ff9c0036f7c">subtract</a> ($other_obj)</td></tr>
+<tr class="memdesc:ac9ad3de83213183bc51f9ff9c0036f7c"><td class="mdescLeft">&#160;</td><td class="mdescRight">Subtracts another <a class="el" href="class_grpc_1_1_timeval.html" title="class Timeval">Timeval</a> from this one and returns the difference.  <a href="class_grpc_1_1_timeval.html#ac9ad3de83213183bc51f9ff9c0036f7c">More...</a><br /></td></tr>
+<tr class="separator:ac9ad3de83213183bc51f9ff9c0036f7c"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:ac99ca9206e9fe2f7d8b5777aa91922c7"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ac99ca9206e9fe2f7d8b5777aa91922c7">add</a> ($other_obj)</td></tr>
+<tr class="memdesc:ac99ca9206e9fe2f7d8b5777aa91922c7"><td class="mdescLeft">&#160;</td><td class="mdescRight">Adds another <a class="el" href="class_grpc_1_1_timeval.html" title="class Timeval">Timeval</a> to this one and returns the sum.  <a href="class_grpc_1_1_timeval.html#ac99ca9206e9fe2f7d8b5777aa91922c7">More...</a><br /></td></tr>
+<tr class="separator:ac99ca9206e9fe2f7d8b5777aa91922c7"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table><table class="memberdecls">
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="pub-static-methods"></a>
 Static Public Member Functions</h2></td></tr>
-<tr class="memitem:ae88d485b702a5711bb779462e0f3890c"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ae88d485b702a5711bb779462e0f3890c">compare</a> ($a_obj, $b_obj)</td></tr>
-<tr class="memdesc:ae88d485b702a5711bb779462e0f3890c"><td class="mdescLeft">&#160;</td><td class="mdescRight">Return negative, 0, or positive according to whether a &lt; b, a == b, or a &gt; b respectively.  <a href="class_grpc_1_1_timeval.html#ae88d485b702a5711bb779462e0f3890c">More...</a><br /></td></tr>
-<tr class="separator:ae88d485b702a5711bb779462e0f3890c"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:a6bc3609d25c19f9297749781efd1071e"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a6bc3609d25c19f9297749781efd1071e">similar</a> ($a_obj, $b_obj, $thresh_obj)</td></tr>
-<tr class="memdesc:a6bc3609d25c19f9297749781efd1071e"><td class="mdescLeft">&#160;</td><td class="mdescRight">Checks whether the two times are within $threshold of each other.  <a href="class_grpc_1_1_timeval.html#a6bc3609d25c19f9297749781efd1071e">More...</a><br /></td></tr>
-<tr class="separator:a6bc3609d25c19f9297749781efd1071e"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:a8df14900363bce541340f81eff797d05"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a8df14900363bce541340f81eff797d05">now</a> ()</td></tr>
-<tr class="memdesc:a8df14900363bce541340f81eff797d05"><td class="mdescLeft">&#160;</td><td class="mdescRight">Returns the current time as a timeval object.  <a href="class_grpc_1_1_timeval.html#a8df14900363bce541340f81eff797d05">More...</a><br /></td></tr>
-<tr class="separator:a8df14900363bce541340f81eff797d05"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:ac46725245b0b70d10c324e9b97dd9829"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ac46725245b0b70d10c324e9b97dd9829">zero</a> ()</td></tr>
-<tr class="memdesc:ac46725245b0b70d10c324e9b97dd9829"><td class="mdescLeft">&#160;</td><td class="mdescRight">Returns the zero time interval as a timeval object.  <a href="class_grpc_1_1_timeval.html#ac46725245b0b70d10c324e9b97dd9829">More...</a><br /></td></tr>
-<tr class="separator:ac46725245b0b70d10c324e9b97dd9829"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a1cabcbffb6869a6cf083b102baabf62b"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a1cabcbffb6869a6cf083b102baabf62b">infFuture</a> ()</td></tr>
 <tr class="memdesc:a1cabcbffb6869a6cf083b102baabf62b"><td class="mdescLeft">&#160;</td><td class="mdescRight">Returns the infinite future time value as a timeval object.  <a href="class_grpc_1_1_timeval.html#a1cabcbffb6869a6cf083b102baabf62b">More...</a><br /></td></tr>
 <tr class="separator:a1cabcbffb6869a6cf083b102baabf62b"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a8df14900363bce541340f81eff797d05"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a8df14900363bce541340f81eff797d05">now</a> ()</td></tr>
+<tr class="memdesc:a8df14900363bce541340f81eff797d05"><td class="mdescLeft">&#160;</td><td class="mdescRight">Returns the current time as a timeval object.  <a href="class_grpc_1_1_timeval.html#a8df14900363bce541340f81eff797d05">More...</a><br /></td></tr>
+<tr class="separator:a8df14900363bce541340f81eff797d05"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a14fa120d255f29fbeb37958b53385466"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a14fa120d255f29fbeb37958b53385466">infPast</a> ()</td></tr>
 <tr class="memdesc:a14fa120d255f29fbeb37958b53385466"><td class="mdescLeft">&#160;</td><td class="mdescRight">Returns the infinite past time value as a timeval object.  <a href="class_grpc_1_1_timeval.html#a14fa120d255f29fbeb37958b53385466">More...</a><br /></td></tr>
 <tr class="separator:a14fa120d255f29fbeb37958b53385466"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:a6bc3609d25c19f9297749781efd1071e"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#a6bc3609d25c19f9297749781efd1071e">similar</a> ($a_obj, $b_obj, $thresh_obj)</td></tr>
+<tr class="memdesc:a6bc3609d25c19f9297749781efd1071e"><td class="mdescLeft">&#160;</td><td class="mdescRight">Checks whether the two times are within $threshold of each other.  <a href="class_grpc_1_1_timeval.html#a6bc3609d25c19f9297749781efd1071e">More...</a><br /></td></tr>
+<tr class="separator:a6bc3609d25c19f9297749781efd1071e"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:ae88d485b702a5711bb779462e0f3890c"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ae88d485b702a5711bb779462e0f3890c">compare</a> ($a_obj, $b_obj)</td></tr>
+<tr class="memdesc:ae88d485b702a5711bb779462e0f3890c"><td class="mdescLeft">&#160;</td><td class="mdescRight">Return negative, 0, or positive according to whether a &lt; b, a == b, or a &gt; b respectively.  <a href="class_grpc_1_1_timeval.html#ae88d485b702a5711bb779462e0f3890c">More...</a><br /></td></tr>
+<tr class="separator:ae88d485b702a5711bb779462e0f3890c"><td class="memSeparator" colspan="2">&#160;</td></tr>
+<tr class="memitem:ac46725245b0b70d10c324e9b97dd9829"><td class="memItemLeft" align="right" valign="top">static&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_grpc_1_1_timeval.html#ac46725245b0b70d10c324e9b97dd9829">zero</a> ()</td></tr>
+<tr class="memdesc:ac46725245b0b70d10c324e9b97dd9829"><td class="mdescLeft">&#160;</td><td class="mdescRight">Returns the zero time interval as a timeval object.  <a href="class_grpc_1_1_timeval.html#ac46725245b0b70d10c324e9b97dd9829">More...</a><br /></td></tr>
+<tr class="separator:ac46725245b0b70d10c324e9b97dd9829"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>
 <div class="textblock"><p>class <a class="el" href="class_grpc_1_1_timeval.html" title="class Timeval">Timeval</a> </p>
@@ -435,7 +435,7 @@ Static Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/class_grpc_1_1_unary_call.html
+++ b/php/class_grpc_1_1_unary_call.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -213,7 +213,7 @@ Additional Inherited Members</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/classes.html
+++ b/php/classes.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -116,7 +116,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/command__line__tool_8md.html
+++ b/php/command__line__tool_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/compression_8md.html
+++ b/php/compression_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/compression__cookbook_8md.html
+++ b/php/compression__cookbook_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/connection-backoff-interop-test-description_8md.html
+++ b/php/connection-backoff-interop-test-description_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/connection-backoff_8md.html
+++ b/php/connection-backoff_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/connectivity-semantics-and-api_8md.html
+++ b/php/connectivity-semantics-and-api_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/cpp-style-guide_8md.html
+++ b/php/cpp-style-guide_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/dir_4e49b715f9da74892c7bbbdb8130446b.html
+++ b/php/dir_4e49b715f9da74892c7bbbdb8130446b.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -113,7 +113,7 @@ Files</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/dir_6229e6c34e9a233ad01e20b4063ed1b6.html
+++ b/php/dir_6229e6c34e9a233ad01e20b4063ed1b6.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -73,7 +73,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/dir_68267d1309a1af8e8297ef4c3efbcdba.html
+++ b/php/dir_68267d1309a1af8e8297ef4c3efbcdba.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -79,7 +79,7 @@ Directories</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/dir_73429fa3d659a85a5c1bd72b8c229b9f.html
+++ b/php/dir_73429fa3d659a85a5c1bd72b8c229b9f.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -79,7 +79,7 @@ Directories</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/dir_85cc22d3a09b5748bc25e61ded676657.html
+++ b/php/dir_85cc22d3a09b5748bc25e61ded676657.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -81,7 +81,7 @@ Directories</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/dir_e68e8157741866f444e17edd764ebbae.html
+++ b/php/dir_e68e8157741866f444e17edd764ebbae.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -73,7 +73,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/docker_2_r_e_a_d_m_e_8md.html
+++ b/php/docker_2_r_e_a_d_m_e_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/environment__variables_8md.html
+++ b/php/environment__variables_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/fail__fast_8md.html
+++ b/php/fail__fast_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/files.html
+++ b/php/files.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -97,7 +97,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/fork__support_8md.html
+++ b/php/fork__support_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/functions.html
+++ b/php/functions.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -343,7 +343,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/functions_func.html
+++ b/php/functions_func.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -323,7 +323,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/functions_vars.html
+++ b/php/functions_vars.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -83,7 +83,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/g__stands__for_8md.html
+++ b/php/g__stands__for_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/graph_legend.html
+++ b/php/graph_legend.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -129,7 +129,7 @@ A yellow dashed arrow denotes a relation between a template instance and the tem
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/grpc__release__schedule_8md.html
+++ b/php/grpc__release__schedule_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/grpc__xds__features_8md.html
+++ b/php/grpc__xds__features_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/health-checking_8md.html
+++ b/php/health-checking_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/hierarchy.html
+++ b/php/hierarchy.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -90,7 +90,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/http-grpc-status-mapping_8md.html
+++ b/php/http-grpc-status-mapping_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/http2-interop-test-descriptions_8md.html
+++ b/php/http2-interop-test-descriptions_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/index.html
+++ b/php/index.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/interface_grpc_1_1_call_invoker.html
+++ b/php/interface_grpc_1_1_call_invoker.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -297,7 +297,7 @@ Public Member Functions</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/internationalization_8md.html
+++ b/php/internationalization_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/interop-test-descriptions_8md.html
+++ b/php/interop-test-descriptions_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/keepalive_8md.html
+++ b/php/keepalive_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/load-balancing_8md.html
+++ b/php/load-balancing_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc__p_r_o_t_o_c_o_l-_h_t_t_p2.html
+++ b/php/md_doc__p_r_o_t_o_c_o_l-_h_t_t_p2.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -265,7 +265,7 @@ Appendix A - GRPC for Protobuf</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc__p_r_o_t_o_c_o_l-_w_e_b.html
+++ b/php/md_doc__p_r_o_t_o_c_o_l-_w_e_b.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -184,7 +184,7 @@ Other features</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_binary-logging.html
+++ b/php/md_doc_binary-logging.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -121,7 +121,7 @@ Language differences</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_c-style-guide.html
+++ b/php/md_doc_c-style-guide.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -127,7 +127,7 @@ Functions</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_command_line_tool.html
+++ b/php/md_doc_command_line_tool.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -176,7 +176,7 @@ Call a remote method</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_compression.html
+++ b/php/md_doc_compression.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -123,7 +123,7 @@ Test cases</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_compression_cookbook.html
+++ b/php/md_doc_compression_cookbook.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -125,7 +125,7 @@ Per Message Settings</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_connection-backoff-interop-test-description.html
+++ b/php/md_doc_connection-backoff-interop-test-description.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -117,7 +117,7 @@ Server</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_connection-backoff.html
+++ b/php/md_doc_connection-backoff.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -105,7 +105,7 @@ Reset Backoff</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_connectivity-semantics-and-api.html
+++ b/php/md_doc_connectivity-semantics-and-api.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -106,7 +106,7 @@ Channel State API</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_cpp-style-guide.html
+++ b/php/md_doc_cpp-style-guide.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -71,7 +71,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_environment_variables.html
+++ b/php/md_doc_environment_variables.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -174,7 +174,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_fail_fast.html
+++ b/php/md_doc_fail_fast.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -71,7 +71,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_fork_support.html
+++ b/php/md_doc_fork_support.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -87,7 +87,7 @@ Future Work</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_g_stands_for.html
+++ b/php/md_doc_g_stands_for.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -98,14 +98,13 @@ $(function() {
 <li>1.28 'g' stands for <a href="https://github.com/grpc/grpc/tree/v1.28.x">'galactic'</a></li>
 <li>1.29 'g' stands for <a href="https://github.com/grpc/grpc/tree/v1.29.x">'gringotts'</a></li>
 <li>1.30 'g' stands for <a href="https://github.com/grpc/grpc/tree/v1.30.x">'gradius'</a></li>
-<li>1.31 'g' stands for <a href="https://github.com/grpc/grpc/tree/v1.31.x">'galore'</a></li>
-<li>1.32 'g' stands for <a href="https://github.com/grpc/grpc/tree/master">'giggle'</a> </li>
+<li>1.31 'g' stands for <a href="https://github.com/grpc/grpc/tree/v1.31.x">'galore'</a> </li>
 </ul>
 </div></div><!-- contents -->
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_grpc_release_schedule.html
+++ b/php/md_doc_grpc_release_schedule.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -118,7 +118,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_grpc_xds_features.html
+++ b/php/md_doc_grpc_xds_features.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -76,43 +76,23 @@ $(function() {
 <tr class="markdownTableHead">
 <th class="markdownTableHeadNone">Features </th><th class="markdownTableHeadNone">gRFCs </th><th class="markdownTableHeadNone"><a href="https://github.com/grpc/grpc/releases">C++, Python, Ruby, PHP, C#</a> </th><th class="markdownTableHeadNone"><a href="https://github.com/grpc/grpc-java/releases">Java</a> </th><th class="markdownTableHeadNone"><a href="https://github.com/grpc/grpc-go/releases">Go</a>  </th></tr>
 <tr class="markdownTableRowOdd">
-<td class="markdownTableBodyNone"><b>xDS Infrastructure in gRPC client channel:</b><ul>
-<li>
-LDS-&gt;RDS-&gt;CDS-&gt;EDS flow</li>
-<li>
-ADS stream</li>
-</ul>
-</td><td class="markdownTableBodyNone"><a href="https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md">A27</a> </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0  </td></tr>
+<td class="markdownTableBodyNone"><b>xDS Infrastructure in gRPC client channel:</b><br  />
+LDS-&gt;RDS-&gt;CDS-&gt;EDS flow,<br  />
+ADS stream, </td><td class="markdownTableBodyNone"><a href="https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md">A27</a> </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0  </td></tr>
 <tr class="markdownTableRowEven">
-<td class="markdownTableBodyNone"><b>Load Balancing:</b><ul>
-<li>
-<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#route-virtualhost">Virtual host</a> domains matching</li>
-<li>
-Only default path ("" or "/") matching</li>
-<li>
-Priority-based weighted round-robin locality picking</li>
-<li>
-Round-robin endpoint picking within locality</li>
-<li>
-<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#envoy-api-msg-route-routeaction">Cluster</a> route action</li>
-<li>
-Client-side Load reporting via <a href="https://github.com/envoyproxy/data-plane-api/blob/master/envoy/service/load_stats/v2/lrs.proto">LRS</a></li>
-</ul>
-</td><td class="markdownTableBodyNone"><a href="https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md">A27</a> </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0  </td></tr>
-<tr class="markdownTableRowOdd">
-<td class="markdownTableBodyNone">Request matching based on:<ul>
-<li>
-<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#route-routematch">Path</a> (prefix, full path and safe regex)</li>
-<li>
-<a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#route-headermatcher">Headers</a></li>
-</ul>
-Request routing to multiple clusters based on <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route_components.proto#route-weightedcluster">weights</a> </td><td class="markdownTableBodyNone"><a href="https://github.com/grpc/proposal/blob/master/A28-xds-traffic-splitting-and-routing.md">A28</a> </td><td class="markdownTableBodyNone">v1.31.0 </td><td class="markdownTableBodyNone">v1.31.0 </td><td class="markdownTableBodyNone">v1.31.0  </td></tr>
+<td class="markdownTableBodyNone"><b>Load Balancing:</b><br  />
+Virtual host matching,<br  />
+Only default path ("" or "/") matching,<br  />
+Priority-based weighted round-robin locality picking,<br  />
+Round-robin endpoint picking within locality,<br  />
+Cluster route action,<br  />
+Client-side Load reporting via <a href="https://github.com/envoyproxy/data-plane-api/blob/master/envoy/service/load_stats/v2/lrs.proto">LRS</a> </td><td class="markdownTableBodyNone"><a href="https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md">A27</a> </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0 </td><td class="markdownTableBodyNone">v1.30.0  </td></tr>
 </table>
 </div></div><!-- contents -->
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_health-checking.html
+++ b/php/md_doc_health-checking.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -103,7 +103,7 @@ Service Definition</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_http-grpc-status-mapping.html
+++ b/php/md_doc_http-grpc-status-mapping.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -96,7 +96,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_http2-interop-test-descriptions.html
+++ b/php/md_doc_http2-interop-test-descriptions.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -239,7 +239,7 @@ no_df_padding_sanity_test</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_internationalization.html
+++ b/php/md_doc_internationalization.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -98,7 +98,7 @@ Channel target (in channel creation)</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_interop-test-descriptions.html
+++ b/php/md_doc_interop-test-descriptions.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -713,7 +713,7 @@ Echo OAuth scope</h3>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_keepalive.html
+++ b/php/md_doc_keepalive.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -152,7 +152,7 @@ FAQ</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_load-balancing.html
+++ b/php/md_doc_load-balancing.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -135,7 +135,7 @@ Workflow</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_naming.html
+++ b/php/md_doc_naming.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -123,7 +123,7 @@ Resolver Plugins</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_security_audit.html
+++ b/php/md_doc_security_audit.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -117,7 +117,7 @@ Conclusion</h3>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_server-reflection.html
+++ b/php/md_doc_server-reflection.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -195,7 +195,7 @@ Known Implementations</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_server_reflection_tutorial.html
+++ b/php/md_doc_server_reflection_tutorial.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -169,7 +169,7 @@ Use Server Reflection in a C++ client</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_server_side_auth.html
+++ b/php/md_doc_server_side_auth.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -110,7 +110,7 @@ Status (by language)</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_service_config.html
+++ b/php/md_doc_service_config.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -125,7 +125,7 @@ APIs</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_ssl-performance.html
+++ b/php/md_doc_ssl-performance.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -121,15 +121,7 @@ Other Languages: Binary/Source Packages</h1>
 <tr class="markdownTableRowOdd">
 <td class="markdownTableBodyNone">PHP </td><td class="markdownTableBodyNone">No </td><td class="markdownTableBodyNone">all </td><td class="markdownTableBodyNone">:x:  </td></tr>
 <tr class="markdownTableRowEven">
-<td class="markdownTableBodyNone">Python </td><td class="markdownTableBodyNone">n/a </td><td class="markdownTableBodyNone">Linux, 64bit </td><td class="markdownTableBodyNone">:heavy_check_mark:  </td></tr>
-<tr class="markdownTableRowOdd">
-<td class="markdownTableBodyNone">Python </td><td class="markdownTableBodyNone">n/a </td><td class="markdownTableBodyNone">Linux, 32bit </td><td class="markdownTableBodyNone">:x:  </td></tr>
-<tr class="markdownTableRowEven">
-<td class="markdownTableBodyNone">Python </td><td class="markdownTableBodyNone">n/a </td><td class="markdownTableBodyNone">MacOS, 64bit </td><td class="markdownTableBodyNone">:heavy_check_mark:  </td></tr>
-<tr class="markdownTableRowOdd">
-<td class="markdownTableBodyNone">Python </td><td class="markdownTableBodyNone">n/a </td><td class="markdownTableBodyNone">MacOS, 32bit </td><td class="markdownTableBodyNone">:x:  </td></tr>
-<tr class="markdownTableRowEven">
-<td class="markdownTableBodyNone">Python </td><td class="markdownTableBodyNone">n/a </td><td class="markdownTableBodyNone">Windows </td><td class="markdownTableBodyNone">:x:  </td></tr>
+<td class="markdownTableBodyNone">Python </td><td class="markdownTableBodyNone">n/a </td><td class="markdownTableBodyNone">all </td><td class="markdownTableBodyNone">:x:  </td></tr>
 <tr class="markdownTableRowOdd">
 <td class="markdownTableBodyNone">Ruby </td><td class="markdownTableBodyNone">No </td><td class="markdownTableBodyNone">all </td><td class="markdownTableBodyNone">:x:  </td></tr>
 </table>
@@ -137,7 +129,7 @@ Other Languages: Binary/Source Packages</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_status_ordering.html
+++ b/php/md_doc_status_ordering.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -76,7 +76,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_statuscodes.html
+++ b/php/md_doc_statuscodes.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -168,7 +168,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_unit_testing.html
+++ b/php/md_doc_unit_testing.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -198,7 +198,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_versioning.html
+++ b/php/md_doc_versioning.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -118,7 +118,7 @@ Situations that DON'T warrant a major version bump</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_wait-for-ready.html
+++ b/php/md_doc_wait-for-ready.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -72,7 +72,7 @@ $(function() {
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_workarounds.html
+++ b/php/md_doc_workarounds.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -82,7 +82,7 @@ Cronet Compression</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_doc_xds-test-descriptions.html
+++ b/php/md_doc_xds-test-descriptions.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -374,7 +374,7 @@ traffic_splitting</h2>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_src_php__r_e_a_d_m_e.html
+++ b/php/md_src_php__r_e_a_d_m_e.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -295,7 +295,7 @@ Compression</h2>
 <div class="ttc" id="anamespace_grpc_html"><div class="ttname"><a href="namespace_grpc.html">Grpc</a></div><div class="ttdoc">Class AbstractCall.</div><div class="ttdef"><b>Definition:</b> AbstractCall.php:20</div></div>
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/md_src_php_docker__r_e_a_d_m_e.html
+++ b/php/md_src_php_docker__r_e_a_d_m_e.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -138,7 +138,7 @@ Build and Run Specified Image</h1>
 </div><!-- PageDoc -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/namespace_grpc.html
+++ b/php/namespace_grpc.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -128,7 +128,6 @@ Data Structures</h2></td></tr>
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a name="var-members"></a>
 Variables</h2></td></tr>
 <tr class="memitem:aba15b4f16d9a94dae1458b6f89aa5b1e"><td class="memItemLeft" align="right" valign="top">const&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="namespace_grpc.html#aba15b4f16d9a94dae1458b6f89aa5b1e">CALL_OK</a></td></tr>
-<tr class="memdesc:aba15b4f16d9a94dae1458b6f89aa5b1e"><td class="mdescLeft">&#160;</td><td class="mdescRight">everything went ok  <a href="namespace_grpc.html#aba15b4f16d9a94dae1458b6f89aa5b1e">More...</a><br /></td></tr>
 <tr class="separator:aba15b4f16d9a94dae1458b6f89aa5b1e"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a6f12e0a446b5933efeb43bb0f33f2de4"><td class="memItemLeft" align="right" valign="top">const&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="namespace_grpc.html#a6f12e0a446b5933efeb43bb0f33f2de4">CALL_ERROR</a></td></tr>
 <tr class="memdesc:a6f12e0a446b5933efeb43bb0f33f2de4"><td class="mdescLeft">&#160;</td><td class="mdescRight">something failed, we don't know what  <a href="namespace_grpc.html#a6f12e0a446b5933efeb43bb0f33f2de4">More...</a><br /></td></tr>
@@ -396,8 +395,6 @@ Variables</h2></td></tr>
         </tr>
       </table>
 </div><div class="memdoc">
-
-<p>everything went ok </p>
 
 </div>
 </div>
@@ -940,7 +937,7 @@ Variables</h2></td></tr>
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/namespacemembers.html
+++ b/php/namespacemembers.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -204,7 +204,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/namespacemembers_vars.html
+++ b/php/namespacemembers_vars.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -204,7 +204,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/namespaces.html
+++ b/php/namespaces.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -74,7 +74,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/naming_8md.html
+++ b/php/naming_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/pages.html
+++ b/php/pages.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -113,7 +113,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/security__audit_8md.html
+++ b/php/security__audit_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/server-reflection_8md.html
+++ b/php/server-reflection_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/server__reflection__tutorial_8md.html
+++ b/php/server__reflection__tutorial_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/server__side__auth_8md.html
+++ b/php/server__side__auth_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/service__config_8md.html
+++ b/php/service__config_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/ssl-performance_8md.html
+++ b/php/ssl-performance_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/status__ordering_8md.html
+++ b/php/status__ordering_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/statuscodes_8md.html
+++ b/php/statuscodes_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/unit__testing_8md.html
+++ b/php/unit__testing_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/versioning_8md.html
+++ b/php/versioning_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/wait-for-ready_8md.html
+++ b/php/wait-for-ready_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/workarounds_8md.html
+++ b/php/workarounds_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>

--- a/php/xds-test-descriptions_8md.html
+++ b/php/xds-test-descriptions_8md.html
@@ -22,7 +22,7 @@
  <tr style="height: 56px;">
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">GRPC PHP
-   &#160;<span id="projectnumber">1.32.0-dev</span>
+   &#160;<span id="projectnumber">1.31.0</span>
    </div>
   </td>
  </tr>
@@ -69,7 +69,7 @@ $(function() {
 </div><!-- contents -->
 <!-- start footer part -->
 <hr class="footer"/><address class="footer"><small>
-Generated on Fri Aug 14 2020 18:35:56 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
+Generated on Fri Aug 14 2020 19:53:54 for GRPC PHP by &#160;<a href="http://www.doxygen.org/index.html">
 <img class="footer" src="doxygen.png" alt="doxygen"/>
 </a> 1.8.17
 </small></address>


### PR DESCRIPTION
Fixes #23849 

Should have generated the API reference doc at the `1.31.0` branch rather than from `master`. The diff is going to only reflect these changes.