### PR TITLE
Skip eventmanager_libuv_test under TSAN

### DIFF
--- a/test/core/iomgr/poller/BUILD
+++ b/test/core/iomgr/poller/BUILD
@@ -28,6 +28,11 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = [
+        # TSAN has a false-positive for ShutdownRefAsync
+        # https://github.com/grpc/grpc/issues/24242
+        "notsan",
+    ],
     uses_polling = False,
     deps = [
         "//:eventmanager_libuv",

--- a/test/core/iomgr/poller/eventmanager_libuv_test.cc
+++ b/test/core/iomgr/poller/eventmanager_libuv_test.cc
@@ -58,6 +58,10 @@ TEST(LibuvEventManager, ShutdownRefAsync) {
     for (int j = 0; j < i; j++) {
       em->ShutdownRef();
     }
+    // TSAN doesn't like this approach although this would work. TSAN considers
+    // it dangerous to have a destructor being called while its member function
+    // is called but LibuvEventManager handles this by making LibuvEventManager
+    // wait until all pending operations finish.
     grpc_core::Thread deleter(
         "deleter", [](void* em) { delete static_cast<LibuvEventManager*>(em); },
         em);


### PR DESCRIPTION
Fix #24242 by marking it to skip the TSAN test since it has a false-positive.