### PR TITLE
Increase Python job timeout to deflake build extra job

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -648,7 +648,7 @@ class PythonLanguage(object):
         return [
             self.config.job_spec(
                 config.run,
-                timeout_seconds=5 * 60,
+                timeout_seconds=8 * 60,
                 environ=dict(GRPC_PYTHON_TESTRUNNER_FILTER=str(suite_name),
                              **environment),
                 shortname='%s.%s.%s' %


### PR DESCRIPTION
Since October, job `prod:grpc/core/master/linux/grpc_build_artifacts_extra` has 20% chance to time out. It might related to the change of machine type.

This PR increases the timeout limit for Python jobs to match the timeout limit of `grpc_build_artifacts_extra` job, which is 480 minutes.

b/175350545