### PR TITLE
Make c-ares resolver unit tests runnable under python3

### DIFF
--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -79,7 +79,7 @@ def wait_until_dns_server_is_up(args,
           stdout=subprocess.PIPE)
       dns_resolver_stdout, _ = dns_resolver_subprocess.communicate(str.encode('ascii'))
       if dns_resolver_subprocess.returncode == 0:
-        if bytes('123.123.123.123'.encode('ascii')) in dns_resolver_stdout:
+        if '123.123.123.123'.encode('ascii') in dns_resolver_stdout:
           test_runner_log(('DNS server is up! '
                            'Successfully reached it over UDP and TCP.'))
         return

--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -77,9 +77,9 @@ def wait_until_dns_server_is_up(args,
           '--server_host', '127.0.0.1',
           '--server_port', str(args.dns_server_port)]),
           stdout=subprocess.PIPE)
-      dns_resolver_stdout, _ = dns_resolver_subprocess.communicate()
+      dns_resolver_stdout, _ = dns_resolver_subprocess.communicate(str.encode('ascii'))
       if dns_resolver_subprocess.returncode == 0:
-        if '123.123.123.123' in dns_resolver_stdout:
+        if bytes('123.123.123.123'.encode('ascii')) in dns_resolver_stdout:
           test_runner_log(('DNS server is up! '
                            'Successfully reached it over UDP and TCP.'))
         return

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -79,7 +79,7 @@ def wait_until_dns_server_is_up(args,
           stdout=subprocess.PIPE)
       dns_resolver_stdout, _ = dns_resolver_subprocess.communicate(str.encode('ascii'))
       if dns_resolver_subprocess.returncode == 0:
-        if bytes('123.123.123.123'.encode('ascii')) in dns_resolver_stdout:
+        if '123.123.123.123'.encode('ascii') in dns_resolver_stdout:
           test_runner_log(('DNS server is up! '
                            'Successfully reached it over UDP and TCP.'))
         return

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -77,9 +77,9 @@ def wait_until_dns_server_is_up(args,
           '--server_host', '127.0.0.1',
           '--server_port', str(args.dns_server_port)]),
           stdout=subprocess.PIPE)
-      dns_resolver_stdout, _ = dns_resolver_subprocess.communicate()
+      dns_resolver_stdout, _ = dns_resolver_subprocess.communicate(str.encode('ascii'))
       if dns_resolver_subprocess.returncode == 0:
-        if '123.123.123.123' in dns_resolver_stdout:
+        if bytes('123.123.123.123'.encode('ascii')) in dns_resolver_stdout:
           test_runner_log(('DNS server is up! '
                            'Successfully reached it over UDP and TCP.'))
         return

--- a/test/cpp/naming/utils/dns_server.py
+++ b/test/cpp/naming/utils/dns_server.py
@@ -53,6 +53,7 @@ def start_local_dns_server(args):
     all_records = {}
 
     def _push_record(name, r):
+        name = bytes(name.encode('ascii'))
         print('pushing record: |%s|' % name)
         if all_records.get(name) is not None:
             all_records[name].append(r)
@@ -60,6 +61,7 @@ def start_local_dns_server(args):
         all_records[name] = [r]
 
     def _maybe_split_up_txt_data(name, txt_data, r_ttl):
+        txt_data = bytes(txt_data.encode('ascii'))
         start = 0
         txt_data_list = []
         while len(txt_data[start:]) > 0:
@@ -93,8 +95,8 @@ def start_local_dns_server(args):
                     p = int(p)
                     w = int(w)
                     port = int(port)
-                    target_full_name = '%s.%s' % (target, common_zone_name)
-                    r_data = '%s %s %s %s' % (p, w, port, target_full_name)
+                    target_full_name = bytes(
+                        ('%s.%s' % (target, common_zone_name)).encode('ascii'))
                     _push_record(
                         record_full_name,
                         dns.Record_SRV(p, w, port, target_full_name, ttl=r_ttl))
