### PR TITLE
server_cc: Allow shared ownership of GlobalCallbacks

### DIFF
--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -92,12 +92,18 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
     virtual void AddPort(Server* /*server*/, const std::string& /*addr*/,
                          grpc::ServerCredentials* /*creds*/, int /*port*/) {}
   };
+
   /// Set the global callback object. Can only be called once per application.
-  /// Does not take ownership of callbacks, and expects the pointed to object
-  /// to be alive until all server objects in the process have been destroyed.
+  /// DOES take ownership of callbacks.
   /// The same \a GlobalCallbacks object will be used throughout the
   /// application and is shared among all \a Server objects.
   static void SetGlobalCallbacks(GlobalCallbacks* callbacks);
+
+  /// Set the global callback object. Can only be called once per application.
+  /// Shares ownership of callbacks.
+  /// The same \a GlobalCallbacks object will be used throughout the
+  /// application and is shared among all \a Server objects.
+  static void SetGlobalCallbacks(std::shared_ptr<GlobalCallbacks> callbacks);
 
   /// Returns a \em raw pointer to the underlying \a grpc_server instance.
   /// EXPERIMENTAL:  for internal/test use only

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -985,6 +985,12 @@ Server::~Server() {
   grpc_server_destroy(server_);
 }
 
+void Server::SetGlobalCallbacks(std::shared_ptr<GlobalCallbacks> callbacks) {
+  GPR_ASSERT(!grpc::g_callbacks);
+  GPR_ASSERT(callbacks);
+  grpc::g_callbacks.swap(callbacks);
+}
+
 void Server::SetGlobalCallbacks(GlobalCallbacks* callbacks) {
   GPR_ASSERT(!grpc::g_callbacks);
   GPR_ASSERT(callbacks);


### PR DESCRIPTION
This commit adds an additional static method for providing a shared
instance of GlobalCallbacks.

The original header documentation seemed to imply that the server_cc.cc
implementation did NOT have ownership (which it did via the reset).  If
a caller follows the documentation (deleting their raw pointer, or using
a shared pointer with .get()), a double-free will most likely be
encountered.

It appears that the raw pointer method limits a caller from using a
shared instance.  Maybe this was intended?




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
