### PR TITLE
Modify podfile of CFStreamTests.

### DIFF
--- a/test/core/iomgr/ios/CFStreamTests/Podfile
+++ b/test/core/iomgr/ios/CFStreamTests/Podfile
@@ -8,7 +8,7 @@ GRPC_LOCAL_SRC = '../../../../..'
 
 # Install the dependencies in the main target plus all test targets.
 target 'CFStreamTests' do
-  pod 'gRPC-Core/CFStream-Implementation', :path => GRPC_LOCAL_SRC
+  pod 'gRPC-Core', :path => GRPC_LOCAL_SRC
   pod 'BoringSSL-GRPC', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
 end
 


### PR DESCRIPTION
`CFStreamTests` imports `gRPC-Core/CFStream-Implementation` which  depends on `gRPC-Core/Interface` indirectly. Looking into recent flaky `ios-test-cfstream-tests`, looks like only source files in `gRPC-Core/Interface` can not be found sometimes, I guess it because Cocoapods doesn't fetch `gRPC-Core/Interface` successfully sometime, so I'm trying to import `gRPC-Core` directly instead of `gRPC-Core/CFStream-Implementation` and see if it can improve the test.