### PR TITLE
Fix missing google-explicit-constructor for header files

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -196,10 +196,14 @@ class ByteBuffer final {
 
   class ByteBufferPointer {
    public:
+    /* NOLINTNEXTLINE(google-explicit-constructor) */
     ByteBufferPointer(const ByteBuffer* b)
         : bbuf_(const_cast<ByteBuffer*>(b)) {}
+    /* NOLINTNEXTLINE(google-explicit-constructor) */
     operator ByteBuffer*() { return bbuf_; }
+    /* NOLINTNEXTLINE(google-explicit-constructor) */
     operator grpc_byte_buffer*() { return bbuf_->buffer_; }
+    /* NOLINTNEXTLINE(google-explicit-constructor) */
     operator grpc_byte_buffer**() { return &bbuf_->buffer_; }
 
    private:

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -512,7 +512,7 @@ class DeserializeFunc {
 template <class R>
 class DeserializeFuncType final : public DeserializeFunc {
  public:
-  DeserializeFuncType(R* message) : message_(message) {}
+  explicit DeserializeFuncType(R* message) : message_(message) {}
   Status Deserialize(ByteBuffer* buf) override {
     return SerializationTraits<R>::Deserialize(buf->bbuf_ptr(), message_);
   }

--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -190,6 +190,7 @@ class CallbackWithSuccessTag
   void force_run(bool ok) { Run(ok); }
 
   /// check if this tag is currently set
+  /* NOLINTNEXTLINE(google-explicit-constructor) */
   operator bool() const { return call_ != nullptr; }
 
  private:

--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -243,7 +243,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
 
  protected:
   /// Private constructor of CompletionQueue only visible to friend classes
-  CompletionQueue(const grpc_completion_queue_attributes& attributes) {
+  explicit CompletionQueue(const grpc_completion_queue_attributes& attributes) {
     cq_ = ::grpc::g_core_codegen_interface->grpc_completion_queue_create(
         ::grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
             &attributes),
@@ -301,7 +301,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// initialized, it must be flushed on the same thread.
   class CompletionQueueTLSCache {
    public:
-    CompletionQueueTLSCache(CompletionQueue* cq);
+    explicit CompletionQueueTLSCache(CompletionQueue* cq);
     ~CompletionQueueTLSCache();
     bool Flush(void** tag, bool* ok);
 

--- a/include/grpcpp/impl/codegen/delegating_channel.h
+++ b/include/grpcpp/impl/codegen/delegating_channel.h
@@ -30,7 +30,8 @@ class DelegatingChannel : public ::grpc::ChannelInterface {
  public:
   ~DelegatingChannel() override {}
 
-  DelegatingChannel(std::shared_ptr<::grpc::ChannelInterface> delegate_channel)
+  explicit DelegatingChannel(
+      std::shared_ptr<::grpc::ChannelInterface> delegate_channel)
       : delegate_channel_(delegate_channel) {}
 
   grpc_connectivity_state GetState(bool try_to_connect) override {

--- a/include/grpcpp/impl/codegen/grpc_library.h
+++ b/include/grpcpp/impl/codegen/grpc_library.h
@@ -37,7 +37,8 @@ extern GrpcLibraryInterface* g_glip;
 /// Classes that require gRPC to be initialized should inherit from this class.
 class GrpcLibraryCodegen {
  public:
-  GrpcLibraryCodegen(bool call_grpc_init = true) : grpc_init_called_(false) {
+  explicit GrpcLibraryCodegen(bool call_grpc_init = true)
+      : grpc_init_called_(false) {
     if (call_grpc_init) {
       GPR_CODEGEN_ASSERT(g_glip &&
                          "gRPC library not initialized. See "

--- a/include/grpcpp/impl/codegen/method_handler.h
+++ b/include/grpcpp/impl/codegen/method_handler.h
@@ -261,7 +261,7 @@ class ServerStreamingHandler : public ::grpc::internal::MethodHandler {
 template <class Streamer, bool WriteNeeded>
 class TemplatedBidiStreamingHandler : public ::grpc::internal::MethodHandler {
  public:
-  TemplatedBidiStreamingHandler(
+  explicit TemplatedBidiStreamingHandler(
       std::function<::grpc::Status(::grpc::ServerContext*, Streamer*)> func)
       : func_(func), write_needed_(WriteNeeded) {}
 

--- a/include/grpcpp/impl/codegen/slice.h
+++ b/include/grpcpp/impl/codegen/slice.h
@@ -49,7 +49,7 @@ class Slice final {
   Slice(grpc_slice slice, StealRef) : slice_(slice) {}
 
   /// Allocate a slice of specified size
-  Slice(size_t len)
+  explicit Slice(size_t len)
       : slice_(g_core_codegen_interface->grpc_slice_malloc(len)) {}
 
   /// Construct a slice from a copied buffer
@@ -58,6 +58,7 @@ class Slice final {
             reinterpret_cast<const char*>(buf), len)) {}
 
   /// Construct a slice from a copied string
+  /* NOLINTNEXTLINE(google-explicit-constructor) */
   Slice(const std::string& str)
       : slice_(g_core_codegen_interface->grpc_slice_from_copied_buffer(
             str.c_str(), str.length())) {}

--- a/include/grpcpp/impl/codegen/string_ref.h
+++ b/include/grpcpp/impl/codegen/string_ref.h
@@ -57,8 +57,10 @@ class string_ref {
     return *this;
   }
 
+  /* NOLINTNEXTLINE(google-explicit-constructor) */
   string_ref(const char* s) : data_(s), length_(strlen(s)) {}
   string_ref(const char* s, size_t l) : data_(s), length_(l) {}
+  /* NOLINTNEXTLINE(google-explicit-constructor) */
   string_ref(const std::string& s) : data_(s.data()), length_(s.length()) {}
 
   /// iterators

--- a/include/grpcpp/impl/codegen/time.h
+++ b/include/grpcpp/impl/codegen/time.h
@@ -50,6 +50,7 @@ class TimePoint {
 template <>
 class TimePoint<gpr_timespec> {
  public:
+  /* NOLINTNEXTLINE(google-explicit-constructor) */
   TimePoint(const gpr_timespec& time) : time_(time) {}
   gpr_timespec raw_time() { return time_; }
 
@@ -73,6 +74,7 @@ std::chrono::system_clock::time_point Timespec2Timepoint(gpr_timespec t);
 template <>
 class TimePoint<std::chrono::system_clock::time_point> {
  public:
+  /* NOLINTNEXTLINE(google-explicit-constructor) */
   TimePoint(const std::chrono::system_clock::time_point& time) {
     Timepoint2Timespec(time, &time_);
   }

--- a/include/grpcpp/impl/server_initializer.h
+++ b/include/grpcpp/impl/server_initializer.h
@@ -30,7 +30,7 @@ class Service;
 
 class ServerInitializer {
  public:
-  ServerInitializer(grpc::Server* server) : server_(server) {}
+  explicit ServerInitializer(grpc::Server* server) : server_(server) {}
 
   bool RegisterService(std::shared_ptr<grpc::Service> service) {
     if (!server_->RegisterService(nullptr, service.get())) {

--- a/include/grpcpp/security/server_credentials.h
+++ b/include/grpcpp/security/server_credentials.h
@@ -40,7 +40,7 @@ struct SslServerCredentialsOptions {
   SslServerCredentialsOptions()
       : force_client_auth(false),
         client_certificate_request(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE) {}
-  SslServerCredentialsOptions(
+  explicit SslServerCredentialsOptions(
       grpc_ssl_client_certificate_request_type request_type)
       : force_client_auth(false), client_certificate_request(request_type) {}
 

--- a/include/grpcpp/security/tls_certificate_provider.h
+++ b/include/grpcpp/security/tls_certificate_provider.h
@@ -59,10 +59,10 @@ class StaticDataCertificateProvider : public CertificateProviderInterface {
       const std::string& root_certificate,
       const std::vector<IdentityKeyCertPair>& identity_key_cert_pairs);
 
-  StaticDataCertificateProvider(const std::string& root_certificate)
+  explicit StaticDataCertificateProvider(const std::string& root_certificate)
       : StaticDataCertificateProvider(root_certificate, {}) {}
 
-  StaticDataCertificateProvider(
+  explicit StaticDataCertificateProvider(
       const std::vector<IdentityKeyCertPair>& identity_key_cert_pairs)
       : StaticDataCertificateProvider("", identity_key_cert_pairs) {}
 

--- a/include/grpcpp/security/tls_credentials_options.h
+++ b/include/grpcpp/security/tls_credentials_options.h
@@ -54,7 +54,8 @@ class TlsServerAuthorizationCheckArg {
   /** TlsServerAuthorizationCheckArg does not take ownership of the C arg passed
    * to the constructor. One must remember to free any memory allocated to the
    * C arg after using the setter functions below. **/
-  TlsServerAuthorizationCheckArg(grpc_tls_server_authorization_check_arg* arg);
+  explicit TlsServerAuthorizationCheckArg(
+      grpc_tls_server_authorization_check_arg* arg);
   ~TlsServerAuthorizationCheckArg();
 
   /** Getters for member fields. **/
@@ -101,7 +102,7 @@ struct TlsServerAuthorizationCheckInterface {
  *  purposes for now and it is subject to change. **/
 class TlsServerAuthorizationCheckConfig {
  public:
-  TlsServerAuthorizationCheckConfig(
+  explicit TlsServerAuthorizationCheckConfig(
       std::shared_ptr<TlsServerAuthorizationCheckInterface>
           server_authorization_check_interface);
   ~TlsServerAuthorizationCheckConfig();


### PR DESCRIPTION
The master happened not to pass code-tidy test of the sanity test after #24873 and #24889 got merged independently. This fixed this by fixing all `google-explicit-constructor` issue from header files.