### PR TITLE
Surface build errors from generate_projects.sh

### DIFF
--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -89,8 +89,18 @@ for template in reversed(sorted(templates)):
         cmd.append(args.base + '/' + root + '/' + f)
         jobs.append(jobset.JobSpec(cmd, shortname=out, timeout_seconds=None))
 
-jobset.run(pre_jobs, maxjobs=args.jobs)
-jobset.run(jobs, maxjobs=args.jobs)
+err_cnt, _ = jobset.run(pre_jobs, maxjobs=args.jobs)
+if err_cnt != 0:
+    print('ERROR: {count} error(s) encountered during preprocessing.'.format(
+        count=err_cnt),
+          file=sys.stderr)
+    sys.exit(1)
+err_cnt, _ = jobset.run(jobs, maxjobs=args.jobs)
+if err_cnt != 0:
+    print('ERROR: {count} error(s) found while generating projects.'.format(
+        count=err_cnt),
+          file=sys.stderr)
+    sys.exit(1)
 
 if test is not None:
     for s, g in test.items():


### PR DESCRIPTION
This script was not returning a failure error code on build failures.
This change short-circuits some of the processing when errors are
encountered, prints an error message, and returns 1.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
