### PR TITLE
Fix errors in doxygen param descriptions

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -123,8 +123,8 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// Read from the queue, blocking until an event is available or the queue is
   /// shutting down.
   ///
-  /// \param tag [out] Updated to point to the read event's tag.
-  /// \param ok [out] true if read a successful event, false otherwise.
+  /// \param[out] tag Updated to point to the read event's tag.
+  /// \param[out] ok true if read a successful event, false otherwise.
   ///
   /// Note that each tag sent to the completion queue (through RPC operations
   /// or alarms) will be delivered out of the completion queue by a call to
@@ -179,10 +179,10 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// within the \a deadline).  A \a tag points to an arbitrary location usually
   /// employed to uniquely identify an event.
   ///
-  /// \param tag [out] Upon success, updated to point to the event's tag.
-  /// \param ok [out] Upon success, true if a successful event, false otherwise
+  /// \param[out] tag Upon success, updated to point to the event's tag.
+  /// \param[out] ok Upon success, true if a successful event, false otherwise
   ///        See documentation for CompletionQueue::Next for explanation of ok
-  /// \param deadline [in] How long to block in wait for an event.
+  /// \param[in] deadline How long to block in wait for an event.
   ///
   /// \return The type of event read.
   template <typename T>
@@ -198,11 +198,11 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// within the \a deadline).  A \a tag points to an arbitrary location usually
   /// employed to uniquely identify an event.
   ///
-  /// \param f [in] Function to execute before calling AsyncNext on this queue.
-  /// \param tag [out] Upon success, updated to point to the event's tag.
-  /// \param ok [out] Upon success, true if read a regular event, false
+  /// \param[in] f Function to execute before calling AsyncNext on this queue.
+  /// \param[out] tag Upon success, updated to point to the event's tag.
+  /// \param[out] ok Upon success, true if read a regular event, false
   /// otherwise.
-  /// \param deadline [in] How long to block in wait for an event.
+  /// \param[in] deadline How long to block in wait for an event.
   ///
   /// \return The type of event read.
   template <typename T, typename F>

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -124,7 +124,7 @@ class ServerBuilder {
   /// connections.  Valid values include dns:///localhost:1234, /
   /// 192.168.1.1:31416, dns:///[::1]:27182, etc.).
   /// \param creds The credentials associated with the server.
-  /// \param selected_port[out] If not `nullptr`, gets populated with the port
+  /// \param[out] selected_port If not `nullptr`, gets populated with the port
   /// number bound to the \a grpc::Server for the corresponding endpoint after
   /// it is successfully bound by BuildAndStart(), 0 otherwise. AddListeningPort
   /// does not modify this pointer.


### PR DESCRIPTION
Fixing doxygen param descriptions.

It should be like below.
```
/*!
 * Copies bytes from a source memory area to a destination memory area,
 * where both areas may not overlap.
 * @param[out] dest The memory area to copy to.
 * @param[in]  src  The memory area to copy from.
 * @param[in]  n    The number of bytes to copy
 */
void memcpy(void *dest, const void *src, size_t n);
```

Fixing #23997