### PR TITLE
Bump iOS and OSX version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,8 +236,8 @@ endif()
 if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
   add_definitions(-DGPR_BACKWARDS_COMPATIBILITY_MODE)
   if(_gRPC_PLATFORM_MAC)
-    # some C++11 constructs not supported before OS X 10.9
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
+    # some C++11 constructs not supported before OS X 10.10
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
   endif()
 endif()
 

--- a/examples/objective-c/BUILD
+++ b/examples/objective-c/BUILD
@@ -56,7 +56,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["helloworld/HelloWorld/Info.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     tags = ["manual"],
     deps = [":HelloWorld-lib"],
 )
@@ -113,7 +113,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["route_guide/Misc/Info.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     tags = ["manual"],
     deps = [":RouteGuideClient-lib"],
 )

--- a/examples/objective-c/auth_sample/AuthTestService.podspec
+++ b/examples/objective-c/auth_sample/AuthTestService.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "AuthTestService example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "7.1"
-  s.osx.deployment_target = "10.9"
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.10"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/examples/objective-c/helloworld/HelloWorld.podspec
+++ b/examples/objective-c/helloworld/HelloWorld.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "HelloWorld example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "7.1"
-  s.osx.deployment_target = "10.9"
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.10"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/examples/objective-c/helloworld/Podfile
+++ b/examples/objective-c/helloworld/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/helloworld_macos/HelloWorld.podspec
+++ b/examples/objective-c/helloworld_macos/HelloWorld.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "HelloWorld example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "7.1"
-  s.osx.deployment_target = "10.9"
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.10"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/examples/objective-c/helloworld_macos/Podfile
+++ b/examples/objective-c/helloworld_macos/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :macos, '10.9'
+platform :macos, '10.10'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/route_guide/Podfile
+++ b/examples/objective-c/route_guide/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/route_guide/RouteGuide.podspec
+++ b/examples/objective-c/route_guide/RouteGuide.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "RouteGuide example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "7.1"
-  s.osx.deployment_target = "10.9"
+  s.ios.deployment_target = "9.0"
+  s.osx.deployment_target = "10.10"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -34,8 +34,8 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
   s.requires_arc = false

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -38,8 +38,8 @@ Pod::Spec.new do |s|
   # which was released in Cocoapods v1.2.0.
   s.cocoapods_version = '>= 1.2.0'
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/gRPC-ProtoRPC.podspec
+++ b/gRPC-ProtoRPC.podspec
@@ -33,8 +33,8 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/gRPC-RxLibrary.podspec
+++ b/gRPC-RxLibrary.podspec
@@ -33,8 +33,8 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -44,8 +44,8 @@ Pod::Spec.new do |s|
     'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
   }
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 
@@ -70,8 +70,8 @@ Pod::Spec.new do |s|
                       "src/objective-c/GRPCClient/GRPCTypes.m"
     ss.dependency "gRPC-RxLibrary/Interface", version
 
-    ss.ios.deployment_target = '7.0'
-    ss.osx.deployment_target = '10.9'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.10'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '4.0'
   end
@@ -105,8 +105,8 @@ Pod::Spec.new do |s|
 
     ss.dependency "#{s.name}/Interface-Legacy", version
 
-    ss.ios.deployment_target = '7.0'
-    ss.osx.deployment_target = '10.9'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.10'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '4.0'
   end
@@ -141,8 +141,8 @@ Pod::Spec.new do |s|
     ss.dependency 'gRPC-Core', version
     ss.dependency 'gRPC-RxLibrary', version
 
-    ss.ios.deployment_target = '7.0'
-    ss.osx.deployment_target = '10.9'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.10'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '4.0'
   end
@@ -157,15 +157,15 @@ Pod::Spec.new do |s|
     ss.dependency 'gRPC-Core/Cronet-Implementation', version
     ss.dependency 'CronetFramework'
 
-    ss.ios.deployment_target = '8.0'
+    ss.ios.deployment_target = '9.0'
   end
 
   # CFStream is now default. Leaving this subspec only for compatibility purpose.
   s.subspec 'CFStream' do |ss|
     ss.dependency "#{s.name}/GRPCCore", version
 
-    ss.ios.deployment_target = '7.0'
-    ss.osx.deployment_target = '10.9'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.10'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '4.0'
   end
@@ -176,8 +176,8 @@ Pod::Spec.new do |s|
     ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}'
     ss.header_mappings_dir = 'src/objective-c/GRPCClient'
 
-    ss.ios.deployment_target = '7.0'
-    ss.osx.deployment_target = '10.9'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.10'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '4.0'
   end

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -208,23 +208,6 @@
 #define GRPC_ARES 0
 #else /* TARGET_OS_IPHONE */
 #define GPR_PLATFORM_STRING "osx"
