### PR TITLE
PHP: change return type annotation of generated PHP methods

### DIFF
--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -78,10 +78,15 @@ void PrintMethod(const MethodDescriptor* method, Printer* out) {
   out->Print("/**\n");
   out->Print(GetPHPComments(method, " *").c_str());
   if (method->client_streaming()) {
+    if (method->server_streaming()) {
+      vars["return_type_id"] = "\\Grpc\\BidiStreamingCall";
+    } else {
+      vars["return_type_id"] = "\\Grpc\\ClientStreamingCall";
+    }
     out->Print(vars,
                " * @param array $$metadata metadata\n"
                " * @param array $$options call options\n"
-               " * @return \\$output_type_id$\n */\n"
+               " * @return $return_type_id$\n */\n"
                "public function $name$($$metadata = [], "
                "$$options = []) {\n");
     out->Indent();
@@ -96,11 +101,16 @@ void PrintMethod(const MethodDescriptor* method, Printer* out) {
                "['\\$output_type_id$','decode'],\n"
                "$$metadata, $$options);\n");
   } else {
+    if (method->server_streaming()) {
+      vars["return_type_id"] = "\\Grpc\\ServerStreamingCall";
+    } else {
+      vars["return_type_id"] = "\\Grpc\\UnaryCall";
+    }
     out->Print(vars,
                " * @param \\$input_type_id$ $$argument input argument\n"
                " * @param array $$metadata metadata\n"
                " * @param array $$options call options\n"
-               " * @return \\$output_type_id$\n */\n"
+               " * @return $return_type_id$\n */\n"
                "public function $name$(\\$input_type_id$ $$argument,\n"
                "  $$metadata = [], $$options = []) {\n");
     out->Indent();

--- a/src/php/tests/generated_code/Math/MathClient.php
+++ b/src/php/tests/generated_code/Math/MathClient.php
@@ -37,7 +37,7 @@ class MathClient extends \Grpc\BaseStub {
      * @param \Math\DivArgs $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Math\DivReply
+     * @return \Grpc\UnaryCall
      */
     public function Div(\Math\DivArgs $argument,
       $metadata = [], $options = []) {
@@ -54,7 +54,7 @@ class MathClient extends \Grpc\BaseStub {
      * replies.  The stream ends immediately if either end aborts.
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Math\DivReply
+     * @return \Grpc\BidiStreamingCall
      */
     public function DivMany($metadata = [], $options = []) {
         return $this->_bidiRequest('/math.Math/DivMany',
@@ -69,7 +69,7 @@ class MathClient extends \Grpc\BaseStub {
      * @param \Math\FibArgs $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Math\Num
+     * @return \Grpc\ServerStreamingCall
      */
     public function Fib(\Math\FibArgs $argument,
       $metadata = [], $options = []) {
@@ -84,7 +84,7 @@ class MathClient extends \Grpc\BaseStub {
      * is closed.
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Math\Num
+     * @return \Grpc\ClientStreamingCall
      */
     public function Sum($metadata = [], $options = []) {
         return $this->_clientStreamRequest('/math.Math/Sum',

--- a/src/php/tests/interop/Grpc/Testing/LoadBalancerStatsServiceClient.php
+++ b/src/php/tests/interop/Grpc/Testing/LoadBalancerStatsServiceClient.php
@@ -40,7 +40,7 @@ class LoadBalancerStatsServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\LoadBalancerStatsRequest $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\LoadBalancerStatsResponse
+     * @return \Grpc\UnaryCall
      */
     public function GetClientStats(\Grpc\Testing\LoadBalancerStatsRequest $argument,
       $metadata = [], $options = []) {

--- a/src/php/tests/interop/Grpc/Testing/ReconnectServiceClient.php
+++ b/src/php/tests/interop/Grpc/Testing/ReconnectServiceClient.php
@@ -39,7 +39,7 @@ class ReconnectServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\ReconnectParams $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\EmptyMessage
+     * @return \Grpc\UnaryCall
      */
     public function Start(\Grpc\Testing\ReconnectParams $argument,
       $metadata = [], $options = []) {
@@ -53,7 +53,7 @@ class ReconnectServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\EmptyMessage $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\ReconnectInfo
+     * @return \Grpc\UnaryCall
      */
     public function Stop(\Grpc\Testing\EmptyMessage $argument,
       $metadata = [], $options = []) {

--- a/src/php/tests/interop/Grpc/Testing/TestServiceClient.php
+++ b/src/php/tests/interop/Grpc/Testing/TestServiceClient.php
@@ -41,7 +41,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\EmptyMessage $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\EmptyMessage
+     * @return \Grpc\UnaryCall
      */
     public function EmptyCall(\Grpc\Testing\EmptyMessage $argument,
       $metadata = [], $options = []) {
@@ -56,7 +56,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\SimpleRequest $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\SimpleResponse
+     * @return \Grpc\UnaryCall
      */
     public function UnaryCall(\Grpc\Testing\SimpleRequest $argument,
       $metadata = [], $options = []) {
@@ -73,7 +73,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\SimpleRequest $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\SimpleResponse
+     * @return \Grpc\UnaryCall
      */
     public function CacheableUnaryCall(\Grpc\Testing\SimpleRequest $argument,
       $metadata = [], $options = []) {
@@ -89,7 +89,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\StreamingOutputCallRequest $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\StreamingOutputCallResponse
+     * @return \Grpc\ServerStreamingCall
      */
     public function StreamingOutputCall(\Grpc\Testing\StreamingOutputCallRequest $argument,
       $metadata = [], $options = []) {
@@ -104,7 +104,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * The server returns the aggregated size of client payload as the result.
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\StreamingInputCallResponse
+     * @return \Grpc\ClientStreamingCall
      */
     public function StreamingInputCall($metadata = [], $options = []) {
         return $this->_clientStreamRequest('/grpc.testing.TestService/StreamingInputCall',
@@ -118,7 +118,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * demonstrates the idea of full duplexing.
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\StreamingOutputCallResponse
+     * @return \Grpc\BidiStreamingCall
      */
     public function FullDuplexCall($metadata = [], $options = []) {
         return $this->_bidiRequest('/grpc.testing.TestService/FullDuplexCall',
@@ -133,7 +133,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * first request.
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\StreamingOutputCallResponse
+     * @return \Grpc\BidiStreamingCall
      */
     public function HalfDuplexCall($metadata = [], $options = []) {
         return $this->_bidiRequest('/grpc.testing.TestService/HalfDuplexCall',
@@ -147,7 +147,7 @@ class TestServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\EmptyMessage $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\EmptyMessage
+     * @return \Grpc\UnaryCall
      */
     public function UnimplementedCall(\Grpc\Testing\EmptyMessage $argument,
       $metadata = [], $options = []) {

--- a/src/php/tests/interop/Grpc/Testing/UnimplementedServiceClient.php
+++ b/src/php/tests/interop/Grpc/Testing/UnimplementedServiceClient.php
@@ -41,7 +41,7 @@ class UnimplementedServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\EmptyMessage $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\EmptyMessage
+     * @return \Grpc\UnaryCall
      */
     public function UnimplementedCall(\Grpc\Testing\EmptyMessage $argument,
       $metadata = [], $options = []) {

--- a/src/php/tests/interop/Grpc/Testing/XdsUpdateHealthServiceClient.php
+++ b/src/php/tests/interop/Grpc/Testing/XdsUpdateHealthServiceClient.php
@@ -39,7 +39,7 @@ class XdsUpdateHealthServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\EmptyMessage $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\EmptyMessage
+     * @return \Grpc\UnaryCall
      */
     public function SetServing(\Grpc\Testing\EmptyMessage $argument,
       $metadata = [], $options = []) {
@@ -53,7 +53,7 @@ class XdsUpdateHealthServiceClient extends \Grpc\BaseStub {
      * @param \Grpc\Testing\EmptyMessage $argument input argument
      * @param array $metadata metadata
      * @param array $options call options
-     * @return \Grpc\Testing\EmptyMessage
+     * @return \Grpc\UnaryCall
      */
     public function SetNotServing(\Grpc\Testing\EmptyMessage $argument,
       $metadata = [], $options = []) {


### PR DESCRIPTION
Fixes #23736 