### PR TITLE
Add ruby 3.0 to rake-compiler-dock

### DIFF
--- a/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
@@ -1,7 +1,7 @@
 FROM dockcross/manylinux2010-x86
 
 # Docker file for building gRPC manylinux-based Ruby artifacts.
-# Updated: 2020-07-03
+# Updated: 2020-12-21
 
 # install packages which rvm will require
 RUN yum install -y autoconf gcc-c++ libtool readline-devel ruby sqlite-devel openssl-devel xz
@@ -19,9 +19,10 @@ COPY build/patches /work/patches/
 ENV BASH_ENV /etc/rubybashrc
 
 # install rubies and fix permissions on
+ENV RVM_RUBIES 2.5.7 2.7.0
 RUN bash -c " \
     export CFLAGS='-s -O3 -fno-fast-math -fPIC' && \
-    for v in 2.5.7 ; do \
+    for v in ${RVM_RUBIES} ; do \
         rvm install \$v --patch \$(echo /work/patches/ruby-\$v/* | tr ' ' ','); \
     done && \
     rvm cleanup all && \
@@ -32,7 +33,7 @@ RUN bash -c " \
 RUN echo "gem: --no-ri --no-rdoc" >> ~/.gemrc && \
     bash -c " \
         rvm all do gem update --system --no-document && \
-        rvm all do gem install --no-document bundler 'bundler:~>1.16' rake-compiler:1.1.0 hoe:3.20.0 mini_portile rubygems-tasks mini_portile2 && \
+        rvm all do gem install --no-document bundler 'bundler:~>1.16' 'rake-compiler:1.1.0' 'hoe:3.20.0' mini_portile rubygems-tasks mini_portile2 && \
         find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 
 # Install rake-compiler's cross rubies in global dir instead of /root
@@ -45,10 +46,13 @@ RUN bash -c " \
 
 # Patch rake-compiler and hoe package
 COPY build/patches2 /work/patches/
