### PR TITLE
Remove XDS size test

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -27,20 +27,12 @@ cd /var/local/git/grpc
 
 bazel build :all //test/... //examples/...
 
-BUILD_WITH_XDS_SIZE=$(stat -c %s "bazel-bin/test/cpp/end2end/end2end_test")
 # TODO(jtattersmusch): Adding a build here for --define=grpc_no_xds is not ideal
 # and we should find a better place for this. Refer
 # https://github.com/grpc/grpc/pull/24536#pullrequestreview-517466531 for more
 # details.
 # Test that builds with --define=grpc_no_xds=true work.
 bazel build //test/cpp/end2end:end2end_test --define=grpc_no_xds=true
-BUILD_WITHOUT_XDS_SIZE=$(stat -c %s "bazel-bin/test/cpp/end2end/end2end_test")
-# Test that the binary size with --define=grpc_no_xds=true is smaller
-if [ $BUILD_WITH_XDS_SIZE -le $BUILD_WITHOUT_XDS_SIZE ]
-then
-	echo "Building with --define=grpc_no_xds=true does not reduce binary size"
-	exit 1
-fi
 # Test that builds that need xDS do not build with --define=grpc_no_xds=true
 EXIT_CODE=0
 bazel build //test/cpp/end2end:xds_end2end_test --define=grpc_no_xds=true || EXIT_CODE=$?


### PR DESCRIPTION
Removing the existing XDS size test because it isn't working as expected. It basically measures the size of `end2end_test` artifact by building it with and without `--define=grpc_no_xds=true` option assuming that it creates a single executable file and the one without XDS will be smaller. But Bazel builds doesn't create a single executable in this case. Rather it creates many .so files and a single executable linked with them. Therefore, the code section of both `end2end_test`s are actually identical and headers can vary because of the dependency difference.

Its wrong behavior was observed from https://github.com/grpc/grpc/pull/24653 where both cases resulted in the same size of executable. ([log](https://source.cloud.google.com/results/invocations/1c138617-eace-412f-84a0-0385acc6f3ff/targets), [digest](https://gist.github.com/veblush/e3d4697fc2c2cf675dfa63860a81188b)) Although they were correctly built and xds symbols were found in only one of them, they happened to have the same size.

So let's remove the size test. Since there still is a `Test that builds that need xDS do not build with --define=grpc_no_xds=true`, I think it's not that concerning not having a size test. If we have to have this test, adding `linkstatic=1` to the test can address this issue but it may be too invasive because `grpc_cc_test` in `grpc_build_system.bzl` needs changes, too. 