### PR TITLE
remove --spawn_strategy build option for cfstream_test

### DIFF
--- a/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
@@ -22,7 +22,7 @@ cd $(dirname $0)/../../..
 
 # run cfstream_test separately because it messes with the network
 # The "local" execution strategy is required because the test runs sudo and that doesn't work in a sandboxed environment (the default on mac)
-tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=local --genrule_strategy=local --test_output=all --copt="-DGRPC_CFSTREAM=1" //test/cpp/end2end:cfstream_test
+tools/bazel test $RUN_TESTS_FLAGS --genrule_strategy=local --test_output=all --copt="-DGRPC_CFSTREAM=1" //test/cpp/end2end:cfstream_test
 
 # Missing the /var/db/ntp-kod file may breaks the ntp synchronization.
 # Create the file and change the ownership to root before NTP sync.
@@ -36,7 +36,7 @@ sudo sntp -sS pool.ntp.org
 
 # run time_jump_test separately because it changes system time
 # The "local" execution strategy is required because the test runs sudo and that doesn't work in a sandboxed environment (the default on mac)
-tools/bazel test $RUN_TESTS_FLAGS --spawn_strategy=local --genrule_strategy=local --test_output=all //test/cpp/common:time_jump_test
+tools/bazel test $RUN_TESTS_FLAGS --genrule_strategy=local --test_output=all //test/cpp/common:time_jump_test
 
 # kill port_server.py to prevent the build from hanging
 ps aux | grep port_server\\.py | awk '{print $2}' | xargs kill -9


### PR DESCRIPTION
Having the `--spawn_strategy build` option will cause the following build issue with #23533(more info: b/160165400):

```
ERROR: /Users/jtattermusch/github/grpc/BUILD:3052:1: undeclared inclusion(s) in rule '//:google_api_upbdefs':
this rule is missing dependency declarations for the following files included by 'src/core/ext/upbdefs-generated/google/protobuf/descriptor.upbdefs.c':
  'bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/google/protobuf/descriptor.upbdefs.h'
Target //test/cpp/end2end:cfstream_test failed to build
```

Looks like removing --spawn_strategy will not affect our current tests.