### PR TITLE
Convert ExecCtx::Run to Closure::Run for subchannel call stack destruction

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2211,8 +2211,7 @@ void CallData::Destroy(grpc_call_element* elem,
   if (GPR_LIKELY(subchannel_call != nullptr)) {
     subchannel_call->SetAfterCallStackDestroy(then_schedule_closure);
   } else {
-    // TODO(yashkt) : This can potentially be a Closure::Run
-    ExecCtx::Run(DEBUG_LOCATION, then_schedule_closure, GRPC_ERROR_NONE);
+    Closure::Run(DEBUG_LOCATION, then_schedule_closure, GRPC_ERROR_NONE);
   }
 }
 


### PR DESCRIPTION
Convert ExecCtx::Run to Closure::Run for subchannel call stack destruction