### PR TITLE
Make Python 2 an optional dependency for Bazel build

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -229,6 +229,7 @@ def _check_python_bin(repository_ctx, python_bin, bin_path_key, allow_absent):
                   (bin_path_key, python_bin))
         else:
             return None
+    return True
 
 def _get_python_include(repository_ctx, python_bin):
     """Gets the python include path."""

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -291,15 +291,14 @@ def _create_single_version_package(
     """Creates the repository containing files set up to build with Python."""
     empty_include_rule = "filegroup(\n  name=\"{}_include\",\n  srcs=[],\n)".format(variety_name)
 
-    # A for loop is used in place of a (non-existent in Starlark) goto.
-    for _ in [None]:
-        python_bin = _get_python_bin(repository_ctx, bin_path_key, default_bin_path, allow_absent)
-        if python_bin == None and allow_absent:
+    python_bin = _get_python_bin(repository_ctx, bin_path_key, default_bin_path, allow_absent)
+    if (python_bin == None or
+        _check_python_bin(repository_ctx,
+                          python_bin,
+                          bin_path_key,
+                          allow_absent) == None) and allow_absent:
             python_include_rule = empty_include_rule
-            break
-        if _check_python_bin(repository_ctx, python_bin, bin_path_key, allow_absent) == None and allow_absent:
-            python_include_rule = empty_include_rule
-            break
+    else:
         python_lib = _get_python_lib(repository_ctx, python_bin, lib_path_key)
         _check_python_lib(repository_ctx, python_lib)
         python_include = _get_python_include(repository_ctx, python_bin)


### PR DESCRIPTION
This PR makes a Python 2 runtime with headers an optional dependency for Bazel builds. In case no proper Python 2 environment is detected, we create a rule like

```Starlark
filegroup(
  name="_python2_include",
  srcs=[],
)
```

This empty `filegroup` rule passes the analysis phase, but will fail during the build phase of any Python 2 targets, which are all test targets within our repo, and which downstream repos will not be touching.

This will also be backported to 1.33.