### PR TITLE
Added bazel warm-up step to sanity docker image

### DIFF
--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -45,5 +45,14 @@
   <%include file="../../bazel.include"/>
   <%include file="../../buildifier.include"/>
 
+  #========================
+  # Warm-up Bazel (prefetching required files so that it can use cached ones later)
+  RUN cd /tmp && ${"\\"}
+    git clone https://github.com/grpc/grpc.git && ${"\\"}
+    cd grpc && ${"\\"}
+    tools/distrib/gen_compilation_database.py --include_headers --ignore_system_headers --dedup_targets "//:*" "//src/core/..." "//src/compiler/..." "//test/core/..." "//test/cpp/..." && ${"\\"}
+    cd .. && rm -rf grpc
+
+
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -110,5 +110,14 @@ RUN chmod +x buildifier
 RUN mv buildifier /usr/local/bin
 
 
+#========================
+# Warm-up Bazel (prefetching required files so that it can use cached ones later)
+RUN cd /tmp && \
+  git clone https://github.com/grpc/grpc.git && \
+  cd grpc && \
+  tools/distrib/gen_compilation_database.py --include_headers --ignore_system_headers --dedup_targets "//:*" "//src/core/..." "//src/compiler/..." "//test/core/..." "//test/cpp/..." && \
+  cd .. && rm -rf grpc
+
+
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Adding prefetched components such openjdk/azul-zulu11.2.3 to the sanity docker image to make it more robust from the download failure.

b/171497600
