### PR TITLE
Fixed syntax error in GRPC_ARG_ADDRESS_NAME definition

### DIFF
--- a/src/core/ext/filters/client_channel/resolver.h
+++ b/src/core/ext/filters/client_channel/resolver.h
@@ -33,7 +33,7 @@
 extern grpc_core::DebugOnlyTraceFlag grpc_trace_resolver_refcount;
 
 // Name associated with individual address, if available.
-#define GRPC_ARG_ADDRESS_NAME "grpc.address_name";
+#define GRPC_ARG_ADDRESS_NAME "grpc.address_name"
 
 namespace grpc_core {
 


### PR DESCRIPTION
Removed semicolon from end of #define (oops).