### PR TITLE
Introduce a macro to override the precise clock

### DIFF
--- a/src/core/lib/gpr/time_precise.cc
+++ b/src/core/lib/gpr/time_precise.cc
@@ -31,6 +31,7 @@
 
 #include "src/core/lib/gpr/time_precise.h"
 
+#ifndef GPR_CYCLE_COUNTER_CUSTOM
 #if GPR_CYCLE_COUNTER_RDTSC_32 || GPR_CYCLE_COUNTER_RDTSC_64
 #if GPR_LINUX
 static bool read_freq_from_kernel(double* freq) {
@@ -163,3 +164,4 @@ gpr_timespec gpr_cycle_counter_sub(gpr_cycle_counter a, gpr_cycle_counter b) {
                       gpr_cycle_counter_to_time(b));
 }
 #endif /* GPR_CYCLE_COUNTER_FALLBACK */
+#endif /* !GPR_CYCLE_COUNTER_CUSTOM */

--- a/src/core/lib/gpr/time_precise.h
+++ b/src/core/lib/gpr/time_precise.h
@@ -31,7 +31,10 @@
 // Using gpr_get_cycle_counter() is preferred to using ExecCtx::Get()->Now()
 // whenever possible.
 
-#if GPR_CYCLE_COUNTER_RDTSC_32
+#if GPR_CYCLE_COUNTER_CUSTOM
+typedef int64_t gpr_cycle_counter;
+gpr_cycle_counter gpr_get_cycle_counter();
+#elif GPR_CYCLE_COUNTER_RDTSC_32
 typedef int64_t gpr_cycle_counter;
 inline gpr_cycle_counter gpr_get_cycle_counter() {
   int64_t ret;
@@ -54,7 +57,8 @@ gpr_cycle_counter gpr_get_cycle_counter();
 #else
 #error Must define exactly one of \
     GPR_CYCLE_COUNTER_RDTSC_32, \
-    GPR_CYCLE_COUNTER_RDTSC_64, or \
+    GPR_CYCLE_COUNTER_RDTSC_64, \
+    GPR_CYCLE_COUNTER_CUSTOM, or \
     GPR_CYCLE_COUNTER_FALLBACK
 #endif
 


### PR DESCRIPTION
Normally we provide a way to override the implementation of gpr_now. However, for precise clock, there are a bunch of direct uses of gpr_get_cycle_counter, which is a building block of gpr_now for precise clock. 

See: cl/329747007