### PR TITLE
Cleanup bazel commands in test scripts (for non-RBE invocations)

### DIFF
--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -50,7 +50,11 @@ grpc_cc_test(
         "gtest",
     ],
     tags = [
+        # Test manipulates system time and requires root while running so it is only
+        # run on demand ("manual") and when no other tests are running ("exclusive").
+        # It also means that the test won't work with setups like bazel RBE.
         "manual",
+        "exclusive",
         "no_windows",
     ],
     deps = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -670,7 +670,11 @@ grpc_cc_test(
         "gtest",
     ],
     tags = [
+        # Test manipulates network settings (e.g. using iptables) while running so it is only
+        # run on demand ("manual") and when no other tests are running ("exclusive").
+        # It also means that the test won't work with setups like bazel RBE.
         "manual",
+        "exclusive",
         "no_test_ios",
     ],
     deps = [
@@ -750,10 +754,14 @@ grpc_cc_test(
         "gtest",
     ],
     tags = [
+        # Test requires root and manipulates network settings while running so it is only
+        # run on demand ("manual") and when no other tests are running ("exclusive").
+        # It also means that the test won't work with setups like bazel RBE.
         "manual",
+        "exclusive",
         "no_test_android",
         "no_test_ios",
-    ],  # test requires root, won't work with bazel RBE
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -24,4 +24,5 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 && git submodule update --init --reference /var/local/jenkins/grpc/${name} \
 ${name}')
 cd /var/local/git/grpc
-bazel build --spawn_strategy=standalone --genrule_strategy=standalone :all test/... examples/...
+
+bazel build :all //test/... //examples/...

--- a/tools/internal_ci/linux/grpc_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_test_in_docker.sh
@@ -23,5 +23,6 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 (cd /var/local/jenkins/grpc/ && git submodule foreach 'cd /var/local/git/grpc \
 && git submodule update --init --reference /var/local/jenkins/grpc/${name} \
 ${name}')
-cd /var/local/git/grpc/test
-bazel test --spawn_strategy=standalone --genrule_strategy=standalone ...
+cd /var/local/git/grpc
+
+bazel test //test/...

--- a/tools/internal_ci/linux/grpc_flaky_network_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_flaky_network_in_docker.sh
@@ -28,4 +28,4 @@ cd /var/local/git/grpc/test/cpp/end2end
 # iptables is used to drop traffic between client and server
 apt-get install -y iptables
 
-bazel test --spawn_strategy=standalone --genrule_strategy=standalone --test_output=all --test_timeout=1200 :flaky_network_test --test_env=GRPC_TRACE=http --test_env=GRPC_VERBOSITY=DEBUG
+bazel test --test_output=all --test_timeout=1200 :flaky_network_test --test_env=GRPC_TRACE=http --test_env=GRPC_VERBOSITY=DEBUG

--- a/tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh
@@ -25,7 +25,7 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc/test
 TEST_TARGETS="//src/python/... //tools/distrib/python/grpcio_tools/... //examples/python/..."
-BAZEL_FLAGS="--spawn_strategy=standalone --genrule_strategy=standalone --test_output=errors"
+BAZEL_FLAGS="--test_output=errors"
 bazel test ${BAZEL_FLAGS} ${TEST_TARGETS}
 bazel test --config=python_single_threaded_unary_stream ${BAZEL_FLAGS} ${TEST_TARGETS}
 bazel test --config=python_poller_engine ${BAZEL_FLAGS} ${TEST_TARGETS}

--- a/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
@@ -21,14 +21,16 @@ cd $(dirname $0)/../../..
 ./tools/run_tests/start_port_server.py
 
 # run cfstream_test separately because it messes with the network
-tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=standalone --genrule_strategy=standalone --test_output=all --copt="-DGRPC_CFSTREAM=1" //test/cpp/end2end:cfstream_test
+# The "local" execution strategy is required because the test runs sudo and that doesn't work in a sandboxed environment (the default on mac)
+tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=local --genrule_strategy=local --test_output=all --copt="-DGRPC_CFSTREAM=1" //test/cpp/end2end:cfstream_test
 
 # Make sure time is in sync before running time_jump_test because the test does
 # NTP sync before exiting. Bazel gets confused if test end time < start time.
 sudo sntp -sS pool.ntp.org
 
 # run time_jump_test separately because it changes system time
-tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=standalone --genrule_strategy=standalone --test_output=all //test/cpp/common:time_jump_test
+# The "local" execution strategy is required because the test runs sudo and that doesn't work in a sandboxed environment (the default on mac)
+tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=local --genrule_strategy=local --test_output=all //test/cpp/common:time_jump_test
 
 # kill port_server.py to prevent the build from hanging
 ps aux | grep port_server\\.py | awk '{print $2}' | xargs kill -9


### PR DESCRIPTION
Likely by copy & paste, we ended up with `--spawn_strategy=standalone --genrule_strategy=standalone` in many of our bazel test scripts, without any good reason.
Reduce complexity by removing the unecessary args where possible and add explanatory comments of what is its purpose where needed.

Btw, `standalone` strategy is now deprecated with bazel.