### PR TITLE
Fix PECL problem

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -128,6 +128,9 @@ then
   export LDFLAGS="-L/usr/local/opt/php@7.2/lib $(LDFLAGS)"
   export CPPFLAGS="-I/usr/local/opt/php@7.2/include $(CPPFLAGS)"
   export PATH="/usr/local/opt/php@7.2/bin:/usr/local/opt/php@7.2/sbin:$PATH"
+
+  # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081
+  mkdir -p /usr/local/lib/php/pecl
 fi
 
 # TODO(jtattermusch): better debugging of clock skew, remove once not needed


### PR DESCRIPTION
Currently [distribtest.php7_macos_x64_None](https://source.cloud.google.com/results/invocations/36ba1d80-45c8-4be3-82fb-18e4d956d14a/targets/github%2Fgrpc/tests) is failing. This is believed to be caused by Homebrew bug which fails to install pecl correctly on MacOS. 

```
running: make INSTALL_ROOT="/private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev" install
Installing shared extensions:     /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar/php@7.2/7.2.28/pecl/20170718/
running: find "/private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev" | xargs ls -dils
10548148     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev
10555091     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr
10555092     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local
10555093     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar
10555094     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar/php@7.2
10555095     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar/php@7.2/7.2.28
10555096     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar/php@7.2/7.2.28/pecl
10555097     0 drwxr-xr-x  3 root  wheel       96 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar/php@7.2/7.2.28/pecl/20170718
10555098 16584 -rwxr-xr-x  1 root  wheel  8488844 Dec  4 22:53 /private/tmp/pear/temp/pear-build-rootoQjx91/install-grpc-1.35.0dev/usr/local/Cellar/php@7.2/7.2.28/pecl/20170718/grpc.so

Build process completed successfully
Installing '/usr/local/Cellar/php@7.2/7.2.28/pecl/20170718/grpc.so'

Warning: mkdir(): File exists in System.php on line 294
PHP Warning:  mkdir(): File exists in /usr/local/Cellar/php@7.2/7.2.28/share/php@7.2/pear/System.php on line 294

Warning: mkdir(): File exists in /usr/local/Cellar/php@7.2/7.2.28/share/php@7.2/pear/System.php on line 294
ERROR: failed to mkdir /usr/local/Cellar/php@7.2/7.2.28/pecl/20170718
```

Related to  https://github.com/Homebrew/homebrew-core/issues/41081