### PR TITLE
clang-tidy: enable google-readability-braces-around-statements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks: '-*,
   google-*,
   -google-build-using-namespace,
   -google-explicit-constructor,
-  -google-readability-braces-around-statements,
   -google-readability-casting,
   -google-readability-todo,
   -google-runtime-int,
@@ -46,3 +45,5 @@ CheckOptions:
     value:  'absl::make_unique'
   - key:    modernize-make-unique.MakeSmartPtrFunctionHeader
     value:  'absl/memory/memory.h'
+  - key:    google-readability-braces-around-statements.ShortStatementLines
+    value:  1

--- a/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/eds.cc
@@ -516,8 +516,8 @@ void EdsLb::UpdatePriorityList(XdsApi::EdsUpdate::PriorityList priority_list) {
     if (!child_number.has_value()) {
       for (child_number = 0;
            child_locality_map.find(*child_number) != child_locality_map.end();
-           ++(*child_number))
-        ;
+           ++(*child_number)) {
+      }
       // Add entry so we know that the child number is in use.
       // (Don't need to add the list of localities, since we won't use them.)
       child_locality_map[*child_number];

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -538,8 +538,9 @@ void XdsClusterManagerLb::ClusterChild::OnDelayedRemovalTimerLocked(
 RefCountedPtr<SubchannelInterface>
 XdsClusterManagerLb::ClusterChild::Helper::CreateSubchannel(
     ServerAddress address, const grpc_channel_args& args) {
-  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_)
+  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_) {
     return nullptr;
+  }
   return xds_cluster_manager_child_->xds_cluster_manager_policy_
       ->channel_control_helper()
       ->CreateSubchannel(std::move(address), args);
@@ -557,8 +558,9 @@ void XdsClusterManagerLb::ClusterChild::Helper::UpdateState(
         xds_cluster_manager_child_->name_.c_str(), ConnectivityStateName(state),
         status.ToString().c_str(), picker.get());
   }
-  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_)
+  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_) {
     return;
+  }
   // Cache the picker in the ClusterChild.
   xds_cluster_manager_child_->picker_wrapper_ =
       MakeRefCounted<ChildPickerWrapper>(xds_cluster_manager_child_->name_,
@@ -582,8 +584,9 @@ void XdsClusterManagerLb::ClusterChild::Helper::UpdateState(
 }
 
 void XdsClusterManagerLb::ClusterChild::Helper::RequestReresolution() {
-  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_)
+  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_) {
     return;
+  }
   xds_cluster_manager_child_->xds_cluster_manager_policy_
       ->channel_control_helper()
       ->RequestReresolution();
@@ -591,8 +594,9 @@ void XdsClusterManagerLb::ClusterChild::Helper::RequestReresolution() {
 
 void XdsClusterManagerLb::ClusterChild::Helper::AddTraceEvent(
     TraceSeverity severity, absl::string_view message) {
-  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_)
+  if (xds_cluster_manager_child_->xds_cluster_manager_policy_->shutting_down_) {
     return;
+  }
   xds_cluster_manager_child_->xds_cluster_manager_policy_
       ->channel_control_helper()
       ->AddTraceEvent(severity, message);

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -269,8 +269,8 @@ static grpc_error* hs_filter_incoming_metadata(grpc_call_element* elem,
     /* offset of the character '?' */
     size_t offset = 0;
     for (offset = 0; offset < path_length && *path_ptr != k_query_separator;
-         path_ptr++, offset++)
-      ;
+         path_ptr++, offset++) {
+    }
     if (offset < path_length) {
       grpc_slice query_slice =
           grpc_slice_sub(path_slice, offset + 1, path_length);

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -129,9 +129,10 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       ++cur;
     /* fallthrough */
     case GRPC_CHTTP2_GOAWAY_DEBUG:
-      if (end != cur)
+      if (end != cur) {
         memcpy(p->debug_data + p->debug_pos, cur,
                static_cast<size_t>(end - cur));
+      }
       GPR_ASSERT((size_t)(end - cur) < UINT32_MAX - p->debug_pos);
       p->debug_pos += static_cast<uint32_t>(end - cur);
       p->state = GRPC_CHTTP2_GOAWAY_DEBUG;

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1301,12 +1301,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte0;
+      }
       p->base64_buffer = bits << 18;
     /* fallthrough */
     b64_byte1:
@@ -1317,12 +1318,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte1;
+      }
       p->base64_buffer |= bits << 12;
     /* fallthrough */
     b64_byte2:
@@ -1333,12 +1335,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte2;
+      }
       p->base64_buffer |= bits << 6;
     /* fallthrough */
     b64_byte3:
