### PR TITLE
Allow asyncio API to be imported as grpc.aio

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -2125,5 +2125,5 @@ except ImportError:
     pass
 
 if sys.version_info >= (3, 6):
-    from grpc import aio
+    from grpc import aio  # pylint: disable=ungrouped-imports
     sys.modules.update({'grpc.aio': aio})

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -2123,3 +2123,7 @@ try:
     sys.modules.update({'grpc.reflection': grpc_reflection})
 except ImportError:
     pass
+
+if sys.version_info >= (3, 6):
+    from grpc import aio
+    sys.modules.update({'grpc.aio': aio})

--- a/src/python/grpcio/grpc/aio/__init__.py
+++ b/src/python/grpcio/grpc/aio/__init__.py
@@ -17,6 +17,7 @@ gRPC Async API objects may only be used on the thread on which they were
 created. AsyncIO doesn't provide thread safety for most of its APIs.
 """
 
+import sys
 from typing import Any, Optional, Sequence, Tuple
 
 import grpc

--- a/src/python/grpcio/grpc/aio/__init__.py
+++ b/src/python/grpcio/grpc/aio/__init__.py
@@ -17,7 +17,6 @@ gRPC Async API objects may only be used on the thread on which they were
 created. AsyncIO doesn't provide thread safety for most of its APIs.
 """
 
-import sys
 from typing import Any, Optional, Sequence, Tuple
 
 import grpc

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -28,7 +28,7 @@
   "unit.connectivity_test.TestConnectivityState",
   "unit.context_peer_test.TestContextPeer",
   "unit.done_callback_test.TestDoneCallback",
-  "unit.init_test.TestChannel",
+  "unit.init_test.TestInit",
   "unit.metadata_test.TestMetadata",
   "unit.outside_init_test.TestOutsideInit",
   "unit.secure_call_test.TestStreamStreamSecureCall",

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -14,16 +14,25 @@
 import logging
 import unittest
 
-import grpc
-
 from tests_aio.unit._test_base import AioTestBase
 
 
 class TestInit(AioTestBase):
 
-    async def test_grpc_dot_aio(self):
+    async def test_grpc(self):
+        import grpc  # pylint: disable=wrong-import-position
         channel = grpc.aio.insecure_channel('dummy')
         self.assertIsInstance(channel, grpc.aio.Channel)
+
+    async def test_grpc_dot_aio(self):
+        import grpc.aio  # pylint: disable=wrong-import-position
+        channel = grpc.aio.insecure_channel('dummy')
+        self.assertIsInstance(channel, grpc.aio.Channel)
+
+    async def test_aio_from_grpc(self):
+        from grpc import aio  # pylint: disable=wrong-import-position
+        channel = aio.insecure_channel('dummy')
+        self.assertIsInstance(channel, aio.Channel)
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -16,35 +16,14 @@ import unittest
 
 import grpc
 
-from grpc.experimental import aio
-from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
 
-from tests.unit import resources
 
-_PRIVATE_KEY = resources.private_key()
-_CERTIFICATE_CHAIN = resources.certificate_chain()
-_TEST_ROOT_CERTIFICATES = resources.test_root_certificates()
+class TestInit(AioTestBase):
 
-
-class TestChannel(AioTestBase):
-
-    async def test_insecure_channel(self):
-        server_target, _ = await start_test_server()  # pylint: disable=unused-variable
-
-        channel = aio.insecure_channel(server_target)
-        self.assertIsInstance(channel, aio.Channel)
-
-    async def test_secure_channel(self):
-        server_target, _ = await start_test_server(secure=True)  # pylint: disable=unused-variable
-        credentials = grpc.ssl_channel_credentials(
-            root_certificates=_TEST_ROOT_CERTIFICATES,
-            private_key=_PRIVATE_KEY,
-            certificate_chain=_CERTIFICATE_CHAIN,
-        )
-        secure_channel = aio.secure_channel(server_target, credentials)
-
-        self.assertIsInstance(secure_channel, aio.Channel)
+    async def test_grpc_dot_aio(self):
+        channel = grpc.aio.insecure_channel('dummy')
+        self.assertIsInstance(channel, grpc.aio.Channel)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, gRPC AsyncIO API can only be accessed via `from grpc import aio`. This was because the asyncio API depends on the main package, and might create a cyclic dependency (it might not work well with our internal import magic).

This PR adds the functionality to import the aio module via `import grpc` or `import grpc.aio`.