### PR TITLE
Use a single instance of the drop and locality stats objects.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/eds_drop.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/eds_drop.cc
@@ -207,7 +207,7 @@ EdsDropLb::EdsDropLb(RefCountedPtr<XdsClient> xds_client, Args args)
 
 EdsDropLb::~EdsDropLb() {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_eds_drop_lb_trace)) {
-    gpr_log(GPR_INFO, "[eds_drop_lb %p] destroying xds LB policy", this);
+    gpr_log(GPR_INFO, "[eds_drop_lb %p] destroying eds_drop LB policy", this);
   }
 }
 

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -39,7 +39,7 @@
 
 namespace grpc_core {
 
-extern TraceFlag xds_client_trace;
+extern TraceFlag grpc_xds_client_trace;
 
 class XdsClient : public DualRefCounted<XdsClient> {
  public:
@@ -267,17 +267,13 @@ class XdsClient : public DualRefCounted<XdsClient> {
     absl::optional<XdsApi::EdsUpdate> update;
   };
 
-  // TODO(roth): Change this to store exactly one instance of
-  // XdsClusterDropStats and exactly one instance of
-  // XdsClusterLocalityStats per locality.  We can return multiple refs
-  // to the same object instead of registering multiple objects.
   struct LoadReportState {
     struct LocalityState {
-      std::set<XdsClusterLocalityStats*> locality_stats;
-      std::vector<XdsClusterLocalityStats::Snapshot> deleted_locality_stats;
+      XdsClusterLocalityStats* locality_stats = nullptr;
+      XdsClusterLocalityStats::Snapshot deleted_locality_stats;
     };
 
-    std::set<XdsClusterDropStats*> drop_stats;
+    XdsClusterDropStats* drop_stats = nullptr;
     XdsClusterDropStats::Snapshot deleted_drop_stats;
     std::map<RefCountedPtr<XdsLocalityName>, LocalityState,
              XdsLocalityName::Less>

--- a/src/core/ext/xds/xds_client_stats.cc
+++ b/src/core/ext/xds/xds_client_stats.cc
@@ -45,12 +45,27 @@ XdsClusterDropStats::XdsClusterDropStats(RefCountedPtr<XdsClient> xds_client,
                                          absl::string_view lrs_server_name,
                                          absl::string_view cluster_name,
                                          absl::string_view eds_service_name)
-    : xds_client_(std::move(xds_client)),
+    : RefCounted(&grpc_xds_client_trace),
+      xds_client_(std::move(xds_client)),
       lrs_server_name_(lrs_server_name),
       cluster_name_(cluster_name),
-      eds_service_name_(eds_service_name) {}
+      eds_service_name_(eds_service_name) {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
+    gpr_log(GPR_INFO, "[xds_client %p] created drop stats %p for {%s, %s, %s}",
+            xds_client_.get(), this, std::string(lrs_server_name_).c_str(),
+            std::string(cluster_name_).c_str(),
+            std::string(eds_service_name_).c_str());
+  }
+}
 
 XdsClusterDropStats::~XdsClusterDropStats() {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
+    gpr_log(GPR_INFO,
+            "[xds_client %p] destroying drop stats %p for {%s, %s, %s}",
+            xds_client_.get(), this, std::string(lrs_server_name_).c_str(),
+            std::string(cluster_name_).c_str(),
+            std::string(eds_service_name_).c_str());
+  }
   xds_client_->RemoveClusterDropStats(lrs_server_name_, cluster_name_,
                                       eds_service_name_, this);
   xds_client_.reset(DEBUG_LOCATION, "DropStats");
@@ -81,13 +96,31 @@ XdsClusterLocalityStats::XdsClusterLocalityStats(
     RefCountedPtr<XdsClient> xds_client, absl::string_view lrs_server_name,
     absl::string_view cluster_name, absl::string_view eds_service_name,
     RefCountedPtr<XdsLocalityName> name)
-    : xds_client_(std::move(xds_client)),
+    : RefCounted(&grpc_xds_client_trace),
+      xds_client_(std::move(xds_client)),
       lrs_server_name_(lrs_server_name),
       cluster_name_(cluster_name),
       eds_service_name_(eds_service_name),
-      name_(std::move(name)) {}
+      name_(std::move(name)) {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
+    gpr_log(GPR_INFO,
+            "[xds_client %p] created locality stats %p for {%s, %s, %s, %s}",
+            xds_client_.get(), this, std::string(lrs_server_name_).c_str(),
+            std::string(cluster_name_).c_str(),
+            std::string(eds_service_name_).c_str(),
+            name_->AsHumanReadableString().c_str());
+  }
+}
 
 XdsClusterLocalityStats::~XdsClusterLocalityStats() {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
+    gpr_log(GPR_INFO,
+            "[xds_client %p] destroying locality stats %p for {%s, %s, %s, %s}",
+            xds_client_.get(), this, std::string(lrs_server_name_).c_str(),
+            std::string(cluster_name_).c_str(),
+            std::string(eds_service_name_).c_str(),
+            name_->AsHumanReadableString().c_str());
+  }
   xds_client_->RemoveClusterLocalityStats(lrs_server_name_, cluster_name_,
                                           eds_service_name_, name_, this);
   xds_client_.reset(DEBUG_LOCATION, "LocalityStats");

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -5347,14 +5347,6 @@ TEST_P(BalancerUpdateTest, DeadUpdate) {
       << balancers_[2]->ads_service()->eds_response_state().error_message;
 }
 
-// The re-resolution tests are deferred because they rely on the fallback mode,
-// which hasn't been supported.
-
-// TODO(juanlishen): Add TEST_P(BalancerUpdateTest, ReresolveDeadBackend).
-
-// TODO(juanlishen): Add TEST_P(UpdatesWithClientLoadReportingTest,
-// ReresolveDeadBalancer)
-
 class ClientLoadReportingTest : public XdsEnd2endTest {
  public:
   ClientLoadReportingTest() : XdsEnd2endTest(4, 1, 3) {}


### PR DESCRIPTION
Previously, we would create a new drop stats or locality stats object for each caller that wanted one, and the XdsClient would combine the data from the various stats objects when constructing the load report.  However, since the stats objects are themselves ref-counted, there was actually no good reason for this: instead, we can easily have just one stats object and return a ref to that object to every client that wants one.  This PR changes the code to do that.

Some additional changes:
- Fix an edge case where the load report being all zeroes could cause us to fail to stop the LRS call.
- Fix an edge case that could have potentially caused us to report an incorrect load report interval for a cluster that had been collecting data but was just recently requested by the LRS server.
-  Add a bunch of useful trace logging for stats objects.