### PR TITLE
Upgraded gcc to 8 in python_dev_centos7_x64

### DIFF
--- a/tools/dockerfile/distribtest/python_dev_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_centos7_x64/Dockerfile
@@ -15,8 +15,25 @@
 FROM centos:7
 
 RUN yum install -y python
+RUN yum install -y python-devel
 RUN yum install -y epel-release
 RUN yum install -y python-pip
-RUN pip install virtualenv
-RUN yum groupinstall -y 'Development Tools'
-RUN yum install -y python-devel
+RUN pip install --upgrade pip
+RUN pip install -U virtualenv
+
+# The default gcc of CentOS 7 is gcc 4.8 which is older than gcc 4.9,
+# the minimum supported gcc version for gRPC Core so let's upgrade to
+# the oldest one that can build gRPC on Centos 7.
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-8-binutils devtoolset-8-gcc devtoolset-8-gcc-c++
+
+# Activate devtoolset-8 by default
+# https://austindewey.com/2019/03/26/enabling-software-collections-binaries-on-a-docker-image/
+RUN echo $'#!/bin/bash\n\
+source scl_source enable devtoolset-8\n\
+"$@"\n' > /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+RUN cat /usr/bin/entrypoint.sh
+ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
`python_dev_centos7_x64` still relies on the default gcc 4.8 which is older than gcc 4.9, which is a minimum version of gcc we support so this docker should use the later version, in this PR, gcc-8 which is the oldest one which can build gRPC successfully. (There are three versions available as of today; 7, 8, and 9. 7 has a compiler bug which cannot handle some template in Abseil so 8 is the oldest one)

Required by #23723