### PR TITLE
Make the server-based port picker thread safe

### DIFF
--- a/test/core/util/port.cc
+++ b/test/core/util/port.cc
@@ -38,8 +38,14 @@
 
 static int* chosen_ports = nullptr;
 static size_t num_chosen_ports = 0;
+static grpc_core::Mutex* g_default_port_picker_mu;
+static gpr_once g_default_port_picker_init = GPR_ONCE_INIT;
 
-static int free_chosen_port(int port) {
+static void init_default_port_picker() {
+  g_default_port_picker_mu = new grpc_core::Mutex();
+}
+
+static int free_chosen_port_locked(int port) {
   size_t i;
   int found = 0;
   size_t found_at = 0;
@@ -61,6 +67,7 @@ static int free_chosen_port(int port) {
 }
 
 static void free_chosen_ports(void) {
+  grpc_core::MutexLock lock(g_default_port_picker_mu);
   size_t i;
   grpc_init();
   for (i = 0; i < num_chosen_ports; i++) {
@@ -70,7 +77,7 @@ static void free_chosen_ports(void) {
   gpr_free(chosen_ports);
 }
 
-static void chose_port(int port) {
+static void chose_port_locked(int port) {
   if (chosen_ports == nullptr) {
     atexit(free_chosen_ports);
   }
@@ -81,9 +88,11 @@ static void chose_port(int port) {
 }
 
 static int grpc_pick_unused_port_impl(void) {
+  gpr_once_init(&g_default_port_picker_init, init_default_port_picker);
+  grpc_core::MutexLock lock(g_default_port_picker_mu);
   int port = grpc_pick_port_using_server();
   if (port != 0) {
-    chose_port(port);
+    chose_port_locked(port);
   }
 
   return port;
@@ -103,7 +112,9 @@ static int grpc_pick_unused_port_or_die_impl(void) {
 }
 
 static void grpc_recycle_unused_port_impl(int port) {
-  GPR_ASSERT(free_chosen_port(port));
+  gpr_once_init(&g_default_port_picker_init, init_default_port_picker);
+  grpc_core::MutexLock lock(g_default_port_picker_mu);
+  GPR_ASSERT(free_chosen_port_locked(port));
 }
 
 static grpc_pick_port_functions g_pick_port_functions = {


### PR DESCRIPTION
In internal issue b/162243837, I noticed that the `//test/core/iomgr:stranded_event_test` had hit what appear to be race conditions around manipulation of global port picker data structures. E.g. it was seeing occasional crashes like this:

```
D0812 17:40:42.820609000 123145512964096 stranded_event_test.cc:329]   created test_server with address:127.0.0.1:31302
stranded_event_test(71987,0x70000c862000) malloc: *** error for object 0x7fc631410c50: double free
*** set a breakpoint in malloc_error_break to debug
D0812 17:40:42.825032000 123145514573824 stranded_event_test.cc:329]   created test_server with address:127.0.0.1:15578



*******************************
Caught signal SIGABRT
0   libgrpc_test_util_base.so           0x0000000109da2423 _ZL13crash_handleriP9__siginfoPv + 291
1   libsystem_platform.dylib            0x00007fff5b043f5a _sigtramp + 26
2   ???                                 0x00007fc6316029a0 0x0 + 140489208637856
3   libsystem_c.dylib                   0x00007fff5ade11ae abort + 127
4   libsystem_malloc.dylib              0x00007fff5aeeaad4 szone_error + 596
5   libsystem_malloc.dylib              0x00007fff5aee136f szone_realloc + 2545
6   libsystem_malloc.dylib              0x00007fff5aee092d malloc_zone_realloc + 111
7   libsystem_malloc.dylib              0x00007fff5aee0820 realloc + 253
8   libgpr_base.so                      0x000000010a56e657 gpr_realloc + 23
9   libgrpc_test_util_base.so           0x0000000109da00bf _ZL26grpc_pick_unused_port_implv + 79
10  libgrpc_test_util_base.so           0x0000000109da00ea _ZL33grpc_pick_unused_port_or_die_implv + 10
11  stranded_event_test                 0x0000000109d6b1e5 _ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN12_GLOBAL__N_163Pollers_TestReadabilityNotificationsDontGetStrandedOnOneCq_Test8TestBodyEvE3$_0EEEEEPvSB_ + 181
12  libsystem_pthread.dylib             0x00007fff5b04d661 _pthread_body + 340
13  libsystem_pthread.dylib             0x00007fff5b04d50d _pthread_body + 0
14  libsystem_pthread.dylib             0x00007fff5b04cbf9 thread_start + 13
external/bazel_tools/tools/test/test-setup.sh: line 310: 71987 Abort trap: 6           "${TEST_PATH}" "$@" 2>&1
```

These were getting hit because the test was calling `grpc_pick_unused_port_or_die` from concurrent threads.

Looking at what I believe are all three implementations of `grpc_pick_unused_port_or_die` (OSS server-based, OSS bazel based, and internal version), and it looks like `grpc_pick_unused_port_or_die` is usually thread safe, except that the OSS server-based version isn't. IMO this can lead to some surprising platform-specific test flakes.

The issues are reproduceable e.g. by the failing test in experimental PR: https://github.com/grpc/grpc/pull/24032. I was on the fence of whether this change warrants such a test to be submitted. I left it out because the test is somewhat slow to run, but can add it if wanted.

Note: one side effect is this also serializes all requests to the port server from one process. Doing so led to the simplest code, and I suspect there aren't any worthy test runtime wins by calling to the port server concurrently anyways -- this may also avoid overloading the port server when calling `grpc_pick_unused_port_or_die` concurrently.




