### PR TITLE
[Test] Python Windows2016 Build

### DIFF
--- a/tools/internal_ci/helper_scripts/install_python_interpreters.ps1
+++ b/tools/internal_ci/helper_scripts/install_python_interpreters.ps1
@@ -85,7 +85,7 @@ $Python39x86Config = @{
     PythonInstallPath = "C:\Python39_32bit"
     PythonInstallerHash = "4a2812db8ab9f2e522c96c7728cfcccb"
 }
-# Install-Python @Python39x86Config
+Install-Python @Python39x86Config
 
 $Python39x64Config = @{
     PythonVersion = "3.9.0"
@@ -93,4 +93,4 @@ $Python39x64Config = @{
     PythonInstallPath = "C:\Python39"
     PythonInstallerHash = "b61a33dc28f13b561452f3089c87eb63"
 }
-# Install-Python @Python39x64Config
+Install-Python @Python39x64Config

--- a/tools/internal_ci/windows/grpc_win2016_experiment.cfg
+++ b/tools/internal_ci/windows/grpc_win2016_experiment.cfg
@@ -1,0 +1,13 @@
+build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
+timeout_mins: 60
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "-f basictests windows python -j 1 --inner_jobs 8 --internal_ci"
+}

--- a/tools/internal_ci/windows/grpc_win2016_experiment.cfg
+++ b/tools/internal_ci/windows/grpc_win2016_experiment.cfg
@@ -1,10 +1,14 @@
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/windows/grpc_build_artifacts.bat"
-timeout_mins: 120
+build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
-    regex: "github/grpc/artifacts/**"
   }
+}
+
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "-f basictests windows python -j 1 --inner_jobs 8 --internal_ci"
 }

--- a/tools/internal_ci/windows/grpc_win2016_experiment.cfg
+++ b/tools/internal_ci/windows/grpc_win2016_experiment.cfg
@@ -1,13 +1,10 @@
-build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 60
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_build_artifacts.bat"
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
   }
-}
-
-env_vars {
-  key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows python -j 1 --inner_jobs 8 --internal_ci"
 }

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -763,6 +763,11 @@ class PythonLanguage(object):
                                                    minor='8',
                                                    bits=bits,
                                                    config_vars=config_vars)
+        python39_config = _python_config_generator(name='py39',
+                                                   major='3',
+                                                   minor='9',
+                                                   bits=bits,
+                                                   config_vars=config_vars)
         pypy27_config = _pypy_config_generator(name='pypy',
                                                major='2',
                                                config_vars=config_vars)
@@ -772,7 +777,7 @@ class PythonLanguage(object):
 
         if args.iomgr_platform == 'asyncio':
             if args.compiler not in ('default', 'python3.6', 'python3.7',
-                                     'python3.8'):
+                                     'python3.8', 'python3.9'):
                 raise Exception(
                     'Compiler %s not supported with IO Manager platform: %s' %
                     (args.compiler, args.iomgr_platform))
@@ -784,7 +789,7 @@ class PythonLanguage(object):
                     # gevent to run on later version once issue solved.
                     return (python36_config,)
                 else:
-                    return (python38_config,)
+                    return (python39_config,)
             else:
                 if args.iomgr_platform == 'asyncio':
                     return (python36_config, python38_config)
@@ -813,6 +818,8 @@ class PythonLanguage(object):
             return (python37_config,)
         elif args.compiler == 'python3.8':
             return (python38_config,)
+        elif args.compiler == 'python3.9':
+            return (python39_config,)
         elif args.compiler == 'pypy':
             return (pypy27_config,)
         elif args.compiler == 'pypy3':
@@ -826,6 +833,7 @@ class PythonLanguage(object):
                 python36_config,
                 python37_config,
                 python38_config,
+                python39_config,
             )
         else:
             raise Exception('Compiler %s not supported.' % args.compiler)


### PR DESCRIPTION
gRPC Python Basictest on Windows2016: http://sponge/54ccb02b-5f0d-4966-923a-6f5b2dd8f42b [Successful]
* No Python 3.9, only Python 3.8 and Python 3.6

gRPC Build Artifacts on Windows2016: http://sponge/97fa4327-2959-443c-a335-ebfc917d2471

gRPC Python Basictest on Windows2016 with Python 3.9
* http://sponge/97a805df-6a56-49d3-b4ea-236525b58117
* http://sponge/1f67ac45-7370-4c3f-9f58-2ed3138098df 
