### PR TITLE
In run_xds_tests.py, run clients in bash

### DIFF
--- a/tools/internal_ci/linux/grpc_python_bazel_test.cfg
+++ b/tools/internal_ci/linux/grpc_python_bazel_test.cfg
@@ -1,4 +1,4 @@
-# Copyright 2018 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,15 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_bazel.sh"
-timeout_mins: 240
+build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
+timeout_mins: 90
 env_vars {
   key: "BAZEL_SCRIPT"
-  value: "tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh"
+  value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
 }

--- a/tools/internal_ci/linux/grpc_python_bazel_test.cfg
+++ b/tools/internal_ci/linux/grpc_python_bazel_test.cfg
@@ -1,4 +1,4 @@
-# Copyright 2020 gRPC authors.
+# Copyright 2018 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +15,9 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
-timeout_mins: 90
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel.sh"
+timeout_mins: 240
 env_vars {
   key: "BAZEL_SCRIPT"
-  value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"
-}
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.*"
-    regex: "github/grpc/reports/**"
-  }
+  value: "tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh"
 }

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1801,6 +1801,11 @@ try:
             logger.debug('running client: %s', client_cmd_formatted)
             try:
                 # We invoke the client using bash to avoid https://github.com/nvm-sh/nvm/issues/1866
+                client_process = subprocess.Popen(
+                    ['/bin/bash', '-i', '-c', client_cmd_formatted],
+                    env=client_env,
+                    stderr=subprocess.STDOUT,
+                    stdout=test_log_file)
                 client_process = subprocess.Popen(['/bin/bash', '-i', '-c', client_cmd_formatted],
                                                   env=client_env,
                                                   stderr=subprocess.STDOUT,

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1800,6 +1800,7 @@ try:
                 metadata_to_send=metadata_to_send)
             logger.debug('running client: %s', client_cmd_formatted)
             try:
+                # We invoke the client using bash to avoid https://github.com/nvm-sh/nvm/issues/1866
                 client_process = subprocess.Popen(['/bin/bash', '-i', '-c', client_cmd_formatted],
                                                   env=client_env,
                                                   stderr=subprocess.STDOUT,

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1806,10 +1806,6 @@ try:
                     env=client_env,
                     stderr=subprocess.STDOUT,
                     stdout=test_log_file)
-                client_process = subprocess.Popen(['/bin/bash', '-i', '-c', client_cmd_formatted],
-                                                  env=client_env,
-                                                  stderr=subprocess.STDOUT,
-                                                  stdout=test_log_file)
                 if test_case == 'backends_restart':
                     test_backends_restart(gcp, backend_service, instance_group)
                 elif test_case == 'change_backend_service':

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import random
-import shlex
 import socket
 import subprocess
 import sys
@@ -1800,9 +1799,8 @@ try:
                 rpcs_to_send=rpcs_to_send,
                 metadata_to_send=metadata_to_send)
             logger.debug('running client: %s', client_cmd_formatted)
-            client_cmd = shlex.split(client_cmd_formatted)
             try:
-                client_process = subprocess.Popen(client_cmd,
+                client_process = subprocess.Popen(['/bin/bash', '-i', '-c', client_cmd_formatted],
                                                   env=client_env,
                                                   stderr=subprocess.STDOUT,
                                                   stdout=test_log_file)


### PR DESCRIPTION
The Node tests are failing with an error that appears to be caused by using an old version of Node. We use nvm to install Node, so I think these failures are caused by nvm-sh/nvm#1866: `Popen`'s default shell does not load the right profile files to source `nvm.sh`. I tried to fix this with grpc/grpc-node#1577 but that didn't work. So I suggest this change, which is the remedy that reportedly worked in the linked nvm issue.