### PR TITLE
[Clang-Tidy] readability-inconsistent-declaration-parameter-name

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,7 +30,7 @@ Checks: '-*,
   readability-container-size-empty,
   readability-deleted-default,
   readability-function-size,
-  -readability-inconsistent-declaration-parameter-name,
+  readability-inconsistent-declaration-parameter-name,
   readability-redundant-control-flow,
   readability-redundant-smartptr-get,
   readability-string-compare'

--- a/include/grpc/compression.h
+++ b/include/grpc/compression.h
@@ -41,7 +41,7 @@ GRPCAPI int grpc_compression_algorithm_is_stream(
 /** Parses the \a slice as a grpc_compression_algorithm instance and updating \a
  * algorithm. Returns 1 upon success, 0 otherwise. */
 GRPCAPI int grpc_compression_algorithm_parse(
-    grpc_slice value, grpc_compression_algorithm* algorithm);
+    grpc_slice name, grpc_compression_algorithm* algorithm);
 
 /** Updates \a name with the encoding name corresponding to a valid \a
  * algorithm. Note that \a name is statically allocated and must *not* be freed.

--- a/include/grpc/impl/codegen/byte_buffer.h
+++ b/include/grpc/impl/codegen/byte_buffer.h
@@ -53,7 +53,7 @@ GRPCAPI grpc_byte_buffer* grpc_byte_buffer_copy(grpc_byte_buffer* bb);
 GRPCAPI size_t grpc_byte_buffer_length(grpc_byte_buffer* bb);
 
 /** Destroys \a byte_buffer deallocating all its memory. */
-GRPCAPI void grpc_byte_buffer_destroy(grpc_byte_buffer* byte_buffer);
+GRPCAPI void grpc_byte_buffer_destroy(grpc_byte_buffer* bb);
 
 /** Reader for byte buffers. Iterates over slices in the byte buffer */
 struct grpc_byte_buffer_reader;

--- a/include/grpc/slice_buffer.h
+++ b/include/grpc/slice_buffer.h
@@ -59,7 +59,7 @@ GPRAPI void grpc_slice_buffer_swap(grpc_slice_buffer* a, grpc_slice_buffer* b);
 GPRAPI void grpc_slice_buffer_move_into(grpc_slice_buffer* src,
                                         grpc_slice_buffer* dst);
 /** remove n bytes from the end of a slice buffer */
