### PR TITLE
Remove non-existent grpc_impl forward declaration

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -44,10 +44,6 @@
 
 struct grpc_completion_queue;
 
-namespace grpc_impl {
-class ServerContextBase;
-}  // namespace grpc_impl
-
 namespace grpc {
 template <class R>
 class ClientReader;


### PR DESCRIPTION
Looks like another leftover from the grpc_impl deprecation
