### PR TITLE
Implement xDS circuit breaking interop test (advanced)

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1069,7 +1069,7 @@ def test_circuit_breaking(gcp,
         patch_backend_service(gcp, alternate_backend_service,
                                 [same_zone_instance_group],
                                 circuit_breakers={'maxRequests': max_requests})
-        wait_until_rpcs_in_flight(int(_WAIT_FOR_STATS_SEC + max_requests / args.qps),
+        wait_until_rpcs_in_flight(_WAIT_FOR_BACKEND_SEC + int(max_requests / args.qps),
                                   max_requests)
         wait_until_all_rpcs_go_to_given_backends_or_fail([], _WAIT_FOR_BACKEND_SEC)
         _assert_rpcs_in_flight(max_requests)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -311,6 +311,7 @@ def get_client_stats(num_rpcs, timeout_sec):
             logger.debug('Invoked GetClientStats RPC to %s: %s', host, response)
             return response
 
+
 def get_client_accumulated_stats():
     if CLIENT_HOSTS:
         hosts = CLIENT_HOSTS
@@ -330,6 +331,7 @@ def get_client_accumulated_stats():
                          host,
                          response)
             return response
+
 
 def configure_client(rpc_types, metadata):
     if CLIENT_HOSTS:
@@ -355,6 +357,7 @@ def configure_client(rpc_types, metadata):
                            wait_for_ready=True,
                            timeout=_CONNECTION_TIMEOUT_SEC)
             logger.debug('Invoked XdsUpdateClientConfigureService RPC to %s', host)
+
 
 class RpcDistributionError(Exception):
     pass

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1161,6 +1161,11 @@ def test_circuit_breaking_advanced(gcp,
         },
     ]
     try:
