### PR TITLE
csharp - proposed fix for #24784 - expose marshaller faults in DebugException

### DIFF
--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -553,7 +553,7 @@ namespace Grpc.Core.Internal
 
                 if (deserializeException != null && receivedStatus.Status.StatusCode == StatusCode.OK)
                 {
-                    receivedStatus = new ClientSideStatus(DeserializeResponseFailureStatus, receivedStatus.Trailers);
+                    receivedStatus = new ClientSideStatus(CreateDeserializeResponseFailureStatus(deserializeException), receivedStatus.Trailers);
                 }
                 finishedStatus = receivedStatus;
 

--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -38,7 +38,10 @@ namespace Grpc.Core.Internal
     internal abstract class AsyncCallBase<TWrite, TRead> : IReceivedMessageCallback, ISendCompletionCallback
     {
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<AsyncCallBase<TWrite, TRead>>();
-        protected static readonly Status DeserializeResponseFailureStatus = new Status(StatusCode.Internal, "Failed to deserialize response message.");
+        protected static Status CreateDeserializeResponseFailureStatus(Exception exception)
+        {
+            return new Status(StatusCode.Internal, "Failed to deserialize response message.", exception);
+        }
 
         readonly Action<TWrite, SerializationContext> serializer;
         readonly Func<DeserializationContext, TRead> deserializer;
@@ -351,7 +354,7 @@ namespace Grpc.Core.Internal
                     readingDone = true;
 
                     // TODO(jtattermusch): it might be too late to set the status
-                    CancelWithStatus(DeserializeResponseFailureStatus);
+                    CancelWithStatus(CreateDeserializeResponseFailureStatus(deserializeException));
                 }
 
                 if (!readingDone)


### PR DESCRIPTION
context from #24784:

If the marshaller faults, the [original exception is lost](https://github.com/grpc/grpc/blob/a1ad4800da2bb02c843bdaea8fb06518916b6fba/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs#L349-L355) - it is never exposed to the client and a pre-defined [status is reported](https://github.com/grpc/grpc/blob/a1ad4800da2bb02c843bdaea8fb06518916b6fba/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs#L41).

This makes it very hard to diagnose underlying causes, as seen [in this Stack Overflow question](https://stackoverflow.com/questions/64868856/serializing-an-ienumerable-in-protobuf-net?noredirect=1#comment114732115_64868856).

For server-side faults, the original exception [is exposed](https://github.com/grpc/grpc/blob/a1ad4800da2bb02c843bdaea8fb06518916b6fba/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs#L372).

Suggestion: allow client-code to expose the fault in the `DebugException`; this is a trivial change.