### PR TITLE
Fix implicit decalaration in rb_event_thread.c

### DIFF
--- a/src/ruby/ext/grpc/rb_event_thread.c
+++ b/src/ruby/ext/grpc/rb_event_thread.c
@@ -29,6 +29,8 @@
 #include <grpc/support/time.h>
 #include <ruby/thread.h>
 
+#include "rb_grpc.h"
+
 typedef struct grpc_rb_event {
   // callback will be called with argument while holding the GVL
   void (*callback)(void*);


### PR DESCRIPTION
As seen in https://github.com/grpc/grpc/issues/24881, the current grpc-ruby doesn't build on recent macOS.

This PR does **not** fix the exact problem mentioned above (because the problematic file is in `./third_party`), but the similar problem in `rb_event_thread.c`.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
