### PR TITLE
[Aio] Fix the emtpy response handling in streaming RPC

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -360,7 +360,7 @@ cdef class _AioCall(GrpcCallWrapper):
             self,
             self._loop
         )
-        if received_message:
+        if received_message is not None:
             return received_message
         else:
             return EOF

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -130,6 +130,8 @@ async def _receive_message(GrpcCallWrapper grpc_call_wrapper,
         #
         # Since they all indicates finish, they are better be merged.
         _LOGGER.debug('Failed to receive any message from Core')
+    # NOTE(lidiz) The returned message might be an empty bytess (aka. b'').
+    # Please explicitly check if it is None or falsified string object!
     return receive_op.message()
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -131,7 +131,7 @@ async def _receive_message(GrpcCallWrapper grpc_call_wrapper,
         # Since they all indicates finish, they are better be merged.
         _LOGGER.debug('Failed to receive any message from Core')
     # NOTE(lidiz) The returned message might be an empty bytess (aka. b'').
-    # Please explicitly check if it is None or falsified string object!
+    # Please explicitly check if it is None or falsey string object!
     return receive_op.message()
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -130,7 +130,7 @@ async def _receive_message(GrpcCallWrapper grpc_call_wrapper,
         #
         # Since they all indicates finish, they are better be merged.
         _LOGGER.debug('Failed to receive any message from Core')
-    # NOTE(lidiz) The returned message might be an empty bytess (aka. b'').
+    # NOTE(lidiz) The returned message might be an empty bytes (aka. b'').
     # Please explicitly check if it is None or falsey string object!
     return receive_op.message()
 

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -67,10 +67,13 @@ class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
                 await asyncio.sleep(
                     datetime.timedelta(microseconds=response_parameters.
                                        interval_us).total_seconds())
-            yield messages_pb2.StreamingOutputCallResponse(
-                payload=messages_pb2.Payload(type=request.response_type,
-                                             body=b'\x00' *
-                                             response_parameters.size))
+            if response_parameters.size != 0:
+                yield messages_pb2.StreamingOutputCallResponse(
+                    payload=messages_pb2.Payload(type=request.response_type,
+                                                 body=b'\x00' *
+                                                 response_parameters.size))
+            else:
+                yield messages_pb2.StreamingOutputCallResponse()
 
     # Next methods are extra ones that are registred programatically
     # when the sever is instantiated. They are not being provided by
@@ -96,10 +99,13 @@ class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
                     await asyncio.sleep(
                         datetime.timedelta(microseconds=response_parameters.
                                            interval_us).total_seconds())
-                yield messages_pb2.StreamingOutputCallResponse(
-                    payload=messages_pb2.Payload(type=request.payload.type,
-                                                 body=b'\x00' *
-                                                 response_parameters.size))
+                if response_parameters.size != 0:
+                    yield messages_pb2.StreamingOutputCallResponse(
+                        payload=messages_pb2.Payload(type=request.payload.type,
+                                                     body=b'\x00' *
+                                                     response_parameters.size))
+                else:
+                    yield messages_pb2.StreamingOutputCallResponse()
 
 
 def _create_extra_generic_handler(servicer: TestServiceServicer):


### PR DESCRIPTION
A user trying out asyncio found our API doesn't work with simple streaming ping-pong case. Like:

```python
async def async_client_hangs():
  async with grpc.aio.insecure_channel('...') as channel:
    await channel.channel_ready()
    stub = test_pb2_grpc.TestStub(channel)

    stream = stub.Call()
    await stream.write(test_pb2.EmptyRequest())
    # Getting test_pb2.EmptyResponse()
    _ = await stream.read()
    # Never reached here!
    print('got response!')
```

It's indeed a bug. We have test cases guarding ping-pong streaming RPC usages, but the message is always non-empty. In the script above, if we add any content in the response, everything will be working again.

Beneath the hang, the empty ProtoBuf message serialized to `b''`, which being treated as None or "no message received something wrong must happened in lower layer". While the upper layer is waiting the none-existing error to propagate, hence hanged.

The fix is adding `is not None` to the if condition. This PR also added test cases to unary-stream RPC and stream-stream RPC.
