### PR TITLE
xds k8s baseline test: add baseline subtest names to show their order

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
@@ -29,31 +29,31 @@ _XdsTestClient = xds_k8s_testcase.XdsTestClient
 class BaselineTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     def test_traffic_director_grpc_setup(self):
-        with self.subTest('create_health_check'):
+        with self.subTest('0_create_health_check'):
             self.td.create_health_check()
 
-        with self.subTest('create_backend_service'):
+        with self.subTest('1_create_backend_service'):
             self.td.create_backend_service()
 
-        with self.subTest('create_url_map'):
+        with self.subTest('2_create_url_map'):
             self.td.create_url_map(self.server_xds_host, self.server_xds_port)
 
-        with self.subTest('create_target_proxy'):
+        with self.subTest('3_create_target_proxy'):
             self.td.create_target_grpc_proxy()
 
-        with self.subTest('create_forwarding_rule'):
+        with self.subTest('4_create_forwarding_rule'):
             self.td.create_forwarding_rule(self.server_xds_port)
 
-        with self.subTest('start_test_server'):
+        with self.subTest('5_start_test_server'):
             test_server: _XdsTestServer = self.startTestServer()
 
-        with self.subTest('add_server_backends_to_backend_service'):
+        with self.subTest('6_add_server_backends_to_backend_service'):
             self.setupServerBackends()
 
-        with self.subTest('start_test_client'):
+        with self.subTest('7_start_test_client'):
             test_client: _XdsTestClient = self.startTestClient(test_server)
 
-        with self.subTest('test_server_received_rpcs_from_test_client'):
+        with self.subTest('8_test_server_received_rpcs_from_test_client'):
             self.assertSuccessfulRpcs(test_client)
 
 


### PR DESCRIPTION
Purely cosmetic change to show baseline subtests in order for easier debugging