### PR TITLE
Increment Index when parsing not plumbed SAN fields

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -411,10 +411,9 @@ static tsi_result add_subject_alt_names_properties_to_peer(
           TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY, name,
           &peer->properties[(*current_insert_index)++]);
     } else {
-      // for the SAN field that we are not going to plumb, we will still
-      // increment the index, because the caller will make a check of the final
-      // index and total property length.
-      (*current_insert_index)++;
+      result = tsi_construct_string_peer_property_from_cstring(
+          TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY, "other types of SAN",
+          &peer->properties[(*current_insert_index)++]);
     }
     if (result != TSI_OK) break;
   }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -410,6 +410,11 @@ static tsi_result add_subject_alt_names_properties_to_peer(
       result = tsi_construct_string_peer_property_from_cstring(
           TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY, name,
           &peer->properties[(*current_insert_index)++]);
+    } else {
+      // for the SAN field that we are not going to plumb, we will still
+      // increment the index, because the caller will make a check of the final
+      // index and total property length.
+      (*current_insert_index)++;
     }
     if (result != TSI_OK) break;
   }


### PR DESCRIPTION
This PR aims to fix https://github.com/grpc/grpc/issues/24469, where we have certs with SAN fields not plumbed through tsi_peer. If the user is using certificates with SAN fields not plumbed(such as `othername`), we still need to increment the index, because we will have an assert check https://github.com/grpc/grpc/blob/master/src/core/tsi/ssl_transport_security.cc#L473 that will check the property length and the final index.