### PR TITLE
Replace grpc_shutdown_blocking with grpc_shutdown

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -86,8 +86,7 @@ GRPCAPI void grpc_shutdown(void);
     https://github.com/grpc/grpc/issues/15334 */
 GRPCAPI int grpc_is_initialized(void);
 
-/** EXPERIMENTAL. Blocking shut down grpc library.
-    This is only for wrapped language to use now. */
+/** DEPRECATED. Recommend to use grpc_shutdown only */
 GRPCAPI void grpc_shutdown_blocking(void);
 
 /** Return a string representing the current version of grpc */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -191,7 +191,7 @@ void postfork_child() {
   grpc_php_shutdown_completion_queue(TSRMLS_C);
 
   // clean-up grpc_core
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   if (grpc_is_initialized() > 0) {
     zend_throw_exception(spl_ce_UnexpectedValueException,
                          "Oops, failed to shutdown gRPC Core after fork()",
@@ -567,7 +567,7 @@ PHP_MSHUTDOWN_FUNCTION(grpc) {
     zend_hash_destroy(&grpc_target_upper_bound_map);
     grpc_shutdown_timeval(TSRMLS_C);
     grpc_php_shutdown_completion_queue(TSRMLS_C);
-    grpc_shutdown_blocking();
+    grpc_shutdown();
     GRPC_G(initialized) = 0;
   }
   return SUCCESS;

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -153,7 +153,7 @@ int main(int argc, char** argv) {
   for (i = 3; i <= 4; i++) {
     grpc_init();
     run_test(args[2], i);
-    grpc_shutdown_blocking();
+    grpc_shutdown();
   }
 
   gpr_subprocess_interrupt(svr);

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -332,7 +332,7 @@ int main(int argc, char** argv) {
 
   test_cooldown();
 
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   GPR_ASSERT(g_all_callbacks_invoked);
   return 0;
 }

--- a/test/core/compression/message_compress_fuzzer.cc
+++ b/test/core/compression/message_compress_fuzzer.cc
@@ -51,6 +51,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   grpc_slice_buffer_destroy(&input_buffer);
   grpc_slice_buffer_destroy(&output_buffer);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/compression/message_decompress_fuzzer.cc
+++ b/test/core/compression/message_decompress_fuzzer.cc
@@ -51,6 +51,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   grpc_slice_buffer_destroy(&input_buffer);
   grpc_slice_buffer_destroy(&output_buffer);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/compression/stream_compression_fuzzer.cc
+++ b/test/core/compression/stream_compression_fuzzer.cc
@@ -47,6 +47,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   grpc_stream_compression_context_destroy(context);
   grpc_slice_buffer_destroy(&input_buffer);
   grpc_slice_buffer_destroy(&output_buffer);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/compression/stream_decompression_fuzzer.cc
+++ b/test/core/compression/stream_decompression_fuzzer.cc
@@ -48,6 +48,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   grpc_stream_compression_context_destroy(context);
   grpc_slice_buffer_destroy(&input_buffer);
   grpc_slice_buffer_destroy(&output_buffer);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -156,6 +156,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       grpc_byte_buffer_destroy(response_payload_recv);
     }
   }
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/handshake/readahead_handshaker_server_ssl.cc
+++ b/test/core/handshake/readahead_handshaker_server_ssl.cc
@@ -84,6 +84,6 @@ int main(int /*argc*/, char* /*argv*/[]) {
       absl::make_unique<ReadAheadHandshakerFactory>());
   const char* full_alpn_list[] = {"grpc-exp", "h2"};
   GPR_ASSERT(server_ssl_test(full_alpn_list, 2, "grpc-exp"));
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -122,6 +122,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     grpc_core::ExecCtx::Get()->Flush();
   }
 
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/slice/b64_decode_fuzzer.cc
+++ b/test/core/slice/b64_decode_fuzzer.cc
@@ -33,6 +33,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   grpc_slice res = grpc_base64_decode_with_len(
       reinterpret_cast<const char*>(data + 1), size - 1, url_safe);
   grpc_slice_unref(res);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/slice/percent_decode_fuzzer.cc
+++ b/test/core/slice/percent_decode_fuzzer.cc
@@ -43,6 +43,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
   grpc_slice_unref(grpc_permissive_percent_decode_slice(input));
   grpc_slice_unref(input);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   return 0;
 }

