### PR TITLE
Add observability_services interop test case for config dump + admin

### DIFF
--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -331,3 +331,32 @@ Test driver asserts:
 
 1.  All backends in the primary locality receive at least 1 RPC.
 1.  No backends in the secondary locality receive RPCs.
+
+### observability_services
+
+This test validates if the observability services are accessible via the CLI
+tool between local (test driver) and backends.
+
+Both the backends and the clients should include Channelz and CSDS servicers
+on their controlling port (the port communicating with test driver).
+
+Client parameters:
+
+1.  --num_channels=1
+2.  --qps=100
+
+Load balancer configuration:
+
+N/A (We only need one backend under xDS control)
+
+Test driver asserts:
+
+1. The CLI is able to fetch Channelz responses from the backend and the client;
+2. The Channelz responses correctly reflect the traffic between client and
+   backend;
+3. The CLI is able to fetch xDS config dump (CSDS) from the backend and the
+   client;
+4. The dumped xDS config should be identical with the latest version in the
+   control plane (can be obtained via CSDS).
+   * This assertion assumes that the xDS resources on the client and the
+     backend are fully synced.


### PR DESCRIPTION
@ericgribkoff 

Since people are pointing me to this doc, I assume the test plan people want is an additional interop test case. This test case will test all 3 observability projects that I'm working on:

* CSDS
* Admin interface
* Admin CLI (the name isn't settled yet)

From the test driver point of view, this test will be quite special because it needs to invoke another binary. It probably would cause a little hassle in dependency management to fetch the latest admin CLI in our CI. But the logic is straightforward.

From the client and the backend point of view, we will need to add admin interface to the controlling port. It will require code changes to each language.