### PR TITLE
Fix check_trailing_newlines bug

### DIFF
--- a/tools/distrib/check_trailing_newlines.sh
+++ b/tools/distrib/check_trailing_newlines.sh
@@ -29,7 +29,7 @@ function find_without_newline() {
     if [[ ! -z $f ]]; then
       if [[ $(tail -c 1 "$f") != $NEWLINE ]]; then
         echo "Error: file '$f' is missing a trailing newline character."
-        if $2; then  # fix
+        if $1; then  # fix
           sed -i -e '$a\' $f
           echo 'Fixed!'
         fi
@@ -39,11 +39,12 @@ function find_without_newline() {
 }
 
 if [[ $# == 1 && $1 == '--fix' ]]; then
-  ERRORS=$(find_without_newline true)
+  FIX=true
 else
-  ERRORS=$(find_without_newline false)
+  FIX=false
 fi
 
+ERRORS=$(find_without_newline $FIX)
 if [[ "$ERRORS" != '' ]]; then
   echo "$ERRORS"
   if ! $FIX; then

--- a/tools/distrib/sanitize.sh
+++ b/tools/distrib/sanitize.sh
@@ -20,5 +20,5 @@ cd $(dirname $0)/../..
 tools/buildgen/generate_projects.sh
 tools/distrib/clang_format_code.sh
 tools/distrib/check_copyright.py
-tools/distrib/check_trailing_newlines.sh
+tools/distrib/check_trailing_newlines.sh --fix
 


### PR DESCRIPTION
`check_trailing_newlines.sh` has a bug not to return an error code when it detects files without a newline.

Related to https://github.com/grpc/grpc/pull/24519

For Reviewer: current sanity error will be gone after #24519 is merged.