### PR TITLE
Re-generate protos for Ruby

### DIFF
--- a/src/ruby/pb/src/proto/grpc/testing/messages_pb.rb
+++ b/src/ruby/pb/src/proto/grpc/testing/messages_pb.rb
@@ -76,6 +76,28 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     add_message "grpc.testing.LoadBalancerStatsResponse.RpcsByPeer" do
       map :rpcs_by_peer, :string, :int32, 1
     end
+    add_message "grpc.testing.LoadBalancerAccumulatedStatsRequest" do
+    end
+    add_message "grpc.testing.LoadBalancerAccumulatedStatsResponse" do
+      map :num_rpcs_started_by_method, :string, :int32, 1
+      map :num_rpcs_succeeded_by_method, :string, :int32, 2
+      map :num_rpcs_failed_by_method, :string, :int32, 3
+    end
+    add_message "grpc.testing.ClientConfigureRequest" do
+      repeated :types, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
+      repeated :metadata, :message, 2, "grpc.testing.ClientConfigureRequest.Metadata"
+    end
+    add_message "grpc.testing.ClientConfigureRequest.Metadata" do
+      optional :type, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
+      optional :key, :string, 2
+      optional :value, :string, 3
+    end
+    add_enum "grpc.testing.ClientConfigureRequest.RpcType" do
+      value :EMPTY_CALL, 0
+      value :UNARY_CALL, 1
+    end
+    add_message "grpc.testing.ClientConfigureResponse" do
+    end
     add_enum "grpc.testing.PayloadType" do
       value :COMPRESSABLE, 0
     end
@@ -104,6 +126,12 @@ module Grpc
     LoadBalancerStatsRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsRequest").msgclass
     LoadBalancerStatsResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsResponse").msgclass
     LoadBalancerStatsResponse::RpcsByPeer = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsResponse.RpcsByPeer").msgclass
+    LoadBalancerAccumulatedStatsRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsRequest").msgclass
+    LoadBalancerAccumulatedStatsResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsResponse").msgclass
+    ClientConfigureRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest").msgclass
+    ClientConfigureRequest::Metadata = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.Metadata").msgclass
+    ClientConfigureRequest::RpcType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.RpcType").enummodule
+    ClientConfigureResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureResponse").msgclass
     PayloadType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.PayloadType").enummodule
     GrpclbRouteType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.GrpclbRouteType").enummodule
   end

--- a/src/ruby/pb/src/proto/grpc/testing/test_services_pb.rb
+++ b/src/ruby/pb/src/proto/grpc/testing/test_services_pb.rb
@@ -110,6 +110,8 @@ module Grpc
 
         # Gets the backend distribution for RPCs sent by a test client.
         rpc :GetClientStats, ::Grpc::Testing::LoadBalancerStatsRequest, ::Grpc::Testing::LoadBalancerStatsResponse
+        # Gets the accumulated stats for RPCs sent by a test client.
+        rpc :GetClientAccumulatedStats, ::Grpc::Testing::LoadBalancerAccumulatedStatsRequest, ::Grpc::Testing::LoadBalancerAccumulatedStatsResponse
       end
 
       Stub = Service.rpc_stub_class
@@ -126,6 +128,22 @@ module Grpc
 
         rpc :SetServing, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
         rpc :SetNotServing, ::Grpc::Testing::Empty, ::Grpc::Testing::Empty
+      end
+
+      Stub = Service.rpc_stub_class
+    end
+    module XdsUpdateClientConfigureService
+      # A service to dynamically update the configuration of an xDS test client.
+      class Service
+
+        include GRPC::GenericService
+
+        self.marshal_class_method = :encode
+        self.unmarshal_class_method = :decode
+        self.service_name = 'grpc.testing.XdsUpdateClientConfigureService'
+
+        # Update the tes client's configuration.
+        rpc :Configure, ::Grpc::Testing::ClientConfigureRequest, ::Grpc::Testing::ClientConfigureResponse
       end
 
       Stub = Service.rpc_stub_class

--- a/src/ruby/qps/src/proto/grpc/testing/messages_pb.rb
+++ b/src/ruby/qps/src/proto/grpc/testing/messages_pb.rb
@@ -76,6 +76,28 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     add_message "grpc.testing.LoadBalancerStatsResponse.RpcsByPeer" do
       map :rpcs_by_peer, :string, :int32, 1
     end
+    add_message "grpc.testing.LoadBalancerAccumulatedStatsRequest" do
+    end
+    add_message "grpc.testing.LoadBalancerAccumulatedStatsResponse" do
+      map :num_rpcs_started_by_method, :string, :int32, 1
+      map :num_rpcs_succeeded_by_method, :string, :int32, 2
+      map :num_rpcs_failed_by_method, :string, :int32, 3
+    end
+    add_message "grpc.testing.ClientConfigureRequest" do
+      repeated :types, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
+      repeated :metadata, :message, 2, "grpc.testing.ClientConfigureRequest.Metadata"
+    end
+    add_message "grpc.testing.ClientConfigureRequest.Metadata" do
+      optional :type, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
+      optional :key, :string, 2
+      optional :value, :string, 3
+    end
+    add_enum "grpc.testing.ClientConfigureRequest.RpcType" do
+      value :EMPTY_CALL, 0
+      value :UNARY_CALL, 1
+    end
+    add_message "grpc.testing.ClientConfigureResponse" do
+    end
     add_enum "grpc.testing.PayloadType" do
       value :COMPRESSABLE, 0
     end
@@ -104,6 +126,12 @@ module Grpc
     LoadBalancerStatsRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsRequest").msgclass
     LoadBalancerStatsResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsResponse").msgclass
     LoadBalancerStatsResponse::RpcsByPeer = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsResponse.RpcsByPeer").msgclass
+    LoadBalancerAccumulatedStatsRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsRequest").msgclass
+    LoadBalancerAccumulatedStatsResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsResponse").msgclass
+    ClientConfigureRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest").msgclass
+    ClientConfigureRequest::Metadata = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.Metadata").msgclass
+    ClientConfigureRequest::RpcType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.RpcType").enummodule
+    ClientConfigureResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureResponse").msgclass
     PayloadType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.PayloadType").enummodule
     GrpclbRouteType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.GrpclbRouteType").enummodule
   end


### PR DESCRIPTION
Similar to #24880 

Re-generate protos for Ruby ahead of the work needed to modify the xDS client. We need these new classes to be generated.

This PR basically ran the following commands:

```
$ ./tools/bazel build @com_google_protobuf//:protoc
$ ./tools/bazel build src/compiler:grpc_ruby_plugin
$ ./src/ruby/pb/generate_proto_ruby.sh
```