@@ -107,9 +109,9 @@ def start_local_dns_server(args):
     # Server health check record
     _push_record(_SERVER_HEALTH_CHECK_RECORD_NAME,
                  dns.Record_A(_SERVER_HEALTH_CHECK_RECORD_DATA, ttl=0))
-    soa_record = dns.Record_SOA(mname=common_zone_name)
+    soa_record = dns.Record_SOA(mname=bytes(common_zone_name.encode('ascii')))
     test_domain_com = NoFileAuthority(
-        soa=(common_zone_name, soa_record),
+        soa=(bytes(common_zone_name.encode('ascii')), soa_record),
         records=all_records,
     )
     server = twisted.names.server.DNSServerFactory(

--- a/test/cpp/naming/utils/dns_server.py
+++ b/test/cpp/naming/utils/dns_server.py
@@ -53,7 +53,7 @@ def start_local_dns_server(args):
     all_records = {}
 
     def _push_record(name, r):
-        name = bytes(name.encode('ascii'))
+        name = name.encode('ascii')
         print('pushing record: |%s|' % name)
         if all_records.get(name) is not None:
             all_records[name].append(r)
@@ -61,7 +61,7 @@ def start_local_dns_server(args):
         all_records[name] = [r]
 
     def _maybe_split_up_txt_data(name, txt_data, r_ttl):
-        txt_data = bytes(txt_data.encode('ascii'))
+        txt_data = txt_data.encode('ascii')
         start = 0
         txt_data_list = []
         while len(txt_data[start:]) > 0:
@@ -95,8 +95,7 @@ def start_local_dns_server(args):
                     p = int(p)
                     w = int(w)
                     port = int(port)
-                    target_full_name = bytes(
-                        ('%s.%s' % (target, common_zone_name)).encode('ascii'))
+                    target_full_name = ('%s.%s' % (target, common_zone_name)).encode('ascii')
                     _push_record(
                         record_full_name,
                         dns.Record_SRV(p, w, port, target_full_name, ttl=r_ttl))
@@ -109,9 +108,9 @@ def start_local_dns_server(args):
     # Server health check record
     _push_record(_SERVER_HEALTH_CHECK_RECORD_NAME,
                  dns.Record_A(_SERVER_HEALTH_CHECK_RECORD_DATA, ttl=0))
-    soa_record = dns.Record_SOA(mname=bytes(common_zone_name.encode('ascii')))
+    soa_record = dns.Record_SOA(mname=common_zone_name.encode('ascii'))
     test_domain_com = NoFileAuthority(
-        soa=(bytes(common_zone_name.encode('ascii')), soa_record),
+        soa=(common_zone_name.encode('ascii'), soa_record),
         records=all_records,
     )
     server = twisted.names.server.DNSServerFactory(

--- a/test/cpp/naming/utils/dns_server.py
+++ b/test/cpp/naming/utils/dns_server.py
@@ -95,7 +95,8 @@ def start_local_dns_server(args):
                     p = int(p)
                     w = int(w)
                     port = int(port)
-                    target_full_name = ('%s.%s' % (target, common_zone_name)).encode('ascii')
+                    target_full_name = (
+                        '%s.%s' % (target, common_zone_name)).encode('ascii')
                     _push_record(
                         record_full_name,
                         dns.Record_SRV(p, w, port, target_full_name, ttl=r_ttl))


### PR DESCRIPTION
This resolves internal issue b/159243208

In python2, `<string object>.split(<bytes object>)` worked, but in python3, this throws an exception complaining that the parameter to split "must be string or None".

The twisted DNS module makes `split` calls on objects with `byte` parameters (https://github.com/twisted/twisted/blob/121c98e006a31750661107d390ec2dc4ffe28e8a/src/twisted/names/dns.py#L245), thus when using the twisted DNS module in python3, we can no longer configure DNS records as `strings`. This PR makes sure to only configure DNS records as `bytes` objects.
