### PR TITLE
Add generation to multiple directories for C# plugin

### DIFF
--- a/src/compiler/csharp_generator_helpers.h
+++ b/src/compiler/csharp_generator_helpers.h
@@ -24,13 +24,6 @@
 
 namespace grpc_csharp_generator {
 
-inline bool ServicesFilename(const grpc::protobuf::FileDescriptor* file,
-                             std::string* file_name_or_error) {
-  *file_name_or_error =
-      grpc_generator::FileNameInUpperCamel(file, false) + "Grpc.cs";
-  return true;
-}
-
 // Get leading or trailing comments in a string. Comment lines start with "// ".
 // Leading detached comments are put in front of leading comments.
 template <typename DescriptorType>


### PR DESCRIPTION
I've added an option for the C# plugin to generate nested directories just like the protobuf C# generator.
See [here](https://github.com/protocolbuffers/protobuf/issues/773) for original issue in protobuf and [here](https://github.com/protocolbuffers/protobuf/pull/785) for the PR that introduces it in the protobuf repo. I've reused the same helper that is used by the protobuf C# generator for this too. This will allow the two plugins to be more consistent with each other.

@donnadionne
