### PR TITLE
Fix windows build failure due to winserver2016 upgrade

### DIFF
--- a/src/csharp/build_unitypackage.bat
+++ b/src/csharp/build_unitypackage.bat
@@ -16,7 +16,7 @@
 set VERSION=2.33.0-dev
 
 @rem Adjust the location of nuget.exe
-set NUGET=C:\nuget\nuget.exe
+set NUGET=nuget
 set DOTNET=dotnet
 
 mkdir ..\..\artifacts

--- a/templates/src/csharp/build_unitypackage.bat.template
+++ b/templates/src/csharp/build_unitypackage.bat.template
@@ -18,7 +18,7 @@
   set VERSION=${settings.csharp_version}
   
   @rem Adjust the location of nuget.exe
-  set NUGET=C:\nuget\nuget.exe
+  set NUGET=nuget
   set DOTNET=dotnet
   
   mkdir ..\..\artifacts

--- a/test/distrib/csharp/run_distrib_test.bat
+++ b/test/distrib/csharp/run_distrib_test.bat
@@ -20,7 +20,7 @@ powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [Sys
 
 update_version.sh auto
 
-set NUGET=C:\nuget\nuget.exe
+set NUGET=nuget
 
 @rem TODO(jtattermusch): Get rid of this hack. See #8034
 @rem We can't do just "nuget restore" because restoring a .sln solution doesn't work

--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -14,7 +14,8 @@
 
 @rem make sure msys binaries are preferred over cygwin binaries
 @rem set path to python 2.7
-set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
+@rem set path to CMake
+set PATH=C:\tools\msys64\usr\bin;C:\Python27;C:\Program Files\CMake\bin;%PATH%
 
 @rem If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if defined KOKORO_GITHUB_PULL_REQUEST_NUMBER if defined RUN_TESTS_FLAGS (


### PR DESCRIPTION
This PR is intended to fix following tests.

- windows/grpc_build_packages
- windows/grpc_distribtests
- windows/grpc_distribtests_standalone
- windows/grpc_portability_build_only

These tests failed because i) cmake is not accessible by default and ii) nuget.exe is located at the different path.