### PR TITLE
Don't call grpc_call_cancel() from within core.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -801,7 +801,7 @@ void GrpcLb::BalancerCallState::Orphan() {
   // lb_on_balancer_status_received_ will complete the cancellation and clean
   // up. Otherwise, we are here because grpclb_policy has to orphan a failed
   // call, then the following cancellation will be a no-op.
-  grpc_call_cancel(lb_call_, nullptr);
+  grpc_call_cancel_internal(lb_call_);
   if (client_load_report_timer_callback_pending_) {
     grpc_timer_cancel(&client_load_report_timer_);
   }

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -787,7 +787,7 @@ void XdsClient::ChannelState::AdsCallState::Orphan() {
   // on_status_received_ will complete the cancellation and clean up. Otherwise,
   // we are here because xds_client has to orphan a failed call, then the
   // following cancellation will be a no-op.
-  grpc_call_cancel(call_, nullptr);
+  grpc_call_cancel_internal(call_);
   state_map_.clear();
   // Note that the initial ref is hold by on_status_received_. So the
   // corresponding unref happens in on_status_received_ instead of here.
@@ -1553,7 +1553,7 @@ void XdsClient::ChannelState::LrsCallState::Orphan() {
   // on_status_received_ will complete the cancellation and clean up. Otherwise,
   // we are here because xds_client has to orphan a failed call, then the
   // following cancellation will be a no-op.
-  grpc_call_cancel(call_, nullptr);
+  grpc_call_cancel_internal(call_);
   // Note that the initial ref is hold by on_status_received_. So the
   // corresponding unref happens in on_status_received_ instead of here.
 }

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -43,7 +43,7 @@ BANNED_EXCEPT = {
     'grpc_wsa_error(': ['src/core/lib/iomgr/error.cc'],
     'grpc_log_if_error(': ['src/core/lib/iomgr/error.cc'],
     'grpc_slice_malloc(': ['src/core/lib/slice/slice.cc'],
-    'grpc_call_cancel_internal(': ['src/core/lib/surface/call.cc'],
+    'grpc_call_cancel(': ['src/core/lib/surface/call.cc'],
     'grpc_closure_create(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_init(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_sched(': ['src/core/lib/iomgr/closure.cc'],


### PR DESCRIPTION
It looks like the entry in tools/run_tests/sanity/core_banned_functions.py was entered wrong when this function was added in #17148, so these cases were not getting caught before.  This avoids creating a nested ExecCtx in these cases.