### PR TITLE
Increase attempt number waiting for round_robin config propagation

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -568,7 +568,9 @@ def test_round_robin(gcp, backend_service, instance_group):
     # may result in briefly receiving an empty EDS update, resulting in failed
     # RPCs. Retry distribution validation if this occurs; long-term fix is
     # creating new backend resources for each individual test case.
-    max_attempts = 10
+    # Each attempt takes 10 seconds. Config propagation can take several
+    # minutes.
+    max_attempts = 40
     for i in range(max_attempts):
         stats = get_client_stats(_NUM_TEST_RPCS, _WAIT_FOR_STATS_SEC)
         requests_received = [stats.rpcs_by_peer[x] for x in stats.rpcs_by_peer]


### PR DESCRIPTION
Confirmed flake with a java client this evening where the xDS response - correctly, from the control plane's perspective - ended up sending zero backends to the client mid-test due to delayed updates from the previous remove_instance_group test. This effectively increases the timeout for this test to 10*40=400 seconds, or double the previous 200 second unconditional wait for config propagation (while still letting us finish the test earlier in the majority of cases).