### PR TITLE
Simplify service config processing and fix config selector handling.

### DIFF
--- a/src/core/ext/filters/client_channel/config_selector.h
+++ b/src/core/ext/filters/client_channel/config_selector.h
@@ -76,14 +76,17 @@ class ConfigSelector : public RefCounted<ConfigSelector> {
 class DefaultConfigSelector : public ConfigSelector {
  public:
   explicit DefaultConfigSelector(RefCountedPtr<ServiceConfig> service_config)
-      : service_config_(std::move(service_config)) {}
+      : service_config_(std::move(service_config)) {
+    // The client channel code ensures that this will never be null.
+    // If neither the resolver nor the client application provide a
+    // config, a default empty config will be used.
+    GPR_DEBUG_ASSERT(service_config_ != nullptr);
+  }
 
   CallConfig GetCallConfig(GetCallConfigArgs args) override {
     CallConfig call_config;
-    if (service_config_ != nullptr) {
-      call_config.method_configs =
-          service_config_->GetMethodParsedConfigVector(*args.path);
-    }
+    call_config.method_configs =
+        service_config_->GetMethodParsedConfigVector(*args.path);
     return call_config;
   }
 

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -232,9 +232,12 @@ void ResolvingLoadBalancingPolicy::CreateOrUpdateLbPolicyLocked(
   UpdateArgs update_args;
   update_args.addresses = std::move(result.addresses);
   update_args.config = std::move(lb_policy_config);
-  // TODO(roth): Once channel args is converted to C++, use std::move() here.
-  update_args.args = result.args;
-  result.args = nullptr;
+  // Remove the config selector from channel args so that we're not holding
+  // unnecessary refs that cause it to be destroyed somewhere other than in the
+  // WorkSerializer.
+  const char* arg_name = GRPC_ARG_CONFIG_SELECTOR;
+  update_args.args =
+      grpc_channel_args_copy_and_remove(result.args, &arg_name, 1);
   // Create policy if needed.
   if (lb_policy_ == nullptr) {
     lb_policy_ = CreateLbPolicyLocked(*update_args.args);
@@ -306,61 +309,46 @@ void ResolvingLoadBalancingPolicy::OnResolverResultChangedLocked(
   //
   // We track a list of strings to eventually be concatenated and traced.
   TraceStringVector trace_strings;
-  const bool resolution_contains_addresses = result.addresses.size() > 0;
-  // Process the resolver result.
-  ChannelConfigHelper::ApplyServiceConfigResult service_config_result;
+  MaybeAddTraceMessagesForAddressChangesLocked(!result.addresses.empty(),
+                                               &trace_strings);
+  // The result of grpc_error_string() is owned by the error itself.
+  // We're storing that string in trace_strings, so we need to make sure
+  // that the error lives until we're done with the string.
+  grpc_error* service_config_error =
+      GRPC_ERROR_REF(result.service_config_error);
+  if (service_config_error != GRPC_ERROR_NONE) {
+    trace_strings.push_back(grpc_error_string(service_config_error));
+  }
+  // Choose the service config.
+  ChannelConfigHelper::ChooseServiceConfigResult service_config_result;
   if (helper_ != nullptr) {
-    service_config_result = helper_->ApplyServiceConfig(result);
-    if (service_config_result.service_config_error != GRPC_ERROR_NONE) {
-      if (service_config_result.no_valid_service_config) {
-        // We received an invalid service config and we don't have a
-        // fallback service config.
-        OnResolverError(service_config_result.service_config_error);
-        service_config_result.service_config_error = GRPC_ERROR_NONE;
-      }
-    }
+    service_config_result = helper_->ChooseServiceConfig(result);
   } else {
     service_config_result.lb_policy_config = child_lb_config_;
   }
-  // Before we send the args to the LB policy, grab the ConfigSelector for
-  // later use.
-  RefCountedPtr<ConfigSelector> config_selector =
-      ConfigSelector::GetFromChannelArgs(*result.args);
-  // Remove the config selector from channel args so that we're not holding
-  // unnecessary refs that cause it to be destroyed somewhere other than in the
-  // WorkSerializer.
-  const char* arg_name = GRPC_ARG_CONFIG_SELECTOR;
-  grpc_channel_args* new_args =
-      grpc_channel_args_copy_and_remove(result.args, &arg_name, 1);
-  grpc_channel_args_destroy(result.args);
-  result.args = new_args;
-  // Create or update LB policy, as needed.
-  if (service_config_result.lb_policy_config != nullptr) {
+  if (service_config_result.no_valid_service_config) {
+    // We received an invalid service config and we don't have a
+    // previous service config to fall back to.
+    OnResolverError(GRPC_ERROR_REF(service_config_error));
+    trace_strings.push_back("no valid service config");
+  } else {
+    // Create or update LB policy, as needed.
     CreateOrUpdateLbPolicyLocked(
         std::move(service_config_result.lb_policy_config), std::move(result));
-  }
-  // Apply ConfigSelector to channel.
-  // This needs to happen after the LB policy has been updated, since
-  // the ConfigSelector may need the LB policy to know about new
-  // destinations before it can send RPCs to those destinations.
-  if (helper_ != nullptr) {
-    helper_->ApplyConfigSelector(service_config_result.service_config_changed,
-                                 std::move(config_selector));
+    if (service_config_result.service_config_changed) {
+      // Tell channel to start using new service config for calls.
+      // This needs to happen after the LB policy has been updated, since
+      // the ConfigSelector may need the LB policy to know about new
+      // destinations before it can send RPCs to those destinations.
+      if (helper_ != nullptr) helper_->StartUsingServiceConfigForCalls();
+      // TODO(ncteisen): might be worth somehow including a snippet of the
+      // config in the trace, at the risk of bloating the trace logs.
+      trace_strings.push_back("Service config changed");
+    }
   }
   // Add channel trace event.
-  if (service_config_result.service_config_changed) {
-    // TODO(ncteisen): might be worth somehow including a snippet of the
-    // config in the trace, at the risk of bloating the trace logs.
-    trace_strings.push_back("Service config changed");
-  }
-  if (service_config_result.service_config_error != GRPC_ERROR_NONE) {
-    trace_strings.push_back(
-        grpc_error_string(service_config_result.service_config_error));
-  }
-  MaybeAddTraceMessagesForAddressChangesLocked(resolution_contains_addresses,
-                                               &trace_strings);
   ConcatenateAndAddChannelTraceLocked(trace_strings);
-  GRPC_ERROR_UNREF(service_config_result.service_config_error);
+  GRPC_ERROR_UNREF(service_config_error);
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -55,29 +55,25 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
  public:
   class ChannelConfigHelper {
    public:
-    struct ApplyServiceConfigResult {
+    struct ChooseServiceConfigResult {
       // Set to true if the service config has changed since the last result.
       bool service_config_changed = false;
       // Set to true if we don't have a valid service config to use.
       // This tells the ResolvingLoadBalancingPolicy to put the channel
       // into TRANSIENT_FAILURE.
       bool no_valid_service_config = false;
-      // A service config parsing error occurred.
-      grpc_error* service_config_error = GRPC_ERROR_NONE;
       // The LB policy config to use.
       RefCountedPtr<LoadBalancingPolicy::Config> lb_policy_config;
     };
 
     virtual ~ChannelConfigHelper() = default;
 
-    // Applies the service config to the channel.
-    virtual ApplyServiceConfigResult ApplyServiceConfig(
+    // Chooses the service config for the channel.
+    virtual ChooseServiceConfigResult ChooseServiceConfig(
         const Resolver::Result& result) = 0;
 
-    // Applies the ConfigSelector to the channel.
-    virtual void ApplyConfigSelector(
-        bool service_config_changed,
-        RefCountedPtr<ConfigSelector> config_selector) = 0;
+    // Starts using the service config for calls.
+    virtual void StartUsingServiceConfigForCalls() = 0;
 
     // Indicates a resolver transient failure.
     virtual void ResolverTransientFailure(grpc_error* error) = 0;

--- a/src/core/ext/filters/client_channel/service_config.cc
+++ b/src/core/ext/filters/client_channel/service_config.cc
@@ -202,15 +202,16 @@ std::string ServiceConfig::ParseJsonMethodName(const Json& json,
 
 const ServiceConfigParser::ParsedConfigVector*
 ServiceConfig::GetMethodParsedConfigVector(const grpc_slice& path) const {
+  if (parsed_method_configs_map_.empty()) return nullptr;
   // Try looking up the full path in the map.
   auto it = parsed_method_configs_map_.find(path);
   if (it != parsed_method_configs_map_.end()) return it->second;
   // If we didn't find a match for the path, try looking for a wildcard
   // entry (i.e., change "/service/method" to "/service/").
   UniquePtr<char> path_str(grpc_slice_to_c_string(path));
-  char* sep = strrchr(path_str.get(), '/') + 1;
+  char* sep = strrchr(path_str.get(), '/');
   if (sep == nullptr) return nullptr;  // Shouldn't ever happen.
-  *sep = '\0';
+  sep[1] = '\0';
   grpc_slice wildcard_path = grpc_slice_from_static_string(path_str.get());
   it = parsed_method_configs_map_.find(wildcard_path);
   if (it != parsed_method_configs_map_.end()) return it->second;

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -437,7 +437,7 @@ TEST_F(ServiceConfigEnd2endTest, NoServiceConfigTest) {
   auto stub = BuildStub(channel);
   SetNextResolutionNoServiceConfig(GetServersPorts());
   CheckRpcSendOk(stub, DEBUG_LOCATION);
-  EXPECT_STREQ("", channel->GetServiceConfigJSON().c_str());
+  EXPECT_STREQ("{}", channel->GetServiceConfigJSON().c_str());
 }
 
 TEST_F(ServiceConfigEnd2endTest, NoServiceConfigWithDefaultConfigTest) {
@@ -456,16 +456,6 @@ TEST_F(ServiceConfigEnd2endTest, InvalidServiceConfigTest) {
   auto stub = BuildStub(channel);
   SetNextResolutionInvalidServiceConfig(GetServersPorts());
   CheckRpcSendFailure(stub);
-}
-
-TEST_F(ServiceConfigEnd2endTest, InvalidServiceConfigWithDefaultConfigTest) {
-  StartServers(1);
-  auto channel = BuildChannelWithDefaultServiceConfig();
-  auto stub = BuildStub(channel);
-  SetNextResolutionInvalidServiceConfig(GetServersPorts());
-  CheckRpcSendOk(stub, DEBUG_LOCATION);
-  EXPECT_STREQ(ValidDefaultServiceConfig(),
-               channel->GetServiceConfigJSON().c_str());
 }
 
 TEST_F(ServiceConfigEnd2endTest, ValidServiceConfigUpdatesTest) {
@@ -490,7 +480,7 @@ TEST_F(ServiceConfigEnd2endTest,
   EXPECT_STREQ(ValidServiceConfigV1(), channel->GetServiceConfigJSON().c_str());
   SetNextResolutionNoServiceConfig(GetServersPorts());
   CheckRpcSendOk(stub, DEBUG_LOCATION);
-  EXPECT_STREQ("", channel->GetServiceConfigJSON().c_str());
+  EXPECT_STREQ("{}", channel->GetServiceConfigJSON().c_str());
 }
 
 TEST_F(ServiceConfigEnd2endTest,
@@ -552,7 +542,7 @@ TEST_F(ServiceConfigEnd2endTest, NoServiceConfigAfterInvalidServiceConfigTest) {
   CheckRpcSendFailure(stub);
   SetNextResolutionNoServiceConfig(GetServersPorts());
   CheckRpcSendOk(stub, DEBUG_LOCATION);
-  EXPECT_STREQ("", channel->GetServiceConfigJSON().c_str());
+  EXPECT_STREQ("{}", channel->GetServiceConfigJSON().c_str());
 }
 
 TEST_F(ServiceConfigEnd2endTest,


### PR DESCRIPTION
This PR accomplishes the following:
- It fixes a problem that @donnadionne ran into in #23659 where, when the resolver returned a service config error, we retained the old ServiceConfig but failed to retain the old ConfigSelector.  I fixed that by more tightly integrating the ServiceConfig and ConfigSelector handling so that we always handle them in the same places and in the same ways.  (This is a better alternative to #24091, which I will revert in favor of this.)
- Simplifies the service config handling logic, eliminating some edge cases that no longer exist since #23051, due to the changes described in grpc/proposal#188.  This brings us closer to where we ultimately want to be with the client channel principles revamp design.