### PR TITLE
Fix MSAN adjustment

### DIFF
--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -689,19 +689,26 @@ void ssl_tsi_test_do_round_trip_for_all_configs() {
   gpr_free(bit_array);
 }
 
+static bool is_slow_build() {
+#if defined(GPR_ARCH_32) || defined(__APPLE__)
+  return true;
+#else
+  return BuiltUnderMsan();
+#endif
+}
+
 void ssl_tsi_test_do_round_trip_odd_buffer_size() {
   gpr_log(GPR_INFO, "ssl_tsi_test_do_round_trip_odd_buffer_size");
-#if !defined(MEMORY_SANITIZER) && !defined(GPR_ARCH_32) && !defined(__APPLE__)
   const size_t odd_sizes[] = {1025, 2051, 4103, 8207, 16409};
-#else
+  size_t size = sizeof(odd_sizes) / sizeof(size_t);
   // 1. avoid test being extremely slow under MSAN
   // 2. on 32-bit, the test is much slower (probably due to lack of boringssl
   // asm optimizations) so we only run a subset of tests to avoid timeout
   // 3. on Mac OS, we have slower testing machines so we only run a subset
   // of tests to avoid timeout
-  const size_t odd_sizes[] = {1025};
-#endif
-  const size_t size = sizeof(odd_sizes) / sizeof(size_t);
+  if (is_slow_build()) {
+    size = 1;
+  }
   for (size_t ind1 = 0; ind1 < size; ind1++) {
     for (size_t ind2 = 0; ind2 < size; ind2++) {
       for (size_t ind3 = 0; ind3 < size; ind3++) {

--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -37,6 +37,18 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms);
 #define GRPC_TEST_PICK_PORT
 #endif
 
+// Returns whether this is built under ThreadSanitizer
+bool BuiltUnderTsan();
+
+// Returns whether this is built under AddressSanitizer
+bool BuiltUnderAsan();
+
+// Returns whether this is built under MemorySanitizer
+bool BuiltUnderMsan();
+
+// Returns whether this is built under UndefinedBehaviorSanitizer
+bool BuiltUnderUbsan();
+
 // Prefer TestEnvironment below.
 void grpc_test_init(int argc, char** argv);
 

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -1904,13 +1904,13 @@ std::vector<TestScenario> CreateTestScenarios(bool /*test_secure*/,
       }
       messages.push_back(big_msg);
     }
-#ifndef MEMORY_SANITIZER
-    // 4MB message processing with SSL is very slow under msan
-    // (causes timeouts) and doesn't really increase the signal from tests.
-    // Reserve 100 bytes for other fields of the message proto.
-    messages.push_back(
-        std::string(GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH - 100, 'a'));
-#endif
+    if (!BuiltUnderMsan()) {
+      // 4MB message processing with SSL is very slow under msan
+      // (causes timeouts) and doesn't really increase the signal from tests.
+      // Reserve 100 bytes for other fields of the message proto.
+      messages.push_back(
+          std::string(GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH - 100, 'a'));
+    }
   }
 
   // TODO (sreek) Renable tests with health check service after the issue


### PR DESCRIPTION
We have two tests which do less job when running under MSAN not to end up with timeout. They used to check if `MEMORY_SANITIZER` is defined but it actually doesn't work well. This PR is to addess this problem by using `BuiltUnderMsan` which already figured this out.