### PR TITLE
PHP: add ifdef for compiling on php8

### DIFF
--- a/src/php/docker/php-future/Dockerfile
+++ b/src/php/docker/php-future/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7.4.5-buster
+FROM php:7.4.11-buster
 
 RUN apt-get -qq update && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -789,14 +789,12 @@ GRPC_STARTUP_FUNCTION(channel) {
   gpr_mu_init(&global_persistent_list_mu);
   le_plink = zend_register_list_destructors_ex(
       NULL, php_grpc_channel_plink_dtor, "Persistent Channel", module_number);
-  zend_hash_init_ex(&grpc_persistent_list, 20, NULL,
-                    EG(persistent_list).pDestructor, 1, 0);
+  ZEND_HASH_INIT(&grpc_persistent_list, 20, EG(persistent_list).pDestructor, 1);
   // Register the target->upper_bound map.
   le_bound = zend_register_list_destructors_ex(
       NULL, php_grpc_target_bound_dtor, "Target Bound", module_number);
-  zend_hash_init_ex(&grpc_target_upper_bound_map, 20, NULL,
-                    EG(persistent_list).pDestructor, 1, 0);
-
+  ZEND_HASH_INIT(&grpc_target_upper_bound_map, 20, EG(persistent_list).pDestructor, 1);
+  
   PHP_GRPC_INIT_HANDLER(wrapped_grpc_channel, channel_ce_handlers);
   return SUCCESS;
 }

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -22,6 +22,12 @@
 #include "channel_credentials.h"
 #include "php_grpc.h"
 
+#if PHP_MAJOR_VERSION >= 8
+#define ZEND_HASH_INIT(hash_table, limit, descriptor, zend_bool) _zend_hash_init(hash_table, limit, descriptor, zend_bool);
+#else
+#define ZEND_HASH_INIT(hash_table, limit, descriptor, zend_bool) zend_hash_init_ex(hash_table, limit, NULL, descriptor, zend_bool, 0);
+#endif
+
 /* Class entry for the PHP Channel class */
 extern zend_class_entry *grpc_ce_channel;
 

--- a/src/php/ext/grpc/completion_queue.h
+++ b/src/php/ext/grpc/completion_queue.h
@@ -23,6 +23,10 @@
 
 #include <grpc/grpc.h>
 
+#if PHP_MAJOR_VERSION >= 8
+#define TSRMLS_D
+#endif
+
 /* The global completion queue for all operations */
 extern grpc_completion_queue *completion_queue;
 

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -46,6 +46,14 @@ extern zend_module_entry grpc_module_entry;
 #define PHP_GRPC_API
 #endif
 
+#if PHP_MAJOR_VERSION >= 8
+#define TSRMLS_CC
+#define TSRMLS_C
+#define TSRMLS_DC
+#define TSRMLS_D
+#define TSRMLS_FETCH()
+#endif
+
 #ifdef ZTS
 #include "TSRM.h"
 #endif

--- a/templates/src/php/docker/php-future/Dockerfile.template
+++ b/templates/src/php/docker/php-future/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM php:7.4.5-buster
+  FROM php:7.4.11-buster
 
   RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
     autoconf automake git libtool pkg-config ${'\\'}


### PR DESCRIPTION
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->
add ifdef for compiling on php8
verification of external contribution

test dockerfile for php 8 could not be added at this time, due to the mismatch of current phpunit version(phpunit 5~8) and php 8. 

@stanley-cheung 

