### PR TITLE
Increase xDS job timeout while increased run time is investigated

### DIFF
--- a/tools/internal_ci/linux/grpc_xds.cfg
+++ b/tools/internal_ci/linux/grpc_xds.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
-timeout_mins: 90
+timeout_mins: 120
 env_vars {
   key: "BAZEL_SCRIPT"
   value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"


### PR DESCRIPTION
It looks like there's an interaction with a timeout on the C++ client for `backends_restart` test that wastes 20 minutes per test run (only for C++, not for the other languages). We just had a run on master time out. Bumping the timeout up to get our CI healthy again while I get the runtime back down.