-RUN cd /usr/local/rvm/gems/ruby-2.5.7/gems/rake-compiler-1.1.0 && \
-    ( git apply /work/patches/rake-compiler-1.1.0/*.patch || true )
-RUN cd /usr/local/rvm/gems/ruby-2.5.7/gems/hoe-3.20.0 && \
-    ( git apply /work/patches/hoe-3.20.0/*.patch || true )
+RUN bash -c " \
+    for v in ${RVM_RUBIES} ; do \
+      cd /usr/local/rvm/gems/ruby-\$v/gems/rake-compiler-1.1.0 && \
+      ( git apply /home/rvm/patches/rake-compiler-1.1.0/*.patch || true ) && \
+      cd /usr/local/rvm/gems/ruby-\$v/gems/hoe-3.20.0 && \
+      ( git apply /home/rvm/patches/hoe-3.20.0/*.patch || true ) \
+    done "
 
 # Patch ruby-2.7.0 for cross build
 RUN curl -SL http://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.xz | tar -xJC /root/ && \
@@ -70,6 +74,13 @@ RUN bash -c " \
     rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources && \
     find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 
+RUN bash -c " \
+    export CFLAGS='-s -O1 -fno-omit-frame-pointer -fno-fast-math' && \
+    export MAKE='make V=0' && \
+    rvm 2.7.0 do rake-compiler cross-ruby VERSION=3.0.0-preview1 HOST=x86-linux-gnu && \
+    rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources && \
+    find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
+
 # Avoid linking against libruby shared object.
 # See also https://github.com/rake-compiler/rake-compiler-dock/issues/13
 RUN find /usr/local/rake-compiler/ruby/*linux*/ -name libruby.so | xargs rm
@@ -88,4 +99,4 @@ RUN gcc $HOME/sigfw.c -o /usr/local/bin/sigfw
 # Install patchelf_gem.sh
 COPY build/patchelf_gem.sh /usr/local/bin/patchelf_gem.sh
 
-ENV RUBY_CC_VERSION 2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2
+ENV RUBY_CC_VERSION 3.0.0:2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
@@ -1,7 +1,7 @@
 FROM dockcross/manylinux2010-x64
 
 # Docker file for building gRPC manylinux-based Ruby artifacts.
-# Updated: 2020-07-03
+# Updated: 2020-12-21
 
 # install packages which rvm will require
 RUN yum install -y autoconf gcc-c++ libtool readline-devel ruby sqlite-devel openssl-devel xz
@@ -19,9 +19,10 @@ COPY build/patches /work/patches/
 ENV BASH_ENV /etc/rubybashrc
 
 # install rubies and fix permissions on
+ENV RVM_RUBIES 2.5.7 2.7.0
 RUN bash -c " \
     export CFLAGS='-s -O3 -fno-fast-math -fPIC' && \
-    for v in 2.5.7 ; do \
+    for v in ${RVM_RUBIES} ; do \
         rvm install \$v --patch \$(echo /work/patches/ruby-\$v/* | tr ' ' ','); \
     done && \
     rvm cleanup all && \
@@ -32,7 +33,7 @@ RUN bash -c " \
 RUN echo "gem: --no-ri --no-rdoc" >> ~/.gemrc && \
     bash -c " \
         rvm all do gem update --system --no-document && \
-        rvm all do gem install --no-document bundler 'bundler:~>1.16' rake-compiler:1.1.0 hoe:3.20.0 mini_portile rubygems-tasks mini_portile2 && \
+        rvm all do gem install --no-document bundler 'bundler:~>1.16' 'rake-compiler:1.1.0' 'hoe:3.20.0' mini_portile rubygems-tasks mini_portile2 && \
         find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 
 # Install rake-compiler's cross rubies in global dir instead of /root
@@ -45,10 +46,13 @@ RUN bash -c " \
 
 # Patch rake-compiler and hoe package
 COPY build/patches2 /work/patches/
-RUN cd /usr/local/rvm/gems/ruby-2.5.7/gems/rake-compiler-1.1.0 && \
-    ( git apply /work/patches/rake-compiler-1.1.0/*.patch || true )
-RUN cd /usr/local/rvm/gems/ruby-2.5.7/gems/hoe-3.20.0 && \
-    ( git apply /work/patches/hoe-3.20.0/*.patch || true )
+RUN bash -c " \
+    for v in ${RVM_RUBIES} ; do \
+      cd /usr/local/rvm/gems/ruby-\$v/gems/rake-compiler-1.1.0 && \
+      ( git apply /home/rvm/patches/rake-compiler-1.1.0/*.patch || true ) && \
+      cd /usr/local/rvm/gems/ruby-\$v/gems/hoe-3.20.0 && \
+      ( git apply /home/rvm/patches/hoe-3.20.0/*.patch || true ) \
+    done "
 
 # Patch ruby-2.7.0 for cross build
 RUN curl -SL http://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.xz | tar -xJC /root/ && \
@@ -70,6 +74,13 @@ RUN bash -c " \
     rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources && \
     find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
 
+RUN bash -c " \
+    export CFLAGS='-s -O1 -fno-omit-frame-pointer -fno-fast-math' && \
+    export MAKE='make V=0' && \
+    rvm 2.7.0 do rake-compiler cross-ruby VERSION=3.0.0-preview1 HOST=x86_64-linux-gnu && \
+    rm -rf ~/.rake-compiler/builds ~/.rake-compiler/sources && \
+    find /usr/local/rvm -type d -print0 | sudo xargs -0 chmod g+sw "
+
 # Avoid linking against libruby shared object.
 # See also https://github.com/rake-compiler/rake-compiler-dock/issues/13
 RUN find /usr/local/rake-compiler/ruby/*linux*/ -name libruby.so | xargs rm
@@ -88,4 +99,4 @@ RUN gcc $HOME/sigfw.c -o /usr/local/bin/sigfw
 # Install patchelf_gem.sh
 COPY build/patchelf_gem.sh /usr/local/bin/patchelf_gem.sh
 
-ENV RUBY_CC_VERSION 2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2
+ENV RUBY_CC_VERSION 3.0.0:2.7.0:2.6.0:2.5.0:2.4.0:2.3.0:2.2.2


### PR DESCRIPTION
Adding ruby 3.0 support to rake-compiler-dock based on https://github.com/rake-compiler/rake-compiler-dock/pull/40.

This is currently blocked by https://github.com/dockcross/dockcross/issues/458