### PR TITLE
Add .bazeligore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,11 @@
+bazel-bin
+bazel-grpc
+bazel-out
+bazel-testlogs
+bins
+libs
+objs
+third_party/abseil-cpp
+third_party/googleapis
+third_party/protoc-gen-validate
+third_party/udpa


### PR DESCRIPTION
This is to enable recursive bazel query. This is particularly helpful for vscode bazel to iterate all targets.