### PR TITLE
Change require to require_relative for dep file in ruby_generator.cc

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -184,7 +184,7 @@ std::string GetServices(const FileDescriptor* file) {
         "dep.name",
         MessagesRequireName(file),
     });
-    out.Print(dep_vars, "require '$dep.name$'\n");
+    out.Print(dep_vars, "require_relative '$dep.name$'\n");
 
     // Write out services within the modules
     out.Print("\n");


### PR DESCRIPTION
Normally we use require when requiring library. In this case we are generating local file which should be required as require_relative.
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
