### PR TITLE
grpc_cli: allow multiple colon-separated paths in --proto_path

### DIFF
--- a/doc/command_line_tool.md
+++ b/doc/command_line_tool.md
@@ -176,7 +176,8 @@ We can send RPCs to a server and get responses using `grpc_cli call` command.
     ```
 
     If the proto file is not under the current directory, you can use
-    `--proto_path` to specify a new search root.
+    `--proto_path` to specify new search roots
+    (separated by colon on Mac/Linux/Cygwin or semicolon on Windows).
 
     Note that the tool will always attempt to use the reflection service first,
     falling back to local proto files if the service is not found. Use

--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -52,7 +52,9 @@ ABSL_FLAG(bool, remotedb, true,
           "Use server types to parse and format messages");
 ABSL_FLAG(std::string, metadata, "",
           "Metadata to send to server, in the form of key1:val1:key2:val2");
-ABSL_FLAG(std::string, proto_path, ".", "Path to look for the proto file.");
+ABSL_FLAG(std::string, proto_path, ".",
+          "Path to look for the proto file. "
+          "Multiple paths can be separated by " GRPC_CLI_PATH_SEPARATOR);
 ABSL_FLAG(std::string, protofiles, "", "Name of the proto file.");
 ABSL_FLAG(bool, binary_input, false, "Input in binary format");
 ABSL_FLAG(bool, binary_output, false, "Output in binary format");
@@ -489,8 +491,9 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
       "    <request>                ; Text protobuffer (overrides infile)\n"
       "    --protofiles             ; Comma separated proto files used as a"
       " fallback when parsing request/response\n"
-      "    --proto_path             ; The search path of proto files, valid"
-      " only when --protofiles is given\n"
+      "    --proto_path             ; The search paths of proto files"
+      " (" GRPC_CLI_PATH_SEPARATOR
+      " separated), valid only when --protofiles is given\n"
       "    --noremotedb             ; Don't attempt to use reflection service"
       " at all\n"
       "    --metadata               ; The metadata to be sent to the server\n"
@@ -856,8 +859,9 @@ bool GrpcTool::ParseMessage(int argc, const char** argv,
       "    <message>                ; Text protobuffer (overrides --infile)\n"
       "    --protofiles             ; Comma separated proto files used as a"
       " fallback when parsing request/response\n"
-      "    --proto_path             ; The search path of proto files, valid"
-      " only when --protofiles is given\n"
+      "    --proto_path             ; The search paths of proto files"
+      " (" GRPC_CLI_PATH_SEPARATOR
+      " separated), valid  only when --protofiles is given\n"
       "    --noremotedb             ; Don't attempt to use reflection service"
       " at all\n"
       "    --infile                 ; Input filename (defaults to stdin)\n"
@@ -946,7 +950,9 @@ bool GrpcTool::ToText(int argc, const char** argv, const CliCredentials& cred,
       "  grpc_cli totext <protofiles> <type>\n"
       "    <protofiles>             ; Comma separated list of proto files\n"
       "    <type>                   ; Protocol buffer type name\n"
-      "    --proto_path             ; The search path of proto files\n"
+      "    --proto_path             ; The search paths of proto files"
+      " (" GRPC_CLI_PATH_SEPARATOR
+      " separated)\n"
       "    --infile                 ; Input filename (defaults to stdin)\n"
       "    --outfile                ; Output filename (defaults to stdout)\n");
 
@@ -964,7 +970,9 @@ bool GrpcTool::ToJson(int argc, const char** argv, const CliCredentials& cred,
       "  grpc_cli tojson <protofiles> <type>\n"
       "    <protofiles>             ; Comma separated list of proto files\n"
       "    <type>                   ; Protocol buffer type name\n"
-      "    --proto_path             ; The search path of proto files\n"
+      "    --proto_path             ; The search paths of proto files"
+      " (" GRPC_CLI_PATH_SEPARATOR
+      " separated)\n"
       "    --infile                 ; Input filename (defaults to stdin)\n"
       "    --outfile                ; Output filename (defaults to stdout)\n");
 
@@ -983,7 +991,9 @@ bool GrpcTool::ToBinary(int argc, const char** argv, const CliCredentials& cred,
       "  grpc_cli tobinary <protofiles> <type> [<message>]\n"
       "    <protofiles>             ; Comma separated list of proto files\n"
       "    <type>                   ; Protocol buffer type name\n"
-      "    --proto_path             ; The search path of proto files\n"
+      "    --proto_path             ; The search paths of proto files"
+      " (" GRPC_CLI_PATH_SEPARATOR
+      " separated)\n"
       "    --infile                 ; Input filename (defaults to stdin)\n"
       "    --outfile                ; Output filename (defaults to stdout)\n");
 

--- a/test/cpp/util/proto_file_parser.cc
+++ b/test/cpp/util/proto_file_parser.cc
@@ -16,8 +16,6 @@
  *
  */
 
-#include "absl/strings/str_split.h"
-
 #include "test/cpp/util/proto_file_parser.h"
 
 #include <algorithm>
@@ -26,6 +24,7 @@
 #include <unordered_set>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 
 #include <grpcpp/support/config.h>
 

--- a/test/cpp/util/proto_file_parser.cc
+++ b/test/cpp/util/proto_file_parser.cc
@@ -16,6 +16,8 @@
  *
  */
 
+#include "absl/strings/str_split.h"
+
 #include "test/cpp/util/proto_file_parser.h"
 
 #include <algorithm>
@@ -79,7 +81,10 @@ ProtoFileParser::ProtoFileParser(const std::shared_ptr<grpc::Channel>& channel,
 
   std::unordered_set<std::string> known_services;
   if (!protofiles.empty()) {
-    source_tree_.MapPath("", proto_path);
+    for (const absl::string_view single_path :
+         absl::StrSplit(proto_path, GRPC_CLI_PATH_SEPARATOR, absl::AllowEmpty())) {
+      source_tree_.MapPath("", std::string(single_path));
+    }
     error_printer_ = absl::make_unique<ErrorPrinter>(this);
     importer_ = absl::make_unique<protobuf::compiler::Importer>(
         &source_tree_, error_printer_.get());

--- a/test/cpp/util/proto_file_parser.cc
+++ b/test/cpp/util/proto_file_parser.cc
@@ -80,8 +80,8 @@ ProtoFileParser::ProtoFileParser(const std::shared_ptr<grpc::Channel>& channel,
 
   std::unordered_set<std::string> known_services;
   if (!protofiles.empty()) {
-    for (const absl::string_view single_path :
-         absl::StrSplit(proto_path, GRPC_CLI_PATH_SEPARATOR, absl::AllowEmpty())) {
+    for (const absl::string_view single_path : absl::StrSplit(
+             proto_path, GRPC_CLI_PATH_SEPARATOR, absl::AllowEmpty())) {
       source_tree_.MapPath("", std::string(single_path));
     }
     error_printer_ = absl::make_unique<ErrorPrinter>(this);

--- a/test/cpp/util/proto_file_parser.h
+++ b/test/cpp/util/proto_file_parser.h
@@ -26,6 +26,12 @@
 #include "test/cpp/util/config_grpc_cli.h"
 #include "test/cpp/util/proto_reflection_descriptor_database.h"
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#define GRPC_CLI_PATH_SEPARATOR ";"
+#else
+#define GRPC_CLI_PATH_SEPARATOR ":"
+#endif
+
 namespace grpc {
 namespace testing {
 class ErrorPrinter;


### PR DESCRIPTION
grpc_cli: allow multiple colon-separated paths in `--proto_path` (semicolon-separated on Windows)

When calling a method on a server where [ServerReflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) is disabled, grpc_cli needs to know where to find the protobuf files for the service. Previously, only one path could be specified. This change allows multiple paths to be specified in `--proto_path`, separated by a colon (`:`) on Mac/Linux/Cygwin or semicolon (`;`) on Windows.

This is compatible with the `protoc` `--proto_path` command line argument ([command_line_interface.cc](https://github.com/protocolbuffers/protobuf/blob/f4aa17b28af168cb3168f029de796d5994c321f6/src/google/protobuf/compiler/command_line_interface.cc#L1699-L1704)), which similarly separates by `:` on  or `;` on Windows ([command_line_interface.cc](https://github.com/protocolbuffers/protobuf/blob/f4aa17b28af168cb3168f029de796d5994c321f6/src/google/protobuf/compiler/command_line_interface.cc#L872-L876)).

## Motivating Example

For example, if you try querying a [helm 2](https://github.com/helm/helm/tree/release-2.16) tiller GRPC endpoint, you can’t use `helm_cli` without `--protofiles` because it gives errors that the service does not implement ServerReflection:

```sh
$ kubectl port-forward --namespace=kube-system  $(kubectl get pods --namespace=kube-system -l=app=helm,name=tiller -o jsonpath={.items[0].metadata.name}) 12345:44134
$ grpc_cli call localhost:12345   hapi.services.tiller.ReleaseService/GetVersion ''
Method name not found
Failed to find method hapi.services.tiller.ReleaseService/GetVersion in proto files.
Method name not found
Method name not found
Failed to parse request.
Reflection request not implemented; is the ServerReflection service enabled?
```

To fix this, you can try adding `--proto_path` and `--protofiles`, but then `grpc_cli` complains that it can’t find `google/protobuf/any.proto` and other [proto3 well-known types](https://developers.google.com/protocol-buffers/docs/proto3) that protoc automatically finds ([AddDefaultProtoPaths](https://github.com/protocolbuffers/protobuf/blob/f4aa17b28af168cb3168f029de796d5994c321f6/src/google/protobuf/compiler/command_line_interface.cc#L227)):

```
$ git clone --branch release-2.16 https://github.com/helm/helm
$ grpc_cli call localhost:12345  --proto_path  ./helm/_proto/  --protofiles hapi/services/tiller.proto -metadata=x-helm-api-client:2.16 hapi.services.tiller.ReleaseService.GetVersion ''
error google/protobuf/any.proto -1 0 File not found.

error hapi/chart/chart.proto 21 0 Import "google/protobuf/any.proto" was not found or had errors.

error hapi/chart/chart.proto 42 17 "google.protobuf.Any" is not defined.
…
```

So you need to add both the service path and the well-known path to the proto_path. This commit allows proto_path to specify both:

```sh
$ grpc_cli call localhost:12345  --proto_path  ~/third-party/helm/_proto/:$(brew --prefix protobuf)/include  --protofiles hapi/services/tiller.proto -metadata=x-helm-api-client:2.16 hapi.services.tiller.ReleaseService.GetVersion ''
connecting to localhost:12345
Sending client initial metadata:
x-helm-api-client : 2.16
Version {
  sem_ver: "v2.16.1"
  git_commit: "bbdfe5e7803a12bbdf97e94cd847859890cf4050"
  git_tree_state: "clean"
}
Rpc succeeded with OK status
Reflection request not implemented; is the ServerReflection service enabled?
```

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
