### PR TITLE
Implement grpc.Future interface in SingleThreadedRendezvous

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -476,6 +476,9 @@ class _SingleThreadedRendezvous(_Rendezvous, grpc.Call, grpc.Future):  # pylint:
 
         This method will never block. Instead, it will raise an exception
         if calling this method would otherwise result in blocking.
+
+        Since this method will never block, any `timeout` argument passed will
+        be ignored.
         """
         del timeout
         with self._state.condition:
@@ -495,6 +498,9 @@ class _SingleThreadedRendezvous(_Rendezvous, grpc.Call, grpc.Future):  # pylint:
 
         This method will never block. Instead, it will raise an exception
         if calling this method would otherwise result in blocking.
+
+        Since this method will never block, any `timeout` argument passed will
+        be ignored.
         """
         del timeout
         with self._state.condition:
@@ -514,6 +520,9 @@ class _SingleThreadedRendezvous(_Rendezvous, grpc.Call, grpc.Future):  # pylint:
 
         This method will never block. Instead, it will raise an exception
         if calling this method would otherwise result in blocking.
+
+        Since this method will never block, any `timeout` argument passed will
+        be ignored.
         """
         del timeout
         with self._state.condition:

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -549,8 +549,8 @@ class InterceptorTest(unittest.TestCase):
 
     # NOTE: The single-threaded unary-stream path does not support the
     # grpc.Future interface, so this test does not apply.
-    @unittest.skipIf(os.getenv("GRPC_SINGLE_THREADED_UNARY_STREAM"),
-                     "Not supported.")
+    # @unittest.skipIf(os.getenv("GRPC_SINGLE_THREADED_UNARY_STREAM"),
+    #                  "Not supported.")
     def testInterceptedUnaryRequestStreamResponseWithError(self):
         request = _EXCEPTION_REQUEST
 

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -547,10 +547,6 @@ class InterceptorTest(unittest.TestCase):
             's1:intercept_service', 's2:intercept_service'
         ])
 
-    # NOTE: The single-threaded unary-stream path does not support the
-    # grpc.Future interface, so this test does not apply.
-    # @unittest.skipIf(os.getenv("GRPC_SINGLE_THREADED_UNARY_STREAM"),
-    #                  "Not supported.")
     def testInterceptedUnaryRequestStreamResponseWithError(self):
         request = _EXCEPTION_REQUEST
 


### PR DESCRIPTION
This adds partial support for the `grpc.Future` interface to the experimental `_SingleThreadedRendezvous` class. It implements the interface in every case that does not require blocking. In cases where a call would otherwise block, a `UsageError` is raised instead. This is sufficient to call `add_done_callback`, which is useful for implementing interceptors.