### PR TITLE
[grpc-php] update PHPUnit 6.5.14 (save compatability with php 7.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://grpc.io",
   "license": "Apache-2.0",
   "require": {
-    "php": ">=5.5.0"
+    "php": ">=7.0"
   },
   "require-dev": {
     "google/auth": "^v1.3.0"

--- a/package.xml
+++ b/package.xml
@@ -1973,7 +1973,7 @@
  <dependencies>
   <required>
    <php>
-    <min>5.5.0</min>
+    <min>7.0.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0</min>

--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "version": "1.34.0",
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=7.0",
+    "ext-grpc": "*",
     "google/protobuf": "^v3.3.0"
   },
   "require-dev": {

--- a/src/php/docker/alpine/Dockerfile
+++ b/src/php/docker/alpine/Dockerfile
@@ -21,8 +21,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/centos7/Dockerfile
+++ b/src/php/docker/centos7/Dockerfile
@@ -35,8 +35,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/grpc-ext/Dockerfile
+++ b/src/php/docker/grpc-ext/Dockerfile
@@ -23,8 +23,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/grpc-src/Dockerfile
+++ b/src/php/docker/grpc-src/Dockerfile
@@ -23,8 +23,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/i386/Dockerfile
+++ b/src/php/docker/i386/Dockerfile
@@ -23,8 +23,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/php-future/Dockerfile
+++ b/src/php/docker/php-future/Dockerfile
@@ -23,8 +23,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/php-src/Dockerfile
+++ b/src/php/docker/php-src/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get -qq update && apt-get -qq install -y \
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/docker/php-zts/Dockerfile
+++ b/src/php/docker/php-zts/Dockerfile
@@ -23,8 +23,8 @@ ARG MAKEFLAGS=-j8
 
 WORKDIR /tmp
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit
 
 

--- a/src/php/lib/Grpc/Interceptor.php
+++ b/src/php/lib/Grpc/Interceptor.php
@@ -31,8 +31,8 @@ class Interceptor
         $method,
         $argument,
         $deserialize,
-        array $metadata = [],
-        array $options = [],
+        array $metadata,
+        array $options,
         $continuation
     ) {
         return $continuation($method, $argument, $deserialize, $metadata, $options);
@@ -41,8 +41,8 @@ class Interceptor
     public function interceptStreamUnary(
         $method,
         $deserialize,
-        array $metadata = [],
-        array $options = [],
+        array $metadata,
+        array $options,
         $continuation
     ) {
         return $continuation($method, $deserialize, $metadata, $options);
@@ -52,8 +52,8 @@ class Interceptor
         $method,
         $argument,
         $deserialize,
-        array $metadata = [],
-        array $options = [],
+        array $metadata,
+        array $options,
         $continuation
     ) {
         return $continuation($method, $argument, $deserialize, $metadata, $options);
@@ -62,8 +62,8 @@ class Interceptor
     public function interceptStreamStream(
         $method,
         $deserialize,
-        array $metadata = [],
-        array $options = [],
+        array $metadata,
+        array $options,
         $continuation
     ) {
         return $continuation($method, $deserialize, $metadata, $options);

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -23,7 +23,7 @@ require_once realpath(dirname(__FILE__).'/../../vendor/autoload.php');
 @include_once dirname(__FILE__).'/math.pb.php';
 @include_once dirname(__FILE__).'/math_grpc_pb.php';
 
-abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
+abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * These tests require that a server exporting the math service must be
@@ -52,21 +52,17 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_string(self::$client->getTarget()));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testClose()
     {
+        $this->expectException(\InvalidArgumentException::class);
         self::$client->close();
         $div_arg = new Math\DivArgs();
         $call = self::$client->Div($div_arg);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadata()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $div_arg = new Math\DivArgs();
         $call = self::$client->Div($div_arg, [' ' => 'abc123']);
     }
@@ -89,11 +85,9 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
         $call = self::$client->Div($div_arg, ['someKEY._-1' => ['abc123']]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMetadataInvalidKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $div_arg = new Math\DivArgs();
         $call = self::$client->Div($div_arg, ['(somekey)' => ['abc123']]);
     }
@@ -152,11 +146,9 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
         $this->assertSame(\Grpc\STATUS_CANCELLED, $status->code);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMethodName()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $invalid_client = new DummyInvalidClient('host', [
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ]);
@@ -164,11 +156,9 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
         $invalid_client->InvalidUnaryCall($div_arg);
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testMissingCredentials()
     {
+        $this->expectException(\Exception::class);
         $invalid_client = new DummyInvalidClient('host', [
         ]);
     }

--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -17,7 +17,7 @@
  *
  */
 
-class CallCredentials2Test extends PHPUnit_Framework_TestCase
+class CallCredentials2Test extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -17,7 +17,7 @@
  *
  */
 
-class CallCredentialsTest extends PHPUnit_Framework_TestCase
+class CallCredentialsTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
@@ -138,21 +138,17 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
                           get_class($call_credentials3));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateFromPluginInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $call_credentials = Grpc\CallCredentials::createFromPlugin(
             'callbackFunc'
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateCompositeInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $call_credentials3 = Grpc\CallCredentials::createComposite(
             $this->call_credentials,
             $this->credentials

--- a/src/php/tests/unit_tests/CallInvokerTest.php
+++ b/src/php/tests/unit_tests/CallInvokerTest.php
@@ -159,7 +159,7 @@ class CallInvokerChangeRequestCall
     }
 }
 
-class CallInvokerTest extends PHPUnit_Framework_TestCase
+class CallInvokerTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  *
  */
-class CallTest extends PHPUnit_Framework_TestCase
+class CallTest extends \PHPUnit\Framework\TestCase
 {
     public static $server;
     public static $port;
@@ -107,81 +107,65 @@ class CallTest extends PHPUnit_Framework_TestCase
         $this->assertNull($this->call->cancel());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidStartBatchKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             'invalid' => ['key1' => 'value1'],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadataStrKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['Key' => ['value1', 'value2']],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadataIntKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => [1 => ['value1', 'value2']],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadataInnerValue()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['key1' => 'value1'],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstuctor()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call = new Grpc\Call();
         $this->assertNull($this->call);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstuctor2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call = new Grpc\Call('hi', 'hi', 'hi');
         $this->assertNull($this->call);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidSetCredentials()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call->setCredentials('hi');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidSetCredentials2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call->setCredentials([]);
     }
 }

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -17,7 +17,7 @@
  *
  */
 
-class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
+class ChanellCredentialsTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
@@ -56,19 +56,15 @@ class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(Grpc\ChannelCredentials::isDefaultRootsPemSet());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidCreateSsl()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $channel_credentials = Grpc\ChannelCredentials::createSsl([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidCreateComposite()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $channel_credentials = Grpc\ChannelCredentials::createComposite(
             'something', 'something');
     }

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -17,7 +17,7 @@
  *
  */
 
-class ChannelTest extends PHPUnit_Framework_TestCase
+class ChannelTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
@@ -105,67 +105,53 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel->close();
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWithNull()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel();
         $this->assertNull($this->channel);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWith()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50008', 'invalid');
         $this->assertNull($this->channel);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidCredentials()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50009',
             ['credentials' => new Grpc\Timeval(100)]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidOptionsArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50010',
             ['abc' => []]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidGetConnectivityStateWithArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50011',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->getConnectivityState([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWatchConnectivityState()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50012',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWatchConnectivityState2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50013',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState(1, 'hi');
@@ -409,11 +395,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testPersistentChannelSharedChannelClose2()
     {
+        $this->expectException(\RuntimeException::class);
         // same underlying channel
         $this->channel1 = new Grpc\Channel('localhost:50223', [
             "grpc_target_persist_bound" => 3,
@@ -645,11 +629,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testPersistentChannelForceNewOldChannelClose2()
     {
+        $this->expectException(\RuntimeException::class);
 
         $this->channel1 = new Grpc\Channel('localhost:50230', [
             "grpc_target_persist_bound" => 2,

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  *
  */
-class EndToEndTest extends PHPUnit_Framework_TestCase
+class EndToEndTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
@@ -188,11 +188,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         unset($server_call);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidClientMessageArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -209,11 +208,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidClientMessageString()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -230,11 +228,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidClientMessageFlags()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -253,11 +250,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidServerStatusMetadata()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -294,11 +290,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidServerStatusCode()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -335,11 +330,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMissingServerStatusCode()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -375,11 +369,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidServerStatusDetails()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -416,11 +409,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMissingServerStatusDetails()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -456,11 +448,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidStartBatchKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -475,11 +466,10 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testInvalidStartBatch()
     {
+        $this->expectException(\LogicException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -557,29 +547,23 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($new_state == Grpc\CHANNEL_IDLE);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetConnectivityStateInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->assertTrue($this->channel->getConnectivityState(
             new Grpc\Timeval()));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWatchConnectivityStateInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->assertTrue($this->channel->watchConnectivityState(
             0, 1000));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testChannelConstructorInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:'.$this->port, null);
     }
 

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -96,20 +96,20 @@ class ChangeMetadataInterceptor extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
-                                        array $metadata = [],
-                                        array $options = [],
+                                        array $metadata,
+                                        array $options,
                                         $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_unary_request');
+        $metadata["foo"] = ['interceptor_from_unary_request'];
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
-                                         array $metadata = [],
-                                         array $options = [],
+                                         array $metadata,
+                                         array $options,
                                          $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_stream_request');
+        $metadata["foo"] = ['interceptor_from_stream_request'];
         return $continuation($method, $deserialize, $metadata, $options);
     }
 }
@@ -119,27 +119,27 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
-                                        array $metadata = [],
-                                        array $options = [],
+                                        array $metadata,
+                                        array $options,
                                         $continuation)
     {
         if (array_key_exists('foo', $metadata)) {
-            $metadata['bar'] = array('ChangeMetadataInterceptor should be executed first');
+            $metadata['bar'] = ['ChangeMetadataInterceptor should be executed first'];
         } else {
-            $metadata["bar"] = array('interceptor_from_unary_request');
+            $metadata["bar"] = ['interceptor_from_unary_request'];
         }
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
-                                         array $metadata = [],
-                                         array $options = [],
+                                         array $metadata,
+                                         array $options,
                                          $continuation)
     {
         if (array_key_exists('foo', $metadata)) {
-            $metadata['bar'] = array('ChangeMetadataInterceptor should be executed first');
+            $metadata['bar'] = ['ChangeMetadataInterceptor should be executed first'];
         } else {
-            $metadata["bar"] = array('interceptor_from_stream_request');
+            $metadata["bar"] = ['interceptor_from_stream_request'];
         }
         return $continuation($method, $deserialize, $metadata, $options);
     }
@@ -175,8 +175,8 @@ class ChangeRequestInterceptor extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
-                                        array $metadata = [],
-                                        array $options = [],
+                                        array $metadata,
+                                        array $options,
                                         $continuation)
     {
         $argument->setData('intercepted_unary_request');
@@ -184,8 +184,8 @@ class ChangeRequestInterceptor extends Grpc\Interceptor
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
-                                         array $metadata = [],
-                                         array $options = [],
+                                         array $metadata,
+                                         array $options,
                                          $continuation)
     {
         return new ChangeRequestCall(
@@ -199,23 +199,23 @@ class StopCallInterceptor extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
-                                        array $metadata = [],
-                                        array $options = [],
+                                        array $metadata,
+                                        array $options,
                                         $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_request_response');
+        $metadata["foo"] = ['interceptor_from_request_response'];
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
-                                         array $metadata = [],
-                                         array $options = [],
+                                         array $metadata,
+                                         array $options,
                                          $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_request_response');
+        $metadata["foo"] = ['interceptor_from_request_response'];
     }
 }
 
-class InterceptorTest extends PHPUnit_Framework_TestCase
+class InterceptorTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -20,7 +20,7 @@
 /**
  * @group persistent_list_bound_tests
  */
-class PersistentListTest extends PHPUnit_Framework_TestCase
+class PersistentListTest extends \PHPUnit\Framework\TestCase
 {
   public function setUp()
   {
@@ -167,12 +167,11 @@ class PersistentListTest extends PHPUnit_Framework_TestCase
       $this->channel2->close();
   }
 
-  /**
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage startBatch Error. Channel is closed
-   */
   public function testPersistentChannelSharedChannelClose()
   {
+      $this->expectException(\RuntimeException::class);
+      $this->expectExceptionMessage('startBatch Error. Channel is closed');
+
       // same underlying channel
       $this->channel1 = new Grpc\Channel('localhost:10001', [
           "grpc_target_persist_bound" => 2,

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  *
  */
-class SecureEndToEndTest extends PHPUnit_Framework_TestCase
+class SecureEndToEndTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -17,7 +17,7 @@
  *
  */
 
-class ServerTest extends PHPUnit_Framework_TestCase
+class ServerTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
@@ -90,65 +90,53 @@ class ServerTest extends PHPUnit_Framework_TestCase
         return $server_credentials;
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructor()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server('invalid_host');
         $this->assertNull($this->server);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWithNumKeyOfArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->server = new Grpc\Server([10 => '127.0.0.1',
                                          20 => '8080', ]);
         $this->assertNull($this->server);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWithList()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server(['127.0.0.1', '8080']);
         $this->assertNull($this->server);
     }
-    /**
-     * @expectedException InvalidArgumentException
-     */
+
     public function testInvalidAddHttp2Port()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server([]);
         $port = $this->server->addHttp2Port(['0.0.0.0:0']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidAddSecureHttp2Port()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server([]);
         $port = $this->server->addSecureHttp2Port(['0.0.0.0:0']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidAddSecureHttp2Port2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server();
         $port = $this->server->addSecureHttp2Port('0.0.0.0:0');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidAddSecureHttp2Port3()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server();
         $port = $this->server->addSecureHttp2Port('0.0.0.0:0', 'invalid');
     }

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -16,7 +16,7 @@
  * limitations under the License.
  *
  */
-class TimevalTest extends PHPUnit_Framework_TestCase
+class TimevalTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {
@@ -185,45 +185,35 @@ class TimevalTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(($done_microtime - $curr_microtime) > 0.0009);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testConstructorInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $delta = new Grpc\Timeval('abc');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testAddInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::now();
         $a->add(1000);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testSubtractInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::now();
         $a->subtract(1000);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCompareInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::compare(1000, 1100);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testSimilarInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::similar(1000, 1100, 1200);
         $this->assertNull($delta);
     }

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -52,7 +52,7 @@
    <dependencies>
     <required>
      <php>
-      <min>5.5.0</min>
+      <min>7.0.0</min>
      </php>
      <pearinstaller>
       <min>1.4.0</min>

--- a/templates/src/php/docker/download_phpunit.include
+++ b/templates/src/php/docker/download_phpunit.include
@@ -1,3 +1,3 @@
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && ${'\\'}
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && ${'\\'}
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && ${'\\'}
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && ${'\\'}
   chmod +x /usr/local/bin/phpunit

--- a/tools/dockerfile/distribtest/php7_stretch_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/php7_stretch_x64/Dockerfile
@@ -16,6 +16,6 @@ FROM debian:stretch
 
 RUN apt-get update && apt-get install -y php php-dev php-pear wget zlib1g-dev
 
-RUN wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-  mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+RUN wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+  mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
   chmod +x /usr/local/bin/phpunit

--- a/tools/gce/linux_kokoro_performance_worker_init.sh
+++ b/tools/gce/linux_kokoro_performance_worker_init.sh
@@ -162,8 +162,8 @@ gem install bundler
 
 # PHP dependencies
 sudo apt-get install -y php7.2 php7.2-dev php-pear unzip zlib1g-dev
-sudo wget https://phar.phpunit.de/phpunit-5.7.27.phar && \
-    sudo mv phpunit-5.7.27.phar /usr/local/bin/phpunit && \
+sudo wget https://phar.phpunit.de/phpunit-6.5.14.phar && \
+    sudo mv phpunit-6.5.14.phar /usr/local/bin/phpunit && \
     sudo chmod +x /usr/local/bin/phpunit
 curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
update PHPUnit 6.5.14  (save compatability with php 7.0)

@nicolasnoble
@stanley-cheung separate chunk of PR: https://github.com/grpc/grpc/pull/24525
With saving compatability for PHP 7.0