### PR TITLE
Update file watcher certificate provider factory with provider implementation

### DIFF
--- a/src/core/ext/xds/file_watcher_certificate_provider_factory.h
+++ b/src/core/ext/xds/file_watcher_certificate_provider_factory.h
@@ -61,10 +61,7 @@ class FileWatcherCertificateProviderFactory
                                   grpc_error** error) override;
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<CertificateProviderFactory::Config> config) override {
-    // TODO(yashykt) : To be implemented
-    return nullptr;
-  }
+      RefCountedPtr<CertificateProviderFactory::Config> config) override;
 };
 
 }  // namespace grpc_core

--- a/src/core/plugin_registry/grpc_plugin_registry.cc
+++ b/src/core/plugin_registry/grpc_plugin_registry.cc
@@ -68,6 +68,10 @@ void XdsClientGlobalShutdown();
 }  // namespace grpc_core
 void grpc_certificate_provider_registry_init(void);
 void grpc_certificate_provider_registry_shutdown(void);
+namespace grpc_core {
+void FileWatcherCertificateProviderInit();
+void FileWatcherCertificateProviderShutdown();
+}  // namespace grpc_core
 void grpc_lb_policy_cds_init(void);
 void grpc_lb_policy_cds_shutdown(void);
 void grpc_lb_policy_eds_init(void);
@@ -126,6 +130,8 @@ void grpc_register_built_in_plugins(void) {
                        grpc_core::XdsClientGlobalShutdown);
   grpc_register_plugin(grpc_certificate_provider_registry_init,
                        grpc_certificate_provider_registry_shutdown);
+  grpc_register_plugin(grpc_core::FileWatcherCertificateProviderInit,
+                       grpc_core::FileWatcherCertificateProviderShutdown);
   grpc_register_plugin(grpc_lb_policy_cds_init,
                        grpc_lb_policy_cds_shutdown);
   grpc_register_plugin(grpc_lb_policy_eds_init,

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -184,6 +184,14 @@ constexpr char kBootstrapFileV3[] =
     "    },\n"
     "    \"fake_plugin2\": {\n"
     "      \"plugin_name\": \"fake2\"\n"
+    "    },\n"
+    "    \"file_plugin\": {\n"
+    "      \"plugin_name\": \"file_watcher\",\n"
+    "      \"config\": {\n"
+    "        \"certificate_file\": \"src/core/tsi/test_creds/client.pem\",\n"
+    "        \"private_key_file\": \"src/core/tsi/test_creds/client.key\",\n"
+    "        \"ca_certificate_file\": \"src/core/tsi/test_creds/ca.pem\"\n"
+    "      }"
     "    }\n"
     "  }\n"
     "}\n";
@@ -5628,6 +5636,11 @@ TEST_P(XdsSecurityTest, TestFallbackToTls) {
   UpdateAndVerifyXdsSecurityConfiguration("fake_plugin1", "", "", "",
                                           {} /* unauthenticated */);
   g_fake1_cert_data_map = nullptr;
+}
+
+TEST_P(XdsSecurityTest, TestFileWatcherCertificateProvider) {
+  UpdateAndVerifyXdsSecurityConfiguration("file_plugin", "", "file_plugin", "",
+                                          authenticated_identity_1_);
 }
 
 using EdsTest = BasicTest;


### PR DESCRIPTION
Summary of changes - 

- Register FileWatcherCertificateProviderFactory on init
- Update file watcher certificate provider factory with provider implementation.
- Add basic xds end to end test for "file_watcher" plugin. (The provider implementation itself is tested at https://github.com/grpc/grpc/blob/master/test/core/security/grpc_tls_certificate_provider_test.cc)

