### PR TITLE
Extend timeout for ios-cpp-test-cronet

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1137,7 +1137,7 @@ class ObjCLanguage(object):
                                  environ={'SCHEME': 'PerfTestsPosix'}))
         out.append(
             self.config.job_spec(['test/cpp/ios/build_and_run_tests.sh'],
-                                 timeout_seconds=30 * 60,
+                                 timeout_seconds=60 * 60,
                                  shortname='ios-cpp-test-cronet',
                                  cpu_cost=1e6,
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS))


### PR DESCRIPTION
Extend timeout for ios-cpp-test-cronet and keep it the same as ios-test-cfstream-tests.