### PR TITLE
ruby: grpc: event-thread: add missing include for grpc_ruby_init

### DIFF
--- a/src/ruby/ext/grpc/rb_event_thread.c
+++ b/src/ruby/ext/grpc/rb_event_thread.c
@@ -20,6 +20,7 @@
 
 #include "rb_event_thread.h"
 #include "rb_grpc_imports.generated.h"
+#include "rb_grpc.h"
 
 #include <stdbool.h>
 


### PR DESCRIPTION
And grpc_ruby_shutdown.

Newer compilers (clang on catalina) will fail on implicit functions.

This makes rake compile correctly the dependencies before running




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
