### PR TITLE
interop: Update Go interop build scripts.

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM golang:1.11
+  FROM golang:1.15
   
   <%include file="../../go_path.include"/>
   <%include file="../../python_deps.include"/>

--- a/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.11
+FROM golang:1.15
 
 # Using login shell removes Go from path, so we add it.
 RUN ln -s /usr/local/go/bin/go /usr/local/bin

--- a/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
@@ -23,9 +23,6 @@ if [[ -z "$GOPATH" ]]; then
     GOPATH="$(go env GOPATH)"
 fi
 
-# Download the gRPC-Go package at head. This puts the sources in $GOPATH/src.
-go get -d google.golang.org/grpc@HEAD
-
-# Build the interop client and server
-(cd ${GOPATH}/src/google.golang.org/grpc/interop/client && go install)
-(cd ${GOPATH}/src/google.golang.org/grpc/interop/server && go install)
+# Download the interop server and client at head.
+GO111MODULE=on go get google.golang.org/grpc/interop/client@HEAD \
+  google.golang.org/grpc/interop/server@HEAD

--- a/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
@@ -16,18 +16,16 @@
 # Builds Go interop server and client in a base image.
 set -e
 
-# Clone just the grpc-go source code without any dependencies.
-# We are cloning from a local git repo that contains the right revision
-# to test instead of using "go get" to download from Github directly.
-git clone --recursive /var/local/jenkins/grpc-go src/google.golang.org/grpc
-
-# Get all gRPC Go dependencies
-(cd src/google.golang.org/grpc && make deps && make testdeps)
-
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
+if [[ -z "$GOPATH" ]]; then
+    GOPATH="$(go env GOPATH)"
+fi
+
+# Download the gRPC-Go package at head. This puts the sources in $GOPATH/src.
+go get -d google.golang.org/grpc@HEAD
+
 # Build the interop client and server
-(cd src/google.golang.org/grpc/interop/client && go install)
-(cd src/google.golang.org/grpc/interop/server && go install)
-  
+(cd ${GOPATH}/src/google.golang.org/grpc/interop/client && go install)
+(cd ${GOPATH}/src/google.golang.org/grpc/interop/server && go install)


### PR DESCRIPTION
Summary of changes:
- Change the base image to use Go1.15, which is the latest version
- Use `go get -d` to download the gRPC-Go package. This is the preferred
  way of downloading packages in the module-aware Go ecosystem.
- Remove calls to `make deps` and `make testdeps` which have been
  removed from gRPC-Go repo.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
