### PR TITLE
remove zend_hash_destroy() from postfork handler

### DIFF
--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -171,9 +171,7 @@ void prefork() {
 // Called at post fork
 void php_grpc_clean_persistent_list(TSRMLS_D) {
     zend_hash_clean(&grpc_persistent_list);
-    zend_hash_destroy(&grpc_persistent_list);
     zend_hash_clean(&grpc_target_upper_bound_map);
-    zend_hash_destroy(&grpc_target_upper_bound_map);
 }
 
 void postfork_child() {


### PR DESCRIPTION
At the moment gRPC PHP extension tries to [cleanup](https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/php_grpc.c#L172) the environment at fork() by freeing every resource allocated before the fork(). Unfortunately, this leads to double frees in case we don't exec() after fork() and just continue running PHP itself.

The `grpc_persistent_list` and `grpc_target_upper_bound_map` hashes are [initialized in MINIT](https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/channel.c#L792) and [destroyed in MSHUTDOWN](https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/php_grpc.c#L565). The hashes do not get initialized again in the child process, so destroying them in the postfork handler means that they are destroyed twice: in the postfork and in MSHUTDOWN. This is when the crash happens.

This issue is quite complex to reproduce since PHP delays actual hash initialization and does it when the first element is being added, so just `pcntl_fork();` is not enough to reproduce it (even though I see quite a number of invalid reads there in Valgrind log). I guess to make reproduce case one has actually to establish a connection and then execute a fork(), but most likely even that is not enough since we only see some intermittent crashes.

It does look like the patch in this PR introduces a minor memory leak in case when exec() is executed after fork(), but it's extremely minor and should only exist in case there were gRPC connections established before the fork(). I can't think of a proper way to prevent it at the moment.

@markdroth
