### PR TITLE
Add some debug logs for flaky cfstream and cronet tests.

### DIFF
--- a/test/core/iomgr/ios/CFStreamTests/build_tests.sh
+++ b/test/core/iomgr/ios/CFStreamTests/build_tests.sh
@@ -37,3 +37,15 @@ rm -f Podfile.lock
 echo "TIME:  $(date)"
 pod install
 
+# ios-test-cfstream-tests flakes sometimes because of missing files in gRPC-Core,
+# add some log to help find out the root cause.
+# TODO(yulinliang): Delete it after solving the issue.
+if [ -d "./Pods/Headers/Public/gRPC-Core/grpc/impl/codegen" ]
+then 
+    echo "grpc/impl/codegen/ has been imported."
+    number_of_files=$(find Pods/Headers/Public/gRPC-Core/grpc/impl/codegen -name "*.h" | wc -l)
+    echo "The number of files in Pods/Headers/Public/gRPC-Core/grpc/impl/codegen/ is $number_of_files"
+else
+    echo "Error: grpc/impl/codegen/ hasn't been imported."
+fi
+

--- a/test/cpp/ios/build_tests.sh
+++ b/test/cpp/ios/build_tests.sh
@@ -38,3 +38,14 @@ rm -rf RemoteTestClientCpp/src
 echo "TIME:  $(date)"
 pod install
 
+# ios-cpp-test-cronet flakes sometimes because of missing files in Protobuf-C++,
+# add some log to help find out the root cause.
+# TODO(yulinliang): Delete it after solving the issue.
+if [ -d "./Pods/Headers/Public/Protobuf-C++/google/protobuf" ]
+then 
+    echo "Protobuf-C++/google/protobuf/ has been imported."
+    number_of_files=$(find Pods/Headers/Public/Protobuf-C++/google/protobuf -name "*.h" | wc -l)
+    echo "The number of header files in Pods/Headers/Public/Protobuf-C++/google/protobuf/ is $number_of_files"
+else
+    echo "Error: Protobuf-C++/google/protobuf/ hasn't been imported."
+fi


### PR DESCRIPTION
`ios-cpp-test-cronet` and `ios-test-cfstream-tests` flake sometimes because of missing files, add some log to help find out the root cause.
