### PR TITLE
Revert "Enable GPR_ABSEIL_SYNC on Apple"

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -31,7 +31,12 @@
  * Defines GPR_ABSEIL_SYNC to use synchronization features from Abseil
  */
 #ifndef GPR_ABSEIL_SYNC
+#if defined(__APPLE__)
+// This is disabled on Apple platforms because macos/grpc_basictests_c_cpp
+// fails with this. https://github.com/grpc/grpc/issues/23661
+#else
 #define GPR_ABSEIL_SYNC 1
+#endif
 #endif  // GPR_ABSEIL_SYNC
 
 /* Get windows.h included everywhere (we need it) */


### PR DESCRIPTION
This reverts commit 2197855c8048f5981070faea8f327eb451701db8. (#23866) Although new Mojave Kokoro Mac image has shown much better stability over High Seirra one on Abseil's thread-local storage implementation using pthread, it's still having flakiness. (#24747 #24769)

Abseil already fixed this issue on its master branch by using C++ TLS as a default implementation (b/170119606) and gRPC will pick it up once its next LTS version is released. (Presumably in early 2021) Once it happens, this will be reenabled.

Notable flaky test suites (on Nov 17, 2020):
- `macos/grpc_basictests_c_cpp` (6 fails over 30 runs)
- `macos/grpc_bazel_cpp_ios_tests` (6 fails over 30 runs)