### PR TITLE
Incur setuptools as an dependency for grpcio_tools

### DIFF
--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -232,6 +232,7 @@ setuptools.setup(
     install_requires=[
         'protobuf>=3.5.0.post1, < 4.0dev',
         'grpcio>={version}'.format(version=grpc_version.VERSION),
+        'setuptools',
     ],
     package_data=package_data(),
 )


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/24746

As Protobuf removed their direct dependency on `setuptools` (see https://github.com/protocolbuffers/protobuf/commit/7daf0aa7b00261bc8e0a433c58e74083cd58ea43), we need to depend on `setuptools` to keep `pkg_resources` working.