### PR TITLE
Increase timeout of build_artifact_csharp_ios to 45 mins

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -233,6 +233,7 @@ class CSharpExtArtifact:
             return create_jobspec(
                 self.name,
                 ['tools/run_tests/artifacts/build_artifact_csharp_ios.sh'],
+                timeout_seconds=45 * 60,
                 use_workspace=True)
         elif self.platform == 'windows':
             return create_jobspec(self.name, [


### PR DESCRIPTION
Increasing timeout of `build_artifact_csharp_ios` from 30 mins to 45 mins.

When it's done successfully, it usually takes ~20 minutes but it's quite often to have them with timeout of 30 minutes. Presumably it's caused by inconsistent mac machines so let's bump it to 45 mins to mitigate it.  

Fixing #25029