### PR TITLE
Reduce templating for async client unary call codegen without adding protobuf dependence

### DIFF
--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -40,8 +40,7 @@ template <class W>
 class ClientAsyncWriterFactory;
 template <class W, class R>
 class ClientAsyncReaderWriterFactory;
-template <class R>
-class ClientAsyncResponseReaderFactory;
+class ClientAsyncResponseReaderHelper;
 template <class W, class R>
 class ClientCallbackReaderWriterFactory;
 template <class R>
@@ -116,8 +115,7 @@ class ChannelInterface {
   friend class ::grpc::internal::ClientAsyncWriterFactory;
   template <class W, class R>
   friend class ::grpc::internal::ClientAsyncReaderWriterFactory;
-  template <class R>
-  friend class ::grpc::internal::ClientAsyncResponseReaderFactory;
+  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
   template <class W, class R>
   friend class ::grpc::internal::ClientCallbackReaderWriterFactory;
   template <class R>

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -72,6 +72,7 @@ template <class Request>
 class ClientCallbackWriterImpl;
 class ClientCallbackUnaryImpl;
 class ClientContextAccessor;
+class ClientAsyncResponseReaderHelper;
 }  // namespace internal
 
 template <class R>
@@ -439,6 +440,7 @@ class ClientContext {
   friend class ::grpc::ClientAsyncReaderWriter;
   template <class R>
   friend class ::grpc::ClientAsyncResponseReader;
+  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
   template <class InputMessage, class OutputMessage>
   friend class ::grpc::internal::BlockingUnaryCallImpl;
   template <class InputMessage, class OutputMessage>

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1924,10 +1924,11 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "::grpc::CompletionQueue* cq) {\n");
     printer->Print(*vars,
                    "  return "
-                   "::grpc::internal::ClientAsyncResponseReaderFactory"
-                   "< $Response$>::Create(channel_.get(), cq, "
-                   "rpcmethod_$Method$_, "
-                   "context, request, false);\n"
+                   "::grpc::internal::ClientAsyncResponseReaderHelper::Create"
+                   "< $Response$, $Request$, ::grpc::protobuf::MessageLite, "
+                   "::grpc::protobuf::MessageLite>"
+                   "(channel_.get(), cq, rpcmethod_$Method$_, "
+                   "context, request);\n"
                    "}\n\n");
     printer->Print(*vars,
                    "::grpc::ClientAsyncResponseReader< $Response$>* "


### PR DESCRIPTION
Client unary code size reduction by reducing template usage for the CQ-based async API turned out to be harder than for sync or callback since there must be active type erasure. This issue arises for two reasons:

1. The templated CallOpSet is created with the new ClientAsyncResponseReader but is not initiated until StartCall, by which point we no longer have the benefit of the codegen feeding us the actual base class
1. The parameter to Finish is of the API type but the internal classes must be done according to the base class. In this case, we actually detour through void to facilitate this usage.

Type erasure is done through std::function and use of base classes rather than the specifically templated CallOpSet.

When combined with the sync and callback code reductions in #24420 and #24423, the generated code size drops from 4.9MB to 2.5 MB. This is partly because these PRs are superadditive in effects since some templates are not removed from the generated code unless they appear to have gone from any usage.
