### PR TITLE
[Ruby] Implement setter for logger of GRPC module

### DIFF
--- a/src/ruby/lib/grpc/logconfig.rb
+++ b/src/ruby/lib/grpc/logconfig.rb
@@ -18,7 +18,7 @@ module GRPC
     # Need a free variable here to keep value of logger_obj for logger closure
     @logger = logger_obj
 
-    self.extend(
+    extend(
       Module.new do
         def logger
           @logger

--- a/src/ruby/lib/grpc/logconfig.rb
+++ b/src/ruby/lib/grpc/logconfig.rb
@@ -14,6 +14,19 @@
 
 # GRPC contains the General RPC module.
 module GRPC
+  def self.logger=(logger_obj)
+    # Need a free variable here to keep value of logger_obj for logger closure
+    @logger = logger_obj
+
+    self.extend(
+      Module.new do
+        def logger
+          @logger
+        end
+      end
+    )
+  end
+
   # DefaultLogger is a module included in GRPC if no other logging is set up for
   # it.  See ../spec/spec_helpers an example of where other logging is added.
   module DefaultLogger

--- a/src/ruby/spec/logconfig_spec.rb
+++ b/src/ruby/spec/logconfig_spec.rb
@@ -18,6 +18,7 @@ require 'logger'
 describe GRPC do
   describe '.logger=' do
     it 'sets logger' do
+      GRPC.logger = GRPC::DefaultLogger::NoopLogger.new
       expect(GRPC.logger).to be_kind_of(GRPC::DefaultLogger::NoopLogger)
 
       GRPC.logger = Logger.new(STDOUT)

--- a/src/ruby/spec/logconfig_spec.rb
+++ b/src/ruby/spec/logconfig_spec.rb
@@ -1,0 +1,27 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'logger'
+
+describe GRPC do
+  describe '.logger=' do
+    it 'sets logger' do
+      expect(GRPC.logger).to be_kind_of(GRPC::DefaultLogger::NoopLogger)
+
+      GRPC.logger = Logger.new(STDOUT)
+      expect(GRPC.logger).to be_kind_of(Logger)
+    end
+  end
+end


### PR DESCRIPTION
This commit implements `logger=` for GRPC module. It will allow us to
easy inject a custom logger on the fly. Using `self.extend` inside this
setter will help us on dealing with backward compatible for some custom
Logger Module.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

Fixed #24084 

@markdroth
