### PR TITLE
Allow channel args to modify service config parsing behavior.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1698,7 +1698,8 @@ ChannelData::ChannelData(grpc_channel_element_args* args, grpc_error** error)
       grpc_channel_args_find(args->channel_args, GRPC_ARG_SERVICE_CONFIG));
   if (service_config_json == nullptr) service_config_json = "{}";
   *error = GRPC_ERROR_NONE;
-  default_service_config_ = ServiceConfig::Create(service_config_json, error);
+  default_service_config_ =
+      ServiceConfig::Create(args->channel_args, service_config_json, error);
   if (*error != GRPC_ERROR_NONE) {
     default_service_config_.reset();
     return;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -352,7 +352,7 @@ void AresDnsResolver::OnResolvedLocked(grpc_error* error) {
         GRPC_CARES_TRACE_LOG("resolver:%p selected service config choice: %s",
                              this, service_config_string.c_str());
         result.service_config = ServiceConfig::Create(
-            service_config_string, &result.service_config_error);
+            channel_args_, service_config_string, &result.service_config_error);
       }
     }
     absl::InlinedVector<grpc_arg, 1> new_args;

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -620,7 +620,7 @@ void XdsResolver::OnResourceDoesNotExist() {
           this);
   Result result;
   result.service_config =
-      ServiceConfig::Create("{}", &result.service_config_error);
+      ServiceConfig::Create(args_, "{}", &result.service_config_error);
   GPR_ASSERT(result.service_config != nullptr);
   result.args = grpc_channel_args_copy(args_);
   result_handler()->ReturnResult(std::move(result));
@@ -654,7 +654,7 @@ grpc_error* XdsResolver::CreateServiceConfig(
       "}");
   std::string json = absl::StrJoin(config_parts, "");
   grpc_error* error = GRPC_ERROR_NONE;
-  *service_config = ServiceConfig::Create(json.c_str(), &error);
+  *service_config = ServiceConfig::Create(args_, json.c_str(), &error);
   return error;
 }
 

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -284,8 +284,8 @@ const char* ParseHealthCheckConfig(const Json& field, grpc_error** error) {
 }  // namespace
 
 std::unique_ptr<ServiceConfigParser::ParsedConfig>
