### PR TITLE
Fix StatusCode

### DIFF
--- a/test/cpp/server/server_request_call_test.cc
+++ b/test/cpp/server/server_request_call_test.cc
@@ -138,7 +138,7 @@ TEST(ServerRequestCallTest, ShortDeadlineDoesNotCauseOkayFalse) {
     ctx.set_deadline(std::chrono::system_clock::now() +
                      std::chrono::milliseconds(1));
     grpc::Status status = stub->Echo(&ctx, request, &response);
-    EXPECT_EQ(DEADLINE_EXCEEDED, status.error_code());
+    EXPECT_EQ(StatusCode::DEADLINE_EXCEEDED, status.error_code());
     gpr_log(GPR_INFO, "Success.");
   }
   gpr_log(GPR_INFO, "Done sending RPCs.");


### PR DESCRIPTION
Added `StatusCode` namespace to `DEADLINE_EXCEEDED` so that it can be compiled internally with a different definition of StatusCode.