### PR TITLE
Properly synchronize thread creation failure case

### DIFF
--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -184,6 +184,8 @@ void ThreadManager::MainWorkLoop() {
             if (worker->created()) {
               worker->Start();
             } else {
+              // Get lock again to undo changes to poller/thread counters.
+              grpc_core::MutexLock failure_lock(&mu_);
               num_pollers_--;
               num_threads_--;
               resource_exhausted = true;


### PR DESCRIPTION
Shouldn't update thread counters without being under lock. This case has never been seen in practice afaik.
