### PR TITLE
use e2 instances in GCE creation scripts

### DIFF
--- a/tools/gce/create_linux_kokoro_performance_worker.sh
+++ b/tools/gce/create_linux_kokoro_performance_worker.sh
@@ -30,7 +30,7 @@ CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-b  # this zone allows 32core machines
 
 INSTANCE_NAME="${1:-grpc-kokoro-performance-server1}"
-MACHINE_TYPE=n1-standard-32
+MACHINE_TYPE=e2-standard-32
 
 gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \

--- a/tools/gce/create_linux_kokoro_performance_worker_from_image.sh
+++ b/tools/gce/create_linux_kokoro_performance_worker_from_image.sh
@@ -25,7 +25,7 @@ ZONE=us-central1-b  # this zone allows 32core machines
 LATEST_PERF_WORKER_IMAGE=grpc-performance-kokoro-v5  # update if newer image exists
 
 INSTANCE_NAME="${1:-grpc-kokoro-performance-server}"
-MACHINE_TYPE="${2:-n1-standard-32}"
+MACHINE_TYPE="${2:-e2-standard-32}"
 
 gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \

--- a/tools/gce/create_windows_debug_worker.sh
+++ b/tools/gce/create_windows_debug_worker.sh
@@ -31,7 +31,7 @@ else
   INSTANCE_NAME="${USER}-windows-kokoro-debug1"
 fi
 
-MACHINE_TYPE=n1-standard-8
+MACHINE_TYPE=e2-standard-8
 TMP_DISK_NAME="$INSTANCE_NAME-temp-disk"
 
 gcloud compute disks create "$TMP_DISK_NAME" \


### PR DESCRIPTION
Update GCE VM creating script with the desired machine type (e2 is more efficient than n1). This doesn't affect existing VMs, but prevents folks from creating new n1 instances by accident in the future.
