### PR TITLE
xds-k8s driver: implement PSM security mtls_error test

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
@@ -11,6 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Channelz debugging tool for xDS test client/server.
+
+This is intended as a debugging / local development helper and not executed
+as a part of interop test suites.
+
+Typical usage examples:
+
+    # Show channel and socket info
+    python -m bin.run_channelz --flagfile=config/local-dev.cfg
+
+    # Evaluate setup for mtls_error test case
+    python -m bin.run_channelz --flagfile=config/local-dev.cfg --security=mtls_error
+
+    # More information and usage options
+    python -m bin.run_channelz --helpfull
+"""
 import hashlib
 import logging
 
@@ -21,8 +37,8 @@ from framework import xds_flags
 from framework import xds_k8s_flags
 from framework.infrastructure import k8s
 from framework.rpc import grpc_channelz
-from framework.test_app import server_app
 from framework.test_app import client_app
+from framework.test_app import server_app
 
 logger = logging.getLogger(__name__)
 # Flags
@@ -32,11 +48,17 @@ _SERVER_RPC_HOST = flags.DEFINE_string('server_rpc_host',
 _CLIENT_RPC_HOST = flags.DEFINE_string('client_rpc_host',
                                        default='127.0.0.1',
                                        help='Client RPC host')
+_SECURITY = flags.DEFINE_enum('security',
+                              default='positive_cases',
+                              enum_values=['positive_cases', 'mtls_error'],
+                              help='Test for security setup')
 flags.adopt_module_key_flags(xds_flags)
 flags.adopt_module_key_flags(xds_k8s_flags)
 
 # Type aliases
+_Channel = grpc_channelz.Channel
 _Socket = grpc_channelz.Socket
+_ChannelState = grpc_channelz.ChannelState
 _XdsTestServer = server_app.XdsTestServer
 _XdsTestClient = client_app.XdsTestClient
 
@@ -59,65 +81,112 @@ def get_deployment_pod_ips(k8s_ns, deployment_name):
     return [pod.status.pod_ip for pod in pods]
 
 
+def negative_case_mtls(test_client, test_server):
+    """Debug mTLS Error case.
+
+    Server expects client mTLS cert, but client configured only for TLS.
+    """
+    # Client side.
+    client_correct_setup = True
+    channel: _Channel = test_client.wait_for_server_channel_state(
+        state=_ChannelState.TRANSIENT_FAILURE)
+    try:
+        subchannel, *subchannels = list(
+            test_client.channelz.list_channel_subchannels(channel))
+    except ValueError:
+        print("(mTLS-error) Client setup fail: subchannel not found. "
+              "Common causes: test client didn't connect to TD; "
+              "test client exhausted retries, and closed all subchannels.")
+        return
+
+    # Client must have exactly one subchannel.
+    logger.debug('Found subchannel, %s', subchannel)
+    if subchannels:
+        client_correct_setup = False
+        print(f'(mTLS-error) Unexpected subchannels {subchannels}')
+    subchannel_state: _ChannelState = subchannel.data.state.state
+    if subchannel_state is not _ChannelState.TRANSIENT_FAILURE:
+        client_correct_setup = False
+        print('(mTLS-error) Subchannel expected to be in '
+              'TRANSIENT_FAILURE, same as its channel')
+
+    # Client subchannel must have no sockets.
+    sockets = list(test_client.channelz.list_subchannels_sockets(subchannel))
+    if sockets:
+        client_correct_setup = False
+        print(f'(mTLS-error) Unexpected subchannel sockets {sockets}')
+
+    # Results.
+    if client_correct_setup:
+        print('(mTLS-error) Client setup pass: the channel '
+              'to the server has exactly one subchannel '
+              'in TRANSIENT_FAILURE, and no sockets')
+
+
+def positive_case_all(test_client, test_server):
+    """Debug positive cases: mTLS, TLS, Plaintext."""
+    test_client.wait_for_active_server_channel()
+    client_sock: _Socket = test_client.get_active_server_channel_socket()
+    server_sock: _Socket = test_server.get_server_socket_matching_client(
+        client_sock)
+
+    server_tls = server_sock.security.tls
+    client_tls = client_sock.security.tls
+
+    print(f'\nServer certs:\n{debug_sock_tls(server_tls)}')
+    print(f'\nClient certs:\n{debug_sock_tls(client_tls)}')
+    print()
+
+    if server_tls.local_certificate:
+        eq = server_tls.local_certificate == client_tls.remote_certificate
+        print(f'(TLS)  Server local matches client remote: {eq}')
+    else:
+        print('(TLS)  Not detected')
+
+    if server_tls.remote_certificate:
+        eq = server_tls.remote_certificate == client_tls.local_certificate
+        print(f'(mTLS) Server remote matches client local: {eq}')
+    else:
+        print('(mTLS) Not detected')
+
+
 def main(argv):
     if len(argv) > 1:
         raise app.UsageError('Too many command-line arguments.')
 
     k8s_api_manager = k8s.KubernetesApiManager(xds_k8s_flags.KUBE_CONTEXT.value)
 
-    # Namespaces
-    namespace = xds_flags.NAMESPACE.value
-    server_namespace = namespace
-    client_namespace = namespace
-
     # Server
-    server_k8s_ns = k8s.KubernetesNamespace(k8s_api_manager, server_namespace)
     server_name = xds_flags.SERVER_NAME.value
-    server_port = xds_flags.SERVER_PORT.value
+    server_namespace = xds_flags.NAMESPACE.value
+    server_k8s_ns = k8s.KubernetesNamespace(k8s_api_manager, server_namespace)
     server_pod_ip = get_deployment_pod_ips(server_k8s_ns, server_name)[0]
     test_server: _XdsTestServer = _XdsTestServer(
         ip=server_pod_ip,
-        rpc_port=server_port,
+        rpc_port=xds_flags.SERVER_PORT.value,
         xds_host=xds_flags.SERVER_XDS_HOST.value,
         xds_port=xds_flags.SERVER_XDS_PORT.value,
         rpc_host=_SERVER_RPC_HOST.value)
 
     # Client
-    client_k8s_ns = k8s.KubernetesNamespace(k8s_api_manager, client_namespace)
     client_name = xds_flags.CLIENT_NAME.value
-    client_port = xds_flags.CLIENT_PORT.value
+    client_namespace = xds_flags.NAMESPACE.value
+    client_k8s_ns = k8s.KubernetesNamespace(k8s_api_manager, client_namespace)
     client_pod_ip = get_deployment_pod_ips(client_k8s_ns, client_name)[0]
-
     test_client: _XdsTestClient = _XdsTestClient(
         ip=client_pod_ip,
         server_target=test_server.xds_uri,
-        rpc_port=client_port,
+        rpc_port=xds_flags.CLIENT_PORT.value,
         rpc_host=_CLIENT_RPC_HOST.value)
 
-    with test_client, test_server:
-        test_client.wait_for_active_server_channel()
-        client_sock: _Socket = test_client.get_client_socket_with_test_server()
-        server_sock: _Socket = test_server.get_server_socket_matching_client(
-            client_sock)
+    # Run checks
+    if _SECURITY.value in 'positive_cases':
+        positive_case_all(test_client, test_server)
+    elif _SECURITY.value == 'mtls_error':
+        negative_case_mtls(test_client, test_server)
 
-        server_tls = server_sock.security.tls
-        client_tls = client_sock.security.tls
-
-        print(f'\nServer certs:\n{debug_sock_tls(server_tls)}')
-        print(f'\nClient certs:\n{debug_sock_tls(client_tls)}')
-        print()
-
-        if server_tls.local_certificate:
-            eq = server_tls.local_certificate == client_tls.remote_certificate
-            print(f'(TLS)  Server local matches client remote: {eq}')
-        else:
-            print('(TLS)  Not detected')
-
-        if server_tls.remote_certificate:
-            eq = server_tls.remote_certificate == client_tls.local_certificate
-            print(f'(mTLS) Server remote matches client local: {eq}')
-        else:
-            print('(mTLS) Not detected')
+    test_client.close()
+    test_server.close()
 
 
 if __name__ == '__main__':

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/__init__.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
@@ -1,0 +1,53 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This contains common retrying helpers (retryers).
+
+We use tenacity as a general-purpose retrying library.
+
+> It [tenacity] originates from a fork of retrying which is sadly no
+> longer maintained. Tenacity isn’t api compatible with retrying but >
+> adds significant new functionality and fixes a number of longstanding bugs.
+> - https://tenacity.readthedocs.io/en/latest/index.html
+"""
+import datetime
+from typing import Any, List, Optional
+
+import tenacity
+
+# Type aliases
+timedelta = datetime.timedelta
+Retrying = tenacity.Retrying
+_retry_if_exception_type = tenacity.retry_if_exception_type
+_stop_after_delay = tenacity.stop_after_delay
+_wait_exponential = tenacity.wait_exponential
+
+
+def _retry_on_exceptions(retry_on_exceptions: Optional[List[Any]] = None):
+    # Retry on all exceptions by default
+    if retry_on_exceptions is None:
+        retry_on_exceptions = (Exception,)
+    return _retry_if_exception_type(retry_on_exceptions)
+
+
+def exponential_retryer_with_timeout(
+        *,
+        wait_min: timedelta,
+        wait_max: timedelta,
+        timeout: timedelta,
+        retry_on_exceptions: Optional[List[Any]] = None) -> Retrying:
+    return Retrying(retry=_retry_on_exceptions(retry_on_exceptions),
+                    wait=_wait_exponential(min=wait_min.total_seconds(),
+                                           max=wait_max.total_seconds()),
+                    stop=_stop_after_delay(timeout.total_seconds()),
+                    reraise=True)

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
@@ -20,7 +20,7 @@ from typing import Optional
 # Workaround: `grpc` must be imported before `google.protobuf.json_format`,
 # to prevent "Segmentation fault". Ref https://github.com/grpc/grpc/issues/24897
 # TODO(sergiitk): Remove after #24897 is solved
