### PR TITLE
[Windows] Python 3.9 Precompiled Wheels

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -39,7 +39,10 @@ set PATH=%LOCALAPPDATA%\Microsoft\dotnet;%PATH%
 @rem Install Python interpreters
 @rem NOTE(lidiz): Python installer process may live longer than expected, and
 @rem has other side effects. It needs to be installed last to reduce impact.
-powershell -File tools\internal_ci\helper_scripts\install_python_interpreters.ps1 || goto :error
+@REM powershell -File tools\internal_ci\helper_scripts\install_python_interpreters.ps1 || goto :error
+choco install python --version=3.8.0
+choco install python --version=3.9.0
+choco install python --pre
 
 @rem Disable some unwanted dotnet options
 set NUGET_XMLDOC_MODE=skip

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -400,15 +400,13 @@ def targets():
         PythonArtifact('windows', 'x86', 'Python36_32bit'),
         PythonArtifact('windows', 'x86', 'Python37_32bit'),
         PythonArtifact('windows', 'x86', 'Python38_32bit'),
-        # TODO(lidiz) uncomment if Python39 installs stably.
-        # PythonArtifact('windows', 'x86', 'Python39_32bit'),
+        PythonArtifact('windows', 'x86', 'Python39_32bit'),
         PythonArtifact('windows', 'x64', 'Python27'),
         PythonArtifact('windows', 'x64', 'Python35'),
         PythonArtifact('windows', 'x64', 'Python36'),
         PythonArtifact('windows', 'x64', 'Python37'),
         PythonArtifact('windows', 'x64', 'Python38'),
-        # TODO(lidiz) uncomment if Python39 installs stably.
-        # PythonArtifact('windows', 'x64', 'Python39'),
+        PythonArtifact('windows', 'x64', 'Python39'),
         RubyArtifact('linux', 'x64'),
         RubyArtifact('macos', 'x64'),
         PHPArtifact('linux', 'x64')


### PR DESCRIPTION
Let's see if CI is happy.

---

Blockers:
* "Expand-Archive" is not avaiable.
* Chocolatey installation failed.
* Full-installer installation failed.
* [0A9C:0FF8][2020-10-29T15:31:25]e000: Windows 8.1 or later is required to continue installation

---

To turn on logging for Python installation:
```
./python-3.9.0.exe /log "C:\tools\install.log" /quiet InstallAllUsers=0 PrependPath=1 Include_test=0 TargetDir="C:\Python39"
```

---

In short, our Kokoro image is Win7 which is too old to install Python 3.9+.