### PR TITLE
Remove C++ default generation of preserialized request call

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -604,10 +604,6 @@ void PrintHeaderClientMethodCallbackInterfaces(
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
                    "std::function<void(::grpc::Status)>) = 0;\n");
-    printer->Print(*vars,
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "const ::grpc::ByteBuffer* request, $Response$* response, "
-                   "std::function<void(::grpc::Status)>) = 0;\n");
     // TODO(vjpai): Remove experimental versions and macros when callback API is
     //              fully de-experimentalized.
     printer->Print(*vars,
@@ -618,16 +614,6 @@ void PrintHeaderClientMethodCallbackInterfaces(
                    "#else\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
-                   "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n"
-                   "#endif\n");
-    printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "const ::grpc::ByteBuffer* request, $Response$* response, "
-                   "::grpc::ClientUnaryReactor* reactor) = 0;\n"
-                   "#else\n"
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "const ::grpc::ByteBuffer* request, $Response$* response, "
                    "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n"
                    "#endif\n");
   } else if (ClientOnlyStreaming(method)) {
@@ -716,10 +702,6 @@ void PrintHeaderClientMethodCallback(grpc_generator::Printer* printer,
                    "void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
                    "std::function<void(::grpc::Status)>) override;\n");
-    printer->Print(*vars,
-                   "void $Method$(::grpc::ClientContext* context, "
-                   "const ::grpc::ByteBuffer* request, $Response$* response, "
-                   "std::function<void(::grpc::Status)>) override;\n");
     printer->Print(
         *vars,
         "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
@@ -729,17 +711,6 @@ void PrintHeaderClientMethodCallback(grpc_generator::Printer* printer,
         "#else\n"
         "void $Method$(::grpc::ClientContext* context, "
         "const $Request$* request, $Response$* response, "
-        "::grpc::experimental::ClientUnaryReactor* reactor) override;\n"
-        "#endif\n");
-    printer->Print(
-        *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "void $Method$(::grpc::ClientContext* context, "
-        "const ::grpc::ByteBuffer* request, $Response$* response, "
-        "::grpc::ClientUnaryReactor* reactor) override;\n"
-        "#else\n"
-        "void $Method$(::grpc::ClientContext* context, "
-        "const ::grpc::ByteBuffer* request, $Response$* response, "
         "::grpc::experimental::ClientUnaryReactor* reactor) override;\n"
         "#endif\n");
   } else if (ClientOnlyStreaming(method)) {
@@ -1932,27 +1903,7 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
     printer->Print(*vars,
                    "void $ns$$Service$::Stub::experimental_async::$Method$("
                    "::grpc::ClientContext* context, "
-                   "const ::grpc::ByteBuffer* request, $Response$* response, "
-                   "std::function<void(::grpc::Status)> f) {\n");
-    printer->Print(*vars,
-                   "  ::grpc::internal::CallbackUnaryCall"
-                   "(stub_->channel_.get(), stub_->rpcmethod_$Method$_, "
-                   "context, request, response, std::move(f));\n}\n\n");
-
-    printer->Print(*vars,
-                   "void $ns$$Service$::Stub::experimental_async::$Method$("
-                   "::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
-                   "::grpc::experimental::ClientUnaryReactor* reactor) {\n");
-    printer->Print(*vars,
-                   "  ::grpc::internal::ClientCallbackUnaryFactory::Create"
-                   "(stub_->channel_.get(), stub_->rpcmethod_$Method$_, "
-                   "context, request, response, reactor);\n}\n\n");
-
-    printer->Print(*vars,
-                   "void $ns$$Service$::Stub::experimental_async::$Method$("
-                   "::grpc::ClientContext* context, "
-                   "const ::grpc::ByteBuffer* request, $Response$* response, "
                    "::grpc::experimental::ClientUnaryReactor* reactor) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::ClientCallbackUnaryFactory::Create"

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -112,16 +112,10 @@ class ServiceA final {
       virtual ~experimental_async_interface() {}
       // MethodA1 leading comment 1
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       #else
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      #else
-      virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
       // MethodA1 trailing comment 1
       // MethodA2 detached leading comment 1
@@ -210,16 +204,10 @@ class ServiceA final {
       public StubInterface::experimental_async_interface {
      public:
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
-      void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
       #else
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
-      #else
-      void MethodA1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::ClientWriteReactor< ::grpc::testing::Request>* reactor) override;
@@ -914,16 +902,10 @@ class ServiceB final {
       virtual ~experimental_async_interface() {}
       // MethodB1 leading comment 1
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       #else
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      #else
-      virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
       // MethodB1 trailing comment 1
     };
@@ -952,16 +934,10 @@ class ServiceB final {
       public StubInterface::experimental_async_interface {
      public:
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
-      void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
       #else
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
-      #else
-      void MethodB1(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
      private:
       friend class Stub;


### PR DESCRIPTION
Unary calls using a preserialized request can be an optimization for fan-out clients, but it is an uncommonly used feature. In fact, we have no known users of this experimental feature at the current time. Producing these for every RPC is increasing code size by about 3K for each RPC, which adds up if your proto includes lots of RPCs. We should provide this feature when needed using a more efficient mechanism rather than blowing up the generated code.
