### PR TITLE
Set enabling circuit breaking env var in xDS test client environment

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2035,6 +2035,7 @@ try:
                             bootstrap_server_features)).encode('utf-8'))
                 bootstrap_path = bootstrap_file.name
         client_env['GRPC_XDS_BOOTSTRAP'] = bootstrap_path
+        client_env['GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING'] = 'true'
         test_results = {}
         failed_tests = []
         for test_case in args.test_case:


### PR DESCRIPTION
Circuit breaking feature in gRPC client should be protected by the env var `GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING`. We enable it for the interop test environment.
