### PR TITLE
Optimization single-threaded unary-stream benchmark

### DIFF
--- a/src/python/grpcio_tests/tests/qps/client_runner.py
+++ b/src/python/grpcio_tests/tests/qps/client_runner.py
@@ -67,12 +67,15 @@ class OpenLoopClientRunner(ClientRunner):
 
 class ClosedLoopClientRunner(ClientRunner):
 
-    def __init__(self, client, request_count):
+    def __init__(self, client, request_count, no_ping_pong):
         super(ClosedLoopClientRunner, self).__init__(client)
         self._is_running = False
         self._request_count = request_count
-        # Send a new request on each response for closed loop
-        self._client.add_response_callback(self._send_request)
+        # For server-streaming RPC, don't spawn new RPC after each responses.
+        # This yield at most ~17% for single RPC scenarios.
+        if not no_ping_pong:
+            # Send a new request on each response for closed loop
+            self._client.add_response_callback(self._send_request)
 
     def start(self):
         self._is_running = True
@@ -85,6 +88,6 @@ class ClosedLoopClientRunner(ClientRunner):
         self._client.stop()
         self._client = None
 
-    def _send_request(self, client, response_time):
+    def _send_request(self, client, unused_response_time):
         if self._is_running:
             client.send_request()

--- a/src/python/grpcio_tests/tests/qps/worker_server.py
+++ b/src/python/grpcio_tests/tests/qps/worker_server.py
@@ -148,6 +148,7 @@ class WorkerServer(worker_service_pb2_grpc.WorkerServiceServicer):
         return control_pb2.ClientStatus(stats=stats)
 
     def _create_client_runner(self, server, config, qps_data):
+        no_ping_pong = False
         if config.client_type == control_pb2.SYNC_CLIENT:
             if config.rpc_type == control_pb2.UNARY:
                 client = benchmark_client.UnarySyncBenchmarkClient(
@@ -156,6 +157,7 @@ class WorkerServer(worker_service_pb2_grpc.WorkerServiceServicer):
                 client = benchmark_client.StreamingSyncBenchmarkClient(
                     server, config, qps_data)
             elif config.rpc_type == control_pb2.STREAMING_FROM_SERVER:
+                no_ping_pong = True
                 client = benchmark_client.ServerStreamingSyncBenchmarkClient(
                     server, config, qps_data)
         elif config.client_type == control_pb2.ASYNC_CLIENT:
@@ -172,7 +174,7 @@ class WorkerServer(worker_service_pb2_grpc.WorkerServiceServicer):
         load_factor = float(config.client_channels)
         if config.load_params.WhichOneof('load') == 'closed_loop':
             runner = client_runner.ClosedLoopClientRunner(
-                client, config.outstanding_rpcs_per_channel)
+                client, config.outstanding_rpcs_per_channel, no_ping_pong)
         else:  # Open loop Poisson
             alpha = config.load_params.poisson.offered_load / load_factor
 


### PR DESCRIPTION
Unfortunately, the architecture of benchmark client requires a thread running the qps_worker and another one running the RPC itself. So, it can't really be a one-threaded application. However, I do discover another performance dragging issue that impacts at most 17% (maxed at large size messages).

(The internal chart is updated.)