@@ -1349,12 +1352,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte3;
+      }
       p->base64_buffer |= bits;
       bits = p->base64_buffer;
       decoded[0] = static_cast<uint8_t>(bits >> 16);

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -184,8 +184,9 @@ grpc_channel_args* grpc_channel_args_normalize(const grpc_channel_args* a) {
   for (size_t i = 0; i < a->num_args; i++) {
     args[i] = &a->args[i];
   }
-  if (a->num_args > 1)
+  if (a->num_args > 1) {
     qsort(args, a->num_args, sizeof(grpc_arg*), cmp_key_stable);
+  }
 
   grpc_channel_args* b =
       static_cast<grpc_channel_args*>(gpr_malloc(sizeof(grpc_channel_args)));

--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -67,16 +67,18 @@ ChannelTrace::ChannelTrace(size_t max_event_memory)
       max_event_memory_(max_event_memory),
       head_trace_(nullptr),
       tail_trace_(nullptr) {
-  if (max_event_memory_ == 0)
+  if (max_event_memory_ == 0) {
     return;  // tracing is disabled if max_event_memory_ == 0
+  }
   gpr_mu_init(&tracer_mu_);
   time_created_ = grpc_millis_to_timespec(grpc_core::ExecCtx::Get()->Now(),
                                           GPR_CLOCK_REALTIME);
 }
 
 ChannelTrace::~ChannelTrace() {
-  if (max_event_memory_ == 0)
+  if (max_event_memory_ == 0) {
     return;  // tracing is disabled if max_event_memory_ == 0
+  }
   TraceEvent* it = head_trace_;
   while (it != nullptr) {
     TraceEvent* to_free = it;

--- a/src/core/lib/compression/compression.cc
+++ b/src/core/lib/compression/compression.cc
@@ -150,14 +150,18 @@ grpc_slice grpc_compression_algorithm_slice(
 
 grpc_compression_algorithm grpc_compression_algorithm_from_slice(
     const grpc_slice& str) {
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_IDENTITY))
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_IDENTITY)) {
     return GRPC_COMPRESS_NONE;
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_DEFLATE))
+  }
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_DEFLATE)) {
     return GRPC_COMPRESS_DEFLATE;
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_GZIP))
+  }
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_GZIP)) {
     return GRPC_COMPRESS_GZIP;
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_STREAM_SLASH_GZIP))
+  }
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_STREAM_SLASH_GZIP)) {
     return GRPC_COMPRESS_STREAM_GZIP;
+  }
   return GRPC_COMPRESS_ALGORITHMS_COUNT;
 }
 

--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -34,21 +34,26 @@
 
 grpc_message_compression_algorithm
 grpc_message_compression_algorithm_from_slice(const grpc_slice& str) {
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_IDENTITY))
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_IDENTITY)) {
     return GRPC_MESSAGE_COMPRESS_NONE;
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_DEFLATE))
+  }
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_DEFLATE)) {
     return GRPC_MESSAGE_COMPRESS_DEFLATE;
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_GZIP))
+  }
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_GZIP)) {
     return GRPC_MESSAGE_COMPRESS_GZIP;
+  }
   return GRPC_MESSAGE_COMPRESS_ALGORITHMS_COUNT;
 }
 
 grpc_stream_compression_algorithm grpc_stream_compression_algorithm_from_slice(
     const grpc_slice& str) {
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_IDENTITY))
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_IDENTITY)) {
     return GRPC_STREAM_COMPRESS_NONE;
-  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_GZIP))
+  }
+  if (grpc_slice_eq_static_interned(str, GRPC_MDSTR_GZIP)) {
     return GRPC_STREAM_COMPRESS_GZIP;
+  }
   return GRPC_STREAM_COMPRESS_ALGORITHMS_COUNT;
 }
 

--- a/src/core/lib/gpr/log_linux.cc
+++ b/src/core/lib/gpr/log_linux.cc
@@ -77,10 +77,11 @@ void gpr_default_log(gpr_log_func_args* args) {
 
   timer = static_cast<time_t>(now.tv_sec);
   final_slash = strrchr(args->file, '/');
-  if (final_slash == nullptr)
+  if (final_slash == nullptr) {
     display_file = args->file;
-  else
+  } else {
     display_file = final_slash + 1;
+  }
 
   if (!localtime_r(&timer, &tm)) {
     strcpy(time_buffer, "error:localtime");

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -42,36 +42,48 @@ static grpc_error* handle_response_line(grpc_http_parser* parser) {
   uint8_t* cur = beg;
   uint8_t* end = beg + parser->cur_line_length;
 
-  if (cur == end || *cur++ != 'H')
+  if (cur == end || *cur++ != 'H') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'H'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'P')
+  }
+  if (cur == end || *cur++ != 'P') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'P'");
-  if (cur == end || *cur++ != '/')
+  }
+  if (cur == end || *cur++ != '/') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '/'");
-  if (cur == end || *cur++ != '1')
+  }
+  if (cur == end || *cur++ != '1') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '1'");
-  if (cur == end || *cur++ != '.')
+  }
+  if (cur == end || *cur++ != '.') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '.'");
+  }
   if (cur == end || *cur < '0' || *cur++ > '1') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Expected HTTP/1.0 or HTTP/1.1");
   }
-  if (cur == end || *cur++ != ' ')
+  if (cur == end || *cur++ != ' ') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected ' '");
-  if (cur == end || *cur < '1' || *cur++ > '9')
+  }
+  if (cur == end || *cur < '1' || *cur++ > '9') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
-  if (cur == end || *cur < '0' || *cur++ > '9')
+  }
+  if (cur == end || *cur < '0' || *cur++ > '9') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
-  if (cur == end || *cur < '0' || *cur++ > '9')
+  }
+  if (cur == end || *cur < '0' || *cur++ > '9') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
+  }
   parser->http.response->status =
       (cur[-3] - '0') * 100 + (cur[-2] - '0') * 10 + (cur[-1] - '0');
