### PR TITLE
Bump MACOSX_DEPLOYMENT_TARGET to 10.10 for Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,15 +341,15 @@ if "linux" in sys.platform or "darwin" in sys.platform:
     DEFINE_MACROS += (('GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK', 1),)
 
 # By default, Python3 distutils enforces compatibility of
-# c plugins (.so files) with the OSX version Python3 was built with.
-# For Python3.4, this is OSX 10.6, but we need Thread Local Support (__thread)
-if 'darwin' in sys.platform and PY3:
+# c plugins (.so files) with the OSX version Python was built with.
+# We need OSX 10.10, the oldest which supports C++ thread_local.
+if 'darwin' in sys.platform:
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target and (pkg_resources.parse_version(mac_target) <
-                       pkg_resources.parse_version('10.7.0')):
-        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
+                       pkg_resources.parse_version('10.10.0')):
+        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
         os.environ['_PYTHON_HOST_PLATFORM'] = re.sub(
-            r'macosx-[0-9]+\.[0-9]+-(.+)', r'macosx-10.7-\1',
+            r'macosx-[0-9]+\.[0-9]+-(.+)', r'macosx-10.10-\1',
             util.get_platform())
 
 

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -150,9 +150,9 @@ elif "linux" in sys.platform or "darwin" in sys.platform:
     DEFINE_MACROS += (('HAVE_PTHREAD', 1),)
 
 # By default, Python3 distutils enforces compatibility of
-# c plugins (.so files) with the OSX version Python3 was built with.
-# For Python3.4, this is OSX 10.6, but we need Thread Local Support (__thread)
-if 'darwin' in sys.platform and PY3:
+# c plugins (.so files) with the OSX version Python was built with.
+# We need OSX 10.10, the oldest which supports C++ thread_local.
+if 'darwin' in sys.platform:
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target and (pkg_resources.parse_version(mac_target) <
                        pkg_resources.parse_version('10.10.0')):


### PR DESCRIPTION
Bumping the minimum version of OSX of Python to 10.10.

This is part of #24247 and #24282.