### PR TITLE
Added third_party/bloaty to bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -6,6 +6,7 @@ bins
 libs
 objs
 third_party/abseil-cpp
+third_party/bloaty
 third_party/googleapis
 third_party/protoc-gen-validate
 third_party/udpa


### PR DESCRIPTION
One more missing dependency required to be ignored to make bazel work correctly.