### PR TITLE
proto_utils.h: suppress conversion warning

### DIFF
--- a/include/grpcpp/impl/codegen/proto_utils.h
+++ b/include/grpcpp/impl/codegen/proto_utils.h
@@ -49,7 +49,7 @@ Status GenericSerialize(const grpc::protobuf::MessageLite& msg, ByteBuffer* bb,
                 "ProtoBufferWriter must be a subclass of "
                 "::protobuf::io::ZeroCopyOutputStream");
   *own_buffer = true;
-  int byte_size = msg.ByteSizeLong();
+  int byte_size = static_cast<int>(msg.ByteSizeLong());
   if ((size_t)byte_size <= GRPC_SLICE_INLINED_SIZE) {
     Slice slice(byte_size);
     // We serialize directly into the allocated slices memory


### PR DESCRIPTION
Adding a static_cast<int> to proto_utils.h (grpc::GenericSerialize()) to suppress a clang-conversion warning (size_t).

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
