### PR TITLE
Updated parse_json.cc to rely on config_protobuf.h for protobuf types

### DIFF
--- a/include/grpcpp/impl/codegen/config_protobuf.h
+++ b/include/grpcpp/impl/codegen/config_protobuf.h
@@ -65,6 +65,7 @@
 
 #ifndef GRPC_CUSTOM_JSONUTIL
 #include <google/protobuf/util/json_util.h>
+#include <google/protobuf/util/type_resolver_util.h>
 #define GRPC_CUSTOM_JSONUTIL ::google::protobuf::util
 #define GRPC_CUSTOM_UTIL_STATUS ::google::protobuf::util::Status
 #endif

--- a/test/cpp/qps/parse_json.cc
+++ b/test/cpp/qps/parse_json.cc
@@ -20,8 +20,6 @@
 
 #include <string>
 
-#include <google/protobuf/util/json_util.h>
-#include <google/protobuf/util/type_resolver_util.h>
 #include <grpc/support/log.h>
 
 namespace grpc {
@@ -29,17 +27,16 @@ namespace testing {
 
 void ParseJson(const std::string& json, const std::string& type,
                GRPC_CUSTOM_MESSAGE* msg) {
-  std::unique_ptr<google::protobuf::util::TypeResolver> type_resolver(
-      google::protobuf::util::NewTypeResolverForDescriptorPool(
-          "type.googleapis.com",
-          google::protobuf::DescriptorPool::generated_pool()));
+  std::unique_ptr<protobuf::json::TypeResolver> type_resolver(
+      protobuf::json::NewTypeResolverForDescriptorPool(
+          "type.googleapis.com", protobuf::DescriptorPool::generated_pool()));
   std::string binary;
   auto status = JsonToBinaryString(
       type_resolver.get(), "type.googleapis.com/" + type, json, &binary);
   if (!status.ok()) {
     std::string errmsg(status.error_message());
     gpr_log(GPR_ERROR, "Failed to convert json to binary: errcode=%d msg=%s",
-            status.error_code(), errmsg.c_str());
+            status.code(), errmsg.c_str());
     gpr_log(GPR_ERROR, "JSON: %s", json.c_str());
     abort();
   }
@@ -48,10 +45,9 @@ void ParseJson(const std::string& json, const std::string& type,
 
 std::string SerializeJson(const GRPC_CUSTOM_MESSAGE& msg,
                           const std::string& type) {
-  std::unique_ptr<google::protobuf::util::TypeResolver> type_resolver(
-      google::protobuf::util::NewTypeResolverForDescriptorPool(
-          "type.googleapis.com",
-          google::protobuf::DescriptorPool::generated_pool()));
+  std::unique_ptr<protobuf::json::TypeResolver> type_resolver(
+      protobuf::json::NewTypeResolverForDescriptorPool(
+          "type.googleapis.com", protobuf::DescriptorPool::generated_pool()));
   std::string binary;
   std::string json_string;
   msg.SerializeToString(&binary);


### PR DESCRIPTION
Google's internal version of the gRPC codebase uses a version of
protobuf with a different namespace and include paths. This commit makes
parse_json.cc rely on config_protobuf.h for protobuf types so that it
will work properly in that environment. I also replaced a call to
Status::error_code() with a call to Status::code() instead. This way the
code will work with absl::Status, which has a somewhat different API
compared to google::protobuf::util::Status.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
