### PR TITLE
Also reduce templating for ClientUnaryReactor

### DIFF
--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -1191,7 +1191,8 @@ class ClientCallbackUnaryImpl final : public ClientCallbackUnary {
 
 class ClientCallbackUnaryFactory {
  public:
-  template <class Request, class Response>
+  template <class Request, class Response, class BaseRequest = Request,
+            class BaseResponse = Response>
   static void Create(::grpc::ChannelInterface* channel,
                      const ::grpc::internal::RpcMethod& method,
                      ::grpc::ClientContext* context, const Request* request,
@@ -1203,7 +1204,9 @@ class ClientCallbackUnaryFactory {
 
     new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientCallbackUnaryImpl)))
-        ClientCallbackUnaryImpl(call, context, request, response, reactor);
+        ClientCallbackUnaryImpl(call, context,
+                                static_cast<const BaseRequest*>(request),
+                                static_cast<BaseResponse*>(response), reactor);
   }
 };
 

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1911,6 +1911,8 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "::grpc::experimental::ClientUnaryReactor* reactor) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::ClientCallbackUnaryFactory::Create"
+                   "< ::grpc::protobuf::MessageLite, "
+                   "::grpc::protobuf::MessageLite>"
                    "(stub_->channel_.get(), stub_->rpcmethod_$Method$_, "
                    "context, request, response, reactor);\n}\n\n");
 


### PR DESCRIPTION
Should have done this as part of #24423....

Along with the other sync/callback/async changes, the cumulative effect is reducing from 4.9MB to 1.6MB (superadditive effects). None of this takes a protobuf dependence.

