### PR TITLE
Add extra comments that explain that #19196 is not an issue

### DIFF
--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -62,6 +62,10 @@ namespace Grpc.Core.Internal
 
             try
             {
+                // NOTE: The serviceUrlPtr and methodNamePtr values come from the grpc_auth_metadata_context
+                // and are only guaranteed to be valid until synchronous return of this handler.
+                // We are effectively making a copy of these strings by creating C# string from the native char pointers,
+                // and passing the resulting C# strings to the context is therefore safe.
                 var context = new AuthInterceptorContext(Marshal.PtrToStringAnsi(serviceUrlPtr), Marshal.PtrToStringAnsi(methodNamePtr));
                 // Make a guarantee that credentials_notify_from_plugin is invoked async to be compliant with c-core API.
                 ThreadPool.QueueUserWorkItem(async (stateInfo) => await GetMetadataAsync(context, callbackPtr, userDataPtr));

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -1136,6 +1136,11 @@ static int grpcsharp_get_metadata_handler(
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t* num_creds_md, grpc_status_code* status,
     const char** error_details) {
+  // the "context" object and its contents are only guaranteed to live until
+  // this handler returns (which could result in use-after-free for async
+  // handling of the callback), so the C# counterpart of this handler
+  // must make a copy of the "service_url" and "method_name" strings before
+  // it returns if it wants to uses these strings.
   native_callback_dispatcher(state, (void*)context.service_url,
                              (void*)context.method_name, cb, user_data,
                              (void*)0, NULL);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/19196

This PR actually doesn't change any code, I just looked into https://github.com/grpc/grpc/issues/19196 more in depth and concluded that C# is not affected by it. Adding comments that explain why there cannot be a grpc_auth_metadata_context's use-after-free with C#.