### PR TITLE
Fix undefined behavior when Python plugin is given no args

### DIFF
--- a/src/compiler/python_generator_helpers.h
+++ b/src/compiler/python_generator_helpers.h
@@ -138,11 +138,20 @@ StringVector get_all_comments(const DescriptorType* descriptor) {
 
 inline void Split(const std::string& s, char delim,
                   std::vector<std::string>* append_to) {
-  auto current = s.begin();
-  while (current <= s.end()) {
-    auto next = std::find(current, s.end(), delim);
-    append_to->emplace_back(current, next);
-    current = next + 1;
+  if (s.empty()) {
+    // splitting an empty string logically produces a single-element list
+    append_to->emplace_back();
+  } else {
+    auto current = s.begin();
+    while (current < s.end()) {
+      const auto next = std::find(current, s.end(), delim);
+      append_to->emplace_back(current, next);
+      current = next;
+      if (current != s.end()) {
+        // it was the delimiter - need to be at the start of the next entry
+        ++current;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Split() was incrementing the iterator past the end iterator when given
an empty string, which is undefined behaviour, and triggered an assert
when compiled with debug iterators in MSVC.

Fixes #22431

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