-import grpc  # noqa  # pylint: disable=unused-import
+import grpc  # noqa pylint: disable=unused-import
 from absl import flags
 from google.cloud import secretmanager_v1
 from google.longrunning import operations_pb2

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dataclasses
 import enum
 import logging
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
-import dataclasses
-import googleapiclient.errors
 from googleapiclient import discovery
+import googleapiclient.errors
 # TODO(sergiitk): replace with tenacity
 import retrying
 
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 
 class ComputeV1(gcp.api.GcpProjectApiResource):
     # TODO(sergiitk): move someplace better
-    _WAIT_FOR_BACKEND_SEC = 1200
-    _WAIT_FOR_OPERATION_SEC = 1200
+    _WAIT_FOR_BACKEND_SEC = 60 * 5
+    _WAIT_FOR_OPERATION_SEC = 60 * 5
 
     @dataclasses.dataclass(frozen=True)
     class GcpResource:

--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 import re
-from typing import Optional, ClassVar, Dict
+from typing import ClassVar, Dict, Optional
 
 # Workaround: `grpc` must be imported before `google.protobuf.json_format`,
 # to prevent "Segmentation fault". Ref https://github.com/grpc/grpc/issues/24897
@@ -72,6 +72,10 @@ class GrpcApp:
 
     class NotFound(Exception):
         """Requested resource not found"""
