### PR TITLE
Store address hierarchy information in attributes instead of channel args.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/address_filtering.h
+++ b/src/core/ext/filters/client_channel/lb_policy/address_filtering.h
@@ -23,8 +23,6 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"
-
 #include "src/core/ext/filters/client_channel/server_address.h"
 
 // The resolver returns a flat list of addresses.  When a hierarchy of
@@ -81,9 +79,13 @@
 
 namespace grpc_core {
 
-// Constructs a channel arg containing the hierarchical path
-// to be associated with an address.
-grpc_arg MakeHierarchicalPathArg(const std::vector<std::string>& path);
+// The attribute key to be used for hierarchical paths in ServerAddress.
+extern const char* kHierarchicalPathAttributeKey;
+
+// Constructs an address attribute containing the hierarchical path
+// to be associated with the address.
+std::unique_ptr<ServerAddress::AttributeInterface>
+MakeHierarchicalPathAttribute(std::vector<std::string> path);
 
 // A map from the next path element to the addresses that fall under
 // that path element.

--- a/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
@@ -591,10 +591,9 @@ ServerAddressList EdsLb::CreateChildPolicyAddressesLocked() {
       std::vector<std::string> hierarchical_path = {
           priority_child_name, locality_name->AsHumanReadableString()};
       for (const auto& endpoint : locality.endpoints) {
-        grpc_arg new_arg = MakeHierarchicalPathArg(hierarchical_path);
-        grpc_channel_args* args =
-            grpc_channel_args_copy_and_add(endpoint.args(), &new_arg, 1);
-        addresses.emplace_back(endpoint.address(), args);
+        addresses.emplace_back(endpoint.WithAttribute(
+            kHierarchicalPathAttributeKey,
+            MakeHierarchicalPathAttribute(hierarchical_path)));
       }
     }
   }

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -381,9 +381,7 @@ XdsApi::RdsUpdate::VirtualHost* XdsApi::RdsUpdate::FindVirtualHostForDomain(
 std::string XdsApi::EdsUpdate::Priority::Locality::ToString() const {
   std::vector<std::string> endpoint_strings;
   for (const ServerAddress& endpoint : endpoints) {
-    endpoint_strings.emplace_back(
-        absl::StrCat(grpc_sockaddr_to_string(&endpoint.address(), false), "{",
-                     grpc_channel_args_string(endpoint.args()), "}"));
+    endpoint_strings.emplace_back(endpoint.ToString());
   }
   return absl::StrCat("{name=", name->AsHumanReadableString(),
                       ", lb_weight=", lb_weight, ", endpoints=[",


### PR DESCRIPTION
This is more appropriate, since the attributes are not part of the key in the subchannel pool and therefore do not affect uniqueness.  The address hierarchy information is relevant only to LB policies and should not affect the subchannel identity.