### PR TITLE
InitialMetadata callback shouldn't be triggered with empty initialMet…

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCCallInternal.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCCallInternal.m
@@ -249,7 +249,7 @@
 }
 
 - (void)issueInitialMetadata:(NSDictionary *)initialMetadata {
-  if (initialMetadata != nil) {
+  if (initialMetadata != nil && [initialMetadata count] == 0) {
     // cannot directly call callback because this may not be running on manager's dispatch queue
     GRPCTransportManager *copiedManager = _transportManager;
     dispatch_async(copiedManager.dispatchQueue, ^{


### PR DESCRIPTION
Fix #24554.