### PR TITLE
Member variable should not be a reference; causing crash when used in

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -169,7 +169,7 @@ class WeightedTargetLb : public LoadBalancingPolicy {
     // The owning LB policy.
     RefCountedPtr<WeightedTargetLb> weighted_target_policy_;
 
-    const std::string& name_;
+    const std::string name_;
 
     uint32_t weight_;
 
@@ -288,9 +288,8 @@ void WeightedTargetLb::UpdateLocked(UpdateArgs args) {
     const std::string& name = p.first;
     auto it = targets_.find(name);
     if (it == targets_.end()) {
-      it = targets_.emplace(std::make_pair(name, nullptr)).first;
-      it->second = MakeOrphanable<WeightedChild>(
-          Ref(DEBUG_LOCATION, "WeightedChild"), it->first);
+      targets_.emplace(name, MakeOrphanable<WeightedChild>(
+                                 Ref(DEBUG_LOCATION, "WeightedChild"), name));
     }
   }
   // Update all children.


### PR DESCRIPTION
destructor (backport into 1.30.x)




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
