### PR TITLE
Stop requiring json key for RBE on Linux and Windows

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
@@ -34,7 +34,6 @@ tools/bazel \
   test \
   --invocation_id="${BAZEL_INVOCATION_ID}" \
   --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh \
-  --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
   $@ \
   -- //test/... || FAILED="true"
 

--- a/tools/internal_ci/linux/grpc_bazel_rbe_asan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_asan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_asan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_dbg.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/grpc_bazel_rbe_msan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_msan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_msan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_opt.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/grpc_bazel_rbe_tsan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_tsan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_tsan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/grpc_bazel_rbe_ubsan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_ubsan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/grpc_ubsan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_asan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_asan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_asan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_msan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_msan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_msan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_tsan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_tsan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_tsan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_ubsan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_ubsan.cfg
@@ -18,7 +18,6 @@
 build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_ubsan_on_foundry.sh"
 timeout_mins: 90
 
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %BAZEL_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %BAZEL_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
 if not "%UPLOAD_TEST_RESULTS%"=="" (

--- a/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
@@ -21,7 +21,6 @@ timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/rbe-windows-credentials.json"
 
 bazel_setting {
   # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,

--- a/tools/internal_ci/windows/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_opt.cfg
@@ -21,7 +21,6 @@ timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/rbe-windows-credentials.json"
 
 bazel_setting {
   # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -21,7 +21,6 @@ timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/rbe-windows-credentials.json"
 
 bazel_setting {
   # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_opt.cfg
@@ -21,7 +21,6 @@ timeout_mins: 90
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
-gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/rbe-windows-credentials.json"
 
 bazel_setting {
   # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,


### PR DESCRIPTION
On Linux and Windows workers, we can authenticate with the RBE service using the compute engine credentials available on the GCE VMs (which is a better way than using the json service account key).

See b/171660981 for more context.