+
+        def __init__(self, message):
+            self.message = message
+            super().__init__(message)
 
     def __init__(self, rpc_host):
         self.rpc_host = rpc_host

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -19,7 +19,7 @@ modules.
 """
 import functools
 import logging
-from typing import Optional
+from typing import Iterator, Optional
 
 from framework.infrastructure import k8s
 import framework.rpc
@@ -78,19 +78,37 @@ class XdsTestServer(framework.rpc.grpc.GrpcApp):
             return ''
         return f'xds:///{self.xds_address}'
 
-    def get_test_server(self):
+    def get_test_server(self) -> grpc_channelz.Server:
+        """Return channelz representation of a server running TestService.
+
+        Raises:
+            GrpcApp.NotFound: Test server not found.
+        """
         server = self.channelz.find_server_listening_on_port(self.rpc_port)
         if not server:
             raise self.NotFound(
                 f'Server listening on port {self.rpc_port} not found')
         return server
 
-    def get_test_server_sockets(self):
+    def get_test_server_sockets(self) -> Iterator[grpc_channelz.Socket]:
+        """List all sockets of the test server.
+
+        Raises:
+            GrpcApp.NotFound: Test server not found.
+        """
         server = self.get_test_server()
-        return self.channelz.list_server_sockets(server.ref.server_id)
+        return self.channelz.list_server_sockets(server)
 
     def get_server_socket_matching_client(self,
                                           client_socket: grpc_channelz.Socket):
+        """Find test server socket that matches given test client socket.
+
+        Sockets are matched using TCP endpoints (ip:port), further on "address".
+        Server socket remote address matched with client socket local address.
+
+         Raises:
+             GrpcApp.NotFound: Server socket matching client socket not found.
+         """
         client_local = self.channelz.sock_address_to_str(client_socket.local)
         logger.debug('Looking for a server socket connected to the client %s',
                      client_local)
@@ -99,7 +117,7 @@ class XdsTestServer(framework.rpc.grpc.GrpcApp):
             self.get_test_server_sockets(), client_socket)
         if not server_socket:
             raise self.NotFound(
-                f'Server socket for client {client_local} not found')
+                f'Server socket to client {client_local} not found')
 
         logger.info('Found matching socket pair: server(%s) <-> client(%s)',
                     self.channelz.sock_addresses_pretty(server_socket),

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -14,7 +14,7 @@
 import enum
 import hashlib
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
 from absl import flags
 from absl.testing import absltest
@@ -40,15 +40,13 @@ flags.adopt_module_key_flags(xds_k8s_flags)
 # Type aliases
 XdsTestServer = server_app.XdsTestServer
 XdsTestClient = client_app.XdsTestClient
-_LoadBalancerStatsResponse = grpc_testing.LoadBalancerStatsResponse
+LoadBalancerStatsResponse = grpc_testing.LoadBalancerStatsResponse
+_ChannelState = grpc_channelz.ChannelState
 
 
 class XdsKubernetesTestCase(absltest.TestCase):
     k8s_api_manager: k8s.KubernetesApiManager
     gcp_api_manager: gcp.api.GcpApiManager
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @classmethod
     def setUpClass(cls):
@@ -110,26 +108,41 @@ class XdsKubernetesTestCase(absltest.TestCase):
     def setupTrafficDirectorGrpc(self):
         self.td.setup_for_grpc(self.server_xds_host, self.server_xds_port)
 
-    def setupServerBackends(self):
+    def setupServerBackends(self, *, wait_for_healthy_status=True):
         # Load Backends
         neg_name, neg_zones = self.server_runner.k8s_namespace.get_service_neg(
             self.server_runner.service_name, self.server_port)
 
         # Add backends to the Backend Service
         self.td.backend_service_add_neg_backends(neg_name, neg_zones)
+        if wait_for_healthy_status:
+            self.td.wait_for_backends_healthy_status()
 
     def assertSuccessfulRpcs(self,
                              test_client: XdsTestClient,
                              num_rpcs: int = 100):
-        # Run the test
-        lb_stats: _LoadBalancerStatsResponse
+        lb_stats = self.sendRpcs(test_client, num_rpcs)
+        self.assertAllBackendsReceivedRpcs(lb_stats)
+        self.assertFailedRpcsAtMost(lb_stats, 0)
+
+    def assertFailedRpcs(self,
+                         test_client: XdsTestClient,
+                         num_rpcs: Optional[int] = 100):
+        lb_stats = self.sendRpcs(test_client, num_rpcs)
+        failed = int(lb_stats.num_failures)
+        self.assertEqual(
+            failed,
+            num_rpcs,
+            msg=f'Expected all {num_rpcs} RPCs to fail, but {failed} failed')
+
+    @staticmethod
+    def sendRpcs(test_client: XdsTestClient,
+                 num_rpcs: int) -> LoadBalancerStatsResponse:
         lb_stats = test_client.get_load_balancer_stats(num_rpcs=num_rpcs)
         logger.info(
             'Received LoadBalancerStatsResponse from test client %s:\n%s',
             test_client.ip, lb_stats)
-        # Check the results
-        self.assertAllBackendsReceivedRpcs(lb_stats)
-        self.assertFailedRpcsAtMost(lb_stats, 0)
+        return lb_stats
 
     def assertAllBackendsReceivedRpcs(self, lb_stats):
         # TODO(sergiitk): assert backends length
@@ -261,12 +274,16 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
                                       tls=server_tls,
                                       mtls=server_mtls)
 
-    def startSecureTestClient(self, test_server: XdsTestServer,
+    def startSecureTestClient(self,
+                              test_server: XdsTestServer,
+                              *,
+                              wait_for_active_server_channel=True,
                               **kwargs) -> XdsTestClient:
         test_client = self.client_runner.run(server_target=test_server.xds_uri,
                                              secure_mode=True,
                                              **kwargs)
-        test_client.wait_for_active_server_channel()
+        if wait_for_active_server_channel:
+            test_client.wait_for_active_server_channel()
         return test_client
 
     def assertTestAppSecurity(self, mode: SecurityMode,
@@ -286,7 +303,7 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         elif mode is self.SecurityMode.PLAINTEXT:
             self.assertSecurityPlaintext(client_security, server_security)
         else:
-            raise TypeError(f'Incorrect security mode')
+            raise TypeError('Incorrect security mode')
 
     def assertSecurityMtls(self, client_security: grpc_channelz.Security,
                            server_security: grpc_channelz.Security):
@@ -377,11 +394,30 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         # Success
         logger.info('Plaintext security mode confirmed!')
 
+    def assertMtlsErrorSetup(self, test_client: XdsTestClient):
+        channel = test_client.wait_for_server_channel_state(
+            state=_ChannelState.TRANSIENT_FAILURE)
+        subchannels = list(
+            test_client.channelz.list_channel_subchannels(channel))
+        self.assertLen(subchannels,
+                       1,
+                       msg="Client channel must have exactly one subchannel "
+                       "in state TRANSIENT_FAILURE.")
+        sockets = list(
+            test_client.channelz.list_subchannels_sockets(subchannels[0]))
+        self.assertEmpty(sockets, msg="Client subchannel must have no sockets")
+
+        # With negative tests we can't be absolutely certain expected
+        # failure state is not caused by something else.
+        logger.info(
+            "Client's connectivity state is consistent with a mTLS error "
+            "caused by not presenting mTLS certificate to the server.")
+
     @staticmethod
     def getConnectedSockets(
             test_client: XdsTestClient, test_server: XdsTestServer
     ) -> Tuple[grpc_channelz.Socket, grpc_channelz.Socket]:
-        client_sock = test_client.get_client_socket_with_test_server()
+        client_sock = test_client.get_active_server_channel_socket()
         server_sock = test_server.get_server_socket_matching_client(client_sock)
         return client_sock, server_sock
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
@@ -39,7 +39,7 @@ class BaselineTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             self.td.create_url_map(self.server_xds_host, self.server_xds_port)
 
         with self.subTest('3_create_target_proxy'):
-            self.td.create_target_grpc_proxy()
+            self.td.create_target_proxy()
 
         with self.subTest('4_create_forwarding_rule'):
             self.td.create_forwarding_rule(self.server_xds_port)

--- a/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import time
 
 from absl import flags
 from absl.testing import absltest
@@ -31,6 +32,10 @@ _SecurityMode = xds_k8s_testcase.SecurityXdsKubernetesTestCase.SecurityMode
 class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
 
     def test_mtls(self):
+        """mTLS test.
+
+        Both client and server configured to use TLS and mTLS.
+        """
         self.setupTrafficDirectorGrpc()
         self.setupSecurityPolicies(server_tls=True,
                                    server_mtls=True,
@@ -45,6 +50,10 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         self.assertSuccessfulRpcs(test_client)
 
     def test_tls(self):
+        """TLS test.
+
+        Both client and server configured to use TLS and not use mTLS.
+        """
         self.setupTrafficDirectorGrpc()
         self.setupSecurityPolicies(server_tls=True,
                                    server_mtls=False,
@@ -59,6 +68,11 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         self.assertSuccessfulRpcs(test_client)
 
     def test_plaintext_fallback(self):
+        """Plain-text fallback test.
+
+        Control plane provides no security config so both client and server
+        fallback to plaintext based on fallback-credentials.
+        """
         self.setupTrafficDirectorGrpc()
         self.setupSecurityPolicies(server_tls=False,
                                    server_mtls=False,
@@ -73,13 +87,70 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
                                    test_server)
         self.assertSuccessfulRpcs(test_client)
 
-    @absltest.skip(SKIP_REASON)
     def test_mtls_error(self):
-        pass
+        """Negative test: mTLS Error.
+
+        Server expects client mTLS cert, but client configured only for TLS.
+
+        Note: because this is a negative test we need to make sure the mTLS
+        failure happens after receiving the correct configuration at the
+        client. To ensure that we will perform the following steps in that
+        sequence:
+
+        - Creation of a backendService, and attaching the backend (NEG)
+        - Creation of the Server mTLS Policy, and attaching to the ECS
+        - Creation of the Client TLS Policy, and attaching to the backendService
+        - Creation of the urlMap, targetProxy, and forwardingRule
+
+        With this sequence we are sure that when the client receives the
+        endpoints of the backendService the security-config would also have
+        been received as confirmed by the TD team.
+        """
+        # Create backend service
+        self.td.setup_backend_for_grpc()
+
+        # Start server and attach its NEGs to the backend service
+        test_server: _XdsTestServer = self.startSecureTestServer()
+        self.setupServerBackends(wait_for_healthy_status=False)
+
+        # Setup policies and attach them.
+        self.setupSecurityPolicies(server_tls=True,
+                                   server_mtls=True,
+                                   client_tls=True,
+                                   client_mtls=False)
+
+        # Create the routing rule map
+        self.td.setup_routing_rule_map_for_grpc(self.server_xds_host,
+                                                self.server_xds_port)
+        # Wait for backends healthy after url map is created
+        self.td.wait_for_backends_healthy_status()
+
+        # Start the client.
+        test_client: _XdsTestClient = self.startSecureTestClient(
+            test_server, wait_for_active_server_channel=False)
+
+        # With negative tests we can't be absolutely certain expected
+        # failure state is not caused by something else.
+        # To mitigate for this, we repeat the checks a few times in case
+        # the channel eventually stabilizes and RPCs pass.
+        # TODO(sergiitk): use tenacity retryer, move nums to constants
+        wait_sec = 10
+        checks = 3
+        for check in range(1, checks + 1):
+            self.assertMtlsErrorSetup(test_client)
+            self.assertFailedRpcs(test_client)
+            if check != checks:
+                logger.info(
+                    'Check %s successful, waiting %s sec before the next check',
+                    check, wait_sec)
+                time.sleep(wait_sec)
 
     @absltest.skip(SKIP_REASON)
     def test_server_authz_error(self):
-        pass
+        """Negative test: AuthZ error.
+
+        Client does not authorize server because of mismatched SAN name.
+        """
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Changes
- implement PSM security mtls_error test
- implement framework features and add helpers needed for `mtls_error`
- changed the default wait time for compute resources from 20 minutes to 5 minutes
- added extra check when waiting for active client channel to the server: now making sure there's an active subchannel too. This was useful to deflake waiting for TRANSIENT_FAILURE in the negative test cases
- docs, autosort imports in changed files, misc fixes

### Note to reviewers
- automatically formatted code style is enforced, sometimes it's messy. hoping to improve it by updating global repo setup, ref #25071 
- `bin/run_*.py` are helpers for local dev and debugging, can be safely ignored

Most important pieces to review (and the best place to start):
- [tools/run_tests/xds_k8s_test_driver/tests/security_test.py: `test_mtls_error`](https://github.com/grpc/grpc/pull/25075/files#diff-34a45446c13f1b7e02b9e7b96a8b64c4e0007b242c1fe9aaa0322504dd2034dcR90)
- [tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py: `assertMtlsErrorSetup `](https://github.com/grpc/grpc/pull/25075/files#diff-d5da82ad1da6d1311ac50f0b13f0b2cfc6440ce605ccd608259eb468b2c46c80R397)
