### PR TITLE
RBE: rely on labels to select the right worker pool (instead of hardcoding GCE machine types)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,10 @@ custom_exec_properties(
             # manually (see create_exec_properties_dict logic for how labels get transformed)
             # Remove this workaround once we transition to a new-enough bazel toolchain.
             # The next line corresponds to 'labels = {"os": "ubuntu", "machine_size": "large"}'
-            {"label:os": "ubuntu", "label:machine_size": "large"}
+            {
+                "label:os": "ubuntu",
+                "label:machine_size": "large",
+            },
         ),
     },
 )
@@ -55,7 +58,10 @@ rbe_autoconfig(
         # manually (see create_exec_properties_dict logic for how labels get transformed)
         # Remove this workaround once we transition to a new-enough bazel toolchain.
         # The next line corresponds to 'labels = {"os": "ubuntu", "machine_size": "small"}'
-        {"label:os": "ubuntu", "label:machine_size": "small"}
+        {
+            "label:os": "ubuntu",
+            "label:machine_size": "small",
+        },
     ),
     # use exec_properties instead of deprecated remote_execution_properties
     use_legacy_platform_definition = False,

--- a/third_party/toolchains/BUILD
+++ b/third_party/toolchains/BUILD
@@ -16,7 +16,7 @@ licenses(["notice"])  # Apache v2
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_exec_properties_dict")
+load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_exec_properties_dict", "merge_dicts")
 
 alias(
     name = "rbe_windows",
@@ -30,14 +30,19 @@ platform(
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:windows",
     ],
-    exec_properties = create_exec_properties_dict(
-        # See rbe_win2019/Dockerfile for image details
-        container_image = "docker://gcr.io/grpc-testing/rbe_windows2019_withdbg_toolchain@sha256:7b04ee7e29f942adbf4f70edd2ec4ba20a3e7237e1b54f5cae4b239c6ca41105",
-        
-        # Use a different machine type than used on linux to avoid accidentally scheduling linux jobs on windows workers and vice versa on older release branches
-        gce_machine_type = "n1-standard-2",
-        os_family = "Windows",
-        # labels only supported starting from https://github.com/bazelbuild/bazel-toolchains/pull/748
-        #labels = {"os": "windows_2019"},
+    exec_properties = merge_dicts(
+        create_exec_properties_dict(
+            # See rbe_win2019/Dockerfile for image details
+            container_image = "docker://gcr.io/grpc-testing/rbe_windows2019_withdbg_toolchain@sha256:7b04ee7e29f942adbf4f70edd2ec4ba20a3e7237e1b54f5cae4b239c6ca41105",
+            os_family = "Windows",
+        ),
+        # TODO(jtattermusch): specifying 'labels = {"abc": "xyz"}' in create_exec_properties_dict
+        # is not possible without https://github.com/bazelbuild/bazel-toolchains/pull/748
+        # and currently the toolchain we're using is too old for that. To be able to select worker
+        # pools through labels, we use a workaround and populate the corresponding label values
+        # manually (see create_exec_properties_dict logic for how labels get transformed)
+        # Remove this workaround once we transition to a new-enough bazel toolchain.
+        # The next line corresponds to 'labels = {"os": "windows_2019", "machine_size": "small"}'
+        {"label:os": "windows_2019", "label:machine_size": "small"}
     ),
 )


### PR DESCRIPTION
Motivation: we want to switch our RBE worker pools from n1 instances to e2 instances. The problem is that currently our RBE configuration relies on hardcoded machine types (e.g. `n1-standard-8`) to determine on which worker pool should a given test run (there are 2 linux pools, one with 8core "large" machines and one with 2core "small" machines; there is also a windows pool. Tests need to run on the right pools to avoid unexpected failures.

Challenges:
- currently our bazel toolchain we're using is too old to understand the concept of RBE worker pool labels (and we cannot upgrade our toolchain right now for unrelated reason and even if we could, we could not easily backport that to older release branches).
- we need a solution that is non-intrusive enough so we can backport it to older release branches if needed (remember that the older branches have the machine types "n1-standard-8" etc hardcoded in them so if we migrate our existing pools to e2, they will suddenly break).

This PR represents an approach that seems to work and that would allow us to switch our existing worker pools to e2 instances seamlessly without breaking the world (and it can be backported to older branches as needed).