### PR TITLE
Explicitly set encoding to ascii to prevent TypeError in Python 3

### DIFF
--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -59,7 +59,7 @@ class CaptureFile(object):
         """Get all output from the redirected-to file if it exists."""
         if self._into_file:
             self._into_file.seek(0)
-            return bytes(self._into_file.read(), 'ascii')
+            return self._into_file.read().encode('ascii')
         else:
             return bytes()
 
@@ -80,7 +80,7 @@ class CaptureFile(object):
       value (str): What to write to the original file.
     """
         if six.PY3 and not isinstance(value, six.binary_type):
-            value = bytes(value, 'ascii')
+            value = value.encode('ascii')
         if self._saved_fd is None:
             os.write(self._redirect_fd, value)
         else:

--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -59,7 +59,7 @@ class CaptureFile(object):
         """Get all output from the redirected-to file if it exists."""
         if self._into_file:
             self._into_file.seek(0)
-            return bytes(self._into_file.read())
+            return bytes(self._into_file.read(), 'ascii')
         else:
             return bytes()
 

--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -59,7 +59,7 @@ class CaptureFile(object):
         """Get all output from the redirected-to file if it exists."""
         if self._into_file:
             self._into_file.seek(0)
-            return self._into_file.read().encode('ascii')
+            return bytes(self._into_file.read())
         else:
             return bytes()
 

--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -157,7 +157,7 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             p = allocate_port(self)
             self.log_message('allocated port %d' % p)
-            self.wfile.write(bytes('%d' % p))
+            self.wfile.write(('%d' % p).encode('utf8'))
         elif self.path[0:6] == '/drop/':
             self.send_response(200)
             self.send_header('Content-Type', 'text/plain')
@@ -177,7 +177,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-Type', 'text/plain')
             self.end_headers()
-            self.wfile.write(bytes('%d' % _MY_VERSION))
+            self.wfile.write(bytes('%d' % _MY_VERSION, 'ascii'))
         elif self.path == '/dump':
             # yaml module is not installed on Macs and Windows machines by default
             # so we import it lazily (/dump action is only used for debugging)
@@ -192,7 +192,7 @@ class Handler(BaseHTTPRequestHandler):
                 'in_use': dict((k, now - v) for k, v in in_use.items())
             })
             mu.release()
-            self.wfile.write(bytes(out))
+            self.wfile.write(bytes(out, 'ascii'))
         elif self.path == '/quitquitquit':
             self.send_response(200)
             self.end_headers()

--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -157,7 +157,7 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             p = allocate_port(self)
             self.log_message('allocated port %d' % p)
-            self.wfile.write(('%d' % p).encode('utf8'))
+            self.wfile.write(bytes('%d' % p, 'ascii'))
         elif self.path[0:6] == '/drop/':
             self.send_response(200)
             self.send_header('Content-Type', 'text/plain')

--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -157,7 +157,7 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             p = allocate_port(self)
             self.log_message('allocated port %d' % p)
-            self.wfile.write(bytes('%d' % p, 'ascii'))
+            self.wfile.write(str(p).encode('ascii'))
         elif self.path[0:6] == '/drop/':
             self.send_response(200)
             self.send_header('Content-Type', 'text/plain')
@@ -177,7 +177,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-Type', 'text/plain')
             self.end_headers()
-            self.wfile.write(bytes('%d' % _MY_VERSION, 'ascii'))
+            self.wfile.write(str(_MY_VERSION).encode('ascii'))
         elif self.path == '/dump':
             # yaml module is not installed on Macs and Windows machines by default
             # so we import it lazily (/dump action is only used for debugging)
@@ -192,7 +192,7 @@ class Handler(BaseHTTPRequestHandler):
                 'in_use': dict((k, now - v) for k, v in in_use.items())
             })
             mu.release()
-            self.wfile.write(bytes(out, 'ascii'))
+            self.wfile.write(out.encode('ascii'))
         elif self.path == '/quitquitquit':
             self.send_response(200)
             self.end_headers()


### PR DESCRIPTION
This error started appearing if we run port server with Python 3. Using `ascii` instead of `utf8`, since we are only dealing with letters and numbers for now. This PR also fixed other places directly invoking `bytes()`.

```
Exception happened during processing of request from ('127.0.0.1', 57036)
Traceback (most recent call last):
  File "/Users/lidiz/.pyenv/versions/3.7.1/lib/python3.7/socketserver.py", line 647, in process_request_thread
    self.finish_request(request, client_address)
  File "/Users/lidiz/.pyenv/versions/3.7.1/lib/python3.7/socketserver.py", line 357, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/Users/lidiz/.pyenv/versions/3.7.1/lib/python3.7/socketserver.py", line 717, in __init__
    self.handle()
  File "/Users/lidiz/.pyenv/versions/3.7.1/lib/python3.7/http/server.py", line 426, in handle
    self.handle_one_request()
  File "/Users/lidiz/.pyenv/versions/3.7.1/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/Users/lidiz/src/grpc/tools/run_tests/python_utils/port_server.py", line 160, in do_GET
    self.wfile.write(bytes('%d' % p))
TypeError: string argument without an encoding
```