### PR TITLE
Fix cut-and-paste error and change test to catch this kind of bug.

### DIFF
--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -969,7 +969,7 @@ void XdsClient::ChannelState::AdsCallState::AcceptRdsUpdate(
             " resources",
             xds_client(), rds_update_map.size());
   }
-  auto& rds_state = state_map_[XdsApi::kLdsTypeUrl];
+  auto& rds_state = state_map_[XdsApi::kRdsTypeUrl];
   for (auto& p : rds_update_map) {
     const std::string& route_config_name = p.first;
     XdsApi::RdsUpdate& rds_update = p.second;


### PR DESCRIPTION
Fixes a bug from #23938.  Our end2end tests did not catch this because they were using the same resource name for all resource types.  I've changed the test not to do that.