### PR TITLE
xds: Move channel creds creation into bootstrap parser.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15170,7 +15170,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(xds_bootstrap_test
-  test/core/client_channel/xds_bootstrap_test.cc
+  test/core/xds/xds_bootstrap_test.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -7743,7 +7743,7 @@ targets:
   language: c++
   headers: []
   src:
-  - test/core/client_channel/xds_bootstrap_test.cc
+  - test/core/xds/xds_bootstrap_test.cc
   deps:
   - grpc_test_util
   - grpc

--- a/src/core/ext/xds/xds_bootstrap.h
+++ b/src/core/ext/xds/xds_bootstrap.h
@@ -31,8 +31,10 @@
 #include "src/core/ext/xds/certificate_provider_store.h"
 #include "src/core/lib/gprpp/map.h"
 #include "src/core/lib/gprpp/memory.h"
+#include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/json/json.h"
+#include "src/core/lib/security/credentials/credentials.h"
 
 namespace grpc_core {
 
@@ -49,14 +51,11 @@ class XdsBootstrap {
     Json metadata;
   };
 
-  struct ChannelCreds {
-    std::string type;
-    Json config;
-  };
-
   struct XdsServer {
     std::string server_uri;
-    absl::InlinedVector<ChannelCreds, 1> channel_creds;
+    std::string channel_creds_type;
+    Json channel_creds_config;
+    RefCountedPtr<grpc_channel_credentials> channel_creds;
     std::set<std::string> server_features;
 
     bool ShouldUseV3() const;

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -58,17 +58,3 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
     ],
 )
-
-grpc_cc_test(
-    name = "xds_bootstrap_test",
-    srcs = ["xds_bootstrap_test.cc"],
-    external_deps = [
-        "gtest",
-    ],
-    language = "C++",
-    deps = [
-        "//:gpr",
-        "//:grpc",
-        "//test/core/util:grpc_test_util",
-    ],
-)

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -19,6 +19,20 @@ grpc_package(name = "test/core/xds")
 licenses(["notice"])
 
 grpc_cc_test(
+    name = "xds_bootstrap_test",
+    srcs = ["xds_bootstrap_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    language = "C++",
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "certificate_provider_store_test",
     srcs = ["certificate_provider_store_test.cc"],
     external_deps = ["gtest"],


### PR DESCRIPTION
This improvement is possible now that we support xDS only in secure builds.