### PR TITLE
Remove unneeded private methods and friends of generic server contexts

### DIFF
--- a/include/grpcpp/impl/codegen/async_generic_service.h
+++ b/include/grpcpp/impl/codegen/async_generic_service.h
@@ -36,20 +36,13 @@ typedef ServerAsyncResponseWriter<ByteBuffer> GenericServerAsyncResponseWriter;
 typedef ServerAsyncReader<ByteBuffer, ByteBuffer> GenericServerAsyncReader;
 typedef ServerAsyncWriter<ByteBuffer> GenericServerAsyncWriter;
 
-class GenericServerContext final : public ::grpc::ServerContext {
+class GenericServerContext final : public ServerContext {
  public:
   const std::string& method() const { return method_; }
   const std::string& host() const { return host_; }
 
  private:
-  friend class grpc::Server;
-  friend class grpc::ServerInterface;
-
-  void Clear() {
-    method_.clear();
-    host_.clear();
-    ::grpc::ServerContext::Clear();
-  }
+  friend class ServerInterface;
 
   std::string method_;
   std::string host_;
@@ -95,21 +88,13 @@ namespace experimental {
 /// ByteBuffer arguments.
 using ServerGenericBidiReactor = ServerBidiReactor<ByteBuffer, ByteBuffer>;
 
-class GenericCallbackServerContext final
-    : public ::grpc::CallbackServerContext {
+class GenericCallbackServerContext final : public grpc::CallbackServerContext {
  public:
   const std::string& method() const { return method_; }
   const std::string& host() const { return host_; }
 
  private:
   friend class ::grpc::Server;
-  friend class ::grpc::ServerInterface;
-
-  void Clear() {
-    method_.clear();
-    host_.clear();
-    ::grpc::CallbackServerContext::Clear();
-  }
 
   std::string method_;
   std::string host_;


### PR DESCRIPTION
These pieces of generic server context are no longer used or needed (builds on #24184)