### PR TITLE
Increase ruby build timeout to 60min

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -203,7 +203,7 @@ class RubyArtifact:
         return create_jobspec(
             self.name, ['tools/run_tests/artifacts/build_artifact_ruby.sh'],
             use_workspace=True,
-            timeout_seconds=45 * 60)
+            timeout_seconds=60 * 60)
 
 
 class CSharpExtArtifact:


### PR DESCRIPTION
Ruby artifact build on macos has been failing mainly due to "TIMEOUT" on `tasks.build_artifact.ruby_native_gem_macos_x64`. From the reading on recent history logs, it appears that it usually takes 44 minutes when passing successfully but it's too tough with the timeout limit of 45 minutes, which results in many timeout errors recently.

To avoid this, let's bump the timeout to 60 minutes so that it can be done with more generous timeout limit.

Fixing #23905