### PR TITLE
C#: add distribtest for  .NET 5 and dotnet core runtime 3.1 (netcoreapp3.1)

### DIFF
--- a/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
@@ -2,7 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+
+    <!-- set TargetFrameworks, but allow skipping selected frameworks by setting env variables -->
+    <TargetFrameworks></TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NET45_DISTRIBTEST)' == ''">$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NETCOREAPP21_DISTRIBTEST)' == ''">$(TargetFrameworks);netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NET50_DISTRIBTEST)' == ''">$(TargetFrameworks);net5.0</TargetFrameworks>
+
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks></TargetFrameworks>
     <TargetFrameworks Condition="'$(SKIP_NET45_DISTRIBTEST)' == ''">$(TargetFrameworks);net45</TargetFrameworks>
     <TargetFrameworks Condition="'$(SKIP_NETCOREAPP21_DISTRIBTEST)' == ''">$(TargetFrameworks);netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NETCOREAPP31_DISTRIBTEST)' == ''">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(SKIP_NET50_DISTRIBTEST)' == ''">$(TargetFrameworks);net5.0</TargetFrameworks>
 
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/test/distrib/csharp/run_distrib_test_dotnetcli.sh
+++ b/test/distrib/csharp/run_distrib_test_dotnetcli.sh
@@ -53,6 +53,17 @@ then
   dotnet exec bin/Debug/netcoreapp2.1/publish/DistribTestDotNet.dll
 fi
 
+if [ "${SKIP_NETCOREAPP31_DISTRIBTEST}" != "1" ]
+then
+  dotnet publish -f netcoreapp3.1 DistribTestDotNet.csproj
+
+  # .NET Core target after dotnet build
+  dotnet exec bin/Debug/netcoreapp3.1/DistribTestDotNet.dll
+
+  # .NET Core target after dotnet publish
+  dotnet exec bin/Debug/netcoreapp3.1/publish/DistribTestDotNet.dll
+fi
+
 if [ "${SKIP_NET50_DISTRIBTEST}" != "1" ]
 then
   dotnet publish -f net5.0 DistribTestDotNet.csproj

--- a/test/distrib/csharp/run_distrib_test_dotnetcli.sh
+++ b/test/distrib/csharp/run_distrib_test_dotnetcli.sh
@@ -28,13 +28,13 @@ cd DistribTest
 dotnet restore DistribTestDotNet.csproj
 
 dotnet build DistribTestDotNet.csproj
-dotnet publish -f netcoreapp2.1 DistribTestDotNet.csproj
-dotnet publish -f net45 DistribTestDotNet.csproj
 
 ls -R bin
 
-if [ "${SKIP_MONO_DISTRIBTEST}" != "1" ]
+if [ "${SKIP_NET45_DISTRIBTEST}" != "1" ]
 then
+  dotnet publish -f net45 DistribTestDotNet.csproj
+
   # .NET 4.5 target after dotnet build
   mono bin/Debug/net45/publish/DistribTestDotNet.exe
 
@@ -42,8 +42,24 @@ then
   mono bin/Debug/net45/publish/DistribTestDotNet.exe
 fi
 
-# .NET Core target after dotnet build
-dotnet exec bin/Debug/netcoreapp2.1/DistribTestDotNet.dll
+if [ "${SKIP_NETCOREAPP21_DISTRIBTEST}" != "1" ]
+then
+  dotnet publish -f netcoreapp2.1 DistribTestDotNet.csproj
 
-# .NET Core target after dotnet publish
-dotnet exec bin/Debug/netcoreapp2.1/publish/DistribTestDotNet.dll
+  # .NET Core target after dotnet build
+  dotnet exec bin/Debug/netcoreapp2.1/DistribTestDotNet.dll
+
+  # .NET Core target after dotnet publish
+  dotnet exec bin/Debug/netcoreapp2.1/publish/DistribTestDotNet.dll
+fi
+
+if [ "${SKIP_NET50_DISTRIBTEST}" != "1" ]
+then
+  dotnet publish -f net5.0 DistribTestDotNet.csproj
+
+  # .NET Core target after dotnet build
+  dotnet exec bin/Debug/net5.0/DistribTestDotNet.dll
+
+  # .NET Core target after dotnet publish
+  dotnet exec bin/Debug/net5.0/publish/DistribTestDotNet.dll
+fi

--- a/tools/dockerfile/distribtest/csharp_alpine_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_alpine_x64/Dockerfile
@@ -26,5 +26,8 @@ RUN apk add glibc-2.30-r0.apk
 
 # installing mono on alpine is hard and we don't really need it
 ENV SKIP_NET45_DISTRIBTEST=1
+# we have a separate distribtest for netcoreapp3.1
+ENV SKIP_NETCOREAPP31_DISTRIBTEST=1
 # we have a separate distribtest for net5.0
 ENV SKIP_NET50_DISTRIBTEST=1
+

--- a/tools/dockerfile/distribtest/csharp_alpine_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_alpine_x64/Dockerfile
@@ -25,4 +25,6 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/
 RUN apk add glibc-2.30-r0.apk
 
 # installing mono on alpine is hard and we don't really need it
