### PR TITLE
Register certificate provider factories after init

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -5298,13 +5298,13 @@ class XdsSecurityTest : public BasicTest {
  protected:
   static void SetUpTestCase() {
     gpr_setenv("GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT", "true");
+    BasicTest::SetUpTestCase();
     grpc_core::CertificateProviderRegistry::RegisterCertificateProviderFactory(
         absl::make_unique<FakeCertificateProviderFactory>(
             "fake1", &g_fake1_cert_data_map));
     grpc_core::CertificateProviderRegistry::RegisterCertificateProviderFactory(
         absl::make_unique<FakeCertificateProviderFactory>(
             "fake2", &g_fake2_cert_data_map));
-    BasicTest::SetUpTestCase();
   }
 
   static void TearDownTestCase() {


### PR DESCRIPTION
I spotted a data race in xds_end2end_test https://source.cloud.google.com/results/invocations/3bfd7080-b1e4-439c-a967-e020cec00fc1/targets/%2F%2Ftest%2Fcpp%2Fend2end:xds_end2end_test@poller%3Dpoll/log

```
WARNING: ThreadSanitizer: data race (pid=20)
  Read of size 8 at 0x7b0800027c80 by thread T11 (mutexes: write M1361):
    #0 absl::lts_2020_09_23::inlined_vector_internal::Storage<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::GetIsAllocated() const /proc/self/cwd/external/com_google_absl/absl/container/internal/inlined_vector.h:323:40 (liblibgrpc_Uxds_Ucredentials.so+0x27ccd)
    #1 absl::lts_2020_09_23::inlined_vector_internal::Storage<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::~Storage() /proc/self/cwd/external/com_google_absl/absl/container/internal/inlined_vector.h:306:20 (liblibgrpc_Uxds_Ucredentials.so+0x281ef)
    #2 absl::lts_2020_09_23::InlinedVector<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::~InlinedVector() /proc/self/cwd/external/com_google_absl/absl/container/inlined_vector.h:246:21 (liblibgrpc_Uxds_Ucredentials.so+0x281a8)
    #3 grpc_core::(anonymous namespace)::RegistryState::~RegistryState() /proc/self/cwd/src/core/ext/xds/certificate_provider_registry.cc:29:7 (liblibgrpc_Uxds_Ucredentials.so+0x27138)
    #4 grpc_core::CertificateProviderRegistry::ShutdownRegistry() /proc/self/cwd/src/core/ext/xds/certificate_provider_registry.cc:81:3 (liblibgrpc_Uxds_Ucredentials.so+0x270dd)
    #5 grpc_certificate_provider_registry_shutdown() /proc/self/cwd/src/core/ext/xds/certificate_provider_registry.cc:102:3 (liblibgrpc_Uxds_Ucredentials.so+0x27451)
    #6 grpc_shutdown_internal_locked() /proc/self/cwd/src/core/lib/surface/init.cc:181:11 (liblibgrpc.so+0x52dd)
    #7 grpc_shutdown_internal(void*) /proc/self/cwd/src/core/lib/surface/init.cc:211:3 (liblibgrpc.so+0x54d4)
    #8 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:140:23 (liblibgpr_Ubase.so+0x1cdfe)
    #9 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:110:21 (liblibgpr_Ubase.so+0x1cbf8)

  Previous write of size 8 at 0x7b0800027c80 by main thread:
    #0 absl::lts_2020_09_23::inlined_vector_internal::Storage<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::AddSize(unsigned long) /proc/self/cwd/external/com_google_absl/absl/container/internal/inlined_vector.h:412:29 (liblibgrpc_Uxds_Ucredentials.so+0x297bf)
    #1 std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >& absl::lts_2020_09_23::inlined_vector_internal::Storage<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::EmplaceBack<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > >(std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >&&) /proc/self/cwd/external/com_google_absl/absl/container/internal/inlined_vector.h:725:3 (liblibgrpc_Uxds_Ucredentials.so+0x28ecc)
    #2 std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >& absl::lts_2020_09_23::InlinedVector<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::emplace_back<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > >(std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >&&) /proc/self/cwd/external/com_google_absl/absl/container/inlined_vector.h:652:21 (liblibgrpc_Uxds_Ucredentials.so+0x28bcb)
    #3 absl::lts_2020_09_23::InlinedVector<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >, 3ul, std::allocator<std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> > > >::push_back(std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >&&) /proc/self/cwd/external/com_google_absl/absl/container/inlined_vector.h:663:23 (liblibgrpc_Uxds_Ucredentials.so+0x28a5b)
    #4 grpc_core::(anonymous namespace)::RegistryState::RegisterCertificateProviderFactory(std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >) /proc/self/cwd/src/core/ext/xds/certificate_provider_registry.cc:38:16 (liblibgrpc_Uxds_Ucredentials.so+0x273cc)
    #5 grpc_core::CertificateProviderRegistry::RegisterCertificateProviderFactory(std::unique_ptr<grpc_core::CertificateProviderFactory, std::default_delete<grpc_core::CertificateProviderFactory> >) /proc/self/cwd/src/core/ext/xds/certificate_provider_registry.cc:88:12 (liblibgrpc_Uxds_Ucredentials.so+0x271b4)
    #6 grpc::testing::(anonymous namespace)::XdsSecurityTest::SetUpTestCase() /proc/self/cwd/test/cpp/end2end/xds_end2end_test.cc:5303:5 (xds_end2end_test+0x71663c)
    #7 testing::TestSuite::RunSetUpTestSuite() /proc/self/cwd/external/com_google_googletest/googletest/include/gtest/gtest.h:947:7 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0x108a42)
    #8 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::TestSuite, void>(testing::TestSuite*, void (testing::TestSuite::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2439:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0x127acc)
    #9 void testing::internal::HandleExceptionsInMethodIfSupported<testing::TestSuite, void>(testing::TestSuite*, void (testing::TestSuite::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2475:14 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0x1086a1)
    #10 testing::TestSuite::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2817:3 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xe898c)
    #11 testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5342:44 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xfc2cb)
    #12 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2439:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0x12afcc)
    #13 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2475:14 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0x10af57)
    #14 testing::UnitTest::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:4930:10 (libexternal_Scom_Ugoogle_Ugoogletest_Slibgtest.so+0xfbafe)
    #15 RUN_ALL_TESTS() /proc/self/cwd/external/com_google_googletest/googletest/include/gtest/gtest.h:2472:46 (xds_end2end_test+0x730c17)
    #16 main /proc/self/cwd/test/cpp/end2end/xds_end2end_test.cc:7070:23 (xds_end2end_test+0x5b6c78)
```

Looks like the shutdown from a previous test for CertificateProviderRegistry was racing with a RegisterCertificateProviderFactory() from a new test. We should be able to avoid this issue if we make sure to call `grpc_init()` before `RegisterCertificateProviderFactory()` since `grpc_init()` and `grpc_shutdown()` are synchronized. That way, the new test's `grpc_init()` would wait for the previous test's `grpc_shutdown()` to complete and properly re-initialize the global state.