### PR TITLE
Fix 3.9 MacOS from-source build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -354,8 +354,9 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # By default, Python3 distutils enforces compatibility of
 # c plugins (.so files) with the OSX version Python was built with.
 # We need OSX 10.10, the oldest which supports C++ thread_local.
+# Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
-    mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
+    mac_target = str(sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET'))
     if mac_target and (pkg_resources.parse_version(mac_target) <
                        pkg_resources.parse_version('10.10.0')):
         os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.10'

--- a/setup.py
+++ b/setup.py
@@ -356,13 +356,14 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # We need OSX 10.10, the oldest which supports C++ thread_local.
 # Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
-    mac_target = str(sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET'))
-    if mac_target and (pkg_resources.parse_version(mac_target) <
-                       pkg_resources.parse_version('10.10.0')):
-        os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
-        os.environ['_PYTHON_HOST_PLATFORM'] = re.sub(
-            r'macosx-[0-9]+\.[0-9]+-(.+)', r'macosx-10.10-\1',
-            util.get_platform())
+    mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
+    if mac_target:
+        mac_target = pkg_resources.parse_version(str(mac_target))
+        if mac_target < pkg_resources.parse_version('10.10.0'):
+            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
+            os.environ['_PYTHON_HOST_PLATFORM'] = re.sub(
+                r'macosx-[0-9]+\.[0-9]+-(.+)', r'macosx-10.10-\1',
+                util.get_platform())
 
 
 def cython_extensions_and_necessity():


### PR DESCRIPTION
sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')

returns <str> '11.1' in Python 2.7 and <int> 11 in Python 3.9 causing exception: builtins.TypeError: expected string or bytes-like object




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble

Fixes https://github.com/grpc/grpc/issues/25082
