### PR TITLE
Use TestEnvironment to fix flaky test.

### DIFF
--- a/test/core/security/evaluate_args_test.cc
+++ b/test/core/security/evaluate_args_test.cc
@@ -19,6 +19,7 @@
 
 #include "src/core/lib/security/authorization/evaluate_args.h"
 #include "test/core/util/eval_args_mock_endpoint.h"
+#include "test/core/util/test_config.h"
 
 namespace grpc_core {
 
@@ -71,6 +72,7 @@ TEST_F(EvaluateArgsTest, TestEvaluateArgsPeerPort) {
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Fixes flaky test by creating TestEnvironment object.
