### PR TITLE
Remove uses of PIPE in Fork Interop Tests

### DIFF
--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -79,7 +79,14 @@ class ForkInteropTest(unittest.TestCase):
                                 self._server_process.kill)
         try:
             timer.start()
-            self._port = int(self._server_process.stdout.readline())
+            while True:
+                streams[0].seek(0)
+                s = streams[0].readline()
+                if not s:
+                    continue
+                else:
+                    self._port = int(s)
+                    break
         except ValueError:
             raise Exception('Failed to get port from server')
         finally:

--- a/src/python/grpcio_tests/tests/fork/methods.py
+++ b/src/python/grpcio_tests/tests/fork/methods.py
@@ -142,7 +142,8 @@ class _ChildProcess(object):
                              self._process.exitcode)
         try:
             exception = self._exceptions.get(block=False)
-            raise ValueError('Child process failed: %s' % exception)
+            raise ValueError('Child process failed: "%s": "%s"' %
+                             (repr(exception), exception))
         except queue.Empty:
             pass
 


### PR DESCRIPTION
We've seen several instances of the fork interop tests timing out in CI. The individual test case that times out is nondeterministic. I'm unable to reproduce these failures, locally, so this PR is only a prospective fix. `subprocess.PIPE` can cause deadlocks if too much is logged to either STDOUT/STDERR, which is not deterministic, since Core may log anything at any time. However, it's unlikely that Core is logging much of anything unless there's some other error. I think it's likely that there will have to be another PR after this to follow up with the ultimate fix.