### PR TITLE
Bump MACOSX_DEPLOYMENT_TARGET to 10.10 for Ruby

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -22,7 +22,7 @@ grpc_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../..'))
 
 grpc_config = ENV['GRPC_CONFIG'] || 'opt'
 
-ENV['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
+ENV['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
 
 if ENV['AR'].nil? || ENV['AR'].size == 0
     ENV['AR'] = RbConfig::CONFIG['AR']


### PR DESCRIPTION
Bumping the minimum version of OSX of Ruby to 10.10.

This is part of #24247 and #24282.