### PR TITLE
Update xDS interop test proto

### DIFF
--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -218,12 +218,12 @@ message LoadBalancerAccumulatedStatsRequest {}
 
 // Accumulated stats for RPCs sent by a test client.
 message LoadBalancerAccumulatedStatsResponse {
-  // The total number of RPCs have ever issued.
-  int32 num_rpcs_started = 1;
-  // The total number of RPCs have ever completed successfully.
-  int32 num_rpcs_succeeded = 2;
-  // The total number of RPCs have ever failed.
-  int32 num_rpcs_failed = 3;
+  // The total number of RPCs have ever issued for each type.
+  map<string, int32> num_rpcs_started_by_method = 1;
+  // The total number of RPCs have ever completed successfully for each type.
+  map<string, int32> num_rpcs_succeeded_by_method = 2;
+  // The total number of RPCs have ever failed for each type.
+  map<string, int32> num_rpcs_failed_by_method = 3;
 }
 
 // Configurations for a test client.


### PR DESCRIPTION
Updates the xDS interop test proto to support more advanced tests.

- Change the response of accumulated stats to group stats in RPC method.
  - This can be useful to distinguish RPCs routed to different backend services (by configuring different path matchers). So it would be convenient for verifying per backend service configurations.
  - E.g., we can use two backend services with one setting circuit breakers max_request = 500 and the other 1000. Then we apply path matchers to route different RPC methods to separate backend services. We can observe circuit breakers are effective per backend service.
