### PR TITLE
Make qps_worker --server_port behavior consistent with java

### DIFF
--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -234,7 +234,7 @@ class WorkerServiceImpl final : public WorkerService::Service {
     if (!args.has_setup()) {
       return Status(StatusCode::INVALID_ARGUMENT, "Bad server creation args");
     }
-    if (server_port_ > 0) {
+    if (server_port_ > 0 && args.setup().port() == 0) {
       args.mutable_setup()->set_port(server_port_);
     }
     gpr_log(GPR_INFO, "RunServerBody: about to create server");

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -32,7 +32,9 @@
 #include "test/cpp/util/test_credentials_provider.h"
 
 DEFINE_int32(driver_port, 0, "Port for communication with driver");
-DEFINE_int32(server_port, 0, "Port for operation as a server");
+DEFINE_int32(server_port, 0,
+             "Port for operation as a server, if not specified by the server "
+             "config message.");
 DEFINE_string(credential_type, grpc::testing::kInsecureCredentialsType,
               "Credential type for communication with driver");
 


### PR DESCRIPTION
https://github.com/grpc/grpc-java/blob/59528d8efec465326b071ffc6f3f2220bcf641c9/benchmarks/src/main/java/io/grpc/benchmarks/driver/LoadWorker.java#L136
grpc-go also has the same behavior as java.

see https://github.com/grpc/grpc/pull/24350#discussion_r514978461 for more context.