-ClientChannelServiceConfigParser::ParseGlobalParams(const Json& json,
-                                                    grpc_error** error) {
+ClientChannelServiceConfigParser::ParseGlobalParams(
+    const grpc_channel_args* /*args*/, const Json& json, grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   std::vector<grpc_error*> error_list;
   RefCountedPtr<LoadBalancingPolicy::Config> parsed_lb_config;
@@ -363,8 +363,8 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const Json& json,
 }
 
 std::unique_ptr<ServiceConfigParser::ParsedConfig>
-ClientChannelServiceConfigParser::ParsePerMethodParams(const Json& json,
-                                                       grpc_error** error) {
+ClientChannelServiceConfigParser::ParsePerMethodParams(
+    const grpc_channel_args* /*args*/, const Json& json, grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   std::vector<grpc_error*> error_list;
   absl::optional<bool> wait_for_ready;

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.h
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.h
@@ -111,10 +111,12 @@ class ClientChannelMethodParsedConfig
 class ClientChannelServiceConfigParser : public ServiceConfigParser::Parser {
  public:
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParseGlobalParams(
-      const Json& json, grpc_error** error) override;
+      const grpc_channel_args* /*args*/, const Json& json,
+      grpc_error** error) override;
 
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParsePerMethodParams(
-      const Json& json, grpc_error** error) override;
+      const grpc_channel_args* /*args*/, const Json& json,
+      grpc_error** error) override;
 
   static size_t ParserIndex();
   static void Register();

--- a/src/core/ext/filters/client_channel/service_config.h
+++ b/src/core/ext/filters/client_channel/service_config.h
@@ -65,10 +65,12 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
  public:
   /// Creates a new service config from parsing \a json_string.
   /// Returns null on parse error.
-  static RefCountedPtr<ServiceConfig> Create(absl::string_view json_string,
+  static RefCountedPtr<ServiceConfig> Create(const grpc_channel_args* args,
+                                             absl::string_view json_string,
                                              grpc_error** error);
 
-  ServiceConfig(std::string json_string, Json json, grpc_error** error);
+  ServiceConfig(const grpc_channel_args* args, std::string json_string,
+                Json json, grpc_error** error);
   ~ServiceConfig();
 
   const std::string& json_string() const { return json_string_; }
@@ -89,8 +91,9 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
 
  private:
   // Helper functions for parsing the method configs.
-  grpc_error* ParsePerMethodParams();
-  grpc_error* ParseJsonMethodConfig(const Json& json);
+  grpc_error* ParsePerMethodParams(const grpc_channel_args* args);
+  grpc_error* ParseJsonMethodConfig(const grpc_channel_args* args,
+                                    const Json& json);
 
   // Returns a path string for the JSON name object specified by json.
   // Sets *error on error.

--- a/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
+++ b/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
@@ -37,8 +37,8 @@ class ServiceConfigChannelArgChannelData {
         args->channel_args, GRPC_ARG_SERVICE_CONFIG);
     if (service_config_str != nullptr) {
       grpc_error* service_config_error = GRPC_ERROR_NONE;
-      auto service_config =
-          ServiceConfig::Create(service_config_str, &service_config_error);
+      auto service_config = ServiceConfig::Create(
+          args->channel_args, service_config_str, &service_config_error);
       if (service_config_error == GRPC_ERROR_NONE) {
         service_config_ = std::move(service_config);
       } else {

--- a/src/core/ext/filters/client_channel/service_config_parser.cc
+++ b/src/core/ext/filters/client_channel/service_config_parser.cc
@@ -45,14 +45,15 @@ size_t ServiceConfigParser::RegisterParser(std::unique_ptr<Parser> parser) {
 }
 
 ServiceConfigParser::ParsedConfigVector
-ServiceConfigParser::ParseGlobalParameters(const Json& json,
+ServiceConfigParser::ParseGlobalParameters(const grpc_channel_args* args,
+                                           const Json& json,
                                            grpc_error** error) {
   ParsedConfigVector parsed_global_configs;
   std::vector<grpc_error*> error_list;
   for (size_t i = 0; i < g_registered_parsers->size(); i++) {
     grpc_error* parser_error = GRPC_ERROR_NONE;
-    auto parsed_config =
-        (*g_registered_parsers)[i]->ParseGlobalParams(json, &parser_error);
+    auto parsed_config = (*g_registered_parsers)[i]->ParseGlobalParams(
+        args, json, &parser_error);
     if (parser_error != GRPC_ERROR_NONE) {
       error_list.push_back(parser_error);
     }
@@ -65,14 +66,15 @@ ServiceConfigParser::ParseGlobalParameters(const Json& json,
 }
 
 ServiceConfigParser::ParsedConfigVector
-ServiceConfigParser::ParsePerMethodParameters(const Json& json,
+ServiceConfigParser::ParsePerMethodParameters(const grpc_channel_args* args,
+                                              const Json& json,
                                               grpc_error** error) {
   ParsedConfigVector parsed_method_configs;
   std::vector<grpc_error*> error_list;
   for (size_t i = 0; i < g_registered_parsers->size(); i++) {
     grpc_error* parser_error = GRPC_ERROR_NONE;
-    auto parsed_config =
-        (*g_registered_parsers)[i]->ParsePerMethodParams(json, &parser_error);
+    auto parsed_config = (*g_registered_parsers)[i]->ParsePerMethodParams(
+        args, json, &parser_error);
     if (parser_error != GRPC_ERROR_NONE) {
       error_list.push_back(parser_error);
     }

--- a/src/core/ext/filters/client_channel/service_config_parser.h
+++ b/src/core/ext/filters/client_channel/service_config_parser.h
@@ -23,6 +23,8 @@
 
 #include "absl/container/inlined_vector.h"
 
+#include <grpc/impl/codegen/grpc_types.h>
+
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/json/json.h"
 
@@ -45,7 +47,7 @@ class ServiceConfigParser {
     virtual ~Parser() = default;
 
     virtual std::unique_ptr<ParsedConfig> ParseGlobalParams(
-        const Json& /* json */, grpc_error** error) {
+        const grpc_channel_args*, const Json& /* json */, grpc_error** error) {
       // Avoid unused parameter warning on debug-only parameter
       (void)error;
       GPR_DEBUG_ASSERT(error != nullptr);
@@ -53,7 +55,7 @@ class ServiceConfigParser {
     }
 
     virtual std::unique_ptr<ParsedConfig> ParsePerMethodParams(
-        const Json& /* json */, grpc_error** error) {
+        const grpc_channel_args*, const Json& /* json */, grpc_error** error) {
       // Avoid unused parameter warning on debug-only parameter
       (void)error;
       GPR_DEBUG_ASSERT(error != nullptr);
@@ -77,11 +79,12 @@ class ServiceConfigParser {
   /// retrieved using the same index that was returned at registration time.
   static size_t RegisterParser(std::unique_ptr<Parser> parser);
 
-  static ParsedConfigVector ParseGlobalParameters(const Json& json,
+  static ParsedConfigVector ParseGlobalParameters(const grpc_channel_args* args,
+                                                  const Json& json,
                                                   grpc_error** error);
 
-  static ParsedConfigVector ParsePerMethodParameters(const Json& json,
-                                                     grpc_error** error);
+  static ParsedConfigVector ParsePerMethodParameters(
+      const grpc_channel_args* args, const Json& json, grpc_error** error);
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -66,7 +66,8 @@ const MessageSizeParsedConfig* MessageSizeParsedConfig::GetFromCallContext(
 //
 
 std::unique_ptr<ServiceConfigParser::ParsedConfig>
-MessageSizeParser::ParsePerMethodParams(const Json& json, grpc_error** error) {
+MessageSizeParser::ParsePerMethodParams(const grpc_channel_args* /*args*/,
+                                        const Json& json, grpc_error** error) {
   GPR_DEBUG_ASSERT(error != nullptr && *error == GRPC_ERROR_NONE);
   std::vector<grpc_error*> error_list;
   // Max request size.

--- a/src/core/ext/filters/message_size/message_size_filter.h
+++ b/src/core/ext/filters/message_size/message_size_filter.h
@@ -50,7 +50,8 @@ class MessageSizeParsedConfig : public ServiceConfigParser::ParsedConfig {
 class MessageSizeParser : public ServiceConfigParser::Parser {
  public:
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParsePerMethodParams(
-      const Json& json, grpc_error** error) override;
+      const grpc_channel_args* /*args*/, const Json& json,
+      grpc_error** error) override;
 
   static void Register();
 

--- a/src/cpp/common/validate_service_config.cc
+++ b/src/cpp/common/validate_service_config.cc
@@ -26,7 +26,8 @@ namespace experimental {
 std::string ValidateServiceConfigJSON(const std::string& service_config_json) {
   grpc_init();
   grpc_error* error = GRPC_ERROR_NONE;
-  grpc_core::ServiceConfig::Create(service_config_json.c_str(), &error);
+  grpc_core::ServiceConfig::Create(/*args=*/nullptr,
+                                   service_config_json.c_str(), &error);
   std::string return_value;
   if (error != GRPC_ERROR_NONE) {
     return_value = grpc_error_string(error);

--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -34,6 +34,9 @@
 namespace grpc_core {
 namespace testing {
 
+// Set this channel arg to true to disable parsing.
+#define GRPC_ARG_DISABLE_PARSING "disable_parsing"
+
 class TestParsedConfig1 : public ServiceConfigParser::ParsedConfig {
  public:
   TestParsedConfig1(int value) : value_(value) {}
@@ -47,8 +50,12 @@ class TestParsedConfig1 : public ServiceConfigParser::ParsedConfig {
 class TestParser1 : public ServiceConfigParser::Parser {
  public:
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParseGlobalParams(
-      const Json& json, grpc_error** error) override {
+      const grpc_channel_args* args, const Json& json,
+      grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
+    if (grpc_channel_args_find_bool(args, GRPC_ARG_DISABLE_PARSING, false)) {
+      return nullptr;
+    }
     auto it = json.object_value().find("global_param");
     if (it != json.object_value().end()) {
       if (it->second.type() != Json::Type::NUMBER) {
@@ -79,8 +86,12 @@ class TestParser1 : public ServiceConfigParser::Parser {
 class TestParser2 : public ServiceConfigParser::Parser {
  public:
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParsePerMethodParams(
-      const Json& json, grpc_error** error) override {
+      const grpc_channel_args* args, const Json& json,
+      grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
+    if (grpc_channel_args_find_bool(args, GRPC_ARG_DISABLE_PARSING, false)) {
+      return nullptr;
+    }
     auto it = json.object_value().find("method_param");
     if (it != json.object_value().end()) {
       if (it->second.type() != Json::Type::NUMBER) {
@@ -112,14 +123,16 @@ class TestParser2 : public ServiceConfigParser::Parser {
 class ErrorParser : public ServiceConfigParser::Parser {
  public:
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParsePerMethodParams(
-      const Json& /*json*/, grpc_error** error) override {
+      const grpc_channel_args* /*arg*/, const Json& /*json*/,
+      grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(MethodError());
     return nullptr;
   }
 
   std::unique_ptr<ServiceConfigParser::ParsedConfig> ParseGlobalParams(
-      const Json& /*json*/, grpc_error** error) override {
+      const grpc_channel_args* /*arg*/, const Json& /*json*/,
+      grpc_error** error) override {
     GPR_DEBUG_ASSERT(error != nullptr);
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(GlobalError());
     return nullptr;
@@ -154,7 +167,7 @@ class ServiceConfigTest : public ::testing::Test {
 TEST_F(ServiceConfigTest, ErrorCheck1) {
   const char* test_json = "";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(std::string("JSON parse error"));
   VerifyRegexMatch(error, regex);
 }
@@ -162,7 +175,7 @@ TEST_F(ServiceConfigTest, ErrorCheck1) {
 TEST_F(ServiceConfigTest, BasicTest1) {
   const char* test_json = "{}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
 }
 
@@ -174,7 +187,7 @@ TEST_F(ServiceConfigTest, SkipMethodConfigWithNoNameOrEmptyName) {
       "  {\"name\":[{\"service\":\"TestServ\"}], \"method_param\":2}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
       grpc_slice_from_static_string("/TestServ/TestMethod"));
@@ -190,7 +203,7 @@ TEST_F(ServiceConfigTest, ErrorDuplicateMethodConfigNames) {
       "  {\"name\":[{\"service\":\"TestServ\"}]}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       std::string("Service config parsing error.*referenced_errors"
                   ".*Method Params.*referenced_errors"
@@ -206,7 +219,7 @@ TEST_F(ServiceConfigTest, ErrorDuplicateMethodConfigNamesWithNullMethod) {
       "  {\"name\":[{\"service\":\"TestServ\"}]}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       std::string("Service config parsing error.*referenced_errors"
                   ".*Method Params.*referenced_errors"
@@ -222,7 +235,7 @@ TEST_F(ServiceConfigTest, ErrorDuplicateMethodConfigNamesWithEmptyMethod) {
       "  {\"name\":[{\"service\":\"TestServ\"}]}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       std::string("Service config parsing error.*referenced_errors"
                   ".*Method Params.*referenced_errors"
@@ -238,7 +251,7 @@ TEST_F(ServiceConfigTest, ErrorDuplicateDefaultMethodConfigs) {
       "  {\"name\":[{}]}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       std::string("Service config parsing error.*referenced_errors"
                   ".*Method Params.*referenced_errors"
@@ -254,7 +267,7 @@ TEST_F(ServiceConfigTest, ErrorDuplicateDefaultMethodConfigsWithNullService) {
       "  {\"name\":[{}]}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       std::string("Service config parsing error.*referenced_errors"
                   ".*Method Params.*referenced_errors"
@@ -270,7 +283,7 @@ TEST_F(ServiceConfigTest, ErrorDuplicateDefaultMethodConfigsWithEmptyService) {
       "  {\"name\":[{}]}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       std::string("Service config parsing error.*referenced_errors"
                   ".*Method Params.*referenced_errors"
@@ -283,14 +296,14 @@ TEST_F(ServiceConfigTest, ValidMethodConfig) {
   const char* test_json =
       "{\"methodConfig\": [{\"name\":[{\"service\":\"TestServ\"}]}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
 }
 
 TEST_F(ServiceConfigTest, Parser1BasicTest1) {
   const char* test_json = "{\"global_param\":5}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   EXPECT_EQ((static_cast<TestParsedConfig1*>(svc_cfg->GetGlobalParsedConfig(0)))
                 ->value(),
@@ -303,17 +316,28 @@ TEST_F(ServiceConfigTest, Parser1BasicTest1) {
 TEST_F(ServiceConfigTest, Parser1BasicTest2) {
   const char* test_json = "{\"global_param\":1000}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   EXPECT_EQ((static_cast<TestParsedConfig1*>(svc_cfg->GetGlobalParsedConfig(0)))
                 ->value(),
             1000);
 }
 
+TEST_F(ServiceConfigTest, Parser1DisabledViaChannelArg) {
+  grpc_arg arg = grpc_channel_arg_integer_create(
+      const_cast<char*>(GRPC_ARG_DISABLE_PARSING), 1);
+  grpc_channel_args args = {1, &arg};
+  const char* test_json = "{\"global_param\":5}";
+  grpc_error* error = GRPC_ERROR_NONE;
+  auto svc_cfg = ServiceConfig::Create(&args, test_json, &error);
+  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
+  EXPECT_EQ(svc_cfg->GetGlobalParsedConfig(0), nullptr);
+}
+
 TEST_F(ServiceConfigTest, Parser1ErrorInvalidType) {
   const char* test_json = "{\"global_param\":\"5\"}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       absl::StrCat("Service config parsing error.*referenced_errors.*"
                    "Global Params.*referenced_errors.*",
@@ -324,7 +348,7 @@ TEST_F(ServiceConfigTest, Parser1ErrorInvalidType) {
 TEST_F(ServiceConfigTest, Parser1ErrorInvalidValue) {
   const char* test_json = "{\"global_param\":-5}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       absl::StrCat("Service config parsing error.*referenced_errors.*"
                    "Global Params.*referenced_errors.*",
@@ -337,7 +361,7 @@ TEST_F(ServiceConfigTest, Parser2BasicTest) {
       "{\"methodConfig\": [{\"name\":[{\"service\":\"TestServ\"}], "
       "\"method_param\":5}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
       grpc_slice_from_static_string("/TestServ/TestMethod"));
@@ -346,12 +370,29 @@ TEST_F(ServiceConfigTest, Parser2BasicTest) {
   EXPECT_EQ(static_cast<TestParsedConfig1*>(parsed_config)->value(), 5);
 }
 
+TEST_F(ServiceConfigTest, Parser2DisabledViaChannelArg) {
+  grpc_arg arg = grpc_channel_arg_integer_create(
+      const_cast<char*>(GRPC_ARG_DISABLE_PARSING), 1);
+  grpc_channel_args args = {1, &arg};
+  const char* test_json =
+      "{\"methodConfig\": [{\"name\":[{\"service\":\"TestServ\"}], "
+      "\"method_param\":5}]}";
+  grpc_error* error = GRPC_ERROR_NONE;
+  auto svc_cfg = ServiceConfig::Create(&args, test_json, &error);
+  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
+  const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
+      grpc_slice_from_static_string("/TestServ/TestMethod"));
+  ASSERT_NE(vector_ptr, nullptr);
+  auto parsed_config = ((*vector_ptr)[1]).get();
+  EXPECT_EQ(parsed_config, nullptr);
+}
+
 TEST_F(ServiceConfigTest, Parser2ErrorInvalidType) {
   const char* test_json =
       "{\"methodConfig\": [{\"name\":[{\"service\":\"TestServ\"}], "
       "\"method_param\":\"5\"}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       absl::StrCat("Service config parsing error.*referenced_errors\":\\[.*"
                    "Method Params.*referenced_errors.*methodConfig.*"
@@ -365,7 +406,7 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidValue) {
       "{\"methodConfig\": [{\"name\":[{\"service\":\"TestServ\"}], "
       "\"method_param\":-5}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       absl::StrCat("Service config parsing error.*referenced_errors\":\\[.*"
                    "Method Params.*referenced_errors.*methodConfig.*"
@@ -392,7 +433,7 @@ class ErroredParsersScopingTest : public ::testing::Test {
 TEST_F(ErroredParsersScopingTest, GlobalParams) {
   const char* test_json = "{}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(absl::StrCat(
       "Service config parsing error.*referenced_errors\":\\[.*"
       "Global Params.*referenced_errors.*",
@@ -403,7 +444,7 @@ TEST_F(ErroredParsersScopingTest, GlobalParams) {
 TEST_F(ErroredParsersScopingTest, MethodParams) {
   const char* test_json = "{\"methodConfig\": [{}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(absl::StrCat(
       "Service config parsing error.*referenced_errors\":\\[.*"
       "Global Params.*referenced_errors.*",
@@ -428,7 +469,7 @@ class ClientChannelParserTest : public ::testing::Test {
 TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigPickFirst) {
   const char* test_json = "{\"loadBalancingConfig\": [{\"pick_first\":{}}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -441,7 +482,7 @@ TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigRoundRobin) {
   const char* test_json =
       "{\"loadBalancingConfig\": [{\"round_robin\":{}}, {}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   auto parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -455,7 +496,7 @@ TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigGrpclb) {
       "{\"loadBalancingConfig\": "
       "[{\"grpclb\":{\"childPolicy\":[{\"pick_first\":{}}]}}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -473,7 +514,7 @@ TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigXds) {
       "  ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -485,7 +526,7 @@ TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigXds) {
 TEST_F(ClientChannelParserTest, UnknownLoadBalancingConfig) {
   const char* test_json = "{\"loadBalancingConfig\": [{\"unknown\":{}}]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -502,7 +543,7 @@ TEST_F(ClientChannelParserTest, InvalidGrpclbLoadBalancingConfig) {
       "  {\"round_robin\":{}}"
       "]}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -517,7 +558,7 @@ TEST_F(ClientChannelParserTest, InvalidGrpclbLoadBalancingConfig) {
 TEST_F(ClientChannelParserTest, ValidLoadBalancingPolicy) {
   const char* test_json = "{\"loadBalancingPolicy\":\"pick_first\"}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -528,7 +569,7 @@ TEST_F(ClientChannelParserTest, ValidLoadBalancingPolicy) {
 TEST_F(ClientChannelParserTest, ValidLoadBalancingPolicyAllCaps) {
   const char* test_json = "{\"loadBalancingPolicy\":\"PICK_FIRST\"}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -539,7 +580,7 @@ TEST_F(ClientChannelParserTest, ValidLoadBalancingPolicyAllCaps) {
 TEST_F(ClientChannelParserTest, UnknownLoadBalancingPolicy) {
   const char* test_json = "{\"loadBalancingPolicy\":\"unknown\"}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -551,7 +592,7 @@ TEST_F(ClientChannelParserTest, UnknownLoadBalancingPolicy) {
 TEST_F(ClientChannelParserTest, LoadBalancingPolicyXdsNotAllowed) {
   const char* test_json = "{\"loadBalancingPolicy\":\"eds_experimental\"}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -570,7 +611,7 @@ TEST_F(ClientChannelParserTest, ValidRetryThrottling) {
       "  }\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -588,7 +629,7 @@ TEST_F(ClientChannelParserTest, RetryThrottlingMissingFields) {
       "  }\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -607,7 +648,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryThrottlingNegativeMaxTokens) {
       "  }\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -626,7 +667,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryThrottlingInvalidTokenRatio) {
       "  }\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Global Params.*referenced_errors.*"
@@ -647,7 +688,7 @@ TEST_F(ClientChannelParserTest, ValidTimeout) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
       grpc_slice_from_static_string("/TestServ/TestMethod"));
@@ -670,7 +711,7 @@ TEST_F(ClientChannelParserTest, InvalidTimeout) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -691,7 +732,7 @@ TEST_F(ClientChannelParserTest, ValidWaitForReady) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
       grpc_slice_from_static_string("/TestServ/TestMethod"));
@@ -720,7 +761,7 @@ TEST_F(ClientChannelParserTest, InvalidWaitForReady) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -747,7 +788,7 @@ TEST_F(ClientChannelParserTest, ValidRetryPolicy) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
       grpc_slice_from_static_string("/TestServ/TestMethod"));
@@ -781,7 +822,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryPolicyMaxAttempts) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -809,7 +850,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryPolicyInitialBackoff) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -837,7 +878,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryPolicyMaxBackoff) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -865,7 +906,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryPolicyBackoffMultiplier) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -893,7 +934,7 @@ TEST_F(ClientChannelParserTest, InvalidRetryPolicyRetryableStatusCodes) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -912,7 +953,7 @@ TEST_F(ClientChannelParserTest, ValidHealthCheck) {
       "    }\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* parsed_config =
       static_cast<grpc_core::internal::ClientChannelGlobalParsedConfig*>(
@@ -933,7 +974,7 @@ TEST_F(ClientChannelParserTest, InvalidHealthCheckMultipleEntries) {
       "    }\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "JSON parsing failed.*referenced_errors.*"
       "duplicate key \"healthCheckConfig\" at index 104");
@@ -963,7 +1004,7 @@ TEST_F(MessageSizeParserTest, Valid) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   const auto* vector_ptr = svc_cfg->GetMethodParsedConfigVector(
       grpc_slice_from_static_string("/TestServ/TestMethod"));
@@ -986,7 +1027,7 @@ TEST_F(MessageSizeParserTest, InvalidMaxRequestMessageBytes) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"
@@ -1007,7 +1048,7 @@ TEST_F(MessageSizeParserTest, InvalidMaxResponseMessageBytes) {
       "  } ]\n"
       "}";
   grpc_error* error = GRPC_ERROR_NONE;
-  auto svc_cfg = ServiceConfig::Create(test_json, &error);
+  auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   std::regex regex(
       "Service config parsing error.*referenced_errors.*"
       "Method Params.*referenced_errors.*"

--- a/test/cpp/client/client_channel_stress_test.cc
+++ b/test/cpp/client/client_channel_stress_test.cc
@@ -244,7 +244,7 @@ class ClientChannelStressTest {
     grpc_core::Resolver::Result result;
     grpc_error* error = GRPC_ERROR_NONE;
     result.service_config = grpc_core::ServiceConfig::Create(
-        "{\"loadBalancingConfig\":[{\"grpclb\":{}}]}", &error);
+        nullptr, "{\"loadBalancingConfig\":[{\"grpclb\":{}}]}", &error);
     GPR_ASSERT(error == GRPC_ERROR_NONE);
     grpc_core::ServerAddressList balancer_addresses =
         CreateAddressListFromAddressDataList(balancer_address_data);

--- a/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
+++ b/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
@@ -71,7 +71,7 @@ void TryConnectAndDestroy() {
   grpc_core::Resolver::Result lb_address_result;
   grpc_error* error = GRPC_ERROR_NONE;
   lb_address_result.service_config = grpc_core::ServiceConfig::Create(
-      "{\"loadBalancingConfig\":[{\"grpclb\":{}}]}", &error);
+      nullptr, "{\"loadBalancingConfig\":[{\"grpclb\":{}}]}", &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   grpc_arg arg = grpc_core::CreateGrpclbBalancerAddressesArg(&addresses);
   lb_address_result.args = grpc_channel_args_copy_and_add(nullptr, &arg, 1);

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -210,7 +210,7 @@ class FakeResolverResponseGeneratorWrapper {
     }
     if (service_config_json != nullptr) {
       result.service_config = grpc_core::ServiceConfig::Create(
-          service_config_json, &result.service_config_error);
+          nullptr, service_config_json, &result.service_config_error);
       GPR_ASSERT(result.service_config != nullptr);
     }
     return result;

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -574,7 +574,7 @@ class GrpclbEnd2endTest : public ::testing::Test {
         CreateLbAddressesFromAddressDataList(backend_address_data);
     grpc_error* error = GRPC_ERROR_NONE;
     result.service_config =
-        grpc_core::ServiceConfig::Create(service_config_json, &error);
+        grpc_core::ServiceConfig::Create(nullptr, service_config_json, &error);
     GPR_ASSERT(error == GRPC_ERROR_NONE);
     grpc_core::ServerAddressList balancer_addresses =
         CreateLbAddressesFromAddressDataList(balancer_address_data);

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -190,16 +190,16 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
   void SetNextResolutionValidServiceConfig(const std::vector<int>& ports) {
     grpc_core::ExecCtx exec_ctx;
     grpc_core::Resolver::Result result = BuildFakeResults(ports);
-    result.service_config =
-        grpc_core::ServiceConfig::Create("{}", &result.service_config_error);
+    result.service_config = grpc_core::ServiceConfig::Create(
+        nullptr, "{}", &result.service_config_error);
     response_generator_->SetResponse(result);
   }
 
   void SetNextResolutionInvalidServiceConfig(const std::vector<int>& ports) {
     grpc_core::ExecCtx exec_ctx;
     grpc_core::Resolver::Result result = BuildFakeResults(ports);
-    result.service_config =
-        grpc_core::ServiceConfig::Create("{", &result.service_config_error);
+    result.service_config = grpc_core::ServiceConfig::Create(
+        nullptr, "{", &result.service_config_error);
     response_generator_->SetResponse(result);
   }
 
@@ -207,8 +207,8 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
                                           const char* svc_cfg) {
     grpc_core::ExecCtx exec_ctx;
     grpc_core::Resolver::Result result = BuildFakeResults(ports);
-    result.service_config =
-        grpc_core::ServiceConfig::Create(svc_cfg, &result.service_config_error);
+    result.service_config = grpc_core::ServiceConfig::Create(
+        nullptr, svc_cfg, &result.service_config_error);
     response_generator_->SetResponse(result);
   }
 

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1632,7 +1632,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
             ? kDefaultServiceConfig
             : kDefaultServiceConfigWithoutLoadReporting;
     result.service_config =
-        grpc_core::ServiceConfig::Create(service_config_json, &error);
+        grpc_core::ServiceConfig::Create(nullptr, service_config_json, &error);
     ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
     ASSERT_NE(result.service_config.get(), nullptr);
     response_generator_->SetResponse(std::move(result));
@@ -1656,8 +1656,8 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
     result.addresses = CreateAddressListFromPortList(ports);
     if (service_config_json != nullptr) {
       grpc_error* error = GRPC_ERROR_NONE;
-      result.service_config =
-          grpc_core::ServiceConfig::Create(service_config_json, &error);
+      result.service_config = grpc_core::ServiceConfig::Create(
+          nullptr, service_config_json, &error);
       ASSERT_NE(result.service_config.get(), nullptr);
       ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
     }


### PR DESCRIPTION
This will allow adding internal-only content to the service config that cannot be activated remotely (e.g., via service configs from a DNS TXT record) without the client explicitly enabling it via a channel arg.

This will require a small internal change as part of the import.