### PR TITLE
Reduce sync client templating for protobuf without protobuf dependence

### DIFF
--- a/include/grpcpp/impl/codegen/client_unary_call.h
+++ b/include/grpcpp/impl/codegen/client_unary_call.h
@@ -30,12 +30,23 @@ namespace grpc {
 class ClientContext;
 namespace internal {
 class RpcMethod;
-/// Wrapper that performs a blocking unary call
-template <class InputMessage, class OutputMessage>
+
+/// Wrapper that performs a blocking unary call. May optionally specify the base
+/// class of the Request and Response so that the internal calls and structures
+/// below this may be based on those base classes and thus achieve code reuse
+/// across different RPCs (e.g., for protobuf, MessageLite would be a base
+/// class).
+template <class InputMessage, class OutputMessage,
+          class BaseInputMessage = InputMessage,
+          class BaseOutputMessage = OutputMessage>
 Status BlockingUnaryCall(ChannelInterface* channel, const RpcMethod& method,
                          grpc::ClientContext* context,
                          const InputMessage& request, OutputMessage* result) {
-  return BlockingUnaryCallImpl<InputMessage, OutputMessage>(
+  static_assert(std::is_base_of<BaseInputMessage, InputMessage>::value,
+                "Invalid input message specification");
+  static_assert(std::is_base_of<BaseOutputMessage, OutputMessage>::value,
+                "Invalid output message specification");
+  return BlockingUnaryCallImpl<BaseInputMessage, BaseOutputMessage>(
              channel, method, context, request, result)
       .status();
 }

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1887,6 +1887,8 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "const $Request$& request, $Response$* response) {\n");
     printer->Print(*vars,
                    "  return ::grpc::internal::BlockingUnaryCall"
+                   "< $Request$, $Response$, ::grpc::protobuf::MessageLite, "
+                   "::grpc::protobuf::MessageLite>"
                    "(channel_.get(), rpcmethod_$Method$_, "
                    "context, request, response);\n}\n\n");
 


### PR DESCRIPTION
Reduces the sync client code size by templating the internal classes and structs on the base class. Uses a 4-way template rather than the pre-existing 2-way template to allow the code generator to specify the base class to use, which allows the benefits of reuse without non-protobuf code requiring a protobuf dependence just to check a base class as in #24385 .

Reduces benchmark code size from 4.91 MB to 4.56 MB (approx 2 KB per RPC)