### PR TITLE
Reduce tested Python version on macOS

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -834,7 +834,6 @@ class PythonLanguage(object):
                     # tested.
                     return (
                         python27_config,
-                        python37_config,
                         python38_config,
                     )
                 else:


### PR DESCRIPTION
According to failed runs [1](https://source.cloud.google.com/results/invocations/771d82d4-8e64-4e29-88b8-5b776aaa49d3/log) [2](https://source.cloud.google.com/results/invocations/7424df2d-e041-43db-a965-034f786bc397/log) and [3](https://source.cloud.google.com/results/invocations/316b02d4-0b8b-4e49-80b1-cebe6f2466da/log), it looks like from time to time the macOS machine will be extremely slow and causing unit tests to fail. The internal tracking issue [b/151336931](http://b/151336931).

This PR further reduces the tested versions on macOS from 8 total compilation (versions x IO platforms) to 6 
This won't fix the `_rpc_test` flake entirely, but it should reduce its flakiness.

Alternatively, we could:

1. extend the test timeout, which is 5400 seconds now;
2. share the same compilation result for each Python version;
3. chop the 2k LOC `_rpc_test` into multiple tests so it can be ran in parallel (hope it does more than increasing CPU contentions).