### PR TITLE
xDS Bootstrap changes for certificate providers

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1306,6 +1306,23 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpc_xds_credentials",
+    srcs = [
+        "src/core/ext/xds/certificate_provider_registry.cc",
+        "src/core/lib/security/credentials/xds/xds_credentials.cc",
+    ],
+    hdrs = [
+        "src/core/ext/xds/certificate_provider_factory.h",
+        "src/core/ext/xds/certificate_provider_registry.h",
+        "src/core/ext/xds/certificate_provider_store.h",
+        "src/core/lib/security/credentials/xds/xds_credentials.h",
+    ],
+    deps = [
+        "grpc_secure",
+    ],
+)
+
+grpc_cc_library(
     name = "grpc_xds_client",
     srcs = [
         "src/core/ext/xds/xds_api.cc",
@@ -1332,7 +1349,7 @@ grpc_cc_library(
         "grpc_base",
         "grpc_client_channel",
         "grpc_google_mesh_ca_certificate_provider_factory",
-        "grpc_secure",
+        "grpc_xds_credentials",
     ],
 )
 
@@ -1347,7 +1364,7 @@ grpc_cc_library(
     language = "c++",
     deps = [
         "grpc_base",
-        "grpc_secure",
+        "grpc_xds_credentials",
     ],
 )
 
@@ -1736,7 +1753,6 @@ grpc_cc_library(
 grpc_cc_library(
     name = "grpc_secure",
     srcs = [
-        "src/core/ext/xds/certificate_provider_registry.cc",
         "src/core/lib/http/httpcli_security_connector.cc",
         "src/core/lib/security/context/security_context.cc",
         "src/core/lib/security/credentials/alts/alts_credentials.cc",
@@ -1780,9 +1796,6 @@ grpc_cc_library(
     ],
     hdrs = [
         "src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.h",
-        "src/core/ext/xds/certificate_provider_factory.h",
-        "src/core/ext/xds/certificate_provider_registry.h",
-        "src/core/ext/xds/certificate_provider_store.h",
         "src/core/ext/xds/xds_channel_args.h",
         "src/core/lib/security/certificate_provider.h",
         "src/core/lib/security/context/security_context.h",
@@ -1827,19 +1840,6 @@ grpc_cc_library(
         "grpc_base",
         "grpc_transport_chttp2_alpn",
         "tsi",
-    ],
-)
-
-grpc_cc_library(
-    name = "grpc_xds_credentials",
-    srcs = [
-        "src/core/lib/security/credentials/xds/xds_credentials.cc",
-    ],
-    hdrs = [
-        "src/core/lib/security/credentials/xds/xds_credentials.h",
-    ],
-    deps = [
-        "grpc_secure",
     ],
 )
 

--- a/src/core/ext/xds/certificate_provider_factory.h
+++ b/src/core/ext/xds/certificate_provider_factory.h
@@ -32,7 +32,7 @@ namespace grpc_core {
 class CertificateProviderFactory {
  public:
   // Interface for configs for CertificateProviders.
-  class Config {
+  class Config : public RefCounted<Config> {
    public:
     virtual ~Config() = default;
 
@@ -46,12 +46,12 @@ class CertificateProviderFactory {
   // Name of the plugin.
   virtual const char* name() const = 0;
 
-  virtual std::unique_ptr<Config> CreateCertificateProviderConfig(
+  virtual RefCountedPtr<Config> CreateCertificateProviderConfig(
       const Json& config_json, grpc_error** error) = 0;
 
   // Create a CertificateProvider instance from config.
   virtual RefCountedPtr<grpc_tls_certificate_provider>
-  CreateCertificateProvider(std::unique_ptr<Config> config) = 0;
+  CreateCertificateProvider(RefCountedPtr<Config> config) = 0;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.cc
+++ b/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.cc
@@ -304,11 +304,11 @@ GoogleMeshCaCertificateProviderFactory::Config::ParseJsonObjectServer(
   return error_list_server;
 }
 
-std::unique_ptr<GoogleMeshCaCertificateProviderFactory::Config>
+RefCountedPtr<GoogleMeshCaCertificateProviderFactory::Config>
 GoogleMeshCaCertificateProviderFactory::Config::Parse(const Json& config_json,
                                                       grpc_error** error) {
   auto config =
-      absl::make_unique<GoogleMeshCaCertificateProviderFactory::Config>();
+      MakeRefCounted<GoogleMeshCaCertificateProviderFactory::Config>();
   if (config_json.type() != Json::Type::OBJECT) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "error:config type should be OBJECT.");
@@ -367,7 +367,7 @@ const char* GoogleMeshCaCertificateProviderFactory::name() const {
   return kMeshCaPlugin;
 }
 
-std::unique_ptr<CertificateProviderFactory::Config>
+RefCountedPtr<CertificateProviderFactory::Config>
 GoogleMeshCaCertificateProviderFactory::CreateCertificateProviderConfig(
     const Json& config_json, grpc_error** error) {
   return GoogleMeshCaCertificateProviderFactory::Config::Parse(config_json,

--- a/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h
+++ b/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h
@@ -60,8 +60,8 @@ class GoogleMeshCaCertificateProviderFactory
 
     const std::string& location() const { return location_; }
 
-    static std::unique_ptr<Config> Parse(const Json& config_json,
-                                         grpc_error** error);
+    static RefCountedPtr<Config> Parse(const Json& config_json,
+                                       grpc_error** error);
 
    private:
     // Helpers for parsing the config
@@ -86,12 +86,12 @@ class GoogleMeshCaCertificateProviderFactory
 
   const char* name() const override;
 
-  std::unique_ptr<CertificateProviderFactory::Config>
+  RefCountedPtr<CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const Json& config_json,
                                   grpc_error** error) override;
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      std::unique_ptr<CertificateProviderFactory::Config> config) override {
+      RefCountedPtr<CertificateProviderFactory::Config> config) override {
     // TODO(yashykt) : To be implemented
     return nullptr;
   }

--- a/src/core/ext/xds/xds_bootstrap.h
+++ b/src/core/ext/xds/xds_bootstrap.h
@@ -28,6 +28,7 @@
 
 #include <grpc/slice.h>
 
+#include "src/core/ext/xds/certificate_provider_store.h"
 #include "src/core/lib/gprpp/map.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/iomgr/error.h"
@@ -75,6 +76,11 @@ class XdsBootstrap {
   const XdsServer& server() const { return servers_[0]; }
   const Node* node() const { return node_.get(); }
 
+  const CertificateProviderStore::PluginDefinitionMap& certificate_providers()
+      const {
+    return certificate_providers_;
+  }
+
  private:
   grpc_error* ParseXdsServerList(Json* json);
   grpc_error* ParseXdsServer(Json* json, size_t idx);
@@ -83,9 +89,13 @@ class XdsBootstrap {
   grpc_error* ParseServerFeaturesArray(Json* json, XdsServer* server);
   grpc_error* ParseNode(Json* json);
   grpc_error* ParseLocality(Json* json);
+  grpc_error* ParseCertificateProviders(Json* json);
+  grpc_error* ParseCertificateProvider(const std::string& instance_name,
+                                       Json* certificate_provider_json);
 
   absl::InlinedVector<XdsServer, 1> servers_;
   std::unique_ptr<Node> node_;
+  CertificateProviderStore::PluginDefinitionMap certificate_providers_;
 };
 
 }  // namespace grpc_core

--- a/test/core/client_channel/certificate_provider_registry_test.cc
+++ b/test/core/client_channel/certificate_provider_registry_test.cc
@@ -32,13 +32,13 @@ class FakeCertificateProviderFactory1 : public CertificateProviderFactory {
  public:
   const char* name() const override { return "fake1"; }
 
-  std::unique_ptr<Config> CreateCertificateProviderConfig(
+  RefCountedPtr<Config> CreateCertificateProviderConfig(
       const Json& config_json, grpc_error** error) override {
     return nullptr;
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      std::unique_ptr<Config> config) override {
+      RefCountedPtr<Config> config) override {
     return nullptr;
   }
 };
@@ -47,13 +47,13 @@ class FakeCertificateProviderFactory2 : public CertificateProviderFactory {
  public:
   const char* name() const override { return "fake2"; }
 
-  std::unique_ptr<Config> CreateCertificateProviderConfig(
+  RefCountedPtr<Config> CreateCertificateProviderConfig(
       const Json& config_json, grpc_error** error) override {
     return nullptr;
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      std::unique_ptr<Config> config) override {
+      RefCountedPtr<Config> config) override {
     return nullptr;
   }
 };


### PR DESCRIPTION
Adds parsing for "certificate_providers" field in xds bootstrap file.

Format for reference -
`
{
  "certificate_providers": {
    "plugin1": {
      "plugin_name": "custom"
    },
    "plugin2": {
      "plugin_name": "zatar",
      "config": {
        /* zatar config JSON */
      }
    }
  }
}
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/24409)
<!-- Reviewable:end -->
