### PR TITLE
Use != with literals in commands.py

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -101,7 +101,7 @@ class SphinxDocumentation(setuptools.Command):
         target_dir = os.path.join(GRPC_STEM, 'doc', 'build')
         exit_code = sphinx.cmd.build.build_main(
             ['-b', 'html', '-W', '--keep-going', source_dir, target_dir])
-        if exit_code is not 0:
+        if exit_code != 0:
             raise CommandError(
                 "Documentation generation has warnings or errors")
 


### PR DESCRIPTION
Fixes a SyntaxWarning:
```
...commands.py:104: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if exit_code is not 0:
```

This is the only place generating this warning in our codebase.