+        # Make client send UNARY_CALL and EMPTY_CALL.
+        configure_client(
+            [messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL, 
+             messages_pb2.ClientConfigureRequest.RpcType.EMPTY_CALL],
+             [])
         logger.info('Patching url map with %s', route_rules)
         patch_url_map_backend_service(gcp,
                                       original_backend_service,

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -62,7 +62,12 @@ _TEST_CASES = [
 # aren't enabled automatically for all languages.
 #
 # TODO: Move them into _TEST_CASES when support is ready in all languages.
-_ADDITIONAL_TEST_CASES = ['path_matching', 'header_matching', 'circuit_breaking']
+_ADDITIONAL_TEST_CASES = [
+    'path_matching',
+    'header_matching',
+    'circuit_breaking',
+    'circuit_breaking_advanced',
+]
 
 
 def parse_test_cases(arg):
@@ -2100,6 +2105,11 @@ try:
                                           instance_group,
                                           alternate_backend_service,
                                           same_zone_instance_group)
+                elif test_case == 'circuit_breaking_advanced':
+                    test_circuit_breaking_advanced(gcp, backend_service,
+                                                   instance_group,
+                                                   alternate_backend_service,
+                                                   same_zone_instance_group)
                 else:
                     logger.error('Unknown test case: %s', test_case)
                     sys.exit(1)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -57,13 +57,12 @@ _TEST_CASES = [
     'secondary_locality_gets_no_requests_on_partial_primary_failure',
     'secondary_locality_gets_requests_on_primary_failure',
     'traffic_splitting',
-    'circuit_breaking',
 ]
 # Valid test cases, but not in all. So the tests can only run manually, and
 # aren't enabled automatically for all languages.
 #
 # TODO: Move them into _TEST_CASES when support is ready in all languages.
-_ADDITIONAL_TEST_CASES = ['path_matching', 'header_matching']
+_ADDITIONAL_TEST_CASES = ['path_matching', 'header_matching', 'circuit_breaking']
 
 
 def parse_test_cases(arg):

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -426,8 +426,8 @@ def wait_until_rpcs_in_flight(rpc_type, timeout_sec, num_rpcs, threshold):
     threshold_fraction = threshold / 100.0
     start_time = time.time()
     error_msg = None
-    logger.debug('Waiting for %d sec until %d RPCs (with %d%% tolerance) in-flight'
-                 % (timeout_sec, num_rpcs, threshold))
+    logger.debug('Waiting for %d sec until %d %s RPCs (with %d%% tolerance) in-flight'
+                 % (timeout_sec, num_rpcs, rpc_type, threshold))
     while time.time() - start_time <= timeout_sec:
         error_msg = _check_rpcs_in_flight(rpc_type,
                                           num_rpcs,
@@ -445,7 +445,8 @@ def wait_until_rpcs_in_flight(rpc_type, timeout_sec, num_rpcs, threshold):
                                           threshold,
                                           threshold_fraction)
     if error_msg:
-        raise Exception(error_msg)
+        raise Exception("Wrong number of %s RPCs in-flight: %s"
+                        % (rpc_type, error_msg))
 
 
 def _check_rpcs_in_flight(rpc_type, num_rpcs, threshold, threshold_fraction):

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -524,7 +524,7 @@ def test_change_backend_service(gcp, original_backend_service, instance_group,
     alternate_backend_instances = get_instance_names(gcp,
                                                      same_zone_instance_group)
     patch_backend_service(gcp, alternate_backend_service,
-                            [same_zone_instance_group])
+                          [same_zone_instance_group])
     wait_for_healthy_backends(gcp, original_backend_service, instance_group)
     wait_for_healthy_backends(gcp, alternate_backend_service,
                               same_zone_instance_group)
@@ -608,9 +608,9 @@ def test_remove_instance_group(gcp, backend_service, instance_group,
     logger.info('Running test_remove_instance_group')
     try:
         patch_backend_service(gcp,
-                                backend_service,
-                                [instance_group, same_zone_instance_group],
-                                balancing_mode='RATE')
+                              backend_service,
+                              [instance_group, same_zone_instance_group],
+                              balancing_mode='RATE')
         wait_for_healthy_backends(gcp, backend_service, instance_group)
         wait_for_healthy_backends(gcp, backend_service,
                                   same_zone_instance_group)
@@ -638,8 +638,8 @@ def test_remove_instance_group(gcp, backend_service, instance_group,
                 remaining_instance_group = instance_group
                 remaining_instance_names = instance_names
         patch_backend_service(gcp,
-                                backend_service, [remaining_instance_group],
-                                balancing_mode='RATE')
+                              backend_service, [remaining_instance_group],
+                              balancing_mode='RATE')
         wait_until_all_rpcs_go_to_given_backends(remaining_instance_names,
                                                  _WAIT_FOR_BACKEND_SEC)
     finally:
@@ -786,7 +786,7 @@ def prepare_services_for_urlmap_tests(gcp, original_backend_service,
     wait_for_healthy_backends(gcp, original_backend_service, instance_group)
 
     patch_backend_service(gcp, alternate_backend_service,
-                            [same_zone_instance_group])
+                          [same_zone_instance_group])
     logger.info('waiting for alternate to become healthy')
     wait_for_healthy_backends(gcp, alternate_backend_service,
                               same_zone_instance_group)
@@ -1067,8 +1067,8 @@ def test_circuit_breaking(gcp,
     try:
         # Switch to a new backend_service configured with circuit breakers.
         patch_backend_service(gcp, alternate_backend_service,
-                                [same_zone_instance_group],
-                                circuit_breakers={'maxRequests': max_requests})
+                              [same_zone_instance_group],
+                              circuit_breakers={'maxRequests': max_requests})
         wait_for_healthy_backends(gcp, alternate_backend_service,
                                   same_zone_instance_group)
         patch_url_map_backend_service(gcp, alternate_backend_service)
@@ -1086,8 +1086,8 @@ def test_circuit_breaking(gcp,
         # Increment circuit breakers max_requests threshold.
         max_requests = _NUM_TEST_RPCS * 2
         patch_backend_service(gcp, alternate_backend_service,
-                                [same_zone_instance_group],
-                                circuit_breakers={'maxRequests': max_requests})
+                              [same_zone_instance_group],
+                              circuit_breakers={'maxRequests': max_requests})
         wait_until_rpcs_in_flight((_WAIT_FOR_BACKEND_SEC +
                                    int(max_requests / args.qps)),
                                   max_requests, 1)
@@ -1537,10 +1537,10 @@ def delete_instance_template(gcp):
 
 
 def patch_backend_service(gcp,
-                            backend_service,
-                            instance_groups,
-                            balancing_mode='UTILIZATION',
-                            circuit_breakers=None):
+                          backend_service,
+                          instance_groups,
+                          balancing_mode='UTILIZATION',
+                          circuit_breakers=None):
     if gcp.alpha_compute:
         compute_to_use = gcp.alpha_compute
     else:

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -401,23 +401,41 @@ def wait_until_all_rpcs_go_to_given_backends(backends,
                                    allow_failures=False)
 
 
