### PR TITLE
Python3ize ios_bin/binary_size.py

### DIFF
--- a/tools/profiling/ios_bin/binary_size.py
+++ b/tools/profiling/ios_bin/binary_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 #
 # Copyright 2018 gRPC authors.
 #
@@ -143,6 +143,6 @@ for frameworks in [False, True]:
             text += '\n No significant differences in binary sizes\n'
     text += '\n'
 
-print text
+print(text)
 
 check_on_pr.check_on_pr('Binary Size', '```\n%s\n```' % text)

--- a/tools/profiling/ios_bin/parse_link_map.py
+++ b/tools/profiling/ios_bin/parse_link_map.py
@@ -36,7 +36,7 @@ def parse_link_map(filename):
     objc_size = 0
     protobuf_size = 0
 
-    lines = list(open(filename))
+    lines = open(filename, encoding='utf-8', errors='ignore').readlines()
     for line in lines:
         line_stripped = line[:-1]
         if "# Object files:" == line_stripped:
@@ -66,6 +66,8 @@ def parse_link_map(filename):
             if len(line_stripped) == 0 or line_stripped[0] == '#':
                 continue
             segs = re.search('^.+?\s+(.+?)\s+(\[.+?\]).*', line_stripped)
+            if not segs:
+                continue
             target = table_tag[segs.group(2)]
             target_stripped = re.search('^(.*?)(\(.+?\))?$', target).group(1)
             size = int(segs.group(1), 16)


### PR DESCRIPTION
Fixing macos/grpc_ios_binary_size [log](https://source.cloud.google.com/results/invocations/cab1ccde-835b-49ac-a432-1142d269d2d2/targets)
Related to #24359