### PR TITLE
Change RefIfNonZero() to return a RefCountedPtr<>.

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -674,8 +674,8 @@ void XdsResolver::GenerateResult() {
 void XdsResolver::MaybeRemoveUnusedClusters() {
   bool update_needed = false;
   for (auto it = cluster_state_map_.begin(); it != cluster_state_map_.end();) {
-    if (it->second->RefIfNonZero()) {
-      it->second->Unref();
+    RefCountedPtr<ClusterState> cluster_state = it->second->RefIfNonZero();
+    if (cluster_state != nullptr) {
       ++it;
     } else {
       update_needed = true;

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -242,7 +242,7 @@ class Delete<T, false> {
 // must be tracked in a registry but the object's entry in the registry
 // cannot be removed from the object's dtor due to synchronization issues.
 // In this case, the registry can be cleaned up later by identifying
-// entries for which RefIfNonZero() returns false.
+// entries for which RefIfNonZero() returns null.
 //
 // This will commonly be used by CRTP (curiously-recurring template pattern)
 // e.g., class MyClass : public RefCounted<MyClass>
@@ -299,9 +299,15 @@ class RefCounted : public Impl {
     }
   }
 
-  bool RefIfNonZero() { return refs_.RefIfNonZero(); }
-  bool RefIfNonZero(const DebugLocation& location, const char* reason) {
-    return refs_.RefIfNonZero(location, reason);
+  RefCountedPtr<Child> RefIfNonZero() GRPC_MUST_USE_RESULT {
+    return RefCountedPtr<Child>(refs_.RefIfNonZero() ? static_cast<Child*>(this)
+                                                     : nullptr);
+  }
+  RefCountedPtr<Child> RefIfNonZero(const DebugLocation& location,
+                                    const char* reason) GRPC_MUST_USE_RESULT {
+    return RefCountedPtr<Child>(refs_.RefIfNonZero(location, reason)
+                                    ? static_cast<Child*>(this)
+                                    : nullptr);
   }
 
   // Not copyable nor movable.


### PR DESCRIPTION
This fixes `RefIfNonZero()` to have the same API as `Ref()`.  I probably should have done this when I originally added `RefIfNonZero()` in #19244.