### PR TITLE
Add target argument to Node example clients

### DIFF
--- a/examples/node/dynamic_codegen/greeter_client.js
+++ b/examples/node/dynamic_codegen/greeter_client.js
@@ -18,6 +18,7 @@
 
 var PROTO_PATH = __dirname + '/../../protos/helloworld.proto';
 
+var parseArgs = require('minimist');
 var grpc = require('@grpc/grpc-js');
 var protoLoader = require('@grpc/proto-loader');
 var packageDefinition = protoLoader.loadSync(
@@ -31,11 +32,20 @@ var packageDefinition = protoLoader.loadSync(
 var hello_proto = grpc.loadPackageDefinition(packageDefinition).helloworld;
 
 function main() {
-  var client = new hello_proto.Greeter('localhost:50051',
+  var argv = parseArgs(process.argv.slice(2), {
+    string: 'target'
+  });
+  var target;
+  if (argv.target) {
+    target = argv.target;
+  } else {
+    target = 'localhost:50051';
+  }
+  var client = new hello_proto.Greeter(target,
                                        grpc.credentials.createInsecure());
   var user;
-  if (process.argv.length >= 3) {
-    user = process.argv[2];
+  if (argv._.length > 0) {
+    user = argv._[0]; 
   } else {
     user = 'world';
   }

--- a/examples/node/static_codegen/greeter_client.js
+++ b/examples/node/static_codegen/greeter_client.js
@@ -22,12 +22,21 @@ var services = require('./helloworld_grpc_pb');
 var grpc = require('@grpc/grpc-js');
 
 function main() {
-  var client = new services.GreeterClient('localhost:50051',
+  var argv = parseArgs(process.argv.slice(2), {
+    string: 'target'
+  });
+  var target;
+  if (argv.target) {
+    target = argv.target;
+  } else {
+    target = 'localhost:50051';
+  }
+  var client = new services.GreeterClient(target,
                                           grpc.credentials.createInsecure());
   var request = new messages.HelloRequest();
   var user;
-  if (process.argv.length >= 3) {
-    user = process.argv[2];
+  if (argv._.length > 0) {
+    user = argv._[0]; 
   } else {
     user = 'world';
   }


### PR DESCRIPTION
This brings the example client functionality in line with clients for other languages, and makes it usable in [Traffic Director examples](https://cloud.google.com/traffic-director/docs/set-up-proxyless-gce). The `minimist` library is already listed as a dependency because it's used in the "route guide" examples.