### PR TITLE
xds-k8s driver: Improve logging INFO-level logging

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,4 +1,4 @@
 --namespace=interop-psm-security
 --td_bootstrap_image=gcr.io/trafficdirector-prod/td-grpc-bootstrap:0.10.0
---logger_levels=__main__:DEBUG,framework:DEBUG
+--logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/network_security.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/network_security.py
@@ -23,8 +23,6 @@ logger = logging.getLogger(__name__)
 
 
 class NetworkSecurityV1Alpha1(gcp.api.GcpStandardCloudApiResource):
-    API_NAME = 'networksecurity'
-    API_VERSION = 'v1alpha1'
     SERVER_TLS_POLICIES = 'serverTlsPolicies'
     CLIENT_TLS_POLICIES = 'clientTlsPolicies'
 
@@ -47,9 +45,17 @@ class NetworkSecurityV1Alpha1(gcp.api.GcpStandardCloudApiResource):
         create_time: str
 
     def __init__(self, api_manager: gcp.api.GcpApiManager, project: str):
-        super().__init__(api_manager.networksecurity(self.API_VERSION), project)
+        super().__init__(api_manager.networksecurity(self.api_version), project)
         # Shortcut to projects/*/locations/ endpoints
         self._api_locations = self.api.projects().locations()
+
+    @property
+    def api_name(self) -> str:
+        return 'networksecurity'
+
+    @property
+    def api_version(self) -> str:
+        return 'v1alpha1'
 
     def create_server_tls_policy(self, name, body: dict):
         return self._create_resource(self._api_locations.serverTlsPolicies(),
@@ -97,7 +103,7 @@ class NetworkSecurityV1Alpha1(gcp.api.GcpStandardCloudApiResource):
             collection=self._api_locations.clientTlsPolicies(),
             full_name=self.resource_full_name(name, self.CLIENT_TLS_POLICIES))
 