-ENV SKIP_MONO_DISTRIBTEST=1
+ENV SKIP_NET45_DISTRIBTEST=1
+# we have a separate distribtest for net5.0
+ENV SKIP_NET50_DISTRIBTEST=1

--- a/tools/dockerfile/distribtest/csharp_dotnet31_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_dotnet31_x64/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# "5.0" tag uses debian buster
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+# "3.1" tag uses debian buster
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 RUN apt-get update && apt-get install -y unzip && apt-get clean
 
-# we only want to test dotnet 5 runtime. This also allows us to keep
+# we only want to test dotnet core 3.1 runtime. This also allows us to keep
 # this docker image minimal by not installing the other runtimes.
 ENV SKIP_NET45_DISTRIBTEST=1
 ENV SKIP_NETCOREAPP21_DISTRIBTEST=1
-ENV SKIP_NETCOREAPP31_DISTRIBTEST=1
+ENV SKIP_NET50_DISTRIBTEST=1

--- a/tools/dockerfile/distribtest/csharp_dotnet5_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_dotnet5_x64/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# "5.0" tag uses debian buster
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+RUN apt-get update && apt-get install -y unzip && apt-get clean
+
+# we only want to test dotnet 5 runtime. This also allows us to keep
+# this docker image minimal by not installing the other runtimes.
+ENV SKIP_NET45_DISTRIBTEST=1
+ENV SKIP_NETCOREAPP21_DISTRIBTEST=1

--- a/tools/dockerfile/distribtest/csharp_stretch_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_stretch_x64/Dockerfile
@@ -40,5 +40,7 @@ RUN apt-get update && apt-get install -y unzip && apt-get clean
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl https://curl.haxx.se/ca/cacert.pem > ~/cacert.pem && cert-sync ~/cacert.pem && rm -f ~/cacert.pem
 
+# we have a separate distribtest for netcoreapp3.1
+ENV SKIP_NETCOREAPP31_DISTRIBTEST=1
 # we have a separate distribtest for net5.0
 ENV SKIP_NET50_DISTRIBTEST=1

--- a/tools/dockerfile/distribtest/csharp_stretch_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_stretch_x64/Dockerfile
@@ -39,3 +39,6 @@ RUN apt-get update && apt-get install -y unzip && apt-get clean
 # Make sure the mono certificate store is up-to-date to prevent issues with nuget restore
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl https://curl.haxx.se/ca/cacert.pem > ~/cacert.pem && cert-sync ~/cacert.pem && rm -f ~/cacert.pem
+
+# we have a separate distribtest for net5.0
+ENV SKIP_NET50_DISTRIBTEST=1

--- a/tools/dockerfile/distribtest/csharp_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1604_x64/Dockerfile
@@ -40,5 +40,7 @@ RUN apt-get update && apt-get install -y unzip && apt-get clean
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl https://curl.haxx.se/ca/cacert.pem > ~/cacert.pem && cert-sync ~/cacert.pem && rm -f ~/cacert.pem
 
+# we have a separate distribtest for netcoreapp3.1
+ENV SKIP_NETCOREAPP31_DISTRIBTEST=1
 # we have a separate distribtest for net5.0
 ENV SKIP_NET50_DISTRIBTEST=1

--- a/tools/dockerfile/distribtest/csharp_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1604_x64/Dockerfile
@@ -39,3 +39,6 @@ RUN apt-get update && apt-get install -y unzip && apt-get clean
 # Make sure the mono certificate store is up-to-date to prevent issues with nuget restore
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl https://curl.haxx.se/ca/cacert.pem > ~/cacert.pem && cert-sync ~/cacert.pem && rm -f ~/cacert.pem
+
+# we have a separate distribtest for net5.0
+ENV SKIP_NET50_DISTRIBTEST=1

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -334,6 +334,7 @@ def targets():
         CSharpDistribTest('linux', 'x64', 'ubuntu1604'),
         CSharpDistribTest('linux', 'x64', 'ubuntu1604', use_dotnet_cli=True),
         CSharpDistribTest('linux', 'x64', 'alpine', use_dotnet_cli=True),
+        CSharpDistribTest('linux', 'x64', 'dotnet31', use_dotnet_cli=True),
         CSharpDistribTest('linux', 'x64', 'dotnet5', use_dotnet_cli=True),
         CSharpDistribTest('macos', 'x64'),
         CSharpDistribTest('windows', 'x86'),

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -334,6 +334,7 @@ def targets():
         CSharpDistribTest('linux', 'x64', 'ubuntu1604'),
         CSharpDistribTest('linux', 'x64', 'ubuntu1604', use_dotnet_cli=True),
         CSharpDistribTest('linux', 'x64', 'alpine', use_dotnet_cli=True),
+        CSharpDistribTest('linux', 'x64', 'dotnet5', use_dotnet_cli=True),
         CSharpDistribTest('macos', 'x64'),
         CSharpDistribTest('windows', 'x86'),
         CSharpDistribTest('windows', 'x64'),


### PR DESCRIPTION
To add coverage for fixes such as https://github.com/grpc/grpc/pull/24485.
