### PR TITLE
Add use_strict_warning option to bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -77,6 +77,11 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
+config_setting(
+    name = "use_strict_warning",
+    values = {"define": "use_strict_warning=true"},
+)
+
 python_config_settings()
 
 # This should be updated along with build_handwritten.yaml

--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -1,0 +1,56 @@
+# Copyright 2021 the gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a list of llvm flags to be used when being built with use_strict_warning=1
+GRPC_LLVM_WARNING_FLAGS = [
+    # Enable all & extra waninrgs
+    "-Wall",
+    "-Wextra",
+    # Consider warnings as errors
+    "-Werror",
+    # Ignore unknown warning flags
+    "-Wno-unknown-warning-option",
+    # A list of flags coming from internal build system
+    "-Wc++20-extensions",
+    "-Wctad-maybe-unsupported",
+    "-Wdeprecated-increment-bool",
+    "-Wfloat-overflow-conversion",
+    "-Wfloat-zero-conversion",
+    "-Wfor-loop-analysis",
+    "-Wformat-security",
+    "-Wgnu-redeclared-enum",
+    "-Winfinite-recursion",
+    "-Wliteral-conversion",
+    "-Wnon-virtual-dtor",
+    "-Woverloaded-virtual",
+    "-Wself-assign",
+    "-Wstring-conversion",
+    "-Wtautological-overlap-compare",
+    "-Wthread-safety-analysis",
+    "-Wthread-safety-beta",
+    "-Wunused-comparison",
+    "-Wvla",
+    # Exceptions but will be removed
+    "-Wno-deprecated-declarations",
+    "-Wno-format",
+    "-Wno-missing-field-initializers",
+    "-Wno-sign-compare",
+    "-Wno-unused-function",
+    "-Wno-unused-parameter",
+]
+
+GRPC_DEFAULT_COPTS = select({
+    "//:use_strict_warning": GRPC_LLVM_WARNING_FLAGS,
+    "//conditions:default": [],
+})

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -24,6 +24,7 @@
 #
 
 load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("//bazel:copts.bzl", "GRPC_DEFAULT_COPTS")
 load("@upb//bazel:upb_proto_library.bzl", "upb_proto_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 
@@ -109,7 +110,7 @@ def grpc_cc_library(
                   }),
         hdrs = hdrs + public_hdrs,
         deps = deps + _get_external_deps(external_deps),
-        copts = copts,
+        copts = GRPC_DEFAULT_COPTS + copts,
         visibility = visibility,
         testonly = testonly,
         linkopts = linkopts,
@@ -187,7 +188,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         "args": args,
         "data": data,
         "deps": deps + _get_external_deps(external_deps),
-        "copts": copts,
+        "copts": GRPC_DEFAULT_COPTS + copts,
         "linkopts": if_not_windows(["-pthread"]),
         "size": size,
         "timeout": timeout,
@@ -249,7 +250,7 @@ def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], da
         testonly = testonly,
         linkshared = linkshared,
         deps = deps + _get_external_deps(external_deps),
-        copts = copts,
+        copts = GRPC_DEFAULT_COPTS + copts,
         linkopts = if_not_windows(["-pthread"]) + linkopts,
         tags = tags,
         features = features,

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
@@ -145,9 +145,7 @@ class XdsClusterImplLbConfig : public LoadBalancingPolicy::Config {
   const absl::optional<std::string>& lrs_load_reporting_server_name() const {
     return lrs_load_reporting_server_name_;
   };
-  const uint32_t max_concurrent_requests() const {
-    return max_concurrent_requests_;
-  }
+  uint32_t max_concurrent_requests() const { return max_concurrent_requests_; }
   RefCountedPtr<XdsApi::EdsUpdate::DropConfig> drop_config() const {
     return drop_config_;
   }

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -25,7 +25,14 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 
-bazel build :all //test/... //examples/...
+# Build all basic targets using the strict warning option which leverages the
+# clang compiler to check if sources can pass a set of warning options.
+bazel build --define=use_strict_warning=true \
+	:all \
+	//src/core/... \
+	//src/compiler/... \
+	//test/... \
+	//examples/...
 
 # TODO(jtattersmusch): Adding a build here for --define=grpc_no_xds is not ideal
 # and we should find a better place for this. Refer


### PR DESCRIPTION
Adding a new `use_strict_warning` bazel option to build target with stricter warning flags including `-Werror`
Modifying the existing bazel build on Linux to use this option to make sure the PR doesn't introduce any warnings.