### PR TITLE
Add init and shutdown to verify_peer_options

### DIFF
--- a/test/core/handshake/verify_peer_options.cc
+++ b/test/core/handshake/verify_peer_options.cc
@@ -235,6 +235,7 @@ static void verify_destruct(void* userdata) { destruct_userdata = userdata; }
 
 int main(int argc, char* argv[]) {
   grpc::testing::TestEnvironment env(argc, argv);
+  grpc_init();
 
   int userdata = 42;
   verify_peer_options verify_options;
@@ -272,6 +273,7 @@ int main(int argc, char* argv[]) {
 
   grpc_slice_unref(cert_slice);
 
+  grpc_shutdown();
   return 0;
 }
 


### PR DESCRIPTION
Extracting the change from #23710 so that this PR hardening `verify_peer_options` test can survive in case of the the original PR rollback. This is required for `verify_peer_option` test to have the last `grpc_shutdown` call as a last shutdown call, which is needed to run shutdown synchronously.
