### PR TITLE
Reduce C++ callback unary call code size by reducing templating

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2296,6 +2296,7 @@ grpc_cc_library(
         "include/grpcpp/impl/codegen/time.h",
     ],
     deps = [
+        "grpc++_config_proto",
         "grpc++_internal_hdrs_only",
         "grpc_codegen",
     ],

--- a/include/grpcpp/generic/generic_stub.h
+++ b/include/grpcpp/generic/generic_stub.h
@@ -64,11 +64,11 @@ class TemplatedGenericStub final {
       ClientContext* context, const std::string& method,
       const RequestType& request, ::grpc::CompletionQueue* cq) {
     return std::unique_ptr<ClientAsyncResponseReader<ResponseType>>(
-        internal::ClientAsyncResponseReaderFactory<ResponseType>::Create(
+        internal::ClientAsyncResponseReaderHelper::Create<ResponseType>(
             channel_.get(), cq,
             grpc::internal::RpcMethod(method.c_str(),
                                       grpc::internal::RpcMethod::NORMAL_RPC),
-            context, request, false));
+            context, request));
   }
 
   /// DEPRECATED for multi-threaded use

--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -40,8 +40,7 @@ template <class W>
 class ClientAsyncWriterFactory;
 template <class W, class R>
 class ClientAsyncReaderWriterFactory;
-template <class R>
-class ClientAsyncResponseReaderFactory;
+class ClientAsyncResponseReaderHelper;
 template <class W, class R>
 class ClientCallbackReaderWriterFactory;
 template <class R>
@@ -116,8 +115,7 @@ class ChannelInterface {
   friend class ::grpc::internal::ClientAsyncWriterFactory;
   template <class W, class R>
   friend class ::grpc::internal::ClientAsyncReaderWriterFactory;
-  template <class R>
-  friend class ::grpc::internal::ClientAsyncResponseReaderFactory;
+  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
   template <class W, class R>
   friend class ::grpc::internal::ClientCallbackReaderWriterFactory;
   template <class R>

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -72,6 +72,7 @@ template <class Request>
 class ClientCallbackWriterImpl;
 class ClientCallbackUnaryImpl;
 class ClientContextAccessor;
+class ClientAsyncResponseReaderHelper;
 }  // namespace internal
 
 template <class R>
@@ -424,6 +425,7 @@ class ClientContext {
   friend class ::grpc::testing::InteropClientContextInspector;
   friend class ::grpc::internal::CallOpClientRecvStatus;
   friend class ::grpc::internal::CallOpRecvInitialMetadata;
+  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
   friend class ::grpc::Channel;
   template <class R>
   friend class ::grpc::ClientReader;

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1918,10 +1918,10 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "::grpc::CompletionQueue* cq) {\n");
     printer->Print(*vars,
                    "  return "
-                   "::grpc::internal::ClientAsyncResponseReaderFactory"
-                   "< $Response$>::Create(channel_.get(), cq, "
+                   "::grpc::internal::ClientAsyncResponseReaderHelper::Create"
+                   "< $Response$>(channel_.get(), cq, "
                    "rpcmethod_$Method$_, "
-                   "context, request, false);\n"
+                   "context, request);\n"
                    "}\n\n");
     printer->Print(*vars,
                    "::grpc::ClientAsyncResponseReader< $Response$>* "


### PR DESCRIPTION
Builds on #24384 

Reduces benchmark code size by 550K (about 3k per RPC). Worth mentioning that some of these PRs actually combine for superadditive benefits because some templated versions in call_op_set.h must exist if even one of the API variants continue to exist.