### PR TITLE
Add include directory to clang-tidy

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -344,6 +344,9 @@ grpc_cc_library(
 grpc_cc_library(
     name = "grpc++_public_hdrs",
     hdrs = GRPCXX_PUBLIC_HDRS,
+    external_deps = [
+        "protobuf_headers",
+    ],
 )
 
 grpc_cc_library(
@@ -366,6 +369,9 @@ grpc_cc_library(
         "src/cpp/common/secure_auth_context.h",
         "src/cpp/common/tls_credentials_options_util.h",
         "src/cpp/server/secure_server_credentials.h",
+    ],
+    external_deps = [
+        "protobuf_headers",
     ],
     language = "c++",
     public_hdrs = GRPCXX_PUBLIC_HDRS,
@@ -2257,6 +2263,9 @@ grpc_cc_library(
     name = "grpc++_base",
     srcs = GRPCXX_SRCS,
     hdrs = GRPCXX_HDRS,
+    external_deps = [
+        "protobuf_headers",
+    ],
     language = "c++",
     public_hdrs = GRPCXX_PUBLIC_HDRS,
     deps = [
@@ -2271,6 +2280,9 @@ grpc_cc_library(
     name = "grpc++_base_unsecure",
     srcs = GRPCXX_SRCS,
     hdrs = GRPCXX_HDRS,
+    external_deps = [
+        "protobuf_headers",
+    ],
     language = "c++",
     public_hdrs = GRPCXX_PUBLIC_HDRS,
     deps = [
@@ -2379,6 +2391,9 @@ grpc_cc_library(
 
 grpc_cc_library(
     name = "grpc++_codegen_proto",
+    external_deps = [
+        "protobuf_headers",
+    ],
     language = "c++",
     public_hdrs = [
         "include/grpc++/impl/codegen/proto_utils.h",
@@ -2449,6 +2464,9 @@ grpc_cc_library(
     name = "grpc++_test",
     srcs = [
         "src/cpp/client/channel_test_peer.cc",
+    ],
+    external_deps = [
+        "gtest",
     ],
     public_hdrs = [
         "include/grpc++/test/mock_stream.h",

--- a/include/grpc/impl/codegen/atm_windows.h
+++ b/include/grpc/impl/codegen/atm_windows.h
@@ -22,6 +22,8 @@
 /** Win32 variant of atm_platform.h */
 #include <grpc/impl/codegen/port_platform.h>
 
+#ifdef GPR_WINDOWS
+
 typedef intptr_t gpr_atm;
 #define GPR_ATM_MAX INTPTR_MAX
 #define GPR_ATM_MIN INTPTR_MIN
@@ -124,5 +126,7 @@ static __inline gpr_atm gpr_atm_full_fetch_add(gpr_atm* p, gpr_atm delta) {
 static __inline gpr_atm gpr_atm_full_xchg(gpr_atm* p, gpr_atm n) {
   return (gpr_atm)InterlockedExchangePointer((PVOID*)p, (PVOID)n);
 }
+
+#endif /* GPR_WINDOWS */
 
 #endif /* GRPC_IMPL_CODEGEN_ATM_WINDOWS_H */

--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -462,7 +462,7 @@ typedef enum grpc_call_error {
 
 /** Default send/receive message size limits in bytes. -1 for unlimited. */
 /** TODO(roth) Make this match the default receive limit after next release */
-#define GRPC_DEFAULT_MAX_SEND_MESSAGE_LENGTH -1
+#define GRPC_DEFAULT_MAX_SEND_MESSAGE_LENGTH (-1)
 #define GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH (4 * 1024 * 1024)
 
 /** Write Flags: */

--- a/include/grpcpp/alarm.h
+++ b/include/grpcpp/alarm.h
@@ -38,7 +38,7 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   Alarm();
 
   /// Destroy the given completion queue alarm, cancelling it in the process.
-  ~Alarm();
+  ~Alarm() override;
 
   /// DEPRECATED: Create and set a completion queue alarm instance associated to
   /// \a cq.
@@ -66,8 +66,8 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   Alarm& operator=(const Alarm&) = delete;
 
   /// Alarms are movable.
-  Alarm(Alarm&& rhs) : alarm_(rhs.alarm_) { rhs.alarm_ = nullptr; }
-  Alarm& operator=(Alarm&& rhs) {
+  Alarm(Alarm&& rhs) noexcept : alarm_(rhs.alarm_) { rhs.alarm_ = nullptr; }
+  Alarm& operator=(Alarm&& rhs) noexcept {
     alarm_ = rhs.alarm_;
     rhs.alarm_ = nullptr;
     return *this;

--- a/include/grpcpp/channel.h
+++ b/include/grpcpp/channel.h
@@ -56,7 +56,7 @@ class Channel final : public ::grpc::ChannelInterface,
                       public std::enable_shared_from_this<Channel>,
                       private ::grpc::GrpcLibraryCodegen {
  public:
-  ~Channel();
+  ~Channel() override;
 
   /// Get the current channel state. If the channel is in IDLE and
   /// \a try_to_connect is set to true, try to connect.

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -58,7 +58,7 @@ inline grpc_metadata* FillMetadataArray(
     return nullptr;
   }
   grpc_metadata* metadata_array =
-      (grpc_metadata*)(g_core_codegen_interface->gpr_malloc(
+      static_cast<grpc_metadata*>(g_core_codegen_interface->gpr_malloc(
           (*metadata_count) * sizeof(grpc_metadata)));
   size_t i = 0;
   for (auto iter = metadata.cbegin(); iter != metadata.cend(); ++iter, ++i) {
@@ -234,7 +234,7 @@ class CallOpSendInitialMetadata {
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_SEND_INITIAL_METADATA;
     op->flags = flags_;
-    op->reserved = NULL;
+    op->reserved = nullptr;
     initial_metadata_ =
         FillMetadataArray(*metadata_map_, &initial_metadata_count_, "");
     op->data.send_initial_metadata.count = initial_metadata_count_;
@@ -318,7 +318,7 @@ class CallOpSendMessage {
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_SEND_MESSAGE;
     op->flags = write_options_.flags();
-    op->reserved = NULL;
+    op->reserved = nullptr;
     op->data.send_message.send_message = send_buf_.c_buffer();
     // Flags are per-message: clear them after use.
     write_options_.Clear();
@@ -436,7 +436,7 @@ class CallOpRecvMessage {
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_RECV_MESSAGE;
     op->flags = 0;
-    op->reserved = NULL;
+    op->reserved = nullptr;
     op->data.recv_message.recv_message = recv_buf_.c_buffer_ptr();
   }
 
@@ -545,7 +545,7 @@ class CallOpGenericRecvMessage {
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_RECV_MESSAGE;
     op->flags = 0;
-    op->reserved = NULL;
+    op->reserved = nullptr;
     op->data.recv_message.recv_message = recv_buf_.c_buffer_ptr();
   }
 
@@ -628,7 +628,7 @@ class CallOpClientSendClose {
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
     op->flags = 0;
-    op->reserved = NULL;
+    op->reserved = nullptr;
   }
   void FinishOp(bool* /*status*/) { send_ = false; }
 
@@ -680,7 +680,7 @@ class CallOpServerSendStatus {
     op->data.send_status_from_server.status_details =
         send_error_message_.empty() ? nullptr : &error_message_slice_;
     op->flags = 0;
-    op->reserved = NULL;
+    op->reserved = nullptr;
   }
 
   void FinishOp(bool* /*status*/) {
@@ -734,7 +734,7 @@ class CallOpRecvInitialMetadata {
     op->op = GRPC_OP_RECV_INITIAL_METADATA;
     op->data.recv_initial_metadata.recv_initial_metadata = metadata_map_->arr();
     op->flags = 0;
-    op->reserved = NULL;
+    op->reserved = nullptr;
   }
 
   void FinishOp(bool* /*status*/) {
@@ -788,7 +788,7 @@ class CallOpClientRecvStatus {
     op->data.recv_status_on_client.status_details = &error_message_;
     op->data.recv_status_on_client.error_string = &debug_error_string_;
     op->flags = 0;
-    op->reserved = NULL;
+    op->reserved = nullptr;
   }
 
   void FinishOp(bool* /*status*/) {
@@ -806,7 +806,8 @@ class CallOpClientRecvStatus {
                  metadata_map_->GetBinaryErrorDetails());
       if (debug_error_string_ != nullptr) {
         client_context_->set_debug_error_string(debug_error_string_);
-        g_core_codegen_interface->gpr_free((void*)debug_error_string_);
+        g_core_codegen_interface->gpr_free(
+            const_cast<char*>(debug_error_string_));
       }
     }
     // TODO(soheil): Find callers that set debug string even for status OK,

--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -24,6 +24,7 @@
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
+#include <grpcpp/impl/codegen/completion_queue_tag.h>
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/status.h>

--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -251,7 +251,7 @@ class ClientBidiReactor : public internal::ClientReactor {
   ///                not deleted or modified until OnWriteDone is called.
   /// \param[in] options The WriteOptions to use for writing this message
   void StartWrite(const Request* req, ::grpc::WriteOptions options) {
-    stream_->Write(req, std::move(options));
+    stream_->Write(req, options);
   }
 
   /// Initiate/post a write operation with specified options and an indication
@@ -264,7 +264,7 @@ class ClientBidiReactor : public internal::ClientReactor {
   ///                not deleted or modified until OnWriteDone is called.
   /// \param[in] options The WriteOptions to use for writing this message
   void StartWriteLast(const Request* req, ::grpc::WriteOptions options) {
-    StartWrite(req, std::move(options.set_last_message()));
+    StartWrite(req, options.set_last_message());
   }
 
   /// Indicate that the RPC will have no more write operations. This can only be
@@ -391,10 +391,10 @@ class ClientWriteReactor : public internal::ClientReactor {
     StartWrite(req, ::grpc::WriteOptions());
   }
   void StartWrite(const Request* req, ::grpc::WriteOptions options) {
-    writer_->Write(req, std::move(options));
+    writer_->Write(req, options);
   }
   void StartWriteLast(const Request* req, ::grpc::WriteOptions options) {
-    StartWrite(req, std::move(options.set_last_message()));
+    StartWrite(req, options.set_last_message());
   }
   void StartWritesDone() { writer_->WritesDone(); }
 

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -311,7 +311,7 @@ class ClientContext {
   ///
   /// \see grpc::AuthContext.
   std::shared_ptr<const grpc::AuthContext> auth_context() const {
-    if (auth_context_.get() == nullptr) {
+    if (auth_context_ == nullptr) {
       auth_context_ = grpc::CreateAuthContext(call_);
     }
     return auth_context_;

--- a/include/grpcpp/impl/codegen/client_unary_call.h
+++ b/include/grpcpp/impl/codegen/client_unary_call.h
@@ -20,6 +20,7 @@
 #define GRPCPP_IMPL_CODEGEN_CLIENT_UNARY_CALL_H
 
 #include <grpcpp/impl/codegen/call.h>
+#include <grpcpp/impl/codegen/call_op_set.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>

--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -114,7 +114,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   explicit CompletionQueue(grpc_completion_queue* take);
 
   /// Destructor. Destroys the owned wrapped completion queue / instance.
-  ~CompletionQueue() {
+  ~CompletionQueue() override {
     ::grpc::g_core_codegen_interface->grpc_completion_queue_destroy(cq_);
   }
 
@@ -247,7 +247,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
     cq_ = ::grpc::g_core_codegen_interface->grpc_completion_queue_create(
         ::grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
             &attributes),
-        &attributes, NULL);
+        &attributes, nullptr);
     InitialAvalanching();  // reserve this for the future shutdown
   }
 

--- a/include/grpcpp/impl/codegen/config.h
+++ b/include/grpcpp/impl/codegen/config.h
@@ -36,8 +36,8 @@ namespace grpc {
 // Using grpc::string and grpc::to_string is discouraged in favor of
 // std::string and std::to_string. This is only for legacy code using
 // them explictly.
-using std::string;     // deprecated
-using std::to_string;  // deprecated
+using std::string;     // deprecated // NOLINT(misc-unused-using-decls)
+using std::to_string;  // deprecated // NOLINT(misc-unused-using-decls)
 
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/config_protobuf.h
+++ b/include/grpcpp/impl/codegen/config_protobuf.h
@@ -90,6 +90,7 @@ namespace util {
 typedef GRPC_CUSTOM_UTIL_STATUS Status;
 }  // namespace util
 
+// NOLINTNEXTLINE(misc-unused-alias-decls)
 namespace json = GRPC_CUSTOM_JSONUTIL;
 
 namespace io {

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -31,10 +31,9 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  virtual const grpc_completion_queue_factory*
-  grpc_completion_queue_factory_lookup(
+  const grpc_completion_queue_factory* grpc_completion_queue_factory_lookup(
       const grpc_completion_queue_attributes* attributes) override;
-  virtual grpc_completion_queue* grpc_completion_queue_create(
+  grpc_completion_queue* grpc_completion_queue_create(
       const grpc_completion_queue_factory* factory,
       const grpc_completion_queue_attributes* attributes,
       void* reserved) override;
@@ -115,8 +114,8 @@ class CoreCodegen final : public CoreCodegenInterface {
   gpr_timespec gpr_inf_future(gpr_clock_type type) override;
   gpr_timespec gpr_time_0(gpr_clock_type type) override;
 
-  virtual const Status& ok() override;
-  virtual const Status& cancelled() override;
+  const Status& ok() override;
+  const Status& cancelled() override;
 
   void assert_fail(const char* failed_assertion, const char* file,
                    int line) override;

--- a/include/grpcpp/impl/codegen/delegating_channel.h
+++ b/include/grpcpp/impl/codegen/delegating_channel.h
@@ -19,12 +19,16 @@
 #ifndef GRPCPP_IMPL_CODEGEN_DELEGATING_CHANNEL_H
 #define GRPCPP_IMPL_CODEGEN_DELEGATING_CHANNEL_H
 
+#include <memory>
+
+#include <grpcpp/impl/codegen/channel_interface.h>
+
 namespace grpc {
 namespace experimental {
 
 class DelegatingChannel : public ::grpc::ChannelInterface {
  public:
-  virtual ~DelegatingChannel() {}
+  ~DelegatingChannel() override {}
 
   DelegatingChannel(std::shared_ptr<::grpc::ChannelInterface> delegate_channel)
       : delegate_channel_(delegate_channel) {}

--- a/include/grpcpp/impl/codegen/intercepted_channel.h
+++ b/include/grpcpp/impl/codegen/intercepted_channel.h
@@ -34,7 +34,7 @@ class InterceptorBatchMethodsImpl;
 /// see the RPC.
 class InterceptedChannel : public ChannelInterface {
  public:
-  virtual ~InterceptedChannel() { channel_ = nullptr; }
+  ~InterceptedChannel() override { channel_ = nullptr; }
 
   /// Get the current channel state. If the channel is in IDLE and
   /// \a try_to_connect is set to true, try to connect.

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -45,7 +45,7 @@ class InterceptorBatchMethodsImpl
     }
   }
 
-  ~InterceptorBatchMethodsImpl() {}
+  ~InterceptorBatchMethodsImpl() override {}
 
   bool QueryInterceptionHookPoint(
       experimental::InterceptionHookPoints type) override {
@@ -223,7 +223,7 @@ class InterceptorBatchMethodsImpl
   bool InterceptorsListEmpty() {
     auto* client_rpc_info = call_->client_rpc_info();
     if (client_rpc_info != nullptr) {
-      if (client_rpc_info->interceptors_.size() == 0) {
+      if (client_rpc_info->interceptors_.empty()) {
         return true;
       } else {
         return false;
@@ -231,8 +231,7 @@ class InterceptorBatchMethodsImpl
     }
 
     auto* server_rpc_info = call_->server_rpc_info();
-    if (server_rpc_info == nullptr ||
-        server_rpc_info->interceptors_.size() == 0) {
+    if (server_rpc_info == nullptr || server_rpc_info->interceptors_.empty()) {
       return true;
     }
     return false;
@@ -247,7 +246,7 @@ class InterceptorBatchMethodsImpl
     GPR_CODEGEN_ASSERT(ops_);
     auto* client_rpc_info = call_->client_rpc_info();
     if (client_rpc_info != nullptr) {
-      if (client_rpc_info->interceptors_.size() == 0) {
+      if (client_rpc_info->interceptors_.empty()) {
         return true;
       } else {
         RunClientInterceptors();
@@ -256,8 +255,7 @@ class InterceptorBatchMethodsImpl
     }
 
     auto* server_rpc_info = call_->server_rpc_info();
-    if (server_rpc_info == nullptr ||
-        server_rpc_info->interceptors_.size() == 0) {
+    if (server_rpc_info == nullptr || server_rpc_info->interceptors_.empty()) {
       return true;
     }
     RunServerInterceptors();
@@ -273,8 +271,7 @@ class InterceptorBatchMethodsImpl
     GPR_CODEGEN_ASSERT(reverse_ == true);
     GPR_CODEGEN_ASSERT(call_->client_rpc_info() == nullptr);
     auto* server_rpc_info = call_->server_rpc_info();
-    if (server_rpc_info == nullptr ||
-        server_rpc_info->interceptors_.size() == 0) {
+    if (server_rpc_info == nullptr || server_rpc_info->interceptors_.empty()) {
       return true;
     }
     callback_ = std::move(f);
@@ -489,7 +486,6 @@ class CancelInterceptorBatchMethods
     GPR_CODEGEN_ASSERT(false &&
                        "It is illegal to call ModifySendStatus on a method "
                        "which has a Cancel notification");
-    return;
   }
 
   std::multimap<std::string, std::string>* GetSendTrailingMetadata() override {

--- a/include/grpcpp/impl/codegen/method_handler_impl.h
+++ b/include/grpcpp/impl/codegen/method_handler_impl.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015 gRPC authors.
+ * Copyright 2018 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,7 @@
  *
  */
 
-#ifndef GRPC_IMPL_CODEGEN_SYNC_WINDOWS_H
-#define GRPC_IMPL_CODEGEN_SYNC_WINDOWS_H
+#ifndef GRPCPP_IMPL_CODEGEN_METHOD_HANDLER_IMPL_H
+#define GRPCPP_IMPL_CODEGEN_METHOD_HANDLER_IMPL_H
 
-#include <grpc/impl/codegen/port_platform.h>
-
-#ifdef GPR_WINDOWS
-
-#include <grpc/impl/codegen/sync_generic.h>
-
-typedef struct {
-  CRITICAL_SECTION cs; /* Not an SRWLock until Vista is unsupported */
-  int locked;
-} gpr_mu;
-
-typedef CONDITION_VARIABLE gpr_cv;
-
-typedef INIT_ONCE gpr_once;
-#define GPR_ONCE_INIT INIT_ONCE_STATIC_INIT
-
-#endif /* GPR_WINDOWS */
-
-#endif /* GRPC_IMPL_CODEGEN_SYNC_WINDOWS_H */
+#endif  // GRPCPP_IMPL_CODEGEN_METHOD_HANDLER_IMPL_H

--- a/include/grpcpp/impl/codegen/proto_buffer_reader.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_reader.h
@@ -59,7 +59,7 @@ class ProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
     }
   }
 
-  ~ProtoBufferReader() {
+  ~ProtoBufferReader() override {
     if (status_.ok()) {
       g_core_codegen_interface->grpc_byte_buffer_reader_destroy(&reader_);
     }
@@ -76,7 +76,7 @@ class ProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
       *data = GRPC_SLICE_START_PTR(*slice_) + GRPC_SLICE_LENGTH(*slice_) -
               backup_count_;
       GPR_CODEGEN_ASSERT(backup_count_ <= INT_MAX);
-      *size = (int)backup_count_;
+      *size = static_cast<int>(backup_count_);
       backup_count_ = 0;
       return true;
     }
@@ -88,7 +88,7 @@ class ProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
     *data = GRPC_SLICE_START_PTR(*slice_);
     // On win x64, int is only 32bit
     GPR_CODEGEN_ASSERT(GRPC_SLICE_LENGTH(*slice_) <= INT_MAX);
-    byte_count_ += * size = (int)GRPC_SLICE_LENGTH(*slice_);
+    byte_count_ += * size = static_cast<int>(GRPC_SLICE_LENGTH(*slice_));
     return true;
   }
 

--- a/include/grpcpp/impl/codegen/proto_buffer_writer.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_writer.h
@@ -65,12 +65,12 @@ class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
     GPR_CODEGEN_ASSERT(!byte_buffer->Valid());
     /// Create an empty raw byte buffer and look at its underlying slice buffer
     grpc_byte_buffer* bp =
-        g_core_codegen_interface->grpc_raw_byte_buffer_create(NULL, 0);
+        g_core_codegen_interface->grpc_raw_byte_buffer_create(nullptr, 0);
     byte_buffer->set_buffer(bp);
     slice_buffer_ = &bp->data.raw.slice_buffer;
   }
 
-  ~ProtoBufferWriter() {
+  ~ProtoBufferWriter() override {
     if (have_backup_) {
       g_core_codegen_interface->grpc_slice_unref(backup_slice_);
     }
@@ -107,7 +107,7 @@ class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
     *data = GRPC_SLICE_START_PTR(slice_);
     // On win x64, int is only 32bit
     GPR_CODEGEN_ASSERT(GRPC_SLICE_LENGTH(slice_) <= INT_MAX);
-    byte_count_ += * size = (int)GRPC_SLICE_LENGTH(slice_);
+    byte_count_ += * size = static_cast<int>(GRPC_SLICE_LENGTH(slice_));
     g_core_codegen_interface->grpc_slice_buffer_add(slice_buffer_, slice_);
     return true;
   }
@@ -122,7 +122,7 @@ class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
     /// 4. Mark that we still have the remaining part (for later use/unref)
     GPR_CODEGEN_ASSERT(count <= static_cast<int>(GRPC_SLICE_LENGTH(slice_)));
     g_core_codegen_interface->grpc_slice_buffer_pop(slice_buffer_);
-    if ((size_t)count == GRPC_SLICE_LENGTH(slice_)) {
+    if (static_cast<size_t>(count) == GRPC_SLICE_LENGTH(slice_)) {
       backup_slice_ = slice_;
     } else {
       backup_slice_ = g_core_codegen_interface->grpc_slice_split_tail(
@@ -133,7 +133,7 @@ class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
     // on a following Next() call, a reference will be returned to this slice
     // via GRPC_SLICE_START_PTR, which will not be an address held by
     // slice_buffer_.
-    have_backup_ = backup_slice_.refcount != NULL;
+    have_backup_ = backup_slice_.refcount != nullptr;
     byte_count_ -= count;
   }
 

--- a/include/grpcpp/impl/codegen/proto_utils.h
+++ b/include/grpcpp/impl/codegen/proto_utils.h
@@ -50,7 +50,7 @@ Status GenericSerialize(const grpc::protobuf::MessageLite& msg, ByteBuffer* bb,
                 "::protobuf::io::ZeroCopyOutputStream");
   *own_buffer = true;
   int byte_size = static_cast<int>(msg.ByteSizeLong());
-  if ((size_t)byte_size <= GRPC_SLICE_INLINED_SIZE) {
+  if (static_cast<size_t>(byte_size) <= GRPC_SLICE_INLINED_SIZE) {
     Slice slice(byte_size);
     // We serialize directly into the allocated slices memory
     GPR_CODEGEN_ASSERT(slice.end() == msg.SerializeWithCachedSizesToArray(

--- a/include/grpcpp/impl/codegen/rpc_method.h
+++ b/include/grpcpp/impl/codegen/rpc_method.h
@@ -36,7 +36,7 @@ class RpcMethod {
   };
 
   RpcMethod(const char* name, RpcType type)
-      : name_(name), method_type_(type), channel_tag_(NULL) {}
+      : name_(name), method_type_(type), channel_tag_(nullptr) {}
 
   RpcMethod(const char* name, RpcType type,
             const std::shared_ptr<ChannelInterface>& channel)

--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -190,7 +190,7 @@ class ServerBidiReactor;
 // the API.
 class ServerCallbackUnary : public internal::ServerCallbackCall {
  public:
-  virtual ~ServerCallbackUnary() {}
+  ~ServerCallbackUnary() override {}
   virtual void Finish(::grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
 
@@ -206,7 +206,7 @@ class ServerCallbackUnary : public internal::ServerCallbackCall {
 template <class Request>
 class ServerCallbackReader : public internal::ServerCallbackCall {
  public:
-  virtual ~ServerCallbackReader() {}
+  ~ServerCallbackReader() override {}
   virtual void Finish(::grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
   virtual void Read(Request* msg) = 0;
@@ -220,7 +220,7 @@ class ServerCallbackReader : public internal::ServerCallbackCall {
 template <class Response>
 class ServerCallbackWriter : public internal::ServerCallbackCall {
  public:
-  virtual ~ServerCallbackWriter() {}
+  ~ServerCallbackWriter() override {}
 
   virtual void Finish(::grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
@@ -237,7 +237,7 @@ class ServerCallbackWriter : public internal::ServerCallbackCall {
 template <class Request, class Response>
 class ServerCallbackReaderWriter : public internal::ServerCallbackCall {
  public:
-  virtual ~ServerCallbackReaderWriter() {}
+  ~ServerCallbackReaderWriter() override {}
 
   virtual void Finish(::grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
@@ -268,7 +268,7 @@ class ServerBidiReactor : public internal::ServerReactor {
   // TODO(vjpai): Switch to default constructor and default initializer when
   //              gcc-4.x is no longer supported
   ServerBidiReactor() : stream_(nullptr) {}
-  ~ServerBidiReactor() = default;
+  ~ServerBidiReactor() override = default;
 
   /// Send any initial metadata stored in the RPC context. If not invoked,
   /// any initial metadata will be passed along with the first Write or the
@@ -328,11 +328,11 @@ class ServerBidiReactor : public internal::ServerReactor {
       stream = stream_.load(std::memory_order_relaxed);
       if (stream == nullptr) {
         backlog_.write_wanted = resp;
-        backlog_.write_options_wanted = std::move(options);
+        backlog_.write_options_wanted = options;
         return;
       }
     }
-    stream->Write(resp, std::move(options));
+    stream->Write(resp, options);
   }
 
   /// Initiate a write operation with specified options and final RPC Status,
@@ -358,12 +358,12 @@ class ServerBidiReactor : public internal::ServerReactor {
       if (stream == nullptr) {
         backlog_.write_and_finish_wanted = true;
         backlog_.write_wanted = resp;
-        backlog_.write_options_wanted = std::move(options);
+        backlog_.write_options_wanted = options;
         backlog_.status_wanted = std::move(s);
         return;
       }
     }
-    stream->WriteAndFinish(resp, std::move(options), std::move(s));
+    stream->WriteAndFinish(resp, options, std::move(s));
   }
 
   /// Inform system of a planned write operation with specified options, but
@@ -375,7 +375,7 @@ class ServerBidiReactor : public internal::ServerReactor {
   ///                 not deleted or modified until OnWriteDone is called.
   /// \param[in] options The WriteOptions to use for writing this message
   void StartWriteLast(const Response* resp, ::grpc::WriteOptions options) {
-    StartWrite(resp, std::move(options.set_last_message()));
+    StartWrite(resp, options.set_last_message());
   }
 
   /// Indicate that the stream is to be finished and the trailing metadata and
@@ -484,7 +484,7 @@ template <class Request>
 class ServerReadReactor : public internal::ServerReactor {
  public:
   ServerReadReactor() : reader_(nullptr) {}
-  ~ServerReadReactor() = default;
+  ~ServerReadReactor() override = default;
 
   /// The following operation initiations are exactly like ServerBidiReactor.
   void StartSendInitialMetadata() {
@@ -571,7 +571,7 @@ template <class Response>
 class ServerWriteReactor : public internal::ServerReactor {
  public:
   ServerWriteReactor() : writer_(nullptr) {}
-  ~ServerWriteReactor() = default;
+  ~ServerWriteReactor() override = default;
 
   /// The following operation initiations are exactly like ServerBidiReactor.
   void StartSendInitialMetadata() {
@@ -598,11 +598,11 @@ class ServerWriteReactor : public internal::ServerReactor {
       writer = writer_.load(std::memory_order_relaxed);
       if (writer == nullptr) {
         backlog_.write_wanted = resp;
-        backlog_.write_options_wanted = std::move(options);
+        backlog_.write_options_wanted = options;
         return;
       }
     }
-    writer->Write(resp, std::move(options));
+    writer->Write(resp, options);
   }
   void StartWriteAndFinish(const Response* resp, ::grpc::WriteOptions options,
                            ::grpc::Status s) {
@@ -614,15 +614,15 @@ class ServerWriteReactor : public internal::ServerReactor {
       if (writer == nullptr) {
         backlog_.write_and_finish_wanted = true;
         backlog_.write_wanted = resp;
-        backlog_.write_options_wanted = std::move(options);
+        backlog_.write_options_wanted = options;
         backlog_.status_wanted = std::move(s);
         return;
       }
     }
-    writer->WriteAndFinish(resp, std::move(options), std::move(s));
+    writer->WriteAndFinish(resp, options, std::move(s));
   }
   void StartWriteLast(const Response* resp, ::grpc::WriteOptions options) {
-    StartWrite(resp, std::move(options.set_last_message()));
+    StartWrite(resp, options.set_last_message());
   }
   void Finish(::grpc::Status s) {
     ServerCallbackWriter<Response>* writer =
@@ -688,7 +688,7 @@ class ServerWriteReactor : public internal::ServerReactor {
 class ServerUnaryReactor : public internal::ServerReactor {
  public:
   ServerUnaryReactor() : call_(nullptr) {}
-  ~ServerUnaryReactor() = default;
+  ~ServerUnaryReactor() override = default;
 
   /// StartSendInitialMetadata is exactly like ServerBidiReactor.
   void StartSendInitialMetadata() {

--- a/include/grpcpp/impl/codegen/server_callback_handlers.h
+++ b/include/grpcpp/impl/codegen/server_callback_handlers.h
@@ -53,7 +53,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
         param.call->call(), sizeof(ServerCallbackUnaryImpl)))
         ServerCallbackUnaryImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
-            param.call, allocator_state, std::move(param.call_requester));
+            param.call, allocator_state, param.call_requester);
     param.server_context->BeginCompletionOp(
         param.call, [call](bool) { call->MaybeDone(); }, call);
 
@@ -266,7 +266,7 @@ class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
         param.call->call(), sizeof(ServerCallbackReaderImpl)))
         ServerCallbackReaderImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
-            param.call, std::move(param.call_requester));
+            param.call, param.call_requester);
     // Inlineable OnDone can be false in the CompletionOp callback because there
     // is no read reactor that has an inlineable OnDone; this only applies to
     // the DefaultReactor (which is unary).
@@ -453,7 +453,7 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
         ServerCallbackWriterImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
             param.call, static_cast<RequestType*>(param.request),
-            std::move(param.call_requester));
+            param.call_requester);
     // Inlineable OnDone can be false in the CompletionOp callback because there
     // is no write reactor that has an inlineable OnDone; this only applies to
     // the DefaultReactor (which is unary).
@@ -673,7 +673,7 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
         param.call->call(), sizeof(ServerCallbackReaderWriterImpl)))
         ServerCallbackReaderWriterImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
-            param.call, std::move(param.call_requester));
+            param.call, param.call_requester);
     // Inlineable OnDone can be false in the CompletionOp callback because there
     // is no bidi reactor that has an inlineable OnDone; this only applies to
     // the DefaultReactor (which is unary).

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -265,7 +265,7 @@ class ServerContextBase {
   ///
   /// \see grpc::AuthContext.
   std::shared_ptr<const ::grpc::AuthContext> auth_context() const {
-    if (auth_context_.get() == nullptr) {
+    if (auth_context_ == nullptr) {
       auth_context_ = ::grpc::CreateAuthContext(call_.call);
     }
     return auth_context_;
@@ -415,7 +415,7 @@ class ServerContextBase {
       const char* method, ::grpc::internal::RpcMethod::RpcType type,
       const std::vector<std::unique_ptr<
           ::grpc::experimental::ServerInterceptorFactoryInterface>>& creators) {
-    if (creators.size() != 0) {
+    if (!creators.empty()) {
       rpc_info_ = new ::grpc::experimental::ServerRpcInfo(this, method, type);
       rpc_info_->RegisterInterceptors(creators);
     }
@@ -476,6 +476,7 @@ class ServerContextBase {
   };
 
   void SetupTestDefaultReactor(std::function<void(::grpc::Status)> func) {
+    // NOLINTNEXTLINE(modernize-make-unique)
     test_unary_.reset(new TestServerCallbackUnary(this, std::move(func)));
   }
   bool test_status_set() const {

--- a/include/grpcpp/impl/codegen/server_interface.h
+++ b/include/grpcpp/impl/codegen/server_interface.h
@@ -64,7 +64,7 @@ class ServerInterceptorFactoryInterface;
 
 class ServerInterface : public internal::CallHook {
  public:
-  virtual ~ServerInterface() {}
+  ~ServerInterface() override {}
 
   /// \a Shutdown does the following things:
   ///
@@ -186,8 +186,8 @@ class ServerInterface : public internal::CallHook {
 
   virtual grpc_server* server() = 0;
 
-  virtual void PerformOpsOnCall(internal::CallOpSetInterface* ops,
-                                internal::Call* call) = 0;
+  void PerformOpsOnCall(internal::CallOpSetInterface* ops,
+                        internal::Call* call) override = 0;
 
   class BaseAsyncRequest : public internal::CompletionQueueTag {
    public:
@@ -196,7 +196,7 @@ class ServerInterface : public internal::CallHook {
                      ::grpc::CompletionQueue* call_cq,
                      ::grpc::ServerCompletionQueue* notification_cq, void* tag,
                      bool delete_on_finalize);
-    virtual ~BaseAsyncRequest();
+    ~BaseAsyncRequest() override;
 
     bool FinalizeResult(void** tag, bool* status) override;
 
@@ -228,7 +228,7 @@ class ServerInterface : public internal::CallHook {
                            void* tag, const char* name,
                            internal::RpcMethod::RpcType type);
 
-    virtual bool FinalizeResult(void** tag, bool* status) override {
+    bool FinalizeResult(void** tag, bool* status) override {
       /* If we are done intercepting, then there is nothing more for us to do */
       if (done_intercepting_) {
         return BaseAsyncRequest::FinalizeResult(tag, status);
@@ -283,7 +283,7 @@ class ServerInterface : public internal::CallHook {
                    notification_cq);
     }
 
-    ~PayloadAsyncRequest() {
+    ~PayloadAsyncRequest() override {
       payload_.Release();  // We do not own the payload_
     }
 

--- a/include/grpcpp/impl/codegen/service_type.h
+++ b/include/grpcpp/impl/codegen/service_type.h
@@ -91,7 +91,7 @@ class Service {
 
   bool has_generic_methods() const {
     for (const auto& method : methods_) {
-      if (method.get() == nullptr) {
+      if (method == nullptr) {
         return true;
       }
     }

--- a/include/grpcpp/resource_quota.h
+++ b/include/grpcpp/resource_quota.h
@@ -36,7 +36,7 @@ class ResourceQuota final : private ::grpc::GrpcLibraryCodegen {
   /// \param name - a unique name for this ResourceQuota.
   explicit ResourceQuota(const std::string& name);
   ResourceQuota();
-  ~ResourceQuota();
+  ~ResourceQuota() override;
 
   /// Resize this \a ResourceQuota to a new size. If \a new_size is smaller
   /// than the current size of the pool, memory usage will be monotonically

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -69,7 +69,7 @@ std::shared_ptr<ChannelCredentials> XdsCredentials(
 class ChannelCredentials : private grpc::GrpcLibraryCodegen {
  public:
   ChannelCredentials();
-  ~ChannelCredentials();
+  ~ChannelCredentials() override;
 
  protected:
   friend std::shared_ptr<ChannelCredentials> CompositeChannelCredentials(
@@ -126,7 +126,7 @@ class ChannelCredentials : private grpc::GrpcLibraryCodegen {
 class CallCredentials : private grpc::GrpcLibraryCodegen {
  public:
   CallCredentials();
-  ~CallCredentials();
+  ~CallCredentials() override;
 
   /// Apply this instance's credentials to \a call.
   virtual bool ApplyToCall(grpc_call* call) = 0;

--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -58,7 +58,7 @@ class ExternalConnectionAcceptorImpl;
 /// \a Server instances.
 class Server : public ServerInterface, private GrpcLibraryCodegen {
  public:
-  ~Server();
+  ~Server() override;
 
   /// Block until the server shuts down.
   ///

--- a/include/grpcpp/support/channel_arguments.h
+++ b/include/grpcpp/support/channel_arguments.h
@@ -117,7 +117,7 @@ class ChannelArguments {
   grpc_channel_args c_channel_args() const {
     grpc_channel_args out;
     out.num_args = args_.size();
-    out.args = args_.empty() ? NULL : const_cast<grpc_arg*>(&args_[0]);
+    out.args = args_.empty() ? nullptr : const_cast<grpc_arg*>(&args_[0]);
     return out;
   }
 

--- a/tools/distrib/run_clang_tidy.py
+++ b/tools/distrib/run_clang_tidy.py
@@ -60,5 +60,5 @@ for filename in args.files:
             timeout_seconds=15 * 60,
         ))
 
-num_fails, res_set = jobset.run(jobs, maxjobs=args.jobs)
+num_fails, res_set = jobset.run(jobs, maxjobs=args.jobs, quiet_success=True)
 sys.exit(num_fails)

--- a/tools/dockerfile/grpc_clang_tidy/clang_tidy_all_the_things.sh
+++ b/tools/dockerfile/grpc_clang_tidy/clang_tidy_all_the_things.sh
@@ -22,7 +22,7 @@ cd ${CLANG_TIDY_ROOT}
 
 # run clang tidy for all source files
 cat compile_commands.json | jq -r '.[].file' \
-  | grep -E "(^src/core/|^src/cpp/|^test/core/|^test/cpp/)" \
+  | grep -E "(^include/|^src/core/|^src/cpp/|^test/core/|^test/cpp/)" \
   | grep -v -E "/upb-generated/|/upbdefs-generated/" \
   | sort \
   | xargs tools/distrib/run_clang_tidy.py "$@"


### PR DESCRIPTION
Enable clang-tidy on all files in include directory. This is helpful to keep code clean and also self-sufficient header files. (Related to #24676)