### PR TITLE
PHP: fix phpunit 8 warnings

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -423,9 +423,9 @@ class BaseStub
                     $method,
                     $argument,
                     $deserialize,
+                    $this->_UnaryUnaryCallFactory($channel->getNext()),
                     $metadata,
-                    $options,
-                    $this->_UnaryUnaryCallFactory($channel->getNext())
+                    $options
                 );
             };
         }
@@ -452,9 +452,9 @@ class BaseStub
                     $method,
                     $argument,
                     $deserialize,
+                    $this->_UnaryStreamCallFactory($channel->getNext()),
                     $metadata,
-                    $options,
-                    $this->_UnaryStreamCallFactory($channel->getNext())
+                    $options
                 );
             };
         }
@@ -479,9 +479,9 @@ class BaseStub
                 return $channel->getInterceptor()->interceptStreamUnary(
                     $method,
                     $deserialize,
+                    $this->_StreamUnaryCallFactory($channel->getNext()),
                     $metadata,
-                    $options,
-                    $this->_StreamUnaryCallFactory($channel->getNext())
+                    $options
                 );
             };
         }
@@ -506,9 +506,9 @@ class BaseStub
                 return $channel->getInterceptor()->interceptStreamStream(
                     $method,
                     $deserialize,
+                    $this->_StreamStreamCallFactory($channel->getNext()),
                     $metadata,
-                    $options,
-                    $this->_StreamStreamCallFactory($channel->getNext())
+                    $options
                 );
             };
         }

--- a/src/php/lib/Grpc/Interceptor.php
+++ b/src/php/lib/Grpc/Interceptor.php
@@ -31,9 +31,9 @@ class Interceptor
         $method,
         $argument,
         $deserialize,
+        $continuation,
         array $metadata = [],
-        array $options = [],
-        $continuation
+        array $options = []
     ) {
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
@@ -41,9 +41,9 @@ class Interceptor
     public function interceptStreamUnary(
         $method,
         $deserialize,
+        $continuation,
         array $metadata = [],
-        array $options = [],
-        $continuation
+        array $options = []
     ) {
         return $continuation($method, $deserialize, $metadata, $options);
     }
@@ -52,9 +52,9 @@ class Interceptor
         $method,
         $argument,
         $deserialize,
+        $continuation,
         array $metadata = [],
-        array $options = [],
-        $continuation
+        array $options = []
     ) {
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
@@ -62,9 +62,9 @@ class Interceptor
     public function interceptStreamStream(
         $method,
         $deserialize,
+        $continuation,
         array $metadata = [],
-        array $options = [],
-        $continuation
+        array $options = []
     ) {
         return $continuation($method, $deserialize, $metadata, $options);
     }

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -96,18 +96,18 @@ class ChangeMetadataInterceptor extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+                                        $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         $metadata["foo"] = array('interceptor_from_unary_request');
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
+                                         $continuation,
                                          array $metadata = [],
-                                         array $options = [],
-                                         $continuation)
+                                         array $options = [])
     {
         $metadata["foo"] = array('interceptor_from_stream_request');
         return $continuation($method, $deserialize, $metadata, $options);
@@ -119,9 +119,9 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+                                        $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         if (array_key_exists('foo', $metadata)) {
             $metadata['bar'] = array('ChangeMetadataInterceptor should be executed first');
@@ -132,9 +132,9 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
+                                         $continuation,
                                          array $metadata = [],
-                                         array $options = [],
-                                         $continuation)
+                                         array $options = [])
     {
         if (array_key_exists('foo', $metadata)) {
             $metadata['bar'] = array('ChangeMetadataInterceptor should be executed first');
@@ -175,18 +175,18 @@ class ChangeRequestInterceptor extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+                                        $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         $argument->setData('intercepted_unary_request');
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
+                                         $continuation,
                                          array $metadata = [],
-                                         array $options = [],
-                                         $continuation)
+                                         array $options = [])
     {
         return new ChangeRequestCall(
             $continuation($method, $deserialize, $metadata, $options)
@@ -199,17 +199,17 @@ class StopCallInterceptor extends Grpc\Interceptor
     public function interceptUnaryUnary($method,
                                         $argument,
                                         $deserialize,
+                                        $continuation,
                                         array $metadata = [],
-                                        array $options = [],
-                                        $continuation)
+                                        array $options = [])
     {
         $metadata["foo"] = array('interceptor_from_request_response');
     }
     public function interceptStreamUnary($method,
                                          $deserialize,
+                                         $continuation,
                                          array $metadata = [],
-                                         array $options = [],
-                                         $continuation)
+                                         array $options = [])
     {
         $metadata["foo"] = array('interceptor_from_request_response');
     }


### PR DESCRIPTION
put all required parameters before optional parameters.

This is one of clean up tasks for migrating to PHPUnit 8.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@stanley-cheung 
