### PR TITLE
PHP: fix windows build error

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -983,6 +983,7 @@ if (PHP_GRPC != "no") {
     "/I"+configure_module_dirname+" "+
     "/I"+configure_module_dirname+"\\include "+
     "/I"+configure_module_dirname+"\\src\\core\\ext\\upb-generated "+
+    "/I"+configure_module_dirname+"\\src\\core\\ext\\upbdefs-generated "+
     "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
     "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
     "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -30,6 +30,7 @@
       "/I"+configure_module_dirname+" "+
       "/I"+configure_module_dirname+"\\include "+
       "/I"+configure_module_dirname+"\\src\\core\\ext\\upb-generated "+
+      "/I"+configure_module_dirname+"\\src\\core\\ext\\upbdefs-generated "+
       "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
       "/I"+configure_module_dirname+"\\third_party\\abseil-cpp "+
       "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include "+


### PR DESCRIPTION
Upmerge of #24807. Verified that the fix indeed fixed the Windows build issue on the `1.34.0RC2` release.