### PR TITLE
xds-k8s test runner: load API key from Cloud Secret Manager

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/grpc-testing.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/grpc-testing.cfg
@@ -2,3 +2,4 @@
 --project=grpc-testing
 --network=default-vpc
 --gcp_service_account=830293263384-compute@developer.gserviceaccount.com
+--private_api_key_secret_name=projects/830293263384/secrets/xds-interop-tests-private-api-access-key

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
@@ -18,10 +18,10 @@ import os
 
 # Workaround: `grpc` must be imported before `google.protobuf.json_format`,
 # to prevent "Segmentation fault". Ref https://github.com/grpc/grpc/issues/24897
-from google.cloud import secretmanager_v1
 # TODO(sergiitk): Remove after #24897 is solved
 import grpc
 from absl import flags
+from google.cloud import secretmanager_v1
 from google.longrunning import operations_pb2
 from google.protobuf import json_format
 from google.rpc import code_pb2

--- a/tools/run_tests/xds_k8s_test_driver/requirements.txt
+++ b/tools/run_tests/xds_k8s_test_driver/requirements.txt
@@ -3,6 +3,7 @@ PyYAML~=5.3
 absl-py~=0.11
 dataclasses~=0.8
 google-api-python-client~=1.12
+google-cloud-secret-manager~=2.1
 grpcio~=1.34
 grpcio-tools~=1.34
 grpcio-channelz~=1.34


### PR DESCRIPTION
Load Private API key from Cloud Secret Manager secret instead of the env var.
Context: https://github.com/grpc/grpc-java/pull/7742#discussion_r546996195