### PR TITLE
PHP: fix windows build error

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -983,6 +983,7 @@ if (PHP_GRPC != "no") {
     "/I"+configure_module_dirname+" "+
     "/I"+configure_module_dirname+"\\include "+
     "/I"+configure_module_dirname+"\\src\\core\\ext\\upb-generated "+
+    "/I"+configure_module_dirname+"\\src\\core\\ext\\upbdefs-generated "+
     "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
     "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
     "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -30,6 +30,7 @@
       "/I"+configure_module_dirname+" "+
       "/I"+configure_module_dirname+"\\include "+
       "/I"+configure_module_dirname+"\\src\\core\\ext\\upb-generated "+
+      "/I"+configure_module_dirname+"\\src\\core\\ext\\upbdefs-generated "+
       "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
       "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
       "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+


### PR DESCRIPTION
Error (from `1.34.0RC1` [build log](https://windows.php.net/downloads/pecl/releases/grpc/1.34.0rc1/logs/)):

```
C:\php-snap-build\php-src\php72\x64\php-src\ext\grpc\third_party\upb\upb/table.int.h(203): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) (compiling source file ext\grpc\src\core\ext\upbdefs-generated\envoy\annotations\resource.upbdefs.c)
ext\grpc\src\core\ext\upbdefs-generated\envoy\annotations\deprecation.upbdefs.c(10): fatal error C1083: Cannot open include file: 'envoy/annotations/deprecation.upbdefs.h': No such file or directory
ext\grpc\src\core\ext\upbdefs-generated\envoy\annotations\resource.upbdefs.c(10): fatal error C1083: Cannot open include file: 'envoy/annotations/resource.upbdefs.h': No such file or directory
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\cl.exe"' : return code '0x2'
Stop.
```

Fix is to re-do this particular change in #23904 (https://github.com/grpc/grpc/pull/23904/commits/6d6339db34654cf8f9035f8cdb2935a7649e6d0d#diff-0a1d1dbd41d065a1a51c66ec9cc141135fa725bbc0d5f557a859e3ed43438950) but in the corresponding `config.w32` file as well.