### PR TITLE
Add TestGrpcScope

### DIFF
--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -40,6 +40,10 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms);
 // Prefer TestEnvironment below.
 void grpc_test_init(int argc, char** argv);
 
+// Wait until gRPC is fully shut down.
+// Returns if grpc is shutdown
+bool grpc_wait_until_shutdown(int64_t time_s);
+
 namespace grpc {
 namespace testing {
 
@@ -49,6 +53,15 @@ class TestEnvironment {
  public:
   TestEnvironment(int argc, char** argv);
   ~TestEnvironment();
+};
+
+// A TestGrpcScope makes sure that
+// - when it's created, gRPC will be initialized
+// - when it's destroyed, gRPC will shutdown and it waits until shutdown
+class TestGrpcScope {
+ public:
+  TestGrpcScope();
+  ~TestGrpcScope();
 };
 
 }  // namespace testing

--- a/test/cpp/microbenchmarks/bm_opencensus_plugin.cc
+++ b/test/cpp/microbenchmarks/bm_opencensus_plugin.cc
@@ -83,8 +83,7 @@ class EchoServerThread final {
 };
 
 static void BM_E2eLatencyCensusDisabled(benchmark::State& state) {
-  grpc::testing::TestEnvironment env(0, {});
-
+  grpc::testing::TestGrpcScope grpc_scope;
   EchoServerThread server;
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub =
       grpc::testing::EchoTestService::NewStub(grpc::CreateChannel(
@@ -100,14 +99,13 @@ static void BM_E2eLatencyCensusDisabled(benchmark::State& state) {
 BENCHMARK(BM_E2eLatencyCensusDisabled);
 
 static void BM_E2eLatencyCensusEnabled(benchmark::State& state) {
-  grpc::testing::TestEnvironment env(0, {});
-
   // Now start the test by registering the plugin (once in the execution)
   RegisterOnce();
   // This we can safely repeat, and doing so clears accumulated data to avoid
   // initialization costs varying between runs.
   grpc::RegisterOpenCensusViewsForExport();
 
+  grpc::testing::TestGrpcScope grpc_scope;
   EchoServerThread server;
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub =
       grpc::testing::EchoTestService::NewStub(grpc::CreateChannel(
@@ -122,4 +120,9 @@ static void BM_E2eLatencyCensusEnabled(benchmark::State& state) {
 }
 BENCHMARK(BM_E2eLatencyCensusEnabled);
 
-BENCHMARK_MAIN();
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
+  ::benchmark::Initialize(&argc, argv);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
Add `TestGrpcScope` to control timing for gRPC init and shutdown. This is developed for `bm_opencensus` which needs to configure gRPC before init to run test with or without census. Previously `bm_opencensus` used to call `TestEnvironment` without argv multiple times but this is not right because i) `TestEnvironment` is not designed to be called several times and ii) having null argv happened to be safe but not anymore.