-    def _execute(self, *args, **kwargs):
+    def _execute(self, *args, **kwargs):  # pylint: disable=signature-differs
         # Workaround TD bug: throttled operations are reported as internal.
         # Ref b/175345578
         retryer = tenacity.Retrying(

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/network_services.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/network_services.py
@@ -24,9 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class NetworkServicesV1Alpha1(gcp.api.GcpStandardCloudApiResource):
-    API_NAME = 'networkservices'
-    API_VERSION = 'v1alpha1'
-    DEFAULT_GLOBAL = 'global'
     ENDPOINT_CONFIG_SELECTORS = 'endpointConfigSelectors'
 
     @dataclasses.dataclass(frozen=True)
@@ -42,9 +39,17 @@ class NetworkServicesV1Alpha1(gcp.api.GcpStandardCloudApiResource):
         create_time: str
 
     def __init__(self, api_manager: gcp.api.GcpApiManager, project: str):
-        super().__init__(api_manager.networkservices(self.API_VERSION), project)
+        super().__init__(api_manager.networkservices(self.api_version), project)
         # Shortcut to projects/*/locations/ endpoints
         self._api_locations = self.api.projects().locations()
+
+    @property
+    def api_name(self) -> str:
+        return 'networkservices'
+
+    @property
+    def api_version(self) -> str:
+        return 'v1alpha1'
 
     def create_endpoint_config_selector(self, name, body: dict):
         return self._create_resource(
@@ -74,7 +79,7 @@ class NetworkServicesV1Alpha1(gcp.api.GcpStandardCloudApiResource):
             full_name=self.resource_full_name(name,
                                               self.ENDPOINT_CONFIG_SELECTORS))
 
-    def _execute(self, *args, **kwargs):
+    def _execute(self, *args, **kwargs):  # pylint: disable=signature-differs
         # Workaround TD bug: throttled operations are reported as internal.
         # Ref b/175345578
         retryer = tenacity.Retrying(

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -67,7 +67,11 @@ class KubernetesApiManager:
     @classmethod
     @functools.lru_cache(None)
     def _cached_api_client_for_context(cls, context: str) -> client.ApiClient:
-        return kubernetes.config.new_client_from_config(context=context)
+        client_instance = kubernetes.config.new_client_from_config(
+            context=context)
+        logger.info('Using kubernetes context "%s", active host: %s', context,
+                    client_instance.configuration.host)
+        return client_instance
 
 
 class PortForwardingError(Exception):
@@ -134,8 +138,8 @@ class KubernetesNamespace:
         def _wait_for_deleted_service_with_retry():
             service = self.get_service(name)
             if service is not None:
-                logger.info('Waiting for service %s to be deleted',
-                            service.metadata.name)
+                logger.debug('Waiting for service %s to be deleted',
+                             service.metadata.name)
             return service
 
         _wait_for_deleted_service_with_retry()
@@ -151,13 +155,13 @@ class KubernetesNamespace:
         def _wait_for_deleted_service_account_with_retry():
             service_account = self.get_service_account(name)
             if service_account is not None:
-                logger.info('Waiting for service account %s to be deleted',
-                            service_account.metadata.name)
+                logger.debug('Waiting for service account %s to be deleted',
+                             service_account.metadata.name)
             return service_account
 
         _wait_for_deleted_service_account_with_retry()
 
-    def wait_for_namespace_deleted(self, timeout_sec=240, wait_sec=2):
+    def wait_for_namespace_deleted(self, timeout_sec=240, wait_sec=5):
 
         @retrying.retry(retry_on_result=lambda r: r is not None,
                         stop_max_delay=timeout_sec * 1000,
@@ -165,8 +169,8 @@ class KubernetesNamespace:
         def _wait_for_deleted_namespace_with_retry():
             namespace = self.get()
             if namespace is not None:
-                logger.info('Waiting for namespace %s to be deleted',
-                            namespace.metadata.name)
+                logger.debug('Waiting for namespace %s to be deleted',
+                             namespace.metadata.name)
             return namespace
 
         _wait_for_deleted_namespace_with_retry()
@@ -179,7 +183,8 @@ class KubernetesNamespace:
         def _wait_for_service_neg():
             service = self.get_service(name)
             if self.NEG_STATUS_META not in service.metadata.annotations:
-                logger.info('Waiting for service %s NEG', service.metadata.name)
+                logger.debug('Waiting for service %s NEG',
+                             service.metadata.name)
                 return False
             return True
 
@@ -216,7 +221,7 @@ class KubernetesNamespace:
                                                name,
                                                count=1,
                                                timeout_sec=60,
-                                               wait_sec=1):
+                                               wait_sec=3):
 
         @retrying.retry(
             retry_on_result=lambda r: not self._replicas_available(r, count),
@@ -224,7 +229,7 @@ class KubernetesNamespace:
             wait_fixed=wait_sec * 1000)
         def _wait_for_deployment_available_replicas():
             deployment = self.get_deployment(name)
-            logger.info(
+            logger.debug(
                 'Waiting for deployment %s to have %s available '
                 'replicas, current count %s', deployment.metadata.name, count,
                 deployment.status.available_replicas)
@@ -243,7 +248,7 @@ class KubernetesNamespace:
         def _wait_for_deleted_deployment_with_retry():
             deployment = self.get_deployment(deployment_name)
             if deployment is not None:
-                logger.info(
+                logger.debug(
                     'Waiting for deployment %s to be deleted. '
                     'Non-terminated replicas: %s', deployment.metadata.name,
                     deployment.status.replicas)
@@ -266,8 +271,8 @@ class KubernetesNamespace:
                         wait_fixed=wait_sec * 1000)
         def _wait_for_pod_started():
             pod = self.get_pod(pod_name)
-            logger.info('Waiting for pod %s to start, current phase: %s',
-                        pod.metadata.name, pod.status.phase)
+            logger.debug('Waiting for pod %s to start, current phase: %s',
+                         pod.metadata.name, pod.status.phase)
             return pod
 
         _wait_for_pod_started()
@@ -324,8 +329,7 @@ class KubernetesNamespace:
         pf.kill()
         stdout, _stderr = pf.communicate(timeout=5)
         logger.info('Port forwarding stopped')
-        # TODO(sergiitk): make debug
-        logger.info('Port forwarding remaining stdout: %s', stdout)
+        logger.debug('Port forwarding remaining stdout: %s', stdout)
 
     @staticmethod
     def _pod_started(pod: V1Pod):

--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc.py
@@ -46,7 +46,8 @@ class GrpcClientHelper:
             req: Message,
             wait_for_ready_sec: Optional[int] = DEFAULT_WAIT_FOR_READY_SEC,
             connection_timeout_sec: Optional[
-                int] = DEFAULT_CONNECTION_TIMEOUT_SEC) -> Message:
+                int] = DEFAULT_CONNECTION_TIMEOUT_SEC,
+            log_level: Optional[int] = logging.DEBUG) -> Message:
         if wait_for_ready_sec is None:
             wait_for_ready_sec = self.DEFAULT_WAIT_FOR_READY_SEC
         if connection_timeout_sec is None:
@@ -56,14 +57,14 @@ class GrpcClientHelper:
         rpc_callable: grpc.UnaryUnaryMultiCallable = getattr(self.stub, rpc)
 
         call_kwargs = dict(wait_for_ready=True, timeout=timeout_sec)
-        self._log_debug(rpc, req, call_kwargs)
+        self._log_rpc_request(rpc, req, call_kwargs, log_level)
         return rpc_callable(req, **call_kwargs)
 
-    def _log_debug(self, rpc, req, call_kwargs):
-        logger.debug('RPC %s.%s(request=%s(%r), %s)',
-                     self.log_service_name, rpc, req.__class__.__name__,
-                     json_format.MessageToDict(req),
-                     ', '.join({f'{k}={v}' for k, v in call_kwargs.items()}))
+    def _log_rpc_request(self, rpc, req, call_kwargs, log_level=logging.DEBUG):
+        logger.log(logging.DEBUG if log_level is None else log_level,
+                   'RPC %s.%s(request=%s(%r), %s)', self.log_service_name, rpc,
+                   req.__class__.__name__, json_format.MessageToDict(req),
+                   ', '.join({f'{k}={v}' for k, v in call_kwargs.items()}))
 
 
 class GrpcApp:

--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_testing.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_testing.py
@@ -15,6 +15,7 @@
 This contains helpers for gRPC services defined in
 https://github.com/grpc/grpc/blob/master/src/proto/grpc/testing/test.proto
 """
+import logging
 from typing import Optional
 
 import grpc
@@ -25,7 +26,7 @@ from src.proto.grpc.testing import messages_pb2
 
 # Type aliases
 _LoadBalancerStatsRequest = messages_pb2.LoadBalancerStatsRequest
-_LoadBalancerStatsResponse = messages_pb2.LoadBalancerStatsResponse
+LoadBalancerStatsResponse = messages_pb2.LoadBalancerStatsResponse
 
 
 class LoadBalancerStatsServiceClient(framework.rpc.grpc.GrpcClientHelper):
@@ -40,12 +41,13 @@ class LoadBalancerStatsServiceClient(framework.rpc.grpc.GrpcClientHelper):
             *,
             num_rpcs: int,
             timeout_sec: Optional[int] = STATS_PARTIAL_RESULTS_TIMEOUT_SEC,
-    ) -> _LoadBalancerStatsResponse:
+    ) -> LoadBalancerStatsResponse:
         if timeout_sec is None:
             timeout_sec = self.STATS_PARTIAL_RESULTS_TIMEOUT_SEC
 
         return self.call_unary_with_deadline(rpc='GetClientStats',
-                                             wait_for_ready_sec=timeout_sec,
                                              req=_LoadBalancerStatsRequest(
                                                  num_rpcs=num_rpcs,
-                                                 timeout_sec=timeout_sec))
+                                                 timeout_sec=timeout_sec),
+                                             wait_for_ready_sec=timeout_sec,
+                                             log_level=logging.INFO)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/base_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/base_runner.py
@@ -28,10 +28,9 @@ class RunnerError(Exception):
     """Error running app"""
 
 
-TEMPLATE_DIR = '../../kubernetes-manifests'
-
-
 class KubernetesBaseRunner:
+    TEMPLATE_DIR_NAME = 'kubernetes-manifests'
+    TEMPLATE_DIR_RELATIVE_PATH = f'../../{TEMPLATE_DIR_NAME}'
 
     def __init__(self,
                  k8s_namespace,
@@ -75,17 +74,19 @@ class KubernetesBaseRunner:
             for manifest in yml:
                 yield manifest
 
-    @staticmethod
-    def _template_file_from_name(template_name):
-        templates_path = pathlib.Path(__file__).parent / TEMPLATE_DIR
-        return templates_path.joinpath(template_name).absolute()
+    @classmethod
+    def _template_file_from_name(cls, template_name):
+        templates_path = (pathlib.Path(__file__).parent /
+                          cls.TEMPLATE_DIR_RELATIVE_PATH)
+        return templates_path.joinpath(template_name).resolve()
 
     def _create_from_template(self, template_name, **kwargs):
         template_file = self._template_file_from_name(template_name)
-        logger.info("Loading template: %s", template_file)
+        logger.debug("Loading k8s manifest template: %s", template_file)
 
         yaml_doc = self._render_template(template_file, **kwargs)
-        logger.info("Rendered template:\n%s\n", yaml_doc)
+        logger.info("Rendered template %s/%s:\n%s", self.TEMPLATE_DIR_NAME,
+                    template_name, yaml_doc)
 
         manifests = self._manifests_from_str(yaml_doc)
         manifest = next(manifests)
@@ -121,10 +122,11 @@ class KubernetesBaseRunner:
             raise RunnerError('Expected V1Namespace to be created '
                               f'from manifest {template}')
         if namespace.metadata.name != kwargs['namespace_name']:
-            raise RunnerError('Namespace created with unexpected name: '
+            raise RunnerError('V1Namespace created with unexpected name: '
                               f'{namespace.metadata.name}')
-        logger.info('Deployment %s created at %s', namespace.metadata.self_link,
-                    namespace.metadata.creation_timestamp)
+        logger.debug('V1Namespace %s created at %s',
+                     namespace.metadata.self_link,
+                     namespace.metadata.creation_timestamp)
         return namespace
 
     def _create_service_account(self, template,
@@ -136,9 +138,9 @@ class KubernetesBaseRunner:
         if resource.metadata.name != kwargs['service_account_name']:
             raise RunnerError('V1ServiceAccount created with unexpected name: '
                               f'{resource.metadata.name}')
-        logger.info('V1ServiceAccount %s created at %s',
-                    resource.metadata.self_link,
-                    resource.metadata.creation_timestamp)
+        logger.debug('V1ServiceAccount %s created at %s',
+                     resource.metadata.self_link,
+                     resource.metadata.creation_timestamp)
         return resource
 
     def _create_deployment(self, template, **kwargs) -> k8s.V1Deployment:
@@ -147,11 +149,11 @@ class KubernetesBaseRunner:
             raise RunnerError('Expected V1Deployment to be created '
                               f'from manifest {template}')
         if deployment.metadata.name != kwargs['deployment_name']:
-            raise RunnerError('Deployment created with unexpected name: '
+            raise RunnerError('V1Deployment created with unexpected name: '
                               f'{deployment.metadata.name}')
-        logger.info('Deployment %s created at %s',
-                    deployment.metadata.self_link,
-                    deployment.metadata.creation_timestamp)
+        logger.debug('V1Deployment %s created at %s',
+                     deployment.metadata.self_link,
+                     deployment.metadata.creation_timestamp)
         return deployment
 
     def _create_service(self, template, **kwargs) -> k8s.V1Service:
@@ -160,13 +162,14 @@ class KubernetesBaseRunner:
             raise RunnerError('Expected V1Service to be created '
                               f'from manifest {template}')
         if service.metadata.name != kwargs['service_name']:
-            raise RunnerError('Service created with unexpected name: '
+            raise RunnerError('V1Service created with unexpected name: '
                               f'{service.metadata.name}')
-        logger.info('Service %s created at %s', service.metadata.self_link,
-                    service.metadata.creation_timestamp)
+        logger.debug('V1Service %s created at %s', service.metadata.self_link,
+                     service.metadata.creation_timestamp)
         return service
 
     def _delete_deployment(self, name, wait_for_deletion=True):
+        logger.info('Deleting deployment %s', name)
         try:
             self.k8s_namespace.delete_deployment(name)
         except k8s.ApiException as e:
@@ -176,9 +179,10 @@ class KubernetesBaseRunner:
 
         if wait_for_deletion:
             self.k8s_namespace.wait_for_deployment_deleted(name)
-        logger.info('Deployment %s deleted', name)
+        logger.debug('Deployment %s deleted', name)
 
     def _delete_service(self, name, wait_for_deletion=True):
+        logger.info('Deleting service %s', name)
         try:
             self.k8s_namespace.delete_service(name)
         except k8s.ApiException as e:
@@ -188,9 +192,10 @@ class KubernetesBaseRunner:
 
         if wait_for_deletion:
             self.k8s_namespace.wait_for_service_deleted(name)
-        logger.info('Service %s deleted', name)
+        logger.debug('Service %s deleted', name)
 
     def _delete_service_account(self, name, wait_for_deletion=True):
+        logger.info('Deleting service account %s', name)
         try:
             self.k8s_namespace.delete_service_account(name)
         except k8s.ApiException as e:
@@ -200,9 +205,10 @@ class KubernetesBaseRunner:
 
         if wait_for_deletion:
             self.k8s_namespace.wait_for_service_account_deleted(name)
-        logger.info('Service account %s deleted', name)
+        logger.debug('Service account %s deleted', name)
 
     def _delete_namespace(self, wait_for_deletion=True):
+        logger.info('Deleting namespace %s', self.k8s_namespace.name)
         try:
             self.k8s_namespace.delete()
         except k8s.ApiException as e:
@@ -212,10 +218,10 @@ class KubernetesBaseRunner:
 
         if wait_for_deletion:
             self.k8s_namespace.wait_for_namespace_deleted()
-        logger.info('Namespace %s deleted', self.k8s_namespace.name)
+        logger.debug('Namespace %s deleted', self.k8s_namespace.name)
 
     def _wait_deployment_with_available_replicas(self, name, count=1, **kwargs):
-        logger.info('Waiting for deployment %s to have %s available replicas',
+        logger.info('Waiting for deployment %s to have %s available replica(s)',
                     name, count)
         self.k8s_namespace.wait_for_deployment_available_replicas(
             name, count, **kwargs)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -233,8 +233,8 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         rpc_host = None
         # Experimental, for local debugging.
         if self.debug_use_port_forwarding:
-            logger.info('Enabling port forwarding from %s:%s', pod_ip,
-                        maintenance_port)
+            logger.info('LOCAL DEV MODE: Enabling port forwarding to %s:%s',
+                        pod_ip, maintenance_port)
             self.port_forwarder = self.k8s_namespace.port_forward_pod(
                 pod, remote_port=maintenance_port)
             rpc_host = self.k8s_namespace.PORT_FORWARD_LOCAL_ADDRESS

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -78,3 +79,4 @@ spec:
         - name: gke-spiffe-certs-volume
           csi:
             driver: certs.spiffe.gke.io
+...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -65,3 +66,4 @@ spec:
         - name: grpc-td-conf
           emptyDir:
             medium: Memory
+...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/namespace.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -5,3 +6,4 @@ metadata:
   labels:
     name: ${namespace_name}
     owner: xds-k8s-interop-test
+...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -77,3 +78,4 @@ spec:
         - name: gke-spiffe-certs-volume
           csi:
             driver: certs.spiffe.gke.io
+...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,3 +33,4 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.service.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
   - port: ${test_port}
     protocol: TCP
     targetPort: ${test_port}
+...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/service-account.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/service-account.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,3 +8,4 @@ metadata:
     owner: xds-k8s-interop-test
   annotations:
     iam.gke.io/gcp-service-account: ${gcp_service_account}
+...


### PR DESCRIPTION
- Various improvements to logging that make it possible to switch to the INFO level
- Minor changes to retry wait times (to be improved when moving retries to tenacity)
- [Log example](https://source.cloud.google.com/results/invocations/9c0a9879-b224-41de-aee5-4fd102d76e23/targets/grpc%2Fjava%2Fmaster%2Fbranch%2Fxds-k8s/log) (starts at `[ RUN      ] BaselineTest.test_traffic_director_grpc_setup`)

#### Main improvements to logging
- Reduced noise from retries and other debug-level log messages
- Improved wording and readability in many places
- Readable resource body

##### Before
```
I1228 04:56:20.451639 140011363297024 traffic_director.py:134] Creating GRPC Backend Service interop-psm-security-backend-service
I1228 04:56:20.456702 140011363297024 compute.py:287] Creating {'name': 'interop-psm-security-backend-service', 'loadBalancingScheme': 'INTERNAL_SELF_MANAGED', 'healthChecks': ['https://www.googleapis.com/compute/v1/projects/grpc-testing/global/healthChecks/interop-psm-security-health-check'], 'protocol': 'GRPC'}
I1228 04:56:20.994087 140011363297024 compute.py:316] Response {'id': '8440634783566162715', 'name': 'operation-1609160180462-5b785ccf17358-68b3c2ca-4c940869', 'operationType': 'insert', 'targetLink': 'https://www.googleapis.com/compute/v1/projects/grpc-testing/global/backendServices/interop-psm-security-backend-service', 'targetId': '197015044004014875', 'status': 'RUNNING', 'user': '830293263384-compute@developer.gserviceaccount.com', 'progress': 0, 'insertTime': '2020-12-28T04:56:20.831-08:00', 'startTime': '2020-12-28T04:56:20.840-08:00', 'selfLink': 'https://www.googleapis.com/compute/v1/projects/grpc-testing/global/operations/operation-1609160180462-5b785ccf17358-68b3c2ca-4c940869', 'kind': 'compute#operation'}
I1228 04:56:20.995448 140011363297024 compute.py:327] Waiting for global operation operation-1609160180462-5b785ccf17358-68b3c2ca-4c940869, timeout 1200 sec
I1228 04:56:21.173710 140011363297024 after.py:33] Finished call to 'googleapiclient.http.HttpRequest.execute' after 0.178(s), this was the 1st time calling it.
I1228 04:56:23.310541 140011363297024 after.py:33] Finished call to 'googleapiclient.http.HttpRequest.execute' after 2.315(s), this was the 2nd time calling it.
```

##### After
```
I1228 11:41:18.970465 140531656869632 traffic_director.py:134] Creating GRPC Backend Service "interop-psm-security-backend-service"
I1228 11:41:18.976150 140531656869632 compute.py:289] Creating compute resource:
---
healthChecks:
- https://www.googleapis.com/compute/v1/projects/grpc-testing/global/healthChecks/interop-psm-security-health-check
loadBalancingScheme: INTERNAL_SELF_MANAGED
name: interop-psm-security-backend-service
protocol: GRPC
...
``` 