-  if (cur == end || *cur++ != ' ')
+  if (cur == end || *cur++ != ' ') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected ' '");
+  }
 
   /* we don't really care about the status code message */
 
@@ -85,36 +97,44 @@ static grpc_error* handle_request_line(grpc_http_parser* parser) {
   uint8_t vers_major = 0;
   uint8_t vers_minor = 0;
 
-  while (cur != end && *cur++ != ' ')
-    ;
-  if (cur == end)
+  while (cur != end && *cur++ != ' ') {
+  }
+  if (cur == end) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "No method on HTTP request line");
+  }
   parser->http.request->method =
       buf2str(beg, static_cast<size_t>(cur - beg - 1));
 
   beg = cur;
-  while (cur != end && *cur++ != ' ')
-    ;
-  if (cur == end)
+  while (cur != end && *cur++ != ' ') {
+  }
+  if (cur == end) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No path on HTTP request line");
+  }
   parser->http.request->path = buf2str(beg, static_cast<size_t>(cur - beg - 1));
 
-  if (cur == end || *cur++ != 'H')
+  if (cur == end || *cur++ != 'H') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'H'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'P')
+  }
+  if (cur == end || *cur++ != 'P') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'P'");
-  if (cur == end || *cur++ != '/')
+  }
+  if (cur == end || *cur++ != '/') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '/'");
+  }
   vers_major = static_cast<uint8_t>(*cur++ - '1' + 1);
   ++cur;
