### PR TITLE
Add a Node xDS example client

### DIFF
--- a/examples/node/dynamic_codegen/greeter_client.js
+++ b/examples/node/dynamic_codegen/greeter_client.js
@@ -18,6 +18,7 @@
 
 var PROTO_PATH = __dirname + '/../../protos/helloworld.proto';
 
+var parseArgs = require('minimist');
 var grpc = require('@grpc/grpc-js');
 var protoLoader = require('@grpc/proto-loader');
 var packageDefinition = protoLoader.loadSync(
@@ -31,11 +32,20 @@ var packageDefinition = protoLoader.loadSync(
 var hello_proto = grpc.loadPackageDefinition(packageDefinition).helloworld;
 
 function main() {
-  var client = new hello_proto.Greeter('localhost:50051',
+  var argv = parseArgs(process.argv.slice(2), {
+    string: 'target'
+  });
+  var target;
+  if (argv.target) {
+    target = argv.target;
+  } else {
+    target = 'localhost:50051';
+  }
+  var client = new hello_proto.Greeter(target,
                                        grpc.credentials.createInsecure());
   var user;
-  if (process.argv.length >= 3) {
-    user = process.argv[2];
+  if (argv._.length > 0) {
+    user = argv._[0]; 
   } else {
     user = 'world';
   }

--- a/examples/node/static_codegen/greeter_client.js
+++ b/examples/node/static_codegen/greeter_client.js
@@ -22,12 +22,21 @@ var services = require('./helloworld_grpc_pb');
 var grpc = require('@grpc/grpc-js');
 
 function main() {
-  var client = new services.GreeterClient('localhost:50051',
+  var argv = parseArgs(process.argv.slice(2), {
+    string: 'target'
+  });
+  var target;
+  if (argv.target) {
+    target = argv.target;
+  } else {
+    target = 'localhost:50051';
+  }
+  var client = new services.GreeterClient(target,
                                           grpc.credentials.createInsecure());
   var request = new messages.HelloRequest();
   var user;
-  if (process.argv.length >= 3) {
-    user = process.argv[2];
+  if (argv._.length > 0) {
+    user = argv._[0]; 
   } else {
     user = 'world';
   }

--- a/examples/node/xds/greeter_client.js
+++ b/examples/node/xds/greeter_client.js
@@ -1,0 +1,60 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+var PROTO_PATH = __dirname + '/../../protos/helloworld.proto';
+
+var parseArgs = require('minimist');
+var grpc = require('@grpc/grpc-js');
+var grpc_xds = require('@grpc/grpc-js-xds');
+grpc_xds.register();
+
+var protoLoader = require('@grpc/proto-loader');
+var packageDefinition = protoLoader.loadSync(
+    PROTO_PATH,
+    {keepCase: true,
+     longs: String,
+     enums: String,
+     defaults: true,
+     oneofs: true
+    });
+var hello_proto = grpc.loadPackageDefinition(packageDefinition).helloworld;
+
+function main() {
+  var argv = parseArgs(process.argv.slice(2), {
+    string: 'target'
+  });
+  var target;
+  if (argv.target) {
+    target = argv.target;
+  } else {
+    target = 'localhost:50051';
+  }
+  var client = new hello_proto.Greeter(target,
+                                       grpc.credentials.createInsecure());
+  var user;
+  if (argv._.length > 0) {
+    user = argv._[0]; 
+  } else {
+    user = 'world';
+  }
+  client.sayHello({name: user}, function(err, response) {
+    console.log('Greeting:', response.message);
+  });
+}
+
+main();

--- a/examples/node/xds/package.json
+++ b/examples/node/xds/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "grpc-examples-xds",
+  "version": "0.1.0",
+  "dependencies": {
+    "@grpc/proto-loader": "^0.5.0",
+    "@grpc/grpc-js": "^1.2.0",
+    "@grpc/grpc-js-xds": "^1.2.0",
+    "minimist": "^1.2.0"
+  }
+}


### PR DESCRIPTION
We need a separate xDS example for Node because it needs to depend on the `@grpc/grpc-js-xds` package, which is unnecessary for the regular examples. I want this to be in the 1.34.0 release zip file so that I can reference it from a [Traffic Director example](https://cloud.google.com/traffic-director/docs/set-up-proxyless-gce).

I also cherry-picked #24795