### PR TITLE
[Clang-Tidy] Enable modernize-make-unique

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,7 @@ Checks: '-*,
   misc-uniqueptr-reset-release,
   misc-unused-alias-decls,
   -misc-unused-using-decls,
-  -modernize-make-unique,
+  modernize-make-unique,
   -modernize-redundant-void-arg,
   modernize-replace-auto-ptr,
   modernize-shrink-to-fit,
@@ -42,3 +42,7 @@ WarningsAsErrors: '*'
 CheckOptions:
   - key:    readability-function-size.StatementThreshold
     value:  '450'
+  - key:    modernize-make-unique.MakeSmartPtrFunction
+    value:  'absl::make_unique'
+  - key:    modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:  'absl/memory/memory.h'

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.cc
@@ -25,6 +25,8 @@
 #include <grpc/support/atm.h>
 #include <grpc/support/string_util.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/gprpp/sync.h"
 
 namespace grpc_core {
@@ -52,7 +54,7 @@ void GrpcLbClientStats::AddCallDropped(const char* token) {
   // Record the drop.
   MutexLock lock(&drop_count_mu_);
   if (drop_token_counts_ == nullptr) {
-    drop_token_counts_.reset(new DroppedCallCounts());
+    drop_token_counts_ = absl::make_unique<DroppedCallCounts>();
   }
   for (size_t i = 0; i < drop_token_counts_->size(); ++i) {
     if (strcmp((*drop_token_counts_)[i].token.get(), token) == 0) {

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -30,6 +30,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/memory/memory.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/alloc.h>
@@ -1000,7 +1001,8 @@ void Server::ChannelData::InitTransport(RefCountedPtr<Server> server,
   if (num_registered_methods > 0) {
     uint32_t max_probes = 0;
     size_t slots = 2 * num_registered_methods;
-    registered_methods_.reset(new std::vector<ChannelRegisteredMethod>(slots));
+    registered_methods_ =
+        absl::make_unique<std::vector<ChannelRegisteredMethod>>(slots);
     for (std::unique_ptr<RegisteredMethod>& rm : server_->registered_methods_) {
       ExternallyManagedSlice host;
       ExternallyManagedSlice method(rm->method.c_str());

--- a/src/cpp/ext/filters/census/context.h
+++ b/src/cpp/ext/filters/census/context.h
@@ -22,15 +22,18 @@
 #include <grpc/support/port_platform.h>
 
 #include <grpc/status.h>
+
 #include "absl/memory/memory.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
+
 #include "opencensus/context/context.h"
 #include "opencensus/tags/tag_map.h"
 #include "opencensus/trace/context_util.h"
 #include "opencensus/trace/span.h"
 #include "opencensus/trace/span_context.h"
 #include "opencensus/trace/trace_params.h"
+
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/cpp/common/channel_filter.h"
 #include "src/cpp/ext/filters/census/rpc_encoding.h"

--- a/src/cpp/server/health/default_health_check_service.cc
+++ b/src/cpp/server/health/default_health_check_service.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "absl/memory/memory.h"
 #include "upb/upb.hpp"
 
 #include <grpc/slice.h>
@@ -114,7 +115,7 @@ DefaultHealthCheckService::HealthCheckServiceImpl*
 DefaultHealthCheckService::GetHealthCheckService(
     std::unique_ptr<ServerCompletionQueue> cq) {
   GPR_ASSERT(impl_ == nullptr);
-  impl_.reset(new HealthCheckServiceImpl(this, std::move(cq)));
+  impl_ = absl::make_unique<HealthCheckServiceImpl>(this, std::move(cq));
   return impl_.get();
 }
 
@@ -160,8 +161,8 @@ DefaultHealthCheckService::HealthCheckServiceImpl::HealthCheckServiceImpl(
   AddMethod(new internal::RpcServiceMethod(
       kHealthWatchMethodName, internal::RpcMethod::SERVER_STREAMING, nullptr));
   // Create serving thread.
-  thread_ = std::unique_ptr<::grpc_core::Thread>(
-      new ::grpc_core::Thread("grpc_health_check_service", Serve, this));
+  thread_ = absl::make_unique<::grpc_core::Thread>("grpc_health_check_service",
+                                                   Serve, this);
 }
 
 DefaultHealthCheckService::HealthCheckServiceImpl::~HealthCheckServiceImpl() {

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -42,6 +42,8 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/time.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/ext/transport/inproc/inproc_transport.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/profiling/timers.h"
@@ -810,9 +812,9 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
 
   void AddUnknownSyncMethod() {
     if (!sync_requests_.empty()) {
-      unknown_method_.reset(new grpc::internal::RpcServiceMethod(
+      unknown_method_ = absl::make_unique<grpc::internal::RpcServiceMethod>(
           "unknown", grpc::internal::RpcMethod::BIDI_STREAMING,
-          new grpc::internal::UnknownMethodHandler));
+          new grpc::internal::UnknownMethodHandler);
       sync_requests_.emplace_back(
           new SyncRequest(unknown_method_.get(), nullptr));
     }
@@ -1155,7 +1157,7 @@ void Server::Start(grpc::ServerCompletionQueue** cqs, size_t num_cqs) {
   // service to handle any unimplemented methods using the default reactor
   // creator
   if (has_callback_methods_ && !has_callback_generic_service_) {
-    unimplemented_service_.reset(new grpc::CallbackGenericService);
+    unimplemented_service_ = absl::make_unique<grpc::CallbackGenericService>();
     RegisterCallbackGenericService(unimplemented_service_.get());
   }
 
@@ -1186,8 +1188,8 @@ void Server::Start(grpc::ServerCompletionQueue** cqs, size_t num_cqs) {
   // server CQs), make sure that we have a ResourceExhausted handler
   // to deal with the case of thread exhaustion
   if (sync_server_cqs_ != nullptr && !sync_server_cqs_->empty()) {
-    resource_exhausted_handler_.reset(
-        new grpc::internal::ResourceExhaustedHandler);
+    resource_exhausted_handler_ =
+        absl::make_unique<grpc::internal::ResourceExhaustedHandler>();
   }
 
   for (const auto& value : sync_req_mgrs_) {

--- a/test/core/iomgr/work_serializer_test.cc
+++ b/test/core/iomgr/work_serializer_test.cc
@@ -24,6 +24,8 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/work_serializer.h"
@@ -94,7 +96,7 @@ TEST(WorkSerializerTest, ExecuteMany) {
   {
     std::vector<std::unique_ptr<TestThread>> threads;
     for (size_t i = 0; i < 100; ++i) {
-      threads.push_back(std::unique_ptr<TestThread>(new TestThread(&lock)));
+      threads.push_back(absl::make_unique<TestThread>(&lock));
     }
   }
 }

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
@@ -61,7 +62,8 @@ class ServerThread {
     cq_ = grpc_completion_queue_create_for_next(nullptr);
     grpc_server_register_completion_queue(server_, cq_, nullptr);
     grpc_server_start(server_);
-    thread_.reset(new std::thread(std::bind(&ServerThread::Serve, this)));
+    thread_ =
+        absl::make_unique<std::thread>(std::bind(&ServerThread::Serve, this));
   }
 
   void Shutdown() {

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -31,6 +31,7 @@
 #include <set>
 #include <thread>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
@@ -158,8 +159,7 @@ class TestServer {
     grpc_server_start(server_);
     gpr_log(GPR_DEBUG, "Start TestServer %p. listen on %s", this,
             server_addr_.c_str());
-    server_thd_ =
-        std::unique_ptr<std::thread>(new std::thread(PollUntilShutdown, this));
+    server_thd_ = absl::make_unique<std::thread>(PollUntilShutdown, this);
   }
 
   ~TestServer() {
@@ -212,7 +212,7 @@ class ConnectLoopRunner {
         loops_(loops),
         expected_connectivity_states_(expected_connectivity_states),
         reconnect_backoff_ms_(reconnect_backoff_ms) {
-    thd_ = std::unique_ptr<std::thread>(new std::thread(ConnectLoop, this));
+    thd_ = absl::make_unique<std::thread>(ConnectLoop, this);
   }
 
   ~ConnectLoopRunner() { thd_->join(); }
@@ -310,12 +310,11 @@ TEST(AltsConcurrentConnectivityTest, TestConcurrentClientServerHandshakes) {
     gpr_log(GPR_DEBUG,
             "start performing concurrent expected-to-succeed connects");
     for (size_t i = 0; i < num_concurrent_connects; i++) {
-      connect_loop_runners.push_back(
-          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
-              test_server.address(), fake_handshake_server.address(),
-              15 /* per connect deadline seconds */, 5 /* loops */,
-              GRPC_CHANNEL_READY /* expected connectivity states */,
-              0 /* reconnect_backoff_ms unset */)));
+      connect_loop_runners.push_back(absl::make_unique<ConnectLoopRunner>(
+          test_server.address(), fake_handshake_server.address(),
+          15 /* per connect deadline seconds */, 5 /* loops */,
+          GRPC_CHANNEL_READY /* expected connectivity states */,
+          0 /* reconnect_backoff_ms unset */));
     }
     connect_loop_runners.clear();
     gpr_log(GPR_DEBUG,
@@ -381,8 +380,7 @@ class FakeTcpServer {
       abort();
     }
     gpr_event_init(&stop_ev_);
-    run_server_loop_thd_ =
-        std::unique_ptr<std::thread>(new std::thread(RunServerLoop, this));
+    run_server_loop_thd_ = absl::make_unique<std::thread>(RunServerLoop, this);
   }
 
   ~FakeTcpServer() {
@@ -558,12 +556,11 @@ TEST(AltsConcurrentConnectivityTest,
     size_t num_concurrent_connects = 100;
     gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
     for (size_t i = 0; i < num_concurrent_connects; i++) {
-      connect_loop_runners.push_back(
-          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
-              fake_backend_server.address(), fake_handshake_server.address(),
-              10 /* per connect deadline seconds */, 3 /* loops */,
-              GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
-              0 /* reconnect_backoff_ms unset */)));
+      connect_loop_runners.push_back(absl::make_unique<ConnectLoopRunner>(
+          fake_backend_server.address(), fake_handshake_server.address(),
+          10 /* per connect deadline seconds */, 3 /* loops */,
+          GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
+          0 /* reconnect_backoff_ms unset */));
     }
     connect_loop_runners.clear();
     gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");
@@ -596,12 +593,11 @@ TEST(AltsConcurrentConnectivityTest,
     size_t num_concurrent_connects = 100;
     gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
     for (size_t i = 0; i < num_concurrent_connects; i++) {
-      connect_loop_runners.push_back(
-          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
-              fake_backend_server.address(), fake_handshake_server.address(),
-              20 /* per connect deadline seconds */, 2 /* loops */,
-              GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
-              0 /* reconnect_backoff_ms unset */)));
+      connect_loop_runners.push_back(absl::make_unique<ConnectLoopRunner>(
+          fake_backend_server.address(), fake_handshake_server.address(),
+          20 /* per connect deadline seconds */, 2 /* loops */,
+          GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
+          0 /* reconnect_backoff_ms unset */));
     }
     connect_loop_runners.clear();
     gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");
@@ -635,12 +631,11 @@ TEST(AltsConcurrentConnectivityTest,
     size_t num_concurrent_connects = 100;
     gpr_log(GPR_DEBUG, "start performing concurrent expected-to-fail connects");
     for (size_t i = 0; i < num_concurrent_connects; i++) {
-      connect_loop_runners.push_back(
-          std::unique_ptr<ConnectLoopRunner>(new ConnectLoopRunner(
-              fake_backend_server.address(), fake_handshake_server.address(),
-              10 /* per connect deadline seconds */, 2 /* loops */,
-              GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
-              100 /* reconnect_backoff_ms */)));
+      connect_loop_runners.push_back(absl::make_unique<ConnectLoopRunner>(
+          fake_backend_server.address(), fake_handshake_server.address(),
+          10 /* per connect deadline seconds */, 2 /* loops */,
+          GRPC_CHANNEL_TRANSIENT_FAILURE /* expected connectivity states */,
+          100 /* reconnect_backoff_ms */));
     }
     connect_loop_runners.clear();
     gpr_log(GPR_DEBUG, "done performing concurrent expected-to-fail connects");

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -32,6 +32,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/ext/filters/client_channel/backup_poller.h"
 #include "src/core/lib/gpr/tls.h"
 #include "src/core/lib/iomgr/port.h"
@@ -282,7 +284,8 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<TestScenario> {
     auto server_creds = GetCredentialsProvider()->GetServerCredentials(
         GetParam().credentials_type);
     builder.AddListeningPort(server_address_.str(), server_creds);
-    service_.reset(new grpc::testing::EchoTestService::AsyncService());
+    service_ =
+        absl::make_unique<grpc::testing::EchoTestService::AsyncService>();
     builder.RegisterService(service_.get());
     if (GetParam().health_check_service) {
       builder.RegisterService(&health_check_);

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -22,13 +22,15 @@
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
+#include <grpcpp/ext/channelz_service_plugin.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
-#include <grpcpp/ext/channelz_service_plugin.h>
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/gpr/env.h"
 #include "src/proto/grpc/channelz/channelz.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
@@ -140,7 +142,7 @@ class ChannelzServerTest : public ::testing::Test {
           "localhost:" + to_string(backends_[i].port);
       backend_builder.AddListeningPort(backend_server_address,
                                        InsecureServerCredentials());
-      backends_[i].service.reset(new TestServiceImpl);
+      backends_[i].service = absl::make_unique<TestServiceImpl>();
       // ensure that the backend itself has channelz disabled.
       backend_builder.AddChannelArgument(GRPC_ARG_ENABLE_CHANNELZ, 0);
       backend_builder.RegisterService(backends_[i].service.get());

--- a/test/cpp/end2end/client_crash_test.cc
+++ b/test/cpp/end2end/client_crash_test.cc
@@ -26,6 +26,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/proto/grpc/testing/duplicate/echo_duplicate.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -54,7 +56,7 @@ class CrashTest : public ::testing::Test {
     std::ostringstream addr_stream;
     addr_stream << "localhost:" << port;
     auto addr = addr_stream.str();
-    server_.reset(new SubProcess({
+    server_ = absl::make_unique<SubProcess>(std::vector<std::string>({
         g_root + "/client_crash_test_server",
         "--address=" + addr,
     }));

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -29,6 +29,7 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/client_interceptor.h>
 
+#include "absl/memory/memory.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
@@ -759,12 +760,10 @@ TEST_P(ParameterizedClientInterceptorsEnd2endTest,
   DummyInterceptor::Reset();
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
   // Add 20 dummy interceptors
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -803,8 +802,7 @@ TEST_F(ClientInterceptorsEnd2endTest,
   ChannelArguments args;
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<HijackingInterceptorFactory>(
-      new HijackingInterceptorFactory()));
+  creators.push_back(absl::make_unique<HijackingInterceptorFactory>());
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, nullptr, args, std::move(creators));
   MakeCall(channel);
@@ -818,15 +816,12 @@ TEST_F(ClientInterceptorsEnd2endTest, ClientInterceptorHijackingTest) {
   // Add 20 dummy interceptors before hijacking interceptor
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
-  creators.push_back(std::unique_ptr<HijackingInterceptorFactory>(
-      new HijackingInterceptorFactory()));
+  creators.push_back(absl::make_unique<HijackingInterceptorFactory>());
   // Add 20 dummy interceptors after hijacking interceptor
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -839,10 +834,8 @@ TEST_F(ClientInterceptorsEnd2endTest, ClientInterceptorLogThenHijackTest) {
   ChannelArguments args;
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
-  creators.push_back(std::unique_ptr<HijackingInterceptorFactory>(
-      new HijackingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
+  creators.push_back(absl::make_unique<HijackingInterceptorFactory>());
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
   MakeCall(channel);
@@ -858,16 +851,14 @@ TEST_F(ClientInterceptorsEnd2endTest,
   // Add 5 dummy interceptors before hijacking interceptor
   creators.reserve(5);
   for (auto i = 0; i < 5; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   creators.push_back(
       std::unique_ptr<experimental::ClientInterceptorFactoryInterface>(
           new HijackingInterceptorMakesAnotherCallFactory()));
   // Add 7 dummy interceptors after hijacking interceptor
   for (auto i = 0; i < 7; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = server_->experimental().InProcessChannelWithInterceptors(
       args, std::move(creators));
@@ -903,12 +894,10 @@ TEST_F(ClientInterceptorsCallbackEnd2endTest,
   DummyInterceptor::Reset();
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
   // Add 20 dummy interceptors
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = server_->experimental().InProcessChannelWithInterceptors(
       args, std::move(creators));
@@ -924,14 +913,11 @@ TEST_F(ClientInterceptorsCallbackEnd2endTest,
   DummyInterceptor::Reset();
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
   // Add 20 dummy interceptors and 20 null interceptors
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
-    creators.push_back(
-        std::unique_ptr<NullInterceptorFactory>(new NullInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
+    creators.push_back(absl::make_unique<NullInterceptorFactory>());
   }
   auto channel = server_->experimental().InProcessChannelWithInterceptors(
       args, std::move(creators));
@@ -965,12 +951,10 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, ClientStreamingTest) {
   DummyInterceptor::Reset();
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
   // Add 20 dummy interceptors
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -985,12 +969,10 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, ServerStreamingTest) {
   DummyInterceptor::Reset();
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
   // Add 20 dummy interceptors
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -1005,8 +987,7 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, ClientStreamingHijackingTest) {
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
   creators.push_back(
-      std::unique_ptr<ClientStreamingRpcHijackingInterceptorFactory>(
-          new ClientStreamingRpcHijackingInterceptorFactory()));
+      absl::make_unique<ClientStreamingRpcHijackingInterceptorFactory>());
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
 
@@ -1035,8 +1016,7 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, ServerStreamingHijackingTest) {
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
   creators.push_back(
-      std::unique_ptr<ServerStreamingRpcHijackingInterceptorFactory>(
-          new ServerStreamingRpcHijackingInterceptorFactory()));
+      absl::make_unique<ServerStreamingRpcHijackingInterceptorFactory>());
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
   MakeServerStreamingCall(channel);
@@ -1050,8 +1030,7 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest,
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
   creators.push_back(
-      std::unique_ptr<ServerStreamingRpcHijackingInterceptorFactory>(
-          new ServerStreamingRpcHijackingInterceptorFactory()));
+      absl::make_unique<ServerStreamingRpcHijackingInterceptorFactory>());
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
   MakeAsyncCQServerStreamingCall(channel);
@@ -1064,8 +1043,7 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, BidiStreamingHijackingTest) {
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
   creators.push_back(
-      std::unique_ptr<BidiStreamingRpcHijackingInterceptorFactory>(
-          new BidiStreamingRpcHijackingInterceptorFactory()));
+      absl::make_unique<BidiStreamingRpcHijackingInterceptorFactory>());
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
   MakeBidiStreamingCall(channel);
@@ -1076,12 +1054,10 @@ TEST_F(ClientInterceptorsStreamingEnd2endTest, BidiStreamingTest) {
   DummyInterceptor::Reset();
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       creators;
-  creators.push_back(std::unique_ptr<LoggingInterceptorFactory>(
-      new LoggingInterceptorFactory()));
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
   // Add 20 dummy interceptors
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -1123,8 +1099,7 @@ TEST_F(ClientGlobalInterceptorEnd2endTest, DummyGlobalInterceptor) {
   // Add 20 dummy interceptors
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -1147,8 +1122,7 @@ TEST_F(ClientGlobalInterceptorEnd2endTest, LoggingGlobalInterceptor) {
   // Add 20 dummy interceptors
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));
@@ -1172,8 +1146,7 @@ TEST_F(ClientGlobalInterceptorEnd2endTest, HijackingGlobalInterceptor) {
   // Add 20 dummy interceptors
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   auto channel = experimental::CreateCustomChannelWithInterceptors(
       server_address_, InsecureChannelCredentials(), args, std::move(creators));

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -37,7 +37,9 @@
 #include <mutex>
 #include <thread>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_format.h"
+
 #include "src/core/ext/filters/client_channel/backup_poller.h"
 #include "src/core/lib/gpr/env.h"
 #include "src/core/lib/iomgr/iomgr.h"
@@ -376,8 +378,7 @@ class End2endTest : public ::testing::TestWithParam<TestScenario> {
       // Add 20 dummy server interceptors
       creators.reserve(20);
       for (auto i = 0; i < 20; i++) {
-        creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-            new DummyInterceptorFactory()));
+        creators.push_back(absl::make_unique<DummyInterceptorFactory>());
       }
       builder.experimental().SetInterceptorCreators(std::move(creators));
     }
@@ -447,7 +448,7 @@ class End2endTest : public ::testing::TestWithParam<TestScenario> {
           interceptor_creators = {}) {
     ResetChannel(std::move(interceptor_creators));
     if (GetParam().use_proxy) {
-      proxy_service_.reset(new Proxy(channel_));
+      proxy_service_ = absl::make_unique<Proxy>(channel_);
       int port = grpc_pick_unused_port_or_die();
       std::ostringstream proxyaddr;
       proxyaddr << "localhost:" << port;
@@ -1887,8 +1888,8 @@ TEST_P(SecureEnd2endTest, CallCredentialsInterception) {
   }
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       interceptor_creators;
-  interceptor_creators.push_back(std::unique_ptr<CredentialsInterceptorFactory>(
-      new CredentialsInterceptorFactory()));
+  interceptor_creators.push_back(
+      absl::make_unique<CredentialsInterceptorFactory>());
   ResetStub(std::move(interceptor_creators));
   EchoRequest request;
   EchoResponse response;
@@ -1917,8 +1918,8 @@ TEST_P(SecureEnd2endTest, CallCredentialsInterceptionWithSetCredentials) {
   }
   std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
       interceptor_creators;
-  interceptor_creators.push_back(std::unique_ptr<CredentialsInterceptorFactory>(
-      new CredentialsInterceptorFactory()));
+  interceptor_creators.push_back(
+      absl::make_unique<CredentialsInterceptorFactory>());
   ResetStub(std::move(interceptor_creators));
   EchoRequest request;
   EchoResponse response;

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -34,6 +34,8 @@
 #include <grpcpp/support/config.h>
 #include <grpcpp/support/slice.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/cpp/common/channel_filter.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -160,7 +162,7 @@ class FilterEnd2endTest : public ::testing::Test {
   void ResetStub() {
     std::shared_ptr<Channel> channel = grpc::CreateChannel(
         server_address_.str(), InsecureChannelCredentials());
-    generic_stub_.reset(new GenericStub(channel));
+    generic_stub_ = absl::make_unique<GenericStub>(channel);
     ResetConnectionCounter();
     ResetCallCounter();
   }

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -32,6 +32,8 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/slice.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
@@ -98,7 +100,7 @@ class GenericEnd2endTest : public ::testing::Test {
     std::shared_ptr<Channel> channel = grpc::CreateChannel(
         server_address_.str(), InsecureChannelCredentials());
     stub_ = grpc::testing::EchoTestService::NewStub(channel);
-    generic_stub_.reset(new GenericStub(channel));
+    generic_stub_ = absl::make_unique<GenericStub>(channel);
   }
 
   void server_ok(int i) { verify_ok(srv_cq_.get(), i, true); }

--- a/test/cpp/end2end/interceptors_util.cc
+++ b/test/cpp/end2end/interceptors_util.cc
@@ -18,6 +18,8 @@
 
 #include "test/cpp/end2end/interceptors_util.h"
 
+#include "absl/memory/memory.h"
+
 namespace grpc {
 namespace testing {
 
@@ -203,8 +205,7 @@ CreateDummyClientInterceptors() {
   // Add 20 dummy interceptors before hijacking interceptor
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   return creators;
 }

--- a/test/cpp/end2end/nonblocking_test.cc
+++ b/test/cpp/end2end/nonblocking_test.cc
@@ -25,6 +25,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/gpr/tls.h"
 #include "src/core/lib/iomgr/port.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
@@ -109,7 +111,8 @@ class NonblockingTest : public ::testing::Test {
     ServerBuilder builder;
     builder.AddListeningPort(server_address_.str(),
                              grpc::InsecureServerCredentials());
-    service_.reset(new grpc::testing::EchoTestService::AsyncService());
+    service_ =
+        absl::make_unique<grpc::testing::EchoTestService::AsyncService>();
     builder.RegisterService(service_.get());
     cq_ = builder.AddCompletionQueue();
     server_ = builder.BuildAndStart();

--- a/test/cpp/end2end/proto_server_reflection_test.cc
+++ b/test/cpp/end2end/proto_server_reflection_test.cc
@@ -27,6 +27,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
@@ -57,8 +59,8 @@ class ProtoServerReflectionTest : public ::testing::Test {
     std::shared_ptr<Channel> channel =
         grpc::CreateChannel(target, InsecureChannelCredentials());
     stub_ = grpc::testing::EchoTestService::NewStub(channel);
-    desc_db_.reset(new ProtoReflectionDescriptorDatabase(channel));
-    desc_pool_.reset(new protobuf::DescriptorPool(desc_db_.get()));
+    desc_db_ = absl::make_unique<ProtoReflectionDescriptorDatabase>(channel);
+    desc_pool_ = absl::make_unique<protobuf::DescriptorPool>(desc_db_.get());
   }
 
   string to_string(const int number) {

--- a/test/cpp/end2end/server_builder_plugin_test.cc
+++ b/test/cpp/end2end/server_builder_plugin_test.cc
@@ -31,6 +31,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
@@ -138,7 +140,7 @@ class ServerBuilderPluginTest : public ::testing::TestWithParam<bool> {
 
   void SetUp() override {
     port_ = grpc_pick_unused_port_or_die();
-    builder_.reset(new ServerBuilder());
+    builder_ = absl::make_unique<ServerBuilder>();
   }
 
   void InsertPlugin() {

--- a/test/cpp/end2end/server_crash_test.cc
+++ b/test/cpp/end2end/server_crash_test.cc
@@ -26,6 +26,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/proto/grpc/testing/duplicate/echo_duplicate.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -99,7 +101,8 @@ class CrashTest : public ::testing::Test {
     std::ostringstream addr_stream;
     addr_stream << "localhost:" << port;
     auto addr = addr_stream.str();
-    client_.reset(new SubProcess({g_root + "/server_crash_test_client",
+    client_ = absl::make_unique<SubProcess>(
+        std::vector<std::string>({g_root + "/server_crash_test_client",
                                   "--address=" + addr, "--mode=" + mode}));
     GPR_ASSERT(client_);
 

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -29,6 +29,7 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/server_interceptor.h>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
@@ -253,10 +254,8 @@ class ServerInterceptorsEnd2endSyncUnaryTest : public ::testing::Test {
             new LoggingInterceptorFactory()));
     // Add 20 dummy interceptor factories and null interceptor factories
     for (auto i = 0; i < 20; i++) {
-      creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-          new DummyInterceptorFactory()));
-      creators.push_back(std::unique_ptr<NullInterceptorFactory>(
-          new NullInterceptorFactory()));
+      creators.push_back(absl::make_unique<DummyInterceptorFactory>());
+      creators.push_back(absl::make_unique<NullInterceptorFactory>());
     }
     builder.experimental().SetInterceptorCreators(std::move(creators));
     server_ = builder.BuildAndStart();
@@ -299,8 +298,7 @@ class ServerInterceptorsEnd2endSyncStreamingTest : public ::testing::Test {
         std::unique_ptr<experimental::ServerInterceptorFactoryInterface>(
             new LoggingInterceptorFactory()));
     for (auto i = 0; i < 20; i++) {
-      creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-          new DummyInterceptorFactory()));
+      creators.push_back(absl::make_unique<DummyInterceptorFactory>());
     }
     builder.experimental().SetInterceptorCreators(std::move(creators));
     server_ = builder.BuildAndStart();
@@ -356,8 +354,7 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, UnaryTest) {
       std::unique_ptr<experimental::ServerInterceptorFactoryInterface>(
           new LoggingInterceptorFactory()));
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   builder.experimental().SetInterceptorCreators(std::move(creators));
   auto cq = builder.AddCompletionQueue();
@@ -429,8 +426,7 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, BidiStreamingTest) {
       std::unique_ptr<experimental::ServerInterceptorFactoryInterface>(
           new LoggingInterceptorFactory()));
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   builder.experimental().SetInterceptorCreators(std::move(creators));
   auto cq = builder.AddCompletionQueue();
@@ -510,8 +506,7 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, GenericRPCTest) {
       creators;
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   builder.experimental().SetInterceptorCreators(std::move(creators));
   auto srv_cq = builder.AddCompletionQueue();
@@ -616,8 +611,7 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, UnimplementedRpcTest) {
       creators;
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   builder.experimental().SetInterceptorCreators(std::move(creators));
   auto cq = builder.AddCompletionQueue();
@@ -670,8 +664,7 @@ TEST_F(ServerInterceptorsSyncUnimplementedEnd2endTest, UnimplementedRpcTest) {
       creators;
   creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
-    creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
-        new DummyInterceptorFactory()));
+    creators.push_back(absl::make_unique<DummyInterceptorFactory>());
   }
   builder.experimental().SetInterceptorCreators(std::move(creators));
   auto server = builder.BuildAndStart();

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -24,6 +24,7 @@
 #include <string>
 #include <thread>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/grpc.h>
@@ -311,8 +312,8 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
       grpc::internal::Mutex mu;
       grpc::internal::MutexLock lock(&mu);
       grpc::internal::CondVar cond;
-      thread_.reset(new std::thread(
-          std::bind(&ServerData::Serve, this, server_host, &mu, &cond)));
+      thread_ = absl::make_unique<std::thread>(
+          std::bind(&ServerData::Serve, this, server_host, &mu, &cond));
       cond.WaitUntil(&mu, [this] { return server_ready_; });
       server_ready_ = false;
       gpr_log(GPR_INFO, "server startup complete");

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -26,6 +26,8 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/iomgr/timer.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -133,7 +135,7 @@ class TimeChangeTest : public ::testing::Test {
     std::ostringstream addr_stream;
     addr_stream << "localhost:" << port;
     server_address_ = addr_stream.str();
-    server_.reset(new SubProcess({
+    server_ = absl::make_unique<SubProcess>(std::vector<std::string>({
         g_root + "/client_crash_test_server",
         "--address=" + server_address_,
     }));

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -29,6 +29,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 
@@ -1794,8 +1795,8 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
       // by ServerThread::Serve from firing before the wait below is hit.
       grpc_core::MutexLock lock(&mu);
       grpc_core::CondVar cond;
-      thread_.reset(
-          new std::thread(std::bind(&ServerThread::Serve, this, &mu, &cond)));
+      thread_ = absl::make_unique<std::thread>(
+          std::bind(&ServerThread::Serve, this, &mu, &cond));
       cond.Wait(&mu);
       gpr_log(GPR_INFO, "%s server startup complete", Type());
     }

--- a/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
@@ -22,6 +22,8 @@
 #include <gflags/gflags.h>
 #include <fstream>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/lib/iomgr/timer_manager.h"
@@ -89,7 +91,7 @@ class TrickledCHTTP2 : public EndpointPairFixture {
       std::ostringstream fn;
       fn << "trickle." << (streaming ? "streaming" : "unary") << "." << req_size
          << "." << resp_size << "." << kilobits_per_second << ".csv";
-      log_.reset(new std::ofstream(fn.str().c_str()));
+      log_ = absl::make_unique<std::ofstream>(fn.str().c_str());
       write_csv(log_.get(), "t", "iteration", "client_backlog",
                 "server_backlog", "client_t_stall", "client_s_stall",
                 "server_t_stall", "server_s_stall", "client_t_remote",

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -29,6 +29,7 @@
 #include <gflags/gflags.h>
 #include <gmock/gmock.h>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -590,9 +591,10 @@ void RunResolvesRelevantRecordsTest(
       fake_non_responsive_dns_server;
   if (FLAGS_inject_broken_nameserver_list == "True") {
     g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
-    fake_non_responsive_dns_server.reset(
-        new grpc::testing::FakeNonResponsiveDNSServer(
-            g_fake_non_responsive_dns_server_port));
+    fake_non_responsive_dns_server =
+        absl::make_unique<grpc::testing::FakeNonResponsiveDNSServer>(
+
+            g_fake_non_responsive_dns_server_port);
     grpc_ares_test_only_inject_config = InjectBrokenNameServerList;
     whole_uri = absl::StrCat("dns:///", FLAGS_target_name);
   } else if (FLAGS_inject_broken_nameserver_list == "False") {

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -34,6 +34,7 @@
 #include <grpcpp/support/channel_arguments.h>
 #include <grpcpp/support/slice.h>
 
+#include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 
 #include "src/proto/grpc/testing/benchmark_service.grpc.pb.h"
@@ -362,8 +363,8 @@ class Client {
         // Closed-loop doesn't use random dist at all
         break;
       case LoadParams::kPoisson:
-        random_dist.reset(
-            new ExpDist(load.poisson().offered_load() / num_threads));
+        random_dist = absl::make_unique<ExpDist>(load.poisson().offered_load() /
+                                                 num_threads);
         break;
       default:
         GPR_ASSERT(false);

--- a/test/cpp/qps/client_async.cc
+++ b/test/cpp/qps/client_async.cc
@@ -35,6 +35,8 @@
 #include <grpcpp/client_context.h>
 #include <grpcpp/generic/generic_stub.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/surface/completion_queue.h"
 #include "src/proto/grpc/testing/benchmark_service.grpc.pb.h"
 #include "test/cpp/qps/client.h"
@@ -802,7 +804,7 @@ class ClientRpcContextGenericStreamingImpl : public ClientRpcContext {
           break;  // loop around, don't return
         case State::WAIT:
           next_state_ = State::READY_TO_WRITE;
-          alarm_.reset(new Alarm);
+          alarm_ = absl::make_unique<Alarm>();
           alarm_->Set(cq_, next_issue_(), ClientRpcContext::tag(this));
           return true;
         case State::READY_TO_WRITE:
@@ -899,7 +901,7 @@ class ClientRpcContextGenericStreamingImpl : public ClientRpcContext {
 
 static std::unique_ptr<grpc::GenericStub> GenericStubCreator(
     const std::shared_ptr<Channel>& ch) {
-  return std::unique_ptr<grpc::GenericStub>(new grpc::GenericStub(ch));
+  return absl::make_unique<grpc::GenericStub>(ch);
 }
 
 class GenericAsyncStreamingClient final

--- a/test/cpp/qps/qps_server_builder.cc
+++ b/test/cpp/qps/qps_server_builder.cc
@@ -18,6 +18,8 @@
 
 #include "qps_server_builder.h"
 
+#include "absl/memory/memory.h"
+
 using grpc::ServerBuilder;
 
 namespace grpc {
@@ -25,7 +27,7 @@ namespace testing {
 
 namespace {
 std::unique_ptr<ServerBuilder> DefaultCreateQpsServerBuilder() {
-  return std::unique_ptr<ServerBuilder>(new ServerBuilder());
+  return absl::make_unique<ServerBuilder>();
 }
 
 std::function<std::unique_ptr<ServerBuilder>()> g_create_qps_server_builder =

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -34,6 +34,8 @@
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/proto/grpc/testing/worker_service.grpc.pb.h"
 #include "test/core/util/grpc_profiler.h"
@@ -276,7 +278,7 @@ class WorkerServiceImpl final : public WorkerService::Service {
 
 QpsWorker::QpsWorker(int driver_port, int server_port,
                      const std::string& credential_type) {
-  impl_.reset(new WorkerServiceImpl(server_port, this));
+  impl_ = absl::make_unique<WorkerServiceImpl>(server_port, this);
   gpr_atm_rel_store(&done_, static_cast<gpr_atm>(0));
 
   std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();

--- a/test/cpp/server/load_reporter/load_reporter_test.cc
+++ b/test/cpp/server/load_reporter/load_reporter_test.cc
@@ -25,6 +25,8 @@
 #include <grpc/grpc.h>
 #include <gtest/gtest.h>
 
+#include "absl/memory/memory.h"
+
 #include "src/core/ext/filters/load_reporting/registered_opencensus_objects.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/cpp/server/load_reporter/constants.h"
@@ -140,10 +142,10 @@ class LoadReporterTest : public ::testing::Test {
     EXPECT_CALL(*mock_cpu, GetCpuStats())
         .WillOnce(Return(initial_cpu_stats_))
         .RetiresOnSaturation();
-    load_reporter_ = std::unique_ptr<LoadReporter>(
-        new LoadReporter(kFeedbackSampleWindowSeconds,
-                         std::unique_ptr<CensusViewProvider>(mock_census),
-                         std::unique_ptr<CpuStatsProvider>(mock_cpu)));
+    load_reporter_ = absl::make_unique<LoadReporter>(
+        kFeedbackSampleWindowSeconds,
+        std::unique_ptr<CensusViewProvider>(mock_census),
+        std::unique_ptr<CpuStatsProvider>(mock_cpu));
   }
 };
 

--- a/test/cpp/util/byte_buffer_proto_helper.cc
+++ b/test/cpp/util/byte_buffer_proto_helper.cc
@@ -18,6 +18,8 @@
 
 #include "test/cpp/util/byte_buffer_proto_helper.h"
 
+#include "absl/memory/memory.h"
+
 namespace grpc {
 namespace testing {
 
@@ -37,7 +39,7 @@ std::unique_ptr<ByteBuffer> SerializeToByteBuffer(
   std::string buf;
   message->SerializeToString(&buf);
   Slice slice(buf);
-  return std::unique_ptr<ByteBuffer>(new ByteBuffer(&slice, 1));
+  return absl::make_unique<ByteBuffer>(&slice, 1);
 }
 
 bool SerializeToByteBufferInPlace(grpc::protobuf::Message* message,

--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -35,6 +35,8 @@
 #include <string>
 #include <thread>
 
+#include "absl/memory/memory.h"
+
 #include "test/cpp/util/cli_call.h"
 #include "test/cpp/util/proto_file_parser.h"
 #include "test/cpp/util/proto_reflection_descriptor_database.h"
@@ -514,9 +516,8 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
       CreateCliChannel(server_address, cred);
 
   if (!FLAGS_binary_input || !FLAGS_binary_output) {
-    parser.reset(
-        new grpc::testing::ProtoFileParser(FLAGS_remotedb ? channel : nullptr,
-                                           FLAGS_proto_path, FLAGS_protofiles));
+    parser = absl::make_unique<grpc::testing::ProtoFileParser>(
+        FLAGS_remotedb ? channel : nullptr, FLAGS_proto_path, FLAGS_protofiles);
     if (parser->HasError()) {
       fprintf(
           stderr,
@@ -887,9 +888,8 @@ bool GrpcTool::ParseMessage(int argc, const char** argv,
   if (!FLAGS_binary_input || !FLAGS_binary_output) {
     std::shared_ptr<grpc::Channel> channel =
         CreateCliChannel(server_address, cred);
-    parser.reset(
-        new grpc::testing::ProtoFileParser(FLAGS_remotedb ? channel : nullptr,
-                                           FLAGS_proto_path, FLAGS_protofiles));
+    parser = absl::make_unique<grpc::testing::ProtoFileParser>(
+        FLAGS_remotedb ? channel : nullptr, FLAGS_proto_path, FLAGS_protofiles);
     if (parser->HasError()) {
       fprintf(
           stderr,


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize-make-unique.html

Fix is done automatically by clang-tidy except `SubProcess` using brace initialization which needs a manual fix.

Code like below
```
server_.reset(new SubProcess({
  g_root + "/client_crash_test_server",
  "--address=" + addr,
}));
```

changed to like below to specify `std::vector<std::string>` to let the compiler know the type that brace initialization is for.
```
server_ = absl::make_unique<SubProcess>(std::vector<std::string>({
  g_root + "/client_crash_test_server",
  "--address=" + addr,
}));
```