### PR TITLE
Fix visibility of libprotobuf symbols in protoc_compiler.so on Mac

### DIFF
--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -45,10 +45,10 @@ import protoc_lib_deps
 import grpc_version
 
 _EXT_INIT_SYMBOL = None
-if sys.version[0] == 2:
+if sys.version_info[0] == 2:
     _EXT_INIT_SYMBOL = "init_protoc_compiler"
 else:
-    _EXT_INIT_SYMBOL = "_PyInit__protoc_compiler"
+    _EXT_INIT_SYMBOL = "PyInit__protoc_compiler"
 
 _parallel_compile_patch.monkeypatch_compile_maybe()
 
@@ -139,8 +139,11 @@ if EXTRA_ENV_LINK_ARGS is None:
     # This is not required on Linux since the compiler does not produce global weak
     # symbols. This is not required on Windows as our ".pyd" file does not contain any
     # symbols.
+    #
+    # Finally, the leading underscore here is part of the Mach-O ABI. Unlike more modern
+    # ABIs (ELF et al.), Mach-O prepends an underscore to the names of C functions.
     if "darwin" in sys.platform:
-        EXTRA_ENV_LINK_ARGS += ' -Wl,-exported_symbol,{}'.format(
+        EXTRA_ENV_LINK_ARGS += ' -Wl,-exported_symbol,_{}'.format(
             _EXT_INIT_SYMBOL)
     if "linux" in sys.platform or "darwin" in sys.platform:
         EXTRA_ENV_LINK_ARGS += ' -lpthread'

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -124,24 +124,25 @@ if EXTRA_ENV_COMPILE_ARGS is None:
         EXTRA_ENV_COMPILE_ARGS += ' -fno-wrapv -frtti'
 if EXTRA_ENV_LINK_ARGS is None:
     EXTRA_ENV_LINK_ARGS = ''
-    # NOTE(rbellevi): Clang on Mac OS will make all static symbols (both variables
-    # and objects) global weak symbols. When a process loads the
+    # NOTE(rbellevi): Clang on Mac OS will make all static symbols (both
+    # variables and objects) global weak symbols. When a process loads the
     # protobuf wheel's shared object library before loading *this* C extension,
-    # the runtime linker will prefer the protobuf module's version of symbols. This
-    # results in the process using a mixture of symbols from the protobuf wheel and
-    # this wheel, which may be using different versions of libprotobuf. In the case
-    # that they *are* using different versions of libprotobuf *and* there has been a
-    # change in data layout (or in other invariants) segfaults, data corruption, or
-    # "bad things" may happen.
+    # the runtime linker will prefer the protobuf module's version of symbols.
+    # This results in the process using a mixture of symbols from the protobuf
+    # wheel and this wheel, which may be using different versions of
+    # libprotobuf. In the case that they *are* using different versions of
+    # libprotobuf *and* there has been a change in data layout (or in other
+    # invariants) segfaults, data corruption, or "bad things" may happen.
     #
-    # This flag ensures that on Mac, the only global symbol is the one loaded by the
-    # Python interpreter. The problematic global weak symbols become local weak symbols.
-    # This is not required on Linux since the compiler does not produce global weak
-    # symbols. This is not required on Windows as our ".pyd" file does not contain any
-    # symbols.
+    # This flag ensures that on Mac, the only global symbol is the one loaded by
+    # the Python interpreter. The problematic global weak symbols become local
+    # weak symbols.  This is not required on Linux since the compiler does not
+    # produce global weak symbols. This is not required on Windows as our ".pyd"
+    # file does not contain any symbols.
     #
-    # Finally, the leading underscore here is part of the Mach-O ABI. Unlike more modern
-    # ABIs (ELF et al.), Mach-O prepends an underscore to the names of C functions.
+    # Finally, the leading underscore here is part of the Mach-O ABI. Unlike
+    # more modern ABIs (ELF et al.), Mach-O prepends an underscore to the names
+    # of C functions.
     if "darwin" in sys.platform:
         EXTRA_ENV_LINK_ARGS += ' -Wl,-exported_symbol,_{}'.format(
             _EXT_INIT_SYMBOL)

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -118,6 +118,23 @@ if EXTRA_ENV_COMPILE_ARGS is None:
         EXTRA_ENV_COMPILE_ARGS += ' -fno-wrapv -frtti'
 if EXTRA_ENV_LINK_ARGS is None:
     EXTRA_ENV_LINK_ARGS = ''
+    # NOTE(rbellevi): Clang on Mac OS will make all static symbols (both variables
+    # and objects) global weak symbols. When a process loads the
+    # protobuf wheel's shared object library before loading *this* C extension,
+    # the runtime linker will prefer the protobuf module's version of symbols. This
+    # results in the process using a mixture of symbols from the protobuf wheel and
+    # this wheel, which may be using different versions of libprotobuf. In the case
+    # that they *are* using different versions of libprotobuf *and* there has been a
+    # change in data layout (or in other invariants) segfaults, data corruption, or
+    # "bad things" may happen.
+    #
+    # This flag ensures that on Mac, the only global symbol is the one loaded by the
+    # Python interpreter. The problematic global weak symbols become local weak symbols.
+    # This is not required on Linux since the compiler does not produce global weak
+    # symbols. This is not required on Windows as our ".pyd" file does not contain any
+    # symbols.
+    if "darwin" in sys.platform:
+        EXTRA_ENV_LINK_ARGS += ' -Wl,-exported_symbol,_PyInit__protoc_compiler'
     if "linux" in sys.platform or "darwin" in sys.platform:
         EXTRA_ENV_LINK_ARGS += ' -lpthread'
         if check_linker_need_libatomic():

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -44,6 +44,12 @@ import _parallel_compile_patch
 import protoc_lib_deps
 import grpc_version
 
+_EXT_INIT_SYMBOL = None
+if sys.version[0] == 2:
+    _EXT_INIT_SYMBOL = "init_protoc_compiler"
+else:
+    _EXT_INIT_SYMBOL = "_PyInit__protoc_compiler"
+
 _parallel_compile_patch.monkeypatch_compile_maybe()
 
 CLASSIFIERS = [
@@ -134,7 +140,8 @@ if EXTRA_ENV_LINK_ARGS is None:
     # symbols. This is not required on Windows as our ".pyd" file does not contain any
     # symbols.
     if "darwin" in sys.platform:
-        EXTRA_ENV_LINK_ARGS += ' -Wl,-exported_symbol,_PyInit__protoc_compiler'
+        EXTRA_ENV_LINK_ARGS += ' -Wl,-exported_symbol,{}'.format(
+            _EXT_INIT_SYMBOL)
     if "linux" in sys.platform or "darwin" in sys.platform:
         EXTRA_ENV_LINK_ARGS += ' -lpthread'
         if check_linker_need_libatomic():


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/24897

@yulin-liang This will require a backport (and patch to) to `v1.34.x`.

Our Mac OS build currently produces many global [weak](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html) symbols corresponding to static variables and functions in libprotobuf:

```
000000000041a008 gw    O __DATA,__data guard variable for google::protobuf::FileDescriptorTables::GetEmptyInstance()::file_descriptor_tables
0000000000419708 gw    O __DATA,__data guard variable for google::protobuf::util::converter::ProtoStreamObjectWriter::Options::Defaults()::defaults
000000000041a198 gw    O __DATA,__data guard variable for google::protobuf::internal::ShutdownData::get()::data
0000000000209940 gw    F __TEXT,__text google::protobuf::safe_strtod(google::protobuf::StringPiece, double*)
```

On Mac OS, clang will produce global weak symbols for function-local static variables when the function is a class method. For example:

```c++
class Bar {                                                                                                                    
public:                                                                                                                        
  int bar() {                                                                                                                  
    static int foo;                                                                                                            
    return foo;                                                                                                                
  }                                                                                                                            
};                                                                                                                             
                                                                                                                               
int main() {                                                                                                                   
  Bar bar;                                                                                                                     
  auto foo = bar.bar();                                                                                                        
  return foo;                                                                                                                  
}  
```

This C++ snippet produces the following symbol table:

```bash
$ objdump -t -wide foo.o | c++filt

foo.o:	file format Mach-O 64-bit x86-64

SYMBOL TABLE:
0000000000000030 gw    F __TEXT,__text Bar::bar()
0000000000000044 gw    O __DATA,__data Bar::bar()::foo
0000000000000000 __float128     F __TEXT,__text _main
```

When given a choice between two weak symbols with the same name in the same process, the Mac OS runtime linker will prefer the first one:

```
dyld: weak bind: _protoc_compiler.cpython-36m-darwin.so:0x110772158 = _message.cpython-36m-darwin.so:guard variable for google::protobuf::FileDescriptorTables::GetEmptyInstance()::file_descriptor_tables, *0x110772158 = 0x10EE03388
dyld: weak bind: _protoc_compiler.cpython-36m-darwin.so:0x110772168 = _message.cpython-36m-darwin.so:guard variable for google::protobuf::internal::ShutdownData::get()::data, *0x110772168 = 0x10EE03370
dyld: weak bind: _protoc_compiler.cpython-36m-darwin.so:0x110772968 = _message.cpython-36m-darwin.so:google::protobuf::RepeatedField<bool>::SwapElements(int, int), *0x110772968 = 0x10ECF2CB0
dyld: weak bind: _protoc_compiler.cpython-36m-darwin.so:0x110772970 = _message.cpython-36m-darwin.so:google::protobuf::RepeatedField<bool>::Swap(google::protobuf::RepeatedField<bool>*), *0x110772970 = 0x10ECF2B50
dyld: weak bind: _protoc_compiler.cpython-36m-darwin.so:0x110772978 = _message.cpython-36m-darwin.so:google::protobuf::RepeatedField<bool>::Reserve(int), *0x110772978 = 0x10ECF1710
```

Above, you see references to `libprotobuf` symbols in `_protoc_compiler.so` (`grpcio-tools`) resolving to addresses corresponding to symbols in `_message.so` (`protobuf` wheel).

When this happens, as in #24897, the initializer for static variables may come from one version of `libprotobuf` while, the runtime code may come from another version of it. When data layouts or other pertinent invariants change, this may result in segmentation faults, data corruption, or other "bad behavior."

The fix in this PR is to make all symbols in `_protoc_compiler.so` besides `_PyInit__protoc_compiler` (the Python interpreter's entrypoint to the `grpcio-tools` C extension) local:

```
00000000003f87a0 lw    O __DATA,__data google::protobuf::FileDescriptorTables::GetEmptyInstance()::file_descriptor_tables
00000000003f87a8 lw    O __DATA,__data guard variable for google::protobuf::FileDescriptorTables::GetEmptyInstance()::file_descriptor_tables
00000000003f8930 lw    O __DATA,__data google::protobuf::internal::ShutdownData::get()::data
00000000003f8938 lw    O __DATA,__data guard variable for google::protobuf::internal::ShutdownData::get()::data
```

This issue only ever affected Mac OS. Our Linux shared object libraries contain no global weak symbols and (somewhat perplexingly), the `.pyd` files in our Windows artifacts contain no symbols at all, according to [`winedump`](https://linux.die.net/man/1/winedump).