### PR TITLE
Fix to not require libc-dev on .NET 5 or later

### DIFF
--- a/src/csharp/Grpc.Auth/GoogleAuthInterceptors.cs
+++ b/src/csharp/Grpc.Auth/GoogleAuthInterceptors.cs
@@ -101,7 +101,7 @@ namespace Grpc.Auth
         /// </summary>
         private static Task GetCompletedTask()
         {
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
             return Task.CompletedTask;
 #else
             return Task.FromResult<object>(null);  // for .NET45, emulate the functionality

--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -448,7 +448,7 @@ namespace Grpc.Core
                         // the gRPC channels and servers before the application exits. The following
                         // hooks provide some extra handling for cases when this is not the case,
                         // in the effort to achieve a reasonable behavior on shutdown.
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
                         // No action required at shutdown on .NET Core
                         // - In-progress P/Invoke calls (such as grpc_completion_queue_next) don't seem
                         //   to prevent a .NET core application from terminating, so no special handling

--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -156,7 +156,7 @@ namespace Grpc.Core.Internal
         private static string GetAssemblyPath()
         {
             var assembly = typeof(NativeExtension).GetTypeInfo().Assembly;
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
             // Assembly.EscapedCodeBase does not exist under CoreCLR, but assemblies imported from a nuget package
             // don't seem to be shadowed by DNX-based projects at all.
             return assembly.Location;
@@ -175,7 +175,7 @@ namespace Grpc.Core.Internal
 #endif
         }
 
-#if !NETSTANDARD1_5 && !NETSTANDARD2_0
+#if !NETSTANDARD
         private static bool IsFileUri(string uri)
         {
             return uri.ToLowerInvariant().StartsWith(Uri.UriSchemeFile);

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -49,11 +49,15 @@ namespace Grpc.Core.Internal
 
         static PlatformApis()
         {
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
             isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
             isMacOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            isNetCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+            isNetCore =
+#if NETSTANDARD2_0
+                Environment.Version.Major >= 5 ||
+#endif
+                RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
 #else
             var platform = Environment.OSVersion.Platform;
 

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -175,7 +175,7 @@ namespace Grpc.Core.Internal
         public static string GetUnityRuntimePlatform()
         {
             GrpcPreconditions.CheckState(IsUnity, "Not running on Unity.");
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
             return Type.GetType(UnityEngineApplicationClassName).GetTypeInfo().GetProperty("platform").GetValue(null).ToString();
 #else
             return Type.GetType(UnityEngineApplicationClassName).GetProperty("platform").GetValue(null).ToString();

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -120,7 +120,7 @@ namespace Grpc.Core.Internal
             {
                 throw new MissingMethodException(string.Format("The native method \"{0}\" does not exist", methodName));
             }
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
             return Marshal.GetDelegateForFunctionPointer<T>(ptr);  // non-generic version is obsolete
 #else
             return Marshal.GetDelegateForFunctionPointer(ptr, typeof(T)) as T;  // generic version not available in .NET45

--- a/src/csharp/Grpc.Core/Utils/TaskUtils.cs
+++ b/src/csharp/Grpc.Core/Utils/TaskUtils.cs
@@ -33,7 +33,7 @@ namespace Grpc.Core.Utils
         {
             get
             {
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD
                 return Task.CompletedTask;
 #else
                 return Task.FromResult<object>(null);  // for .NET45, emulate the functionality


### PR DESCRIPTION
@jtattermusch Fixes #24153 using approach recommended in https://github.com/dotnet/runtime/issues/12124#issuecomment-712523511.