### PR TITLE
Rebuild manylinux images to include python 3.9

### DIFF
--- a/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC artifacts.
-# Updated: 2020-06-16
+# Updated: 2020-10-08
 
 ##################
 # Base

--- a/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC artifacts.
-# Updated: 2020-06-16
+# Updated: 2020-10-08
 
 ##################
 # Base

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC manylinux Python artifacts.
-# Updated: 2020-06-25
+# Updated: 2020-10-08
 
 FROM quay.io/pypa/manylinux2010_x86_64
 

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC manylinux Python artifacts.
-# Updated: 2020-06-25
+# Updated: 2020-10-08
 
 FROM quay.io/pypa/manylinux2010_i686
 

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_x64/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC manylinux Python artifacts.
-# Updated: 2020-06-25
+# Updated: 2020-10-08
 
 FROM quay.io/pypa/manylinux2014_x86_64
 

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_x86/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC manylinux Python artifacts.
-# Updated: 2020-06-25
+# Updated: 2020-10-08
 
 FROM quay.io/pypa/manylinux2014_i686
 


### PR DESCRIPTION
Python 3.9 just released so python docker images need to update to support 3.9. `artifact_targets.py` needs a change to have actually new artifacts for Python 3.9, though.