### PR TITLE
Enable GPR_ABSEIL_SYNC on Apple

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -31,12 +31,7 @@
  * Defines GPR_ABSEIL_SYNC to use synchronization features from Abseil
  */
 #ifndef GPR_ABSEIL_SYNC
-#if defined(__APPLE__)
-// This is disabled on Apple platforms because macos/grpc_basictests_c_cpp
-// fails with this. https://github.com/grpc/grpc/issues/23661
-#else
 #define GPR_ABSEIL_SYNC 1
-#endif
 #endif  // GPR_ABSEIL_SYNC
 
 /* Get windows.h included everywhere (we need it) */


### PR DESCRIPTION
Try to reintroduce `GPR_ABSEIL_SYNC` on Mac.

[macos/grpc_basictests_c_cpp](https://g3c.corp.google.com/results/invocations/570c3caf-08a8-4fff-9bc2-7e02581f6463): failed.

Internal b/170119606