### PR TITLE
Make sure clang_tidy dockerfile is buildable

### DIFF
--- a/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:10
+  <%include file="../python_debian10.include"/>
   
   # Install clang-tidy 6.0
   # This is because clang-tidy 7.0 started treating compiler errors as tidy errors
@@ -23,7 +23,6 @@
   RUN apt-get update && apt-get install -y clang-tidy-6.0
   ENV CLANG_TIDY=clang-tidy-6.0
 
-  <%include file="../python_deps.include"/>
   ADD clang_tidy_all_the_things.sh /
   
   # When running locally, we'll be impersonating the current user, so we need

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -13,6 +13,53 @@
 # limitations under the License.
 
 FROM debian:10
+  
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  gcc \
+  gcc-multilib \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#================
+# Build profiling
+RUN apt-get update && apt-get install -y time && apt-get clean
+
+# Install Python 2.7
+RUN apt-get update && apt-get install -y python2.7 python-all-dev
+RUN curl https://bootstrap.pypa.io/get-pip.py | python2.7
+
+# Google Cloud platform API libraries
+RUN pip install --upgrade google-api-python-client oauth2client
+
+
+RUN mkdir /var/local/jenkins
+
+
 
 # Install clang-tidy 6.0
 # This is because clang-tidy 7.0 started treating compiler errors as tidy errors
@@ -20,22 +67,6 @@ FROM debian:10
 # should be using 6.0 version until all compilation errors are addressed.
 RUN apt-get update && apt-get install -y clang-tidy-6.0
 ENV CLANG_TIDY=clang-tidy-6.0
-
-#====================
-# Python dependencies
-
-# Install dependencies
-
-RUN apt-get update && apt-get install -y \
-    python-all-dev \
-    python3-all-dev \
-    python-setuptools
-
-# Install Python packages from PyPI
-RUN curl https://bootstrap.pypa.io/get-pip.py | python2.7
-RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
 ADD clang_tidy_all_the_things.sh /
 


### PR DESCRIPTION
When trying to run tools/distrib/clang_tidy_code.sh on my machine, I had trouble building the grpc_clang_tidy dockerfile.

Made a few fixes (and make the docker file looks more similar to our sanity dockerfile: https://github.com/grpc/grpc/blob/fb8e4556c250bbcc523b55e6ebe69cb2b3d95998/templates/tools/dockerfile/test/sanity/Dockerfile.template#L17).