### PR TITLE
Use upb_proto_library BUILD rule for health proto.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3112,25 +3112,21 @@ grpc_cc_library(
     ],
 )
 
-# Once upb code-gen issue is resolved, replace grpc_health_upb with this.
-# grpc_upb_proto_library(
-#     name = "grpc_health_upb",
-#     deps = ["//src/proto/grpc/health/v1:health_proto_descriptor"],
-# )
+grpc_upb_proto_library(
+    name = "grpc_health_upb_proto",
+    deps = ["//src/proto/grpc/health/v1:health_proto_descriptor"],
+)
 
 grpc_cc_library(
     name = "grpc_health_upb",
-    srcs = [
-        "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c",
-    ],
-    hdrs = [
-        "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h",
-    ],
     external_deps = [
         "upb_lib",
         "upb_lib_descriptor",
     ],
     language = "c++",
+    deps = [
+        ":grpc_health_upb_proto",
+    ],
 )
 
 # Once upb code-gen issue is resolved, remove this.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -534,8 +534,6 @@ config("grpc_config") {
         "src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.h",
         "src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c",
         "src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.h",
-        "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c",
-        "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h",
         "src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c",
         "src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.h",
         "src/core/ext/upb-generated/udpa/annotations/migrate.upb.c",
@@ -1203,6 +1201,7 @@ config("grpc_config") {
     deps = [
         "//third_party/boringssl",
         "//third_party/zlib",
+        ":grpc_health_upb",
         ":gpr",
         ":address_sorting",
         ":upb",
@@ -1476,6 +1475,7 @@ config("grpc_config") {
     deps = [
         "//third_party/protobuf:protobuf_lite",
         ":grpc",
+        ":grpc_health_upb",
         ":gpr",
         ":address_sorting",
         ":upb",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1133,6 +1133,7 @@ target_link_libraries(end2end_nosec_tests
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -1268,6 +1269,7 @@ target_link_libraries(end2end_tests
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -1605,7 +1607,6 @@ add_library(grpc
   src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.c
   src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.c
   src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c
-  src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
   src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c
   src/core/ext/upb-generated/udpa/annotations/migrate.upb.c
   src/core/ext/upb-generated/udpa/annotations/security.upb.c
@@ -1989,6 +1990,7 @@ target_link_libraries(grpc
   ${_gRPC_RE2_LIBRARIES}
   ${_gRPC_UPB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2072,6 +2074,7 @@ target_include_directories(grpc_csharp_ext
 target_link_libraries(grpc_csharp_ext
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2079,6 +2082,54 @@ target_link_libraries(grpc_csharp_ext
 
 
 endif()
+
+add_library(grpc_health_upb
+  src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
+)
+
+set_target_properties(grpc_health_upb PROPERTIES
+  VERSION ${gRPC_CORE_VERSION}
+  SOVERSION ${gRPC_CORE_SOVERSION}
+)
+
+if(WIN32 AND MSVC)
+  set_target_properties(grpc_health_upb PROPERTIES COMPILE_PDB_NAME "grpc_health_upb"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  if(gRPC_INSTALL)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_health_upb.pdb
+      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+    )
+  endif()
+endif()
+
+target_include_directories(grpc_health_upb
+  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+)
+target_link_libraries(grpc_health_upb
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  upb
+)
+
+
+
+if(gRPC_INSTALL)
+  install(TARGETS grpc_health_upb EXPORT gRPCTargets
+    RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
+  )
+endif()
+
 if(gRPC_BUILD_TESTS)
 
 add_library(grpc_test_util
@@ -2138,6 +2189,7 @@ target_include_directories(grpc_test_util
 target_link_libraries(grpc_test_util
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2210,6 +2262,7 @@ target_include_directories(grpc_test_util_unsecure
 target_link_libraries(grpc_test_util_unsecure
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_unsecure
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2335,7 +2388,6 @@ add_library(grpc_unsecure
   src/core/ext/upb-generated/google/protobuf/timestamp.upb.c
   src/core/ext/upb-generated/google/protobuf/wrappers.upb.c
   src/core/ext/upb-generated/google/rpc/status.upb.c
-  src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
   src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c
   src/core/ext/upb-generated/udpa/data/orca/v1/orca_load_report.upb.c
   src/core/ext/upb-generated/validate/validate.upb.c
@@ -2543,6 +2595,7 @@ target_link_libraries(grpc_unsecure
   ${_gRPC_RE2_LIBRARIES}
   ${_gRPC_UPB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2646,6 +2699,7 @@ target_link_libraries(benchmark_helpers
   grpc++_unsecure
   grpc_unsecure
   grpc++_test_config
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2743,6 +2797,7 @@ target_link_libraries(grpc++
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -2990,6 +3045,7 @@ target_link_libraries(grpc++_alts
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3059,6 +3115,7 @@ target_link_libraries(grpc++_error_details
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3132,6 +3189,7 @@ target_link_libraries(grpc++_reflection
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3204,6 +3262,7 @@ target_link_libraries(grpc++_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3327,6 +3386,7 @@ target_link_libraries(grpc++_test_util
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3413,6 +3473,7 @@ target_link_libraries(grpc++_unsecure
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_unsecure
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3732,6 +3793,7 @@ target_link_libraries(grpcpp_channelz
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3822,6 +3884,54 @@ target_link_libraries(upb
 
 if(gRPC_INSTALL)
   install(TARGETS upb EXPORT gRPCTargets
+    RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
+  )
+endif()
+
+
+add_library(grpc_health_upb_proto
+  src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
+)
+
+set_target_properties(grpc_health_upb_proto PROPERTIES
+  VERSION ${gRPC_CORE_VERSION}
+  SOVERSION ${gRPC_CORE_SOVERSION}
+)
+
+if(WIN32 AND MSVC)
+  set_target_properties(grpc_health_upb_proto PROPERTIES COMPILE_PDB_NAME "grpc_health_upb_proto"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  if(gRPC_INSTALL)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_health_upb_proto.pdb
+      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+    )
+  endif()
+endif()
+
+target_include_directories(grpc_health_upb_proto
+  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+)
+target_link_libraries(grpc_health_upb_proto
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  upb
+)
+
+
+
+if(gRPC_INSTALL)
+  install(TARGETS grpc_health_upb_proto EXPORT gRPCTargets
     RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
     LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
@@ -3954,6 +4064,7 @@ target_link_libraries(algorithm_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -3984,6 +4095,7 @@ target_link_libraries(alloc_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4014,6 +4126,7 @@ target_link_libraries(alpn_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4045,6 +4158,7 @@ target_link_libraries(alts_counter_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4076,6 +4190,7 @@ target_link_libraries(alts_crypt_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4107,6 +4222,7 @@ target_link_libraries(alts_crypter_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4139,6 +4255,7 @@ target_link_libraries(alts_frame_protector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4170,6 +4287,7 @@ target_link_libraries(alts_grpc_record_protocol_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4201,6 +4319,7 @@ target_link_libraries(alts_handshaker_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4232,6 +4351,7 @@ target_link_libraries(alts_iovec_record_protocol_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4262,6 +4382,7 @@ target_link_libraries(alts_security_connector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4293,6 +4414,7 @@ target_link_libraries(alts_tsi_handshaker_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4324,6 +4446,7 @@ target_link_libraries(alts_tsi_utils_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4355,6 +4478,7 @@ target_link_libraries(alts_zero_copy_grpc_protector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4385,6 +4509,7 @@ target_link_libraries(arena_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4415,6 +4540,7 @@ target_link_libraries(auth_context_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4445,6 +4571,7 @@ target_link_libraries(avl_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4475,6 +4602,7 @@ target_link_libraries(b64_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4506,6 +4634,7 @@ target_link_libraries(bad_server_response_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4538,6 +4667,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -4571,6 +4701,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -4602,6 +4733,7 @@ target_link_libraries(bin_decoder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4632,6 +4764,7 @@ target_link_libraries(bin_encoder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4662,6 +4795,7 @@ target_link_libraries(buffer_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4692,6 +4826,7 @@ target_link_libraries(channel_args_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4722,6 +4857,7 @@ target_link_libraries(channel_create_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4752,6 +4888,7 @@ target_link_libraries(channel_stack_builder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4782,6 +4919,7 @@ target_link_libraries(channel_stack_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4812,6 +4950,7 @@ target_link_libraries(check_gcp_environment_linux_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4842,6 +4981,7 @@ target_link_libraries(check_gcp_environment_windows_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4873,6 +5013,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -4904,6 +5045,7 @@ target_link_libraries(cmdline_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4935,6 +5077,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -4966,6 +5109,7 @@ target_link_libraries(completion_queue_threading_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -4996,6 +5140,7 @@ target_link_libraries(compression_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5026,6 +5171,7 @@ target_link_libraries(concurrent_connectivity_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5057,6 +5203,7 @@ target_link_libraries(connection_refused_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5087,6 +5234,7 @@ target_link_libraries(cpu_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5117,6 +5265,7 @@ target_link_libraries(dns_resolver_connectivity_using_ares_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5147,6 +5296,7 @@ target_link_libraries(dns_resolver_connectivity_using_native_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5177,6 +5327,7 @@ target_link_libraries(dns_resolver_cooldown_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5207,6 +5358,7 @@ target_link_libraries(dns_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5239,6 +5391,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5271,6 +5424,7 @@ target_link_libraries(endpoint_pair_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5301,6 +5455,7 @@ target_link_libraries(env_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5332,6 +5487,7 @@ target_link_libraries(error_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5363,6 +5519,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5394,6 +5551,7 @@ target_link_libraries(fake_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5425,6 +5583,7 @@ target_link_libraries(fake_transport_security_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5456,6 +5615,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5488,6 +5648,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5524,6 +5685,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5560,6 +5722,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5592,6 +5755,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5627,6 +5791,7 @@ target_link_libraries(format_request_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5658,6 +5823,7 @@ target_link_libraries(frame_handler_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5689,6 +5855,7 @@ target_link_libraries(goaway_server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5719,6 +5886,7 @@ target_link_libraries(grpc_alts_credentials_options_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5749,6 +5917,7 @@ target_link_libraries(grpc_byte_buffer_reader_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5779,6 +5948,7 @@ target_link_libraries(grpc_completion_queue_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5809,6 +5979,7 @@ target_link_libraries(grpc_ipv6_loopback_available_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5841,6 +6012,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5873,6 +6045,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -5904,6 +6077,7 @@ target_link_libraries(histogram_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5934,6 +6108,7 @@ target_link_libraries(host_port_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5964,6 +6139,7 @@ target_link_libraries(hpack_encoder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -5994,6 +6170,7 @@ target_link_libraries(hpack_parser_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6024,6 +6201,7 @@ target_link_libraries(hpack_table_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6059,6 +6237,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -6095,6 +6274,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -6127,6 +6307,7 @@ target_link_libraries(inproc_callback_test
   end2end_tests
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6158,6 +6339,7 @@ target_link_libraries(invalid_call_argument_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6188,6 +6370,7 @@ target_link_libraries(json_token_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6218,6 +6401,7 @@ target_link_libraries(jwt_verifier_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6249,6 +6433,7 @@ target_link_libraries(lame_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6279,6 +6464,7 @@ target_link_libraries(load_file_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6309,6 +6495,7 @@ target_link_libraries(log_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6339,6 +6526,7 @@ target_link_libraries(manual_constructor_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6369,6 +6557,7 @@ target_link_libraries(message_compress_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6399,6 +6588,7 @@ target_link_libraries(metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6429,6 +6619,7 @@ target_link_libraries(minimal_stack_is_minimal_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6459,6 +6650,7 @@ target_link_libraries(mpmcqueue_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6490,6 +6682,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -6522,6 +6715,7 @@ target_link_libraries(multiple_server_queues_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6552,6 +6746,7 @@ target_link_libraries(murmur_hash_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6583,6 +6778,7 @@ target_link_libraries(no_server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6613,6 +6809,7 @@ target_link_libraries(num_external_connectivity_watchers_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6643,6 +6840,7 @@ target_link_libraries(parse_address_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6674,6 +6872,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -6709,6 +6908,7 @@ target_link_libraries(parser_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6739,6 +6939,7 @@ target_link_libraries(percent_encoding_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6769,6 +6970,7 @@ target_link_libraries(public_headers_must_be_c89
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6800,6 +7002,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -6831,6 +7034,7 @@ target_link_libraries(resolve_address_using_ares_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6862,6 +7066,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -6893,6 +7098,7 @@ target_link_libraries(resolve_address_using_native_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6923,6 +7129,7 @@ target_link_libraries(resource_quota_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6953,6 +7160,7 @@ target_link_libraries(secure_channel_create_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -6984,6 +7192,7 @@ target_link_libraries(secure_endpoint_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7014,6 +7223,7 @@ target_link_libraries(security_connector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7044,6 +7254,7 @@ target_link_libraries(sequential_connectivity_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7076,6 +7287,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -7107,6 +7319,7 @@ target_link_libraries(server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7137,6 +7350,7 @@ target_link_libraries(slice_buffer_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7167,6 +7381,7 @@ target_link_libraries(slice_string_helpers_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7197,6 +7412,7 @@ target_link_libraries(sockaddr_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7227,6 +7443,7 @@ target_link_libraries(sockaddr_utils_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7258,6 +7475,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -7289,6 +7507,7 @@ target_link_libraries(spinlock_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7319,6 +7538,7 @@ target_link_libraries(ssl_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7351,6 +7571,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -7382,6 +7603,7 @@ target_link_libraries(status_conversion_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7412,6 +7634,7 @@ target_link_libraries(stream_compression_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7442,6 +7665,7 @@ target_link_libraries(stream_map_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7472,6 +7696,7 @@ target_link_libraries(stream_owned_slice_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7502,6 +7727,7 @@ target_link_libraries(string_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7532,6 +7758,7 @@ target_link_libraries(sync_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7563,6 +7790,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -7596,6 +7824,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -7628,6 +7857,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -7659,6 +7889,7 @@ target_link_libraries(test_core_gpr_time_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7689,6 +7920,7 @@ target_link_libraries(test_core_security_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7719,6 +7951,7 @@ target_link_libraries(test_core_slice_slice_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7749,6 +7982,7 @@ target_link_libraries(thd_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7779,6 +8013,7 @@ target_link_libraries(threadpool_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7809,6 +8044,7 @@ target_link_libraries(time_averaged_stats_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7839,6 +8075,7 @@ target_link_libraries(timeout_encoding_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7869,6 +8106,7 @@ target_link_libraries(timer_heap_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7899,6 +8137,7 @@ target_link_libraries(timer_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7929,6 +8168,7 @@ target_link_libraries(tls_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7959,6 +8199,7 @@ target_link_libraries(transport_security_common_api_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -7989,6 +8230,7 @@ target_link_libraries(transport_security_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8020,6 +8262,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8051,6 +8294,7 @@ target_link_libraries(uri_parser_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8081,6 +8325,7 @@ target_link_libraries(useful_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8111,6 +8356,7 @@ target_link_libraries(varint_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8153,6 +8399,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc++
     grpc++_test_config
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8199,6 +8446,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8241,6 +8489,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util_unsecure
     grpc++_unsecure
     grpc_unsecure
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8293,6 +8542,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8336,6 +8586,7 @@ target_link_libraries(alts_util_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8397,6 +8648,7 @@ target_link_libraries(async_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8438,6 +8690,7 @@ target_link_libraries(auth_property_iterator_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8477,6 +8730,7 @@ target_link_libraries(authorization_engine_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8516,6 +8770,7 @@ target_link_libraries(backoff_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8557,6 +8812,7 @@ target_link_libraries(bad_streaming_id_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8598,6 +8854,7 @@ target_link_libraries(badreq_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -8638,6 +8895,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8682,6 +8940,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8727,6 +8986,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8772,6 +9032,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8817,6 +9078,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8866,6 +9128,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8915,6 +9178,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -8960,6 +9224,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9005,6 +9270,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9050,6 +9316,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9095,6 +9362,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9140,6 +9408,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9185,6 +9454,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9230,6 +9500,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9275,6 +9546,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9320,6 +9592,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9365,6 +9638,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9410,6 +9684,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9455,6 +9730,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9500,6 +9776,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9545,6 +9822,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9590,6 +9868,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     grpc++_unsecure
     grpc_unsecure
     grpc++_test_config
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -9633,6 +9912,7 @@ target_link_libraries(byte_buffer_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9672,6 +9952,7 @@ target_link_libraries(byte_stream_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9716,6 +9997,7 @@ target_link_libraries(cancel_ares_query_test
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9755,6 +10037,7 @@ target_link_libraries(certificate_provider_registry_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9794,6 +10077,7 @@ target_link_libraries(certificate_provider_store_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9848,6 +10132,7 @@ target_link_libraries(cfstream_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9888,6 +10173,7 @@ target_link_libraries(channel_arguments_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9928,6 +10214,7 @@ target_link_libraries(channel_filter_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -9973,6 +10260,7 @@ target_link_libraries(channel_trace_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10013,6 +10301,7 @@ target_link_libraries(channelz_registry_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10068,6 +10357,7 @@ target_link_libraries(channelz_service_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10113,6 +10403,7 @@ target_link_libraries(channelz_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10176,6 +10467,7 @@ target_link_libraries(cli_call_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10231,6 +10523,7 @@ target_link_libraries(client_callback_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10294,6 +10587,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -10350,6 +10644,7 @@ target_link_libraries(client_interceptors_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10414,6 +10709,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -10455,6 +10751,7 @@ target_link_libraries(codegen_test_full
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10495,6 +10792,7 @@ target_link_libraries(codegen_test_minimal
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10536,6 +10834,7 @@ target_link_libraries(connection_prefix_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10575,6 +10874,7 @@ target_link_libraries(connectivity_state_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10614,6 +10914,7 @@ target_link_libraries(context_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10668,6 +10969,7 @@ target_link_libraries(delegating_channel_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10709,6 +11011,7 @@ target_link_libraries(destroy_grpclb_channel_with_active_connect_stress_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10748,6 +11051,7 @@ target_link_libraries(dual_ref_counted_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10789,6 +11093,7 @@ target_link_libraries(duplicate_header_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10849,6 +11154,7 @@ target_link_libraries(end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10894,6 +11200,7 @@ target_link_libraries(error_details_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10933,6 +11240,7 @@ target_link_libraries(evaluate_args_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -10972,6 +11280,7 @@ target_link_libraries(eventmanager_libuv_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11025,6 +11334,7 @@ target_link_libraries(exception_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11082,6 +11392,7 @@ target_link_libraries(filter_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11136,6 +11447,7 @@ target_link_libraries(flaky_network_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11193,6 +11505,7 @@ target_link_libraries(generic_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11233,6 +11546,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -11273,6 +11587,7 @@ target_link_libraries(global_config_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11312,6 +11627,7 @@ target_link_libraries(google_mesh_ca_certificate_provider_factory_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11362,6 +11678,7 @@ target_link_libraries(grpc_cli
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11667,6 +11984,7 @@ target_link_libraries(grpc_tls_certificate_distributor_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11706,6 +12024,7 @@ target_link_libraries(grpc_tls_credentials_options_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11767,6 +12086,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -11813,6 +12133,7 @@ target_link_libraries(grpclb_api_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11876,6 +12197,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -11917,6 +12239,7 @@ target_link_libraries(h2_ssl_session_reuse_test
   end2end_tests
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11958,6 +12281,7 @@ target_link_libraries(head_of_line_blocking_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -11999,6 +12323,7 @@ target_link_libraries(headers_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12062,6 +12387,7 @@ target_link_libraries(health_service_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12116,6 +12442,7 @@ target_link_libraries(http2_client
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12174,6 +12501,7 @@ target_link_libraries(hybrid_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12213,6 +12541,7 @@ target_link_libraries(init_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12254,6 +12583,7 @@ target_link_libraries(initial_settings_frame_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12293,6 +12623,7 @@ target_link_libraries(insecure_security_connector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12350,6 +12681,7 @@ target_link_libraries(interop_client
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12406,6 +12738,7 @@ target_link_libraries(interop_server
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12449,6 +12782,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc++
     grpc++_test_config
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -12489,6 +12823,7 @@ target_link_libraries(json_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12530,6 +12865,7 @@ target_link_libraries(large_metadata_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12574,6 +12910,7 @@ target_link_libraries(lb_get_cpu_stats_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12615,6 +12952,7 @@ target_link_libraries(lb_load_data_store_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12654,6 +12992,7 @@ target_link_libraries(linux_system_roots_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12708,6 +13047,7 @@ target_link_libraries(message_allocator_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12766,6 +13106,7 @@ target_link_libraries(mock_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12819,6 +13160,7 @@ target_link_libraries(nonblocking_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12858,6 +13200,7 @@ target_link_libraries(noop-benchmark
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12898,6 +13241,7 @@ target_link_libraries(orphanable_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12939,6 +13283,7 @@ target_link_libraries(out_of_bounds_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -12978,6 +13323,7 @@ target_link_libraries(pid_controller_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13032,6 +13378,7 @@ target_link_libraries(port_sharing_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13092,6 +13439,7 @@ target_link_libraries(proto_server_reflection_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13132,6 +13480,7 @@ target_link_libraries(proto_utils_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13220,6 +13569,7 @@ target_link_libraries(qps_json_driver
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13300,6 +13650,7 @@ target_link_libraries(qps_worker
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13358,6 +13709,7 @@ target_link_libraries(raw_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13397,6 +13749,7 @@ target_link_libraries(ref_counted_ptr_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13436,6 +13789,7 @@ target_link_libraries(ref_counted_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13476,6 +13830,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -13516,6 +13871,7 @@ target_link_libraries(retry_throttle_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13557,6 +13913,7 @@ target_link_libraries(secure_auth_context_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13615,6 +13972,7 @@ target_link_libraries(server_builder_plugin_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13668,6 +14026,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util_unsecure
     grpc++_unsecure
     grpc_unsecure
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -13722,6 +14081,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util_unsecure
     grpc++_unsecure
     grpc_unsecure
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -13762,6 +14122,7 @@ target_link_libraries(server_chttp2_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13804,6 +14165,7 @@ target_link_libraries(server_context_test_spouse_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13857,6 +14219,7 @@ target_link_libraries(server_early_return_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13912,6 +14275,7 @@ target_link_libraries(server_interceptors_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -13953,6 +14317,7 @@ target_link_libraries(server_registered_method_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14006,6 +14371,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util_unsecure
     grpc++_unsecure
     grpc_unsecure
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -14065,6 +14431,7 @@ target_link_libraries(service_config_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14104,6 +14471,7 @@ target_link_libraries(service_config_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14143,6 +14511,7 @@ target_link_libraries(settings_timeout_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14200,6 +14569,7 @@ target_link_libraries(shutdown_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14241,6 +14611,7 @@ target_link_libraries(simple_request_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14280,6 +14651,7 @@ target_link_libraries(stat_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14319,6 +14691,7 @@ target_link_libraries(static_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14358,6 +14731,7 @@ target_link_libraries(stats_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14397,6 +14771,7 @@ target_link_libraries(status_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14436,6 +14811,7 @@ target_link_libraries(status_util_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14477,6 +14853,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -14536,6 +14913,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -14577,6 +14955,7 @@ target_link_libraries(string_ref_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14617,6 +14996,7 @@ target_link_libraries(test_cpp_client_credentials_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14657,6 +15037,7 @@ target_link_libraries(test_cpp_server_credentials_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14698,6 +15079,7 @@ target_link_libraries(test_cpp_util_slice_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14739,6 +15121,7 @@ target_link_libraries(test_cpp_util_time_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14781,6 +15164,7 @@ target_link_libraries(thread_manager_test
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14839,6 +15223,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -14881,6 +15266,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -14922,6 +15308,7 @@ target_link_libraries(timer_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -14961,6 +15348,7 @@ target_link_libraries(tls_security_connector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15004,6 +15392,7 @@ target_link_libraries(too_many_pings_test
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15045,6 +15434,7 @@ target_link_libraries(unknown_frame_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15086,6 +15476,7 @@ target_link_libraries(window_overflow_bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15126,6 +15517,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -15202,6 +15594,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -15245,6 +15638,7 @@ target_link_libraries(xds_bootstrap_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15284,6 +15678,7 @@ target_link_libraries(xds_certificate_provider_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15338,6 +15733,7 @@ target_link_libraries(xds_credentials_end2end_test
   grpc_test_util
   grpc++
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15481,6 +15877,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     grpc_test_util
     grpc++
     grpc
+    grpc_health_upb
     gpr
     address_sorting
     upb
@@ -15535,6 +15932,7 @@ target_link_libraries(xds_interop_client
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15588,6 +15986,7 @@ target_link_libraries(xds_interop_server
   grpc++
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15629,6 +16028,7 @@ target_link_libraries(alts_credentials_fuzzer_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15670,6 +16070,7 @@ target_link_libraries(client_fuzzer_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15711,6 +16112,7 @@ target_link_libraries(hpack_parser_fuzzer_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15752,6 +16154,7 @@ target_link_libraries(http_request_fuzzer_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15793,6 +16196,7 @@ target_link_libraries(http_response_fuzzer_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15834,6 +16238,7 @@ target_link_libraries(json_fuzzer_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15875,6 +16280,7 @@ target_link_libraries(nanopb_fuzzer_response_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15916,6 +16322,7 @@ target_link_libraries(nanopb_fuzzer_serverlist_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15957,6 +16364,7 @@ target_link_libraries(percent_decode_fuzzer_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -15998,6 +16406,7 @@ target_link_libraries(percent_encode_fuzzer_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -16039,6 +16448,7 @@ target_link_libraries(server_fuzzer_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -16080,6 +16490,7 @@ target_link_libraries(ssl_server_fuzzer_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb
@@ -16121,6 +16532,7 @@ target_link_libraries(uri_fuzzer_test_one_entry
   grpc_test_util
   grpc++_test_config
   grpc
+  grpc_health_upb
   gpr
   address_sorting
   upb

--- a/Makefile
+++ b/Makefile
@@ -800,7 +800,7 @@ $(LIBDIR)/$(CONFIG)/protobuf/libprotobuf.a: third_party/protobuf/configure
 
 static: static_c static_cxx
 
-static_c: cache.mk  $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.a $(LIBDIR)/$(CONFIG)/libupb.a
+static_c: cache.mk  $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.a $(LIBDIR)/$(CONFIG)/libupb.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto.a
 
 static_cxx: cache.mk  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc++_alts.a $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
 
@@ -808,7 +808,7 @@ static_csharp: static_c
 
 shared: shared_c shared_cxx
 
-shared_c: cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
+shared_c: cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
 shared_cxx: cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 
 shared_csharp: shared_c 
@@ -842,10 +842,14 @@ ifeq ($(CONFIG),opt)
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc.a
 	$(E) "[STRIP]   Stripping libgrpc_csharp_ext.a"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a
+	$(E) "[STRIP]   Stripping libgrpc_health_upb.a"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a
 	$(E) "[STRIP]   Stripping libgrpc_unsecure.a"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.a
 	$(E) "[STRIP]   Stripping libupb.a"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libupb.a
+	$(E) "[STRIP]   Stripping libgrpc_health_upb_proto.a"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto.a
 endif
 
 strip-static_cxx: static_cxx
@@ -874,10 +878,14 @@ ifeq ($(CONFIG),opt)
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
+	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
+	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
 endif
 
 strip-shared_cxx: shared_cxx
@@ -2013,7 +2021,6 @@ LIBGRPC_SRC = \
     src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.c \
     src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.c \
     src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c \
-    src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c \
     src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c \
     src/core/ext/upb-generated/udpa/annotations/migrate.upb.c \
     src/core/ext/upb-generated/udpa/annotations/security.upb.c \
@@ -2401,18 +2408,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_OBJS) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-$(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_OBJS) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_OBJS) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 	$(Q) ln -sf $(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).so.13
 	$(Q) ln -sf $(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc$(SHARED_VERSION_CORE).so
 endif
@@ -2460,18 +2467,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_csharp_ext.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_csharp_ext.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 	$(Q) ln -sf $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).so.13
 	$(Q) ln -sf $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).so
 endif
@@ -2485,6 +2492,50 @@ ifneq ($(NO_DEPS),true)
 endif
 endif
 # end of build recipe for library "grpc_csharp_ext"
+
+
+# start of build recipe for library "grpc_health_upb" (generated by makelib(lib) template function)
+LIBGRPC_HEALTH_UPB_SRC = \
+    src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c \
+
+PUBLIC_HEADERS_C += \
+
+LIBGRPC_HEALTH_UPB_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC_HEALTH_UPB_SRC))))
+
+
+$(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a: $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)  $(LIBGRPC_HEALTH_UPB_OBJS) 
+	$(E) "[AR]      Creating $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a
+	$(Q) $(AR) $(ARFLAGS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBGRPC_HEALTH_UPB_OBJS) 
+ifeq ($(SYSTEM),Darwin)
+	$(Q) ranlib -no_warning_for_no_symbols $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a
+endif
+
+
+
+ifeq ($(SYSTEM),MINGW32)
+$(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_HEALTH_UPB_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_health_upb$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_HEALTH_UPB_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS) -lupb$(SHARED_VERSION_CORE)-dll
+else
+$(LIBDIR)/$(CONFIG)/libgrpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_HEALTH_UPB_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+ifeq ($(SYSTEM),Darwin)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_HEALTH_UPB_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS) -lupb
+else
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_health_upb.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_HEALTH_UPB_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS) -lupb
+	$(Q) ln -sf $(SHARED_PREFIX)grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb$(SHARED_VERSION_CORE).so.13
+	$(Q) ln -sf $(SHARED_PREFIX)grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb$(SHARED_VERSION_CORE).so
+endif
+endif
+
+ifneq ($(NO_DEPS),true)
+-include $(LIBGRPC_HEALTH_UPB_OBJS:.o=.dep)
+endif
+# end of build recipe for library "grpc_health_upb"
 
 
 # start of build recipe for library "grpc_unsecure" (generated by makelib(lib) template function)
@@ -2599,7 +2650,6 @@ LIBGRPC_UNSECURE_SRC = \
     src/core/ext/upb-generated/google/protobuf/timestamp.upb.c \
     src/core/ext/upb-generated/google/protobuf/wrappers.upb.c \
     src/core/ext/upb-generated/google/rpc/status.upb.c \
-    src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c \
     src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c \
     src/core/ext/upb-generated/udpa/data/orca/v1/orca_load_report.upb.c \
     src/core/ext/upb-generated/validate/validate.upb.c \
@@ -2800,18 +2850,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
+$(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_UNSECURE_OBJS) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_UNSECURE_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-$(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
+$(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_UNSECURE_OBJS) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_UNSECURE_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_unsecure.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_UNSECURE_OBJS) $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_unsecure.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_UNSECURE_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 	$(Q) ln -sf $(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).so.13
 	$(Q) ln -sf $(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_unsecure$(SHARED_VERSION_CORE).so
 endif
@@ -3095,18 +3145,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc$(SHARED_VERSION_CORE)-dll -lgrpc_health_upb$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
 else
-$(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++$(SHARED_VERSION_CPP).so
 endif
@@ -3168,18 +3218,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ALTS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ALTS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgrpc_health_upb$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
 else
-$(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ALTS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ALTS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_alts.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_alts.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ALTS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_alts$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_alts$(SHARED_VERSION_CPP).so
 endif
@@ -3241,18 +3291,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ERROR_DETAILS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ERROR_DETAILS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_error_details$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ERROR_DETAILS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_error_details$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ERROR_DETAILS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgrpc_health_upb$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
 else
-$(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ERROR_DETAILS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_ERROR_DETAILS_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ERROR_DETAILS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ERROR_DETAILS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_error_details.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ERROR_DETAILS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_error_details.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_ERROR_DETAILS_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_error_details$(SHARED_VERSION_CPP).so
 endif
@@ -3316,18 +3366,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_REFLECTION_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_REFLECTION_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_reflection$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_REFLECTION_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_reflection$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_REFLECTION_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgrpc_health_upb$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
 else
-$(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_REFLECTION_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_REFLECTION_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_REFLECTION_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_REFLECTION_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_reflection.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_REFLECTION_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_reflection.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_REFLECTION_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_reflection$(SHARED_VERSION_CPP).so
 endif
@@ -3600,18 +3650,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
+$(LIBDIR)/$(CONFIG)/grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_unsecure$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_UNSECURE_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc_unsecure$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc++_unsecure$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_UNSECURE_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc_unsecure$(SHARED_VERSION_CORE)-dll -lgrpc_health_upb$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
 else
-$(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE)
+$(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPC++_UNSECURE_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_UNSECURE_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc_unsecure -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_UNSECURE_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc_unsecure -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_unsecure.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_UNSECURE_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc_unsecure -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc++_unsecure.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPC++_UNSECURE_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc_unsecure -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure$(SHARED_VERSION_CPP).so
 endif
@@ -3715,18 +3765,18 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPCPP_CHANNELZ_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPCPP_CHANNELZ_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/grpc_health_upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll -lgrpc_health_upb$(SHARED_VERSION_CORE)-dll -lgpr$(SHARED_VERSION_CORE)-dll -laddress_sorting$(SHARED_VERSION_CORE)-dll -lupb$(SHARED_VERSION_CORE)-dll
 else
-$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPCPP_CHANNELZ_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPCPP_CHANNELZ_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgpr.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libaddress_sorting.$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpcpp_channelz.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgpr -laddress_sorting -lupb
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpcpp_channelz.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc -lgrpc_health_upb -lgpr -laddress_sorting -lupb
 	$(Q) ln -sf $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).so.1
 	$(Q) ln -sf $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).so
 endif
@@ -4154,6 +4204,50 @@ ifneq ($(NO_DEPS),true)
 -include $(LIBUPB_OBJS:.o=.dep)
 endif
 # end of build recipe for library "upb"
+
+
+# start of build recipe for library "grpc_health_upb_proto" (generated by makelib(lib) template function)
+LIBGRPC_HEALTH_UPB_PROTO_SRC = \
+    src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c \
+
+PUBLIC_HEADERS_C += \
+
+LIBGRPC_HEALTH_UPB_PROTO_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC_HEALTH_UPB_PROTO_SRC))))
+
+
+$(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto.a: $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)  $(LIBGRPC_HEALTH_UPB_PROTO_OBJS) 
+	$(E) "[AR]      Creating $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto.a
+	$(Q) $(AR) $(ARFLAGS) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto.a $(LIBGRPC_HEALTH_UPB_PROTO_OBJS) 
+ifeq ($(SYSTEM),Darwin)
+	$(Q) ranlib -no_warning_for_no_symbols $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto.a
+endif
+
+
+
+ifeq ($(SYSTEM),MINGW32)
+$(LIBDIR)/$(CONFIG)/grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_HEALTH_UPB_PROTO_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/upb$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_health_upb_proto$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_HEALTH_UPB_PROTO_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS) -lupb$(SHARED_VERSION_CORE)-dll
+else
+$(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_HEALTH_UPB_PROTO_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libupb.$(SHARED_EXT_CORE)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+ifeq ($(SYSTEM),Darwin)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_HEALTH_UPB_PROTO_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS) -lupb
+else
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_health_upb_proto.so.13 -o $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_HEALTH_UPB_PROTO_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS) -lupb
+	$(Q) ln -sf $(SHARED_PREFIX)grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto$(SHARED_VERSION_CORE).so.13
+	$(Q) ln -sf $(SHARED_PREFIX)grpc_health_upb_proto$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_health_upb_proto$(SHARED_VERSION_CORE).so
+endif
+endif
+
+ifneq ($(NO_DEPS),true)
+-include $(LIBGRPC_HEALTH_UPB_PROTO_OBJS:.o=.dep)
+endif
+# end of build recipe for library "grpc_health_upb_proto"
 
 
 # start of build recipe for library "z" (generated by makelib(lib) template function)

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -118,6 +118,7 @@ libs:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -228,6 +229,7 @@ libs:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -533,7 +535,6 @@ libs:
   - src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.h
   - src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.h
   - src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.h
-  - src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h
   - src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.h
   - src/core/ext/upb-generated/udpa/annotations/migrate.upb.h
   - src/core/ext/upb-generated/udpa/annotations/security.upb.h
@@ -1031,7 +1032,6 @@ libs:
   - src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.c
   - src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.c
   - src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c
-  - src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
   - src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c
   - src/core/ext/upb-generated/udpa/annotations/migrate.upb.c
   - src/core/ext/upb-generated/udpa/annotations/security.upb.c
@@ -1377,6 +1377,7 @@ libs:
   - src/core/tsi/transport_security.cc
   - src/core/tsi/transport_security_grpc.cc
   deps:
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -1400,11 +1401,23 @@ libs:
   - src/csharp/ext/grpc_csharp_ext.c
   deps:
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
   deps_linkage: static
   dll: only
+- name: grpc_health_upb
+  build: all
+  language: c
+  public_headers: []
+  headers:
+  - src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h
+  src:
+  - src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
+  deps:
+  - upb
+  secure: false
 - name: grpc_test_util
   build: private
   language: c
@@ -1457,6 +1470,7 @@ libs:
   - test/core/util/trickle_endpoint.cc
   deps:
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -1515,6 +1529,7 @@ libs:
   - test/core/util/trickle_endpoint.cc
   deps:
   - grpc_unsecure
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -1630,7 +1645,6 @@ libs:
   - src/core/ext/upb-generated/google/protobuf/timestamp.upb.h
   - src/core/ext/upb-generated/google/protobuf/wrappers.upb.h
   - src/core/ext/upb-generated/google/rpc/status.upb.h
-  - src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h
   - src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.h
   - src/core/ext/upb-generated/udpa/data/orca/v1/orca_load_report.upb.h
   - src/core/ext/upb-generated/validate/validate.upb.h
@@ -1892,7 +1906,6 @@ libs:
   - src/core/ext/upb-generated/google/protobuf/timestamp.upb.c
   - src/core/ext/upb-generated/google/protobuf/wrappers.upb.c
   - src/core/ext/upb-generated/google/rpc/status.upb.c
-  - src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
   - src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c
   - src/core/ext/upb-generated/udpa/data/orca/v1/orca_load_report.upb.c
   - src/core/ext/upb-generated/validate/validate.upb.c
@@ -2063,6 +2076,7 @@ libs:
   - src/core/lib/uri/uri_parser.cc
   - src/core/plugin_registry/grpc_unsecure_plugin_registry.cc
   deps:
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2093,6 +2107,7 @@ libs:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2349,6 +2364,7 @@ libs:
   - src/cpp/util/time_cc.cc
   deps:
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2367,6 +2383,7 @@ libs:
   deps:
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2384,6 +2401,7 @@ libs:
   deps:
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2402,6 +2420,7 @@ libs:
   deps:
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2421,6 +2440,7 @@ libs:
   deps:
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2459,6 +2479,7 @@ libs:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2700,6 +2721,7 @@ libs:
   - src/cpp/util/time_cc.cc
   deps:
   - grpc_unsecure
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2760,6 +2782,7 @@ libs:
   deps:
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2773,6 +2796,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2786,6 +2810,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2799,6 +2824,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2813,6 +2839,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2827,6 +2854,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2841,6 +2869,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2857,6 +2886,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2871,6 +2901,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2885,6 +2916,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2899,6 +2931,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2911,6 +2944,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2925,6 +2959,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2939,6 +2974,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2953,6 +2989,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2965,6 +3002,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2978,6 +3016,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -2991,6 +3030,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3004,6 +3044,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3019,6 +3060,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3033,6 +3075,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3051,6 +3094,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3067,6 +3111,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3080,6 +3125,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3093,6 +3139,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3105,6 +3152,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3118,6 +3166,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3130,6 +3179,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3142,6 +3192,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3155,6 +3206,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3167,6 +3219,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3179,6 +3232,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3195,6 +3249,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3208,6 +3263,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3225,6 +3281,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3237,6 +3294,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3251,6 +3309,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3265,6 +3324,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3277,6 +3337,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3290,6 +3351,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3304,6 +3366,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3318,6 +3381,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3330,6 +3394,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3344,6 +3409,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3362,6 +3428,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3374,6 +3441,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3389,6 +3457,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3402,6 +3471,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3418,6 +3488,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3432,6 +3503,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3444,6 +3516,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3460,6 +3533,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3481,6 +3555,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3502,6 +3577,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3518,6 +3594,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3540,6 +3617,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3554,6 +3632,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3568,6 +3647,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3580,6 +3660,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3592,6 +3673,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3605,6 +3687,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3617,6 +3700,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3631,6 +3715,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3647,6 +3732,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3663,6 +3749,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3676,6 +3763,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3689,6 +3777,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3702,6 +3791,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3715,6 +3805,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3733,6 +3824,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3754,6 +3846,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3771,6 +3864,7 @@ targets:
   - end2end_tests
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3786,6 +3880,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3798,6 +3893,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3811,6 +3907,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3826,6 +3923,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3838,6 +3936,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3851,6 +3950,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3864,6 +3964,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3877,6 +3978,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3890,6 +3992,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3902,6 +4005,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3915,6 +4019,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3928,6 +4033,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3947,6 +4053,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3959,6 +4066,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3974,6 +4082,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3986,6 +4095,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -3998,6 +4108,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4010,6 +4121,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4032,6 +4144,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4045,6 +4158,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4058,6 +4172,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4070,6 +4185,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4088,6 +4204,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4102,6 +4219,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4120,6 +4238,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4134,6 +4253,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4146,6 +4266,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4160,6 +4281,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4172,6 +4294,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4185,6 +4308,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4199,6 +4323,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4215,6 +4340,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4227,6 +4353,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4240,6 +4367,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4253,6 +4381,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4265,6 +4394,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4277,6 +4407,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4293,6 +4424,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4306,6 +4438,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4320,6 +4453,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4336,6 +4470,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4349,6 +4484,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4362,6 +4498,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4374,6 +4511,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4387,6 +4525,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4400,6 +4539,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4413,6 +4553,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4431,6 +4572,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4446,6 +4588,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4462,6 +4605,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4475,6 +4619,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4487,6 +4632,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4500,6 +4646,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4513,6 +4660,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4526,6 +4674,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4539,6 +4688,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4552,6 +4702,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4565,6 +4716,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4578,6 +4730,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4591,6 +4744,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4603,6 +4757,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4615,6 +4770,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4631,6 +4787,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4643,6 +4800,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4656,6 +4814,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4673,6 +4832,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4698,6 +4858,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4716,6 +4877,7 @@ targets:
   - grpc_test_util_unsecure
   - grpc++_unsecure
   - grpc_unsecure
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4740,6 +4902,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4758,6 +4921,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4777,6 +4941,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4797,6 +4962,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4812,6 +4978,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4826,6 +4993,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4839,6 +5007,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4857,6 +5026,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4874,6 +5044,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4887,6 +5058,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4907,6 +5079,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4928,6 +5101,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4950,6 +5124,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -4972,6 +5147,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5003,6 +5179,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5033,6 +5210,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5054,6 +5232,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5076,6 +5255,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5098,6 +5278,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5119,6 +5300,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5140,6 +5322,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5161,6 +5344,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5183,6 +5367,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5206,6 +5391,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5228,6 +5414,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5250,6 +5437,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5273,6 +5461,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5294,6 +5483,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5316,6 +5506,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5338,6 +5529,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5361,6 +5553,7 @@ targets:
   - grpc++_unsecure
   - grpc_unsecure
   - grpc++_test_config
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5383,6 +5576,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5397,6 +5591,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5419,6 +5614,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5432,6 +5628,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5445,6 +5642,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5466,6 +5664,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5480,6 +5679,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5495,6 +5695,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5513,6 +5714,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5527,6 +5729,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5549,6 +5752,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5566,6 +5770,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5598,6 +5803,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5620,6 +5826,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5643,6 +5850,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5661,6 +5869,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5687,6 +5896,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5712,6 +5922,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5730,6 +5941,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5745,6 +5957,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5763,6 +5976,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5776,6 +5990,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5789,6 +6004,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5810,6 +6026,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5825,6 +6042,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5838,6 +6056,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5855,6 +6074,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5880,6 +6100,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5896,6 +6117,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5909,6 +6131,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5922,6 +6145,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5941,6 +6165,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5960,6 +6185,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -5981,6 +6207,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6000,6 +6227,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6013,6 +6241,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6031,6 +6260,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6045,6 +6275,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6073,6 +6304,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6149,6 +6381,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6162,6 +6395,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6194,6 +6428,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6214,6 +6449,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6237,6 +6473,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6255,6 +6492,7 @@ targets:
   - end2end_tests
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6272,6 +6510,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6289,6 +6528,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6313,6 +6553,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6327,6 +6568,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6350,6 +6592,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6364,6 +6607,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6381,6 +6625,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6405,6 +6650,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6418,6 +6664,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6436,6 +6683,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6449,6 +6697,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6474,6 +6723,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6496,6 +6746,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6511,6 +6762,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6529,6 +6781,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6545,6 +6798,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6563,6 +6817,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6582,6 +6837,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6599,6 +6855,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6612,6 +6869,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6632,6 +6890,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6652,6 +6911,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6666,6 +6926,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6683,6 +6944,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6704,6 +6966,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6716,6 +6979,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6732,6 +6996,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6749,6 +7014,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6763,6 +7029,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6780,6 +7047,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6796,6 +7064,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6816,6 +7085,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6840,6 +7110,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6854,6 +7125,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6906,6 +7178,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6948,6 +7221,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6969,6 +7243,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6982,6 +7257,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -6995,6 +7271,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7008,6 +7285,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7025,6 +7303,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7041,6 +7320,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7062,6 +7342,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7079,6 +7360,7 @@ targets:
   - grpc_test_util_unsecure
   - grpc++_unsecure
   - grpc_unsecure
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7100,6 +7382,7 @@ targets:
   - grpc_test_util_unsecure
   - grpc++_unsecure
   - grpc_unsecure
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7117,6 +7400,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7133,6 +7417,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7151,6 +7436,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7165,6 +7451,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7191,6 +7478,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7208,6 +7496,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7225,6 +7514,7 @@ targets:
   - grpc_test_util_unsecure
   - grpc++_unsecure
   - grpc_unsecure
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7250,6 +7540,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7263,6 +7554,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7277,6 +7569,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7296,6 +7589,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7313,6 +7607,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7327,6 +7622,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7343,6 +7639,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7357,6 +7654,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7370,6 +7668,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7384,6 +7683,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7398,6 +7698,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7415,6 +7716,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7438,6 +7740,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7456,6 +7759,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7471,6 +7775,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7485,6 +7790,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7500,6 +7806,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7516,6 +7823,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7533,6 +7841,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7552,6 +7861,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7571,6 +7881,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7589,6 +7900,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7602,6 +7914,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7620,6 +7933,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7637,6 +7951,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7651,6 +7966,7 @@ targets:
   - grpc_test_util
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7671,6 +7987,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7684,6 +8001,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7748,6 +8066,7 @@ targets:
   deps:
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7768,6 +8087,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7781,6 +8101,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7801,6 +8122,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7844,6 +8166,7 @@ targets:
   - grpc_test_util
   - grpc++
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7866,6 +8189,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb
@@ -7884,6 +8208,7 @@ targets:
   - grpc++
   - grpc++_test_config
   - grpc
+  - grpc_health_upb
   - gpr
   - address_sorting
   - upb

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -176,6 +176,7 @@
       'dependencies': [
         'grpc_test_util',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -278,6 +279,7 @@
       'dependencies': [
         'grpc_test_util',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -437,6 +439,7 @@
       'target_name': 'grpc',
       'type': 'static_library',
       'dependencies': [
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -625,7 +628,6 @@
         'src/core/ext/upb-generated/src/proto/grpc/gcp/altscontext.upb.c',
         'src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.c',
         'src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c',
-        'src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c',
         'src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c',
         'src/core/ext/upb-generated/udpa/annotations/migrate.upb.c',
         'src/core/ext/upb-generated/udpa/annotations/security.upb.c',
@@ -977,6 +979,7 @@
       'type': 'static_library',
       'dependencies': [
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -986,10 +989,21 @@
       ],
     },
     {
+      'target_name': 'grpc_health_upb',
+      'type': 'static_library',
+      'dependencies': [
+        'upb',
+      ],
+      'sources': [
+        'src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c',
+      ],
+    },
+    {
       'target_name': 'grpc_test_util',
       'type': 'static_library',
       'dependencies': [
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1028,6 +1042,7 @@
       'type': 'static_library',
       'dependencies': [
         'grpc_unsecure',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1065,6 +1080,7 @@
       'target_name': 'grpc_unsecure',
       'type': 'static_library',
       'dependencies': [
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1184,7 +1200,6 @@
         'src/core/ext/upb-generated/google/protobuf/timestamp.upb.c',
         'src/core/ext/upb-generated/google/protobuf/wrappers.upb.c',
         'src/core/ext/upb-generated/google/rpc/status.upb.c',
-        'src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c',
         'src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c',
         'src/core/ext/upb-generated/udpa/data/orca/v1/orca_load_report.upb.c',
         'src/core/ext/upb-generated/validate/validate.upb.c',
@@ -1364,6 +1379,7 @@
         'grpc++_unsecure',
         'grpc_unsecure',
         'grpc++_test_config',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1381,6 +1397,7 @@
       'type': 'static_library',
       'dependencies': [
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1443,6 +1460,7 @@
       'dependencies': [
         'grpc++',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1458,6 +1476,7 @@
       'dependencies': [
         'grpc++',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1473,6 +1492,7 @@
       'dependencies': [
         'grpc++',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1489,6 +1509,7 @@
       'dependencies': [
         'grpc++',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1514,6 +1535,7 @@
         'grpc_test_util',
         'grpc++',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1535,6 +1557,7 @@
       'type': 'static_library',
       'dependencies': [
         'grpc_unsecure',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1603,6 +1626,7 @@
       'dependencies': [
         'grpc++',
         'grpc',
+        'grpc_health_upb',
         'gpr',
         'address_sorting',
         'upb',
@@ -1986,6 +2010,16 @@
         'src/core/ext/upbdefs-generated/google/protobuf/struct.upbdefs.c',
         'src/core/ext/upbdefs-generated/google/protobuf/timestamp.upbdefs.c',
         'src/core/ext/upbdefs-generated/google/protobuf/wrappers.upbdefs.c',
+      ],
+    },
+    {
+      'target_name': 'grpc_health_upb_proto',
+      'type': 'static_library',
+      'dependencies': [
+        'upb',
+      ],
+      'sources': [
+        'src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c',
       ],
     },
     {

--- a/src/core/ext/upb-generated/gen_build_yaml.py
+++ b/src/core/ext/upb-generated/gen_build_yaml.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python2.7
+
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import re
+import os
+import sys
+import yaml
+
+out = {}
+
+out['libs'] = [
+    {
+        'name': 'grpc_health_upb_proto',
+        'build': 'all',
+        'language': 'c',
+        'src': [
+            "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c",
+        ],
+        'headers': [
+            "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h",
+        ],
+        'secure': False,
+        'deps': ['upb'],
+    },
+]
+
+print(yaml.dump(out))

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -89,8 +89,12 @@ def _extract_rules_from_bazel_xml(xml_tree):
             rule_clazz = rule_dict['class']
             rule_name = rule_dict['name']
             if rule_clazz in [
-                    'cc_library', 'cc_binary', 'cc_test', 'cc_proto_library',
-                    'proto_library'
+                    'cc_library',
+                    'cc_binary',
+                    'cc_test',
+                    'cc_proto_library',
+                    'proto_library',
+                    'upb_proto_library',
             ]:
                 if rule_name in result:
                     raise Exception('Rule %s already present' % rule_name)
@@ -393,6 +397,28 @@ def _generate_build_metadata(build_extra_metadata, bazel_rules):
     return result
 
 
+def _expand_upb_proto_sources(target_dict):
+    # TODO(jtattermusch): Some targets specify ".proto" files as their dependencies.
+    # CMake/make normally handle generation of the sources automatically,
+    # but they use google protobuf for that (i.e. not UPB).
+    # For UPB proto libraries, the .upb.c and .upb.h files have already been
+    # generated, so we just replace the ".proto" sources by their
+    # generated upb counterpart.
+    for target_name, target in target_dict.iteritems():
+        if target_name.endswith('_upb') or target_name.endswith(
+                '_upb_reflection'):
+            srcs = target['src']
+            hdrs = target['headers']
+            for idx in range(0, len(srcs)):
+                src = srcs[idx]
+                if src.endswith('.proto'):
+                    src_extension_stripped = src[:-len('.proto')]
+                    srcs[
+                        idx] = 'src/core/ext/upb-generated/' + src_extension_stripped + '.upb.c'
+                    hdrs.append('src/core/ext/upb-generated/' +
+                                src_extension_stripped + '.upb.h')
+
+
 def _convert_to_build_yaml_like(lib_dict):
     lib_names = list(
         filter(
@@ -634,6 +660,11 @@ _BUILD_EXTRA_METADATA = {
         'build': 'all',
         'secure': False,
         '_RENAME': 'address_sorting'
+    },
+    'grpc_health_upb': {
+        'language': 'c',
+        'build': 'all',
+        'secure': False
     },
     'gpr': {
         'language': 'c',
@@ -1101,6 +1132,9 @@ all_extra_metadata.update(
 #            'deps': ['gpr', 'address_sorting', ...],
 #            ... }
 all_targets_dict = _generate_build_metadata(all_extra_metadata, bazel_rules)
+
+# Step 4.5: Expand upb targets.
+_expand_upb_proto_sources(all_targets_dict)
 
 # Step 5: convert the dictionary with all the targets to a dict that has
 # the desired "build.yaml"-like layout.

--- a/tools/buildgen/generate_build_additions.sh
+++ b/tools/buildgen/generate_build_additions.sh
@@ -15,17 +15,18 @@
 
 set -e
 
-gen_build_yaml_dirs="  \
-  src/abseil-cpp       \
-  src/boringssl        \
-  src/benchmark        \
-  src/proto            \
-  src/re2              \
-  src/upb              \
-  src/zlib             \
-  src/c-ares           \
-  test/core/end2end    \
-  test/cpp/naming      \
+gen_build_yaml_dirs="        \
+  src/abseil-cpp             \
+  src/boringssl              \
+  src/benchmark              \
+  src/proto                  \
+  src/re2                    \
+  src/upb                    \
+  src/core/ext/upb-generated \
+  src/zlib                   \
+  src/c-ares                 \
+  test/core/end2end          \
+  test/cpp/naming            \
   tools/run_tests/lb_interop_tests"
 
 

--- a/tools/distrib/check_upb_output.sh
+++ b/tools/distrib/check_upb_output.sh
@@ -20,6 +20,7 @@ readonly UPBDEFS_GENERATED_SRC=src/core/ext/upbdefs-generated
 readonly UPB_TMP_OUTPUT="$(mktemp -d)"
 
 tools/codegen/core/gen_upb_api.sh "$UPB_TMP_OUTPUT"
+cp src/core/ext/upb-generated/gen_build_yaml.py "${UPB_TMP_OUTPUT}/upb-generated"
 
 diff -rq "$UPB_GENERATED_SRC" "$UPB_TMP_OUTPUT/upb-generated"
 diff -rq "$UPBDEFS_GENERATED_SRC" "$UPB_TMP_OUTPUT/upbdefs-generated"

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -1367,8 +1367,6 @@ src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.c \
 src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.h \
 src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c \
 src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.h \
-src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c \
-src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h \
 src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c \
 src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.h \
 src/core/ext/upb-generated/udpa/annotations/migrate.upb.c \

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -1204,8 +1204,6 @@ src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.c \
 src/core/ext/upb-generated/src/proto/grpc/gcp/handshaker.upb.h \
 src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c \
 src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.h \
-src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c \
-src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h \
 src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.c \
 src/core/ext/upb-generated/src/proto/grpc/lb/v1/load_balancer.upb.h \
 src/core/ext/upb-generated/udpa/annotations/migrate.upb.c \


### PR DESCRIPTION
This attempts to extract the relevant parts of #23122 to use the `upb_proto_library` rule for just one simple proto file, health.proto.  If this doesn't cause any problems on import, we'll be able to do this for other proto files in subsequent PRs.