### PR TITLE
Remove invalid forward declaration

### DIFF
--- a/include/grpcpp/impl/codegen/service_type.h
+++ b/include/grpcpp/impl/codegen/service_type.h
@@ -26,10 +26,6 @@
 #include <grpcpp/impl/codegen/server_interface.h>
 #include <grpcpp/impl/codegen/status.h>
 
-namespace grpc_impl {
-
-class Server;
-}  // namespace grpc_impl
 namespace grpc {
 
 class CompletionQueue;


### PR DESCRIPTION
Maybe this was a side-effect of the grpc_impl de-transition? Triggered a clang-tidy finding internally.
