### PR TITLE
Support Ubuntu 16 docker

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -18,12 +18,23 @@
 # Need to increase open files limit for c tests
 ulimit -n 32768
 
-# Move docker's storage location to scratch disk so we don't run out of space.
-echo 'DOCKER_OPTS="${DOCKER_OPTS} --graph=/tmpfs/docker"' | sudo tee --append /etc/default/docker
-# Use container registry mirror for pulling docker images (should make downloads faster)
-# See https://cloud.google.com/container-registry/docs/using-dockerhub-mirroring
-echo 'DOCKER_OPTS="${DOCKER_OPTS} --registry-mirror=https://mirror.gcr.io"' | sudo tee --append /etc/default/docker
-sudo service docker restart
+# 1. Move docker's storage location to scratch disk so we don't run out of space.
+# 2. Use container registry mirror for pulling docker images (should make downloads faster)
+#    See https://cloud.google.com/container-registry/docs/using-dockerhub-mirroring
+GRPC_DOCKER_OPTS="--data-root=/tmpfs/docker --registry-mirror=https://mirror.gcr.io"
+
+# Update global docker configuration to have GRPC_DOCKER_OPTS
+P1NAME=$(ps -p 1 -o comm=)
+if [[ $P1NAME == *"systemd"* ]];  then
+  # https://stackoverflow.com/questions/27763340
+  sudo sed -i -E "s|ExecStart=(.*)//|EnvironmentFile=/etc/default/docker\nExecStart=\nExecStart=\1// \$DOCKER_OPTS|" /lib/systemd/system/docker.service
+  sudo systemctl daemon-reload
+  echo "DOCKER_OPTS=\"${GRPC_DOCKER_OPTS}\"" | sudo tee --append /etc/default/docker
+  sudo systemctl restart docker.service
+else
+  echo "DOCKER_OPTS=\"\${DOCKER_OPTS} ${GRPC_DOCKER_OPTS}\"" | sudo tee --append /etc/default/docker
+  sudo service docker restart
+fi
 
 # Download Docker images from DockerHub
 export DOCKERHUB_ORGANIZATION=grpctesting


### PR DESCRIPTION
The way how docker global configuration is set has changed from Ubuntu 16 so the prepare_build_linux_rc needs a change to support it.

This is verified with #24038 using adhoc Kokoro Ubuntu 16.