--- a/test/core/slice/percent_encode_fuzzer.cc
+++ b/test/core/slice/percent_encode_fuzzer.cc
@@ -46,7 +46,7 @@ static void test(const uint8_t* data, size_t size, const uint8_t* dict) {
   grpc_slice_unref(output);
   grpc_slice_unref(decoded_output);
   grpc_slice_unref(permissive_decoded_output);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {

--- a/test/core/util/fuzzer_corpus_test.cc
+++ b/test/core/util/fuzzer_corpus_test.cc
@@ -65,7 +65,7 @@ TEST_P(FuzzerCorpusTest, RunOneExample) {
   void* data = gpr_malloc(length);
   memcpy(data, GPR_SLICE_START_PTR(buffer), length);
   grpc_slice_unref(buffer);
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   LLVMFuzzerTestOneInput(static_cast<uint8_t*>(data), length);
   gpr_free(data);
 }

--- a/test/core/util/port.cc
+++ b/test/core/util/port.cc
@@ -73,7 +73,7 @@ static void free_chosen_ports(void) {
   for (i = 0; i < num_chosen_ports; i++) {
     grpc_free_port_using_server(chosen_ports[i]);
   }
-  grpc_shutdown_blocking();
+  grpc_shutdown();
   gpr_free(chosen_ports);
 }
 

--- a/test/cpp/common/time_jump_test.cc
+++ b/test/cpp/common/time_jump_test.cc
@@ -70,7 +70,7 @@ class TimeJumpTest : public ::testing::TestWithParam<std::string> {
     // Skip test if slowdown factor > 1
     if (grpc_test_slowdown_factor() == 1) {
       run_cmd("sudo sntp -sS pool.ntp.org");
-      grpc_shutdown_blocking();
+      grpc_shutdown();
     }
   }
 

--- a/test/cpp/common/timer_test.cc
+++ b/test/cpp/common/timer_test.cc
@@ -56,7 +56,7 @@ class TimerTest : public ::testing::Test {
     }
   }
 
-  void TearDown() override { grpc_shutdown_blocking(); }
+  void TearDown() override { grpc_shutdown(); }
 
   bool do_not_test_{false};
 };

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -246,7 +246,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
     }
     servers_.clear();
     creds_.reset();
-    grpc_shutdown_blocking();
+    grpc_shutdown();
   }
 
   void CreateServers(size_t num_servers,
@@ -1659,7 +1659,7 @@ class ClientLbPickArgsTest : public ClientLbEnd2endTest {
     grpc_core::RegisterTestPickArgsLoadBalancingPolicy(SavePickArgs);
   }
 
-  static void TearDownTestCase() { grpc_shutdown_blocking(); }
+  static void TearDownTestCase() { grpc_shutdown(); }
 
   const std::vector<grpc_core::PickArgsSeen>& args_seen_list() {
     grpc::internal::MutexLock lock(&mu_);
@@ -1725,7 +1725,7 @@ class ClientLbInterceptTrailingMetadataTest : public ClientLbEnd2endTest {
         ReportTrailerIntercepted);
   }
 
-  static void TearDownTestCase() { grpc_shutdown_blocking(); }
+  static void TearDownTestCase() { grpc_shutdown(); }
 
   int trailers_intercepted() {
     grpc::internal::MutexLock lock(&mu_);
@@ -1930,7 +1930,7 @@ class ClientLbAddressTest : public ClientLbEnd2endTest {
     grpc_core::RegisterAddressTestLoadBalancingPolicy(SaveAddress);
   }
 
-  static void TearDownTestCase() { grpc_shutdown_blocking(); }
+  static void TearDownTestCase() { grpc_shutdown(); }
 
   const std::vector<std::string>& addresses_seen() {
     grpc::internal::MutexLock lock(&mu_);

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -143,7 +143,7 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
     stub_.reset();
     servers_.clear();
     creds_.reset();
-    grpc_shutdown_blocking();
+    grpc_shutdown();
   }
 
   void CreateServers(size_t num_servers,

--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -191,7 +191,7 @@ void VerifyLbAddrOutputs(const grpc_core::ServerAddressList& addresses,
 class AddressSortingTest : public ::testing::Test {
  protected:
   void SetUp() override { grpc_init(); }
-  void TearDown() override { grpc_shutdown_blocking(); }
+  void TearDown() override { grpc_shutdown(); }
 };
 
 /* Tests for rule 1 */


### PR DESCRIPTION
Let's remove it because `grpc_shutdown` now can execute synchronously if it's possible. `grpc_shutdown_blocking` can be harmful when it's executed under the event thread, which can lead a deadlock.