### PR TITLE
Improve python3 compatibility of the task_runner.py script

### DIFF
--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -235,7 +235,9 @@ class PHPDistribTest(object):
         self.platform = platform
         self.arch = arch
         self.docker_suffix = docker_suffix
-        self.labels = ['distribtest', 'php', platform, arch, docker_suffix]
+        self.labels = ['distribtest', 'php', platform, arch]
+        if docker_suffix:
+            self.labels.append(docker_suffix)
 
     def pre_build_jobspecs(self):
         return []
@@ -275,8 +277,14 @@ class CppDistribTest(object):
         self.docker_suffix = docker_suffix
         self.testcase = testcase
         self.labels = [
-            'distribtest', 'cpp', platform, arch, docker_suffix, testcase
+            'distribtest',
+            'cpp',
+            platform,
+            arch,
+            testcase,
         ]
+        if docker_suffix:
+            self.labels.append(docker_suffix)
 
     def pre_build_jobspecs(self):
         return []

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -49,7 +49,7 @@ def _create_build_map():
 
     if set(target_build_map.keys()).intersection(label_build_map.keys()):
         raise Exception('Target names need to be distinct from label names')
-    return dict(target_build_map.items() + label_build_map.items())
+    return dict(list(target_build_map.items()) + list(label_build_map.items()))
 
 
 _BUILD_MAP = _create_build_map()
@@ -83,7 +83,7 @@ for label in args.build:
 
 # Among targets selected by -b, filter out those that don't match the filter
 targets = [t for t in targets if all(f in t.labels for f in args.filter)]
-targets = sorted(set(targets))
+targets = sorted(set(targets), key=lambda target: target.name)
 
 # Execute pre-build phase
 prebuild_jobs = []


### PR DESCRIPTION
I was running the script on a machine that only had python3 and ran into some small issues, so I create a PR to fix those (as at some point we will probably want to get rid of python2 entirely)

task_runner.py is being used for building artifacts, packages and distribtests.