### PR TITLE
Revert "Revert "Allow asyncio API to be imported as grpc.aio""

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -2124,7 +2124,7 @@ try:
 except ImportError:
     pass
 
-# The package check is necessary to prevent import order issue in cyclic import.
-if sys.version_info >= (3, 6) and __package__ == "grpc":
+# Prevents import order issue in the case of renamed path.
+if sys.version_info >= (3, 6) and __name__ == "grpc.__init__":
     from grpc import aio  # pylint: disable=ungrouped-imports
     sys.modules.update({'grpc.aio': aio})

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -2124,6 +2124,7 @@ try:
 except ImportError:
     pass
 
-if sys.version_info >= (3, 6):
+# The package check is necessary to prevent import order issue in cyclic import.
+if sys.version_info >= (3, 6) and __package__ == "grpc":
     from grpc import aio  # pylint: disable=ungrouped-imports
     sys.modules.update({'grpc.aio': aio})

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -2123,3 +2123,7 @@ try:
     sys.modules.update({'grpc.reflection': grpc_reflection})
 except ImportError:
     pass
+
+if sys.version_info >= (3, 6):
+    from grpc import aio  # pylint: disable=ungrouped-imports
+    sys.modules.update({'grpc.aio': aio})

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -28,7 +28,7 @@
   "unit.connectivity_test.TestConnectivityState",
   "unit.context_peer_test.TestContextPeer",
   "unit.done_callback_test.TestDoneCallback",
-  "unit.init_test.TestChannel",
+  "unit.init_test.TestInit",
   "unit.metadata_test.TestMetadata",
   "unit.outside_init_test.TestOutsideInit",
   "unit.secure_call_test.TestStreamStreamSecureCall",

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -29,11 +29,6 @@ class TestInit(AioTestBase):
         channel = grpc.aio.insecure_channel('dummy')
         self.assertIsInstance(channel, grpc.aio.Channel)
 
-    async def test_aio_from_grpc(self):
-        from grpc import aio  # pylint: disable=wrong-import-position
-        channel = aio.insecure_channel('dummy')
-        self.assertIsInstance(channel, aio.Channel)
-
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -14,37 +14,25 @@
 import logging
 import unittest
 
-import grpc
-
-from grpc.experimental import aio
-from tests_aio.unit._test_server import start_test_server
 from tests_aio.unit._test_base import AioTestBase
 
-from tests.unit import resources
 
-_PRIVATE_KEY = resources.private_key()
-_CERTIFICATE_CHAIN = resources.certificate_chain()
-_TEST_ROOT_CERTIFICATES = resources.test_root_certificates()
+class TestInit(AioTestBase):
 
+    async def test_grpc(self):
+        import grpc  # pylint: disable=wrong-import-position
+        channel = grpc.aio.insecure_channel('dummy')
+        self.assertIsInstance(channel, grpc.aio.Channel)
 
-class TestChannel(AioTestBase):
+    async def test_grpc_dot_aio(self):
+        import grpc.aio  # pylint: disable=wrong-import-position
+        channel = grpc.aio.insecure_channel('dummy')
+        self.assertIsInstance(channel, grpc.aio.Channel)
 
-    async def test_insecure_channel(self):
-        server_target, _ = await start_test_server()  # pylint: disable=unused-variable
-
-        channel = aio.insecure_channel(server_target)
+    async def test_aio_from_grpc(self):
+        from grpc import aio  # pylint: disable=wrong-import-position
+        channel = aio.insecure_channel('dummy')
         self.assertIsInstance(channel, aio.Channel)
-
-    async def test_secure_channel(self):
-        server_target, _ = await start_test_server(secure=True)  # pylint: disable=unused-variable
-        credentials = grpc.ssl_channel_credentials(
-            root_certificates=_TEST_ROOT_CERTIFICATES,
-            private_key=_PRIVATE_KEY,
-            certificate_chain=_CERTIFICATE_CHAIN,
-        )
-        secure_channel = aio.secure_channel(server_target, credentials)
-
-        self.assertIsInstance(secure_channel, aio.Channel)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reverts grpc/grpc#24337

* Applied the fix suggested by Richard to prevent the import order issue if the gRPC module is in a cyclic import and the import path is renamed.
* Also, removed the test case that executes "from grpc import aio", so the unit tests should cover the importing name "grpc.aio" correctly.

Internally, the OSS gRPC module is renamed to "_open_source_grpc", and will be imported in 2 steps: the import hack, the actual import. Checking package name works in this case.

If we use open source mode internally, the OSS gRPC module name stays "grpc", but still it will be imported in 2 steps: a no-op import, the actual import. The tests failed because the "aio" module tried to initiate itself after the "no-op" import and found "grpc" module to be empty.

So, the (brutal-force) solution is to check the file name to ensure when the import hack happened, don't import "aio" module in this file. The import of "aio" module will happen in the magical `__init__.py` ([cl/335754366](http://cl/335754366)).