### PR TITLE
[Clang-Tidy] Enable readability-redundant-control-flow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,7 +35,7 @@ Checks: '-*,
   readability-deleted-default,
   readability-function-size,
   -readability-inconsistent-declaration-parameter-name,
-  -readability-redundant-control-flow,
+  readability-redundant-control-flow,
   readability-redundant-smartptr-get,
   -readability-string-compare'
 WarningsAsErrors: '*'

--- a/src/core/lib/compression/stream_compression_identity.cc
+++ b/src/core/lib/compression/stream_compression_identity.cc
@@ -82,9 +82,7 @@ grpc_stream_compression_context_create_identity(
 }
 
 static void grpc_stream_compression_context_destroy_identity(
-    grpc_stream_compression_context* /*ctx*/) {
-  return;
-}
+    grpc_stream_compression_context* /*ctx*/) {}
 
 const grpc_stream_compression_vtable grpc_stream_compression_identity_vtable = {
     grpc_stream_compress_identity, grpc_stream_decompress_identity,

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -811,7 +811,7 @@ uint32_t grpc_call_test_only_get_message_flags(grpc_call* call) {
   return flags;
 }
 
-static void destroy_encodings_accepted_by_peer(void* /*p*/) { return; }
+static void destroy_encodings_accepted_by_peer(void* /*p*/) {}
 
 static void set_encodings_accepted_by_peer(grpc_call* /*call*/,
                                            grpc_mdelem mdel,

--- a/test/cpp/naming/resolver_component_tests_runner_invoker.cc
+++ b/test/cpp/naming/resolver_component_tests_runner_invoker.cc
@@ -95,7 +95,6 @@ void RunSigHandlingThread(SubProcess* test_driver, gpr_mu* test_driver_mu,
           "Test timeout reached or received signal. Interrupting test driver "
           "child process.");
   test_driver->Interrupt();
-  return;
 }
 }  // namespace
 

--- a/test/cpp/qps/client_callback.cc
+++ b/test/cpp/qps/client_callback.cc
@@ -164,7 +164,7 @@ class CallbackUnaryClient final : public CallbackClient {
     return true;
   }
 
-  void InitThreadFuncImpl(size_t /*thread_idx*/) override { return; }
+  void InitThreadFuncImpl(size_t /*thread_idx*/) override {}
 
  private:
   void ScheduleRpc(Thread* t, size_t vector_idx) {


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/readability-redundant-control-flow.htm

Fix is done automatically by clang-tidy