-  if (cur == end)
+  if (cur == end) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "End of line in HTTP version string");
+  }
   vers_minor = static_cast<uint8_t>(*cur++ - '1' + 1);
 
   if (vers_major == 1) {
@@ -300,9 +320,10 @@ static grpc_error* addbyte(grpc_http_parser* parser, uint8_t byte,
     case GRPC_HTTP_FIRST_LINE:
     case GRPC_HTTP_HEADERS:
       if (parser->cur_line_length >= GRPC_HTTP_PARSER_MAX_HEADER_LENGTH) {
-        if (GRPC_TRACE_FLAG_ENABLED(grpc_http1_trace))
+        if (GRPC_TRACE_FLAG_ENABLED(grpc_http1_trace)) {
           gpr_log(GPR_ERROR, "HTTP header max line length (%d) exceeded",
                   GRPC_HTTP_PARSER_MAX_HEADER_LENGTH);
+        }
         return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
             "HTTP header max line length exceeded");
       }

--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -805,12 +805,13 @@ static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
 static int poll_deadline_to_millis_timeout(grpc_millis millis) {
   if (millis == GRPC_MILLIS_INF_FUTURE) return -1;
   grpc_millis delta = millis - grpc_core::ExecCtx::Get()->Now();
-  if (delta > INT_MAX)
+  if (delta > INT_MAX) {
     return INT_MAX;
-  else if (delta < 0)
+  } else if (delta < 0) {
     return 0;
-  else
+  } else {
     return static_cast<int>(delta);
+  }
 }
 
 static void fd_become_readable(grpc_fd* fd) { fd->read_closure.SetReady(); }

--- a/src/core/lib/iomgr/poller/eventmanager_libuv.cc
+++ b/src/core/lib/iomgr/poller/eventmanager_libuv.cc
@@ -63,8 +63,9 @@ bool grpc::experimental::LibuvEventManager::ShouldStop() {
 }
 
 void grpc::experimental::LibuvEventManager::Shutdown() {
-  if (should_stop_.Load(grpc_core::MemoryOrder::ACQUIRE))
+  if (should_stop_.Load(grpc_core::MemoryOrder::ACQUIRE)) {
     return;  // Already shut down.
+  }
 
   {
     grpc_core::MutexLock lock(&shutdown_mu_);

--- a/src/core/lib/iomgr/wakeup_fd_pipe.cc
+++ b/src/core/lib/iomgr/wakeup_fd_pipe.cc
@@ -71,8 +71,8 @@ static grpc_error* pipe_consume(grpc_wakeup_fd* fd_info) {
 
 static grpc_error* pipe_wakeup(grpc_wakeup_fd* fd_info) {
   char c = 0;
-  while (write(fd_info->write_fd, &c, 1) != 1 && errno == EINTR)
-    ;
+  while (write(fd_info->write_fd, &c, 1) != 1 && errno == EINTR) {
+  }
   return GRPC_ERROR_NONE;
 }
 

--- a/src/core/lib/json/json_reader.cc
+++ b/src/core/lib/json/json_reader.cc
@@ -413,8 +413,9 @@ JsonReader::Status JsonReader::Run() {
 
           /* This is the \\ case. */
           case State::GRPC_JSON_STATE_STRING_ESCAPE:
-            if (unicode_high_surrogate_ != 0)
+            if (unicode_high_surrogate_ != 0) {
               return Status::GRPC_JSON_PARSE_ERROR;
+            }
             StringAddChar('\\');
             if (escaped_string_was_key_) {
               state_ = State::GRPC_JSON_STATE_OBJECT_KEY_STRING;
@@ -593,14 +594,16 @@ JsonReader::Status JsonReader::Run() {
                  */
                 if ((unicode_char_ & 0xfc00) == 0xd800) {
                   /* high surrogate utf-16 */
-                  if (unicode_high_surrogate_ != 0)
+                  if (unicode_high_surrogate_ != 0) {
                     return Status::GRPC_JSON_PARSE_ERROR;
+                  }
                   unicode_high_surrogate_ = unicode_char_;
                 } else if ((unicode_char_ & 0xfc00) == 0xdc00) {
                   /* low surrogate utf-16 */
                   uint32_t utf32;
-                  if (unicode_high_surrogate_ == 0)
+                  if (unicode_high_surrogate_ == 0) {
                     return Status::GRPC_JSON_PARSE_ERROR;
+                  }
                   utf32 = 0x10000;
                   utf32 += static_cast<uint32_t>(
                       (unicode_high_surrogate_ - 0xd800) * 0x400);
@@ -609,8 +612,9 @@ JsonReader::Status JsonReader::Run() {
                   unicode_high_surrogate_ = 0;
                 } else {
                   /* anything else */
-                  if (unicode_high_surrogate_ != 0)
+                  if (unicode_high_surrogate_ != 0) {
                     return Status::GRPC_JSON_PARSE_ERROR;
+                  }
                   StringAddUtf32(unicode_char_);
                 }
                 if (escaped_string_was_key_) {

--- a/src/core/lib/json/json_writer.cc
+++ b/src/core/lib/json/json_writer.cc
@@ -207,8 +207,9 @@ void JsonWriter::EscapeString(const std::string& string) {
        * Any other range is technically reserved for future usage, so if we
        * don't want the software to break in the future, we have to allow
        * anything else. The first non-unicode character is 0x110000. */
-      if (((utf32 >= 0xd800) && (utf32 <= 0xdfff)) || (utf32 >= 0x110000))
+      if (((utf32 >= 0xd800) && (utf32 <= 0xdfff)) || (utf32 >= 0x110000)) {
         break;
+      }
       if (utf32 >= 0x10000) {
         /* If utf32 contains a character that is above 0xffff, it needs to be
          * broken down into a utf-16 surrogate pair. A surrogate pair is first

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -123,8 +123,9 @@ static grpc_filtered_mdelem remove_consumed_md(void* user_data,
   for (i = 0; i < calld->num_consumed_md; i++) {
     const grpc_metadata* consumed_md = &calld->consumed_md[i];
     if (grpc_slice_eq(GRPC_MDKEY(md), consumed_md->key) &&
-        grpc_slice_eq(GRPC_MDVALUE(md), consumed_md->value))
+        grpc_slice_eq(GRPC_MDVALUE(md), consumed_md->value)) {
       return GRPC_FILTERED_REMOVE();
+    }
   }
   return GRPC_FILTERED_MDELEM(md);
 }

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -555,8 +555,9 @@ int grpc_slice_buf_start_eq(grpc_slice a, const void* b, size_t len) {
 int grpc_slice_rchr(grpc_slice s, char c) {
   const char* b = reinterpret_cast<const char*> GRPC_SLICE_START_PTR(s);
   int i;
-  for (i = static_cast<int> GRPC_SLICE_LENGTH(s) - 1; i != -1 && b[i] != c; i--)
-    ;
+  for (i = static_cast<int> GRPC_SLICE_LENGTH(s) - 1; i != -1 && b[i] != c;
+       i--) {
+  }
   return i;
 }
 
@@ -574,10 +575,12 @@ int grpc_slice_slice(grpc_slice haystack, grpc_slice needle) {
 
   if (haystack_len == 0 || needle_len == 0) return -1;
   if (haystack_len < needle_len) return -1;
-  if (haystack_len == needle_len)
+  if (haystack_len == needle_len) {
     return grpc_slice_eq(haystack, needle) ? 0 : -1;
-  if (needle_len == 1)
+  }
+  if (needle_len == 1) {
     return grpc_slice_chr(haystack, static_cast<char>(*needle_bytes));
+  }
 
   const uint8_t* last = haystack_bytes + haystack_len - needle_len;
   for (const uint8_t* cur = haystack_bytes; cur != last; ++cur) {

--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -106,8 +106,9 @@ uint8_t* grpc_slice_buffer_tiny_add(grpc_slice_buffer* sb, size_t n) {
   if (sb->count == 0) goto add_first;
   back = &sb->slices[sb->count - 1];
   if (back->refcount) goto add_new;
-  if ((back->data.inlined.length + n) > sizeof(back->data.inlined.bytes))
+  if ((back->data.inlined.length + n) > sizeof(back->data.inlined.bytes)) {
     goto add_new;
+  }
   out = back->data.inlined.bytes + back->data.inlined.length;
   back->data.inlined.length =
       static_cast<uint8_t>(back->data.inlined.length + n);

--- a/src/core/lib/slice/slice_intern.cc
+++ b/src/core/lib/slice/slice_intern.cc
@@ -74,8 +74,8 @@ InternedSliceRefcount::~InternedSliceRefcount() {
   InternedSliceRefcount* cur;
   for (prev_next = &shard->strs[TABLE_IDX(this->hash, shard->capacity)],
       cur = *prev_next;
-       cur != this; prev_next = &cur->bucket_next, cur = cur->bucket_next)
-    ;
+       cur != this; prev_next = &cur->bucket_next, cur = cur->bucket_next) {
+  }
   *prev_next = cur->bucket_next;
   shard->count--;
 }

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -298,8 +298,9 @@ static void post_batch_completion(batch_control* bctl);
 
 static void add_init_error(grpc_error** composite, grpc_error* new_err) {
   if (new_err == GRPC_ERROR_NONE) return;
-  if (*composite == GRPC_ERROR_NONE)
+  if (*composite == GRPC_ERROR_NONE) {
     *composite = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Call creation failed");
+  }
   *composite = grpc_error_add_child(*composite, new_err);
 }
 

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -126,8 +126,8 @@ grpc_error* non_polling_poller_work(grpc_pollset* pollset,
   gpr_timespec deadline_ts =
       grpc_millis_to_timespec(deadline, GPR_CLOCK_MONOTONIC);
   while (!npp->shutdown && !w.kicked &&
-         !gpr_cv_wait(&w.cv, &npp->mu, deadline_ts))
-    ;
+         !gpr_cv_wait(&w.cv, &npp->mu, deadline_ts)) {
+  }
   grpc_core::ExecCtx::Get()->InvalidateNow();
   if (&w == npp->root) {
     npp->root = w.next;
@@ -148,8 +148,9 @@ grpc_error* non_polling_poller_work(grpc_pollset* pollset,
 grpc_error* non_polling_poller_kick(grpc_pollset* pollset,
                                     grpc_pollset_worker* specific_worker) {
   non_polling_poller* p = reinterpret_cast<non_polling_poller*>(pollset);
-  if (specific_worker == nullptr)
+  if (specific_worker == nullptr) {
     specific_worker = reinterpret_cast<grpc_pollset_worker*>(p->root);
+  }
   if (specific_worker != nullptr) {
     non_polling_worker* w =
         reinterpret_cast<non_polling_worker*>(specific_worker);

--- a/src/core/lib/transport/timeout_encoding.cc
+++ b/src/core/lib/transport/timeout_encoding.cc
@@ -102,8 +102,8 @@ int grpc_http2_decode_timeout(const grpc_slice& text, grpc_millis* timeout) {
   const uint8_t* end = GRPC_SLICE_END_PTR(text);
   int have_digit = 0;
   /* skip whitespace */
-  for (; p != end && *p == ' '; p++)
-    ;
+  for (; p != end && *p == ' '; p++) {
+  }
   /* decode numeric part */
   for (; p != end && *p >= '0' && *p <= '9'; p++) {
     int32_t digit = static_cast<int32_t>(*p - static_cast<uint8_t>('0'));
@@ -119,8 +119,8 @@ int grpc_http2_decode_timeout(const grpc_slice& text, grpc_millis* timeout) {
   }
   if (!have_digit) return 0;
   /* skip whitespace */
-  for (; p != end && *p == ' '; p++)
-    ;
+  for (; p != end && *p == ' '; p++) {
+  }
   if (p == end) return 0;
   /* decode unit specifier */
   switch (*p) {

--- a/src/core/tsi/transport_security.cc
+++ b/src/core/tsi/transport_security.cc
@@ -150,8 +150,9 @@ tsi_result tsi_handshaker_get_bytes_to_send_to_peer(tsi_handshaker* self,
   }
   if (self->frame_protector_created) return TSI_FAILED_PRECONDITION;
   if (self->handshake_shutdown) return TSI_HANDSHAKE_SHUTDOWN;
-  if (self->vtable->get_bytes_to_send_to_peer == nullptr)
+  if (self->vtable->get_bytes_to_send_to_peer == nullptr) {
     return TSI_UNIMPLEMENTED;
+  }
   return self->vtable->get_bytes_to_send_to_peer(self, bytes, bytes_size);
 }
 
@@ -164,8 +165,9 @@ tsi_result tsi_handshaker_process_bytes_from_peer(tsi_handshaker* self,
   }
   if (self->frame_protector_created) return TSI_FAILED_PRECONDITION;
   if (self->handshake_shutdown) return TSI_HANDSHAKE_SHUTDOWN;
-  if (self->vtable->process_bytes_from_peer == nullptr)
+  if (self->vtable->process_bytes_from_peer == nullptr) {
     return TSI_UNIMPLEMENTED;
+  }
   return self->vtable->process_bytes_from_peer(self, bytes, bytes_size);
 }
 

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -53,8 +53,9 @@ LoadReporterAsyncServiceImpl::~LoadReporterAsyncServiceImpl() {
     grpc_core::MutexLock lock(&cq_shutdown_mu_);
     cq_->Shutdown();
   }
-  if (next_fetch_and_sample_alarm_ != nullptr)
+  if (next_fetch_and_sample_alarm_ != nullptr) {
     next_fetch_and_sample_alarm_->Cancel();
+  }
   thread_->Join();
 }
 

--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -119,8 +119,8 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
   grpc_call_unref(call);
   grpc_channel_destroy(chan);

--- a/test/core/end2end/invalid_call_argument_test.cc
+++ b/test/core/end2end/invalid_call_argument_test.cc
@@ -136,8 +136,8 @@ static void cleanup_test() {
   grpc_completion_queue_shutdown(g_state.cq);
   while (grpc_completion_queue_next(g_state.cq,
                                     gpr_inf_future(GPR_CLOCK_REALTIME), nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(g_state.cq);
 }
 

--- a/test/core/end2end/no_server_test.cc
+++ b/test/core/end2end/no_server_test.cc
@@ -97,8 +97,8 @@ void run_test(bool wait_for_ready) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
   grpc_call_unref(call);
   grpc_channel_destroy(chan);

--- a/test/core/handshake/client_ssl.cc
+++ b/test/core/handshake/client_ssl.cc
@@ -204,8 +204,8 @@ static void server_thread(void* arg) {
 
   // Wait until the client drops its connection.
   char buf;
-  while (SSL_read(ssl, &buf, sizeof(buf)) > 0)
-    ;
+  while (SSL_read(ssl, &buf, sizeof(buf)) > 0) {
+  }
 
   SSL_free(ssl);
   close(client);

--- a/test/core/iomgr/stranded_event_test.cc
+++ b/test/core/iomgr/stranded_event_test.cc
@@ -77,8 +77,8 @@ struct TestCall {
     grpc_completion_queue_shutdown(cq);
     while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                       nullptr)
-               .type != GRPC_QUEUE_SHUTDOWN)
-      ;
+               .type != GRPC_QUEUE_SHUTDOWN) {
+    }
     grpc_completion_queue_destroy(cq);
   }
 
@@ -236,8 +236,8 @@ class TestServer {
     grpc_completion_queue_shutdown(cq_);
     while (grpc_completion_queue_next(cq_, gpr_inf_future(GPR_CLOCK_REALTIME),
                                       nullptr)
-               .type != GRPC_QUEUE_SHUTDOWN)
-      ;
+               .type != GRPC_QUEUE_SHUTDOWN) {
+    }
     grpc_completion_queue_destroy(cq_);
   }
 

--- a/test/core/security/verify_jwt.cc
+++ b/test/core/security/verify_jwt.cc
@@ -101,8 +101,9 @@ int main(int argc, char** argv) {
     grpc_pollset_worker* worker = nullptr;
     if (!GRPC_LOG_IF_ERROR(
             "pollset_work",
-            grpc_pollset_work(sync.pollset, &worker, GRPC_MILLIS_INF_FUTURE)))
+            grpc_pollset_work(sync.pollset, &worker, GRPC_MILLIS_INF_FUTURE))) {
       sync.is_done = true;
+    }
     gpr_mu_unlock(sync.mu);
     grpc_core::ExecCtx::Get()->Flush();
     gpr_mu_lock(sync.mu);

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -131,12 +131,12 @@ static void run_test(const test_fixture* fixture, bool share_subchannel) {
 
   while (grpc_completion_queue_next(server_cq,
                                     gpr_inf_future(GPR_CLOCK_REALTIME), nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
 
   for (size_t i = 0; i < NUM_CONNECTIONS; i++) {
     grpc_channel_destroy(channels[i]);

--- a/test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
+++ b/test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
@@ -163,8 +163,8 @@ class TestServer {
     grpc_completion_queue_shutdown(cq_);
     while (grpc_completion_queue_next(cq_, gpr_inf_future(GPR_CLOCK_REALTIME),
                                       nullptr)
-               .type != GRPC_QUEUE_SHUTDOWN)
-      ;
+               .type != GRPC_QUEUE_SHUTDOWN) {
+    }
     grpc_completion_queue_destroy(cq_);
     return num_calls_handled_;
   }
@@ -256,8 +256,8 @@ class TestServer {
       // including settings frames with window size increases
       while (grpc_completion_queue_next(
                  call_cq, gpr_inf_future(GPR_CLOCK_REALTIME), nullptr)
-                 .type != GRPC_QUEUE_SHUTDOWN)
-        ;
+                 .type != GRPC_QUEUE_SHUTDOWN) {
+      }
     });
     grpc_call_cancel(call, nullptr);
     grpc_call_unref(call);
@@ -320,8 +320,8 @@ TEST(Pollers, TestDontCrashWhenTryingToReproIssueFixedBy23984) {
       grpc_completion_queue_shutdown(cq);
       while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                         nullptr)
-                 .type != GRPC_QUEUE_SHUTDOWN)
-        ;
+                 .type != GRPC_QUEUE_SHUTDOWN) {
+      }
       grpc_completion_queue_destroy(cq);
     }));
   }

--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -171,8 +171,8 @@ TEST(TooManyPings, TestLotsOfServerCancelledRpcsDoesntGiveTooManyPings) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq);
 }
@@ -252,8 +252,8 @@ void ServerShutdownAndDestroy(grpc_server* server, grpc_completion_queue* cq) {
   grpc_server_shutdown_and_notify(server, cq, (void*)(1000));
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .tag != (void*)(1000))
-    ;
+             .tag != (void*)(1000)) {
+  }
   grpc_server_destroy(server);
 }
 
