### PR TITLE
Stop the spamming log generated by ctrl-c for AsyncIO server

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -780,6 +780,7 @@ cdef CallbackFailureHandler SERVER_SHUTDOWN_FAILURE_HANDLER = CallbackFailureHan
     None,
     InternalError)
 
+
 cdef class AioServer:
 
     def __init__(self, loop, thread_pool, generic_handlers, interceptors,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -780,7 +780,6 @@ cdef CallbackFailureHandler SERVER_SHUTDOWN_FAILURE_HANDLER = CallbackFailureHan
     None,
     InternalError)
 
-
 cdef class AioServer:
 
     def __init__(self, loop, thread_pool, generic_handlers, interceptors,
@@ -884,6 +883,8 @@ cdef class AioServer:
 
     def _serving_task_crash_handler(self, object task):
         """Shutdown the server immediately if unexpectedly exited."""
+        if task.cancelled():
+            return
         if task.exception() is None:
             return
         if self._status != AIO_SERVER_STATUS_STOPPING:


### PR DESCRIPTION
TIL that invoking a cancelled Future's `task.exception()` will raise an `asyncio.CancelledError` instead of peacefully return it... Fixes https://github.com/grpc/grpc/issues/24716