### PR TITLE
Node xDS example: show error on failure, close client when done

### DIFF
--- a/examples/node/xds/greeter_client.js
+++ b/examples/node/xds/greeter_client.js
@@ -53,7 +53,9 @@ function main() {
     user = 'world';
   }
   client.sayHello({name: user}, function(err, response) {
+    if (err) throw err;
     console.log('Greeting:', response.message);
+    client.close();
   });
 }
 


### PR DESCRIPTION
Throwing that error is probably better code hygiene in general, and this example in particular depends on a lot more complex setup, so an error is more likely to give useful information about setup errors. Adding `client.close()` is related to grpc/grpc-node#1641: even with that change, we will still need to close clients with `xds:///` targets explicitly to let the process end.