### PR TITLE
Make check_linker_need_libatomic more robust

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,22 +166,22 @@ def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cc_test = subprocess.Popen(['cc', '-x', 'c++', '-std=c++11', '-'],
-                               stdin=PIPE,
-                               stdout=PIPE,
-                               stderr=PIPE)
-    cc_test.communicate(input=code_test)
-    if cc_test.returncode == 0:
+    cpp_test = subprocess.Popen(['c++', '-x', 'c++', '-std=c++11', '-'],
+                                stdin=PIPE,
+                                stdout=PIPE,
+                                stderr=PIPE)
+    cpp_test.communicate(input=code_test)
+    if cpp_test.returncode == 0:
         return False
     # Double-check to see if -latomic actually can solve the problem.
     # https://github.com/grpc/grpc/issues/22491
-    cc_test = subprocess.Popen(
-        ['cc', '-x', 'c++', '-std=c++11', '-latomic', '-'],
+    cpp_test = subprocess.Popen(
+        ['c++', '-x', 'c++', '-std=c++11', '-latomic', '-'],
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE)
-    cc_test.communicate(input=code_test)
-    return cc_test.returncode == 0
+    cpp_test.communicate(input=code_test)
+    return cpp_test.returncode == 0
 
 
 # There are some situations (like on Windows) where CC, CFLAGS, and LDFLAGS are

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,17 @@ def check_linker_need_libatomic():
                                stdout=PIPE,
                                stderr=PIPE)
     cc_test.communicate(input=code_test)
-    return cc_test.returncode != 0
+    if cc_test.returncode == 0:
+        return False
+    # Double-check to see if -latomic actually can solve the problem.
+    # https://github.com/grpc/grpc/issues/22491
+    cc_test = subprocess.Popen(
+        ['cc', '-x', 'c++', '-std=c++11', '-latomic', '-'],
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE)
+    cc_test.communicate(input=code_test)
+    return cc_test.returncode == 0
 
 
 # There are some situations (like on Windows) where CC, CFLAGS, and LDFLAGS are


### PR DESCRIPTION
`check_linker_need_libatomic` doesn't seem to work on Mac properly so it has to check again `-latomic` actually solves the problem.

Fixes #22491
Related to #20414