### PR TITLE
upgrade Google.Protobuf to 3.13.0 in C# distribtests

### DIFF
--- a/test/distrib/csharp/DistribTest/DistribTest.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTest.csproj
@@ -101,7 +101,7 @@
       <HintPath>..\packages\Google.Apis.Auth.1.15.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf">
-      <HintPath>..\packages\Google.Protobuf.3.12.2\lib\net45\Google.Protobuf.dll</HintPath>
+      <HintPath>..\packages\Google.Protobuf.3.13.0\lib\net45\Google.Protobuf.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/distrib/csharp/DistribTest/DistribTest.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTest.csproj
@@ -61,6 +61,10 @@
          Use GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE to still allow building the protobuf
          generate code -->
     <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE</DefineConstants>
+    <!-- Create a binding redirect to avoid mismatch between different versions of System.Memory
+         being referenced by Grpc.Core and Google.Protobuf.
+         See http://go.microsoft.com/fwlink/?LinkId=294190  -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Grpc.Auth">

--- a/test/distrib/csharp/DistribTest/DistribTest.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTest.csproj
@@ -56,6 +56,12 @@
     <Prefer32Bit>true</Prefer32Bit>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- this project is built with a legacy C# compiler, so ref structs are not supported.
+         Use GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE to still allow building the protobuf
+         generate code -->
+    <DefineConstants>$(DefineConstants);GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Grpc.Auth">
       <HintPath>..\packages\Grpc.Auth.__GRPC_NUGET_VERSION__\lib\net45\Grpc.Auth.dll</HintPath>

--- a/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Grpc" Version="__GRPC_NUGET_VERSION__" />
     <PackageReference Include="Grpc.Auth" Version="__GRPC_NUGET_VERSION__" />
     <PackageReference Include="Grpc.Tools" Version="__GRPC_NUGET_VERSION__" />
-    <PackageReference Include="Google.Protobuf" Version="3.12.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/distrib/csharp/DistribTest/packages.config
+++ b/test/distrib/csharp/DistribTest/packages.config
@@ -8,7 +8,7 @@
   <package id="Grpc.Core" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
   <package id="Grpc.Core.Api" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
   <package id="Grpc.Tools" version="__GRPC_NUGET_VERSION__" targetFramework="net45" />
-  <package id="Google.Protobuf" version="3.12.2" targetFramework="net45" />
+  <package id="Google.Protobuf" version="3.13.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net45" />
   <package id="System.Memory" version="4.5.3" targetFramework="net45" />


### PR DESCRIPTION
This should fix the C# distribtests which are currently failing.

The issue it that protobuf codegen was updated with Grpc.Tools in the distribtest and it requires newer protobuf runtime (3.
13.0), which needs to be upgraded as well.

https://source.cloud.google.com/results/invocations/f5be0d8b-aab0-4cd3-9262-85f340fc9349/targets/github%2Fgrpc/tests;group=tasks;test=distribtest.csharp_linux_x64_alpine_dotnetcli;row=1