### PR TITLE
Only include circuitBreakers field in the backend service config body if its value is not None

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1649,8 +1649,9 @@ def patch_backend_service(gcp,
             'balancingMode': balancing_mode,
             'maxRate': 1 if balancing_mode == 'RATE' else None
         } for instance_group in instance_groups],
-        'circuitBreakers': circuit_breakers,
     }
+    if circuit_breakers:
+        config['circuitBreakers'] = circuit_breakers
     logger.debug('Sending GCP request with body=%s', config)
     result = compute_to_use.backendServices().patch(
         project=gcp.project, backendService=backend_service.name,


### PR DESCRIPTION
It looks when `validate_for_proxyless` is set for the target proxy, the GCP API does not allow you include the 'circuitBreakers' field in the config request body even if the value is `None`.


This happens in finishing the circuit breaking test and turning the `validate_for_proxyless` back to `True`.