### PR TITLE
Backport #24980 to v1.34.x

### DIFF
--- a/src/csharp/Grpc.Auth/Grpc.Auth.csproj
+++ b/src/csharp/Grpc.Auth/Grpc.Auth.csproj
@@ -12,7 +12,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
-    <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/csharp/Grpc.Core.Api/Properties/AssemblyInfo.cs
+++ b/src/csharp/Grpc.Core.Api/Properties/AssemblyInfo.cs
@@ -28,7 +28,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-#if SIGNED
 [assembly: InternalsVisibleTo("Grpc.Core,PublicKey=" +
     "00240000048000009400000006020000002400005253413100040000010001002f5797a92c6fcde81bd4098f43" +
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
@@ -54,10 +53,3 @@ using System.Runtime.CompilerServices;
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
     "27fc95aff3dc604a6971417453f9483c7b5e836756d5b271bf8f2403fe186e31956148c03d804487cf642f8cc0" +
     "71394ee9672dfe5b55ea0f95dfd5a7f77d22c962ccf51320d3")]
-#else
-[assembly: InternalsVisibleTo("Grpc.Core")]
-[assembly: InternalsVisibleTo("Grpc.Core.Tests")]
-[assembly: InternalsVisibleTo("Grpc.Core.Testing")]
-[assembly: InternalsVisibleTo("Grpc.IntegrationTesting")]
-[assembly: InternalsVisibleTo("Grpc.Microbenchmarks")]
-#endif

--- a/src/csharp/Grpc.Core/Properties/AssemblyInfo.cs
+++ b/src/csharp/Grpc.Core/Properties/AssemblyInfo.cs
@@ -28,7 +28,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-#if SIGNED
 [assembly: InternalsVisibleTo("Grpc.Core.Tests,PublicKey=" +
     "00240000048000009400000006020000002400005253413100040000010001002f5797a92c6fcde81bd4098f43" +
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
@@ -49,9 +48,3 @@ using System.Runtime.CompilerServices;
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
     "27fc95aff3dc604a6971417453f9483c7b5e836756d5b271bf8f2403fe186e31956148c03d804487cf642f8cc0" +
     "71394ee9672dfe5b55ea0f95dfd5a7f77d22c962ccf51320d3")]
-#else
-[assembly: InternalsVisibleTo("Grpc.Core.Tests")]
-[assembly: InternalsVisibleTo("Grpc.Core.Testing")]
-[assembly: InternalsVisibleTo("Grpc.IntegrationTesting")]
-[assembly: InternalsVisibleTo("Grpc.Microbenchmarks")]
-#endif

--- a/src/csharp/Grpc.HealthCheck/Properties/AssemblyInfo.cs
+++ b/src/csharp/Grpc.HealthCheck/Properties/AssemblyInfo.cs
@@ -28,12 +28,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-#if SIGNED
 [assembly: InternalsVisibleTo("Grpc.HealthCheck.Tests,PublicKey=" +
     "00240000048000009400000006020000002400005253413100040000010001002f5797a92c6fcde81bd4098f43" +
     "0442bb8e12768722de0b0cb1b15e955b32a11352740ee59f2c94c48edc8e177d1052536b8ac651bce11ce5da3a" +
     "27fc95aff3dc604a6971417453f9483c7b5e836756d5b271bf8f2403fe186e31956148c03d804487cf642f8cc0" +
     "71394ee9672dfe5b55ea0f95dfd5a7f77d22c962ccf51320d3")]
-#else
-[assembly: InternalsVisibleTo("Grpc.HealthCheck.Tests")]
-#endif

--- a/src/csharp/build/common.props
+++ b/src/csharp/build/common.props
@@ -16,7 +16,6 @@
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <AssemblyOriginatorKeyFile>../keys/Grpc.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/csharp/build/common.props
+++ b/src/csharp/build/common.props
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <AssemblyOriginatorKeyFile>../keys/Grpc.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/24980 (to fix https://github.com/grpc/grpc/issues/24935).

After this is merged, we will probably need to do a patch-release (C# only is fine if nothing else needs a patch release)
