### PR TITLE
Improve ref-count tracing.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -894,7 +894,10 @@ class ChannelData::SubchannelWrapper : public SubchannelInterface {
  public:
   SubchannelWrapper(ChannelData* chand, Subchannel* subchannel,
                     grpc_core::UniquePtr<char> health_check_service_name)
-      : SubchannelInterface(&grpc_client_channel_routing_trace),
+      : SubchannelInterface(
+            GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)
+                ? "SubchannelWrapper"
+                : nullptr),
         chand_(chand),
         subchannel_(subchannel),
         health_check_service_name_(std::move(health_check_service_name)) {

--- a/src/core/ext/filters/client_channel/health/health_check_client.cc
+++ b/src/core/ext/filters/client_channel/health/health_check_client.cc
@@ -51,7 +51,10 @@ HealthCheckClient::HealthCheckClient(
     grpc_pollset_set* interested_parties,
     RefCountedPtr<channelz::SubchannelNode> channelz_node,
     RefCountedPtr<ConnectivityStateWatcherInterface> watcher)
-    : InternallyRefCounted<HealthCheckClient>(&grpc_health_check_client_trace),
+    : InternallyRefCounted<HealthCheckClient>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_health_check_client_trace)
+              ? "HealthCheckClient"
+              : nullptr),
       service_name_(service_name),
       connected_subchannel_(std::move(connected_subchannel)),
       interested_parties_(interested_parties),

--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -32,7 +32,11 @@ DebugOnlyTraceFlag grpc_trace_lb_policy_refcount(false, "lb_policy_refcount");
 //
 
 LoadBalancingPolicy::LoadBalancingPolicy(Args args, intptr_t initial_refcount)
-    : InternallyRefCounted(&grpc_trace_lb_policy_refcount, initial_refcount),
+    : InternallyRefCounted(
+          GRPC_TRACE_FLAG_ENABLED(grpc_trace_lb_policy_refcount)
+              ? "LoadBalancingPolicy"
+              : nullptr,
+          initial_refcount),
       work_serializer_(std::move(args.work_serializer)),
       interested_parties_(grpc_pollset_set_create()),
       channel_control_helper_(std::move(args.channel_control_helper)) {}

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -745,7 +745,9 @@ void GrpcLb::Helper::AddTraceEvent(TraceSeverity severity,
 
 GrpcLb::BalancerCallState::BalancerCallState(
     RefCountedPtr<LoadBalancingPolicy> parent_grpclb_policy)
-    : InternallyRefCounted<BalancerCallState>(&grpc_lb_glb_trace),
+    : InternallyRefCounted<BalancerCallState>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_lb_glb_trace) ? "BalancerCallState"
+                                                     : nullptr),
       grpclb_policy_(std::move(parent_grpclb_policy)) {
   GPR_ASSERT(grpclb_policy_ != nullptr);
   GPR_ASSERT(!grpclb_policy()->shutting_down_);

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -353,7 +353,8 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
     LoadBalancingPolicy* policy, TraceFlag* tracer, ServerAddressList addresses,
     LoadBalancingPolicy::ChannelControlHelper* helper,
     const grpc_channel_args& args)
