### PR TITLE
Reduce template use for CQ-based async unary client calls to reduce code size

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2296,6 +2296,7 @@ grpc_cc_library(
         "include/grpcpp/impl/codegen/time.h",
     ],
     deps = [
+        "grpc++_config_proto",
         "grpc++_internal_hdrs_only",
         "grpc_codegen",
     ],

--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -107,6 +107,7 @@ Pod::Spec.new do |s|
                       'include/grpcpp/impl/codegen/completion_queue.h',
                       'include/grpcpp/impl/codegen/completion_queue_tag.h',
                       'include/grpcpp/impl/codegen/config.h',
+                      'include/grpcpp/impl/codegen/config_protobuf.h',
                       'include/grpcpp/impl/codegen/core_codegen.h',
                       'include/grpcpp/impl/codegen/core_codegen_interface.h',
                       'include/grpcpp/impl/codegen/create_auth_context.h',
@@ -1191,8 +1192,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = 'include/grpcpp'
     ss.dependency "#{s.name}/Interface", version
 
-    ss.source_files = 'include/grpcpp/impl/codegen/config_protobuf.h',
-                      'include/grpcpp/impl/codegen/proto_buffer_reader.h',
+    ss.source_files = 'include/grpcpp/impl/codegen/proto_buffer_reader.h',
                       'include/grpcpp/impl/codegen/proto_buffer_writer.h',
                       'include/grpcpp/impl/codegen/proto_utils.h'
   end

--- a/include/grpcpp/generic/generic_stub.h
+++ b/include/grpcpp/generic/generic_stub.h
@@ -64,11 +64,11 @@ class TemplatedGenericStub final {
       ClientContext* context, const std::string& method,
       const RequestType& request, ::grpc::CompletionQueue* cq) {
     return std::unique_ptr<ClientAsyncResponseReader<ResponseType>>(
-        internal::ClientAsyncResponseReaderFactory<ResponseType>::Create(
+        internal::ClientAsyncResponseReaderHelper::Create<ResponseType>(
             channel_.get(), cq,
             grpc::internal::RpcMethod(method.c_str(),
                                       grpc::internal::RpcMethod::NORMAL_RPC),
-            context, request, false));
+            context, request));
   }
 
   /// DEPRECATED for multi-threaded use

--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -40,8 +40,7 @@ template <class W>
 class ClientAsyncWriterFactory;
 template <class W, class R>
 class ClientAsyncReaderWriterFactory;
-template <class R>
-class ClientAsyncResponseReaderFactory;
+class ClientAsyncResponseReaderHelper;
 template <class W, class R>
 class ClientCallbackReaderWriterFactory;
 template <class R>
@@ -116,8 +115,7 @@ class ChannelInterface {
   friend class ::grpc::internal::ClientAsyncWriterFactory;
   template <class W, class R>
   friend class ::grpc::internal::ClientAsyncReaderWriterFactory;
-  template <class R>
-  friend class ::grpc::internal::ClientAsyncResponseReaderFactory;
+  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
   template <class W, class R>
   friend class ::grpc::internal::ClientCallbackReaderWriterFactory;
   template <class R>

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -72,6 +72,7 @@ template <class Request>
 class ClientCallbackWriterImpl;
 class ClientCallbackUnaryImpl;
 class ClientContextAccessor;
+class ClientAsyncResponseReaderHelper;
 }  // namespace internal
 
 template <class R>
@@ -424,6 +425,7 @@ class ClientContext {
   friend class ::grpc::testing::InteropClientContextInspector;
   friend class ::grpc::internal::CallOpClientRecvStatus;
   friend class ::grpc::internal::CallOpRecvInitialMetadata;
+  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
   friend class ::grpc::Channel;
   template <class R>
   friend class ::grpc::ClientReader;

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1918,10 +1918,10 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "::grpc::CompletionQueue* cq) {\n");
     printer->Print(*vars,
                    "  return "
-                   "::grpc::internal::ClientAsyncResponseReaderFactory"
-                   "< $Response$>::Create(channel_.get(), cq, "
+                   "::grpc::internal::ClientAsyncResponseReaderHelper::Create"
+                   "< $Response$>(channel_.get(), cq, "
                    "rpcmethod_$Method$_, "
-                   "context, request, false);\n"
+                   "context, request);\n"
                    "}\n\n");
     printer->Print(*vars,
                    "::grpc::ClientAsyncResponseReader< $Response$>* "

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -73,8 +73,7 @@
 
   # TODO(jtattermusch): build.yaml no longer has filegroups, so the files here are just hand-listed
   # This template shouldn't be touching the filegroups anyway, so this is only a bit more fragile.
-  grpcpp_proto_files = ['include/grpcpp/impl/codegen/config_protobuf.h',
-                        'include/grpcpp/impl/codegen/proto_buffer_reader.h',
+  grpcpp_proto_files = ['include/grpcpp/impl/codegen/proto_buffer_reader.h',
                         'include/grpcpp/impl/codegen/proto_buffer_writer.h',
                         'include/grpcpp/impl/codegen/proto_utils.h']
 


### PR DESCRIPTION
Reduces codesize benchmark by 1M (approximately 5K per RPC)

Moves grpc++ protobuf dependency from grpc++ library to grpc++_base subtarget (this does not affect Makefile or CMake at all, but only bazel-based builds)

