### PR TITLE
PHP: support 32bit timeval value

### DIFF
--- a/src/php/bin/build_all_docker_images.sh
+++ b/src/php/bin/build_all_docker_images.sh
@@ -17,7 +17,7 @@ set -e
 cd $(dirname $0)/../../..
 
 ALL_IMAGES=( grpc-ext grpc-src alpine centos7 php5 php-src php-future php-zts
-             fork-support )
+             fork-support i386 )
 
 if [[ "$1" == "--cmds" ]]; then
   for arg in "${ALL_IMAGES[@]}"

--- a/src/php/bin/run_all_docker_images.sh
+++ b/src/php/bin/run_all_docker_images.sh
@@ -17,7 +17,7 @@ set -e
 cd $(dirname $0)/../../..
 
 ALL_IMAGES=( grpc-ext grpc-src alpine centos7 php5 php-src php-future php-zts
-             fork-support )
+             fork-support i386 )
 
 if [[ "$1" == "--cmds" ]]; then
   for arg in "${ALL_IMAGES[@]}"

--- a/src/php/docker/i386/Dockerfile
+++ b/src/php/docker/i386/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM i386/php:7.2
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  valgrind wget zlib1g-dev
+
+ARG MAKEFLAGS=-j8
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
+  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+COPY . .
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests", "--ignore-valgrind-undef-errors"]

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -55,19 +55,27 @@ zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC) {
 
 /**
  * Constructs a new instance of the Timeval class
- * @param long $microseconds The number of microseconds in the interval
+ * @param number $microseconds The number of microseconds in the interval
  */
 PHP_METHOD(Timeval, __construct) {
   wrapped_grpc_timeval *timeval =
     PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, getThis());
-  php_grpc_long microseconds;
+  int64_t microseconds = 0;
 
-  /* "l" == 1 long */
-  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &microseconds) ==
-      FAILURE) {
-    zend_throw_exception(spl_ce_InvalidArgumentException,
-                         "Timeval expects a long", 1 TSRMLS_CC);
-    return;
+  /* parse $microseconds as long */
+  if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                               ZEND_NUM_ARGS() TSRMLS_CC, "l",
+                               &microseconds) == FAILURE) {
+    double microsecondsDouble = 0.0;
+    /* parse $microseconds as double */
+    if (zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET,
+                              ZEND_NUM_ARGS() TSRMLS_CC, "d",
+                              &microsecondsDouble) == FAILURE) {
+      zend_throw_exception(spl_ce_InvalidArgumentException,
+                           "Timeval expects a long or double", 1 TSRMLS_CC);
+      return;
+    }
+    microseconds = (int64_t)microsecondsDouble;
   }
   gpr_timespec time = gpr_time_from_micros(microseconds, GPR_TIMESPAN);
   memcpy(&timeval->wrapped, &time, sizeof(gpr_timespec));

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -82,6 +82,17 @@ class TimevalTest extends PHPUnit_Framework_TestCase
         $this->assertSame(0, Grpc\Timeval::compare($this->time, $twoHour));
     }
 
+    public function testAddAndSubtractWithBigInt()
+    {
+        $time = new Grpc\Timeval(7200000000);
+        $delta = new Grpc\Timeval(7200000000);
+        $delta2 = new Grpc\Timeval(7200000000*2);
+        $time2 = $time->add($delta2);
+        $time2 = $time2->subtract($delta);
+        $time2 = $time2->subtract($delta);
+        $this->assertSame(0, Grpc\Timeval::compare($time, $time2));
+    }
+
     public function testCompareSame()
     {
         $zero = Grpc\Timeval::zero();
@@ -141,6 +152,16 @@ class TimevalTest extends PHPUnit_Framework_TestCase
         $back_to_now = $deadline->subtract($delta);
         $this->assertSame(0, Grpc\Timeval::compare($back_to_now, $now));
     }
+
+    public function testAddAndSubtractBigInt()
+    {
+        $now = Grpc\Timeval::now();
+        $delta = new Grpc\Timeval(7200000000);
+        $deadline = $now->add($delta);
+        $back_to_now = $deadline->subtract($delta);
+        $this->assertSame(0, Grpc\Timeval::compare($back_to_now, $now));
+    }
+
 
     public function testSimilar()
     {

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -67,6 +67,19 @@ class TimevalTest extends PHPUnit_Framework_TestCase
         $this->time = new Grpc\Timeval(123.456);
         $this->assertNotNull($this->time);
         $this->assertSame('Grpc\Timeval', get_class($this->time));
+        $timeFromInt = new Grpc\Timeval(123);
+        $this->assertSame(0, Grpc\Timeval::compare($this->time, $timeFromInt));
+    }
+
+    public function testConstructorWithBigInt()
+    {
+        $this->time = new Grpc\Timeval(7200000000); // > 2^32
+        $this->assertNotNull($this->time);
+        $this->assertSame('Grpc\Timeval', get_class($this->time));
+        $halfHour = new Grpc\Timeval(1800000000); // < 2^31
+        $hour = $halfHour->add($halfHour);
+        $twoHour = $hour->add($hour);
+        $this->assertSame(0, Grpc\Timeval::compare($this->time, $twoHour));
     }
 
     public function testCompareSame()

--- a/templates/src/php/docker/i386/Dockerfile.template
+++ b/templates/src/php/docker/i386/Dockerfile.template
@@ -1,0 +1,32 @@
+%YAML 1.2
+--- |
+  # Copyright 2020 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM i386/php:${settings.php_version.php_current_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake git libtool pkg-config ${'\\'}
+    valgrind wget zlib1g-dev
+
+  ARG MAKEFLAGS=-j8
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests", "--ignore-valgrind-undef-errors"]


### PR DESCRIPTION
Fixes #23790 and #18916.

This allows the `Timeval` constructor to accept a double value.