### PR TITLE
Avoid internal build failure

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1995,7 +1995,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
         EchoRequest request;
         request.mutable_param()->set_client_cancel_after_us(1 * 1000 * 1000);
         request.set_message(kRequestMessage);
-        stub->Echo(&context_, request, &response);
+        (void)stub->Echo(&context_, request, &response);
       });
     }
 


### PR DESCRIPTION
This fixes an internal build failure blocking the import.

```
third_party/grpc/test/cpp/end2end/xds_end2end_test.cc:1998:9: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
        stub->Echo(&context_, request, &response);
        ^~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```