### PR TITLE
Extend timeout for cfstream-test.

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1100,7 +1100,7 @@ class ObjCLanguage(object):
         out.append(
             self.config.job_spec(
                 ['test/core/iomgr/ios/CFStreamTests/build_and_run_tests.sh'],
-                timeout_seconds=30 * 60,
+                timeout_seconds=60 * 60,
                 shortname='ios-test-cfstream-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))


### PR DESCRIPTION
Extend timeout for `ios-test-cfstream-tests` and keep it the same as `ios-test-cronettests`.