### PR TITLE
Add support for "unix-abstract:" URIs to support abstract unix domain sockets

### DIFF
--- a/doc/naming.md
+++ b/doc/naming.md
@@ -34,12 +34,23 @@ Most gRPC implementations support the following URI schemes:
     resolver does not support this, but the c-ares based resolver
     supports specifying this in the form "IP:port".)
 
-- `unix:path` or `unix://absolute_path` -- Unix domain sockets (Unix systems only)
+- `unix:path`, `unix://absolute_path` -- Unix domain sockets (Unix systems only)
   - `path` indicates the location of the desired socket.
   - In the first form, the path may be relative or absolute; in the
     second form, the path must be absolute (i.e., there will actually be
     three slashes, two prior to the path and another to begin the
     absolute path).
+
+- `unix-abstract:abstract_path` -- Unix domain socket in abstract namespace (Unix systems only)
+  - `abstract_path` indicates a name in the abstract namespace.
+  - The name has no connection with filesystem pathnames.
+  - No permissions will apply to the socket - any process/user may access the socket.
+  - The underlying implementation of Abstract sockets uses a null byte ('\0')
+    as the first character; the implementation will prepend this null. Do not include 
+    the null in `abstract_path`.
+  - `abstract_path` cannot contain null bytes.
+    - TODO(https://github.com/grpc/grpc/issues/24638): Unix allows abstract socket names to contain null bytes, 
+      but this is not supported by the gRPC C-core implementation.
 
 The following schemes are supported by the gRPC C-core implementation,
 but may not be supported in other languages:

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -168,6 +168,24 @@ class UnixResolverFactory : public ResolverFactory {
 
   const char* scheme() const override { return "unix"; }
 };
+
+class UnixAbstractResolverFactory : public ResolverFactory {
+ public:
+  bool IsValidUri(const grpc_uri* uri) const override {
+    return ParseUri(uri, grpc_parse_unix_abstract, nullptr);
+  }
+
+  OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
+    return CreateSockaddrResolver(std::move(args), grpc_parse_unix_abstract);
+  }
+
+  grpc_core::UniquePtr<char> GetDefaultAuthority(
+      grpc_uri* /*uri*/) const override {
+    return grpc_core::UniquePtr<char>(gpr_strdup("localhost"));
+  }
+
+  const char* scheme() const override { return "unix-abstract"; }
+};
 #endif  // GRPC_HAVE_UNIX_SOCKET
 
 }  // namespace
@@ -182,6 +200,8 @@ void grpc_resolver_sockaddr_init() {
 #ifdef GRPC_HAVE_UNIX_SOCKET
   grpc_core::ResolverRegistry::Builder::RegisterResolverFactory(
       absl::make_unique<grpc_core::UnixResolverFactory>());
+  grpc_core::ResolverRegistry::Builder::RegisterResolverFactory(
+      absl::make_unique<grpc_core::UnixAbstractResolverFactory>());
 #endif
 }
 

--- a/src/core/lib/iomgr/parse_address.h
+++ b/src/core/lib/iomgr/parse_address.h
@@ -23,12 +23,19 @@
 
 #include <stddef.h>
 
+#include "absl/strings/string_view.h"
+
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/uri/uri_parser.h"
 
 /** Populate \a resolved_addr from \a uri, whose path is expected to contain a
  * unix socket path. Returns true upon success. */
 bool grpc_parse_unix(const grpc_uri* uri, grpc_resolved_address* resolved_addr);
+
+/** Populate \a resolved_addr from \a uri, whose path is expected to contain a
+ * unix socket path in the abstract namespace. Returns true upon success. */
+bool grpc_parse_unix_abstract(const grpc_uri* uri,
+                              grpc_resolved_address* resolved_addr);
 
 /** Populate \a resolved_addr from \a uri, whose path is expected to contain an
  * IPv4 host:port pair. Returns true upon success. */
