### PR TITLE
Add trimming attribute to BindServiceMethodAttribute

### DIFF
--- a/src/csharp/Grpc.Core.Api/BindServiceMethodAttribute.cs
+++ b/src/csharp/Grpc.Core.Api/BindServiceMethodAttribute.cs
@@ -15,6 +15,7 @@
 #endregion
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Grpc.Core
 {
@@ -29,12 +30,16 @@ namespace Grpc.Core
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class BindServiceMethodAttribute : Attribute
     {
+        // grpc-dotnet uses reflection to find the bind service method.
+        // DynamicallyAccessedMembersAttribute instructs the linker to never trim the method.
+        private const DynamicallyAccessedMemberTypes ServiceBinderAccessibility = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BindServiceMethodAttribute"/> class.
         /// </summary>
         /// <param name="bindType">The type the service bind method is defined on.</param>
         /// <param name="bindMethodName">The name of the service bind method.</param>
-        public BindServiceMethodAttribute(Type bindType, string bindMethodName)
+        public BindServiceMethodAttribute([DynamicallyAccessedMembers(ServiceBinderAccessibility)] Type bindType, string bindMethodName)
         {
             BindType = bindType;
             BindMethodName = bindMethodName;
@@ -43,6 +48,7 @@ namespace Grpc.Core
         /// <summary>
         /// Gets the type the service bind method is defined on.
         /// </summary>
+        [DynamicallyAccessedMembers(ServiceBinderAccessibility)]
         public Type BindType { get; }
 
         /// <summary>

--- a/src/csharp/Grpc.Core.Api/Internal/CodeAnalysisAttributes.cs
+++ b/src/csharp/Grpc.Core.Api/Internal/CodeAnalysisAttributes.cs
@@ -1,0 +1,146 @@
+#region Copyright notice and license
+
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+}

--- a/src/csharp/Grpc.Core.Api/Internal/CodeAnalysisAttributes.cs
+++ b/src/csharp/Grpc.Core.Api/Internal/CodeAnalysisAttributes.cs
@@ -16,6 +16,11 @@
 
 #endregion
 
+// Content of this file is copied with permission from:
+// https://github.com/dotnet/runtime/tree/e2e43f44f1032780fa7c2bb965153c9da615c3d0/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis
+// These types are intented to be added as internalized source to libraries and apps that want to
+// use them without requiring a dependency on .NET 5.
+
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>


### PR DESCRIPTION
PR adds trimming attribute to `BindServiceMethodAttribute`. It instructs the .NET 5 trimmer to not remove the BindService method from generated code during trimming.

Example of it working:

```csharp
public static class ServiceStatic
{
    [BindServiceMethod(typeof(ServiceStatic), "BindService")]
    public class ServiceBase
    {
        public virtual void DoThing();
    }

    public static void BindService(Binder binder, ServiceBase serviceImpl)
    {
        binder.AddMethod(new Action(serviceImpl.DoThing));
    }
}
```

1. `ServiceBase` is used by the implementation so isn't trimmed
2. The linker checks all attributes on `ServiceBase`, and notices `BindServiceMethod` has `typeof(ServiceStatic)` parameter.
3. That constructor parameter now has `DynamicallyAccessedMembers` attribute on it which tells the compiler to not remove any methods from types passed to it. In this case that is `ServiceStatic`.
4. The `BindServiceMethodAttribute.BindType` property also has the attribute so reflection using the `BindType` property doesn't generate warnings.

The new attribute and enum have been added in .NET 5. To avoid adding a new target to the NuGet package I have instead added internal copies. Because they have the same name and namespace they work fine.

There is no new public API in the PR.

@jtattermusch @apolcyn @JunTaoLuo @davidfowl