### PR TITLE
[Clang-Tidy] readability-redundant-smartptr-get

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,7 +36,7 @@ Checks: '-*,
   readability-function-size,
   -readability-inconsistent-declaration-parameter-name,
   -readability-redundant-control-flow,
-  -readability-redundant-smartptr-get,
+  readability-redundant-smartptr-get,
   -readability-string-compare'
 WarningsAsErrors: '*'
 CheckOptions:

--- a/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h
@@ -247,13 +247,13 @@ struct grpc_tls_credentials_options
  public:
   ~grpc_tls_credentials_options() {
     if (key_materials_config_.get() != nullptr) {
-      key_materials_config_.get()->Unref();
+      key_materials_config_->Unref();
     }
     if (credential_reload_config_.get() != nullptr) {
-      credential_reload_config_.get()->Unref();
+      credential_reload_config_->Unref();
     }
     if (server_authorization_check_config_.get() != nullptr) {
-      server_authorization_check_config_.get()->Unref();
+      server_authorization_check_config_->Unref();
     }
   }
 

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -160,7 +160,7 @@ TlsChannelSecurityConnector::~TlsChannelSecurityConnector() {
     tsi_ssl_client_handshaker_factory_unref(client_handshaker_factory_);
   }
   if (key_materials_config_.get() != nullptr) {
-    key_materials_config_.get()->Unref();
+    key_materials_config_->Unref();
   }
   ServerAuthorizationCheckArgDestroy(check_arg_);
 }
@@ -469,7 +469,7 @@ TlsServerSecurityConnector::~TlsServerSecurityConnector() {
     tsi_ssl_server_handshaker_factory_unref(server_handshaker_factory_);
   }
   if (key_materials_config_.get() != nullptr) {
-    key_materials_config_.get()->Unref();
+    key_materials_config_->Unref();
   }
 }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1014,7 +1014,7 @@ bool Server::RegisterService(const std::string* host, grpc::Service* service) {
   const char* method_name = nullptr;
 
   for (const auto& method : service->methods_) {
-    if (method.get() == nullptr) {  // Handled by generic service if any.
+    if (method == nullptr) {  // Handled by generic service if any.
       continue;
     }
 

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -285,8 +285,8 @@ TEST_F(GenericEnd2endTest, SequentialUnaryRpcs) {
         SerializeToByteBuffer(&send_request);
     std::thread request_call([this]() { server_ok(4); });
     std::unique_ptr<GenericClientAsyncResponseReader> call =
-        generic_stub_->PrepareUnaryCall(&cli_ctx, kMethodName,
-                                        *cli_send_buffer.get(), &cli_cq_);
+        generic_stub_->PrepareUnaryCall(&cli_ctx, kMethodName, *cli_send_buffer,
+                                        &cli_cq_);
     call->StartCall();
     ByteBuffer cli_recv_buffer;
     call->Finish(&cli_recv_buffer, &recv_status, tag(1));

--- a/test/cpp/util/proto_file_parser.cc
+++ b/test/cpp/util/proto_file_parser.cc
@@ -298,14 +298,14 @@ std::string ProtoFileParser::GetFormattedStringFromMessageType(
   if (is_json_format) {
     grpc::protobuf::json::JsonPrintOptions jsonPrintOptions;
     jsonPrintOptions.add_whitespace = true;
-    if (!grpc::protobuf::json::MessageToJsonString(
-             *msg.get(), &formatted_string, jsonPrintOptions)
+    if (!grpc::protobuf::json::MessageToJsonString(*msg, &formatted_string,
+                                                   jsonPrintOptions)
              .ok()) {
       LogError("Failed to print proto message to json format");
       return "";
     }
   } else {
-    if (!protobuf::TextFormat::PrintToString(*msg.get(), &formatted_string)) {
+    if (!protobuf::TextFormat::PrintToString(*msg, &formatted_string)) {
       LogError("Failed to print proto message to text format");
       return "";
     }


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-smartptr-get.html

Fix is done automatically by clang-tidy