### PR TITLE
Fix package build (caused by Grpc.csproj failures)

### DIFF
--- a/src/csharp/Grpc.sln
+++ b/src/csharp/Grpc.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc.Core.Xamarin", "Grpc.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc", "Grpc\Grpc.csproj", "{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc.Core.NativeDebug", "Grpc.Core.NativeDebug\Grpc.Core.NativeDebug.csproj", "{502E19BC-3E9A-487F-B871-94CC2E66AC0A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,10 @@ Global
 		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{502E19BC-3E9A-487F-B871-94CC2E66AC0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{502E19BC-3E9A-487F-B871-94CC2E66AC0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{502E19BC-3E9A-487F-B871-94CC2E66AC0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{502E19BC-3E9A-487F-B871-94CC2E66AC0A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/csharp/Grpc.sln
+++ b/src/csharp/Grpc.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc.IntegrationTesting.Xds
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc.Core.Xamarin", "Grpc.Core.Xamarin\Grpc.Core.Xamarin.csproj", "{1DCB698B-1383-4297-975A-EC8383295141}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grpc", "Grpc\Grpc.csproj", "{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -147,6 +149,10 @@ Global
 		{1DCB698B-1383-4297-975A-EC8383295141}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1DCB698B-1383-4297-975A-EC8383295141}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DCB698B-1383-4297-975A-EC8383295141}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6029123D-BA2B-4333-A2FD-67FB1F6CBBCD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/csharp/Grpc/Grpc.csproj
+++ b/src/csharp/Grpc/Grpc.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\Grpc.Core\Common.csproj.include" />
-
   <PropertyGroup>
     <Authors>The gRPC Authors</Authors>
     <Copyright>Copyright 2015 The gRPC Authors</Copyright>


### PR DESCRIPTION
Currently the package build is broken on master:
https://source.cloud.google.com/results/invocations/541467c2-7c40-4a7e-8b0e-07772fae1554/targets/github%2Fgrpc/tests
```
+ dotnet pack --configuration Release Grpc --output ../../../artifacts
Microsoft (R) Build Engine version 15.9.20+g88f5fadfbe for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for /var/local/git/grpc/src/csharp/Grpc/Grpc.csproj...
  Restore completed in 18.16 ms for /var/local/git/grpc/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj.
  Restore completed in 18.16 ms for /var/local/git/grpc/src/csharp/Grpc.Core/Grpc.Core.csproj.
  Generating MSBuild file /var/local/git/grpc/src/csharp/Grpc/obj/Grpc.csproj.nuget.g.props.
  Generating MSBuild file /var/local/git/grpc/src/csharp/Grpc/obj/Grpc.csproj.nuget.g.targets.
  Restore completed in 376.17 ms for /var/local/git/grpc/src/csharp/Grpc/Grpc.csproj.
/var/local/git/grpc/src/csharp/Grpc/Grpc.csproj(3,3): error MSB4019: The imported project "/var/local/git/grpc/src/csharp/Grpc.Core/Common.csproj.include" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
```

This is a followup for https://github.com/grpc/grpc/pull/24567 (where I forgot to update Grpc.csproj)

The reason why the tests didn't catch this is that Grpc.csproj was missing from the solution.