-#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7
-#define GPR_CPU_IPHONE 1
-#define GPR_PTHREAD_TLS 1
-#else /* __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7 */
-#define GPR_CPU_POSIX 1
-/* TODO(vjpai): there is a reported issue in bazel build for Mac where __thread
-   in a header is currently not working (bazelbuild/bazel#4341). Remove
-   the following conditional and use GPR_GCC_TLS when that is fixed */
-#ifndef GRPC_BAZEL_BUILD
-#define GPR_GCC_TLS 1
-#else /* GRPC_BAZEL_BUILD */
-#define GPR_PTHREAD_TLS 1
-#endif /* GRPC_BAZEL_BUILD */
-#define GPR_APPLE_PTHREAD_NAME 1
-#endif
-#else /* __MAC_OS_X_VERSION_MIN_REQUIRED */
 #define GPR_CPU_POSIX 1
 /* TODO(vjpai): Remove the following conditional and use only GPR_GCC_TLS
    when bazelbuild/bazel#4341 is fixed */
@@ -233,7 +216,6 @@
 #else /* GRPC_BAZEL_BUILD */
 #define GPR_PTHREAD_TLS 1
 #endif /* GRPC_BAZEL_BUILD */
-#endif
 #define GPR_POSIX_CRASH_HANDLER 1
 #endif
 #define GPR_APPLE 1

--- a/src/cpp/Protobuf-C++.podspec
+++ b/src/cpp/Protobuf-C++.podspec
@@ -25,8 +25,8 @@ Pod::Spec.new do |s|
 
   s.header_mappings_dir = 'src'
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 

--- a/src/csharp/experimental/build_native_ext_for_ios.sh
+++ b/src/csharp/experimental/build_native_ext_for_ios.sh
@@ -28,8 +28,8 @@ function build {
     PATH_CC="$(xcrun --sdk $SDK --find clang)"
     PATH_CXX="$(xcrun --sdk $SDK --find clang++)"
 
-    CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -mios-version-min=6.0 -DPB_NO_PACKED_STRUCTS=1"
-    LDFLAGS="-arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -Wl,ios_version_min=6.0"
+    CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -mios-version-min=9.0 -DPB_NO_PACKED_STRUCTS=1"
+    LDFLAGS="-arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -Wl,ios_version_min=9.0"
 
     # TODO(jtattermusch): revisit the build arguments
     make -j4 static_csharp \

--- a/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
@@ -102,8 +102,8 @@ Pod::Spec.new do |s|
   # Restrict the protoc version to the one supported by this plugin.
   s.dependency '!ProtoCompiler', '3.13.0'
   # For the Protobuf dependency not to complain:
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '2.0'
 

--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -104,8 +104,8 @@ Pod::Spec.new do |s|
   # Restrict the protoc version to the one supported by this plugin.
   s.dependency '!ProtoCompiler', '3.13.0'
   # For the Protobuf dependency not to complain:
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
   # watchOS is disabled due to #20258.

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -110,8 +110,8 @@ Pod::Spec.new do |s|
   # Restrict the protobuf runtime version to the one supported by this version of protoc.
   s.dependency 'Protobuf', '~> 3.0'
   # For the Protobuf dependency not to complain:
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -79,8 +79,8 @@ Pod::Spec.new do |s|
     :commit => "88aeb757f1a415c71fb4cbf5af936ecae4bc8179",
   }
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.7'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/src/objective-c/CronetFramework.podspec
+++ b/src/objective-c/CronetFramework.podspec
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
   }
   s.vendored_framework = "Cronet.framework"
   s.author             = "The Chromium Authors"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.source       = { :http => "https://storage.googleapis.com/grpc-precompiled-binaries/cronet/Cronet.framework-v#{v}.zip"}
   s.preserve_paths = "Cronet.framework"
   s.public_header_files = "Cronet.framework/Headers/**/*{.h}"

