### PR TITLE
Backport "PHP: avoid destroy channel more than once" to v1.31.x

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -50,7 +50,7 @@ extern HashTable grpc_persistent_list;
 extern HashTable grpc_target_upper_bound_map;
 
 void free_grpc_channel_wrapper(grpc_channel_wrapper* channel, bool free_channel) {
-  if (free_channel) {
+  if (free_channel && channel->wrapped) {
     grpc_channel_destroy(channel->wrapped);
     channel->wrapped = NULL;
   }

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -159,6 +159,7 @@ void destroy_grpc_channels() {
     wrapped_channel.wrapper = le->channel;
     grpc_channel_wrapper *channel = wrapped_channel.wrapper;
     grpc_channel_destroy(channel->wrapped);
+    channel->wrapped = NULL;
   PHP_GRPC_HASH_FOREACH_END()
 }
 


### PR DESCRIPTION
Backport #23567 to the `v1.31.x` branch.