### PR TITLE
Add a workaround for CERTIFICATE_VERIFY_FAILED

### DIFF
--- a/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
@@ -48,7 +48,7 @@ if [ "$UPLOAD_TEST_RESULTS" != "" ]
 then
   # Sleep to let ResultStore finish writing results before querying
   sleep 60
-  python ./tools/run_tests/python_utils/upload_rbe_results.py
+  PYTHONHTTPSVERIFY=0 python ./tools/run_tests/python_utils/upload_rbe_results.py
 fi
 
 if [ "$FAILED" != "" ]


### PR DESCRIPTION
Python 2.7 on Mac Mojave appears to have a `CERTIFICATE_VERIFY_FAILED` issue. ([ref](https://moreless.medium.com/how-to-fix-python-ssl-certificate-verify-failed-97772d9dd14c)) Let's disable certificate validation by specifying `PYTHONHTTPSVERIFY=0`.

Related to #24738