-GPRAPI void grpc_slice_buffer_trim_end(grpc_slice_buffer* src, size_t n,
+GPRAPI void grpc_slice_buffer_trim_end(grpc_slice_buffer* sb, size_t n,
                                        grpc_slice_buffer* garbage);
 /** move the first n bytes of src into dst */
 GPRAPI void grpc_slice_buffer_move_first(grpc_slice_buffer* src, size_t n,
@@ -72,9 +72,9 @@ GPRAPI void grpc_slice_buffer_move_first_no_ref(grpc_slice_buffer* src,
 GPRAPI void grpc_slice_buffer_move_first_into_buffer(grpc_slice_buffer* src,
                                                      size_t n, void* dst);
 /** take the first slice in the slice buffer */
-GPRAPI grpc_slice grpc_slice_buffer_take_first(grpc_slice_buffer* src);
+GPRAPI grpc_slice grpc_slice_buffer_take_first(grpc_slice_buffer* sb);
 /** undo the above with (a possibly different) \a slice */
-GPRAPI void grpc_slice_buffer_undo_take_first(grpc_slice_buffer* src,
+GPRAPI void grpc_slice_buffer_undo_take_first(grpc_slice_buffer* sb,
                                               grpc_slice slice);
 
 #ifdef __cplusplus

--- a/include/grpc/support/sync.h
+++ b/include/grpc/support/sync.h
@@ -94,12 +94,12 @@ GPRAPI void gpr_cv_broadcast(gpr_cv* cv);
    GPR_ONCE_INIT.  e.g.,
      static gpr_once once_var = GPR_ONCE_INIT;     */
 
-/** Ensure that (*init_routine)() has been called exactly once (for the
+/** Ensure that (*init_function)() has been called exactly once (for the
    specified gpr_once instance) and then return.
    If multiple threads call gpr_once() on the same gpr_once instance, one of
-   them will call (*init_routine)(), and the others will block until that call
+   them will call (*init_function)(), and the others will block until that call
    finishes.*/
-GPRAPI void gpr_once_init(gpr_once* once, void (*init_routine)(void));
+GPRAPI void gpr_once_init(gpr_once* once, void (*init_function)(void));
 
 /** --- One-time event notification ---
 

--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -51,7 +51,7 @@ GPRAPI gpr_timespec gpr_now(gpr_clock_type clock);
 
 /** Convert a timespec from one clock to another */
 GPRAPI gpr_timespec gpr_convert_clock_type(gpr_timespec t,
-                                           gpr_clock_type target_clock);
+                                           gpr_clock_type clock_type);
 
 /** Return -ve, 0, or +ve according to whether a < b, a == b, or a > b
    respectively.  */
@@ -66,12 +66,12 @@ GPRAPI gpr_timespec gpr_time_sub(gpr_timespec a, gpr_timespec b);
 
 /** Return a timespec representing a given number of time units. INT64_MIN is
    interpreted as gpr_inf_past, and INT64_MAX as gpr_inf_future.  */
-GPRAPI gpr_timespec gpr_time_from_micros(int64_t x, gpr_clock_type clock_type);
-GPRAPI gpr_timespec gpr_time_from_nanos(int64_t x, gpr_clock_type clock_type);
-GPRAPI gpr_timespec gpr_time_from_millis(int64_t x, gpr_clock_type clock_type);
-GPRAPI gpr_timespec gpr_time_from_seconds(int64_t x, gpr_clock_type clock_type);
-GPRAPI gpr_timespec gpr_time_from_minutes(int64_t x, gpr_clock_type clock_type);
-GPRAPI gpr_timespec gpr_time_from_hours(int64_t x, gpr_clock_type clock_type);
+GPRAPI gpr_timespec gpr_time_from_micros(int64_t us, gpr_clock_type clock_type);
+GPRAPI gpr_timespec gpr_time_from_nanos(int64_t ns, gpr_clock_type clock_type);
+GPRAPI gpr_timespec gpr_time_from_millis(int64_t ms, gpr_clock_type clock_type);
+GPRAPI gpr_timespec gpr_time_from_seconds(int64_t s, gpr_clock_type clock_type);
+GPRAPI gpr_timespec gpr_time_from_minutes(int64_t m, gpr_clock_type clock_type);
+GPRAPI gpr_timespec gpr_time_from_hours(int64_t h, gpr_clock_type clock_type);
 
 GPRAPI int32_t gpr_time_to_millis(gpr_timespec timespec);
 

--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -133,7 +133,7 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
  protected:
   /// Register a service. This call does not take ownership of the service.
   /// The service must exist for the lifetime of the Server instance.
-  bool RegisterService(const std::string* host, Service* service) override;
+  bool RegisterService(const std::string* addr, Service* service) override;
 
   /// Try binding the server to the given \a addr endpoint
   /// (port, and optionally including IP address to bind to).

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -173,7 +173,7 @@ class ServerBuilder {
   /// The service must exist for the lifetime of the \a Server instance
   /// returned by \a BuildAndStart(). Only matches requests with :authority \a
   /// host
-  ServerBuilder& RegisterService(const std::string& host,
+  ServerBuilder& RegisterService(const std::string& addr,
                                  grpc::Service* service);
 
   /// Register a generic service.

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -173,7 +173,7 @@ class ServerBuilder {
   /// The service must exist for the lifetime of the \a Server instance
   /// returned by \a BuildAndStart(). Only matches requests with :authority \a
   /// host
-  ServerBuilder& RegisterService(const std::string& addr,
+  ServerBuilder& RegisterService(const std::string& host,
                                  grpc::Service* service);
 
   /// Register a generic service.

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -4219,17 +4219,17 @@ int grpc_client_channel_num_external_connectivity_watchers(
 
 void grpc_client_channel_watch_connectivity_state(
     grpc_channel_element* elem, grpc_polling_entity pollent,
-    grpc_connectivity_state* state, grpc_closure* closure,
+    grpc_connectivity_state* state, grpc_closure* on_complete,
     grpc_closure* watcher_timer_init) {
   auto* chand = static_cast<ChannelData*>(elem->channel_data);
   if (state == nullptr) {
     // Handle cancellation.
     GPR_ASSERT(watcher_timer_init == nullptr);
-    chand->RemoveExternalConnectivityWatcher(closure, /*cancel=*/true);
+    chand->RemoveExternalConnectivityWatcher(on_complete, /*cancel=*/true);
     return;
   }
   // Handle addition.
-  return chand->AddExternalConnectivityWatcher(pollent, state, closure,
+  return chand->AddExternalConnectivityWatcher(pollent, state, on_complete,
                                                watcher_timer_init);
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
@@ -155,13 +155,13 @@ grpc_millis grpc_grpclb_duration_to_millis(
 
 }  // namespace
 
-bool GrpcLbResponseParse(const grpc_slice& encoded_grpc_grpclb_response,
+bool GrpcLbResponseParse(const grpc_slice& serialized_response,
                          upb_arena* arena, GrpcLbResponse* result) {
   grpc_lb_v1_LoadBalanceResponse* response =
       grpc_lb_v1_LoadBalanceResponse_parse(
           reinterpret_cast<const char*>(
-              GRPC_SLICE_START_PTR(encoded_grpc_grpclb_response)),
-          GRPC_SLICE_LENGTH(encoded_grpc_grpclb_response), arena);
+              GRPC_SLICE_START_PTR(serialized_response)),
+          GRPC_SLICE_LENGTH(serialized_response), arena);
   // Handle serverlist responses.
   if (ParseServerList(*response, &result->serverlist)) {
     result->type = result->SERVERLIST;

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h
@@ -66,7 +66,7 @@ grpc_slice GrpcLbLoadReportRequestCreate(
 
 // Deserialize a grpclb response.
 bool GrpcLbResponseParse(const grpc_slice& serialized_response,
-                         upb_arena* arena, GrpcLbResponse* response);
+                         upb_arena* arena, GrpcLbResponse* result);
 
 }  // namespace grpc_core
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
@@ -133,10 +133,10 @@ static void fd_node_shutdown_locked(fd_node* fdn, const char* reason) {
 }
 
 static void on_timeout(void* arg, grpc_error* error);
-static void on_timeout_locked(grpc_ares_ev_driver* arg, grpc_error* error);
+static void on_timeout_locked(grpc_ares_ev_driver* driver, grpc_error* error);
 
 static void on_ares_backup_poll_alarm(void* arg, grpc_error* error);
-static void on_ares_backup_poll_alarm_locked(grpc_ares_ev_driver* arg,
+static void on_ares_backup_poll_alarm_locked(grpc_ares_ev_driver* driver,
                                              grpc_error* error);
 
 static void noop_inject_channel_config(ares_channel /*channel*/) {}

--- a/src/core/ext/filters/client_channel/resolver_registry.cc
+++ b/src/core/ext/filters/client_channel/resolver_registry.cc
@@ -114,10 +114,9 @@ void ResolverRegistry::Builder::ShutdownRegistry() {
   g_state = nullptr;
 }
 
-void ResolverRegistry::Builder::SetDefaultPrefix(
-    const char* default_resolver_prefix) {
+void ResolverRegistry::Builder::SetDefaultPrefix(const char* default_prefix) {
   InitRegistry();
-  g_state->SetDefaultPrefix(default_resolver_prefix);
+  g_state->SetDefaultPrefix(default_prefix);
 }
 
 void ResolverRegistry::Builder::RegisterResolverFactory(

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -126,10 +126,10 @@ static void connectivity_state_set(grpc_chttp2_transport* t,
                                    const absl::Status& status,
                                    const char* reason);
 
-static void benign_reclaimer(void* t, grpc_error* error);
-static void destructive_reclaimer(void* t, grpc_error* error);
-static void benign_reclaimer_locked(void* t, grpc_error* error);
-static void destructive_reclaimer_locked(void* t, grpc_error* error);
+static void benign_reclaimer(void* arg, grpc_error* error);
+static void destructive_reclaimer(void* arg, grpc_error* error);
+static void benign_reclaimer_locked(void* arg, grpc_error* error);
+static void destructive_reclaimer_locked(void* arg, grpc_error* error);
 
 static void post_benign_reclaimer(grpc_chttp2_transport* t);
 static void post_destructive_reclaimer(grpc_chttp2_transport* t);
@@ -146,8 +146,7 @@ static void next_bdp_ping_timer_expired_locked(void* tp, grpc_error* error);
 
 static void cancel_pings(grpc_chttp2_transport* t, grpc_error* error);
 static void send_ping_locked(grpc_chttp2_transport* t,
-                             grpc_closure* on_initiate,
-                             grpc_closure* on_complete);
+                             grpc_closure* on_initiate, grpc_closure* on_ack);
 static void retry_initiate_ping_locked(void* tp, grpc_error* error);
 
 // keepalive-relevant functions

--- a/src/core/ext/transport/chttp2/transport/frame_settings.h
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.h
@@ -43,7 +43,8 @@ struct grpc_chttp2_settings_parser {
   uint32_t incoming_settings[GRPC_CHTTP2_NUM_SETTINGS];
 };
 /* Create a settings frame by diffing old & new, and updating old to be new */
-grpc_slice grpc_chttp2_settings_create(uint32_t* old, const uint32_t* newval,
+grpc_slice grpc_chttp2_settings_create(uint32_t* old_settings,
+                                       const uint32_t* new_settings,
                                        uint32_t force_mask, size_t count);
 /* Create an ack settings frame */
 grpc_slice grpc_chttp2_settings_ack_create(void);

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -28,13 +28,13 @@
 #include <grpc/support/log.h>
 
 grpc_slice grpc_chttp2_window_update_create(
-    uint32_t id, uint32_t window_update, grpc_transport_one_way_stats* stats) {
+    uint32_t id, uint32_t window_delta, grpc_transport_one_way_stats* stats) {
   static const size_t frame_size = 13;
   grpc_slice slice = GRPC_SLICE_MALLOC(frame_size);
   stats->header_bytes += frame_size;
   uint8_t* p = GRPC_SLICE_START_PTR(slice);
 
-  GPR_ASSERT(window_update);
+  GPR_ASSERT(window_delta);
 
   *p++ = 0;
   *p++ = 0;
@@ -45,10 +45,10 @@ grpc_slice grpc_chttp2_window_update_create(
   *p++ = static_cast<uint8_t>(id >> 16);
   *p++ = static_cast<uint8_t>(id >> 8);
   *p++ = static_cast<uint8_t>(id);
-  *p++ = static_cast<uint8_t>(window_update >> 24);
-  *p++ = static_cast<uint8_t>(window_update >> 16);
-  *p++ = static_cast<uint8_t>(window_update >> 8);
-  *p++ = static_cast<uint8_t>(window_update);
+  *p++ = static_cast<uint8_t>(window_delta >> 24);
+  *p++ = static_cast<uint8_t>(window_delta >> 16);
+  *p++ = static_cast<uint8_t>(window_delta >> 8);
+  *p++ = static_cast<uint8_t>(window_delta);
 
   return slice;
 }

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -178,21 +178,21 @@ static int cmp_key_stable(const void* ap, const void* bp) {
   return c;
 }
 
-grpc_channel_args* grpc_channel_args_normalize(const grpc_channel_args* a) {
+grpc_channel_args* grpc_channel_args_normalize(const grpc_channel_args* src) {
   grpc_arg** args =
-      static_cast<grpc_arg**>(gpr_malloc(sizeof(grpc_arg*) * a->num_args));
-  for (size_t i = 0; i < a->num_args; i++) {
-    args[i] = &a->args[i];
+      static_cast<grpc_arg**>(gpr_malloc(sizeof(grpc_arg*) * src->num_args));
+  for (size_t i = 0; i < src->num_args; i++) {
+    args[i] = &src->args[i];
   }
-  if (a->num_args > 1) {
-    qsort(args, a->num_args, sizeof(grpc_arg*), cmp_key_stable);
+  if (src->num_args > 1) {
+    qsort(args, src->num_args, sizeof(grpc_arg*), cmp_key_stable);
   }
 
   grpc_channel_args* b =
       static_cast<grpc_channel_args*>(gpr_malloc(sizeof(grpc_channel_args)));
-  b->num_args = a->num_args;
+  b->num_args = src->num_args;
   b->args = static_cast<grpc_arg*>(gpr_malloc(sizeof(grpc_arg) * b->num_args));
-  for (size_t i = 0; i < a->num_args; i++) {
+  for (size_t i = 0; i < src->num_args; i++) {
     b->args[i] = copy_arg(args[i]);
   }
 

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -33,6 +33,7 @@
 grpc_channel_args* grpc_channel_args_copy(const grpc_channel_args* src);
 
 /** Copy the arguments in \a src into a new instance, stably sorting keys */
+
 grpc_channel_args* grpc_channel_args_normalize(const grpc_channel_args* src);
 
 /** Copy the arguments in \a src and append \a to_add. If \a to_add is NULL, it

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -33,7 +33,6 @@
 grpc_channel_args* grpc_channel_args_copy(const grpc_channel_args* src);
 
 /** Copy the arguments in \a src into a new instance, stably sorting keys */
-
 grpc_channel_args* grpc_channel_args_normalize(const grpc_channel_args* src);
 
 /** Copy the arguments in \a src and append \a to_add. If \a to_add is NULL, it

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -114,21 +114,21 @@ void CallCountingHelper::CollectData(CounterData* out) {
   }
 }
 
-void CallCountingHelper::PopulateCallCounts(Json::Object* object) {
+void CallCountingHelper::PopulateCallCounts(Json::Object* json) {
   CounterData data;
   CollectData(&data);
   if (data.calls_started != 0) {
-    (*object)["callsStarted"] = std::to_string(data.calls_started);
+    (*json)["callsStarted"] = std::to_string(data.calls_started);
     gpr_timespec ts = gpr_convert_clock_type(
         gpr_cycle_counter_to_time(data.last_call_started_cycle),
         GPR_CLOCK_REALTIME);
-    (*object)["lastCallStartedTimestamp"] = gpr_format_timespec(ts);
+    (*json)["lastCallStartedTimestamp"] = gpr_format_timespec(ts);
   }
   if (data.calls_succeeded != 0) {
-    (*object)["callsSucceeded"] = std::to_string(data.calls_succeeded);
+    (*json)["callsSucceeded"] = std::to_string(data.calls_succeeded);
   }
   if (data.calls_failed) {
-    (*object)["callsFailed"] = std::to_string(data.calls_failed);
+    (*json)["callsFailed"] = std::to_string(data.calls_failed);
   }
 }
 

--- a/src/core/lib/debug/stats.h
+++ b/src/core/lib/debug/stats.h
@@ -61,10 +61,10 @@ void grpc_stats_diff(const grpc_stats_data* b, const grpc_stats_data* a,
 std::string grpc_stats_data_as_json(const grpc_stats_data* data);
 int grpc_stats_histo_find_bucket_slow(int value, const int* table,
                                       int table_size);
-double grpc_stats_histo_percentile(const grpc_stats_data* data,
+double grpc_stats_histo_percentile(const grpc_stats_data* stats,
                                    grpc_stats_histograms histogram,
                                    double percentile);
-size_t grpc_stats_histo_count(const grpc_stats_data* data,
+size_t grpc_stats_histo_count(const grpc_stats_data* stats,
                               grpc_stats_histograms histogram);
 
 #endif

--- a/src/core/lib/debug/stats_data.h
+++ b/src/core/lib/debug/stats_data.h
@@ -397,43 +397,43 @@ typedef enum {
   GRPC_STATS_INC_COUNTER(GRPC_STATS_COUNTER_CQ_EV_QUEUE_TRANSIENT_POP_FAILURES)
 #define GRPC_STATS_INC_CALL_INITIAL_SIZE(value) \
   grpc_stats_inc_call_initial_size((int)(value))
-void grpc_stats_inc_call_initial_size(int x);
+void grpc_stats_inc_call_initial_size(int value);
 #define GRPC_STATS_INC_POLL_EVENTS_RETURNED(value) \
   grpc_stats_inc_poll_events_returned((int)(value))
-void grpc_stats_inc_poll_events_returned(int x);
+void grpc_stats_inc_poll_events_returned(int value);
 #define GRPC_STATS_INC_TCP_WRITE_SIZE(value) \
   grpc_stats_inc_tcp_write_size((int)(value))
-void grpc_stats_inc_tcp_write_size(int x);
+void grpc_stats_inc_tcp_write_size(int value);
 #define GRPC_STATS_INC_TCP_WRITE_IOV_SIZE(value) \
   grpc_stats_inc_tcp_write_iov_size((int)(value))
-void grpc_stats_inc_tcp_write_iov_size(int x);
+void grpc_stats_inc_tcp_write_iov_size(int value);
 #define GRPC_STATS_INC_TCP_READ_SIZE(value) \
   grpc_stats_inc_tcp_read_size((int)(value))
-void grpc_stats_inc_tcp_read_size(int x);
+void grpc_stats_inc_tcp_read_size(int value);
 #define GRPC_STATS_INC_TCP_READ_OFFER(value) \
   grpc_stats_inc_tcp_read_offer((int)(value))
-void grpc_stats_inc_tcp_read_offer(int x);
+void grpc_stats_inc_tcp_read_offer(int value);
 #define GRPC_STATS_INC_TCP_READ_OFFER_IOV_SIZE(value) \
   grpc_stats_inc_tcp_read_offer_iov_size((int)(value))
-void grpc_stats_inc_tcp_read_offer_iov_size(int x);
+void grpc_stats_inc_tcp_read_offer_iov_size(int value);
 #define GRPC_STATS_INC_HTTP2_SEND_MESSAGE_SIZE(value) \
   grpc_stats_inc_http2_send_message_size((int)(value))
-void grpc_stats_inc_http2_send_message_size(int x);
+void grpc_stats_inc_http2_send_message_size(int value);
 #define GRPC_STATS_INC_HTTP2_SEND_INITIAL_METADATA_PER_WRITE(value) \
   grpc_stats_inc_http2_send_initial_metadata_per_write((int)(value))
-void grpc_stats_inc_http2_send_initial_metadata_per_write(int x);
+void grpc_stats_inc_http2_send_initial_metadata_per_write(int value);
 #define GRPC_STATS_INC_HTTP2_SEND_MESSAGE_PER_WRITE(value) \
   grpc_stats_inc_http2_send_message_per_write((int)(value))
-void grpc_stats_inc_http2_send_message_per_write(int x);
+void grpc_stats_inc_http2_send_message_per_write(int value);
 #define GRPC_STATS_INC_HTTP2_SEND_TRAILING_METADATA_PER_WRITE(value) \
   grpc_stats_inc_http2_send_trailing_metadata_per_write((int)(value))
-void grpc_stats_inc_http2_send_trailing_metadata_per_write(int x);
+void grpc_stats_inc_http2_send_trailing_metadata_per_write(int value);
 #define GRPC_STATS_INC_HTTP2_SEND_FLOWCTL_PER_WRITE(value) \
   grpc_stats_inc_http2_send_flowctl_per_write((int)(value))
-void grpc_stats_inc_http2_send_flowctl_per_write(int x);
+void grpc_stats_inc_http2_send_flowctl_per_write(int value);
 #define GRPC_STATS_INC_SERVER_CQS_CHECKED(value) \
   grpc_stats_inc_server_cqs_checked((int)(value))
-void grpc_stats_inc_server_cqs_checked(int x);
+void grpc_stats_inc_server_cqs_checked(int value);
 #else
 #define GRPC_STATS_INC_CLIENT_CALLS_CREATED()
 #define GRPC_STATS_INC_SERVER_CALLS_CREATED()

--- a/src/core/lib/gpr/string.cc
+++ b/src/core/lib/gpr/string.cc
@@ -172,45 +172,45 @@ void gpr_reverse_bytes(char* str, int len) {
   }
 }
 
-int gpr_ltoa(long value, char* string) {
+int gpr_ltoa(long value, char* output) {
   long sign;
   int i = 0;
 
   if (value == 0) {
-    string[0] = '0';
-    string[1] = 0;
+    output[0] = '0';
+    output[1] = 0;
     return 1;
   }
 
   sign = value < 0 ? -1 : 1;
   while (value) {
-    string[i++] = static_cast<char>('0' + sign * (value % 10));
+    output[i++] = static_cast<char>('0' + sign * (value % 10));
     value /= 10;
   }
-  if (sign < 0) string[i++] = '-';
-  gpr_reverse_bytes(string, i);
-  string[i] = 0;
+  if (sign < 0) output[i++] = '-';
+  gpr_reverse_bytes(output, i);
+  output[i] = 0;
   return i;
 }
 
-int int64_ttoa(int64_t value, char* string) {
+int int64_ttoa(int64_t value, char* output) {
   int64_t sign;
   int i = 0;
 
   if (value == 0) {
-    string[0] = '0';
-    string[1] = 0;
+    output[0] = '0';
+    output[1] = 0;
     return 1;
   }
 
   sign = value < 0 ? -1 : 1;
   while (value) {
-    string[i++] = static_cast<char>('0' + sign * (value % 10));
+    output[i++] = static_cast<char>('0' + sign * (value % 10));
     value /= 10;
   }
-  if (sign < 0) string[i++] = '-';
-  gpr_reverse_bytes(string, i);
-  string[i] = 0;
+  if (sign < 0) output[i++] = '-';
+  gpr_reverse_bytes(output, i);
+  output[i] = 0;
   return i;
 }
 
@@ -321,19 +321,19 @@ void* gpr_memrchr(const void* s, int c, size_t n) {
   return nullptr;
 }
 
-bool gpr_parse_bool_value(const char* s, bool* dst) {
+bool gpr_parse_bool_value(const char* value, bool* dst) {
   const char* kTrue[] = {"1", "t", "true", "y", "yes"};
   const char* kFalse[] = {"0", "f", "false", "n", "no"};
   static_assert(sizeof(kTrue) == sizeof(kFalse), "true_false_equal");
 
-  if (s == nullptr) {
+  if (value == nullptr) {
     return false;
   }
   for (size_t i = 0; i < GPR_ARRAY_SIZE(kTrue); ++i) {
-    if (gpr_stricmp(s, kTrue[i]) == 0) {
+    if (gpr_stricmp(value, kTrue[i]) == 0) {
       *dst = true;
       return true;
-    } else if (gpr_stricmp(s, kFalse[i]) == 0) {
+    } else if (gpr_stricmp(value, kFalse[i]) == 0) {
       *dst = false;
       return true;
     }

--- a/src/core/lib/gpr/string.h
+++ b/src/core/lib/gpr/string.h
@@ -45,8 +45,7 @@ char* gpr_dump_return_len(const char* buf, size_t len, uint32_t flags,
 
 /* Parses an array of bytes into an integer (base 10). Returns 1 on success,
    0 on failure. */
-int gpr_parse_bytes_to_uint32(const char* data, size_t length,
-                              uint32_t* result);
+int gpr_parse_bytes_to_uint32(const char* buf, size_t len, uint32_t* result);
 
 /* Minimum buffer size for calling ltoa */
 #define GPR_LTOA_MIN_BUFSIZE (3 * sizeof(long))
@@ -77,15 +76,15 @@ void gpr_reverse_bytes(char* str, int len);
 char* gpr_leftpad(const char* str, char flag, size_t length);
 
 /* Join a set of strings, returning the resulting string.
-   Total combined length (excluding null terminator) is returned in total_length
+   Total combined length (excluding null terminator) is returned in final_length
    if it is non-null. */
-char* gpr_strjoin(const char** strs, size_t nstrs, size_t* total_length);
+char* gpr_strjoin(const char** strs, size_t nstrs, size_t* final_length);
 
 /* Join a set of strings using a separator, returning the resulting string.
-   Total combined length (excluding null terminator) is returned in total_length
+   Total combined length (excluding null terminator) is returned in final_length
    if it is non-null. */
 char* gpr_strjoin_sep(const char** strs, size_t nstrs, const char* sep,
-                      size_t* total_length);
+                      size_t* final_length);
 
 void gpr_string_split(const char* input, const char* sep, char*** strs,
                       size_t* nstrs);

--- a/src/core/lib/gpr/time.cc
+++ b/src/core/lib/gpr/time.cc
@@ -107,28 +107,28 @@ static gpr_timespec to_seconds_from_above_second_time(int64_t time_in_units,
   return out;
 }
 
-gpr_timespec gpr_time_from_nanos(int64_t ns, gpr_clock_type type) {
-  return to_seconds_from_sub_second_time(ns, GPR_NS_PER_SEC, type);
+gpr_timespec gpr_time_from_nanos(int64_t ns, gpr_clock_type clock_type) {
+  return to_seconds_from_sub_second_time(ns, GPR_NS_PER_SEC, clock_type);
 }
 
-gpr_timespec gpr_time_from_micros(int64_t us, gpr_clock_type type) {
-  return to_seconds_from_sub_second_time(us, GPR_US_PER_SEC, type);
+gpr_timespec gpr_time_from_micros(int64_t us, gpr_clock_type clock_type) {
+  return to_seconds_from_sub_second_time(us, GPR_US_PER_SEC, clock_type);
 }
 
-gpr_timespec gpr_time_from_millis(int64_t ms, gpr_clock_type type) {
-  return to_seconds_from_sub_second_time(ms, GPR_MS_PER_SEC, type);
+gpr_timespec gpr_time_from_millis(int64_t ms, gpr_clock_type clock_type) {
+  return to_seconds_from_sub_second_time(ms, GPR_MS_PER_SEC, clock_type);
 }
 
-gpr_timespec gpr_time_from_seconds(int64_t s, gpr_clock_type type) {
-  return to_seconds_from_sub_second_time(s, 1, type);
+gpr_timespec gpr_time_from_seconds(int64_t s, gpr_clock_type clock_type) {
+  return to_seconds_from_sub_second_time(s, 1, clock_type);
 }
 
-gpr_timespec gpr_time_from_minutes(int64_t m, gpr_clock_type type) {
-  return to_seconds_from_above_second_time(m, 60, type);
+gpr_timespec gpr_time_from_minutes(int64_t m, gpr_clock_type clock_type) {
+  return to_seconds_from_above_second_time(m, 60, clock_type);
 }
 
-gpr_timespec gpr_time_from_hours(int64_t h, gpr_clock_type type) {
-  return to_seconds_from_above_second_time(h, 3600, type);
+gpr_timespec gpr_time_from_hours(int64_t h, gpr_clock_type clock_type) {
+  return to_seconds_from_above_second_time(h, 3600, clock_type);
 }
 
 gpr_timespec gpr_time_add(gpr_timespec a, gpr_timespec b) {

--- a/src/core/lib/http/httpcli.h
+++ b/src/core/lib/http/httpcli.h
@@ -83,8 +83,7 @@ void grpc_httpcli_get(grpc_httpcli_context* context,
                       grpc_polling_entity* pollent,
                       grpc_resource_quota* resource_quota,
                       const grpc_httpcli_request* request, grpc_millis deadline,
-                      grpc_closure* on_complete,
-                      grpc_httpcli_response* response);
+                      grpc_closure* on_done, grpc_httpcli_response* response);
 
 /* Asynchronously perform a HTTP POST.
    'context' specifies the http context under which to do the post
@@ -105,7 +104,7 @@ void grpc_httpcli_post(grpc_httpcli_context* context,
                        grpc_resource_quota* resource_quota,
                        const grpc_httpcli_request* request,
                        const char* body_bytes, size_t body_size,
-                       grpc_millis deadline, grpc_closure* on_complete,
+                       grpc_millis deadline, grpc_closure* on_done,
                        grpc_httpcli_response* response);
 
 /* override functions return 1 if they handled the request, 0 otherwise */

--- a/src/core/lib/iomgr/endpoint.h
+++ b/src/core/lib/iomgr/endpoint.h
@@ -99,7 +99,7 @@ void grpc_endpoint_add_to_pollset_set(grpc_endpoint* ep,
 void grpc_endpoint_delete_from_pollset_set(grpc_endpoint* ep,
                                            grpc_pollset_set* pollset_set);
 
-grpc_resource_user* grpc_endpoint_get_resource_user(grpc_endpoint* endpoint);
+grpc_resource_user* grpc_endpoint_get_resource_user(grpc_endpoint* ep);
 
 bool grpc_endpoint_can_track_err(grpc_endpoint* ep);
 

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -148,12 +148,12 @@ static gpr_mu fork_fd_list_mu;
    MUST NOT be called with a pollset lock taken */
 static uint32_t fd_begin_poll(grpc_fd* fd, grpc_pollset* pollset,
                               grpc_pollset_worker* worker, uint32_t read_mask,
-                              uint32_t write_mask, grpc_fd_watcher* rec);
+                              uint32_t write_mask, grpc_fd_watcher* watcher);
 /* Complete polling previously started with fd_begin_poll
    MUST NOT be called with a pollset lock taken
    if got_read or got_write are 1, also does the become_{readable,writable} as
    appropriate. */
-static void fd_end_poll(grpc_fd_watcher* rec, int got_read, int got_write);
+static void fd_end_poll(grpc_fd_watcher* watcher, int got_read, int got_write);
 
 /* Return 1 if this fd is orphaned, 0 otherwise */
 static bool fd_is_orphaned(grpc_fd* fd);

--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -58,8 +58,8 @@ typedef struct grpc_combiner grpc_combiner;
 #define GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD 1
 
 gpr_timespec grpc_millis_to_timespec(grpc_millis millis, gpr_clock_type clock);
-grpc_millis grpc_timespec_to_millis_round_down(gpr_timespec timespec);
-grpc_millis grpc_timespec_to_millis_round_up(gpr_timespec timespec);
+grpc_millis grpc_timespec_to_millis_round_down(gpr_timespec ts);
+grpc_millis grpc_timespec_to_millis_round_up(gpr_timespec ts);
 grpc_millis grpc_cycle_counter_to_millis_round_down(gpr_cycle_counter cycles);
 grpc_millis grpc_cycle_counter_to_millis_round_up(gpr_cycle_counter cycles);
 

--- a/src/core/lib/iomgr/load_file.h
+++ b/src/core/lib/iomgr/load_file.h
@@ -27,7 +27,7 @@
 
 #include "src/core/lib/iomgr/error.h"
 
-/* Loads the content of a file into an output. add_null_terminator will add
+/* Loads the content of a file into a slice. add_null_terminator will add
    a NULL terminator if non-zero. */
 grpc_error* grpc_load_file(const char* filename, int add_null_terminator,
                            grpc_slice* output);

--- a/src/core/lib/iomgr/load_file.h
+++ b/src/core/lib/iomgr/load_file.h
@@ -27,9 +27,9 @@
 
 #include "src/core/lib/iomgr/error.h"
 
-/* Loads the content of a file into a slice. add_null_terminator will add
+/* Loads the content of a file into an output. add_null_terminator will add
    a NULL terminator if non-zero. */
 grpc_error* grpc_load_file(const char* filename, int add_null_terminator,
-                           grpc_slice* slice);
+                           grpc_slice* output);
 
 #endif /* GRPC_CORE_LIB_IOMGR_LOAD_FILE_H */

--- a/src/core/lib/iomgr/lockfree_event.h
+++ b/src/core/lib/iomgr/lockfree_event.h
@@ -55,8 +55,8 @@ class LockfreeEvent {
   void NotifyOn(grpc_closure* closure);
 
   // Sets the shutdown state. If a closure had been provided by NotifyOn and has
-  // not yet been scheduled, it will be scheduled with \a error.
-  bool SetShutdown(grpc_error* error);
+  // not yet been scheduled, it will be scheduled with \a shutdown_error.
+  bool SetShutdown(grpc_error* shutdown_error);
 
   // Signals that the event has been received.
   void SetReady();

--- a/src/core/lib/iomgr/resolve_address.cc
+++ b/src/core/lib/iomgr/resolve_address.cc
@@ -35,11 +35,11 @@ void grpc_resolve_address(const char* addr, const char* default_port,
       addr, default_port, interested_parties, on_done, addresses);
 }
 
-void grpc_resolved_addresses_destroy(grpc_resolved_addresses* addrs) {
-  if (addrs != nullptr) {
-    gpr_free(addrs->addrs);
+void grpc_resolved_addresses_destroy(grpc_resolved_addresses* addresses) {
+  if (addresses != nullptr) {
+    gpr_free(addresses->addrs);
   }
-  gpr_free(addrs);
+  gpr_free(addresses);
 }
 
 grpc_error* grpc_blocking_resolve_address(const char* name,

--- a/src/core/lib/iomgr/tcp_client.cc
+++ b/src/core/lib/iomgr/tcp_client.cc
@@ -22,13 +22,13 @@
 
 grpc_tcp_client_vtable* grpc_tcp_client_impl;
 
-void grpc_tcp_client_connect(grpc_closure* closure, grpc_endpoint** ep,
+void grpc_tcp_client_connect(grpc_closure* on_connect, grpc_endpoint** endpoint,
                              grpc_pollset_set* interested_parties,
                              const grpc_channel_args* channel_args,
                              const grpc_resolved_address* addr,
                              grpc_millis deadline) {
-  grpc_tcp_client_impl->connect(closure, ep, interested_parties, channel_args,
-                                addr, deadline);
+  grpc_tcp_client_impl->connect(on_connect, endpoint, interested_parties,
+                                channel_args, addr, deadline);
 }
 
 void grpc_set_tcp_client_impl(grpc_tcp_client_vtable* impl) {

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -163,12 +163,12 @@ static void custom_close_callback(grpc_custom_socket* socket) {
   }
 }
 
-void grpc_custom_close_server_callback(grpc_tcp_listener* sp) {
-  if (sp) {
+void grpc_custom_close_server_callback(grpc_tcp_listener* listener) {
+  if (listener) {
     grpc_core::ExecCtx exec_ctx;
-    sp->server->open_ports--;
-    if (sp->server->open_ports == 0 && sp->server->shutdown) {
-      finish_shutdown(sp->server);
+    listener->server->open_ports--;
+    if (listener->server->open_ports == 0 && listener->server->shutdown) {
+      finish_shutdown(listener->server);
     }
   }
 }

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -342,8 +342,8 @@ void grpc_timer_manager_shutdown(void) {
   gpr_cv_destroy(&g_cv_shutdown);
 }
 
-void grpc_timer_manager_set_threading(bool threaded) {
-  if (threaded) {
+void grpc_timer_manager_set_threading(bool enabled) {
+  if (enabled) {
     start_threads();
   } else {
     stop_threads();

--- a/src/core/lib/iomgr/unix_sockets_posix.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix.cc
@@ -42,24 +42,24 @@ void grpc_create_socketpair_if_unix(int sv[2]) {
   GPR_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
 }
 
-grpc_error* grpc_resolve_unix_domain_address(const char* name,
-                                             grpc_resolved_addresses** addrs) {
-  *addrs = static_cast<grpc_resolved_addresses*>(
+grpc_error* grpc_resolve_unix_domain_address(
+    const char* name, grpc_resolved_addresses** addresses) {
+  *addresses = static_cast<grpc_resolved_addresses*>(
       gpr_malloc(sizeof(grpc_resolved_addresses)));
-  (*addrs)->naddrs = 1;
-  (*addrs)->addrs = static_cast<grpc_resolved_address*>(
+  (*addresses)->naddrs = 1;
+  (*addresses)->addrs = static_cast<grpc_resolved_address*>(
       gpr_malloc(sizeof(grpc_resolved_address)));
-  return grpc_core::UnixSockaddrPopulate(name, (*addrs)->addrs);
+  return grpc_core::UnixSockaddrPopulate(name, (*addresses)->addrs);
 }
 
 grpc_error* grpc_resolve_unix_abstract_domain_address(
-    const absl::string_view name, grpc_resolved_addresses** addrs) {
-  *addrs = static_cast<grpc_resolved_addresses*>(
+    const absl::string_view name, grpc_resolved_addresses** addresses) {
+  *addresses = static_cast<grpc_resolved_addresses*>(
       gpr_malloc(sizeof(grpc_resolved_addresses)));
-  (*addrs)->naddrs = 1;
-  (*addrs)->addrs = static_cast<grpc_resolved_address*>(
+  (*addresses)->naddrs = 1;
+  (*addresses)->addrs = static_cast<grpc_resolved_address*>(
       gpr_malloc(sizeof(grpc_resolved_address)));
-  return grpc_core::UnixAbstractSockaddrPopulate(name, (*addrs)->addrs);
+  return grpc_core::UnixAbstractSockaddrPopulate(name, (*addresses)->addrs);
 }
 
 int grpc_is_unix_socket(const grpc_resolved_address* resolved_addr) {

--- a/src/core/lib/security/context/security_context.cc
+++ b/src/core/lib/security/context/security_context.cc
@@ -294,8 +294,8 @@ static const grpc_arg_pointer_vtable auth_context_pointer_vtable = {
     auth_context_pointer_arg_copy, auth_context_pointer_arg_destroy,
     auth_context_pointer_cmp};
 
-grpc_arg grpc_auth_context_to_arg(grpc_auth_context* p) {
-  return grpc_channel_arg_pointer_create((char*)GRPC_AUTH_CONTEXT_ARG, p,
+grpc_arg grpc_auth_context_to_arg(grpc_auth_context* c) {
+  return grpc_channel_arg_pointer_create((char*)GRPC_AUTH_CONTEXT_ARG, c,
                                          &auth_context_pointer_vtable);
 }
 

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -134,8 +134,8 @@ static const grpc_arg_pointer_vtable cred_ptr_vtable = {
     server_credentials_pointer_arg_copy, server_credentials_pointer_arg_destroy,
     server_credentials_pointer_cmp};
 
-grpc_arg grpc_server_credentials_to_arg(grpc_server_credentials* p) {
-  return grpc_channel_arg_pointer_create((char*)GRPC_SERVER_CREDENTIALS_ARG, p,
+grpc_arg grpc_server_credentials_to_arg(grpc_server_credentials* c) {
+  return grpc_channel_arg_pointer_create((char*)GRPC_SERVER_CREDENTIALS_ARG, c,
                                          &cred_ptr_vtable);
 }
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -109,8 +109,8 @@ class FileWatcherCertificateProvider final
       const std::string& root_cert_full_path);
   // Read the root certificates from files and update the distributor.
   absl::optional<PemKeyCertPairList> ReadIdentityKeyCertPairFromFiles(
-      const std::string& private_key_file_name,
-      const std::string& identity_certificate_file_name);
+      const std::string& private_key_path,
+      const std::string& identity_certificate_path);
 
   // Information that is used by the refreshing thread.
   std::string private_key_path_;

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -68,12 +68,12 @@ tsi_ssl_pem_key_cert_pair* ConvertToTsiPemKeyCertPair(
 // -------------------channel security connector-------------------
 grpc_core::RefCountedPtr<grpc_channel_security_connector>
 TlsChannelSecurityConnector::CreateTlsChannelSecurityConnector(
-    grpc_core::RefCountedPtr<grpc_channel_credentials> ch_creds,
+    grpc_core::RefCountedPtr<grpc_channel_credentials> channel_creds,
     grpc_core::RefCountedPtr<grpc_tls_credentials_options> options,
     grpc_core::RefCountedPtr<grpc_call_credentials> request_metadata_creds,
     const char* target_name, const char* overridden_target_name,
     tsi_ssl_session_cache* ssl_session_cache) {
-  if (ch_creds == nullptr) {
+  if (channel_creds == nullptr) {
     gpr_log(GPR_ERROR,
             "channel_creds is nullptr in "
             "TlsChannelSecurityConnectorCreate()");
@@ -93,19 +93,20 @@ TlsChannelSecurityConnector::CreateTlsChannelSecurityConnector(
   }
   grpc_core::RefCountedPtr<TlsChannelSecurityConnector> c =
       grpc_core::MakeRefCounted<TlsChannelSecurityConnector>(
-          std::move(ch_creds), std::move(options),
+          std::move(channel_creds), std::move(options),
           std::move(request_metadata_creds), target_name,
           overridden_target_name, ssl_session_cache);
   return c;
 }
 
 TlsChannelSecurityConnector::TlsChannelSecurityConnector(
-    grpc_core::RefCountedPtr<grpc_channel_credentials> ch_creds,
+    grpc_core::RefCountedPtr<grpc_channel_credentials> channel_creds,
     grpc_core::RefCountedPtr<grpc_tls_credentials_options> options,
     grpc_core::RefCountedPtr<grpc_call_credentials> request_metadata_creds,
     const char* target_name, const char* overridden_target_name,
     tsi_ssl_session_cache* ssl_session_cache)
-    : grpc_channel_security_connector(GRPC_SSL_URL_SCHEME, std::move(ch_creds),
+    : grpc_channel_security_connector(GRPC_SSL_URL_SCHEME,
+                                      std::move(channel_creds),
                                       std::move(request_metadata_creds)),
       options_(std::move(options)),
       overridden_target_name_(

--- a/src/core/lib/security/transport/secure_endpoint.cc
+++ b/src/core/lib/security/transport/secure_endpoint.cc
@@ -443,10 +443,10 @@ static const grpc_endpoint_vtable vtable = {endpoint_read,
 grpc_endpoint* grpc_secure_endpoint_create(
     struct tsi_frame_protector* protector,
     struct tsi_zero_copy_grpc_protector* zero_copy_protector,
-    grpc_endpoint* transport, grpc_slice* leftover_slices,
+    grpc_endpoint* to_wrap, grpc_slice* leftover_slices,
     size_t leftover_nslices) {
   secure_endpoint* ep =
-      new secure_endpoint(&vtable, protector, zero_copy_protector, transport,
+      new secure_endpoint(&vtable, protector, zero_copy_protector, to_wrap,
                           leftover_slices, leftover_nslices);
   return &ep->base;
 }

--- a/src/core/lib/slice/slice_intern.cc
+++ b/src/core/lib/slice/slice_intern.cc
@@ -273,17 +273,16 @@ grpc_core::ManagedMemorySlice::ManagedMemorySlice(const char* string)
     : grpc_core::ManagedMemorySlice::ManagedMemorySlice(string,
                                                         strlen(string)) {}
 
-grpc_core::ManagedMemorySlice::ManagedMemorySlice(const char* string,
-                                                  size_t len) {
+grpc_core::ManagedMemorySlice::ManagedMemorySlice(const char* buf, size_t len) {
   GPR_TIMER_SCOPE("grpc_slice_intern", 0);
-  const uint32_t hash = gpr_murmur_hash3(string, len, g_hash_seed);
+  const uint32_t hash = gpr_murmur_hash3(buf, len, g_hash_seed);
   const StaticMetadataSlice* static_slice =
-      MatchStaticSlice(hash, std::pair<const char*, size_t>(string, len));
+      MatchStaticSlice(hash, std::pair<const char*, size_t>(buf, len));
   if (static_slice) {
     *this = *static_slice;
   } else {
     *this = grpc_core::InternedSlice(FindOrCreateInternedSlice(
-        hash, std::pair<const char*, size_t>(string, len)));
+        hash, std::pair<const char*, size_t>(buf, len)));
   }
 }
 

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -310,7 +310,7 @@ inline bool grpc_slice_static_interned_equal(const grpc_slice& a,
 
 void grpc_slice_intern_init(void);
 void grpc_slice_intern_shutdown(void);
-void grpc_test_only_set_slice_hash_seed(uint32_t key);
+void grpc_test_only_set_slice_hash_seed(uint32_t seed);
 // if slice matches a static slice, returns the static slice
 // otherwise returns the passed in slice (without reffing it)
 // used for surface boundaries where we might receive an un-interned static

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -637,11 +637,10 @@ static void execute_batch_in_call_combiner(void* arg, grpc_error* /*ignored*/) {
 
 // start_batch_closure points to a caller-allocated closure to be used
 // for entering the call combiner.
-static void execute_batch(grpc_call* call,
-                          grpc_transport_stream_op_batch* batch,
+static void execute_batch(grpc_call* call, grpc_transport_stream_op_batch* op,
                           grpc_closure* start_batch_closure) {
-  batch->handler_private.extra_arg = call;
-  GRPC_CLOSURE_INIT(start_batch_closure, execute_batch_in_call_combiner, batch,
+  op->handler_private.extra_arg = call;
+  GRPC_CLOSURE_INIT(start_batch_closure, execute_batch_in_call_combiner, op,
                     grpc_schedule_on_exec_ctx);
   GRPC_CALL_COMBINER_START(&call->call_combiner, start_batch_closure,
                            GRPC_ERROR_NONE, "executing batch");
@@ -655,8 +654,8 @@ char* grpc_call_get_peer(grpc_call* call) {
   return gpr_strdup("unknown");
 }
 
-grpc_call* grpc_call_from_top_element(grpc_call_element* elem) {
-  return CALL_FROM_TOP_ELEM(elem);
+grpc_call* grpc_call_from_top_element(grpc_call_element* surface_element) {
+  return CALL_FROM_TOP_ELEM(surface_element);
 }
 
 /*******************************************************************************

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -284,7 +284,8 @@ grpc_core::TraceFlag grpc_compression_trace(false, "compression");
 #define CALL_FROM_TOP_ELEM(top_elem) \
   CALL_FROM_CALL_STACK(grpc_call_stack_from_top_element(top_elem))
 
-static void execute_batch(grpc_call* call, grpc_transport_stream_op_batch* op,
+static void execute_batch(grpc_call* call,
+                          grpc_transport_stream_op_batch* batch,
                           grpc_closure* start_batch_closure);
 
 static void cancel_with_status(grpc_call* c, grpc_status_code status,
@@ -637,10 +638,11 @@ static void execute_batch_in_call_combiner(void* arg, grpc_error* /*ignored*/) {
 
 // start_batch_closure points to a caller-allocated closure to be used
 // for entering the call combiner.
-static void execute_batch(grpc_call* call, grpc_transport_stream_op_batch* op,
+static void execute_batch(grpc_call* call,
+                          grpc_transport_stream_op_batch* batch,
                           grpc_closure* start_batch_closure) {
-  op->handler_private.extra_arg = call;
-  GRPC_CLOSURE_INIT(start_batch_closure, execute_batch_in_call_combiner, op,
+  batch->handler_private.extra_arg = call;
+  GRPC_CLOSURE_INIT(start_batch_closure, execute_batch_in_call_combiner, batch,
                     grpc_schedule_on_exec_ctx);
   GRPC_CALL_COMBINER_START(&call->call_combiner, start_batch_closure,
                            GRPC_ERROR_NONE, "executing batch");

--- a/src/core/lib/surface/call_details.cc
+++ b/src/core/lib/surface/call_details.cc
@@ -27,15 +27,15 @@
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/api_trace.h"
 
-void grpc_call_details_init(grpc_call_details* cd) {
-  GRPC_API_TRACE("grpc_call_details_init(cd=%p)", 1, (cd));
-  cd->method = grpc_empty_slice();
-  cd->host = grpc_empty_slice();
+void grpc_call_details_init(grpc_call_details* details) {
+  GRPC_API_TRACE("grpc_call_details_init(details=%p)", 1, (details));
+  details->method = grpc_empty_slice();
+  details->host = grpc_empty_slice();
 }
 
-void grpc_call_details_destroy(grpc_call_details* cd) {
-  GRPC_API_TRACE("grpc_call_details_destroy(cd=%p)", 1, (cd));
+void grpc_call_details_destroy(grpc_call_details* details) {
+  GRPC_API_TRACE("grpc_call_details_destroy(details=%p)", 1, (details));
   grpc_core::ExecCtx exec_ctx;
-  grpc_slice_unref_internal(cd->method);
-  grpc_slice_unref_internal(cd->host);
+  grpc_slice_unref_internal(details->method);
+  grpc_slice_unref_internal(details->host);
 }

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -378,14 +378,14 @@ static grpc_call* grpc_channel_create_call_internal(
 grpc_call* grpc_channel_create_call(grpc_channel* channel,
                                     grpc_call* parent_call,
                                     uint32_t propagation_mask,
-                                    grpc_completion_queue* cq,
+                                    grpc_completion_queue* completion_queue,
                                     grpc_slice method, const grpc_slice* host,
                                     gpr_timespec deadline, void* reserved) {
   GPR_ASSERT(!reserved);
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
   grpc_call* call = grpc_channel_create_call_internal(
-      channel, parent_call, propagation_mask, cq, nullptr,
+      channel, parent_call, propagation_mask, completion_queue, nullptr,
       grpc_mdelem_create(GRPC_MDSTR_PATH, method, nullptr),
       host != nullptr ? grpc_mdelem_create(GRPC_MDSTR_AUTHORITY, *host, nullptr)
                       : GRPC_MDNULL,

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -439,7 +439,7 @@ grpc_core::TraceFlag grpc_cq_pluck_trace(false, "queue_pluck");
     }                                                    \
   } while (0)
 
-static void on_pollset_shutdown_done(void* cq, grpc_error* error);
+static void on_pollset_shutdown_done(void* arg, grpc_error* error);
 
 void grpc_cq_global_init() {
   gpr_tls_init(&g_cached_event);

--- a/src/core/lib/surface/completion_queue.h
+++ b/src/core/lib/surface/completion_queue.h
@@ -51,19 +51,19 @@ typedef struct grpc_cq_completion {
 } grpc_cq_completion;
 
 #ifndef NDEBUG
-void grpc_cq_internal_ref(grpc_completion_queue* cc, const char* reason,
+void grpc_cq_internal_ref(grpc_completion_queue* cq, const char* reason,
                           const char* file, int line);
-void grpc_cq_internal_unref(grpc_completion_queue* cc, const char* reason,
+void grpc_cq_internal_unref(grpc_completion_queue* cq, const char* reason,
                             const char* file, int line);
-#define GRPC_CQ_INTERNAL_REF(cc, reason) \
-  grpc_cq_internal_ref(cc, reason, __FILE__, __LINE__)
-#define GRPC_CQ_INTERNAL_UNREF(cc, reason) \
-  grpc_cq_internal_unref(cc, reason, __FILE__, __LINE__)
+#define GRPC_CQ_INTERNAL_REF(cq, reason) \
+  grpc_cq_internal_ref(cq, reason, __FILE__, __LINE__)
+#define GRPC_CQ_INTERNAL_UNREF(cq, reason) \
+  grpc_cq_internal_unref(cq, reason, __FILE__, __LINE__)
 #else
-void grpc_cq_internal_ref(grpc_completion_queue* cc);
-void grpc_cq_internal_unref(grpc_completion_queue* cc);
-#define GRPC_CQ_INTERNAL_REF(cc, reason) grpc_cq_internal_ref(cc)
-#define GRPC_CQ_INTERNAL_UNREF(cc, reason) grpc_cq_internal_unref(cc)
+void grpc_cq_internal_ref(grpc_completion_queue* cq);
+void grpc_cq_internal_unref(grpc_completion_queue* cq);
+#define GRPC_CQ_INTERNAL_REF(cq, reason) grpc_cq_internal_ref(cq)
+#define GRPC_CQ_INTERNAL_UNREF(cq, reason) grpc_cq_internal_unref(cq)
 #endif
 
 /* Initializes global variables used by completion queues */
@@ -73,22 +73,22 @@ void grpc_cq_global_init();
    shutdown until a corrensponding grpc_cq_end_* call is made.
    \a tag is currently used only in debug builds. Return true on success, and
    false if completion_queue has been shutdown. */
-bool grpc_cq_begin_op(grpc_completion_queue* cc, void* tag);
+bool grpc_cq_begin_op(grpc_completion_queue* cq, void* tag);
 
 /* Queue a GRPC_OP_COMPLETED operation; tag must correspond to the tag passed to
    grpc_cq_begin_op */
-void grpc_cq_end_op(grpc_completion_queue* cc, void* tag, grpc_error* error,
+void grpc_cq_end_op(grpc_completion_queue* cq, void* tag, grpc_error* error,
                     void (*done)(void* done_arg, grpc_cq_completion* storage),
                     void* done_arg, grpc_cq_completion* storage,
                     bool internal = false);
 
-grpc_pollset* grpc_cq_pollset(grpc_completion_queue* cc);
+grpc_pollset* grpc_cq_pollset(grpc_completion_queue* cq);
 
-bool grpc_cq_can_listen(grpc_completion_queue* cc);
+bool grpc_cq_can_listen(grpc_completion_queue* cq);
 
-grpc_cq_completion_type grpc_get_cq_completion_type(grpc_completion_queue* cc);
+grpc_cq_completion_type grpc_get_cq_completion_type(grpc_completion_queue* cq);
 
-int grpc_get_cq_poll_num(grpc_completion_queue* cc);
+int grpc_get_cq_poll_num(grpc_completion_queue* cq);
 
 grpc_completion_queue* grpc_completion_queue_create_internal(
     grpc_cq_completion_type completion_type, grpc_cq_polling_type polling_type,

--- a/src/core/lib/transport/error_utils.h
+++ b/src/core/lib/transport/error_utils.h
@@ -36,7 +36,7 @@
 /// NULL.
 void grpc_error_get_status(grpc_error* error, grpc_millis deadline,
                            grpc_status_code* code, grpc_slice* slice,
-                           grpc_http2_error_code* http_status,
+                           grpc_http2_error_code* http_error,
                            const char** error_string);
 
 /// Utility Function to convert a grpc_error * \a error to an absl::Status.

--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -73,7 +73,7 @@ void grpc_metadata_batch_remove(grpc_metadata_batch* batch,
 /** Substitute a new mdelem for an old value */
 grpc_error* grpc_metadata_batch_substitute(grpc_metadata_batch* batch,
                                            grpc_linked_mdelem* storage,
-                                           grpc_mdelem new_value);
+                                           grpc_mdelem new_mdelem);
 
 void grpc_metadata_batch_set_value(grpc_linked_mdelem* storage,
                                    const grpc_slice& value);
@@ -172,10 +172,10 @@ grpc_error* grpc_metadata_batch_filter(
     void* user_data, const char* composite_error_string) GRPC_MUST_USE_RESULT;
 
 #ifndef NDEBUG
-void grpc_metadata_batch_assert_ok(grpc_metadata_batch* comd);
+void grpc_metadata_batch_assert_ok(grpc_metadata_batch* batch);
 #else
-#define grpc_metadata_batch_assert_ok(comd) \
-  do {                                      \
+#define grpc_metadata_batch_assert_ok(batch) \
+  do {                                       \
   } while (0)
 #endif
 

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -177,31 +177,33 @@ grpc_endpoint* grpc_transport_get_endpoint(grpc_transport* transport) {
 // though it lives in lib, it handles transport stream ops sure
 // it's grpc_transport_stream_op_batch_finish_with_failure
 void grpc_transport_stream_op_batch_finish_with_failure(
-    grpc_transport_stream_op_batch* op, grpc_error* error,
+    grpc_transport_stream_op_batch* batch, grpc_error* error,
     grpc_core::CallCombiner* call_combiner) {
-  if (op->send_message) {
-    op->payload->send_message.send_message.reset();
+  if (batch->send_message) {
+    batch->payload->send_message.send_message.reset();
   }
-  if (op->cancel_stream) {
-    GRPC_ERROR_UNREF(op->payload->cancel_stream.cancel_error);
+  if (batch->cancel_stream) {
+    GRPC_ERROR_UNREF(batch->payload->cancel_stream.cancel_error);
   }
   // Construct a list of closures to execute.
   grpc_core::CallCombinerClosureList closures;
-  if (op->recv_initial_metadata) {
-    closures.Add(op->payload->recv_initial_metadata.recv_initial_metadata_ready,
-                 GRPC_ERROR_REF(error), "failing recv_initial_metadata_ready");
+  if (batch->recv_initial_metadata) {
+    closures.Add(
+        batch->payload->recv_initial_metadata.recv_initial_metadata_ready,
+        GRPC_ERROR_REF(error), "failing recv_initial_metadata_ready");
   }
-  if (op->recv_message) {
-    closures.Add(op->payload->recv_message.recv_message_ready,
+  if (batch->recv_message) {
+    closures.Add(batch->payload->recv_message.recv_message_ready,
                  GRPC_ERROR_REF(error), "failing recv_message_ready");
   }
-  if (op->recv_trailing_metadata) {
+  if (batch->recv_trailing_metadata) {
     closures.Add(
-        op->payload->recv_trailing_metadata.recv_trailing_metadata_ready,
+        batch->payload->recv_trailing_metadata.recv_trailing_metadata_ready,
         GRPC_ERROR_REF(error), "failing recv_trailing_metadata_ready");
   }
-  if (op->on_complete != nullptr) {
-    closures.Add(op->on_complete, GRPC_ERROR_REF(error), "failing on_complete");
+  if (batch->on_complete != nullptr) {
+    closures.Add(batch->on_complete, GRPC_ERROR_REF(error),
+                 "failing on_complete");
   }
   // Execute closures.
   closures.RunClosures(call_combiner);
@@ -224,11 +226,11 @@ static void destroy_made_transport_op(void* arg, grpc_error* error) {
   delete op;
 }
 
-grpc_transport_op* grpc_make_transport_op(grpc_closure* on_consumed) {
+grpc_transport_op* grpc_make_transport_op(grpc_closure* on_complete) {
   made_transport_op* op = new made_transport_op();
   GRPC_CLOSURE_INIT(&op->outer_on_complete, destroy_made_transport_op, op,
                     grpc_schedule_on_exec_ctx);
-  op->inner_on_complete = on_consumed;
+  op->inner_on_complete = on_complete;
   op->op.on_consumed = &op->outer_on_complete;
   return &op->op;
 }
@@ -247,13 +249,13 @@ static void destroy_made_transport_stream_op(void* arg, grpc_error* error) {
 }
 
 grpc_transport_stream_op_batch* grpc_make_transport_stream_op(
-    grpc_closure* on_consumed) {
+    grpc_closure* on_complete) {
   made_transport_stream_op* op =
       static_cast<made_transport_stream_op*>(gpr_zalloc(sizeof(*op)));
   op->op.payload = &op->payload;
   GRPC_CLOSURE_INIT(&op->outer_on_complete, destroy_made_transport_stream_op,
                     op, grpc_schedule_on_exec_ctx);
-  op->inner_on_complete = on_consumed;
+  op->inner_on_complete = on_complete;
   op->op.on_complete = &op->outer_on_complete;
   return &op->op;
 }

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -411,7 +411,7 @@ void grpc_transport_destroy_stream(grpc_transport* transport,
                                    grpc_closure* then_schedule_closure);
 
 void grpc_transport_stream_op_batch_finish_with_failure(
-    grpc_transport_stream_op_batch* op, grpc_error* error,
+    grpc_transport_stream_op_batch* batch, grpc_error* error,
     grpc_core::CallCombiner* call_combiner);
 
 std::string grpc_transport_stream_op_batch_string(
@@ -450,14 +450,14 @@ void grpc_transport_destroy(grpc_transport* transport);
 /* Get the endpoint used by \a transport */
 grpc_endpoint* grpc_transport_get_endpoint(grpc_transport* transport);
 
-/* Allocate a grpc_transport_op, and preconfigure the on_consumed closure to
-   \a on_consumed and then delete the returned transport op */
-grpc_transport_op* grpc_make_transport_op(grpc_closure* on_consumed);
-/* Allocate a grpc_transport_stream_op_batch, and preconfigure the on_consumed
+/* Allocate a grpc_transport_op, and preconfigure the on_complete closure to
+   \a on_complete and then delete the returned transport op */
+grpc_transport_op* grpc_make_transport_op(grpc_closure* on_complete);
+/* Allocate a grpc_transport_stream_op_batch, and preconfigure the on_complete
    closure
-   to \a on_consumed and then delete the returned transport op */
+   to \a on_complete and then delete the returned transport op */
 grpc_transport_stream_op_batch* grpc_make_transport_stream_op(
-    grpc_closure* on_consumed);
+    grpc_closure* on_complete);
 
 namespace grpc_core {
 // This is the key to be used for loading/storing keepalive_throttling in the

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -253,8 +253,8 @@ static const tsi_handshaker_result_vtable result_vtable = {
 
 tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
                                              bool is_client,
-                                             tsi_handshaker_result** self) {
-  if (self == nullptr || resp == nullptr) {
+                                             tsi_handshaker_result** result) {
+  if (result == nullptr || resp == nullptr) {
     gpr_log(GPR_ERROR, "Invalid arguments to create_handshaker_result()");
     return TSI_INVALID_ARGUMENT;
   }
@@ -305,19 +305,19 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
       grpc_gcp_Identity_service_account(local_identity);
   // We don't check if local service account is empty here
   // because local identity could be empty in certain situations.
-  alts_tsi_handshaker_result* result =
-      static_cast<alts_tsi_handshaker_result*>(gpr_zalloc(sizeof(*result)));
-  result->key_data =
+  alts_tsi_handshaker_result* sresult =
+      static_cast<alts_tsi_handshaker_result*>(gpr_zalloc(sizeof(*sresult)));
+  sresult->key_data =
       static_cast<char*>(gpr_zalloc(kAltsAes128GcmRekeyKeyLength));
-  memcpy(result->key_data, key_data.data, kAltsAes128GcmRekeyKeyLength);
-  result->peer_identity =
+  memcpy(sresult->key_data, key_data.data, kAltsAes128GcmRekeyKeyLength);
+  sresult->peer_identity =
       static_cast<char*>(gpr_zalloc(peer_service_account.size + 1));
-  memcpy(result->peer_identity, peer_service_account.data,
+  memcpy(sresult->peer_identity, peer_service_account.data,
          peer_service_account.size);
-  result->max_frame_size = grpc_gcp_HandshakerResult_max_frame_size(hresult);
+  sresult->max_frame_size = grpc_gcp_HandshakerResult_max_frame_size(hresult);
   upb::Arena rpc_versions_arena;
   bool serialized = grpc_gcp_rpc_protocol_versions_encode(
-      peer_rpc_version, rpc_versions_arena.ptr(), &result->rpc_versions);
+      peer_rpc_version, rpc_versions_arena.ptr(), &sresult->rpc_versions);
   if (!serialized) {
     gpr_log(GPR_ERROR, "Failed to serialize peer's RPC protocol versions.");
     return TSI_FAILED_PRECONDITION;
@@ -363,11 +363,11 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
     gpr_log(GPR_ERROR, "Failed to serialize peer's ALTS context.");
     return TSI_FAILED_PRECONDITION;
   }
-  result->serialized_context =
+  sresult->serialized_context =
       grpc_slice_from_copied_buffer(serialized_ctx, serialized_ctx_length);
-  result->is_client = is_client;
-  result->base.vtable = &result_vtable;
-  *self = &result->base;
+  sresult->is_client = is_client;
+  sresult->base.vtable = &result_vtable;
+  *result = &sresult->base;
   return TSI_OK;
 }
 
@@ -652,21 +652,21 @@ tsi_result alts_tsi_handshaker_create(
   return TSI_OK;
 }
 
-void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* self,
+void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* result,
                                                  grpc_slice* recv_bytes,
                                                  size_t bytes_consumed) {
-  GPR_ASSERT(recv_bytes != nullptr && self != nullptr);
+  GPR_ASSERT(recv_bytes != nullptr && result != nullptr);
   if (GRPC_SLICE_LENGTH(*recv_bytes) == bytes_consumed) {
     return;
   }
-  alts_tsi_handshaker_result* result =
-      reinterpret_cast<alts_tsi_handshaker_result*>(self);
-  result->unused_bytes_size = GRPC_SLICE_LENGTH(*recv_bytes) - bytes_consumed;
-  result->unused_bytes =
-      static_cast<unsigned char*>(gpr_zalloc(result->unused_bytes_size));
-  memcpy(result->unused_bytes,
+  alts_tsi_handshaker_result* sresult =
+      reinterpret_cast<alts_tsi_handshaker_result*>(result);
+  sresult->unused_bytes_size = GRPC_SLICE_LENGTH(*recv_bytes) - bytes_consumed;
+  sresult->unused_bytes =
+      static_cast<unsigned char*>(gpr_zalloc(sresult->unused_bytes_size));
+  memcpy(sresult->unused_bytes,
          GRPC_SLICE_START_PTR(*recv_bytes) + bytes_consumed,
-         result->unused_bytes_size);
+         sresult->unused_bytes_size);
 }
 
 namespace grpc_core {

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -78,20 +78,20 @@ tsi_result alts_tsi_handshaker_create(
  * - resp: data received from the handshaker service.
  * - is_client: a boolean value indicating if the result belongs to a
  *   client or not.
- * - result: address of ALTS TSI handshaker result instance.
+ * - self: address of ALTS TSI handshaker result instance.
  */
 tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
                                              bool is_client,
-                                             tsi_handshaker_result** result);
+                                             tsi_handshaker_result** self);
 
 /**
  * This method sets unused bytes of ALTS TSI handshaker result instance.
  *
- * - result: an ALTS TSI handshaker result instance.
+ * - self: an ALTS TSI handshaker result instance.
  * - recv_bytes: data received from the handshaker service.
  * - bytes_consumed: size of data consumed by the handshaker service.
  */
-void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* result,
+void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* self,
                                                  grpc_slice* recv_bytes,
                                                  size_t bytes_consumed);
 

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.h
@@ -78,20 +78,20 @@ tsi_result alts_tsi_handshaker_create(
  * - resp: data received from the handshaker service.
  * - is_client: a boolean value indicating if the result belongs to a
  *   client or not.
- * - self: address of ALTS TSI handshaker result instance.
+ * - result: address of ALTS TSI handshaker result instance.
  */
 tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
                                              bool is_client,
-                                             tsi_handshaker_result** self);
+                                             tsi_handshaker_result** result);
 
 /**
  * This method sets unused bytes of ALTS TSI handshaker result instance.
  *
- * - self: an ALTS TSI handshaker result instance.
+ * - result: an ALTS TSI handshaker result instance.
  * - recv_bytes: data received from the handshaker service.
  * - bytes_consumed: size of data consumed by the handshaker service.
  */
-void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* self,
+void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* result,
                                                  grpc_slice* recv_bytes,
                                                  size_t bytes_consumed);
 

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1150,11 +1150,11 @@ static const tsi_frame_protector_vtable frame_protector_vtable = {
 /* --- tsi_server_handshaker_factory methods implementation. --- */
 
 static void tsi_ssl_handshaker_factory_destroy(
-    tsi_ssl_handshaker_factory* self) {
-  if (self == nullptr) return;
+    tsi_ssl_handshaker_factory* factory) {
+  if (factory == nullptr) return;
 
-  if (self->vtable != nullptr && self->vtable->destroy != nullptr) {
-    self->vtable->destroy(self);
+  if (factory->vtable != nullptr && factory->vtable->destroy != nullptr) {
+    factory->vtable->destroy(factory);
   }
   /* Note, we don't free(self) here because this object is always directly
    * embedded in another object. If tsi_ssl_handshaker_factory_init allocates
@@ -1162,17 +1162,18 @@ static void tsi_ssl_handshaker_factory_destroy(
 }
 
 static tsi_ssl_handshaker_factory* tsi_ssl_handshaker_factory_ref(
-    tsi_ssl_handshaker_factory* self) {
-  if (self == nullptr) return nullptr;
-  gpr_refn(&self->refcount, 1);
-  return self;
+    tsi_ssl_handshaker_factory* factory) {
+  if (factory == nullptr) return nullptr;
+  gpr_refn(&factory->refcount, 1);
+  return factory;
 }
 
-static void tsi_ssl_handshaker_factory_unref(tsi_ssl_handshaker_factory* self) {
-  if (self == nullptr) return;
+static void tsi_ssl_handshaker_factory_unref(
+    tsi_ssl_handshaker_factory* factory) {
+  if (factory == nullptr) return;
 
-  if (gpr_unref(&self->refcount)) {
-    tsi_ssl_handshaker_factory_destroy(self);
+  if (gpr_unref(&factory->refcount)) {
+    tsi_ssl_handshaker_factory_destroy(factory);
   }
 }
 
@@ -1682,16 +1683,17 @@ static int select_protocol_list(const unsigned char** out,
 /* --- tsi_ssl_client_handshaker_factory methods implementation. --- */
 
 tsi_result tsi_ssl_client_handshaker_factory_create_handshaker(
-    tsi_ssl_client_handshaker_factory* self, const char* server_name_indication,
-    tsi_handshaker** handshaker) {
-  return create_tsi_ssl_handshaker(self->ssl_context, 1, server_name_indication,
-                                   &self->base, handshaker);
+    tsi_ssl_client_handshaker_factory* factory,
+    const char* server_name_indication, tsi_handshaker** handshaker) {
+  return create_tsi_ssl_handshaker(factory->ssl_context, 1,
+                                   server_name_indication, &factory->base,
+                                   handshaker);
 }
 
 void tsi_ssl_client_handshaker_factory_unref(
-    tsi_ssl_client_handshaker_factory* self) {
-  if (self == nullptr) return;
-  tsi_ssl_handshaker_factory_unref(&self->base);
+    tsi_ssl_client_handshaker_factory* factory) {
+  if (factory == nullptr) return;
+  tsi_ssl_handshaker_factory_unref(&factory->base);
 }
 
 static void tsi_ssl_client_handshaker_factory_destroy(
@@ -1718,18 +1720,18 @@ static int client_handshaker_factory_npn_callback(
 /* --- tsi_ssl_server_handshaker_factory methods implementation. --- */
 
 tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
-    tsi_ssl_server_handshaker_factory* self, tsi_handshaker** handshaker) {
-  if (self->ssl_context_count == 0) return TSI_INVALID_ARGUMENT;
+    tsi_ssl_server_handshaker_factory* factory, tsi_handshaker** handshaker) {
+  if (factory->ssl_context_count == 0) return TSI_INVALID_ARGUMENT;
   /* Create the handshaker with the first context. We will switch if needed
      because of SNI in ssl_server_handshaker_factory_servername_callback.  */
-  return create_tsi_ssl_handshaker(self->ssl_contexts[0], 0, nullptr,
-                                   &self->base, handshaker);
+  return create_tsi_ssl_handshaker(factory->ssl_contexts[0], 0, nullptr,
+                                   &factory->base, handshaker);
 }
 
 void tsi_ssl_server_handshaker_factory_unref(
-    tsi_ssl_server_handshaker_factory* self) {
-  if (self == nullptr) return;
-  tsi_ssl_handshaker_factory_unref(&self->base);
+    tsi_ssl_server_handshaker_factory* factory) {
+  if (factory == nullptr) return;
+  tsi_ssl_handshaker_factory_unref(&factory->base);
 }
 
 static void tsi_ssl_server_handshaker_factory_destroy(

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -199,7 +199,7 @@ tsi_result tsi_ssl_client_handshaker_factory_create_handshaker(
 /* Decrements reference count of the handshaker factory. Handshaker factory will
  * be destroyed once no references exist. */
 void tsi_ssl_client_handshaker_factory_unref(
-    tsi_ssl_client_handshaker_factory* factory);
+    tsi_ssl_client_handshaker_factory* self);
 
 /* --- tsi_ssl_server_handshaker_factory object ---
 

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -184,7 +184,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
     tsi_ssl_client_handshaker_factory** factory);
 
 /* Creates a client handshaker.
-  - self is the factory from which the handshaker will be created.
+  - factory is the factory from which the handshaker will be created.
   - server_name_indication indicates the name of the server the client is
     trying to connect to which will be relayed to the server using the SNI
     extension.
@@ -193,13 +193,13 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
   - This method returns TSI_OK on success or TSI_INVALID_PARAMETER in the case
     where a parameter is invalid.  */
 tsi_result tsi_ssl_client_handshaker_factory_create_handshaker(
-    tsi_ssl_client_handshaker_factory* self, const char* server_name_indication,
-    tsi_handshaker** handshaker);
+    tsi_ssl_client_handshaker_factory* factory,
+    const char* server_name_indication, tsi_handshaker** handshaker);
 
 /* Decrements reference count of the handshaker factory. Handshaker factory will
  * be destroyed once no references exist. */
 void tsi_ssl_client_handshaker_factory_unref(
-    tsi_ssl_client_handshaker_factory* self);
+    tsi_ssl_client_handshaker_factory* factory);
 
 /* --- tsi_ssl_server_handshaker_factory object ---
 
@@ -315,18 +315,18 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
     tsi_ssl_server_handshaker_factory** factory);
 
 /* Creates a server handshaker.
-  - self is the factory from which the handshaker will be created.
+  - factory is the factory from which the handshaker will be created.
   - handshaker is the address of the handshaker pointer to be created.
 
   - This method returns TSI_OK on success or TSI_INVALID_PARAMETER in the case
     where a parameter is invalid.  */
 tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
-    tsi_ssl_server_handshaker_factory* self, tsi_handshaker** handshaker);
+    tsi_ssl_server_handshaker_factory* factory, tsi_handshaker** handshaker);
 
 /* Decrements reference count of the handshaker factory. Handshaker factory will
  * be destroyed once no references exist. */
 void tsi_ssl_server_handshaker_factory_unref(
-    tsi_ssl_server_handshaker_factory* self);
+    tsi_ssl_server_handshaker_factory* factory);
 
 /* Util that checks that an ssl peer matches a specific name.
    Still TODO(jboeuf):

--- a/src/core/tsi/transport_security.cc
+++ b/src/core/tsi/transport_security.cc
@@ -194,7 +194,7 @@ tsi_result tsi_handshaker_extract_peer(tsi_handshaker* self, tsi_peer* peer) {
 }
 
 tsi_result tsi_handshaker_create_frame_protector(
-    tsi_handshaker* self, size_t* max_protected_frame_size,
+    tsi_handshaker* self, size_t* max_output_protected_frame_size,
     tsi_frame_protector** protector) {
   tsi_result result;
   if (self == nullptr || self->vtable == nullptr || protector == nullptr) {
@@ -204,8 +204,8 @@ tsi_result tsi_handshaker_create_frame_protector(
   if (self->handshake_shutdown) return TSI_HANDSHAKE_SHUTDOWN;
   if (tsi_handshaker_get_result(self) != TSI_OK) return TSI_FAILED_PRECONDITION;
   if (self->vtable->create_frame_protector == nullptr) return TSI_UNIMPLEMENTED;
-  result = self->vtable->create_frame_protector(self, max_protected_frame_size,
-                                                protector);
+  result = self->vtable->create_frame_protector(
+      self, max_output_protected_frame_size, protector);
   if (result == TSI_OK) {
     self->frame_protector_created = true;
   }
@@ -252,14 +252,14 @@ tsi_result tsi_handshaker_result_extract_peer(const tsi_handshaker_result* self,
 }
 
 tsi_result tsi_handshaker_result_create_frame_protector(
-    const tsi_handshaker_result* self, size_t* max_protected_frame_size,
+    const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
     tsi_frame_protector** protector) {
   if (self == nullptr || self->vtable == nullptr || protector == nullptr) {
     return TSI_INVALID_ARGUMENT;
   }
   if (self->vtable->create_frame_protector == nullptr) return TSI_UNIMPLEMENTED;
-  return self->vtable->create_frame_protector(self, max_protected_frame_size,
-                                              protector);
+  return self->vtable->create_frame_protector(
+      self, max_output_protected_frame_size, protector);
 }
 
 tsi_result tsi_handshaker_result_get_unused_bytes(

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -247,7 +247,7 @@ tsi_result tsi_handshaker_result_create_frame_protector(
    consequence, the caller must not free the bytes.  */
 tsi_result tsi_handshaker_result_get_unused_bytes(
     const tsi_handshaker_result* self, const unsigned char** bytes,
-    size_t* byte_size);
+    size_t* bytes_size);
 
 /* This method releases the tsi_handshaker_handshaker object. After this method
    is called, no other method can be called on the object.  */

--- a/src/cpp/ext/proto_server_reflection.cc
+++ b/src/cpp/ext/proto_server_reflection.cc
@@ -109,14 +109,14 @@ Status ProtoServerReflection::ListService(ServerContext* /*context*/,
 }
 
 Status ProtoServerReflection::GetFileByName(
-    ServerContext* /*context*/, const std::string& filename,
+    ServerContext* /*context*/, const std::string& file_name,
     ServerReflectionResponse* response) {
   if (descriptor_pool_ == nullptr) {
     return Status::CANCELLED;
   }
 
   const protobuf::FileDescriptor* file_desc =
-      descriptor_pool_->FindFileByName(filename);
+      descriptor_pool_->FindFileByName(file_name);
   if (file_desc == nullptr) {
     return Status(StatusCode::NOT_FOUND, "File not found.");
   }

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -55,18 +55,18 @@ void AuthMetadataProcessorAyncWrapper::Process(
 }
 
 void AuthMetadataProcessorAyncWrapper::InvokeProcessor(
-    grpc_auth_context* ctx, const grpc_metadata* md, size_t num_md,
+    grpc_auth_context* context, const grpc_metadata* md, size_t num_md,
     grpc_process_auth_metadata_done_cb cb, void* user_data) {
   AuthMetadataProcessor::InputMetadata metadata;
   for (size_t i = 0; i < num_md; i++) {
     metadata.insert(std::make_pair(StringRefFromSlice(&md[i].key),
                                    StringRefFromSlice(&md[i].value)));
   }
-  SecureAuthContext context(ctx);
+  SecureAuthContext ctx(context);
   AuthMetadataProcessor::OutputMetadata consumed_metadata;
   AuthMetadataProcessor::OutputMetadata response_metadata;
 
-  Status status = processor_->Process(metadata, &context, &consumed_metadata,
+  Status status = processor_->Process(metadata, &ctx, &consumed_metadata,
                                       &response_metadata);
 
   std::vector<grpc_metadata> consumed_md;

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -83,9 +83,9 @@ ServerBuilder& ServerBuilder::RegisterService(Service* service) {
   return *this;
 }
 
-ServerBuilder& ServerBuilder::RegisterService(const std::string& addr,
+ServerBuilder& ServerBuilder::RegisterService(const std::string& host,
                                               Service* service) {
-  services_.emplace_back(new NamedService(addr, service));
+  services_.emplace_back(new NamedService(host, service));
   return *this;
 }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1009,7 +1009,7 @@ static grpc_server_register_method_payload_handling PayloadHandlingForMethod(
   GPR_UNREACHABLE_CODE(return GRPC_SRM_PAYLOAD_NONE;);
 }
 
-bool Server::RegisterService(const std::string* host, grpc::Service* service) {
+bool Server::RegisterService(const std::string* addr, grpc::Service* service) {
   bool has_async_methods = service->has_async_methods();
   if (has_async_methods) {
     GPR_ASSERT(service->server_ == nullptr &&
@@ -1025,7 +1025,7 @@ bool Server::RegisterService(const std::string* host, grpc::Service* service) {
     }
 
     void* method_registration_tag = grpc_server_register_method(
-        server_, method->name(), host ? host->c_str() : nullptr,
+        server_, method->name(), addr ? addr->c_str() : nullptr,
         PayloadHandlingForMethod(method.get()), 0);
     if (method_registration_tag == nullptr) {
       gpr_log(GPR_DEBUG, "Attempt to register %s multiple times",

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -47,7 +47,7 @@ extern grpc_compression_algorithm_is_message_type grpc_compression_algorithm_is_
 typedef int(*grpc_compression_algorithm_is_stream_type)(grpc_compression_algorithm algorithm);
 extern grpc_compression_algorithm_is_stream_type grpc_compression_algorithm_is_stream_import;
 #define grpc_compression_algorithm_is_stream grpc_compression_algorithm_is_stream_import
-typedef int(*grpc_compression_algorithm_parse_type)(grpc_slice value, grpc_compression_algorithm* algorithm);
+typedef int(*grpc_compression_algorithm_parse_type)(grpc_slice name, grpc_compression_algorithm* algorithm);
 extern grpc_compression_algorithm_parse_type grpc_compression_algorithm_parse_import;
 #define grpc_compression_algorithm_parse grpc_compression_algorithm_parse_import
 typedef int(*grpc_compression_algorithm_name_type)(grpc_compression_algorithm algorithm, const char** name);
@@ -515,7 +515,7 @@ extern grpc_byte_buffer_copy_type grpc_byte_buffer_copy_import;
 typedef size_t(*grpc_byte_buffer_length_type)(grpc_byte_buffer* bb);
 extern grpc_byte_buffer_length_type grpc_byte_buffer_length_import;
 #define grpc_byte_buffer_length grpc_byte_buffer_length_import
-typedef void(*grpc_byte_buffer_destroy_type)(grpc_byte_buffer* byte_buffer);
+typedef void(*grpc_byte_buffer_destroy_type)(grpc_byte_buffer* bb);
 extern grpc_byte_buffer_destroy_type grpc_byte_buffer_destroy_import;
 #define grpc_byte_buffer_destroy grpc_byte_buffer_destroy_import
 typedef int(*grpc_byte_buffer_reader_init_type)(grpc_byte_buffer_reader* reader, grpc_byte_buffer* buffer);
@@ -683,7 +683,7 @@ extern grpc_slice_buffer_swap_type grpc_slice_buffer_swap_import;
 typedef void(*grpc_slice_buffer_move_into_type)(grpc_slice_buffer* src, grpc_slice_buffer* dst);
 extern grpc_slice_buffer_move_into_type grpc_slice_buffer_move_into_import;
 #define grpc_slice_buffer_move_into grpc_slice_buffer_move_into_import
-typedef void(*grpc_slice_buffer_trim_end_type)(grpc_slice_buffer* src, size_t n, grpc_slice_buffer* garbage);
+typedef void(*grpc_slice_buffer_trim_end_type)(grpc_slice_buffer* sb, size_t n, grpc_slice_buffer* garbage);
 extern grpc_slice_buffer_trim_end_type grpc_slice_buffer_trim_end_import;
 #define grpc_slice_buffer_trim_end grpc_slice_buffer_trim_end_import
 typedef void(*grpc_slice_buffer_move_first_type)(grpc_slice_buffer* src, size_t n, grpc_slice_buffer* dst);
@@ -695,10 +695,10 @@ extern grpc_slice_buffer_move_first_no_ref_type grpc_slice_buffer_move_first_no_
 typedef void(*grpc_slice_buffer_move_first_into_buffer_type)(grpc_slice_buffer* src, size_t n, void* dst);
 extern grpc_slice_buffer_move_first_into_buffer_type grpc_slice_buffer_move_first_into_buffer_import;
 #define grpc_slice_buffer_move_first_into_buffer grpc_slice_buffer_move_first_into_buffer_import
-typedef grpc_slice(*grpc_slice_buffer_take_first_type)(grpc_slice_buffer* src);
+typedef grpc_slice(*grpc_slice_buffer_take_first_type)(grpc_slice_buffer* sb);
 extern grpc_slice_buffer_take_first_type grpc_slice_buffer_take_first_import;
 #define grpc_slice_buffer_take_first grpc_slice_buffer_take_first_import
-typedef void(*grpc_slice_buffer_undo_take_first_type)(grpc_slice_buffer* src, grpc_slice slice);
+typedef void(*grpc_slice_buffer_undo_take_first_type)(grpc_slice_buffer* sb, grpc_slice slice);
 extern grpc_slice_buffer_undo_take_first_type grpc_slice_buffer_undo_take_first_import;
 #define grpc_slice_buffer_undo_take_first grpc_slice_buffer_undo_take_first_import
 typedef void*(*gpr_malloc_type)(size_t size);
@@ -764,7 +764,7 @@ extern gpr_cv_signal_type gpr_cv_signal_import;
 typedef void(*gpr_cv_broadcast_type)(gpr_cv* cv);
 extern gpr_cv_broadcast_type gpr_cv_broadcast_import;
 #define gpr_cv_broadcast gpr_cv_broadcast_import
-typedef void(*gpr_once_init_type)(gpr_once* once, void (*init_routine)(void));
+typedef void(*gpr_once_init_type)(gpr_once* once, void (*init_function)(void));
 extern gpr_once_init_type gpr_once_init_import;
 #define gpr_once_init gpr_once_init_import
 typedef void(*gpr_event_init_type)(gpr_event* ev);
@@ -824,7 +824,7 @@ extern gpr_time_init_type gpr_time_init_import;
 typedef gpr_timespec(*gpr_now_type)(gpr_clock_type clock);
 extern gpr_now_type gpr_now_import;
 #define gpr_now gpr_now_import
-typedef gpr_timespec(*gpr_convert_clock_type_type)(gpr_timespec t, gpr_clock_type target_clock);
+typedef gpr_timespec(*gpr_convert_clock_type_type)(gpr_timespec t, gpr_clock_type clock_type);
 extern gpr_convert_clock_type_type gpr_convert_clock_type_import;
 #define gpr_convert_clock_type gpr_convert_clock_type_import
 typedef int(*gpr_time_cmp_type)(gpr_timespec a, gpr_timespec b);
@@ -842,22 +842,22 @@ extern gpr_time_add_type gpr_time_add_import;
 typedef gpr_timespec(*gpr_time_sub_type)(gpr_timespec a, gpr_timespec b);
 extern gpr_time_sub_type gpr_time_sub_import;
 #define gpr_time_sub gpr_time_sub_import
-typedef gpr_timespec(*gpr_time_from_micros_type)(int64_t x, gpr_clock_type clock_type);
+typedef gpr_timespec(*gpr_time_from_micros_type)(int64_t us, gpr_clock_type clock_type);
 extern gpr_time_from_micros_type gpr_time_from_micros_import;
 #define gpr_time_from_micros gpr_time_from_micros_import
-typedef gpr_timespec(*gpr_time_from_nanos_type)(int64_t x, gpr_clock_type clock_type);
+typedef gpr_timespec(*gpr_time_from_nanos_type)(int64_t ns, gpr_clock_type clock_type);
 extern gpr_time_from_nanos_type gpr_time_from_nanos_import;
 #define gpr_time_from_nanos gpr_time_from_nanos_import
-typedef gpr_timespec(*gpr_time_from_millis_type)(int64_t x, gpr_clock_type clock_type);
+typedef gpr_timespec(*gpr_time_from_millis_type)(int64_t ms, gpr_clock_type clock_type);
 extern gpr_time_from_millis_type gpr_time_from_millis_import;
 #define gpr_time_from_millis gpr_time_from_millis_import
-typedef gpr_timespec(*gpr_time_from_seconds_type)(int64_t x, gpr_clock_type clock_type);
+typedef gpr_timespec(*gpr_time_from_seconds_type)(int64_t s, gpr_clock_type clock_type);
 extern gpr_time_from_seconds_type gpr_time_from_seconds_import;
 #define gpr_time_from_seconds gpr_time_from_seconds_import
-typedef gpr_timespec(*gpr_time_from_minutes_type)(int64_t x, gpr_clock_type clock_type);
+typedef gpr_timespec(*gpr_time_from_minutes_type)(int64_t m, gpr_clock_type clock_type);
 extern gpr_time_from_minutes_type gpr_time_from_minutes_import;
 #define gpr_time_from_minutes gpr_time_from_minutes_import
-typedef gpr_timespec(*gpr_time_from_hours_type)(int64_t x, gpr_clock_type clock_type);
+typedef gpr_timespec(*gpr_time_from_hours_type)(int64_t h, gpr_clock_type clock_type);
 extern gpr_time_from_hours_type gpr_time_from_hours_import;
 #define gpr_time_from_hours gpr_time_from_hours_import
 typedef int32_t(*gpr_time_to_millis_type)(gpr_timespec timespec);

--- a/test/core/end2end/cq_verifier.h
+++ b/test/core/end2end/cq_verifier.h
@@ -62,7 +62,7 @@ void cq_expect_completion_any_status(cq_verifier* v, const char* file, int line,
   cq_expect_completion_any_status(v, __FILE__, __LINE__, tag)
 
 int byte_buffer_eq_slice(grpc_byte_buffer* bb, grpc_slice b);
-int byte_buffer_eq_string(grpc_byte_buffer* byte_buffer, const char* string);
+int byte_buffer_eq_string(grpc_byte_buffer* bb, const char* str);
 int contains_metadata(grpc_metadata_array* array, const char* key,
                       const char* value);
 int contains_metadata_slices(grpc_metadata_array* array, grpc_slice key,

--- a/test/core/tsi/alts/crypt/gsec_test_util.h
+++ b/test/core/tsi/alts/crypt/gsec_test_util.h
@@ -55,9 +55,9 @@ uint32_t gsec_test_bias_random_uint32(uint32_t max_length);
  *
  * - src: a source buffer.
  * - des: a destination buffer.
- * - length: the length of source buffer to be copied from its beginning.
+ * - source_len: the length of source buffer to be copied from its beginning.
  */
-void gsec_test_copy(const uint8_t* src, uint8_t** des, size_t length);
+void gsec_test_copy(const uint8_t* src, uint8_t** des, size_t source_len);
 
 /**
  * This method copies data from a source to a destination buffer, and flips one

--- a/test/core/util/cmdline.cc
+++ b/test/core/util/cmdline.cc
@@ -59,7 +59,7 @@ struct gpr_cmdline {
   int survive_failure;
 };
 
-static int normal_state(gpr_cmdline* cl, char* arg);
+static int normal_state(gpr_cmdline* cl, char* str);
 
 gpr_cmdline* gpr_cmdline_create(const char* description) {
   gpr_cmdline* cl = static_cast<gpr_cmdline*>(gpr_zalloc(sizeof(gpr_cmdline)));

--- a/test/core/util/histogram.cc
+++ b/test/core/util/histogram.cc
@@ -124,23 +124,23 @@ int grpc_histogram_merge(grpc_histogram* dst, const grpc_histogram* src) {
   return 1;
 }
 
-void grpc_histogram_merge_contents(grpc_histogram* dst, const uint32_t* data,
-                                   size_t data_count, double min_seen,
-                                   double max_seen, double sum,
+void grpc_histogram_merge_contents(grpc_histogram* histogram,
+                                   const uint32_t* data, size_t data_count,
+                                   double min_seen, double max_seen, double sum,
                                    double sum_of_squares, double count) {
   size_t i;
-  GPR_ASSERT(dst->num_buckets == data_count);
-  dst->sum += sum;
-  dst->sum_of_squares += sum_of_squares;
-  dst->count += count;
-  if (min_seen < dst->min_seen) {
-    dst->min_seen = min_seen;
+  GPR_ASSERT(histogram->num_buckets == data_count);
+  histogram->sum += sum;
+  histogram->sum_of_squares += sum_of_squares;
+  histogram->count += count;
+  if (min_seen < histogram->min_seen) {
+    histogram->min_seen = min_seen;
   }
-  if (max_seen > dst->max_seen) {
-    dst->max_seen = max_seen;
+  if (max_seen > histogram->max_seen) {
+    histogram->max_seen = max_seen;
   }
-  for (i = 0; i < dst->num_buckets; i++) {
-    dst->buckets[i] += data[i];
+  for (i = 0; i < histogram->num_buckets; i++) {
+    histogram->buckets[i] += data[i];
   }
 }
 
@@ -224,7 +224,8 @@ double grpc_histogram_sum_of_squares(grpc_histogram* h) {
   return h->sum_of_squares;
 }
 
-const uint32_t* grpc_histogram_get_contents(grpc_histogram* h, size_t* size) {
-  *size = h->num_buckets;
-  return h->buckets;
+const uint32_t* grpc_histogram_get_contents(grpc_histogram* histogram,
+                                            size_t* count) {
+  *count = histogram->num_buckets;
+  return histogram->buckets;
 }

--- a/test/core/util/mock_endpoint.h
+++ b/test/core/util/mock_endpoint.h
@@ -23,7 +23,6 @@
 
 grpc_endpoint* grpc_mock_endpoint_create(void (*on_write)(grpc_slice slice),
                                          grpc_resource_quota* resource_quota);
-void grpc_mock_endpoint_put_read(grpc_endpoint* mock_endpoint,
-                                 grpc_slice slice);
+void grpc_mock_endpoint_put_read(grpc_endpoint* ep, grpc_slice slice);
 
 #endif

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -566,11 +566,11 @@ class ClientImpl : public Client {
       create_stub_;
 };
 
-std::unique_ptr<Client> CreateSynchronousClient(const ClientConfig& args);
-std::unique_ptr<Client> CreateAsyncClient(const ClientConfig& args);
-std::unique_ptr<Client> CreateCallbackClient(const ClientConfig& args);
+std::unique_ptr<Client> CreateSynchronousClient(const ClientConfig& config);
+std::unique_ptr<Client> CreateAsyncClient(const ClientConfig& config);
+std::unique_ptr<Client> CreateCallbackClient(const ClientConfig& config);
 std::unique_ptr<Client> CreateGenericAsyncStreamingClient(
-    const ClientConfig& args);
+    const ClientConfig& config);
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/qps/client_async.cc
+++ b/test/cpp/qps/client_async.cc
@@ -955,8 +955,8 @@ std::unique_ptr<Client> CreateAsyncClient(const ClientConfig& config) {
   }
 }
 std::unique_ptr<Client> CreateGenericAsyncStreamingClient(
-    const ClientConfig& args) {
-  return std::unique_ptr<Client>(new GenericAsyncStreamingClient(args));
+    const ClientConfig& config) {
+  return std::unique_ptr<Client>(new GenericAsyncStreamingClient(config));
 }
 
 }  // namespace testing


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html

Fix them manually.