### PR TITLE
Increase timeout of macos/grpc_build_artifacts to 150min

### DIFF
--- a/tools/internal_ci/macos/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/macos/grpc_build_artifacts.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_build_artifacts.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 120
+timeout_mins: 150
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
From [the history](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod%3Agrpc%2Fcore%2Fpull_request%2Fmacos%2Fgrpc_build_artifacts), there were 14 runs which took over 110 minutes from the past 30 runs. So current 120 minutes timeout is not enough so it's increased to 150 minutes.

Fixes #23905.
