### PR TITLE
Add all test credentials to GetSecureCredentialsTypeList()

### DIFF
--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -143,6 +143,9 @@ class DefaultCredentialsProvider : public CredentialsProvider {
   std::vector<std::string> GetSecureCredentialsTypeList() override {
     std::vector<std::string> types;
     types.push_back(grpc::testing::kTlsCredentialsType);
+    types.push_back(grpc::testing::kInsecureCredentialsType);
+    types.push_back(grpc::testing::kAltsCredentialsType);
+    types.push_back(grpc::testing::kGoogleDefaultCredentialsType);
     std::unique_lock<std::mutex> lock(mu_);
     for (auto it = added_secure_type_names_.begin();
          it != added_secure_type_names_.end(); it++) {


### PR DESCRIPTION
Currently, the function `GetSecureCredentialsTypeList()` only return the credential `ssl`. Add all test credentials to it. 