### PR TITLE
Modify script to add CI checks for --define=grpc_no_xds=true

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,7 +42,6 @@ config_setting(
     values = {"define": "grpc_no_ares=true"},
 )
 
-# TODO(yashykt): Add a build target with this flag.
 config_setting(
     name = "grpc_no_xds",
     values = {"define": "grpc_no_xds=true"},

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -26,3 +26,26 @@ ${name}')
 cd /var/local/git/grpc
 
 bazel build :all //test/... //examples/...
+
+BUILD_WITH_XDS_SIZE=$(stat -c %s "bazel-bin/test/cpp/end2end/end2end_test")
+# TODO(jtattersmusch): Adding a build here for --define=grpc_no_xds is not ideal
+# and we should find a better place for this. Refer
+# https://github.com/grpc/grpc/pull/24536#pullrequestreview-517466531 for more
+# details.
+# Test that builds with --define=grpc_no_xds=true work.
+bazel build //test/cpp/end2end:end2end_test --define=grpc_no_xds=true
+BUILD_WITHOUT_XDS_SIZE=$(stat -c %s "bazel-bin/test/cpp/end2end/end2end_test")
+# Test that the binary size with --define=grpc_no_xds=true is smaller
+if [ $BUILD_WITH_XDS_SIZE -le $BUILD_WITHOUT_XDS_SIZE ]
+then
+	echo "Building with --define=grpc_no_xds=true does not reduce binary size"
+	exit 1
+fi
+# Test that builds that need xDS do not build with --define=grpc_no_xds=true
+EXIT_CODE=0
+bazel build //test/cpp/end2end:xds_end2end_test --define=grpc_no_xds=true || EXIT_CODE=$?
+if [ $EXIT_CODE -eq 0 ]
+then
+	echo "Building xds_end2end_test succeeded even with --define=grpc_no_xds=true"
+	exit 1
+fi


### PR DESCRIPTION
The aim is to add a CI build for --define=grpc_no_xds=true
Motivation and context can be found in #24503

Tests added - 
1) Builds with --define=grpc_no_xds=true work.
2) The binary size without xds is smaller
3) Builds that need xDS do not build with --define=grpc_no_xds=true
