### PR TITLE
Eliminate ServerContextBase::Clear/Setup and fix unref process for core call

### DIFF
--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -91,7 +91,7 @@ void ClientContext::set_credentials(
 std::unique_ptr<ClientContext> ClientContext::FromInternalServerContext(
     const grpc::ServerContextBase& context, PropagationOptions options) {
   std::unique_ptr<ClientContext> ctx(new ClientContext);
-  ctx->propagate_from_call_ = context.call_;
+  ctx->propagate_from_call_ = context.call_.call;
   ctx->propagation_options_ = options;
   return ctx;
 }

--- a/test/cpp/interop/server_helper.cc
+++ b/test/cpp/interop/server_helper.cc
@@ -54,17 +54,18 @@ InteropServerContextInspector::InteropServerContextInspector(
 
 grpc_compression_algorithm
 InteropServerContextInspector::GetCallCompressionAlgorithm() const {
-  return grpc_call_test_only_get_compression_algorithm(context_.call_);
+  return grpc_call_test_only_get_compression_algorithm(context_.call_.call);
 }
 
 uint32_t InteropServerContextInspector::GetEncodingsAcceptedByClient() const {
-  return grpc_call_test_only_get_encodings_accepted_by_peer(context_.call_);
+  return grpc_call_test_only_get_encodings_accepted_by_peer(
+      context_.call_.call);
 }
 
 bool InteropServerContextInspector::WasCompressed() const {
-  return (grpc_call_test_only_get_message_flags(context_.call_) &
+  return (grpc_call_test_only_get_message_flags(context_.call_.call) &
           GRPC_WRITE_INTERNAL_COMPRESS) ||
-         (grpc_call_test_only_get_message_flags(context_.call_) &
+         (grpc_call_test_only_get_message_flags(context_.call_.call) &
           GRPC_WRITE_INTERNAL_TEST_ONLY_WAS_COMPRESSED);
 }
 


### PR DESCRIPTION
This is in preparation for allowing the ServerContextBase to be allocated as part of the call arena or as an entirely separate object and reflects the fact that ServerContextBase is no longer reused. The functions being removed are all private and the variables being changed are implementation details, though some tests are directly using them.
