### PR TITLE
Fix Ruby xDS tests

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_ruby.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/ruby_jessie_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/ruby_buster_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh


### PR DESCRIPTION
#24000 seems to have broken `grpc_xds_ruby`: https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_xds_ruby.

I think the Ruby xDS tests were relying on the `ruby_jessie_x64` image, which was renamed to `ruby_buster_x64`. So may have to fix this line: https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_xds_ruby.sh#L23.

https://github.com/grpc/grpc/pull/24000#issuecomment-745055915