### PR TITLE
Upgrade bazel used for all tests to 2.2.0

### DIFF
--- a/bazel/update_mirror.sh
+++ b/bazel/update_mirror.sh
@@ -56,6 +56,10 @@ upload github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-linux-x86
 upload github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-darwin-x86_64
 upload github.com/bazelbuild/bazel/releases/download/1.0.0/bazel-1.0.0-windows-x86_64.exe
 
+upload github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-linux-x86_64
+upload github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-darwin-x86_64
+upload github.com/bazelbuild/bazel/releases/download/2.2.0/bazel-2.2.0-windows-x86_64.exe
+
 # Collect the github archives to mirror from grpc_deps.bzl
 grep -o '"https://github.com/[^"]*"' bazel/grpc_deps.bzl | sed 's/^"https:\/\///' | sed 's/"$//' | while read -r line ; do
     echo "Updating mirror for ${line}"

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -56,6 +56,11 @@ grpc_proto_library(
     srcs = ["protos/route_guide.proto"],
 )
 
+proto_library(
+    name = "keyvaluestore_proto",
+    srcs = ["protos/keyvaluestore.proto"],
+)
+
 grpc_proto_library(
     name = "keyvaluestore",
     srcs = ["protos/keyvaluestore.proto"],

--- a/examples/objective-c/BUILD
+++ b/examples/objective-c/BUILD
@@ -27,12 +27,12 @@ objc_grpc_library(
     deps = ["//examples:helloworld_proto"],
 )
 
-# This one works with import "external/com_github_grpc_grpc/examples/protos/Helloworld.pbrpc.h"
+# This one works with import "external/com_github_grpc_grpc/examples/protos/Keyvaluestore.pbrpc.h"
 objc_grpc_library(
-    name = "HelloWorld_grpc_proto_external",
-    srcs = ["//external/com_github_grpc_grpc/examples:protos/helloworld.proto"],
+    name = "Keyvaluestore_grpc_proto_external",
+    srcs = ["//external/com_github_grpc_grpc/examples:protos/keyvaluestore.proto"],
     tags = ["manual"],
-    deps = ["@com_github_grpc_grpc//examples:helloworld_proto"],
+    deps = ["@com_github_grpc_grpc//examples:keyvaluestore_proto"],
 )
 
 objc_library(

--- a/templates/tools/dockerfile/bazel.include
+++ b/templates/tools/dockerfile/bazel.include
@@ -2,7 +2,7 @@
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 1.0.0
+ENV BAZEL_VERSION 2.2.0
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/bazel
+++ b/tools/bazel
@@ -40,7 +40,7 @@ then
   fi
 fi
 
-VERSION=1.0.0
+VERSION=2.2.0
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
 # update tools/update_mirror.sh to populate the mirror with new bazel archives

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -75,7 +75,7 @@ RUN python3.6 -m ensurepip && \
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 1.0.0
+ENV BAZEL_VERSION 2.2.0
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -96,7 +96,7 @@ ENV CLANG_TIDY=clang-tidy-6.0
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 1.0.0
+ENV BAZEL_VERSION 2.2.0
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -14,7 +14,7 @@
 
 @rem TODO(jtattermusch): make this generate less output
 @rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync
-choco install bazel -y --version 1.0.0 --limit-output
+choco install bazel -y --version 2.2.0 --limit-output
 
 cd github/grpc
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%


### PR DESCRIPTION
Starting from protobuf 3.13.0, bazel protobuf rules don't work with bazel 1.x (due to https://github.com/protocolbuffers/protobuf/pull/7652 which makes protobuf compatible with the upcoming bazel 4.x release).

As a result, this PR upgrades the bazel version we are using for all the tests to the latest 2.x version (which is 2.2.0).
That allows https://github.com/grpc/grpc/pull/23855 to be merged.

Note that with this PR, we're not making any changes to break grpc build with bazel 1.x, but bazel 2.x will be transitively required to build grpc anyway (because the protobuf codegen rules won't work correctly with 1.x).

Workaround for users that cannot upgrade their build from bazel 1.x to bazel 2.x right away is to downgrade the protobuf dependency to < 3.13.0 and they should be able to build with 1.x again (note that this workaround is most likely temporary as eventually there will be some change that would require bazel 2.x anyway - but the workaround could still buy you some time).