### PR TITLE
Reduce templating for unary callback client RPC without protobuf dependence

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1897,6 +1897,8 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "std::function<void(::grpc::Status)> f) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::CallbackUnaryCall"
+                   "< $Request$, $Response$, ::grpc::protobuf::MessageLite, "
+                   "::grpc::protobuf::MessageLite>"
                    "(stub_->channel_.get(), stub_->rpcmethod_$Method$_, "
                    "context, request, response, std::move(f));\n}\n\n");
 


### PR DESCRIPTION
Like #24420, this introduces extra template parameters to the CallbackUnaryCall so that the code generator can supply the actual base class name for use in the internal implementation and structs (and thereby allow reuse across RPCs). Saves 250K on benchmark (1.3K per RPC).
