### PR TITLE
Add XdsChannelCredsRegistry

### DIFF
--- a/src/core/ext/xds/xds_bootstrap.h
+++ b/src/core/ext/xds/xds_bootstrap.h
@@ -40,6 +40,14 @@ namespace grpc_core {
 
 class XdsClient;
 
+class XdsChannelCredsRegistry {
+ public:
+  static bool IsSupported(const std::string& creds_type);
+  static bool IsValidConfig(const std::string& creds_type, const Json& config);
+  static RefCountedPtr<grpc_channel_credentials> MakeChannelCreds(
+      const std::string& creds_type, const Json& config);
+};
+
 class XdsBootstrap {
  public:
   struct Node {
@@ -55,7 +63,6 @@ class XdsBootstrap {
     std::string server_uri;
     std::string channel_creds_type;
     Json channel_creds_config;
-    RefCountedPtr<grpc_channel_credentials> channel_creds;
     std::set<std::string> server_features;
 
     bool ShouldUseV3() const;

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -444,9 +444,13 @@ grpc_channel* CreateXdsChannel(const XdsBootstrap::XdsServer& server) {
   };
   grpc_channel_args* new_args = grpc_channel_args_copy_and_add(
       g_channel_args, args_to_add.data(), args_to_add.size());
+  // Create channel creds.
+  RefCountedPtr<grpc_channel_credentials> channel_creds =
+      XdsChannelCredsRegistry::MakeChannelCreds(server.channel_creds_type,
+                                                server.channel_creds_config);
   // Create channel.
   grpc_channel* channel = grpc_secure_channel_create(
-      server.channel_creds.get(), server.server_uri.c_str(), new_args, nullptr);
+      channel_creds.get(), server.server_uri.c_str(), new_args, nullptr);
   grpc_channel_args_destroy(new_args);
   return channel;
 }

--- a/src/core/lib/gprpp/ref_counted_ptr.h
+++ b/src/core/lib/gprpp/ref_counted_ptr.h
@@ -39,9 +39,7 @@ class RefCountedPtr {
 
   // If value is non-null, we take ownership of a ref to it.
   template <typename Y>
-  explicit RefCountedPtr(Y* value) {
-    value_ = value;
-  }
+  RefCountedPtr(Y* value) : value_(value) {}
 
   // Move ctors.
   RefCountedPtr(RefCountedPtr&& other) noexcept {

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -94,9 +94,6 @@ TEST_F(XdsBootstrapTest, Basic) {
   EXPECT_EQ(bootstrap.server().channel_creds_type, "fake");
   EXPECT_EQ(bootstrap.server().channel_creds_config.type(),
             Json::Type::JSON_NULL);
-  ASSERT_NE(bootstrap.server().channel_creds, nullptr);
-  EXPECT_STREQ(bootstrap.server().channel_creds->type(),
-               "FakeTransportSecurity");
   ASSERT_NE(bootstrap.node(), nullptr);
   EXPECT_EQ(bootstrap.node()->id, "foo");
   EXPECT_EQ(bootstrap.node()->cluster, "bar");
@@ -155,8 +152,6 @@ TEST_F(XdsBootstrapTest, InsecureCreds) {
   EXPECT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   EXPECT_EQ(bootstrap.server().server_uri, "fake:///lb");
   EXPECT_EQ(bootstrap.server().channel_creds_type, "insecure");
-  ASSERT_NE(bootstrap.server().channel_creds, nullptr);
-  EXPECT_STREQ(bootstrap.server().channel_creds->type(), "insecure");
   EXPECT_EQ(bootstrap.node(), nullptr);
 }
 
@@ -193,8 +188,6 @@ TEST_F(XdsBootstrapTest, GoogleDefaultCreds) {
   EXPECT_EQ(error, GRPC_ERROR_NONE) << grpc_error_string(error);
   EXPECT_EQ(bootstrap.server().server_uri, "fake:///lb");
   EXPECT_EQ(bootstrap.server().channel_creds_type, "google_default");
-  ASSERT_NE(bootstrap.server().channel_creds, nullptr);
-  EXPECT_STREQ(bootstrap.server().channel_creds->type(), "GoogleDefault");
   EXPECT_EQ(bootstrap.node(), nullptr);
 }
 


### PR DESCRIPTION
This allows us to defer creds creation until we actually create the xDS channel, but still centralize the list of supported credential types.  For now, all the supported creds types remain hard-coded, but at some point in the future, this could become a real dynamic registry.