### PR TITLE
Update grpc_android for new CI environment

### DIFF
--- a/examples/android/helloworld/app/CMakeLists.txt
+++ b/examples/android/helloworld/app/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+# https://github.com/abseil/abseil-cpp/issues/626
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DABSL_NO_XRAY_ATTRIBUTES=1")
+
 set(helloworld_PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(helloworld_GRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")
 

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/examples/android/helloworld/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/helloworld/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip

--- a/src/android/test/interop/app/CMakeLists.txt
+++ b/src/android/test/interop/app/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+# https://github.com/abseil/abseil-cpp/issues/626
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DABSL_NO_XRAY_ATTRIBUTES=1")
+
 set(PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(gRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")
 

--- a/src/android/test/interop/app/build.gradle
+++ b/src/android/test/interop/app/build.gradle
@@ -29,6 +29,9 @@ android {
                 arguments '-DgRPC_CPP_PLUGIN_EXECUTABLE=' + grpc_cpp_plugin
             }
         }
+        ndk {
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+        }
     }
     buildTypes {
         debug {

--- a/src/android/test/interop/build.gradle
+++ b/src/android/test/interop/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/src/android/test/interop/gradle/wrapper/gradle-wrapper.properties
+++ b/src/android/test/interop/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip

--- a/tools/internal_ci/linux/grpc_android.sh
+++ b/tools/internal_ci/linux/grpc_android.sh
@@ -15,6 +15,10 @@
 
 set -ex
 
+# Install packages which werer not preinstalled yet.
+# Protobuf needs autoconf & automake to build
+sudo apt-get install -y autoconf automake 
+
 # change to grpc repo root
 cd $(dirname $0)/../../..
 

--- a/tools/internal_ci/linux/grpc_android.sh
+++ b/tools/internal_ci/linux/grpc_android.sh
@@ -19,6 +19,9 @@ set -ex
 # Protobuf needs autoconf & automake to build
 sudo apt-get install -y autoconf automake 
 
+# Accept the Android SDK licences.
+yes | /opt/android-sdk/current/tools/bin/sdkmanager --licenses
+
 # change to grpc repo root
 cd $(dirname $0)/../../..
 

--- a/tools/internal_ci/linux/grpc_android.sh
+++ b/tools/internal_ci/linux/grpc_android.sh
@@ -15,7 +15,7 @@
 
 set -ex
 
-# Install packages which werer not preinstalled yet.
+# Install packages which were not preinstalled yet.
 # Protobuf needs autoconf & automake to build
 sudo apt-get install -y autoconf automake 
 


### PR DESCRIPTION
This is required to upgrade internal CI. Upgrading Ubuntu 14.04 to 16.04 (Internal b/166182477)

Changes:
- Install `autoconf` and `automake`
- Agreeing Android SDK license
- Removing `MIPS` from NDK build targets
- Upgrading gradle & Android gradle plugin
- Add Abseil workaround: `ABSL_NO_XRAY_ATTRIBUTES` (https://github.com/abseil/abseil-cpp/issues/626)