### PR TITLE
Fix iOS binary size build

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -67,7 +67,7 @@ then
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master
 
   # Needed for ios-binary-size
-  time pip install --user pyyaml pyjwt pyOpenSSL cryptography requests
+  time pip install --user pyyaml pyjwt==1.7.1 pyOpenSSL cryptography requests
 
   # Store intermediate build files of ObjC tests into /tmpfs
   # TODO(jtattermusch): this has likely been done to avoid running
@@ -85,7 +85,7 @@ if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
   # python
   time pip install --user virtualenv
-  time pip install --user --upgrade Mako tox setuptools==44.1.1 twisted pyyaml pyjwt pyOpenSSL cryptography requests
+  time pip install --user --upgrade Mako tox setuptools==44.1.1 twisted pyyaml pyjwt==1.7.1 pyOpenSSL cryptography requests
 
   # Install Python 3.7 if it doesn't exist
   if [ ! -f "/usr/local/bin/python3.7" ]; then


### PR DESCRIPTION
Fixes #25053.

cc @yulin-liang 

Looks like this has been failing since Dec 22nd: https://fusion.corp.google.com/projectanalysis/history/KOKORO/prod:grpc%2Fcore%2Fpull_request%2Fmacos%2Fgrpc_ios_binary_size

And looks like that's when the `pyjwt` package has been updated to release `2.0.0`. https://pypi.org/project/PyJWT/#history. The previous stable version that we had been relying on was `1.7.1`.