### PR TITLE
Update the TODO bug number in stranded_event_test's reason flaky=true comment

### DIFF
--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -373,7 +373,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
-    flaky = True,  # TODO(b/162087149)
+    flaky = True,  # TODO(b/162243837)
     language = "C++",
     tags = [
         # TODO(apolcyn): This test is failing on Windows at entry, enable once passing.


### PR DESCRIPTION
I originally meant to set this bug number as b/161998689. Now, the reason it's still marked flaky is b/162243837