### PR TITLE
Include missing string header in retry_throttle.h

### DIFF
--- a/src/core/ext/filters/client_channel/retry_throttle.h
+++ b/src/core/ext/filters/client_channel/retry_throttle.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <string>
+
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 


### PR DESCRIPTION
ServerRetryThrottleMap references std::string but does not `#include
<string>`. Depending on exactly how a C++ implementation lays out its
headers, std::string may or may not be declared already. For example,
Visual C++ 2019 16.8.3 (19.28.29335) does not have std::string declared
at this point.

Add `#include <string>`

This change is needed to get the C# bootstrap script to (`python
.\tools\run_tests\run_tests.py -l csharp -c dbg --build_only`) to
cleanly compile using Visual C++ 2019 instead of the hard-coded 2015
that pre_build_csharp.bat has.

@jtattermusch 