@@ -49,5 +56,18 @@ bool grpc_parse_ipv6_hostport(const char* hostport, grpc_resolved_address* addr,
 
 /* Converts named or numeric port to a uint16 suitable for use in a sockaddr. */
 uint16_t grpc_strhtons(const char* port);
+
+namespace grpc_core {
+
+/** Populate \a resolved_addr to be a unix socket at |path| */
+grpc_error* UnixSockaddrPopulate(absl::string_view path,
+                                 grpc_resolved_address* resolved_addr);
+
+/** Populate \a resolved_addr to be a unix socket in the abstract namespace
+ * at |path| */
+grpc_error* UnixAbstractSockaddrPopulate(absl::string_view path,
+                                         grpc_resolved_address* resolved_addr);
+
+}  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_IOMGR_PARSE_ADDRESS_H */

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -52,11 +52,6 @@ static grpc_error* posix_blocking_resolve_address(
   size_t i;
   grpc_error* err;
 
-  if (name[0] == 'u' && name[1] == 'n' && name[2] == 'i' && name[3] == 'x' &&
-      name[4] == ':' && name[5] != 0) {
-    return grpc_resolve_unix_domain_address(name + 5, addresses);
-  }
-
   std::string host;
   std::string port;
   /* parse name, splitting it into host and port parts */
@@ -67,6 +62,7 @@ static grpc_error* posix_blocking_resolve_address(
         GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
     goto done;
   }
+
   if (port.empty()) {
     if (default_port == nullptr) {
       err = grpc_error_set_str(

--- a/src/core/lib/iomgr/unix_sockets_posix.h
+++ b/src/core/lib/iomgr/unix_sockets_posix.h
@@ -29,10 +29,15 @@
 
 #include "src/core/lib/iomgr/resolve_address.h"
 
+#include "absl/strings/string_view.h"
+
 void grpc_create_socketpair_if_unix(int sv[2]);
 
 grpc_error* grpc_resolve_unix_domain_address(
     const char* name, grpc_resolved_addresses** addresses);
+
+grpc_error* grpc_resolve_unix_abstract_domain_address(
+    absl::string_view name, grpc_resolved_addresses** addresses);
 
 int grpc_is_unix_socket(const grpc_resolved_address* resolved_addr);
 

--- a/src/core/lib/iomgr/unix_sockets_posix_noop.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix_noop.cc
@@ -40,6 +40,13 @@ grpc_error* grpc_resolve_unix_domain_address(
       "Unix domain sockets are not supported on Windows");
 }
 
+grpc_error* grpc_resolve_unix_abstract_domain_address(
+    absl::string_view, grpc_resolved_addresses** addresses) {
+  *addresses = NULL;
+  return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      "Unix domain sockets are not supported on Windows");
+}
+
 int grpc_is_unix_socket(const grpc_resolved_address* addr) { return false; }
 
 void grpc_unlink_if_unix_domain_socket(const grpc_resolved_address* addr) {}

--- a/test/core/client_channel/resolvers/sockaddr_resolver_test.cc
+++ b/test/core/client_channel/resolvers/sockaddr_resolver_test.cc
@@ -101,6 +101,16 @@ int main(int argc, char** argv) {
   test_fails(ipv6, "ipv6:[::]:123456");
   test_fails(ipv6, "ipv6:www.google.com");
 
+#ifdef GRPC_HAVE_UNIX_SOCKET
+  grpc_core::ResolverFactory* uds =
+      grpc_core::ResolverRegistry::LookupResolverFactory("unix");
+  grpc_core::ResolverFactory* uds_abstract =
+      grpc_core::ResolverRegistry::LookupResolverFactory("unix-abstract");
+
+  test_succeeds(uds, "unix:///tmp/sockaddr_resolver_test");
+  test_succeeds(uds_abstract, "unix-abstract:sockaddr_resolver_test");
+#endif  // GRPC_HAVE_UNIX_SOCKET
+
   grpc_shutdown();
 
   return 0;

--- a/test/core/iomgr/parse_address_test.cc
+++ b/test/core/iomgr/parse_address_test.cc
@@ -39,7 +39,7 @@ static void test_grpc_parse_unix(const char* uri_text, const char* pathname) {
   grpc_uri* uri = grpc_uri_parse(uri_text, false);
   grpc_resolved_address addr;
 
-  GPR_ASSERT(1 == grpc_parse_unix(uri, &addr));
+  GPR_ASSERT(1 == grpc_parse_uri(uri, &addr));
   struct sockaddr_un* addr_un =
       reinterpret_cast<struct sockaddr_un*>(addr.addr);
   GPR_ASSERT(AF_UNIX == addr_un->sun_family);
@@ -48,9 +48,27 @@ static void test_grpc_parse_unix(const char* uri_text, const char* pathname) {
   grpc_uri_destroy(uri);
 }
 
+static void test_grpc_parse_unix_abstract(const char* uri_text,
+                                          const char* pathname) {
+  grpc_core::ExecCtx exec_ctx;
+  grpc_uri* uri = grpc_uri_parse(uri_text, false);
+  grpc_resolved_address addr;
+
+  GPR_ASSERT(1 == grpc_parse_uri(uri, &addr));
+  struct sockaddr_un* addr_un =
+      reinterpret_cast<struct sockaddr_un*>(addr.addr);
+  GPR_ASSERT(AF_UNIX == addr_un->sun_family);
+  GPR_ASSERT('\0' == addr_un->sun_path[0]);
+  GPR_ASSERT(0 == strncmp(addr_un->sun_path + 1, pathname, strlen(pathname)));
+
+  grpc_uri_destroy(uri);
+}
+
 #else /* GRPC_HAVE_UNIX_SOCKET */
 
 static void test_grpc_parse_unix(const char* uri_text, const char* pathname) {}
+static void test_grpc_parse_unix_abstract(const char* uri_text,
+                                          const char* pathname) {}
 
 #endif /* GRPC_HAVE_UNIX_SOCKET */
 
@@ -105,6 +123,7 @@ int main(int argc, char** argv) {
   grpc_init();
 
   test_grpc_parse_unix("unix:/path/name", "/path/name");
+  test_grpc_parse_unix_abstract("unix-abstract:foobar", "foobar");
   test_grpc_parse_ipv4("ipv4:192.0.2.1:12345", "192.0.2.1", 12345);
   test_grpc_parse_ipv6("ipv6:[2001:db8::1]:12345", "2001:db8::1", 12345, 0);
   test_grpc_parse_ipv6("ipv6:[2001:db8::1%252]:12345", "2001:db8::1", 12345, 2);


### PR DESCRIPTION
Enables use of Unix Domain Sockets in the Abstract Namespace.

There was an issue for this a long time ago here: #4677 which closed because the issue went stale.

Adopted from PR #21278 by @mheese, which is no longer mergeable.

@markdroth
