### PR TITLE
Fix ruby interceptors to view metadata properly when return_op: true is set, tweak tests to work on ruby 3

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -168,8 +168,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:request_response, intercept_args) do
-            c.request_response(req, metadata: metadata)
+            c.request_response(req, metadata: updated_metadata)
           end
         end
         op
@@ -245,8 +247,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:client_streamer, intercept_args) do
-            c.client_streamer(requests)
+            c.client_streamer(requests, metadata: updated_metadata)
           end
         end
         op
@@ -337,8 +341,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:server_streamer, intercept_args) do
-            c.server_streamer(req, &blk)
+            c.server_streamer(req, metadata: updated_metadata, &blk)
           end
         end
         op
@@ -459,8 +465,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:bidi_streamer, intercept_args) do
-            c.bidi_streamer(requests, &blk)
+            c.bidi_streamer(requests, metadata: updated_metadata, &blk)
           end
         end
         op

--- a/src/ruby/spec/support/services.rb
+++ b/src/ruby/spec/support/services.rb
@@ -49,6 +49,7 @@ class EchoService
 
   def an_rpc(req, call)
     GRPC.logger.info('echo service received a request')
+    call.metadata_to_send.update(call.metadata)
     call.output_metadata.update(@trailing_metadata)
     @received_md << call.metadata unless call.metadata.nil?
     req
@@ -56,6 +57,7 @@ class EchoService
 
   def a_client_streaming_rpc(call)
     # iterate through requests so call can complete
+    call.metadata_to_send.update(call.metadata)
     call.output_metadata.update(@trailing_metadata)
     call.each_remote_read.each do |r|
       GRPC.logger.info(r)
@@ -64,11 +66,13 @@ class EchoService
   end
 
   def a_server_streaming_rpc(_req, call)
+    call.metadata_to_send.update(call.metadata)
     call.output_metadata.update(@trailing_metadata)
     [EchoMsg.new, EchoMsg.new]
   end
 
   def a_bidi_rpc(requests, call)
+    call.metadata_to_send.update(call.metadata)
     call.output_metadata.update(@trailing_metadata)
     requests.each do |r|
       GRPC.logger.info(r)
@@ -81,7 +85,19 @@ EchoStub = EchoService.rpc_stub_class
 
 # For testing server interceptors
 class TestServerInterceptor < GRPC::ServerInterceptor
+  attr_reader :request_counts
+
+  def initialize
+    @request_counts = {
+      request_response: 0,
+      client_streamer: 0,
+      server_streamer: 0,
+      bidi_streamer: 0
+    }
+  end
+
   def request_response(request:, call:, method:)
+    @request_counts[:request_response] += 1
     GRPC.logger.info("Received request/response call at method #{method}" \
       " with request #{request} for call #{call}")
     call.output_metadata[:interc] = 'from_request_response'
@@ -90,6 +106,7 @@ class TestServerInterceptor < GRPC::ServerInterceptor
   end
 
   def client_streamer(call:, method:)
+    @request_counts[:client_streamer] += 1
     call.output_metadata[:interc] = 'from_client_streamer'
     call.each_remote_read.each do |r|
       GRPC.logger.info("In interceptor: #{r}")
@@ -101,6 +118,7 @@ class TestServerInterceptor < GRPC::ServerInterceptor
   end
 
   def server_streamer(request:, call:, method:)
+    @request_counts[:server_streamer] += 1
     GRPC.logger.info("Received server streamer call at method #{method} with request" \
       " #{request} for call #{call}")
     call.output_metadata[:interc] = 'from_server_streamer'
@@ -108,6 +126,7 @@ class TestServerInterceptor < GRPC::ServerInterceptor
   end
 
   def bidi_streamer(requests:, call:, method:)
+    @request_counts[:bidi_streamer] += 1
     requests.each do |r|
       GRPC.logger.info("Bidi request: #{r}")
     end
@@ -120,7 +139,19 @@ end
 
 # For testing client interceptors
 class TestClientInterceptor < GRPC::ClientInterceptor
+  attr_reader :request_counts
+
+  def initialize
+    @request_counts = {
+      request_response: 0,
+      client_streamer: 0,
+      server_streamer: 0,
+      bidi_streamer: 0
+    }
+  end
+
   def request_response(request:, call:, method:, metadata: {})
+    @request_counts[:request_response] += 1
     GRPC.logger.info("Intercepted request/response call at method #{method}" \
       " with request #{request} for call #{call}" \
       " and metadata: #{metadata}")
@@ -129,6 +160,7 @@ class TestClientInterceptor < GRPC::ClientInterceptor
   end
 
   def client_streamer(requests:, call:, method:, metadata: {})
+    @request_counts[:client_streamer] += 1
     GRPC.logger.info("Received client streamer call at method #{method}" \
       " with requests #{requests} for call #{call}" \
       " and metadata: #{metadata}")
@@ -140,6 +172,7 @@ class TestClientInterceptor < GRPC::ClientInterceptor
   end
 
   def server_streamer(request:, call:, method:, metadata: {})
+    @request_counts[:server_streamer] += 1
     GRPC.logger.info("Received server streamer call at method #{method}" \
       " with request #{request} for call #{call}" \
       " and metadata: #{metadata}")
@@ -148,6 +181,7 @@ class TestClientInterceptor < GRPC::ClientInterceptor
   end
 
   def bidi_streamer(requests:, call:, method:, metadata: {})
+    @request_counts[:bidi_streamer] += 1
     GRPC.logger.info("Received bidi streamer call at method #{method}" \
       "with requests #{requests} for call #{call}" \
       " and metadata: #{metadata}")

--- a/src/ruby/spec/user_agent_spec.rb
+++ b/src/ruby/spec/user_agent_spec.rb
@@ -48,8 +48,7 @@ describe 'user agent' do
 
   it 'client sends expected user agent' do
     stub = UserAgentEchoServiceStub.new("localhost:#{@port}",
-                                        :this_channel_is_insecure,
-                                        {})
+                                        :this_channel_is_insecure)
     response = stub.an_rpc(EchoMsg.new)
     expected_user_agent_prefix = "grpc-ruby/#{GRPC::VERSION}"
     expect(response.msg.start_with?(expected_user_agent_prefix)).to be true


### PR DESCRIPTION
This allows ruby unit tests to pass on ruby 3 (just released 6 days ago)

We need to move away from the rspec method call expectation facilities such as `expect(interceptor).to receive(:server_streamer).once.and_call_original`, because these seem to hijack the methods under test in such a way that, at least in our interceptor tests, they rely on hash <-> keyword argument auto-conversion, [and hash <-> keyword argument auto-conversion is no longer supported in ruby 3](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

This PR fixes the tests to verify things about the interceptors in other ways, without using these rspec APIs. Meanwhile, these fixes involve using `return_op: true` in some RPCs, and this revealed a bug in how client interceptors can't view metadata when `return_op: true` is set.