-def wait_until_rpcs_in_flight(timeout_sec, num_rpcs):
+def wait_until_rpcs_in_flight(timeout_sec, num_rpcs, threshold):
+    '''Block until the test client reaches the state with the given number
+    of RPCs being outstanding.
+
+    Args:
+      timeout_sec: Maximum number of seconds to wait until the desired state
+        is reached.
+      num_rpcs: Expected number of RPCs to be in-flight.
+      threshold: Number within [0,100], the tolerable percentage by which
+        the actual number of RPCs in-flight can differ from the expected number.
+    '''
+    if threshold < 0 or threshold > 100:
+        raise ValueError('Value error: Threshold should be between 0 to 100')
+    threshold_fraction = threshold / 100.0
     start_time = time.time()
     error_msg = None
-    logger.debug('Waiting for %d sec until %d RPCs in-flight' % (timeout_sec, num_rpcs))
+    logger.debug('Waiting for %d sec until %d RPCs (with %d%% tolerance) in-flight'
+                 % (timeout_sec, num_rpcs, threshold))
     while time.time() - start_time <= timeout_sec:
         error_msg = None
         stats = get_client_accumulated_stats()
         rpcs_in_flight = (stats.num_rpcs_started
                           - stats.num_rpcs_succeeded
                           - stats.num_rpcs_failed)
-        if rpcs_in_flight < num_rpcs:
-            error_msg = ('Expected %d RPCs in-flight, actual: %d' %
-                        (num_rpcs, rpcs_in_flight))
+        if rpcs_in_flight < (num_rpcs * (1 - threshold_fraction)):
+            error_msg = ('actual(%d) < expected(%d - %d%%)' %
+                        (rpcs_in_flight, num_rpcs, threshold))
+            time.sleep(2)
+        elif rpcs_in_flight > (num_rpcs * (1 + threshold_fraction)):
+            error_msg = ('actual(%d) > expected(%d + %d%%)' %
+                        (rpcs_in_flight, num_rpcs, threshold))
             time.sleep(2)
         else:
             return
-    raise RpcDistributionError(error_msg)
+    raise Exception(error_msg)
 
 
 def compare_distributions(actual_distribution, expected_distribution,
@@ -1061,28 +1079,22 @@ def test_circuit_breaking(gcp,
         configure_client([messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL],
                          [(messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL,
                            'rpc-behavior', 'keep-open')])
-        wait_until_all_rpcs_go_to_given_backends_or_fail([], _WAIT_FOR_BACKEND_SEC)
-        _assert_rpcs_in_flight(max_requests)
+        wait_until_rpcs_in_flight((_WAIT_FOR_BACKEND_SEC +
+                                   int(max_requests / args.qps)),
+                                  max_requests, 1)
 
         # Increment circuit breakers max_requests threshold.
         max_requests = _NUM_TEST_RPCS * 2
         patch_backend_service(gcp, alternate_backend_service,
                                 [same_zone_instance_group],
                                 circuit_breakers={'maxRequests': max_requests})
-        wait_until_rpcs_in_flight(_WAIT_FOR_BACKEND_SEC + int(max_requests / args.qps),
-                                  max_requests)
-        wait_until_all_rpcs_go_to_given_backends_or_fail([], _WAIT_FOR_BACKEND_SEC)
-        _assert_rpcs_in_flight(max_requests)
+        wait_until_rpcs_in_flight((_WAIT_FOR_BACKEND_SEC +
+                                   int(max_requests / args.qps)),
+                                  max_requests, 1)
     finally:
         patch_url_map_backend_service(gcp, original_backend_service)
         patch_backend_service(gcp, alternate_backend_service, [])
 
-def _assert_rpcs_in_flight(num_rpcs):
-    stats = get_client_accumulated_stats()
-    rpcs_in_flight = (stats.num_rpcs_started
-                      - stats.num_rpcs_succeeded
-                      - stats.num_rpcs_failed)
-    compare_distributions([rpcs_in_flight], [num_rpcs], threshold=2)
 
 def get_serving_status(instance, service_port):
     with grpc.insecure_channel('%s:%d' % (instance, service_port)) as channel:


### PR DESCRIPTION
Enhanced xDS circuit breaking interop test. See updated go/grpc-xds-circuit-breaking-interop-tests.

For languages wanting to enable circuit breaking test, add circuit_breaking to the --test_case option and use the new server image projects/grpc-testing/global/images/xds-test-server-3.


--------------
Requires proto definition change in #24703 
Replacement of #24696 
