### PR TITLE
[flaky ios-cpp-test-cronet] - Update Xcode versions used in Kokoro to 9.2

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -67,6 +67,11 @@ then
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master
 
+   # Set xcode version for Obj-C tests.
+   # Lately the objc tests that were using Xcode 10.1 on Kokoro
+   # been very unstable, which might be a problem of Xcode 10.1
+  sudo xcode-select -switch /Applications/Xcode_9.2.app/Contents/Developer/
+
   # Needed for ios-binary-size
   time pip install --user pyyaml pyjwt cryptography requests
 
@@ -111,6 +116,11 @@ then
   export NUGET_XMLDOC_MODE=skip
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
   export DOTNET_CLI_TELEMETRY_OPTOUT=true
+
+  # Set xcode version for Obj-C tests.
+   # Lately the objc tests that were using Xcode 10.1 on Kokoro
+   # been very unstable, which might be a problem of Xcode 10.1
+  sudo xcode-select -switch /Applications/Xcode_9.2.app/Contents/Developer/
 fi
 
 # PHP tests currently require using an older version of PHPUnit


### PR DESCRIPTION
`ios-cpp-test-cronet` flakes a lot after switching from Xcode 9.2 to Xcode 10.1 because of `assertion failure in ROCKRemoteProxy`,  looks like it originates from a framework from Apple. 

failures:
- https://source.cloud.google.com/results/invocations/07685773-8f5e-4a08-9fc7-75fe07738e44/targets/github%2Fgrpc%2Frun_tests%2Fobjc_macos_opt_native%2Fios-cpp-test-cronet/tests
- https://source.cloud.google.com/results/invocations/1e581a82-b543-48c2-aecc-480561c59a8d/targets/github%2Fgrpc%2Frun_tests%2Fobjc_macos_opt_native%2Fios-cpp-test-cronet/tests
- https://g3c.corp.google.com/results/invocations/abf8118d-13a4-47e1-8e51-7a6c389d4996/targets/github%2Fgrpc%2Frun_tests%2Fobjc_macos_opt_native%2Fios-cpp-test-cronet;config=default/tests


A thread here with additional information: There's a thread here with additional information:  https://github.com/Microsoft/azure-pipelines-tasks/issues/8840