### PR TITLE
Add proto definitions for xDS circuit breaking test

### DIFF
--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -228,7 +228,6 @@ message LoadBalancerRealTimeStatsResponse {
 
 // Configurations for a test client.
 message ClientConfigureRequest {
-
   // Type of RPCs to send.
   enum RpcType {
     EMPTY_CALL = 0;

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -213,6 +213,9 @@ message LoadBalancerStatsResponse {
   map<string, RpcsByPeer> rpcs_by_method = 3;
 }
 
+// Request for retrieving a test client's real time stats.
+message LoadBalancerRealTimeStatsRequest {}
+
 // Real-time stats for RPCs sent by a test client.
 message LoadBalancerRealTimeStatsResponse {
   // The real-time total number of RPCs issued.
@@ -244,3 +247,6 @@ message ClientConfigureRequest {
   // The collection of custom metadata to be attached to RPCs sent by the client.
   repeated Metadata metadata = 2;
 }
+
+// Response for updating a test client's configuration.
+message ClientConfigureResponse {}

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -212,3 +212,13 @@ message LoadBalancerStatsResponse {
   int32 num_failures = 2;
   map<string, RpcsByPeer> rpcs_by_method = 3;
 }
+
+// Real-time stats for RPCs sent by a test client.
+message LoadBalancerRealTimeStatsResponse {
+  // The real-time total number of RPCs issued.
+  int32 num_rpcs_started = 1;
+  // The real-time total number of RPCs completed successfully for each peer.
+  map<string, int32> num_rpcs_succeeded_by_peer = 2;
+  // The real-time total number of RPCs failed.
+  int32 num_rpcs_failed = 3;
+}

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -225,6 +225,22 @@ message LoadBalancerRealTimeStatsResponse {
 
 // Configurations for a test client.
 message ClientConfigureRequest {
+
+  // Type of RPCs to send.
+  enum RpcType {
+    EMPTY_CALL = 0;
+    UNARY_CALL = 1;
+  }
+
+  // Metadata to be attached for the given type of RPCs.
+  message Metadata {
+    RpcType type = 1;
+    string key = 2;
+    string value = 3;
+  }
+
+  // The types of RPCs the client sends.
+  repeated RpcType types = 1;
   // The collection of custom metadata to be attached to RPCs sent by the client.
-  map<string, string> custom_metadata = 1;
+  repeated Metadata metadata = 2;
 }

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -222,3 +222,9 @@ message LoadBalancerRealTimeStatsResponse {
   // The real-time total number of RPCs failed.
   int32 num_rpcs_failed = 3;
 }
+
+// Configurations for a test client.
+message ClientConfigureRequest {
+  // The collection of custom metadata to be attached to RPCs sent by the client.
+  map<string, string> custom_metadata = 1;
+}

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -213,16 +213,16 @@ message LoadBalancerStatsResponse {
   map<string, RpcsByPeer> rpcs_by_method = 3;
 }
 
-// Request for retrieving a test client's real time stats.
-message LoadBalancerRealTimeStatsRequest {}
+// Request for retrieving a test client's accumulated stats.
+message LoadBalancerAccumulatedStatsRequest {}
 
-// Real-time stats for RPCs sent by a test client.
-message LoadBalancerRealTimeStatsResponse {
-  // The real-time total number of RPCs issued.
+// Accumulated stats for RPCs sent by a test client.
+message LoadBalancerAccumulatedStatsResponse {
+  // The total number of RPCs have ever issued.
   int32 num_rpcs_started = 1;
-  // The real-time total number of RPCs completed successfully for each peer.
+  // The total number of RPCs have ever completed successfully for each peer.
   map<string, int32> num_rpcs_succeeded_by_peer = 2;
-  // The real-time total number of RPCs failed.
+  // The total number of RPCs have ever failed.
   int32 num_rpcs_failed = 3;
 }
 

--- a/src/proto/grpc/testing/test.proto
+++ b/src/proto/grpc/testing/test.proto
@@ -97,3 +97,8 @@ service XdsUpdateHealthService {
   rpc SetServing(grpc.testing.Empty) returns (grpc.testing.Empty);
   rpc SetNotServing(grpc.testing.Empty) returns (grpc.testing.Empty);
 }
+
+// A service to dynamically update the configuration of an xDS test client.
+service XdsUpdateClientConfigureService {
+  rpc Configure(ClientConfigureRequest) returns (grpc.testing.Empty);
+}

--- a/src/proto/grpc/testing/test.proto
+++ b/src/proto/grpc/testing/test.proto
@@ -88,7 +88,7 @@ service LoadBalancerStatsService {
 // A service used to obtain real-time stats for verifying LB behavior.
 service LoadBalancerRealTimeStatsService {
   // Gets the real-time stats for RPCs sent by a test client.
-  rpc GetClientRealTimeStats(grpc.testing.Empty)
+  rpc GetClientRealTimeStats(LoadBalancerRealTimeStatsRequest)
       returns (LoadBalancerRealTimeStatsResponse) {}
 }
 
@@ -100,5 +100,6 @@ service XdsUpdateHealthService {
 
 // A service to dynamically update the configuration of an xDS test client.
 service XdsUpdateClientConfigureService {
-  rpc Configure(ClientConfigureRequest) returns (grpc.testing.Empty);
+  // Update the tes client's configuration.
+  rpc Configure(ClientConfigureRequest) returns (ClientConfigureResponse);
 }

--- a/src/proto/grpc/testing/test.proto
+++ b/src/proto/grpc/testing/test.proto
@@ -83,13 +83,10 @@ service LoadBalancerStatsService {
   // Gets the backend distribution for RPCs sent by a test client.
   rpc GetClientStats(LoadBalancerStatsRequest)
       returns (LoadBalancerStatsResponse) {}
-}
 
-// A service used to obtain real-time stats for verifying LB behavior.
-service LoadBalancerRealTimeStatsService {
-  // Gets the real-time stats for RPCs sent by a test client.
-  rpc GetClientRealTimeStats(LoadBalancerRealTimeStatsRequest)
-      returns (LoadBalancerRealTimeStatsResponse) {}
+  // Gets the accumulated stats for RPCs sent by a test client.
+  rpc GetClientAccumulatedStats(LoadBalancerAccumulatedStatsRequest)
+      returns (LoadBalancerAccumulatedStatsResponse) {}
 }
 
 // A service to remotely control health status of an xDS test server.

--- a/src/proto/grpc/testing/test.proto
+++ b/src/proto/grpc/testing/test.proto
@@ -85,6 +85,13 @@ service LoadBalancerStatsService {
       returns (LoadBalancerStatsResponse) {}
 }
 
+// A service used to obtain real-time stats for verifying LB behavior.
+service LoadBalancerRealTimeStatsService {
+  // Gets the real-time stats for RPCs sent by a test client.
+  rpc GetClientRealTimeStats(grpc.testing.Empty)
+      returns (LoadBalancerRealTimeStatsResponse) {}
+}
+
 // A service to remotely control health status of an xDS test server.
 service XdsUpdateHealthService {
   rpc SetServing(grpc.testing.Empty) returns (grpc.testing.Empty);


### PR DESCRIPTION
Proto definitions used for xDS circuit breaking interop test. See details in go/grpc-xds-circuit-breaking-interop-tests

/cc @ericgribkoff @menghanl 
