### PR TITLE
Remove unnecessary dependencies for xds_cluster_manager LB policy.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1306,23 +1306,6 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
-    name = "grpc_xds_api_header",
-    hdrs = [
-        "src/core/ext/xds/xds_api.h",
-        "src/core/ext/xds/xds_bootstrap.h",
-        "src/core/ext/xds/xds_client_stats.h",
-    ],
-    external_deps = [
-        "upb_lib",
-        "re2",
-    ],
-    language = "c++",
-    deps = [
-        "grpc_base",
-    ],
-)
-
-grpc_cc_library(
     name = "grpc_xds_client",
     srcs = [
         "src/core/ext/xds/xds_api.cc",
@@ -1331,8 +1314,15 @@ grpc_cc_library(
         "src/core/ext/xds/xds_client_stats.cc",
     ],
     hdrs = [
+        "src/core/ext/xds/xds_api.h",
+        "src/core/ext/xds/xds_bootstrap.h",
         "src/core/ext/xds/xds_channel_args.h",
         "src/core/ext/xds/xds_client.h",
+        "src/core/ext/xds/xds_client_stats.h",
+    ],
+    external_deps = [
+        "upb_lib",
+        "re2",
     ],
     language = "c++",
     deps = [
@@ -1341,7 +1331,6 @@ grpc_cc_library(
         "grpc_client_channel",
         "grpc_google_mesh_ca_certificate_provider_factory",
         "grpc_secure",
-        "grpc_xds_api_header",
     ],
 )
 
@@ -1422,7 +1411,6 @@ grpc_cc_library(
         "grpc_base",
         "grpc_client_channel",
         "grpc_resolver_xds_header",
-        "grpc_xds_api_header",
     ],
 )
 


### PR DESCRIPTION
Looks like we missed these in #23659.