### PR TITLE
Fix use-after-free bug

### DIFF
--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -172,6 +172,7 @@ class XdsClient::ChannelState::AdsCallState
         MutexLock lock(&self->ads_calld_->xds_client()->mu_);
         self->OnTimerLocked(GRPC_ERROR_REF(error));
       }
+      self->ads_calld_.reset();
       self->Unref(DEBUG_LOCATION, "timer");
     }
 
@@ -213,7 +214,6 @@ class XdsClient::ChannelState::AdsCallState
         }
         GRPC_ERROR_UNREF(watcher_error);
       }
-      ads_calld_.reset();
       GRPC_ERROR_UNREF(error);
     }
 


### PR DESCRIPTION
Looks like I introduced this bug in #24200, and it's causing some test flakiness.  I can't seem to reproduce it locally, but I suspect this will fix it.

Here's the TSAN stack trace that led me to this fix:
https://source.cloud.google.com/results/invocations/1df46528-d886-4efa-a704-179f13e17732/targets/%2F%2Ftest%2Fcpp%2Fend2end:xds_end2end_test@poller%3Depollex/log