### PR TITLE
Add transport information into grpc-objc user-agent.

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannel.m
@@ -100,7 +100,8 @@
 - (NSDictionary *)channelArgs {
   NSMutableDictionary *args = [NSMutableDictionary new];
 
-  NSString *userAgent = @"grpc-objc/" GRPC_OBJC_VERSION_STRING;
+  NSString *userAgent = [NSString
+      stringWithFormat:@"grpc-objc-%@/%@", [self getTransportTypeString], GRPC_OBJC_VERSION_STRING];
   NSString *userAgentPrefix = _callOptions.userAgentPrefix;
   if (userAgentPrefix.length != 0) {
     args[@GRPC_ARG_PRIMARY_USER_AGENT_STRING] =
@@ -159,6 +160,18 @@
   [args addEntriesFromDictionary:_callOptions.additionalChannelArgs];
 
   return args;
+}
+
+- (NSString *)getTransportTypeString {
+  switch (_callOptions.transportType) {
+    case GRPCTransportTypeCronet:
+      return @"cronet";
+    case GRPCTransportTypeInsecure:
+    case GRPCTransportTypeChttp2BoringSSL:
+      return @"cfstream";
+    default:
+      return @"unknown";
+  }
 }
 
 - (id)copyWithZone:(NSZone *)zone {

--- a/src/objective-c/tests/UnitTests/APIv2Tests.m
+++ b/src/objective-c/tests/UnitTests/APIv2Tests.m
@@ -226,7 +226,7 @@ static const NSTimeInterval kInvertedTimeout = 2;
                      initWithInitialMetadataCallback:^(NSDictionary *initialMetadata) {
                        NSString *userAgent = initialMetadata[@"x-grpc-test-echo-useragent"];
                        // Test the regex is correct
-                       NSString *expectedUserAgent = @"Foo grpc-objc/";
+                       NSString *expectedUserAgent = @"Foo grpc-objc-cfstream/";
                        expectedUserAgent =
                            [expectedUserAgent stringByAppendingString:GRPC_OBJC_VERSION_STRING];
                        expectedUserAgent = [expectedUserAgent stringByAppendingString:@" grpc-c/"];

--- a/src/objective-c/tests/UnitTests/GRPCClientTests.m
+++ b/src/objective-c/tests/UnitTests/GRPCClientTests.m
@@ -301,7 +301,7 @@ static GRPCProtoMethod *kFullDuplexCallMethod;
         NSError *error = nil;
 
         // Test the regex is correct
-        NSString *expectedUserAgent = @"Foo grpc-objc/";
+        NSString *expectedUserAgent = @"Foo grpc-objc-cfstream/";
         expectedUserAgent = [expectedUserAgent stringByAppendingString:GRPC_OBJC_VERSION_STRING];
         expectedUserAgent = [expectedUserAgent stringByAppendingString:@" grpc-c/"];
         expectedUserAgent = [expectedUserAgent stringByAppendingString:GRPC_C_VERSION_STRING];


### PR DESCRIPTION
Add transport information into grpc-objc user-agent, i.e. `grpc-objc-cronet`, `grpc-objc-cfstream`.