@@ -353,8 +353,8 @@ TEST_F(KeepaliveThrottlingTest, KeepaliveThrottlingMultipleChannels) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
 }
 
@@ -443,8 +443,8 @@ TEST_F(KeepaliveThrottlingTest, NewSubchannelsUseUpdatedKeepaliveTime) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
 }
 
@@ -510,8 +510,8 @@ TEST_F(KeepaliveThrottlingTest,
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
 }
 
@@ -717,8 +717,8 @@ TEST(TooManyPings, BdpPingNotSentWithoutReceiveSideActivity) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
 }
 

--- a/test/core/util/fuzzer_corpus_test.cc
+++ b/test/core/util/fuzzer_corpus_test.cc
@@ -72,8 +72,9 @@ class ExampleGenerator
  private:
   void Materialize() const {
     if (examples_.empty()) {
-      if (!absl::GetFlag(FLAGS_file).empty())
+      if (!absl::GetFlag(FLAGS_file).empty()) {
         examples_.push_back(absl::GetFlag(FLAGS_file));
+      }
       if (!absl::GetFlag(FLAGS_directory).empty()) {
         char* test_srcdir = gpr_getenv("TEST_SRCDIR");
         gpr_log(GPR_DEBUG, "test_srcdir=\"%s\"", test_srcdir);

--- a/test/cpp/codegen/golden_file_test.cc
+++ b/test/cpp/codegen/golden_file_test.cc
@@ -69,8 +69,9 @@ int main(int argc, char** argv) {
   if (absl::GetFlag(FLAGS_generated_file_path).empty()) {
     absl::SetFlag(&FLAGS_generated_file_path, "gens/src/proto/grpc/testing/");
   }
-  if (absl::GetFlag(FLAGS_generated_file_path).back() != '/')
+  if (absl::GetFlag(FLAGS_generated_file_path).back() != '/') {
     absl::SetFlag(&FLAGS_generated_file_path,
                   absl::GetFlag(FLAGS_generated_file_path).append("/"));
+  }
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -272,8 +272,8 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<TestScenario> {
     void* ignored_tag;
     bool ignored_ok;
     cq_->Shutdown();
-    while (cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
     stub_.reset();
     grpc_recycle_unused_port(port_);
   }
@@ -428,8 +428,8 @@ TEST_P(AsyncEnd2endTest, ReconnectChannel) {
   void* ignored_tag;
   bool ignored_ok;
   cq_->Shutdown();
-  while (cq_->Next(&ignored_tag, &ignored_ok))
-    ;
+  while (cq_->Next(&ignored_tag, &ignored_ok)) {
+  }
   BuildAndStartServer();
   // It needs more than GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS time to
   // reconnect the channel.

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -152,10 +152,10 @@ class FilterEnd2endTest : public ::testing::Test {
     bool ignored_ok;
     cli_cq_.Shutdown();
     srv_cq_->Shutdown();
-    while (cli_cq_.Next(&ignored_tag, &ignored_ok))
-      ;
-    while (srv_cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cli_cq_.Next(&ignored_tag, &ignored_ok)) {
+    }
+    while (srv_cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
   }
 
   void ResetStub() {

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -86,10 +86,10 @@ class GenericEnd2endTest : public ::testing::Test {
       bool ignored_ok;
       cli_cq_.Shutdown();
       srv_cq_->Shutdown();
-      while (cli_cq_.Next(&ignored_tag, &ignored_ok))
-        ;
-      while (srv_cq_->Next(&ignored_tag, &ignored_ok))
-        ;
+      while (cli_cq_.Next(&ignored_tag, &ignored_ok)) {
+      }
+      while (srv_cq_->Next(&ignored_tag, &ignored_ok)) {
+      }
       shut_down_ = true;
     }
   }

--- a/test/cpp/end2end/hybrid_end2end_test.cc
+++ b/test/cpp/end2end/hybrid_end2end_test.cc
@@ -305,8 +305,8 @@ class HybridEnd2endTest : public ::testing::TestWithParam<bool> {
     bool ignored_ok;
     for (auto it = cqs_.begin(); it != cqs_.end(); ++it) {
       (*it)->Shutdown();
-      while ((*it)->Next(&ignored_tag, &ignored_ok))
-        ;
+      while ((*it)->Next(&ignored_tag, &ignored_ok)) {
+      }
     }
   }
 

--- a/test/cpp/end2end/nonblocking_test.cc
+++ b/test/cpp/end2end/nonblocking_test.cc
@@ -101,8 +101,8 @@ class NonblockingTest : public ::testing::Test {
     void* ignored_tag;
     bool ignored_ok;
     cq_->Shutdown();
-    while (LoopForTag(&ignored_tag, &ignored_ok))
-      ;
+    while (LoopForTag(&ignored_tag, &ignored_ok)) {
+    }
     stub_.reset();
     grpc_recycle_unused_port(port_);
   }

--- a/test/cpp/end2end/raw_end2end_test.cc
+++ b/test/cpp/end2end/raw_end2end_test.cc
@@ -110,8 +110,8 @@ class RawEnd2EndTest : public ::testing::Test {
     void* ignored_tag;
     bool ignored_ok;
     cq_->Shutdown();
-    while (cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
     stub_.reset();
     grpc_recycle_unused_port(port_);
   }

--- a/test/cpp/end2end/server_builder_plugin_test.cc
+++ b/test/cpp/end2end/server_builder_plugin_test.cc
@@ -229,8 +229,8 @@ class ServerBuilderPluginTest : public ::testing::TestWithParam<bool> {
   void RunCQ() {
     void* tag;
     bool ok;
-    while (cq_->Next(&tag, &ok))
-      ;
+    while (cq_->Next(&tag, &ok)) {
+    }
   }
 };
 

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -407,8 +407,8 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, UnaryTest) {
   cq->Shutdown();
   void* ignored_tag;
   bool ignored_ok;
-  while (cq->Next(&ignored_tag, &ignored_ok))
-    ;
+  while (cq->Next(&ignored_tag, &ignored_ok)) {
+  }
   grpc_recycle_unused_port(port);
 }
 
@@ -489,8 +489,8 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, BidiStreamingTest) {
   cq->Shutdown();
   void* ignored_tag;
   bool ignored_ok;
-  while (cq->Next(&ignored_tag, &ignored_ok))
-    ;
+  while (cq->Next(&ignored_tag, &ignored_ok)) {
+  }
   grpc_recycle_unused_port(port);
 }
 
@@ -594,10 +594,10 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, GenericRPCTest) {
   server->Shutdown();
   void* ignored_tag;
   bool ignored_ok;
-  while (cli_cq.Next(&ignored_tag, &ignored_ok))
-    ;
-  while (srv_cq->Next(&ignored_tag, &ignored_ok))
-    ;
+  while (cli_cq.Next(&ignored_tag, &ignored_ok)) {
+  }
+  while (srv_cq->Next(&ignored_tag, &ignored_ok)) {
+  }
   grpc_recycle_unused_port(port);
 }
 
@@ -644,8 +644,8 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, UnimplementedRpcTest) {
   cq->Shutdown();
   void* ignored_tag;
   bool ignored_ok;
-  while (cq->Next(&ignored_tag, &ignored_ok))
-    ;
+  while (cq->Next(&ignored_tag, &ignored_ok)) {
+  }
   grpc_recycle_unused_port(port);
 }
 

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -206,8 +206,8 @@ class CommonStressTestAsyncServer : public BaseClass {
 
     void* ignored_tag;
     bool ignored_ok;
-    while (cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
     this->TearDownEnd();
   }
 
@@ -341,8 +341,8 @@ class AsyncClientEnd2endTest : public ::testing::Test {
   void TearDown() override {
     void* ignored_tag;
     bool ignored_ok;
-    while (cq_.Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_.Next(&ignored_tag, &ignored_ok)) {
+    }
     common_.TearDown();
   }
 

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1551,16 +1551,19 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
     for (size_t i = start_index; i < stop_index; ++i) {
       switch (rpc_options.service) {
         case SERVICE_ECHO:
-          if (backends_[i]->backend_service()->request_count() == 0)
+          if (backends_[i]->backend_service()->request_count() == 0) {
             return false;
+          }
           break;
         case SERVICE_ECHO1:
-          if (backends_[i]->backend_service1()->request_count() == 0)
+          if (backends_[i]->backend_service1()->request_count() == 0) {
             return false;
+          }
           break;
         case SERVICE_ECHO2:
-          if (backends_[i]->backend_service2()->request_count() == 0)
+          if (backends_[i]->backend_service2()->request_count() == 0) {
             return false;
+          }
           break;
       }
     }

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -872,8 +872,8 @@ bool InteropClient::DoStatusWithMessage() {
   stream->Write(streaming_request);
   stream->WritesDone();
   StreamingOutputCallResponse streaming_response;
-  while (stream->Read(&streaming_response))
-    ;
+  while (stream->Read(&streaming_response)) {
+  }
   s = stream->Finish();
   if (!AssertStatusCode(s, grpc::StatusCode::UNKNOWN,
                         context.debug_error_string())) {
@@ -1006,7 +1006,6 @@ bool InteropClient::DoCustomMetadata() {
   const std::string kEchoTrailingBinMetadataKey(
       "x-grpc-test-echo-trailing-bin");
   const std::string kTrailingBinValue("\x0a\x0b\x0a\x0b\x0a\x0b");
-  ;
 
   {
     gpr_log(GPR_DEBUG, "Sending RPC with custom metadata");

--- a/test/cpp/qps/client_callback.cc
+++ b/test/cpp/qps/client_callback.cc
@@ -344,9 +344,10 @@ class CallbackStreamingPingPongClientImpl final
  public:
   CallbackStreamingPingPongClientImpl(const ClientConfig& config)
       : CallbackStreamingPingPongClient(config) {
-    for (size_t i = 0; i < total_outstanding_rpcs_; i++)
+    for (size_t i = 0; i < total_outstanding_rpcs_; i++) {
       reactor_.emplace_back(
           new CallbackStreamingPingPongReactor(this, std::move(ctx_[i])));
+    }
   }
   ~CallbackStreamingPingPongClientImpl() override {}
 

--- a/test/cpp/qps/interarrival.h
+++ b/test/cpp/qps/interarrival.h
@@ -91,8 +91,9 @@ class InterarrivalTimer {
 
   int64_t next(int thread_num) {
     auto ret = *(thread_posns_[thread_num]++);
-    if (thread_posns_[thread_num] == random_table_.end())
+    if (thread_posns_[thread_num] == random_table_.end()) {
       thread_posns_[thread_num] = random_table_.begin();
+    }
     return ret;
   }
 

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -180,8 +180,8 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     for (auto cq = srv_cqs_.begin(); cq != srv_cqs_.end(); ++cq) {
       bool ok;
       void* got_tag;
-      while ((*cq)->Next(&got_tag, &ok))
-        ;
+      while ((*cq)->Next(&got_tag, &ok)) {
+      }
     }
   }
 


### PR DESCRIPTION
I got tired of asking people to remember to do this in code reviews, and it is something that has caused serious bugs in the past due to automatic merge resolution (e.g., https://dwheeler.com/essays/apple-goto-fail.html).