-    : InternallyRefCounted<SubchannelListType>(tracer),
+    : InternallyRefCounted<SubchannelListType>(
+          GRPC_TRACE_FLAG_ENABLED(*tracer) ? "SubchannelList" : nullptr),
       policy_(policy),
       tracer_(tracer) {
   if (GRPC_TRACE_FLAG_ENABLED(*tracer_)) {

--- a/src/core/ext/filters/client_channel/resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver.cc
@@ -31,7 +31,9 @@ namespace grpc_core {
 
 Resolver::Resolver(std::shared_ptr<WorkSerializer> work_serializer,
                    std::unique_ptr<ResultHandler> result_handler)
-    : InternallyRefCounted(&grpc_trace_resolver_refcount),
+    : InternallyRefCounted(GRPC_TRACE_FLAG_ENABLED(grpc_trace_resolver_refcount)
+                               ? "Resolver"
+                               : nullptr),
       work_serializer_(std::move(work_serializer)),
       result_handler_(std::move(result_handler)) {}
 

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -87,7 +87,10 @@ DebugOnlyTraceFlag grpc_trace_subchannel_refcount(false, "subchannel_refcount");
 ConnectedSubchannel::ConnectedSubchannel(
     grpc_channel_stack* channel_stack, const grpc_channel_args* args,
     RefCountedPtr<channelz::SubchannelNode> channelz_subchannel)
-    : RefCounted<ConnectedSubchannel>(&grpc_trace_subchannel_refcount),
+    : RefCounted<ConnectedSubchannel>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_trace_subchannel_refcount)
+              ? "ConnectedSubchannel"
+              : nullptr),
       channel_stack_(channel_stack),
       args_(grpc_channel_args_copy(args)),
       channelz_subchannel_(std::move(channelz_subchannel)) {}

--- a/src/core/ext/filters/client_channel/subchannel_interface.h
+++ b/src/core/ext/filters/client_channel/subchannel_interface.h
@@ -46,9 +46,8 @@ class SubchannelInterface : public RefCounted<SubchannelInterface> {
     virtual grpc_pollset_set* interested_parties() = 0;
   };
 
-  template <typename TraceFlagT = TraceFlag>
-  explicit SubchannelInterface(TraceFlagT* trace_flag = nullptr)
-      : RefCounted<SubchannelInterface>(trace_flag) {}
+  explicit SubchannelInterface(const char* trace = nullptr)
+      : RefCounted<SubchannelInterface>(trace) {}
 
   virtual ~SubchannelInterface() = default;
 

--- a/src/core/ext/filters/client_channel/subchannel_pool_interface.h
+++ b/src/core/ext/filters/client_channel/subchannel_pool_interface.h
@@ -23,6 +23,7 @@
 
 #include "src/core/lib/avl/avl.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 
 namespace grpc_core {
@@ -62,7 +63,10 @@ class SubchannelKey {
 // shut down safely. See https://github.com/grpc/grpc/issues/12560.
 class SubchannelPoolInterface : public RefCounted<SubchannelPoolInterface> {
  public:
-  SubchannelPoolInterface() : RefCounted(&grpc_subchannel_pool_trace) {}
+  SubchannelPoolInterface()
+      : RefCounted(GRPC_TRACE_FLAG_ENABLED(grpc_subchannel_pool_trace)
+                       ? "SubchannelPoolInterface"
+                       : nullptr) {}
   virtual ~SubchannelPoolInterface() {}
 
   // Registers a subchannel against a key. Returns the subchannel registered

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -434,7 +434,9 @@ static void init_keepalive_pings_if_enabled(grpc_chttp2_transport* t) {
 grpc_chttp2_transport::grpc_chttp2_transport(
     const grpc_channel_args* channel_args, grpc_endpoint* ep, bool is_client,
     grpc_resource_user* resource_user)
-    : refs(1, &grpc_trace_chttp2_refcount),
+    : refs(1, GRPC_TRACE_FLAG_ENABLED(grpc_trace_chttp2_refcount)
+                  ? "chttp2_refcount"
+                  : nullptr),
       ep(ep),
       peer_string(grpc_endpoint_get_peer(ep)),
       resource_user(resource_user),

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -433,7 +433,9 @@ class XdsClient::ChannelState::StateWatcher
 
 XdsClient::ChannelState::ChannelState(WeakRefCountedPtr<XdsClient> xds_client,
                                       grpc_channel* channel)
-    : InternallyRefCounted<ChannelState>(&grpc_xds_client_trace),
+    : InternallyRefCounted<ChannelState>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace) ? "ChannelState"
+                                                         : nullptr),
       xds_client_(std::move(xds_client)),
       channel_(channel) {
   GPR_ASSERT(channel_ != nullptr);
@@ -634,7 +636,9 @@ void XdsClient::ChannelState::RetryableCall<T>::OnRetryTimerLocked(
 
 XdsClient::ChannelState::AdsCallState::AdsCallState(
     RefCountedPtr<RetryableCall<AdsCallState>> parent)
-    : InternallyRefCounted<AdsCallState>(&grpc_xds_client_trace),
+    : InternallyRefCounted<AdsCallState>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace) ? "AdsCallState"
+                                                         : nullptr),
       parent_(std::move(parent)) {
   // Init the ADS call. Note that the call will progress every time there's
   // activity in xds_client()->interested_parties_, which is comprised of
@@ -1385,7 +1389,9 @@ bool XdsClient::ChannelState::LrsCallState::Reporter::OnReportDoneLocked(
 
 XdsClient::ChannelState::LrsCallState::LrsCallState(
     RefCountedPtr<RetryableCall<LrsCallState>> parent)
-    : InternallyRefCounted<LrsCallState>(&grpc_xds_client_trace),
+    : InternallyRefCounted<LrsCallState>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace) ? "LrsCallState"
+                                                         : nullptr),
       parent_(std::move(parent)) {
   // Init the LRS call. Note that the call will progress every time there's
   // activity in xds_client()->interested_parties_, which is comprised of
@@ -1737,7 +1743,9 @@ grpc_channel* CreateXdsChannel(const XdsBootstrap& bootstrap,
 }  // namespace
 
 XdsClient::XdsClient(grpc_error** error)
-    : DualRefCounted<XdsClient>(&grpc_xds_client_trace),
+    : DualRefCounted<XdsClient>(GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)
+                                    ? "XdsClient"
+                                    : nullptr),
       request_timeout_(GetRequestTimeout()),
       interested_parties_(grpc_pollset_set_create()),
       bootstrap_(

--- a/src/core/ext/xds/xds_client_stats.cc
+++ b/src/core/ext/xds/xds_client_stats.cc
@@ -45,7 +45,9 @@ XdsClusterDropStats::XdsClusterDropStats(RefCountedPtr<XdsClient> xds_client,
                                          absl::string_view lrs_server_name,
                                          absl::string_view cluster_name,
                                          absl::string_view eds_service_name)
-    : RefCounted(&grpc_xds_client_trace),
+    : RefCounted(GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)
+                     ? "XdsClusterDropStats"
+                     : nullptr),
       xds_client_(std::move(xds_client)),
       lrs_server_name_(lrs_server_name),
       cluster_name_(cluster_name),
@@ -96,7 +98,9 @@ XdsClusterLocalityStats::XdsClusterLocalityStats(
     RefCountedPtr<XdsClient> xds_client, absl::string_view lrs_server_name,
     absl::string_view cluster_name, absl::string_view eds_service_name,
     RefCountedPtr<XdsLocalityName> name)
-    : RefCounted(&grpc_xds_client_trace),
+    : RefCounted(GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)
+                     ? "XdsClusterLocalityStats"
+                     : nullptr),
       xds_client_(std::move(xds_client)),
       lrs_server_name_(lrs_server_name),
       cluster_name_(cluster_name),

--- a/src/core/lib/gprpp/orphanable.h
+++ b/src/core/lib/gprpp/orphanable.h
@@ -27,7 +27,6 @@
 #include <cinttypes>
 #include <memory>
 
-#include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/ref_counted.h"
@@ -85,13 +84,10 @@ class InternallyRefCounted : public Orphanable {
   template <typename T>
   friend class RefCountedPtr;
 
-  // TraceFlagT is defined to accept both DebugOnlyTraceFlag and TraceFlag.
-  // Note: RefCount tracing is only enabled on debug builds, even when a
-  //       TraceFlag is used.
-  template <typename TraceFlagT = TraceFlag>
-  explicit InternallyRefCounted(TraceFlagT* trace_flag = nullptr,
+  // Note: Tracing is a no-op on non-debug builds.
+  explicit InternallyRefCounted(const char* trace = nullptr,
                                 intptr_t initial_refcount = 1)
-      : refs_(initial_refcount, trace_flag) {}
+      : refs_(initial_refcount, trace) {}
   virtual ~InternallyRefCounted() = default;
 
   RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {

--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -591,7 +591,10 @@ static grpc_error* pollable_create(pollable_type type, pollable** p) {
   }
 
   (*p)->type = type;
-  new (&(*p)->refs) grpc_core::RefCount(1, &grpc_trace_pollable_refcount);
+  new (&(*p)->refs) grpc_core::RefCount(
+      1, GRPC_TRACE_FLAG_ENABLED(grpc_trace_pollable_refcount)
+             ? "pollable_refcount"
+             : nullptr);
   gpr_mu_init(&(*p)->mu);
   (*p)->epfd = epfd;
   (*p)->owner_fd = nullptr;

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -1798,7 +1798,8 @@ grpc_endpoint* grpc_tcp_create(grpc_fd* em_fd,
 #endif
   }
   /* paired with unref in grpc_tcp_destroy */
-  new (&tcp->refcount) grpc_core::RefCount(1, &grpc_tcp_trace);
+  new (&tcp->refcount) grpc_core::RefCount(
+      1, GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace) ? "tcp" : nullptr);
   gpr_atm_no_barrier_store(&tcp->shutdown_count, 0);
   tcp->em_fd = em_fd;
   grpc_slice_buffer_init(&tcp->last_read_buffer);

--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -54,7 +54,9 @@ struct grpc_auth_context
       grpc_core::RefCountedPtr<grpc_auth_context> chained)
       : grpc_core::RefCounted<grpc_auth_context,
                               grpc_core::NonPolymorphicRefCount>(
-            &grpc_trace_auth_context_refcount),
+            GRPC_TRACE_FLAG_ENABLED(grpc_trace_auth_context_refcount)
+                ? "auth_context_refcount"
+                : nullptr),
         chained_(std::move(chained)) {
     if (chained_ != nullptr) {
       peer_identity_property_name_ = chained_->peer_identity_property_name_;

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -49,7 +49,9 @@ class grpc_security_connector
  public:
   explicit grpc_security_connector(const char* url_scheme)
       : grpc_core::RefCounted<grpc_security_connector>(
-            &grpc_trace_security_connector_refcount),
+            GRPC_TRACE_FLAG_ENABLED(grpc_trace_security_connector_refcount)
+                ? "security_connector_refcount"
+                : nullptr),
         url_scheme_(url_scheme) {}
   virtual ~grpc_security_connector() = default;
 

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -91,7 +91,9 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int /*initial_refs*/,
 #endif
   GRPC_CLOSURE_INIT(&refcount->destroy, cb, cb_arg, grpc_schedule_on_exec_ctx);
 
-  new (&refcount->refs) grpc_core::RefCount(1, &grpc_trace_stream_refcount);
+  new (&refcount->refs) grpc_core::RefCount(
+      1, GRPC_TRACE_FLAG_ENABLED(grpc_trace_stream_refcount) ? "stream_refcount"
+                                                             : nullptr);
   new (&refcount->slice_refcount) grpc_slice_refcount(
       grpc_slice_refcount::Type::REGULAR, &refcount->refs, slice_stream_destroy,
       refcount, &refcount->slice_refcount);

--- a/test/core/gprpp/dual_ref_counted_test.cc
+++ b/test/core/gprpp/dual_ref_counted_test.cc
@@ -72,13 +72,9 @@ TEST(DualRefCounted, RefIfNonZero) {
   foo->WeakUnref();
 }
 
-// Note: We use DebugOnlyTraceFlag instead of TraceFlag to ensure that
-// things build properly in both debug and non-debug cases.
-DebugOnlyTraceFlag foo_tracer(true, "foo");
-
 class FooWithTracing : public DualRefCounted<FooWithTracing> {
  public:
-  FooWithTracing() : DualRefCounted(&foo_tracer) {}
+  FooWithTracing() : DualRefCounted("FooWithTracing") {}
   ~FooWithTracing() { GPR_ASSERT(shutting_down_); }
 
   void Orphan() override { shutting_down_ = true; }

--- a/test/core/gprpp/orphanable_test.cc
+++ b/test/core/gprpp/orphanable_test.cc
@@ -79,15 +79,10 @@ TEST(OrphanablePtr, InternallyRefCounted) {
   bar->FinishWork();
 }
 
-// Note: We use DebugOnlyTraceFlag instead of TraceFlag to ensure that
-// things build properly in both debug and non-debug cases.
-DebugOnlyTraceFlag baz_tracer(true, "baz");
-
 class Baz : public InternallyRefCounted<Baz> {
  public:
   Baz() : Baz(0) {}
-  explicit Baz(int value)
-      : InternallyRefCounted<Baz>(&baz_tracer), value_(value) {}
+  explicit Baz(int value) : InternallyRefCounted<Baz>("Baz"), value_(value) {}
   void Orphan() override { Unref(); }
   int value() const { return value_; }
 

--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -180,11 +180,9 @@ TEST(MakeRefCounted, Args) {
   EXPECT_EQ(3, foo->value());
 }
 
-TraceFlag foo_tracer(true, "foo");
-
 class FooWithTracing : public RefCounted<FooWithTracing> {
  public:
-  FooWithTracing() : RefCounted(&foo_tracer) {}
+  FooWithTracing() : RefCounted("FooWithTracing") {}
 };
 
 TEST(RefCountedPtr, RefCountedWithTracing) {
@@ -416,11 +414,9 @@ TEST(WeakRefCountedPtr, Swap) {
   EXPECT_EQ(bar_strong.get(), bar3.get());
 }
 
-TraceFlag bar_tracer(true, "bar");
-
 class BarWithTracing : public DualRefCounted<BarWithTracing> {
  public:
-  BarWithTracing() : DualRefCounted(&bar_tracer) {}
+  BarWithTracing() : DualRefCounted("BarWithTracing") {}
 
   ~BarWithTracing() { GPR_ASSERT(shutting_down_); }
 

--- a/test/core/gprpp/ref_counted_test.cc
+++ b/test/core/gprpp/ref_counted_test.cc
@@ -126,13 +126,9 @@ TEST(RefCountedNonPolymorphic, ExtraRef) {
   foo->Unref();
 }
 
-// Note: We use DebugOnlyTraceFlag instead of TraceFlag to ensure that
-// things build properly in both debug and non-debug cases.
-DebugOnlyTraceFlag foo_tracer(true, "foo");
-
 class FooWithTracing : public RefCounted<FooWithTracing> {
  public:
-  FooWithTracing() : RefCounted(&foo_tracer) {}
+  FooWithTracing() : RefCounted("Foo") {}
 };
 
 TEST(RefCountedWithTracing, Basic) {
@@ -150,7 +146,7 @@ TEST(RefCountedWithTracing, Basic) {
 class FooNonPolymorphicWithTracing
     : public RefCounted<FooNonPolymorphicWithTracing, NonPolymorphicRefCount> {
  public:
-  FooNonPolymorphicWithTracing() : RefCounted(&foo_tracer) {}
+  FooNonPolymorphicWithTracing() : RefCounted("FooNonPolymorphicWithTracing") {}
 };
 
 TEST(RefCountedNonPolymorphicWithTracing, Basic) {


### PR DESCRIPTION
This changes the ref-counted types to take a `const char*` instead of a `TraceFlag`.  This allows subclasses to override the label used in the trace messages, which is useful in cases where the same trace flag is being used to enable tracing for a number of different objects.