### PR TITLE
Drop src/core/README.md, all info is in top README

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,4 +1,0 @@
-# Overview
-
-This directory contains source code for C library (a.k.a the *gRPC C core*) that provides all gRPC's core functionality through a low level API. Libraries in other languages in this repository (C++, C#, Ruby,
-Python, PHP, NodeJS, Objective-C) are layered on top of this library.


### PR DESCRIPTION
It adds no new information that isn't already described in the top-level repo READM.md's section [About This Repository](https://github.com/grpc/grpc#about-this-repository). In particular, there is really no need to enumerate all the languages.

@jtattermusch @lidizheng 