### PR TITLE
Fix a bug where the default port number is not resolved correctly when the host of grpc_uri is an ip address.

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -515,7 +515,13 @@ static bool inner_resolve_as_ip_literal_locked(
     *port = default_port;
   }
   grpc_resolved_address addr;
-  *hostport = grpc_core::JoinHostPort(*host, atoi(port->c_str()));
+  int port_number = atoi(port->c_str());
+  if (strcmp(port->c_str(), "http") == 0) {
+    port_number = 80;
+  } else if (strcmp(port->c_str(), "https") == 0) {
+    port_number = 443;
+  }
+  *hostport = grpc_core::JoinHostPort(*host, port_number);
   if (grpc_parse_ipv4_hostport(hostport->c_str(), &addr,
                                false /* log errors */) ||
       grpc_parse_ipv6_hostport(hostport->c_str(), &addr,


### PR DESCRIPTION
I found there is an issue with `grpc_uri`. The port number is always resolved to 0 when:
1. the host of `grpc_uri` is an ip address
2. the port of `grpc_uri` is not explicitly specified

For example:
If we construct a `grpc_uri` with a url "http://169.254.169.254", the resolved address is expected to be "ipv4:169.254.169.254:**80**", however, it's now always "ipv4:169.254.169.254:**0**".

I doubt it's because the `default_port` gonna be "http" or "https", then `atoi(port->c_str())` turns out to be 0.
This pr fixes the case above, however I'm not sure if there is any side effect.

@markdroth Please take a look. Thanks!
