### PR TITLE
Link to Python gRPC page on grpc.io

### DIFF
--- a/doc/python/sphinx/grpc.rst
+++ b/doc/python/sphinx/grpc.rst
@@ -3,18 +3,7 @@ gRPC
 
 .. module:: grpc
 
-Tutorial
---------
-
-If you want to see gRPC in action first, visit the `Python Quickstart <https://grpc.io/docs/languages/python/quickstart>`_.
-Or, if you would like dive in with more extensive usage of gRPC Python, check `gRPC Basics - Python <https://grpc.io/docs/languages/python/basics>`_ out.
-
-
-Example
--------
-
-Go to `gRPC Python Examples <https://github.com/grpc/grpc/tree/master/examples/python>`_
-
+For documentation, examples, and more, see the `Python gRPC <https://grpc.io/docs/languages/python/>`_ page on `grpc.io <https://grpc.io/>`_.
 
 Module Contents
 ---------------


### PR DESCRIPTION
The newly updated [Python gRPC](https://grpc.io/docs/languages/python/) page (for a screenshot, see beelow), contains links to the quick start, tutorial, examples and more! Link directly to that page, rather than refer to only part of its contents.

@gnossen @lidizheng 

---

Screenshot of new Python gRPC on grpc.io:

> <img src="https://user-images.githubusercontent.com/4140793/98880407-ac82b780-2455-11eb-9b36-cda0133c0230.png" width=500>
