### PR TITLE
Remove Flaky=true flag for some tests

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -3259,7 +3259,6 @@ targets:
   uses_polling: false
 - name: concurrent_connectivity_test
   build: test
-  run: false
   language: c
   headers: []
   src:
@@ -5421,7 +5420,6 @@ targets:
 - name: cancel_ares_query_test
   gtest: true
   build: test
-  run: false
   language: c++
   headers:
   - test/core/end2end/cq_verifier.h
@@ -7523,7 +7521,6 @@ targets:
 - name: stranded_event_test
   gtest: true
   build: test
-  run: false
   language: c++
   headers:
   - test/core/end2end/cq_verifier.h

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -373,7 +373,6 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
-    flaky = True,  # TODO(b/162087149)
     language = "C++",
     tags = [
         # TODO(apolcyn): This test is failing on Windows at entry, enable once passing.

--- a/test/core/surface/BUILD
+++ b/test/core/surface/BUILD
@@ -67,7 +67,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "concurrent_connectivity_test",
     srcs = ["concurrent_connectivity_test.cc"],
-    flaky = True,  # TODO(b/157516542)
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/cpp/naming/BUILD
+++ b/test/cpp/naming/BUILD
@@ -38,7 +38,6 @@ grpc_cc_test(
     name = "cancel_ares_query_test",
     srcs = ["cancel_ares_query_test.cc"],
     external_deps = ["gtest"],
-    flaky = True,  # TODO(b/157516105)
     deps = [
         ":dns_test_util",
         "//:gpr",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -824,6 +824,30 @@
     "flaky": false,
     "gtest": false,
     "language": "c",
+    "name": "concurrent_connectivity_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": false,
+    "language": "c",
     "name": "connection_refused_test",
     "platforms": [
       "linux",
@@ -3870,6 +3894,30 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "cancel_ares_query_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "certificate_provider_registry_test",
     "platforms": [
       "linux",
@@ -5900,6 +5948,28 @@
       "windows"
     ],
     "uses_polling": false
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
+    "name": "stranded_event_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix"
+    ],
+    "uses_polling": true
   },
   {
     "args": [],


### PR DESCRIPTION
I checked that the tests haven't been flaky for a while (see internal comments).
