### PR TITLE
Use unsigned type when iterating unsigned value

### DIFF
--- a/src/core/lib/transport/metadata.cc
+++ b/src/core/lib/transport/metadata.cc
@@ -252,7 +252,7 @@ void grpc_mdctx_global_shutdown() {
     if (shard->count != 0) {
       gpr_log(GPR_ERROR, "WARNING: %" PRIuPTR " metadata elements were leaked",
               shard->count);
-      for (int i = 0; i < shard->capacity; i++) {
+      for (size_t i = 0; i < shard->capacity; i++) {
         for (InternedMetadata* md = shard->elems[i].next; md;
              md = md->bucket_next()) {
           char* key_str = grpc_slice_to_c_string(md->key());


### PR DESCRIPTION
This makes this loop consistent with the rest of the file in use of types.

It also fixes a build warning in GCC for signed/unsigned mismatch.

Warning was visible with `CC=/usr/bin/gcc bazel build :grpc_base_c`.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
