### PR TITLE
extract_metadata_from_bazel.py: add automatic grpc_upb_proto_library expansion 

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3154,25 +3154,21 @@ grpc_cc_library(
     ],
 )
 
-# Once upb code-gen issue is resolved, replace grpc_health_upb with this.
-# grpc_upb_proto_library(
-#     name = "grpc_health_upb",
-#     deps = ["//src/proto/grpc/health/v1:health_proto_descriptor"],
-# )
+grpc_upb_proto_library(
+    name = "grpc_health_upb_proto",
+    deps = ["//src/proto/grpc/health/v1:health_proto_descriptor"],
+)
 
 grpc_cc_library(
     name = "grpc_health_upb",
-    srcs = [
-        "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c",
-    ],
-    hdrs = [
-        "src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.h",
-    ],
     external_deps = [
         "upb_lib",
         "upb_lib_descriptor",
     ],
     language = "c++",
+    deps = [
+        ":grpc_health_upb_proto",
+    ],
 )
 
 # Once upb code-gen issue is resolved, remove this.


### PR DESCRIPTION
Improved version of https://github.com/grpc/grpc/pull/24642.

Add `grpc_upb_proto_library` in bazel build, and update extract_metadata_from_bazel_xml.py so that there is no noticeable change to the generated build systems (cmake, make, etc..)
