### PR TITLE
Make python qps_worker --server_port consistent

### DIFF
--- a/src/python/grpcio_tests/tests/qps/qps_worker.py
+++ b/src/python/grpcio_tests/tests/qps/qps_worker.py
@@ -39,15 +39,18 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     parser = argparse.ArgumentParser(
         description='gRPC Python performance testing worker')
-    parser.add_argument('--driver_port',
-                        type=int,
-                        dest='driver_port',
-                        help='The port the worker should listen on')
-    parser.add_argument('--server_port',
-                        type=int,
-                        default=None,
-                        dest='server_port',
-                        help='The port the server should accept traffic on')
+    parser.add_argument(
+        '--driver_port',
+        type=int,
+        dest='driver_port',
+        help='The port for the worker to expose for driver communication')
+    parser.add_argument(
+        '--server_port',
+        type=int,
+        default=None,
+        dest='server_port',
+        help='The port for the server if not specified by server config message'
+    )
     args = parser.parse_args()
 
     run_worker_server(args.driver_port, args.server_port)

--- a/src/python/grpcio_tests/tests/qps/worker_server.py
+++ b/src/python/grpcio_tests/tests/qps/worker_server.py
@@ -92,7 +92,11 @@ class WorkerServer(worker_service_pb2_grpc.WorkerServiceServicer):
             raise Exception('Unsupported server type {}'.format(
                 config.server_type))
 
-        server_port = config.port if self._server_port is None else self._server_port
+        if self._server_port is not None and config.port == 0:
+            server_port = self._server_port
+        else:
+            server_port = config.port
+
         if config.HasField('security_params'):  # Use SSL
             server_creds = grpc.ssl_server_credentials(
                 ((resources.private_key(), resources.certificate_chain()),))


### PR DESCRIPTION
The python qps_worker was changed in grpc/grpc#24350, adding support for the --server_port flag. When the --server_port flag was set, the python worker ignored the port specified in the Scenario's ServerConfig.

This behavior was inconsistent with Java and Go. In the workers for those languages, the --server_port flag was used only when the Scenario's ServerConfig port was unset. It did not override.

This commit alters the behavior of the python qps_worker to match Java and Go, similar to grpc/grpc#24661 for C++. In addition, it updates the documentation for the flag.