### PR TITLE
setup.py: use CXX to get compiler for libatomic check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,8 @@ def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cpp_test = subprocess.Popen(['c++', '-x', 'c++', '-std=c++11', '-'],
+    cxx = os.environ.get('CXX', 'c++')
+    cpp_test = subprocess.Popen([cxx, '-x', 'c++', '-std=c++11', '-'],
                                 stdin=PIPE,
                                 stdout=PIPE,
                                 stderr=PIPE)
@@ -176,7 +177,7 @@ def check_linker_need_libatomic():
     # Double-check to see if -latomic actually can solve the problem.
     # https://github.com/grpc/grpc/issues/22491
     cpp_test = subprocess.Popen(
-        ['c++', '-x', 'c++', '-std=c++11', '-latomic', '-'],
+        [cxx, '-x', 'c++', '-std=c++11', '-latomic', '-'],
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE)

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -70,7 +70,8 @@ def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cpp_test = subprocess.Popen(['c++', '-x', 'c++', '-std=c++11', '-'],
+    cxx = os.environ.get('CXX', 'c++')
+    cpp_test = subprocess.Popen([cxx, '-x', 'c++', '-std=c++11', '-'],
                                 stdin=PIPE,
                                 stdout=PIPE,
                                 stderr=PIPE)
@@ -80,7 +81,7 @@ def check_linker_need_libatomic():
     # Double-check to see if -latomic actually can solve the problem.
     # https://github.com/grpc/grpc/issues/22491
     cpp_test = subprocess.Popen(
-        ['c++', '-x', 'c++', '-std=c++11', '-latomic', '-'],
+        [cxx, '-x', 'c++', '-std=c++11', '-latomic', '-'],
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE)

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -70,12 +70,22 @@ def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cc_test = subprocess.Popen(['cc', '-x', 'c++', '-std=c++11', '-'],
-                               stdin=PIPE,
-                               stdout=PIPE,
-                               stderr=PIPE)
-    cc_test.communicate(input=code_test)
-    return cc_test.returncode != 0
+    cpp_test = subprocess.Popen(['c++', '-x', 'c++', '-std=c++11', '-'],
+                                stdin=PIPE,
+                                stdout=PIPE,
+                                stderr=PIPE)
+    cpp_test.communicate(input=code_test)
+    if cpp_test.returncode == 0:
+        return False
+    # Double-check to see if -latomic actually can solve the problem.
+    # https://github.com/grpc/grpc/issues/22491
+    cpp_test = subprocess.Popen(
+        ['c++', '-x', 'c++', '-std=c++11', '-latomic', '-'],
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE)
+    cpp_test.communicate(input=code_test)
+    return cpp_test.returncode == 0
 
 
 # There are some situations (like on Windows) where CC, CFLAGS, and LDFLAGS are


### PR DESCRIPTION
This PR removes the hardcoded reference to `c++` used to run the compile test to check whether it is necessary to link to `libatomic`, and replaces it with `distutils.ccompiler`. This allows the build to work when `c++` is not the correct compiler, such as when a prefixed compiler is used when cross-compiling.

The compile test implemented here is roughly based on [`distutils.ccompiler.has_function()`](https://github.com/python/cpython/blob/17b5be0c0a3f74141014e06a660f1b5ddb002fec/Lib/distutils/ccompiler.py#L760).

Someone will need to verify that this doesn't cause a reoccurrence of https://github.com/grpc/grpc/issues/22491 (I don't think the CI will catch it or that bug wouldn't have happened in the first place, right?).

@veblush
