### PR TITLE
Pin setuptools on CI builds

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -88,7 +88,7 @@ if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
   # python
   time pip install --user virtualenv
-  time pip install --user --upgrade Mako six tox setuptools==49.6.0 twisted pyyaml pyjwt cryptography requests
+  time pip install --user --upgrade Mako six tox setuptools==44.1.1 twisted pyyaml pyjwt cryptography requests
   export PYTHONPATH=/Library/Python/3.4/site-packages
 
   # make sure md5sum is available (requires coreutils 8.31+)

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -88,7 +88,7 @@ if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
   # python
   time pip install --user virtualenv
-  time pip install --user --upgrade Mako six tox setuptools twisted pyyaml pyjwt cryptography requests
+  time pip install --user --upgrade Mako six tox setuptools==49.6.0 twisted pyyaml pyjwt cryptography requests
   export PYTHONPATH=/Library/Python/3.4/site-packages
 
   # make sure md5sum is available (requires coreutils 8.31+)

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -24,11 +24,11 @@ export PREPARE_BUILD_INSTALL_DEPS_RUBY=true
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # install cython for all python versions
-python2.7 -m pip install -U cython setuptools wheel --user
-python3.5 -m pip install -U cython setuptools wheel --user
-python3.6 -m pip install -U cython setuptools wheel --user
-python3.7 -m pip install -U cython setuptools wheel --user
-python3.8 -m pip install -U cython setuptools wheel --user
+python2.7 -m pip install -U cython setuptools==49.6.0 wheel --user
+python3.5 -m pip install -U cython setuptools==49.6.0 wheel --user
+python3.6 -m pip install -U cython setuptools==49.6.0 wheel --user
+python3.7 -m pip install -U cython setuptools==49.6.0 wheel --user
+python3.8 -m pip install -U cython setuptools==49.6.0 wheel --user
 
 # needed to build ruby artifacts
 time bash tools/distrib/build_ruby_environment_macos.sh

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -24,11 +24,11 @@ export PREPARE_BUILD_INSTALL_DEPS_RUBY=true
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # install cython for all python versions
-python2.7 -m pip install -U cython setuptools==49.6.0 wheel --user
-python3.5 -m pip install -U cython setuptools==49.6.0 wheel --user
-python3.6 -m pip install -U cython setuptools==49.6.0 wheel --user
-python3.7 -m pip install -U cython setuptools==49.6.0 wheel --user
-python3.8 -m pip install -U cython setuptools==49.6.0 wheel --user
+python2.7 -m pip install -U cython setuptools==44.1.1 wheel --user
+python3.5 -m pip install -U cython setuptools==44.1.1 wheel --user
+python3.6 -m pip install -U cython setuptools==44.1.1 wheel --user
+python3.7 -m pip install -U cython setuptools==44.1.1 wheel --user
+python3.8 -m pip install -U cython setuptools==44.1.1 wheel --user
 
 # needed to build ruby artifacts
 time bash tools/distrib/build_ruby_environment_macos.sh

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -17,7 +17,7 @@ set PATH=C:\%1;C:\%1\scripts;C:\msys64\mingw%2\bin;C:\tools\msys64\mingw%2\bin;%
 
 python -m pip install --upgrade six
 @rem some artifacts are broken for setuptools 38.5.0. See https://github.com/grpc/grpc/issues/14317
-python -m pip install --upgrade setuptools==49.6.0
+python -m pip install --upgrade setuptools==44.1.1
 python -m pip install --upgrade cython
 python -m pip install -rrequirements.txt --user
 

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -17,7 +17,7 @@ set PATH=C:\%1;C:\%1\scripts;C:\msys64\mingw%2\bin;C:\tools\msys64\mingw%2\bin;%
 
 python -m pip install --upgrade six
 @rem some artifacts are broken for setuptools 38.5.0. See https://github.com/grpc/grpc/issues/14317
-python -m pip install --upgrade setuptools==38.2.4
+python -m pip install --upgrade setuptools==49.6.0
 python -m pip install --upgrade cython
 python -m pip install -rrequirements.txt --user
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -184,8 +184,9 @@ case "$VENV" in
   ;;
 esac
 
+
+pip_install --upgrade setuptools==44.1.1
 pip_install --upgrade pip==19.3.1
-pip_install --upgrade setuptools
 pip_install --upgrade cython
 pip_install --upgrade six enum34 protobuf
 


### PR DESCRIPTION
Hopefully fixes https://github.com/grpc/grpc/issues/24028

This PR pins `setuptools` to `44.1.1`, since this is the last version that supports Python 2.