### PR TITLE
Allow grpcio to be built against system re2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,11 @@ BUILD_WITH_SYSTEM_ZLIB = os.environ.get('GRPC_PYTHON_BUILD_SYSTEM_ZLIB', False)
 BUILD_WITH_SYSTEM_CARES = os.environ.get('GRPC_PYTHON_BUILD_SYSTEM_CARES',
                                          False)
 
+# Export this variable to use the system installation of re2. You need to
+# have the header files installed (in /usr/include/re2) and during
+# runtime, the shared library must be installed
+BUILD_WITH_SYSTEM_RE2 = os.environ.get('GRPC_PYTHON_BUILD_SYSTEM_RE2', False)
+
 # For local development use only: This skips building gRPC Core and its
 # dependencies, including protobuf and boringssl. This allows "incremental"
 # compilation by first building gRPC Core using make, then building only the
@@ -258,6 +263,10 @@ if BUILD_WITH_SYSTEM_CARES:
     CORE_C_FILES = filter(lambda x: 'third_party/cares' not in x, CORE_C_FILES)
     CARES_INCLUDE = (os.path.join('/usr', 'include'),)
 
+if BUILD_WITH_SYSTEM_RE2:
+    CORE_C_FILES = filter(lambda x: 'third_party/re2' not in x, CORE_C_FILES)
+    RE2_INCLUDE = (os.path.join('/usr', 'include', 're2'),)
+
 EXTENSION_INCLUDE_DIRECTORIES = ((PYTHON_STEM,) + CORE_INCLUDE + ABSL_INCLUDE +
                                  ADDRESS_SORTING_INCLUDE + CARES_INCLUDE +
                                  RE2_INCLUDE + SSL_INCLUDE + UPB_INCLUDE +
@@ -284,6 +293,8 @@ if BUILD_WITH_SYSTEM_ZLIB:
     EXTENSION_LIBRARIES += ('z',)
 if BUILD_WITH_SYSTEM_CARES:
     EXTENSION_LIBRARIES += ('cares',)
+if BUILD_WITH_SYSTEM_RE2:
+    EXTENSION_LIBRARIES += ('re2',)
 
 DEFINE_MACROS = (('_WIN32_WINNT', 0x600),)
 asm_files = []


### PR DESCRIPTION
The main grpc library can be built with system re2 using the cmake flag `-DgRPC_RE2_PROVIDER=package`. This brings the grpcio package in line with grpc using similar checks and env variables used for `BUILD_WITH_SYSTEM_CARES/OPENSSL/ZLIB`.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
