### PR TITLE
xds-k8s driver: Use GRPC target proxy

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -302,15 +302,6 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
         self.ecs: Optional[EndpointConfigSelector] = None
         self.client_tls_policy: Optional[ClientTlsPolicy] = None
 
-    def setup_for_grpc(self,
-                       service_host,
-                       service_port,
-                       *,
-                       backend_protocol=BackendServiceProtocol.HTTP2):
-        super().setup_for_grpc(service_host,
-                               service_port,
-                               backend_protocol=backend_protocol)
-
     def setup_server_security(self,
                               *,
                               server_namespace,
@@ -335,9 +326,6 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
 
     def cleanup(self, *, force=False):
         # Cleanup in the reverse order of creation
-        # TODO(sergiitk): remove next line once proxy deletion is not dependent
-        # upon proxy type.
-        self.target_proxy_is_http = True
         super().cleanup(force=force)
         self.delete_endpoint_config_selector(force=force)
         self.delete_server_tls_policy(force=force)


### PR DESCRIPTION
Looks like GRPC target proxy / Backend Service protocol now work with PSM Security. Switching from `HTTP2` back to to `GRPC`.
Note: This does not apply to networkservices ECS.