### PR TITLE
Only need to count total number of succeeded RPCs for accumulated stats in xDS tests

### DIFF
--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -220,8 +220,8 @@ message LoadBalancerAccumulatedStatsRequest {}
 message LoadBalancerAccumulatedStatsResponse {
   // The total number of RPCs have ever issued.
   int32 num_rpcs_started = 1;
-  // The total number of RPCs have ever completed successfully for each peer.
-  map<string, int32> num_rpcs_succeeded_by_peer = 2;
+  // The total number of RPCs have ever completed successfully.
+  int32 num_rpcs_succeeded = 2;
   // The total number of RPCs have ever failed.
   int32 num_rpcs_failed = 3;
 }


### PR DESCRIPTION
We can keep using the existing way of checking if each backend has received at least one RPC for test client warmup before starting the test (updated in the design doc). So we do not need to make count RPCs succeeded for each peer separately. This can make the implementation easier.


/cc @menghanl @donnadionne @ericgribkoff 