### PR TITLE
Avoid double underscores in macro name

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -107,8 +107,8 @@ std::string GetHeaderPrologue(grpc_generator::File* file,
       printer->Print(vars, "// Original file comments:\n");
       printer->PrintRaw(leading_comments.c_str());
     }
-    printer->Print(vars, "#ifndef GRPC_$filename_identifier$__INCLUDED\n");
-    printer->Print(vars, "#define GRPC_$filename_identifier$__INCLUDED\n");
+    printer->Print(vars, "#ifndef GRPC_$filename_identifier$_INCLUDED\n");
+    printer->Print(vars, "#define GRPC_$filename_identifier$_INCLUDED\n");
     printer->Print(vars, "\n");
     printer->Print(vars, "#include \"$filename_base$$message_header_ext$\"\n");
     printer->Print(vars, file->additional_headers().c_str());
@@ -1822,7 +1822,7 @@ std::string GetHeaderEpilogue(grpc_generator::File* file,
     }
 
     printer->Print(vars, "\n");
-    printer->Print(vars, "#endif  // GRPC_$filename_identifier$__INCLUDED\n");
+    printer->Print(vars, "#endif  // GRPC_$filename_identifier$_INCLUDED\n");
 
     printer->Print(file->GetTrailingComments("//").c_str());
   }


### PR DESCRIPTION
The include guards created by the grpc_cpp_plugin are of the form "PROTOBUF_2eproto__INCLUDED". However, identifiers with two consecutive underscores are reserved in C++ according to [[lex.name]/3.1](http://eel.is/c++draft/lex.name#3.1).

I'm using Clang with all warnings enabled (-Weverything) and warnings treated as errors (-Werror), so the compilation is stopped with the following message 

```
In file included from protocol.grpc.pb.cc:1:
In file included from protocol.grpc.pb.cc:6:
protocol.grpc.pb.h:5:9: error: macro name is a reserved identifier [-Werror,-Wreserved-id-macro]
#define protocol_2eproto__INCLUDED
        ^
1 error generated.
```

It doesn't seem double underscores are really necessary so I've made this PR.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
