### PR TITLE
Stop building protoc x86 artifacts on macos

### DIFF
--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -62,7 +62,6 @@ Linux and MacOS. Managed runtime is supplied separately in the Grpc.Core package
     <_Asset PackagePath="tools/windows_x64/" Include="$(Assets_ProtoCompiler)windows_x64/protoc.exe" />
     <_Asset PackagePath="tools/linux_x86/" Include="$(Assets_ProtoCompiler)linux_x86/protoc" />
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_ProtoCompiler)linux_x64/protoc" />
-    <_Asset PackagePath="tools/macosx_x86/" Include="$(Assets_ProtoCompiler)macos_x86/protoc" /> <!-- GPB: macosx-->
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_ProtoCompiler)macos_x64/protoc" /> <!-- GPB: macosx-->
 
     <!-- gRPC assets (for Grpc.Tools) -->
@@ -70,7 +69,6 @@ Linux and MacOS. Managed runtime is supplied separately in the Grpc.Core package
     <_Asset PackagePath="tools/windows_x64/" Include="$(Assets_GrpcPlugins)protoc_windows_x64/grpc_csharp_plugin.exe" />
     <_Asset PackagePath="tools/linux_x86/" Include="$(Assets_GrpcPlugins)protoc_linux_x86/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_GrpcPlugins)protoc_linux_x64/grpc_csharp_plugin" />
-    <_Asset PackagePath="tools/macosx_x86/" Include="$(Assets_GrpcPlugins)protoc_macos_x86/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_GrpcPlugins)protoc_macos_x64/grpc_csharp_plugin" />
 
     <None Include="@(_Asset)" Pack="true" Visible="false" />

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -348,7 +348,6 @@ def targets():
         ProtocArtifact('linux', 'x64'),
         ProtocArtifact('linux', 'x86'),
         ProtocArtifact('macos', 'x64'),
-        ProtocArtifact('macos', 'x86'),
         ProtocArtifact('windows', 'x64'),
         ProtocArtifact('windows', 'x86'),
         CSharpExtArtifact('linux', 'x64'),

--- a/tools/run_tests/artifacts/build_package_ruby.sh
+++ b/tools/run_tests/artifacts/build_package_ruby.sh
@@ -41,6 +41,11 @@ for arch in {x86,x64}; do
       ;;
   esac
   for plat in {windows,linux,macos}; do
+    # skip non-existent macos x86 protoc artifact
+    if [[ "${plat}_${arch}" == "macos_x86"]]
+    then
+      continue
+    fi
     input_dir="${EXTERNAL_GIT_ROOT}/input_artifacts/protoc_${plat}_${arch}"
     output_dir="$base/src/ruby/tools/bin/${ruby_arch}-${plat}"
     mkdir -p "$output_dir"/google/protobuf

--- a/tools/run_tests/artifacts/build_package_ruby.sh
+++ b/tools/run_tests/artifacts/build_package_ruby.sh
@@ -42,7 +42,7 @@ for arch in {x86,x64}; do
   esac
   for plat in {windows,linux,macos}; do
     # skip non-existent macos x86 protoc artifact
-    if [[ "${plat}_${arch}" == "macos_x86"]]
+    if [[ "${plat}_${arch}" == "macos_x86" ]]
     then
       continue
     fi


### PR DESCRIPTION
Prerequisite for https://github.com/grpc/grpc/pull/24860.

MacOS mojave no longer has a toolchain to build 32bit binaries.