### PR TITLE
Remove unneeded forward reference

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -29,9 +29,6 @@
 #include "src/core/lib/channel/channelz.h"
 
 namespace grpc_core {
-
-class Subchannel;
-
 namespace channelz {
 
 class SubchannelNode : public BaseNode {


### PR DESCRIPTION
grpc_core::Subchannel is not needed as a forward reference here.
