### PR TITLE
Examples README: add link to android example and fix link text

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This directory contains examples for all the C-based gRPC implementations. Each
 language subdirectory contains a Hello World example and more:
 
+* [Android](android)
 * [C#](csharp)
 * [C++](cpp)
 * [Node.js](node)
@@ -11,8 +12,7 @@ language subdirectory contains a Hello World example and more:
 * [Python](python/helloworld)
 * [Ruby](ruby)
 
-For a complete list of supported languages, see [Supported languages and
-platforms][lang].
+For a complete list of supported languages, see [Supported languages][lang].
 
 For comprehensive documentation, including an [Introduction to gRPC][intro] and
 tutorials that use this example code, visit [grpc.io](https://grpc.io).


### PR DESCRIPTION
Add a link to the android example and fix the link text (platforms are now served from another page).

@veblush @jtattermusch 