### PR TITLE
Don't keep address attributes on the resulting subchannels.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -363,9 +363,9 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
   }
   subchannels_.reserve(addresses.size());
   // Create a subchannel for each address.
-  for (const ServerAddress& address : addresses) {
+  for (ServerAddress& address : addresses) {
     RefCountedPtr<SubchannelInterface> subchannel =
-        helper->CreateSubchannel(std::move(address), args);
+        helper->CreateSubchannel(address, args);
     if (subchannel == nullptr) {
       // Subchannel could not be created.
       if (GRPC_TRACE_FLAG_ENABLED(*tracer_)) {
@@ -383,7 +383,7 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
               tracer_->name(), policy_, this, subchannels_.size(),
               subchannel.get(), address.ToString().c_str());
     }
-    subchannels_.emplace_back(this, address, std::move(subchannel));
+    subchannels_.emplace_back(this, std::move(address), std::move(subchannel));
   }
 }
 

--- a/src/core/ext/filters/client_channel/server_address.h
+++ b/src/core/ext/filters/client_channel/server_address.h
@@ -97,10 +97,6 @@ class ServerAddress {
   std::string ToString() const;
 
  private:
-  // Allows the channel to access the attributes without knowing the keys.
-  // (We intentionally do not allow LB policies to do this.)
-  friend class ChannelServerAddressPeer;
-
   grpc_resolved_address address_;
   grpc_channel_args* args_;
   std::map<const char*, std::unique_ptr<AttributeInterface>> attributes_;

--- a/src/core/ext/filters/client_channel/subchannel_interface.h
+++ b/src/core/ext/filters/client_channel/subchannel_interface.h
@@ -21,9 +21,10 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "src/core/ext/filters/client_channel/server_address.h"
+#include <grpc/impl/codegen/connectivity_state.h>
+#include <grpc/impl/codegen/grpc_types.h>
+
 #include "src/core/lib/gprpp/ref_counted.h"
-#include "src/core/lib/gprpp/ref_counted_ptr.h"
 
 namespace grpc_core {
 
@@ -88,11 +89,6 @@ class SubchannelInterface : public RefCounted<SubchannelInterface> {
 
   // TODO(roth): Need a better non-grpc-specific abstraction here.
   virtual const grpc_channel_args* channel_args() = 0;
-
-  // Allows accessing the attributes associated with the address for
-  // this subchannel.
-  virtual const ServerAddress::AttributeInterface* GetAttribute(
-      const char* key) const = 0;
 };
 
 // A class that delegates to another subchannel, to be used in cases
@@ -123,10 +119,6 @@ class DelegatingSubchannel : public SubchannelInterface {
   void ResetBackoff() override { wrapped_subchannel_->ResetBackoff(); }
   const grpc_channel_args* channel_args() override {
     return wrapped_subchannel_->channel_args();
-  }
-  const ServerAddress::AttributeInterface* GetAttribute(
-      const char* key) const override {
-    return wrapped_subchannel_->GetAttribute(key);
   }
 
  private:


### PR DESCRIPTION
We don't need this anymore, since we're using the subchannel wrapping approach instead.