### PR TITLE
Make version check for importlib.abc in grpcio-tools more stringent (backport of #24098 to 1.32)

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -38,7 +38,8 @@ def main(command_arguments):
     return _protoc_compiler.run_main(command_arguments)
 
 
-if sys.version_info[0] > 2:
+# NOTE(rbellevi): importlib.abc is not supported on 3.4.
+if sys.version_info >= (3, 5, 0):
     import contextlib
     import importlib
     import importlib.machinery


### PR DESCRIPTION
Port of #24098 to 1.32:

@ericgribkoff noticed the following error:

```python
+ python3 -m grpc_tools.protoc --proto_path=. --python_out=tools/run_tests --grpc_python_out=tools/run_tests src/proto/grpc/testing/test.proto src/proto/grpc/testing/messages.proto src/proto/grpc/testing/empty.proto
/usr/bin/python3: Error while finding spec for 'grpc_tools.protoc' (<class 'AttributeError'>: 'module' object has no attribute 'abc')
```

It appears that `importlib.abc` was not available in 3.4 (which is deprecated) and our distribtests are apparently not running `grpcio-tools`. (I've filed [an issue](https://github.com/grpc/grpc/issues/24097) for that.) No external users have complained about this yet and if they do, there's an easy fix (use python3.5+ in your build step, a single time), but I'd nevertheless like to get this fixed quickly.