### PR TITLE
Don't install enum34 for non-2.7 Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # GRPC Python setup requirements
 coverage>=4.0
 cython>=0.29.8
-enum34>=1.0.4
 protobuf>=3.5.0.post1, < 4.0dev
 six>=1.10
 wheel>=0.29

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -38,8 +38,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'coverage>=4.0', 'enum34>=1.0.4',
-    'grpcio>={version}'.format(version=grpc_version.VERSION),
+    'coverage>=4.0', 'grpcio>={version}'.format(version=grpc_version.VERSION),
     'grpcio-channelz>={version}'.format(version=grpc_version.VERSION),
     'grpcio-status>={version}'.format(version=grpc_version.VERSION),
     'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
@@ -48,7 +47,7 @@ INSTALL_REQUIRES = (
     'google-auth>=1.17.2', 'requests>=2.14.2')
 
 if not PY3:
-    INSTALL_REQUIRES += ('futures>=2.2.0',)
+    INSTALL_REQUIRES += ('futures>=2.2.0', 'enum34>=1.0.4')
 
 COMMAND_CLASS = {
     # Run `preprocess` *before* doing any packaging!

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -89,10 +89,9 @@ then
   # python
   time pip install --user virtualenv
   time pip install --user --upgrade Mako six tox setuptools==44.1.1 twisted pyyaml pyjwt cryptography requests
-  export PYTHONPATH=/Library/Python/3.4/site-packages
 
   # make sure md5sum is available (requires coreutils 8.31+)
-  brew update
+  brew update-reset
   brew upgrade coreutils
 
   # Install Python 3.7 and Python 3.8

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -94,7 +94,6 @@ then
   # make sure md5sum is available (requires coreutils 8.31+)
   brew update
   brew upgrade coreutils
-  brew install md5sha1sum
 
   # Install Python 3.7 and Python 3.8
   time curl -O https://www.python.org/ftp/python/3.7.0/python-3.7.0-macosx10.9.pkg

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -94,6 +94,7 @@ then
   # make sure md5sum is available (requires coreutils 8.31+)
   brew update
   brew upgrade coreutils
+  brew install md5sha1sum
 
   # Install Python 3.7 and Python 3.8
   time curl -O https://www.python.org/ftp/python/3.7.0/python-3.7.0-macosx10.9.pkg

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -92,6 +92,7 @@ then
   export PYTHONPATH=/Library/Python/3.4/site-packages
 
   # make sure md5sum is available (requires coreutils 8.31+)
+  brew update
   brew upgrade coreutils
 
   # Install Python 3.7 and Python 3.8

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -104,7 +104,7 @@ then
 
   if [ "$("$PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
   then
-    "${PIP}" install futures>=2.2.0 enum>=1.0.4
+    "${PIP}" install futures>=2.2.0 enum34>=1.0.4
   fi
 
   "${PIP}" install grpcio --no-index --find-links "file://$ARTIFACT_DIR/"

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -104,7 +104,7 @@ then
 
   if [ "$("$PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
   then
-    "${PIP}" install futures>=2.2.0
+    "${PIP}" install futures>=2.2.0 enum>=1.0.4
   fi
 
   "${PIP}" install grpcio --no-index --find-links "file://$ARTIFACT_DIR/"

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -188,7 +188,7 @@ esac
 pip_install --upgrade setuptools==44.1.1
 pip_install --upgrade pip==19.3.1
 pip_install --upgrade cython
-if [ -z $(python -V | grep "Python 2.7") ]; then
+if [ -z $($VENV_PYTHON -V | grep "Python 2.7") ]; then
   pip_install --upgrade six enum34 protobuf
 else
   pip_install --upgrade six protobuf

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -188,7 +188,11 @@ esac
 pip_install --upgrade setuptools==44.1.1
 pip_install --upgrade pip==19.3.1
 pip_install --upgrade cython
-pip_install --upgrade six enum34 protobuf
+if [ -z $(python -V | grep "Python 2.7") ]; then
+  pip_install --upgrade six enum34 protobuf
+else
+  pip_install --upgrade six protobuf
+fi
 
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -188,15 +188,11 @@ esac
 pip_install --upgrade setuptools==44.1.1
 pip_install --upgrade pip==19.3.1
 pip_install --upgrade cython
-if [ -z $($VENV_PYTHON -V | grep "Python 2.7") ]; then
-  pip_install --upgrade six enum34 protobuf
-else
-  pip_install --upgrade six protobuf
-fi
+pip_install --upgrade six protobuf
 
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then
-  pip_install futures
+  pip_install --upgrade futures enum34
 fi
 
 pip_install_dir "$ROOT"


### PR DESCRIPTION
Starting yesterday (Sep 28), the Python 3.8 tests are failing consistently. Majority of them failed due to Python 3.8 accidentally picked up `enum34` as standard enum library. This PR fixes our build script to not install `enum34` for all non-2.7 Python versions.

---

There are also failures caused by Homebrew unsuccessful upgrades which lead to command `md5sum` unavailable.

One interesting error log from Homebrew is:
```
Error: unknown or unsupported macOS version: :lion
```

But according to the hostname of Kokoro machines, their OS version should be High Sierra. So, it's more likely to be a bug in Homebrew. (UPDATE: The log is not complaining the OS version of host, but the installing package. It's basically out-of-date.)

This PR tries to update Homebrew and install md5sum in different ways, hoping the problem will go away.

---

Another reason for the Homebrew failure is the connection to GitHub failed with `fatal: unable to access 'https://github.com/Homebrew/homebrew-core/': transfer closed with outstanding read data remaining
`.

Emm... The issue might caused by Kokoro's network regression or GitHub status (seems Green).