### PR TITLE
Support Default Root Certs in Tls Credentials

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -848,8 +848,8 @@ GRPCAPI grpc_tls_credentials_options* grpc_tls_credentials_options_create(void);
 
 /**
  * Sets the options of whether to request and verify client certs. This should
- * be called only on the server side. It returns 1 on success and 0 on failure.
- * It is used for experimental purpose for now and subject to change.
+ * be called only on the server side. It is used for experimental purpose for
+ * now and subject to change.
  */
 GRPCAPI void grpc_tls_credentials_options_set_cert_request_type(
     grpc_tls_credentials_options* options,
@@ -860,8 +860,7 @@ GRPCAPI void grpc_tls_credentials_options_set_cert_request_type(
  * hostname check, etc. This should be called only on the client side. If
  * |server_verification_option| is not GRPC_TLS_SERVER_VERIFICATION, use of a
  * custom authorization check (grpc_tls_server_authorization_check_config) is
- * mandatory. It returns 1 on success and 0 on failure. It is used for
- * experimental purpose for now and subject to change.
+ * mandatory. It is used for experimental purpose for now and subject to change.
  */
 GRPCAPI void grpc_tls_credentials_options_set_server_verification_option(
     grpc_tls_credentials_options* options,
@@ -870,7 +869,6 @@ GRPCAPI void grpc_tls_credentials_options_set_server_verification_option(
 /**
  * Sets the credential provider in the options.
  * The |options| will implicitly take a new ref to the |provider|.
- * It returns 1 on success and 0 on failure.
  * It is used for experimental purpose for now and subject to change.
  */
 GRPCAPI void grpc_tls_credentials_options_set_certificate_provider(
@@ -879,8 +877,14 @@ GRPCAPI void grpc_tls_credentials_options_set_certificate_provider(
 
 /**
  * If set, gRPC stack will keep watching the root certificates with
- * name |root_cert_name|. It returns 1 on success and 0 on failure. It is used
- * for experimental purpose for now and subject to change.
+ * name |root_cert_name|.
+ * If this is not set on the client side, we will use the root certificates
+ * stored in the default system location, since client side must provide root
+ * certificates in TLS.
+ * If this is not set on the server side, we will not watch any root certificate
+ * updates, and assume no root certificates needed for the server(single-side
+ * TLS). Default root certs on the server side is not supported.
+ * It is used for experimental purpose for now and subject to change.
  */
 GRPCAPI void grpc_tls_credentials_options_watch_root_certs(
     grpc_tls_credentials_options* options);
@@ -895,8 +899,9 @@ GRPCAPI void grpc_tls_credentials_options_set_root_cert_name(
 
 /**
  * If set, gRPC stack will keep watching the identity key-cert pairs
- * with name |identity_cert_name|. It returns 1 on success and 0 on failure. It
- * is used for experimental purpose for now and subject to change.
+ * with name |identity_cert_name|.
+ * This is required on the server side, and optional on the client side.
+ * It is used for experimental purpose for now and subject to change.
  */
 GRPCAPI void grpc_tls_credentials_options_watch_identity_key_cert_pairs(
     grpc_tls_credentials_options* options);
@@ -912,8 +917,8 @@ GRPCAPI void grpc_tls_credentials_options_set_identity_cert_name(
 /**
  * Sets the configuration for a custom authorization check performed at the end
  * of the handshake. The |options| will implicitly take a new ref to the
- * |config|. It returns 1 on success and 0 on failure. It is used for
- * experimental purpose for now and subject to change.
+ * |config|.
+ * It is used for experimental purpose for now and subject to change.
  */
 GRPCAPI void grpc_tls_credentials_options_set_server_authorization_check_config(
     grpc_tls_credentials_options* options,

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -395,6 +395,9 @@ grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
   const char* root_certs;
   const tsi_ssl_root_certs_store* root_store;
   if (pem_root_certs == nullptr) {
+    gpr_log(GPR_INFO,
+            "No root certificates specified; use ones stored in system default "
+            "locations instead");
     // Use default root certificates.
     root_certs = grpc_core::DefaultSslRootStore::GetPemRootCerts();
     if (root_certs == nullptr) {

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -136,9 +136,20 @@ TlsChannelSecurityConnector::TlsChannelSecurityConnector(
   if (options_->watch_identity_pair()) {
     watched_identity_cert_name = options_->identity_cert_name();
   }
-  distributor->WatchTlsCertificates(std::move(watcher_ptr),
-                                    watched_root_cert_name,
-                                    watched_identity_cert_name);
+  // We will use the root certs stored in system default locations if not
+  // watching root certs on the client side. We will handle this case
+  // differently here, because "watching a default roots without the identity
+  // certs" is a valid case(and hence we will need to call
+  // OnCertificatesChanged), but it requires nothing from the provider, and
+  // hence no need to register the watcher.
+  bool use_default_roots = !options_->watch_root_cert();
+  if (use_default_roots && !options_->watch_identity_pair()) {
+    watcher_ptr->OnCertificatesChanged(absl::nullopt, absl::nullopt);
+  } else {
+    distributor->WatchTlsCertificates(std::move(watcher_ptr),
+                                      watched_root_cert_name,
+                                      watched_identity_cert_name);
+  }
 }
 
 TlsChannelSecurityConnector::~TlsChannelSecurityConnector() {
@@ -148,7 +159,9 @@ TlsChannelSecurityConnector::~TlsChannelSecurityConnector() {
   // Cancel all the watchers.
   grpc_tls_certificate_distributor* distributor =
       options_->certificate_distributor();
-  distributor->CancelTlsCertificatesWatch(certificate_watcher_);
+  if (distributor != nullptr) {
+    distributor->CancelTlsCertificatesWatch(certificate_watcher_);
+  }
   if (client_handshaker_factory_ != nullptr) {
     tsi_ssl_client_handshaker_factory_unref(client_handshaker_factory_);
   }
@@ -327,16 +340,12 @@ void TlsChannelSecurityConnector::TlsChannelCertificateWatcher::
   if (key_cert_pairs.has_value()) {
     security_connector_->pem_key_cert_pair_list_ = std::move(key_cert_pairs);
   }
-  bool root_being_watched = security_connector_->options_->watch_root_cert();
-  bool root_has_value = security_connector_->pem_root_certs_.has_value();
-  bool identity_being_watched =
-      security_connector_->options_->watch_identity_pair();
-  bool identity_has_value =
+  const bool root_ready = !security_connector_->options_->watch_root_cert() ||
+                          security_connector_->pem_root_certs_.has_value();
+  const bool identity_ready =
+      !security_connector_->options_->watch_identity_pair() ||
       security_connector_->pem_key_cert_pair_list_.has_value();
-  if ((root_being_watched && root_has_value && identity_being_watched &&
-       identity_has_value) ||
-      (root_being_watched && root_has_value && !identity_being_watched) ||
-      (!root_being_watched && identity_being_watched && identity_has_value)) {
+  if (root_ready && identity_ready) {
     if (security_connector_->UpdateHandshakerFactoryLocked() !=
         GRPC_SECURITY_OK) {
       gpr_log(GPR_ERROR, "Update handshaker factory failed.");
@@ -383,9 +392,11 @@ TlsChannelSecurityConnector::UpdateHandshakerFactoryLocked() {
   if (pem_key_cert_pair_list_.has_value()) {
     pem_key_cert_pair = ConvertToTsiPemKeyCertPair(*pem_key_cert_pair_list_);
   }
+  bool use_default_roots = !options_->watch_root_cert();
   grpc_security_status status = grpc_ssl_tsi_client_handshaker_factory_init(
       pem_key_cert_pair,
-      pem_root_certs.empty() ? nullptr : pem_root_certs.c_str(),
+      pem_root_certs.empty() || use_default_roots ? nullptr
+                                                  : pem_root_certs.c_str(),
       skip_server_certificate_verification,
       grpc_get_tsi_tls_version(options_->min_tls_version()),
       grpc_get_tsi_tls_version(options_->max_tls_version()), ssl_session_cache_,
@@ -516,6 +527,7 @@ TlsServerSecurityConnector::TlsServerSecurityConnector(
   if (options_->watch_identity_pair()) {
     watched_identity_cert_name = options_->identity_cert_name();
   }
+  // Server side won't use default system roots at any time.
   distributor->WatchTlsCertificates(std::move(watcher_ptr),
                                     watched_root_cert_name,
                                     watched_identity_cert_name);

--- a/src/cpp/common/tls_credentials_options.cc
+++ b/src/cpp/common/tls_credentials_options.cc
@@ -124,10 +124,13 @@ TlsServerAuthorizationCheckConfig::~TlsServerAuthorizationCheckConfig() {
   grpc_tls_server_authorization_check_config_release(c_config_);
 }
 
-TlsCredentialsOptions::TlsCredentialsOptions(
-    std::shared_ptr<CertificateProviderInterface> certificate_provider)
-    : certificate_provider_(std::move(certificate_provider)) {
+TlsCredentialsOptions::TlsCredentialsOptions() {
   c_credentials_options_ = grpc_tls_credentials_options_create();
+}
+
+void TlsCredentialsOptions::set_certificate_provider(
+    std::shared_ptr<CertificateProviderInterface> certificate_provider) {
+  certificate_provider_ = std::move(certificate_provider);
   if (certificate_provider_ != nullptr) {
     grpc_tls_credentials_options_set_certificate_provider(
         c_credentials_options_, certificate_provider_->c_provider());

--- a/test/core/security/grpc_tls_credentials_options_test.cc
+++ b/test/core/security/grpc_tls_credentials_options_test.cc
@@ -69,6 +69,21 @@ TEST_F(GrpcTlsCredentialsOptionsTest, ErrorDetails) {
   EXPECT_STREQ(error_details.error_details().c_str(), "test error details");
 }
 
+TEST_F(GrpcTlsCredentialsOptionsTest, ClientOptionsOnDefaultRootCerts) {
+  auto options = MakeRefCounted<grpc_tls_credentials_options>();
+  options->set_server_verification_option(GRPC_TLS_SERVER_VERIFICATION);
+  auto credentials = MakeRefCounted<TlsCredentials>(options);
+  ASSERT_NE(credentials, nullptr);
+  grpc_channel_args* new_args = nullptr;
+  auto connector = credentials->create_security_connector(
+      nullptr, "random targets", nullptr, &new_args);
+  grpc_channel_args_destroy(new_args);
+  ASSERT_NE(connector, nullptr);
+  TlsChannelSecurityConnector* tls_connector =
+      static_cast<TlsChannelSecurityConnector*>(connector.get());
+  EXPECT_NE(tls_connector->ClientHandshakerFactoryForTesting(), nullptr);
+}
+
 // Tests for StaticDataCertificateProvider.
 TEST_F(GrpcTlsCredentialsOptionsTest,
        ClientOptionsWithStaticDataProviderOnBothCerts) {
@@ -136,6 +151,26 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
+       ClientOptionsWithDefaultRootAndStaticDataProviderOnIdentityCerts) {
+  auto options = MakeRefCounted<grpc_tls_credentials_options>();
+  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
+      "", MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+  options->set_certificate_provider(std::move(provider));
+  options->set_watch_identity_pair(true);
+  options->set_server_verification_option(GRPC_TLS_SERVER_VERIFICATION);
+  auto credentials = MakeRefCounted<TlsCredentials>(options);
+  ASSERT_NE(credentials, nullptr);
+  grpc_channel_args* new_args = nullptr;
+  auto connector = credentials->create_security_connector(
+      nullptr, "random targets", nullptr, &new_args);
+  grpc_channel_args_destroy(new_args);
+  ASSERT_NE(connector, nullptr);
+  TlsChannelSecurityConnector* tls_connector =
+      static_cast<TlsChannelSecurityConnector*>(connector.get());
+  EXPECT_NE(tls_connector->ClientHandshakerFactoryForTesting(), nullptr);
+}
+
+TEST_F(GrpcTlsCredentialsOptionsTest,
        ServerOptionsWithStaticDataProviderOnBothCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   auto provider = MakeRefCounted<StaticDataCertificateProvider>(
@@ -192,7 +227,7 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
   EXPECT_EQ(tls_connector->ServerHandshakerFactoryForTesting(), nullptr);
 }
 
-//// Tests for FileWatcherCertificateProvider.
+// Tests for FileWatcherCertificateProvider.
 TEST_F(GrpcTlsCredentialsOptionsTest,
        ClientOptionsWithCertWatcherProviderOnBothCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
@@ -460,6 +495,7 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
+  GPR_GLOBAL_CONFIG_SET(grpc_default_ssl_roots_file_path, CA_CERT_PATH);
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
   int ret = RUN_ALL_TESTS();


### PR DESCRIPTION
This aims to fix https://github.com/grpc/grpc/issues/24724.
It will have C++ API changes, since the provider is now optional for creating `TlsChannelCredentialsOptions`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25018)
<!-- Reviewable:end -->
