### PR TITLE
Decrease log level when BIOS data file is not found for on-GCP indication

### DIFF
--- a/src/core/lib/security/credentials/alts/check_gcp_environment.cc
+++ b/src/core/lib/security/credentials/alts/check_gcp_environment.cc
@@ -57,7 +57,7 @@ namespace internal {
 char* read_bios_file(const char* bios_file) {
   FILE* fp = fopen(bios_file, "r");
   if (!fp) {
-    gpr_log(GPR_ERROR, "BIOS data file cannot be opened.");
+    gpr_log(GPR_INFO, "BIOS data file does not exist or cannot be opened.");
     return nullptr;
   }
   char buf[kBiosDataBufferSize + 1];


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/24675
@markdroth
