### PR TITLE
Revert "PHP: replace php/php-dev to php7.2/php7.2-dev and delete php5 tests"

### DIFF
--- a/tools/dockerfile/distribtest/php_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/php_jessie_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 The gRPC Authors
+# Copyright 2015 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Config file for the internal CI (in protobuf text format)
+FROM debian:jessie
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 60
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.*"
-    regex: "github/grpc/reports/**"
-  }
-}
+RUN apt-get update && apt-get install -y php5 php5-dev php-pear wget
 
-env_vars {
-  key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux php --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
-}
+RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
+  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit

--- a/tools/gce/linux_kokoro_performance_worker_init.sh
+++ b/tools/gce/linux_kokoro_performance_worker_init.sh
@@ -161,7 +161,7 @@ ruby -v
 gem install bundler
 
 # PHP dependencies
-sudo apt-get install -y php7.2 php7.2-dev php-pear unzip zlib1g-dev
+sudo apt-get install -y php php-dev php-pear unzip zlib1g-dev
 sudo wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
     sudo mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
     sudo chmod +x /usr/local/bin/phpunit

--- a/tools/internal_ci/macos/grpc_basictests_php.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_php.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos php7 --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos php --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_php.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_php.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos php7 --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
+  value: "-f basictests macos php --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
 }

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -571,6 +571,46 @@ class RemoteNodeLanguage(object):
         return 'grpc-node'
 
 
+class PhpLanguage(object):
+
+    def configure(self, config, args):
+        self.config = config
+        self.args = args
+        _check_compiler(self.args.compiler, ['default'])
+        self._make_options = ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true']
+
+    def test_specs(self):
+        return [
+            self.config.job_spec(['src/php/bin/run_tests.sh'],
+                                 environ=_FORCE_ENVIRON_FOR_WRAPPERS)
+        ]
+
+    def pre_build_steps(self):
+        return []
+
+    def make_targets(self):
+        return ['static_c', 'shared_c']
+
+    def make_options(self):
+        return self._make_options
+
+    def build_steps(self):
+        return [['tools/run_tests/helper_scripts/build_php.sh']]
+
+    def post_tests_steps(self):
+        return [['tools/run_tests/helper_scripts/post_tests_php.sh']]
+
+    def makefile_name(self):
+        return 'Makefile'
+
+    def dockerfile_dir(self):
+        return 'tools/dockerfile/test/php_jessie_%s' % _docker_arch_suffix(
+            self.args.arch)
+
+    def __str__(self):
+        return 'php'
+
+
 class Php7Language(object):
 
     def configure(self, config, args):
@@ -1248,6 +1288,7 @@ _LANGUAGES = {
     'c++': CLanguage('cxx', 'c++'),
     'c': CLanguage('c', 'c'),
     'grpc-node': RemoteNodeLanguage(),
+    'php': PhpLanguage(),
     'php7': Php7Language(),
     'python': PythonLanguage(),
     'ruby': RubyLanguage(),

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -180,6 +180,15 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
                                 ['--report_multi_target'],
                                 inner_jobs=inner_jobs)
 
+    # supported on linux only
+    test_jobs += _generate_jobs(languages=['php7'],
+                                configs=['dbg', 'opt'],
+                                platforms=['linux'],
+                                labels=['basictests', 'multilang'],
+                                extra_args=extra_args +
+                                ['--report_multi_target'],
+                                inner_jobs=inner_jobs)
+
     # supported on all platforms.
     test_jobs += _generate_jobs(
         languages=['c'],
@@ -230,7 +239,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         inner_jobs=inner_jobs,
         timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
-    test_jobs += _generate_jobs(languages=['grpc-node', 'ruby', 'php7'],
+    test_jobs += _generate_jobs(languages=['grpc-node', 'ruby', 'php'],
                                 configs=['dbg', 'opt'],
                                 platforms=['linux', 'macos'],
                                 labels=['basictests', 'multilang'],


### PR DESCRIPTION
Reverts grpc/grpc#24085 because of the test failure on tasks.distribtest.php_linux_x64_jessie.