### PR TITLE
Fix the grpc.aio import hack and its unit test

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -2125,6 +2125,6 @@ except ImportError:
     pass
 
 # Prevents import order issue in the case of renamed path.
-if sys.version_info >= (3, 6) and __name__ == "grpc.__init__":
+if sys.version_info >= (3, 6) and __name__ == "grpc":
     from grpc import aio  # pylint: disable=ungrouped-imports
     sys.modules.update({'grpc.aio': aio})

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -14,17 +14,15 @@
 import logging
 import unittest
 
-from tests_aio.unit._test_base import AioTestBase
 
+class TestInit(unittest.TestCase):
 
-class TestInit(AioTestBase):
-
-    async def test_grpc(self):
+    def test_grpc(self):
         import grpc  # pylint: disable=wrong-import-position
         channel = grpc.aio.insecure_channel('dummy')
         self.assertIsInstance(channel, grpc.aio.Channel)
 
-    async def test_grpc_dot_aio(self):
+    def test_grpc_dot_aio(self):
         import grpc.aio  # pylint: disable=wrong-import-position
         channel = grpc.aio.insecure_channel('dummy')
         self.assertIsInstance(channel, grpc.aio.Channel)


### PR DESCRIPTION
I made a mistake in https://github.com/grpc/grpc/pull/24398. The `grpc.aio` fix isn't working after the roll back, because the `__name__` of the `__init__.py` file of gRPC Python module is "grpc" instead of `grpc.__init__`. So, it won't load "aio" module under any setup by default.

The `init_test` wasn't testing direct import of "grpc.aio", because it takes a dependency on `AioTestBase` which does `from grpc import aio`. The module space is still polluted, so the test didn't caught the error.

Here is the cherry-pick for google3 ([cl/335987017](http://cl/335987017)).