### PR TITLE
Bug fix: decode bytes object to string for subprocess.check_output ou…

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -212,6 +212,9 @@ class JobSpec(object):
     def __cmp__(self, other):
         return self.identity() == other.identity()
 
+    def __lt__(self, other):
+        return self.identity() < other.identity()
+
     def __repr__(self):
         return 'JobSpec(shortname=%s, cmdline=%s)' % (self.shortname,
                                                       self.cmdline)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -355,7 +355,7 @@ class CLanguage(object):
                             tests = subprocess.check_output(
                                 [binary, '--benchmark_list_tests'],
                                 stderr=fnull)
-                        for line in tests.split('\n'):
+                        for line in tests.decode().split('\n'):
                             test = line.strip()
                             if not test: continue
                             cmdline = [binary,
@@ -380,7 +380,7 @@ class CLanguage(object):
                             tests = subprocess.check_output(
                                 [binary, '--gtest_list_tests'], stderr=fnull)
                         base = None
-                        for line in tests.split('\n'):
+                        for line in tests.decode().split('\n'):
                             i = line.find('#')
                             if i >= 0: line = line[:i]
                             if not line: continue


### PR DESCRIPTION
When running test "./tools/run_tests/run_tests.py -l c++ -c dbg" in python3
environment, the following exception is observed.

```
./tools/run_tests/run_tests.py -l c++ -c dbg
PASSED: make [time=114.9sec, retries=0:0]

Omitting EPOLLEXCLUSIVE tests

2020-12-01 10:45:40,806 detected port server running version 21
2020-12-01 10:45:40,866 my port server is version 21
Traceback (most recent call last):
  File "./tools/run_tests/run_tests.py", line 1919, in <module>
    build_only=args.build_only)
  File "./tools/run_tests/run_tests.py", line 1800, in _build_and_run
    one_run = set(spec for language in languages
  File "./tools/run_tests/run_tests.py", line 1801, in <genexpr>
    for spec in language.test_specs()
  File "./tools/run_tests/run_tests.py", line 383, in test_specs
    for line in tests.split('\n'):
TypeError: a bytes-like object is required, not 'str'
```
