### PR TITLE
C#: make Math service example use async 

### DIFF
--- a/src/csharp/Grpc.Examples.MathClient/MathClient.cs
+++ b/src/csharp/Grpc.Examples.MathClient/MathClient.cs
@@ -13,9 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #endregion
-using System;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 

--- a/src/csharp/Grpc.Examples.MathClient/MathClient.cs
+++ b/src/csharp/Grpc.Examples.MathClient/MathClient.cs
@@ -34,7 +34,7 @@ namespace Math
 
             await MathExamples.DivManyExample(client);
 
-            await MathExamples.DependendRequestsExample(client);
+            await MathExamples.DependentRequestsExample(client);
 
             await channel.ShutdownAsync();
         }

--- a/src/csharp/Grpc.Examples.MathClient/MathClient.cs
+++ b/src/csharp/Grpc.Examples.MathClient/MathClient.cs
@@ -16,29 +16,30 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Math
 {
     class MathClient
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             var channel = new Channel("127.0.0.1", 23456, ChannelCredentials.Insecure);
             Math.MathClient client = new Math.MathClient(channel);
             MathExamples.DivExample(client);
 
-            MathExamples.DivAsyncExample(client).Wait();
+            await MathExamples.DivAsyncExample(client);
 
-            MathExamples.FibExample(client).Wait();
+            await MathExamples.FibExample(client);
 
-            MathExamples.SumExample(client).Wait();
+            await MathExamples.SumExample(client);
 
-            MathExamples.DivManyExample(client).Wait();
+            await MathExamples.DivManyExample(client);
 
-            MathExamples.DependendRequestsExample(client).Wait();
+            await MathExamples.DependendRequestsExample(client);
 
-            channel.ShutdownAsync().Wait();
+            await channel.ShutdownAsync();
         }
     }
 }

--- a/src/csharp/Grpc.Examples.MathServer/MathServer.cs
+++ b/src/csharp/Grpc.Examples.MathServer/MathServer.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Math
@@ -26,7 +27,7 @@ namespace Math
         const string Host = "0.0.0.0";
         const int Port = 23456;
 
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             Server server = new Server
             {
@@ -40,7 +41,7 @@ namespace Math
             Console.WriteLine("Press any key to stop the server...");
             Console.ReadKey();
 
-            server.ShutdownAsync().Wait();
+            await server.ShutdownAsync();
         }
     }
 }

--- a/src/csharp/Grpc.Examples.MathServer/MathServer.cs
+++ b/src/csharp/Grpc.Examples.MathServer/MathServer.cs
@@ -15,8 +15,6 @@
 #endregion
 
 using System;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 

--- a/src/csharp/Grpc.Examples/MathExamples.cs
+++ b/src/csharp/Grpc.Examples/MathExamples.cs
@@ -69,6 +69,7 @@ namespace Math
                 new DivArgs { Dividend = 100, Divisor = 21 },
                 new DivArgs { Dividend = 7, Divisor = 2 }
             };
+
             using (var call = client.DivMany())
             { 
                 await call.RequestStream.WriteAllAsync(divArgsList);
@@ -76,7 +77,7 @@ namespace Math
             }
         }
 
-        public static async Task DependendRequestsExample(Math.MathClient client)
+        public static async Task DependentRequestsExample(Math.MathClient client)
         {
             var numbers = new List<Num>
             {

--- a/src/csharp/Grpc.Examples/MathServiceImpl.cs
+++ b/src/csharp/Grpc.Examples/MathServiceImpl.cs
@@ -16,9 +16,7 @@
 
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Grpc.Core.Utils;


### PR DESCRIPTION
- Changed `void Main()` to `async Task Main()` and made examples async
- Removed unused namespaces from the Example projects
- Fixed typos in the Example project

@markdroth
