### PR TITLE
Specify a large value for max metadata size in grpc_cli client channel.

### DIFF
--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -235,6 +235,9 @@ std::shared_ptr<grpc::Channel> CreateCliChannel(
     args.SetString(GRPC_ARG_SERVICE_CONFIG,
                    FLAGS_default_service_config.c_str());
   }
+  // See |GRPC_ARG_MAX_METADATA_SIZE| in |grpc_types.h|.
+  // Set to large enough size (10M) that should work for most use cases.
+  args.SetInt(GRPC_ARG_MAX_METADATA_SIZE, 10 * 1024 * 1024);
   return ::grpc::CreateCustomChannel(server_address, cred.GetCredentials(),
                                      args);
 }


### PR DESCRIPTION
This is useful in cases where server sends back large stacktrace and
default value of 8192 isn't enough.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
