### PR TITLE
xds: Stop setting PROXYLESS_CLIENT_HOSTNAME node metadata in LRS request.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
@@ -460,8 +460,8 @@ void EdsLb::UpdateLocked(UpdateArgs args) {
     // Initialize XdsClient.
     if (xds_client_from_channel_ == nullptr) {
       grpc_error* error = GRPC_ERROR_NONE;
-      xds_client_ = MakeOrphanable<XdsClient>(
-          work_serializer(), GetEdsResourceName(), *args_, &error);
+      xds_client_ =
+          MakeOrphanable<XdsClient>(work_serializer(), *args_, &error);
       // TODO(roth): If we decide that we care about EDS-only mode, add
       // proper error handling here.
       GPR_ASSERT(error == GRPC_ERROR_NONE);

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -467,8 +467,7 @@ ConfigSelector::CallConfig XdsResolver::XdsConfigSelector::GetCallConfig(
 
 void XdsResolver::StartLocked() {
   grpc_error* error = GRPC_ERROR_NONE;
-  xds_client_ = MakeOrphanable<XdsClient>(work_serializer(), server_name_,
-                                          *args_, &error);
+  xds_client_ = MakeOrphanable<XdsClient>(work_serializer(), *args_, &error);
   if (error != GRPC_ERROR_NONE) {
     gpr_log(GPR_ERROR,
             "Failed to create xds client -- channel will remain in "

--- a/src/core/ext/xds/xds_api.h
+++ b/src/core/ext/xds/xds_api.h
@@ -313,8 +313,8 @@ class XdsApi {
       const std::set<absl::string_view>& expected_cluster_names,
       const std::set<absl::string_view>& expected_eds_service_names);
 
-  // Creates an LRS request querying \a server_name.
-  grpc_slice CreateLrsInitialRequest(const std::string& server_name);
+  // Creates an initial LRS request.
+  grpc_slice CreateLrsInitialRequest();
 
   // Creates an LRS request sending a client-side load report.
   grpc_slice CreateLrsRequest(ClusterLoadReportMap cluster_load_report_map);

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -1431,7 +1431,6 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
   // activity in xds_client()->interested_parties_, which is comprised of
   // the polling entities from client_channel.
   GPR_ASSERT(xds_client() != nullptr);
-  GPR_ASSERT(!xds_client()->server_name_.empty());
   const auto& method =
       xds_client()->bootstrap_->server().ShouldUseV3()
           ? GRPC_MDSTR_SLASH_ENVOY_DOT_SERVICE_DOT_LOAD_STATS_DOT_V3_DOT_LOADREPORTINGSERVICE_SLASH_STREAMLOADSTATS
@@ -1443,7 +1442,7 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
   GPR_ASSERT(call_ != nullptr);
   // Init the request payload.
   grpc_slice request_payload_slice =
-      xds_client()->api_.CreateLrsInitialRequest(xds_client()->server_name_);
+      xds_client()->api_.CreateLrsInitialRequest();
   send_message_payload_ =
       grpc_raw_byte_buffer_create(&request_payload_slice, 1);
   grpc_slice_unref_internal(request_payload_slice);
@@ -1767,7 +1766,6 @@ grpc_channel* CreateXdsChannel(const XdsBootstrap& bootstrap,
 }  // namespace
 
 XdsClient::XdsClient(std::shared_ptr<WorkSerializer> work_serializer,
-                     absl::string_view server_name,
                      const grpc_channel_args& channel_args, grpc_error** error)
     : InternallyRefCounted<XdsClient>(&grpc_xds_client_trace),
       request_timeout_(GetRequestTimeout(channel_args)),
@@ -1775,8 +1773,7 @@ XdsClient::XdsClient(std::shared_ptr<WorkSerializer> work_serializer,
       interested_parties_(grpc_pollset_set_create()),
       bootstrap_(
           XdsBootstrap::ReadFromFile(this, &grpc_xds_client_trace, error)),
-      api_(this, &grpc_xds_client_trace, bootstrap_.get()),
-      server_name_(server_name) {
+      api_(this, &grpc_xds_client_trace, bootstrap_.get()) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
     gpr_log(GPR_INFO, "[xds_client %p] creating xds client", this);
   }

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -91,10 +91,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
 
   // If *error is not GRPC_ERROR_NONE after construction, then there was
   // an error initializing the client.
-  // TODO(roth): Remove the server_name parameter as part of sharing the
-  // XdsClient instance between channels.
   XdsClient(std::shared_ptr<WorkSerializer> work_serializer,
-            absl::string_view server_name,
             const grpc_channel_args& channel_args, grpc_error** error);
   ~XdsClient();
 
@@ -308,12 +305,6 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
 
   std::unique_ptr<XdsBootstrap> bootstrap_;
   XdsApi api_;
-
-  // TODO(roth): In order to share the XdsClient instance between
-  // channels and servers, we will need to remove this field.  In order
-  // to do that, we'll need to figure out if we can stop sending the
-  // server name as part of the node metadata in the LRS request.
-  const std::string server_name_;
 
   // The channel for communicating with the xds server.
   OrphanablePtr<ChannelState> chand_;

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1196,11 +1196,6 @@ class LrsServiceImpl : public std::enable_shared_from_this<LrsServiceImpl> {
       LoadStatsRequest request;
       if (stream->Read(&request)) {
         CountedService<typename RpcApi::Service>::IncreaseRequestCount();
-        // Verify server name set in metadata.
-        auto it = request.node().metadata().fields().find(
-            "PROXYLESS_CLIENT_HOSTNAME");
-        GPR_ASSERT(it != request.node().metadata().fields().end());
-        EXPECT_EQ(it->second.string_value(), kDefaultResourceName);
         // Verify client features.
         EXPECT_THAT(
             request.node().client_features(),


### PR DESCRIPTION
This is no longer needed by TD, and removing it is a prerequisite for sharing the XdsClient between channels.