### PR TITLE
xds-k8s driver: support --xds_server_uri flag

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
@@ -57,8 +57,9 @@ def main(argv):
         deployment_name=xds_flags.CLIENT_NAME.value,
         image_name=xds_k8s_flags.CLIENT_IMAGE.value,
         gcp_service_account=xds_k8s_flags.GCP_SERVICE_ACCOUNT.value,
-        network=xds_flags.NETWORK.value,
         td_bootstrap_image=xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value,
+        xds_server_uri=xds_flags.XDS_SERVER_URI.value,
+        network=xds_flags.NETWORK.value,
         stats_port=xds_flags.CLIENT_PORT.value,
         reuse_namespace=_REUSE_NAMESPACE.value)
 

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
@@ -59,6 +59,7 @@ def main(argv):
     if _SECURE.value:
         runner_kwargs.update(
             td_bootstrap_image=xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value,
+            xds_server_uri=xds_flags.XDS_SERVER_URI.value,
             deployment_template='server-secure.deployment.yaml')
 
     k8s_api_manager = k8s.KubernetesApiManager(xds_k8s_flags.KUBE_CONTEXT.value)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -190,9 +190,10 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
                  image_name,
                  gcp_service_account,
                  td_bootstrap_image,
+                 xds_server_uri=None,
+                 network='default',
                  service_account_name=None,
                  stats_port=8079,
-                 network='default',
                  deployment_template='client.deployment.yaml',
                  service_account_template='service-account.yaml',
                  reuse_namespace=False,
@@ -208,6 +209,7 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
         self.stats_port = stats_port
         # xDS bootstrap generator
         self.td_bootstrap_image = td_bootstrap_image
+        self.xds_server_uri = xds_server_uri
         self.network = network
         self.deployment_template = deployment_template
         self.service_account_template = service_account_template
@@ -243,7 +245,8 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
             namespace_name=self.k8s_namespace.name,
             service_account_name=self.service_account_name,
             td_bootstrap_image=self.td_bootstrap_image,
-            network_name=self.network,
+            xds_server_uri=self.xds_server_uri,
+            network=self.network,
             stats_port=self.stats_port,
             server_target=server_target,
             rpc=rpc,

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -137,6 +137,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
                  service_name=None,
                  neg_name=None,
                  td_bootstrap_image=None,
+                 xds_server_uri=None,
                  network='default',
                  deployment_template='server.deployment.yaml',
                  service_account_template='service-account.yaml',
@@ -155,6 +156,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         self.service_name = service_name or deployment_name
         # xDS bootstrap generator
         self.td_bootstrap_image = td_bootstrap_image
+        self.xds_server_uri = xds_server_uri
         # This only works in k8s >= 1.18.10-gke.600
         # https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg#naming_negs
         self.neg_name = neg_name or (f'{self.k8s_namespace.name}-'
@@ -229,7 +231,8 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
             namespace_name=self.k8s_namespace.name,
             service_account_name=self.service_account_name,
             td_bootstrap_image=self.td_bootstrap_image,
-            network_name=self.network,
+            xds_server_uri=self.xds_server_uri,
+            network=self.network,
             replica_count=replica_count,
             test_port=test_port,
             maintenance_port=maintenance_port,

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -25,6 +25,11 @@ NAMESPACE = flags.DEFINE_string(
 NETWORK = flags.DEFINE_string("network",
                               default="default",
                               help="GCP Network ID")
+# Mirrors --xds-server-uri argument of Traffic Director gRPC Bootstrap
+XDS_SERVER_URI = flags.DEFINE_string(
+    "xds_server_uri",
+    default=None,
+    help="Override Traffic Director server uri, for testing")
 
 # Test server
 SERVER_NAME = flags.DEFINE_string("server_name",

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -58,6 +58,7 @@ class XdsKubernetesTestCase(absltest.TestCase):
         cls.network: str = xds_flags.NETWORK.value
         cls.gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value
         cls.td_bootstrap_image = xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value
+        cls.xds_server_uri = xds_flags.XDS_SERVER_URI.value
 
         # Base namespace
         # TODO(sergiitk): generate for each test
@@ -179,8 +180,9 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             deployment_name=self.server_name,
             image_name=self.server_image,
             gcp_service_account=self.gcp_service_account,
-            network=self.network,
-            td_bootstrap_image=self.td_bootstrap_image)
+            td_bootstrap_image=self.td_bootstrap_image,
+            xds_server_uri=self.xds_server_uri,
+            network=self.network)
 
         # Test Client Runner
         self.client_runner = client_app.KubernetesClientRunner(
@@ -189,8 +191,9 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             deployment_name=self.client_name,
             image_name=self.client_image,
             gcp_service_account=self.gcp_service_account,
-            network=self.network,
             td_bootstrap_image=self.td_bootstrap_image,
+            xds_server_uri=self.xds_server_uri,
+            network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
             stats_port=self.client_port,
             reuse_namespace=self.server_namespace == self.client_namespace)
@@ -236,6 +239,7 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
             gcp_service_account=self.gcp_service_account,
             network=self.network,
             td_bootstrap_image=self.td_bootstrap_image,
+            xds_server_uri=self.xds_server_uri,
             deployment_template='server-secure.deployment.yaml',
             debug_use_port_forwarding=self.debug_use_port_forwarding)
 
@@ -246,8 +250,9 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
             deployment_name=self.client_name,
             image_name=self.client_image,
             gcp_service_account=self.gcp_service_account,
-            network=self.network,
             td_bootstrap_image=self.td_bootstrap_image,
+            xds_server_uri=self.xds_server_uri,
+            network=self.network,
             deployment_template='client-secure.deployment.yaml',
             stats_port=self.client_port,
             reuse_namespace=self.server_namespace == self.client_namespace,

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -59,7 +59,10 @@ spec:
           imagePullPolicy: Always
           args:
             - "--output=/tmp/bootstrap/td-grpc-bootstrap.json"
-            - "--vpc-network-name=${network_name}"
+            - "--vpc-network-name=${network}"
+            % if xds_server_uri:
+            - "--xds-server-uri=${xds_server_uri}"
+            % endif
             - "--include-v3-features-experimental"
             - "--include-psm-security-experimental"
           resources:

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -51,7 +51,10 @@ spec:
           imagePullPolicy: Always
           args:
             - "--output=/tmp/bootstrap/td-grpc-bootstrap.json"
-            - "--vpc-network-name=${network_name}"
+            - "--vpc-network-name=${network}"
+            % if xds_server_uri:
+            - "--xds-server-uri=${xds_server_uri}"
+            % endif
           resources:
             limits:
               cpu: 100m

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -57,7 +57,10 @@ spec:
           imagePullPolicy: Always
           args:
             - "--output=/tmp/bootstrap/td-grpc-bootstrap.json"
-            - "--vpc-network-name=${network_name}"
+            - "--vpc-network-name=${network}"
+            % if xds_server_uri:
+            - "--xds-server-uri=${xds_server_uri}"
+            % endif
             - "--include-v3-features-experimental"
             - "--include-psm-security-experimental"
             - "--node-metadata-experimental=app=${namespace_name}-${deployment_name}"


### PR DESCRIPTION
- support `--xds_server_uri` to allow override Traffic Director URI (mirrors [`traffic-director-grpc-bootstrap`](https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/blob/66de7ea0e170351c9fae17232b81adbfb3e80ec3/main.go#L34))
- minor: consistent naming and order of `--network` argument