### PR TITLE
Ignore several third_party module for Bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -10,3 +10,6 @@ third_party/bloaty
 third_party/googleapis
 third_party/protoc-gen-validate
 third_party/udpa
+third_party/protobuf
+third_party/boringssl-with-bazel
+third_party/googletest


### PR DESCRIPTION
This is a tiny step toward allowing `bazel test ...` in gRPC repo. ObjC requires Xcode, so won't build on Linux. We might not able to create an `...` since the definition of "all" tests is tricky. Internally, the `...` might not work in some cases, because some tests are meant for interop tests or stress tests.

Related https://github.com/grpc/grpc/pull/24981