### PR TITLE
Revert "Propagate warning disables into code."

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,7 @@ let package = Package(
         .headerSearchPath("src/core/ext/upb-generated/"),
         .headerSearchPath("src/core/ext/upbdefs-generated/"),
         .define("GRPC_ARES", to: "0"),
+        .unsafeFlags(["-Wno-module-import-in-extern-c"]),
       ]
     ),
     .target(
@@ -116,6 +117,7 @@ let package = Package(
         .headerSearchPath("include/"),
         .headerSearchPath("third_party/upb/"),
         .headerSearchPath("src/core/ext/upb-generated"),
+        .unsafeFlags(["-Wno-module-import-in-extern-c"]),
       ]
     ),
   ],

--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -33,14 +33,11 @@
 #include "src/core/lib/security/util/json_util.h"
 #include "src/core/lib/slice/b64.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmodule-import-in-extern-c"
 extern "C" {
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 }
-#pragma clang diagnostic pop
 
 using grpc_core::Json;
 

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -28,14 +28,11 @@
 #include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmodule-import-in-extern-c"
 extern "C" {
 #include <openssl/bn.h>
 #include <openssl/pem.h>
 #include <openssl/rsa.h>
 }
-#pragma clang diagnostic pop
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/manual_constructor.h"

--- a/src/core/tsi/ssl/session_cache/ssl_session.h
+++ b/src/core/tsi/ssl/session_cache/ssl_session.h
@@ -23,12 +23,9 @@
 
 #include <grpc/slice.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmodule-import-in-extern-c"
 extern "C" {
 #include <openssl/ssl.h>
 }
-#pragma clang diagnostic pop
 
 #include "src/core/lib/gprpp/ref_counted.h"
 

--- a/src/core/tsi/ssl/session_cache/ssl_session_cache.h
+++ b/src/core/tsi/ssl/session_cache/ssl_session_cache.h
@@ -24,12 +24,9 @@
 #include <grpc/slice.h>
 #include <grpc/support/sync.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmodule-import-in-extern-c"
 extern "C" {
 #include <openssl/ssl.h>
 }
-#pragma clang diagnostic pop
 
 #include "src/core/lib/avl/avl.h"
 #include "src/core/lib/gprpp/memory.h"

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -45,8 +45,6 @@
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmodule-import-in-extern-c"
 extern "C" {
 #include <openssl/bio.h>
 #include <openssl/crypto.h> /* For OPENSSL_free */
@@ -57,7 +55,6 @@ extern "C" {
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 }
-#pragma clang diagnostic pop
 
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/tsi/ssl/session_cache/ssl_session_cache.h"

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -25,12 +25,9 @@
 #include "absl/strings/string_view.h"
 #include "src/core/tsi/transport_security_interface.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmodule-import-in-extern-c"
 extern "C" {
 #include <openssl/x509.h>
 }
-#pragma clang diagnostic pop
 
 /* Value for the TSI_CERTIFICATE_TYPE_PEER_PROPERTY property for X509 certs. */
 #define TSI_X509_CERTIFICATE_TYPE "X509"


### PR DESCRIPTION
Reverts grpc/grpc#24637
`-Wmodule-import-in-extern-c` is not a supported flag in GCC.