--- a/src/objective-c/README.md
+++ b/src/objective-c/README.md
@@ -1,7 +1,7 @@
 [![Cocoapods](https://img.shields.io/cocoapods/v/gRPC.svg)](https://cocoapods.org/pods/gRPC)
 # gRPC for Objective-C
 gRPC Objective C library provides Objective C API for users to make gRPC calls on iOS or OS X
-platforms. Currently, the minimum supported iOS version is 7.0 and OS X version is 10.9 (Mavericks).
+platforms. Currently, the minimum supported iOS version is 9.0 and OS X version is 10.10 (Yosemite).
 
 While gRPC doesn't require the use of an IDL to describe the API of services, using one simplifies
 usage and adds some interoperability guarantees. Here we use [Protocol Buffers][], and provide a
@@ -43,8 +43,8 @@ Pod::Spec.new do |s|
   s.summary = '...'
   s.source = { :git => 'https://github.com/...' }
 
-  s.ios.deployment_target = '7.1'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
 
   # Base directory where the .proto files are.
   src = '.'

--- a/src/objective-c/examples/BUILD
+++ b/src/objective-c/examples/BUILD
@@ -77,7 +77,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Sample/Sample/Info.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     visibility = ["//visibility:public"],
     deps = ["Sample-lib"],
 )

--- a/src/objective-c/examples/InterceptorSample/Podfile
+++ b/src/objective-c/examples/InterceptorSample/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = 'RemoteTest example'
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = '7.1'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/src/objective-c/examples/Sample/Podfile
+++ b/src/objective-c/examples/Sample/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/src/objective-c/examples/SwiftSample/Podfile
+++ b/src/objective-c/examples/SwiftSample/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/src/objective-c/examples/watchOS-sample/Podfile
+++ b/src/objective-c/examples/watchOS-sample/Podfile
@@ -16,7 +16,7 @@ def grpc_deps
 end
 
 target 'watchOS-sample' do
-platform :ios, '8.0'
+platform :ios, '9.0'
   grpc_deps
 end
 

--- a/src/objective-c/manual_tests/Podfile
+++ b/src/objective-c/manual_tests/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -174,7 +174,7 @@ grpc_objc_testing_library(
 
 ios_unit_test(
     name = "UnitTests",
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     test_host = ":ios-host",
     deps = [
         ":APIv2Tests-lib",
@@ -188,7 +188,7 @@ ios_unit_test(
 
 ios_unit_test(
     name = "InteropTests",
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     test_host = ":ios-host",
     deps = [
         ":InteropTestsLocalCleartext-lib",
@@ -199,7 +199,7 @@ ios_unit_test(
 
 macos_unit_test(
     name = "MacTests",
-    minimum_os_version = "10.9",
+    minimum_os_version = "10.10",
     deps = [
         ":APIv2Tests-lib",
         ":InteropTestsLocalCleartext-lib",

--- a/src/objective-c/tests/Connectivity/Podfile
+++ b/src/objective-c/tests/Connectivity/Podfile
@@ -1,5 +1,5 @@
 install! 'cocoapods', :deterministic_uuids => false
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 # Location of gRPC's repo root relative to this file.
 GRPC_LOCAL_SRC = '../../../..'

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -35,13 +35,13 @@ end
   InteropTests
 ).each do |target_name|
   target target_name do
-    platform :ios, '8.0'
+    platform :ios, '9.0'
     grpc_deps
   end
 end
 
 target 'CronetTests' do
-  platform :ios, '8.0'
+  platform :ios, '9.0'
   grpc_deps
 
   pod 'gRPC/GRPCCoreCronet',           :path => GRPC_LOCAL_SRC
@@ -50,7 +50,7 @@ target 'CronetTests' do
 end
 
 target 'PerfTests' do
-  platform :ios, '8.0'
+  platform :ios, '9.0'
   grpc_deps
 
   pod 'gRPC/GRPCCoreCronet',           :path => GRPC_LOCAL_SRC

--- a/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "RemoteTest example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = '7.1'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '4.0'
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -300,8 +300,8 @@
   if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
     add_definitions(-DGPR_BACKWARDS_COMPATIBILITY_MODE)
     if(_gRPC_PLATFORM_MAC)
-      # some C++11 constructs not supported before OS X 10.9
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
+      # some C++11 constructs not supported before OS X 10.10
+      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
     endif()
   endif()
 

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -116,8 +116,8 @@
       :tag => "v#{version}",
     }
 
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
 
     s.requires_arc = false

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -115,8 +115,8 @@
     # which was released in Cocoapods v1.2.0.
     s.cocoapods_version = '>= 1.2.0'
 
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '4.0'
 

--- a/templates/gRPC-ProtoRPC.podspec.template
+++ b/templates/gRPC-ProtoRPC.podspec.template
@@ -35,8 +35,8 @@
       :tag => "v#{version}",
     }
 
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '4.0'
 

--- a/templates/gRPC-RxLibrary.podspec.template
+++ b/templates/gRPC-RxLibrary.podspec.template
@@ -35,8 +35,8 @@
       :tag => "v#{version}",
     }
 
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '4.0'
 

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -46,8 +46,8 @@
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
     }
 
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '4.0'
 
@@ -72,8 +72,8 @@
                         "src/objective-c/GRPCClient/GRPCTypes.m"
       ss.dependency "gRPC-RxLibrary/Interface", version
 
-      ss.ios.deployment_target = '7.0'
-      ss.osx.deployment_target = '10.9'
+      ss.ios.deployment_target = '9.0'
+      ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
@@ -107,8 +107,8 @@
 
       ss.dependency "#{s.name}/Interface-Legacy", version
 
-      ss.ios.deployment_target = '7.0'
-      ss.osx.deployment_target = '10.9'
+      ss.ios.deployment_target = '9.0'
+      ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
@@ -143,8 +143,8 @@
       ss.dependency 'gRPC-Core', version
       ss.dependency 'gRPC-RxLibrary', version
 
-      ss.ios.deployment_target = '7.0'
-      ss.osx.deployment_target = '10.9'
+      ss.ios.deployment_target = '9.0'
+      ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
@@ -159,15 +159,15 @@
       ss.dependency 'gRPC-Core/Cronet-Implementation', version
       ss.dependency 'CronetFramework'
 
-      ss.ios.deployment_target = '8.0'
+      ss.ios.deployment_target = '9.0'
     end
 
     # CFStream is now default. Leaving this subspec only for compatibility purpose.
     s.subspec 'CFStream' do |ss|
       ss.dependency "#{s.name}/GRPCCore", version
 
-      ss.ios.deployment_target = '7.0'
-      ss.osx.deployment_target = '10.9'
+      ss.ios.deployment_target = '9.0'
+      ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end
@@ -178,8 +178,8 @@
       ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}'
       ss.header_mappings_dir = 'src/objective-c/GRPCClient'
 
-      ss.ios.deployment_target = '7.0'
-      ss.osx.deployment_target = '10.9'
+      ss.ios.deployment_target = '9.0'
+      ss.osx.deployment_target = '10.10'
       ss.tvos.deployment_target = '10.0'
       ss.watchos.deployment_target = '4.0'
     end

--- a/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
@@ -104,8 +104,8 @@
     # Restrict the protoc version to the one supported by this plugin.
     s.dependency '!ProtoCompiler', '3.13.0'
     # For the Protobuf dependency not to complain:
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '2.0'
 

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -106,8 +106,8 @@
     # Restrict the protoc version to the one supported by this plugin.
     s.dependency '!ProtoCompiler', '3.13.0'
     # For the Protobuf dependency not to complain:
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.9'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
 
     # watchOS is disabled due to #20258.

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -109,8 +109,8 @@
       :commit => "${boringssl_commit}",
     }
 
-    s.ios.deployment_target = '7.0'
-    s.osx.deployment_target = '10.7'
+    s.ios.deployment_target = '9.0'
+    s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
     s.watchos.deployment_target = '4.0'
 

--- a/test/core/iomgr/ios/CFStreamTests/Podfile
+++ b/test/core/iomgr/ios/CFStreamTests/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/test/cpp/cocoapods/Podfile
+++ b/test/cpp/cocoapods/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/test/cpp/ios/Podfile
+++ b/test/cpp/ios/Podfile
@@ -7,7 +7,7 @@ GRPC_LOCAL_SRC = '../../..'
 
 
 target 'CronetTests' do
-  platform :ios, '8.0'
+  platform :ios, '9.0'
   pod 'Protobuf', :path => "#{GRPC_LOCAL_SRC}/third_party/protobuf", :inhibit_warnings => true
 
   pod '!ProtoCompiler',            :path => "#{GRPC_LOCAL_SRC}/src/objective-c"

--- a/test/cpp/ios/RemoteTestClientCpp/RemoteTestCpp.podspec
+++ b/test/cpp/ios/RemoteTestClientCpp/RemoteTestCpp.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "RemoteTest example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = '7.1'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
 
   # Run protoc with the C++ and gRPC plugins to generate protocol messages and gRPC clients.
   s.dependency "!ProtoCompiler-gRPCCppPlugin"

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -144,10 +144,10 @@ elif "linux" in sys.platform or "darwin" in sys.platform:
 if 'darwin' in sys.platform and PY3:
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target and (pkg_resources.parse_version(mac_target) <
-                       pkg_resources.parse_version('10.9.0')):
-        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+                       pkg_resources.parse_version('10.10.0')):
+        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
         os.environ['_PYTHON_HOST_PLATFORM'] = re.sub(
-            r'macosx-[0-9]+\.[0-9]+-(.+)', r'macosx-10.9-\1',
+            r'macosx-[0-9]+\.[0-9]+-(.+)', r'macosx-10.10-\1',
             util.get_platform())
 
 


### PR DESCRIPTION
Supported platform changes:
- iOS 9 or later (from 7)
- OS 10.10 or later (from 10.9)

This is a prerequisite for #24247 and this PR can be merged after the 1.33 release cut (Oct 6)