### PR TITLE
[Clang-Tidy] Enable two bugprone-*

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,7 @@
 ---
 Checks: '-*,
   bugprone-*,
-  -bugprone-forward-declaration-namespace,
   -bugprone-integer-division,
-  -bugprone-misplaced-widening-cast,
   -bugprone-narrowing-conversions,
   -bugprone-too-small-loop-variable,
   performance-*,


### PR DESCRIPTION
Enable `bugprone-forward-declaration-namespace` and `bugprone-misplaced-widening-cast` and our code already passed them.