### PR TITLE
Fix two bugs for channelz_sampler_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -791,9 +791,6 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx channel_filter_test)
   add_dependencies(buildtests_cxx channel_trace_test)
   add_dependencies(buildtests_cxx channelz_registry_test)
-  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
-    add_dependencies(buildtests_cxx channelz_sampler_test)
-  endif()
   add_dependencies(buildtests_cxx channelz_service_test)
   add_dependencies(buildtests_cxx channelz_test)
   add_dependencies(buildtests_cxx cli_call_test)
@@ -9900,62 +9897,6 @@ target_link_libraries(channelz_registry_test
 )
 
 
-endif()
-if(gRPC_BUILD_TESTS)
-if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
-
-  add_executable(channelz_sampler_test
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.pb.cc
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.grpc.pb.cc
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.pb.h
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.grpc.pb.h
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.pb.cc
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.grpc.pb.cc
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.pb.h
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.grpc.pb.h
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.pb.cc
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.grpc.pb.cc
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.pb.h
-    ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.grpc.pb.h
-    test/cpp/util/channelz_sampler_test.cc
-    third_party/googletest/googletest/src/gtest-all.cc
-    third_party/googletest/googlemock/src/gmock-all.cc
-  )
-
-  target_include_directories(channelz_sampler_test
-    PRIVATE
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      ${CMAKE_CURRENT_SOURCE_DIR}/include
-      ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-      ${_gRPC_RE2_INCLUDE_DIR}
-      ${_gRPC_SSL_INCLUDE_DIR}
-      ${_gRPC_UPB_GENERATED_DIR}
-      ${_gRPC_UPB_GRPC_GENERATED_DIR}
-      ${_gRPC_UPB_INCLUDE_DIR}
-      ${_gRPC_ZLIB_INCLUDE_DIR}
-      third_party/googletest/googletest/include
-      third_party/googletest/googletest
-      third_party/googletest/googlemock/include
-      third_party/googletest/googlemock
-      ${_gRPC_PROTO_GENS_DIR}
-  )
-
-  target_link_libraries(channelz_sampler_test
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpcpp_channelz
-    grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_GFLAGS_LIBRARIES}
-  )
-
-
-endif()
 endif()
 if(gRPC_BUILD_TESTS)
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5349,28 +5349,6 @@ targets:
   - address_sorting
   - upb
   uses_polling: false
-- name: channelz_sampler_test
-  gtest: true
-  build: test
-  language: c++
-  headers: []
-  src:
-  - src/proto/grpc/testing/empty.proto
-  - src/proto/grpc/testing/messages.proto
-  - src/proto/grpc/testing/test.proto
-  - test/cpp/util/channelz_sampler_test.cc
-  deps:
-  - grpcpp_channelz
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  platforms:
-  - linux
-  - posix
 - name: channelz_service_test
   gtest: true
   build: test

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -90,7 +90,11 @@ void RunClient(const std::string& client_id, gpr_event* done_ev) {
     grpc::testing::Empty request;
     grpc::testing::Empty response;
     ClientContext context;
-    stub->EmptyCall(&context, request, &response);
+    Status status = stub->EmptyCall(&context, request, &response);
+    if (!status.ok()) {
+      gpr_log(GPR_ERROR, "Client echo failed.");
+      GPR_ASSERT(0);
+    }
   }
 }
 

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -468,6 +468,12 @@ def _filter_cc_tests(tests):
             lambda test: not test.startswith(
                 'test/core/tsi:ssl_session_cache_test'), tests))
 
+    # the binary of this test does not get built with cmake
+    tests = list(
+        filter(
+            lambda test: not test.startswith(
+                'test/cpp/util:channelz_sampler_test'), tests))
+
     return tests
 
 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4006,26 +4006,6 @@
     "benchmark": false, 
     "ci_platforms": [
       "linux", 
-      "posix"
-    ], 
-    "cpu_cost": 1.0, 
-    "exclude_configs": [], 
-    "exclude_iomgrs": [], 
-    "flaky": false, 
-    "gtest": true, 
-    "language": "c++", 
-    "name": "channelz_sampler_test", 
-    "platforms": [
-      "linux", 
-      "posix"
-    ], 
-    "uses_polling": true
-  }, 
-  {
-    "args": [], 
-    "benchmark": false, 
-    "ci_platforms": [
-      "linux", 
       "mac", 
       "posix", 
       "windows"


### PR DESCRIPTION
Fix two bugs for channelz_sampler_test:

1. The channelz_sampler_test can not pass tests using cmake because somehow the binary does not get build. See https://github.com/grpc/grpc/blob/master/test/cpp/util/BUILD#L347.

2. Fixed an ignoring return value error as when importing to google3.