### PR TITLE
Disable ALTS connectivity test on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,7 +709,7 @@ if(gRPC_BUILD_TESTS)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_cxx alarm_test)
   endif()
-  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_cxx alts_concurrent_connectivity_test)
   endif()
   add_dependencies(buildtests_cxx alts_util_test)
@@ -8266,7 +8266,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 endif()
 endif()
 if(gRPC_BUILD_TESTS)
-if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
 
   add_executable(alts_concurrent_connectivity_test
     ${_gRPC_PROTO_GENS_DIR}/test/core/tsi/alts/fake_handshaker/handshaker.pb.cc

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4761,7 +4761,6 @@ targets:
   platforms:
   - linux
   - posix
-  - mac
 - name: alts_credentials_fuzzer
   build: fuzzer
   language: c++

--- a/test/core/tsi/alts/handshaker/BUILD
+++ b/test/core/tsi/alts/handshaker/BUILD
@@ -87,7 +87,10 @@ grpc_cc_test(
     language = "C++",
     # TODO(apolcyn): make the fake TCP server used in this
     # test portable to Windows.
-    tags = ["no_windows"],
+    tags = [
+        "no_mac",  # TODO(https://github.com/grpc/grpc/issues/24747): Disable temporarily
+        "no_windows",
+    ],
     deps = [
         "//:alts_util",
         "//:grpc",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3222,7 +3222,6 @@
     "benchmark": false,
     "ci_platforms": [
       "linux",
-      "mac",
       "posix"
     ],
     "cpu_cost": 1.0,
@@ -3234,7 +3233,6 @@
     "name": "alts_concurrent_connectivity_test",
     "platforms": [
       "linux",
-      "mac",
       "posix"
     ],
     "uses_polling": true


### PR DESCRIPTION
Let's disable this assertion until why it's a problem on Mac to keep the test green.
Related to #24747