### PR TITLE
Fix EDS update equality check.

### DIFF
--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -390,6 +390,19 @@ std::string XdsApi::EdsUpdate::Priority::Locality::ToString() const {
                       absl::StrJoin(endpoint_strings, ", "), "]}");
 }
 
+bool XdsApi::EdsUpdate::Priority::operator==(const Priority& other) const {
+  if (localities.size() != other.localities.size()) return false;
+  auto it1 = localities.begin();
+  auto it2 = other.localities.begin();
+  while (it1 != localities.end()) {
+    if (*it1->first != *it2->first) return false;
+    if (it1->second != it2->second) return false;
+    ++it1;
+    ++it2;
+  }
+  return true;
+}
+
 std::string XdsApi::EdsUpdate::Priority::ToString() const {
   std::vector<std::string> locality_strings;
   for (const auto& p : localities) {

--- a/src/core/ext/xds/xds_api.h
+++ b/src/core/ext/xds/xds_api.h
@@ -194,14 +194,15 @@ class XdsApi {
           return *name == *other.name && lb_weight == other.lb_weight &&
                  endpoints == other.endpoints;
         }
+        bool operator!=(const Locality& other) const {
+          return !(*this == other);
+        }
         std::string ToString() const;
       };
 
       std::map<XdsLocalityName*, Locality, XdsLocalityName::Less> localities;
 
-      bool operator==(const Priority& other) const {
-        return localities == other.localities;
-      }
+      bool operator==(const Priority& other) const;
       std::string ToString() const;
     };
     using PriorityList = absl::InlinedVector<Priority, 2>;

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -1083,21 +1083,14 @@ void XdsClient::ChannelState::AdsCallState::AcceptEdsUpdate(
     EndpointState& endpoint_state =
         xds_client()->endpoint_map_[eds_service_name];
     // Ignore identical update.
-    if (endpoint_state.update.has_value()) {
-      const XdsApi::EdsUpdate& prev_update = endpoint_state.update.value();
-      const bool priority_list_changed =
-          prev_update.priorities != eds_update.priorities;
-      const bool drop_config_changed =
-          prev_update.drop_config == nullptr ||
-          *prev_update.drop_config != *eds_update.drop_config;
-      if (!priority_list_changed && !drop_config_changed) {
-        if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
-          gpr_log(GPR_INFO,
-                  "[xds_client %p] EDS update identical to current, ignoring.",
-                  xds_client());
-        }
-        continue;
+    if (endpoint_state.update.has_value() &&
+        *endpoint_state.update == eds_update) {
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
+        gpr_log(GPR_INFO,
+                "[xds_client %p] EDS update identical to current, ignoring.",
+                xds_client());
       }
+      continue;
     }
     // Update the cluster state.
     endpoint_state.update = std::move(eds_update);


### PR DESCRIPTION
This caused an interop test failure by needlessly randomly resetting round_robin's current index in its address list.  I've added a test to cover that case, and I've verified that the test fails without the fix.