### PR TITLE
Add missing #include for ABSL_DECLARE_FLAG

### DIFF
--- a/test/cpp/interop/client_helper.cc
+++ b/test/cpp/interop/client_helper.cc
@@ -29,6 +29,7 @@
 #include <memory>
 #include <sstream>
 
+#include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #include "src/cpp/client/secure_credentials.h"
 #include "test/core/security/oauth2_utils.h"

--- a/test/cpp/interop/server_helper.cc
+++ b/test/cpp/interop/server_helper.cc
@@ -22,6 +22,7 @@
 
 #include <memory>
 
+#include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #include "src/core/lib/surface/call_test_only.h"
 #include "src/core/lib/transport/byte_stream.h"

--- a/test/cpp/util/grpc_tool_test.cc
+++ b/test/cpp/util/grpc_tool_test.cc
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <sstream>
 
+#include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #include "src/core/lib/gpr/env.h"
 #include "src/core/lib/iomgr/load_file.h"


### PR DESCRIPTION
@veblush 

Fixes issues introduced in #24506. Looked at all uses of `ABSL_DECLARE_FLAG` and tested them explicitly. Running a full `bazel test test/...` now just in case.