### PR TITLE
Fix a typo s/training/trailing/ in ProtoRPC.h

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Issued when a call finished. If the call finished successfully, \p error is nil and \p
- * trainingMetadata consists any trailing metadata received from the server. Otherwise, \p error
+ * trailingMetadata consists any trailing metadata received from the server. Otherwise, \p error
  * is non-nil and contains the corresponding error information, including gRPC error codes and
  * error descriptions.
  */


### PR DESCRIPTION
Fix a typo in ProtoRPC.h