### PR TITLE
Remove unneeded and incorrect forward reference

### DIFF
--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -53,7 +53,6 @@ class ExternalConnectionAcceptorImpl;
 }  // namespace grpc
 
 namespace grpc_impl {
-class HealthCheckServiceInterface;
 class ServerContext;
 class ServerInitializer;
 


### PR DESCRIPTION
HealthCheckServiceInterface is not part of `grpc_impl::` , and this forward reference is also not needed since the header file is actually included.