### PR TITLE
Upgrade to Bazel 3.7.1

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -40,7 +40,7 @@ then
   fi
 fi
 
-VERSION=2.2.0
+VERSION=3.7.1
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
 # update tools/update_mirror.sh to populate the mirror with new bazel archives


### PR DESCRIPTION
This PR upgraded our Bazel version from 2.2.0 to 3.7.1. This is needed to upgrade upb to the latest version, which includes converting messages into JSON. Newer Bazel broke two features for upb (https://github.com/bazelbuild/bazel/issues/11584 and https://github.com/bazelbuild/bazel/issues/8118), and made upb incompatible with Bazel 2.x.

So far, the tests are looking good, and none of the new backward incompatibilities affect gRPC.

I was blocked by `bazel test ...`. It couldn't build. Just found out this morning, that the `...` works surprisingly as it picks up tests in third_party folder, and those tests assumed different folder structure.

In future, we could have a new target for "all gRPC tests", or somehow exlucde the third_party directory from `...`.

CC @jtattermusch 