### PR TITLE
Rerun clang-tidy fix

### DIFF
--- a/src/core/ext/xds/certificate_provider_factory.h
+++ b/src/core/ext/xds/certificate_provider_factory.h
@@ -34,7 +34,7 @@ class CertificateProviderFactory {
   // Interface for configs for CertificateProviders.
   class Config : public RefCounted<Config> {
    public:
-    virtual ~Config() = default;
+    ~Config() override = default;
 
     // Name of the type of the CertificateProvider. Unique to each type of
     // config.

--- a/test/core/client_channel/xds_bootstrap_test.cc
+++ b/test/core/client_channel/xds_bootstrap_test.cc
@@ -35,7 +35,7 @@ class XdsBootstrapTest : public ::testing::Test {
  public:
   XdsBootstrapTest() { grpc_init(); }
 
-  ~XdsBootstrapTest() { grpc_shutdown_blocking(); }
+  ~XdsBootstrapTest() override { grpc_shutdown_blocking(); }
 };
 
 TEST_F(XdsBootstrapTest, Basic) {


### PR DESCRIPTION
This is fix against missing source files happened to get merged at once.