### PR TITLE
Fix destruction race between subchannel and client_channel

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2176,13 +2176,14 @@ void CallData::Destroy(grpc_call_element* elem,
                        const grpc_call_final_info* /*final_info*/,
                        grpc_closure* then_schedule_closure) {
   CallData* calld = static_cast<CallData*>(elem->call_data);
-  if (GPR_LIKELY(calld->subchannel_call_ != nullptr)) {
-    calld->subchannel_call_->SetAfterCallStackDestroy(then_schedule_closure);
-    then_schedule_closure = nullptr;
-  }
+  RefCountedPtr<SubchannelCall> subchannel_call = calld->subchannel_call_;
   calld->~CallData();
-  // TODO(yashkt) : This can potentially be a Closure::Run
-  ExecCtx::Run(DEBUG_LOCATION, then_schedule_closure, GRPC_ERROR_NONE);
+  if (GPR_LIKELY(subchannel_call != nullptr)) {
+    subchannel_call->SetAfterCallStackDestroy(then_schedule_closure);
+  } else {
+    // TODO(yashkt) : This can potentially be a Closure::Run
+    ExecCtx::Run(DEBUG_LOCATION, then_schedule_closure, GRPC_ERROR_NONE);
+  }
 }
 
 void CallData::StartTransportStreamOpBatch(


### PR DESCRIPTION
I could trigger this heap-use-after-free on extremely rare cases under the callback alternative execution model. This change to CallData::Destroy resembles the structure of CallData::Destroy used in the subchannel code itself. Without this change, we can see a (rare) race between release_call (invoked via then_schedule_closure here) and destroy_call (invoked via the destructor of CallData). As long as the destructor is called before the closure is touched, we avoid this problem.

This use-after-free was causing about 4 failures/1000 of the client_callback_end2end_test under the callback-alternative execution model but 0/1000 with this change.
