### PR TITLE
Fixing Flake with InitialUnavailable test by increasing failover timeout

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -4396,7 +4396,7 @@ class FailoverTest : public BasicTest {
  public:
   void SetUp() override {
     BasicTest::SetUp();
-    ResetStub(100, "");
+    ResetStub(500, "");
   }
 };
 


### PR DESCRIPTION
Currently, there are 2 backends that could will come up after the
initial unavailable.

Even tho the 2 backends have different prioirties, WaitForBackends will
simply send RPCs and then check the interested backend.  It is possible
for a RPC to get through to either backend in the process.

This is difficult to repro but I did manage to repro allowing 3 new backends
to increase the probability:
I0913 23:03:58.281209382      20 xds_end2end_test.cc:4503]   DONNAAA backend 0 has 0
I0913 23:03:58.283252494      20 xds_end2end_test.cc:4503]   DONNAAA backend 1 has 1
I0913 23:03:58.283321621      20 xds_end2end_test.cc:4503]   DONNAAA backend 2 has 0
I0913 23:03:58.283390738      20 xds_end2end_test.cc:4503]   DONNAAA backend 3 has 1

To make this test unflaky, let's just only bring up 1 backend after the
initial unavailable so that the behaviour will be deterministic.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/24147)
<!-- Reviewable:end -->
