### PR TITLE
Destroy health check service before destroying C server.

### DIFF
--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -981,7 +981,10 @@ Server::~Server() {
       }
     }
   }
-
+  // Destroy health check service before we destroy the C server so that
+  // it does not call grpc_server_request_registered_call() after the C
+  // server has been destroyed.
+  health_check_service_.reset();
   grpc_server_destroy(server_);
 }
 


### PR DESCRIPTION
This fixes a use-after-free bug in server shutdown that was somehow triggered by #23581.