### PR TITLE
PHP: fix phpunit warnings

### DIFF
--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -138,21 +138,17 @@ class CallCredentialsTest extends \PHPUnit\Framework\TestCase
                           get_class($call_credentials3));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateFromPluginInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $call_credentials = Grpc\CallCredentials::createFromPlugin(
             'callbackFunc'
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateCompositeInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $call_credentials3 = Grpc\CallCredentials::createComposite(
             $this->call_credentials,
             $this->credentials

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -107,81 +107,65 @@ class CallTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->call->cancel());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidStartBatchKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             'invalid' => ['key1' => 'value1'],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadataStrKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['Key' => ['value1', 'value2']],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadataIntKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => [1 => ['value1', 'value2']],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadataInnerValue()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['key1' => 'value1'],
         ];
         $result = $this->call->startBatch($batch);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstuctor()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call = new Grpc\Call();
         $this->assertNull($this->call);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstuctor2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call = new Grpc\Call('hi', 'hi', 'hi');
         $this->assertNull($this->call);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidSetCredentials()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call->setCredentials('hi');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidSetCredentials2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->call->setCredentials([]);
     }
 }

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -56,19 +56,15 @@ class ChanellCredentialsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(Grpc\ChannelCredentials::isDefaultRootsPemSet());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidCreateSsl()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $channel_credentials = Grpc\ChannelCredentials::createSsl([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidCreateComposite()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $channel_credentials = Grpc\ChannelCredentials::createComposite(
             'something', 'something');
     }

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -105,67 +105,53 @@ class ChannelTest extends \PHPUnit\Framework\TestCase
         $this->channel->close();
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWithNull()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel();
         $this->assertNull($this->channel);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWith()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50008', 'invalid');
         $this->assertNull($this->channel);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidCredentials()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50009',
             ['credentials' => new Grpc\Timeval(100)]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidOptionsArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50010',
             ['abc' => []]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidGetConnectivityStateWithArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50011',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->getConnectivityState([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWatchConnectivityState()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50012',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidWatchConnectivityState2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:50013',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState(1, 'hi');
@@ -409,11 +395,9 @@ class ChannelTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testPersistentChannelSharedChannelClose2()
     {
+        $this->expectException(\RuntimeException::class);
         // same underlying channel
         $this->channel1 = new Grpc\Channel('localhost:50223', [
             "grpc_target_persist_bound" => 3,
@@ -645,12 +629,9 @@ class ChannelTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testPersistentChannelForceNewOldChannelClose2()
     {
-
+        $this->expectException(\RuntimeException::class);
         $this->channel1 = new Grpc\Channel('localhost:50230', [
             "grpc_target_persist_bound" => 2,
         ]);

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -188,11 +188,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         unset($server_call);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidClientMessageArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -209,11 +207,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidClientMessageString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -230,11 +226,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidClientMessageFlags()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -253,11 +247,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidServerStatusMetadata()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -294,11 +286,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidServerStatusCode()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -335,11 +325,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMissingServerStatusCode()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -375,11 +363,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidServerStatusDetails()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -416,11 +402,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMissingServerStatusDetails()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -456,11 +440,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidStartBatchKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -475,11 +457,9 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testInvalidStartBatch()
     {
+        $this->expectException(\LogicException::class);
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -557,29 +537,23 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($new_state == Grpc\CHANNEL_IDLE);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetConnectivityStateInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->assertTrue($this->channel->getConnectivityState(
             new Grpc\Timeval()));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWatchConnectivityStateInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->assertTrue($this->channel->watchConnectivityState(
             0, 1000));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testChannelConstructorInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->channel = new Grpc\Channel('localhost:'.$this->port, null);
     }
 

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -167,13 +167,11 @@ class PersistentListTest extends \PHPUnit\Framework\TestCase
       $this->channel2->close();
   }
 
-  /**
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage startBatch Error. Channel is closed
-   */
   public function testPersistentChannelSharedChannelClose()
   {
-      // same underlying channel
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage("startBatch Error. Channel is closed");
+    // same underlying channel
       $this->channel1 = new Grpc\Channel('localhost:10001', [
           "grpc_target_persist_bound" => 2,
       ]);

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -90,65 +90,52 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         return $server_credentials;
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructor()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server('invalid_host');
         $this->assertNull($this->server);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWithNumKeyOfArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server([10 => '127.0.0.1',
                                          20 => '8080', ]);
         $this->assertNull($this->server);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidConstructorWithList()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server(['127.0.0.1', '8080']);
         $this->assertNull($this->server);
     }
-    /**
-     * @expectedException InvalidArgumentException
-     */
+
     public function testInvalidAddHttp2Port()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server([]);
         $port = $this->server->addHttp2Port(['0.0.0.0:0']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidAddSecureHttp2Port()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server([]);
         $port = $this->server->addSecureHttp2Port(['0.0.0.0:0']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidAddSecureHttp2Port2()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server();
         $port = $this->server->addSecureHttp2Port('0.0.0.0:0');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidAddSecureHttp2Port3()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->server = new Grpc\Server();
         $port = $this->server->addSecureHttp2Port('0.0.0.0:0', 'invalid');
     }

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -185,45 +185,35 @@ class TimevalTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(($done_microtime - $curr_microtime) > 0.0009);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testConstructorInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $delta = new Grpc\Timeval('abc');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testAddInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::now();
         $a->add(1000);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testSubtractInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::now();
         $a->subtract(1000);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCompareInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::compare(1000, 1100);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testSimilarInvalidParam()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $a = Grpc\Timeval::similar(1000, 1100, 1200);
         $this->assertNull($delta);
     }


### PR DESCRIPTION
 The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. Refactored test cases to use expectException() and expectExceptionMessage() instead.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@stanley-cheung 
