### PR TITLE
Make re2 submodule use https:// and not git:// URL (for consistency and to fix infrastructure error)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/google/boringssl.git
 [submodule "third_party/re2"]
 	path = third_party/re2
-	url = git://github.com/google/re2.git
+	url = https://github.com/google/re2.git
 [submodule "third_party/cares/cares"]
 	path = third_party/cares/cares
 	url = https://github.com/c-ares/c-ares.git


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/22987 adds re2 submodule, but unlike all our other submodules, it used the `git://` style URL for the submodule instead of `https://`.

I noticed this because currently there's a bunch of failures on master / PRs that fail with this message
```
fatal: clone of 'git://github.com/google/re2.git' into submodule path '/Volumes/BuildData/tmpfs/src/github/grpc/third_party/re2' failed
Failed to clone 'third_party/re2'. Retry scheduled
Cloning into '/Volumes/BuildData/tmpfs/src/github/grpc/third_party/udpa'...
Cloning into '/Volumes/BuildData/tmpfs/src/github/grpc/third_party/zlib'...
Cloning into '/Volumes/BuildData/tmpfs/src/github/grpc/third_party/re2'...
fatal: unable to connect to github.com:
github.com[0: 140.82.112.3]: errno=Operation timed out

fatal: clone of 'git://github.com/google/re2.git' into submodule path '/Volumes/BuildData/tmpfs/src/github/grpc/third_party/re2' failed
Failed to clone 'third_party/re2' a second time, aborting
```
(and re2 is the only module where this fails).