### PR TITLE
Disable debugging-test when running with MUSL

### DIFF
--- a/test/core/gprpp/examine_stack_test.cc
+++ b/test/core/gprpp/examine_stack_test.cc
@@ -71,7 +71,7 @@ TEST(ExamineStackTest, AbseilStackProvider) {
       grpc_core::GetCurrentStackTrace();
   EXPECT_NE(stack_trace, absl::nullopt);
   gpr_log(GPR_INFO, "stack_trace=%s", stack_trace->c_str());
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(GPR_MUSL_LIBC_COMPAT)
   EXPECT_TRUE(stack_trace->find("GetCurrentStackTrace") != -1);
 #endif
 }

--- a/test/core/util/stack_tracer_test.cc
+++ b/test/core/util/stack_tracer_test.cc
@@ -30,7 +30,7 @@
 TEST(StackTracerTest, Basic) {
   std::string stack_trace = grpc_core::testing::GetCurrentStackTrace();
   gpr_log(GPR_INFO, "stack_trace=%s", stack_trace.c_str());
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(GPR_MUSL_LIBC_COMPAT)
   EXPECT_TRUE(stack_trace.find("Basic") != -1);
 #endif
 }


### PR DESCRIPTION
This is to fix `master/linux/grpc_portability` ([log](https://source.cloud.google.com/results/invocations/1f13f0f2-44d3-4da8-ae94-46c478846166/targets)) introduced by #24245.

Abseil symbolize doesn't seem to work with MUSL.