### PR TITLE
change xDS certificate provider to contain a map by cluster

### DIFF
--- a/src/core/ext/xds/xds_certificate_provider.cc
+++ b/src/core/ext/xds/xds_certificate_provider.cc
@@ -37,15 +37,16 @@ class RootCertificatesWatcher
   // presently, the watcher is immediately deleted when
   // CancelTlsCertificatesWatch() is called, but that can potentially change in
   // the future.
-  explicit RootCertificatesWatcher(
-      RefCountedPtr<grpc_tls_certificate_distributor> parent)
-      : parent_(std::move(parent)) {}
+  RootCertificatesWatcher(
+      RefCountedPtr<grpc_tls_certificate_distributor> parent,
+      std::string cert_name)
+      : parent_(std::move(parent)), cert_name_(std::move(cert_name)) {}
 
   void OnCertificatesChanged(absl::optional<absl::string_view> root_certs,
                              absl::optional<PemKeyCertPairList>
                              /* key_cert_pairs */) override {
     if (root_certs.has_value()) {
-      parent_->SetKeyMaterials("", std::string(root_certs.value()),
+      parent_->SetKeyMaterials(cert_name_, std::string(root_certs.value()),
                                absl::nullopt);
     }
   }
@@ -53,7 +54,7 @@ class RootCertificatesWatcher
   void OnError(grpc_error* root_cert_error,
                grpc_error* identity_cert_error) override {
     if (root_cert_error != GRPC_ERROR_NONE) {
-      parent_->SetErrorForCert("", root_cert_error /* pass the ref */,
+      parent_->SetErrorForCert(cert_name_, root_cert_error /* pass the ref */,
                                absl::nullopt);
     }
     GRPC_ERROR_UNREF(identity_cert_error);
@@ -61,6 +62,7 @@ class RootCertificatesWatcher
 
  private:
   RefCountedPtr<grpc_tls_certificate_distributor> parent_;
+  std::string cert_name_;
 };
 
 class IdentityCertificatesWatcher
@@ -71,22 +73,23 @@ class IdentityCertificatesWatcher
   // presently, the watcher is immediately deleted when
   // CancelTlsCertificatesWatch() is called, but that can potentially change in
   // the future.
-  explicit IdentityCertificatesWatcher(
-      RefCountedPtr<grpc_tls_certificate_distributor> parent)
-      : parent_(std::move(parent)) {}
+  IdentityCertificatesWatcher(
+      RefCountedPtr<grpc_tls_certificate_distributor> parent,
+      std::string cert_name)
+      : parent_(std::move(parent)), cert_name_(std::move(cert_name)) {}
 
   void OnCertificatesChanged(
       absl::optional<absl::string_view> /* root_certs */,
       absl::optional<PemKeyCertPairList> key_cert_pairs) override {
     if (key_cert_pairs.has_value()) {
-      parent_->SetKeyMaterials("", absl::nullopt, key_cert_pairs);
+      parent_->SetKeyMaterials(cert_name_, absl::nullopt, key_cert_pairs);
     }
   }
 
   void OnError(grpc_error* root_cert_error,
                grpc_error* identity_cert_error) override {
     if (identity_cert_error != GRPC_ERROR_NONE) {
-      parent_->SetErrorForCert("", absl::nullopt,
+      parent_->SetErrorForCert(cert_name_, absl::nullopt,
                                identity_cert_error /* pass the ref */);
     }
     GRPC_ERROR_UNREF(root_cert_error);
@@ -94,34 +97,35 @@ class IdentityCertificatesWatcher
 
  private:
   RefCountedPtr<grpc_tls_certificate_distributor> parent_;
+  std::string cert_name_;
 };
 
 }  // namespace
 
-XdsCertificateProvider::XdsCertificateProvider(
-    absl::string_view root_cert_name,
-    RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor,
-    absl::string_view identity_cert_name,
-    RefCountedPtr<grpc_tls_certificate_distributor> identity_cert_distributor,
-    std::vector<XdsApi::StringMatcher> san_matchers)
-    : root_cert_name_(root_cert_name),
-      identity_cert_name_(identity_cert_name),
-      root_cert_distributor_(std::move(root_cert_distributor)),
-      identity_cert_distributor_(std::move(identity_cert_distributor)),
-      san_matchers_(std::move(san_matchers)),
-      distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
-  distributor_->SetWatchStatusCallback(
-      absl::bind_front(&XdsCertificateProvider::WatchStatusCallback, this));
+//
+// XdsCertificateProvider::ClusterCertificateState
+//
+
+XdsCertificateProvider::ClusterCertificateState::~ClusterCertificateState() {
+  if (root_cert_watcher_ != nullptr) {
+    root_cert_distributor_->CancelTlsCertificatesWatch(root_cert_watcher_);
+  }
+  if (identity_cert_watcher_ != nullptr) {
+    identity_cert_distributor_->CancelTlsCertificatesWatch(
+        identity_cert_watcher_);
+  }
 }
 
-XdsCertificateProvider::~XdsCertificateProvider() {
-  distributor_->SetWatchStatusCallback(nullptr);
+bool XdsCertificateProvider::ClusterCertificateState::IsSafeToRemove() const {
+  return !watching_root_certs_ && !watching_identity_certs_ &&
+         root_cert_distributor_ == nullptr &&
+         identity_cert_distributor_ == nullptr;
 }
 
-void XdsCertificateProvider::UpdateRootCertNameAndDistributor(
-    absl::string_view root_cert_name,
-    RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor) {
-  MutexLock lock(&mu_);
+void XdsCertificateProvider::ClusterCertificateState::
+    UpdateRootCertNameAndDistributor(
+        const std::string& cert_name, absl::string_view root_cert_name,
+        RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor) {
   if (root_cert_name_ == root_cert_name &&
       root_cert_distributor_ == root_cert_distributor) {
     return;
@@ -133,10 +137,10 @@ void XdsCertificateProvider::UpdateRootCertNameAndDistributor(
       root_cert_distributor_->CancelTlsCertificatesWatch(root_cert_watcher_);
     }
     if (root_cert_distributor != nullptr) {
-      UpdateRootCertWatcher(root_cert_distributor.get());
+      UpdateRootCertWatcher(cert_name, root_cert_distributor.get());
     } else {
       root_cert_watcher_ = nullptr;
-      distributor_->SetErrorForCert(
+      xds_certificate_provider_->distributor_->SetErrorForCert(
           "",
           GRPC_ERROR_CREATE_FROM_STATIC_STRING(
               "No certificate provider available for root certificates"),
@@ -147,10 +151,11 @@ void XdsCertificateProvider::UpdateRootCertNameAndDistributor(
   root_cert_distributor_ = std::move(root_cert_distributor);
 }
 
-void XdsCertificateProvider::UpdateIdentityCertNameAndDistributor(
-    absl::string_view identity_cert_name,
-    RefCountedPtr<grpc_tls_certificate_distributor> identity_cert_distributor) {
-  MutexLock lock(&mu_);
+void XdsCertificateProvider::ClusterCertificateState::
+    UpdateIdentityCertNameAndDistributor(
+        const std::string& cert_name, absl::string_view identity_cert_name,
+        RefCountedPtr<grpc_tls_certificate_distributor>
+            identity_cert_distributor) {
   if (identity_cert_name_ == identity_cert_name &&
       identity_cert_distributor_ == identity_cert_distributor) {
     return;
@@ -163,10 +168,10 @@ void XdsCertificateProvider::UpdateIdentityCertNameAndDistributor(
           identity_cert_watcher_);
     }
     if (identity_cert_distributor != nullptr) {
-      UpdateIdentityCertWatcher(identity_cert_distributor.get());
+      UpdateIdentityCertWatcher(cert_name, identity_cert_distributor.get());
     } else {
       identity_cert_watcher_ = nullptr;
-      distributor_->SetErrorForCert(
+      xds_certificate_provider_->distributor_->SetErrorForCert(
           "", absl::nullopt,
           GRPC_ERROR_CREATE_FROM_STATIC_STRING(
               "No certificate provider available for identity certificates"));
@@ -176,42 +181,45 @@ void XdsCertificateProvider::UpdateIdentityCertNameAndDistributor(
   identity_cert_distributor_ = std::move(identity_cert_distributor);
 }
 
-void XdsCertificateProvider::UpdateSubjectAlternativeNameMatchers(
-    std::vector<XdsApi::StringMatcher> matchers) {
-  MutexLock lock(&san_matchers_mu_);
-  san_matchers_ = std::move(matchers);
+void XdsCertificateProvider::ClusterCertificateState::UpdateRootCertWatcher(
+    const std::string& cert_name,
+    grpc_tls_certificate_distributor* root_cert_distributor) {
+  auto watcher = absl::make_unique<RootCertificatesWatcher>(
+      xds_certificate_provider_->distributor_, cert_name);
+  root_cert_watcher_ = watcher.get();
+  root_cert_distributor->WatchTlsCertificates(std::move(watcher),
+                                              root_cert_name_, absl::nullopt);
 }
 
-void XdsCertificateProvider::WatchStatusCallback(std::string cert_name,
-                                                 bool root_being_watched,
-                                                 bool identity_being_watched) {
+void XdsCertificateProvider::ClusterCertificateState::UpdateIdentityCertWatcher(
+    const std::string& cert_name,
+    grpc_tls_certificate_distributor* identity_cert_distributor) {
+  auto watcher = absl::make_unique<IdentityCertificatesWatcher>(
+      xds_certificate_provider_->distributor_, cert_name);
+  identity_cert_watcher_ = watcher.get();
+  identity_cert_distributor->WatchTlsCertificates(
+      std::move(watcher), absl::nullopt, identity_cert_name_);
+}
+
+void XdsCertificateProvider::ClusterCertificateState::WatchStatusCallback(
+    const std::string& cert_name, bool root_being_watched,
+    bool identity_being_watched) {
   // We aren't specially handling the case where root_cert_distributor is same
   // as identity_cert_distributor. Always using two separate watchers
   // irrespective of the fact results in a straightforward design, and using a
   // single watcher does not seem to provide any benefit other than cutting down
   // on the number of callbacks.
-  MutexLock lock(&mu_);
-  if (!cert_name.empty()) {
-    grpc_error* error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Illegal certificate name: \'", cert_name,
-                     "\'. Should be empty.")
-            .c_str());
-    distributor_->SetErrorForCert(cert_name, GRPC_ERROR_REF(error),
-                                  GRPC_ERROR_REF(error));
-    GRPC_ERROR_UNREF(error);
-    return;
-  }
   if (root_being_watched && !watching_root_certs_) {
     // We need to start watching root certs.
     watching_root_certs_ = true;
     if (root_cert_distributor_ == nullptr) {
-      distributor_->SetErrorForCert(
-          "",
+      xds_certificate_provider_->distributor_->SetErrorForCert(
+          cert_name,
           GRPC_ERROR_CREATE_FROM_STATIC_STRING(
               "No certificate provider available for root certificates"),
           absl::nullopt);
     } else {
-      UpdateRootCertWatcher(root_cert_distributor_.get());
+      UpdateRootCertWatcher(cert_name, root_cert_distributor_.get());
     }
   } else if (!root_being_watched && watching_root_certs_) {
     // We need to cancel root certs watch.
@@ -225,12 +233,12 @@ void XdsCertificateProvider::WatchStatusCallback(std::string cert_name,
   if (identity_being_watched && !watching_identity_certs_) {
     watching_identity_certs_ = true;
     if (identity_cert_distributor_ == nullptr) {
-      distributor_->SetErrorForCert(
-          "", absl::nullopt,
+      xds_certificate_provider_->distributor_->SetErrorForCert(
+          cert_name, absl::nullopt,
           GRPC_ERROR_CREATE_FROM_STATIC_STRING(
               "No certificate provider available for identity certificates"));
     } else {
-      UpdateIdentityCertWatcher(identity_cert_distributor_.get());
+      UpdateIdentityCertWatcher(cert_name, identity_cert_distributor_.get());
     }
   } else if (!identity_being_watched && watching_identity_certs_) {
     watching_identity_certs_ = false;
@@ -243,20 +251,102 @@ void XdsCertificateProvider::WatchStatusCallback(std::string cert_name,
   }
 }
 
-void XdsCertificateProvider::UpdateRootCertWatcher(
-    grpc_tls_certificate_distributor* root_cert_distributor) {
-  auto watcher = absl::make_unique<RootCertificatesWatcher>(distributor());
-  root_cert_watcher_ = watcher.get();
-  root_cert_distributor->WatchTlsCertificates(std::move(watcher),
-                                              root_cert_name_, absl::nullopt);
+//
+// XdsCertificateProvider
+//
+
+XdsCertificateProvider::XdsCertificateProvider()
+    : distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
+  distributor_->SetWatchStatusCallback(
+      absl::bind_front(&XdsCertificateProvider::WatchStatusCallback, this));
 }
 
-void XdsCertificateProvider::UpdateIdentityCertWatcher(
-    grpc_tls_certificate_distributor* identity_cert_distributor) {
-  auto watcher = absl::make_unique<IdentityCertificatesWatcher>(distributor());
-  identity_cert_watcher_ = watcher.get();
-  identity_cert_distributor->WatchTlsCertificates(
-      std::move(watcher), absl::nullopt, identity_cert_name_);
+XdsCertificateProvider::~XdsCertificateProvider() {
+  distributor_->SetWatchStatusCallback(nullptr);
+}
+
+bool XdsCertificateProvider::ProvidesRootCerts(const std::string& cert_name) {
+  MutexLock lock(&mu_);
+  auto it = certificate_state_map_.find(cert_name);
+  if (it == certificate_state_map_.end()) return false;
+  return it->second->ProvidesRootCerts();
+}
+
+void XdsCertificateProvider::UpdateRootCertNameAndDistributor(
+    const std::string& cert_name, absl::string_view root_cert_name,
+    RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor) {
+  MutexLock lock(&mu_);
+  auto it = certificate_state_map_.find(cert_name);
+  if (it == certificate_state_map_.end()) {
+    it = certificate_state_map_
+             .emplace(cert_name,
+                      absl::make_unique<ClusterCertificateState>(Ref()))
+             .first;
+  }
+  it->second->UpdateRootCertNameAndDistributor(cert_name, root_cert_name,
+                                               root_cert_distributor);
+  // Delete unused entries.
+  if (it->second->IsSafeToRemove()) certificate_state_map_.erase(it);
+}
+
+bool XdsCertificateProvider::ProvidesIdentityCerts(
+    const std::string& cert_name) {
+  MutexLock lock(&mu_);
+  auto it = certificate_state_map_.find(cert_name);
+  if (it == certificate_state_map_.end()) return false;
+  return it->second->ProvidesIdentityCerts();
+}
+
+void XdsCertificateProvider::UpdateIdentityCertNameAndDistributor(
+    const std::string& cert_name, absl::string_view identity_cert_name,
+    RefCountedPtr<grpc_tls_certificate_distributor> identity_cert_distributor) {
+  MutexLock lock(&mu_);
+  auto it = certificate_state_map_.find(cert_name);
+  if (it == certificate_state_map_.end()) {
+    it = certificate_state_map_
+             .emplace(cert_name,
+                      absl::make_unique<ClusterCertificateState>(Ref()))
+             .first;
+  }
+  it->second->UpdateIdentityCertNameAndDistributor(
+      cert_name, identity_cert_name, identity_cert_distributor);
+  // Delete unused entries.
+  if (it->second->IsSafeToRemove()) certificate_state_map_.erase(it);
+}
+
+std::vector<XdsApi::StringMatcher> XdsCertificateProvider::GetSanMatchers(
+    const std::string& cluster) {
+  MutexLock lock(&san_matchers_mu_);
+  auto it = san_matcher_map_.find(cluster);
+  if (it == san_matcher_map_.end()) return {};
+  return it->second;
+}
+
+void XdsCertificateProvider::UpdateSubjectAlternativeNameMatchers(
+    const std::string& cluster, std::vector<XdsApi::StringMatcher> matchers) {
+  MutexLock lock(&san_matchers_mu_);
+  if (matchers.empty()) {
+    san_matcher_map_.erase(cluster);
+  } else {
+    san_matcher_map_[cluster] = std::move(matchers);
+  }
+}
+
+void XdsCertificateProvider::WatchStatusCallback(std::string cert_name,
+                                                 bool root_being_watched,
+                                                 bool identity_being_watched) {
+  MutexLock lock(&mu_);
+  auto it = certificate_state_map_.find(cert_name);
+  if (it == certificate_state_map_.end()) {
+    it = certificate_state_map_
+             .emplace(cert_name,
+                      absl::make_unique<ClusterCertificateState>(Ref()))
+             .first;
+  }
+  it->second->WatchStatusCallback(cert_name, root_being_watched,
+                                  identity_being_watched);
+  // Delete unused entries.
+  if (it->second->IsSafeToRemove()) certificate_state_map_.erase(it);
 }
 
 namespace {

--- a/src/core/ext/xds/xds_certificate_provider.h
+++ b/src/core/ext/xds/xds_certificate_provider.h
@@ -31,44 +31,28 @@ namespace grpc_core {
 
 class XdsCertificateProvider : public grpc_tls_certificate_provider {
  public:
-  XdsCertificateProvider(
-      absl::string_view root_cert_name,
-      RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor,
-      absl::string_view identity_cert_name,
-      RefCountedPtr<grpc_tls_certificate_distributor> identity_cert_distributor,
-      std::vector<XdsApi::StringMatcher> san_matchers);
-
+  XdsCertificateProvider();
   ~XdsCertificateProvider() override;
-
-  void UpdateRootCertNameAndDistributor(
-      absl::string_view root_cert_name,
-      RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor);
-  void UpdateIdentityCertNameAndDistributor(
-      absl::string_view identity_cert_name,
-      RefCountedPtr<grpc_tls_certificate_distributor>
-          identity_cert_distributor);
-  void UpdateSubjectAlternativeNameMatchers(
-      std::vector<XdsApi::StringMatcher> matchers);
 
   grpc_core::RefCountedPtr<grpc_tls_certificate_distributor> distributor()
       const override {
     return distributor_;
   }
 
-  bool ProvidesRootCerts() {
-    MutexLock lock(&mu_);
-    return root_cert_distributor_ != nullptr;
-  }
+  bool ProvidesRootCerts(const std::string& cert_name);
+  void UpdateRootCertNameAndDistributor(
+      const std::string& cert_name, absl::string_view root_cert_name,
+      RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor);
 
-  bool ProvidesIdentityCerts() {
-    MutexLock lock(&mu_);
-    return identity_cert_distributor_ != nullptr;
-  }
+  bool ProvidesIdentityCerts(const std::string& cert_name);
+  void UpdateIdentityCertNameAndDistributor(
+      const std::string& cert_name, absl::string_view identity_cert_name,
+      RefCountedPtr<grpc_tls_certificate_distributor>
+          identity_cert_distributor);
 
-  std::vector<XdsApi::StringMatcher> subject_alternative_name_matchers() {
-    MutexLock lock(&san_matchers_mu_);
-    return san_matchers_;
-  }
+  std::vector<XdsApi::StringMatcher> GetSanMatchers(const std::string& cluster);
+  void UpdateSubjectAlternativeNameMatchers(
+      const std::string& cluster, std::vector<XdsApi::StringMatcher> matchers);
 
   grpc_arg MakeChannelArg() const;
 
@@ -76,14 +60,63 @@ class XdsCertificateProvider : public grpc_tls_certificate_provider {
       const grpc_channel_args* args);
 
  private:
+  class ClusterCertificateState {
+   public:
+    explicit ClusterCertificateState(
+        RefCountedPtr<XdsCertificateProvider> xds_certificate_provider)
+        : xds_certificate_provider_(std::move(xds_certificate_provider)) {}
+
+    ~ClusterCertificateState();
+
+    // Returns true if the certs aren't being watched and there are no
+    // distributors configured.
+    bool IsSafeToRemove() const;
+
+    bool ProvidesRootCerts() const { return root_cert_distributor_ != nullptr; }
+    bool ProvidesIdentityCerts() const {
+      return identity_cert_distributor_ != nullptr;
+    }
+
+    void UpdateRootCertNameAndDistributor(
+        const std::string& cert_name, absl::string_view root_cert_name,
+        RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor);
+    void UpdateIdentityCertNameAndDistributor(
+        const std::string& cert_name, absl::string_view identity_cert_name,
+        RefCountedPtr<grpc_tls_certificate_distributor>
+            identity_cert_distributor);
+
+    void UpdateRootCertWatcher(
+        const std::string& cert_name,
+        grpc_tls_certificate_distributor* root_cert_distributor);
+    void UpdateIdentityCertWatcher(
+        const std::string& cert_name,
+        grpc_tls_certificate_distributor* identity_cert_distributor);
+
+    void WatchStatusCallback(const std::string& cert_name,
+                             bool root_being_watched,
+                             bool identity_being_watched);
+
+   private:
+    RefCountedPtr<XdsCertificateProvider> xds_certificate_provider_;
+    bool watching_root_certs_ = false;
+    bool watching_identity_certs_ = false;
+    std::string root_cert_name_;
+    std::string identity_cert_name_;
+    RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor_;
+    RefCountedPtr<grpc_tls_certificate_distributor> identity_cert_distributor_;
+    grpc_tls_certificate_distributor::TlsCertificatesWatcherInterface*
+        root_cert_watcher_ = nullptr;
+    grpc_tls_certificate_distributor::TlsCertificatesWatcherInterface*
+        identity_cert_watcher_ = nullptr;
+  };
+
   void WatchStatusCallback(std::string cert_name, bool root_being_watched,
                            bool identity_being_watched);
-  void UpdateRootCertWatcher(
-      grpc_tls_certificate_distributor* root_cert_distributor);
-  void UpdateIdentityCertWatcher(
-      grpc_tls_certificate_distributor* identity_cert_distributor);
 
   Mutex mu_;
+  std::map<std::string /*cert_name*/, std::unique_ptr<ClusterCertificateState>>
+      certificate_state_map_;
+
   // Use a separate mutex for san_matchers_ to avoid deadlocks since
   // san_matchers_ needs to be accessed when a handshake is being done and we
   // run into a possible deadlock scenario if using the same mutex. The mutex
@@ -93,18 +126,10 @@ class XdsCertificateProvider : public grpc_tls_certificate_provider {
   // -> HandshakeManager::Add() -> SecurityHandshaker::DoHandshake() ->
   // subject_alternative_names_matchers()
   Mutex san_matchers_mu_;
-  bool watching_root_certs_ = false;
-  bool watching_identity_certs_ = false;
-  std::string root_cert_name_;
-  std::string identity_cert_name_;
-  RefCountedPtr<grpc_tls_certificate_distributor> root_cert_distributor_;
-  RefCountedPtr<grpc_tls_certificate_distributor> identity_cert_distributor_;
-  std::vector<XdsApi::StringMatcher> san_matchers_;
+  std::map<std::string /*cluster_name*/, std::vector<XdsApi::StringMatcher>>
+      san_matcher_map_;
+
   RefCountedPtr<grpc_tls_certificate_distributor> distributor_;
-  grpc_tls_certificate_distributor::TlsCertificatesWatcherInterface*
-      root_cert_watcher_ = nullptr;
-  grpc_tls_certificate_distributor::TlsCertificatesWatcherInterface*
-      identity_cert_watcher_ = nullptr;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/xds/xds_credentials.cc
+++ b/src/core/lib/security/credentials/xds/xds_credentials.cc
@@ -20,6 +20,7 @@
 
 #include "src/core/lib/security/credentials/xds/xds_credentials.h"
 
+#include "src/core/ext/filters/client_channel/lb_policy/xds/xds_channel_args.h"
 #include "src/core/ext/xds/xds_certificate_provider.h"
 #include "src/core/lib/security/credentials/tls/grpc_tls_credentials_options.h"
 #include "src/core/lib/security/credentials/tls/tls_credentials.h"
@@ -60,32 +61,44 @@ bool XdsVerifySubjectAlternativeNames(
   return false;
 }
 
-int ServerAuthCheckSchedule(void* config_user_data,
-                            grpc_tls_server_authorization_check_arg* arg) {
-  XdsCertificateProvider* xds_certificate_provider =
-      static_cast<XdsCertificateProvider*>(config_user_data);
-  if (XdsVerifySubjectAlternativeNames(
-          arg->subject_alternative_names, arg->subject_alternative_names_size,
-          xds_certificate_provider->subject_alternative_name_matchers())) {
-    arg->success = 1;
-    arg->status = GRPC_STATUS_OK;
-  } else {
-    arg->success = 0;
-    arg->status = GRPC_STATUS_UNAUTHENTICATED;
-    if (arg->error_details) {
-      arg->error_details->set_error_details(
-          "SANs from certificate did not match SANs from xDS control plane");
-    }
+class ServerAuthCheck {
+ public:
+  ServerAuthCheck(
+      RefCountedPtr<XdsCertificateProvider> xds_certificate_provider,
+      std::string cluster_name)
+      : xds_certificate_provider_(std::move(xds_certificate_provider)),
+        cluster_name_(std::move(cluster_name)) {}
+
+  static int Schedule(void* config_user_data,
+                      grpc_tls_server_authorization_check_arg* arg) {
+    return static_cast<ServerAuthCheck*>(config_user_data)->ScheduleImpl(arg);
   }
 
-  return 0; /* synchronous check */
-}
+  static void Destroy(void* config_user_data) {
+    delete static_cast<ServerAuthCheck*>(config_user_data);
+  }
 
-void ServerAuthCheckDestroy(void* config_user_data) {
-  XdsCertificateProvider* xds_certificate_provider =
-      static_cast<XdsCertificateProvider*>(config_user_data);
-  xds_certificate_provider->Unref();
-}
+ private:
+  int ScheduleImpl(grpc_tls_server_authorization_check_arg* arg) {
+    if (XdsVerifySubjectAlternativeNames(
+            arg->subject_alternative_names, arg->subject_alternative_names_size,
+            xds_certificate_provider_->GetSanMatchers(cluster_name_))) {
+      arg->success = 1;
+      arg->status = GRPC_STATUS_OK;
+    } else {
+      arg->success = 0;
+      arg->status = GRPC_STATUS_UNAUTHENTICATED;
+      if (arg->error_details) {
+        arg->error_details->set_error_details(
+            "SANs from certificate did not match SANs from xDS control plane");
+      }
+    }
+    return 0; /* synchronous check */
+  }
+
+  RefCountedPtr<XdsCertificateProvider> xds_certificate_provider_;
+  std::string cluster_name_;
+};
 
 }  // namespace
 
@@ -105,49 +118,79 @@ RefCountedPtr<grpc_channel_security_connector>
 XdsCredentials::create_security_connector(
     RefCountedPtr<grpc_call_credentials> call_creds, const char* target_name,
     const grpc_channel_args* args, grpc_channel_args** new_args) {
-  auto xds_certificate_provider =
-      XdsCertificateProvider::GetFromChannelArgs(args);
+  struct ChannelArgsDeleter {
+    const grpc_channel_args* args;
+    bool owned;
+    ~ChannelArgsDeleter() {
+      if (owned) grpc_channel_args_destroy(args);
+    }
+  };
+  ChannelArgsDeleter temp_args{args, false};
   // TODO(yashykt): This arg will no longer need to be added after b/173119596
   // is fixed.
   grpc_arg override_arg = grpc_channel_arg_string_create(
       const_cast<char*>(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG),
       const_cast<char*>(target_name));
   const char* override_arg_name = GRPC_SSL_TARGET_NAME_OVERRIDE_ARG;
-  const grpc_channel_args* temp_args = args;
   if (grpc_channel_args_find(args, override_arg_name) == nullptr) {
-    temp_args = grpc_channel_args_copy_and_add_and_remove(
+    temp_args.args = grpc_channel_args_copy_and_add_and_remove(
         args, &override_arg_name, 1, &override_arg, 1);
+    temp_args.owned = true;
   }
   RefCountedPtr<grpc_channel_security_connector> security_connector;
+  auto xds_certificate_provider =
+      XdsCertificateProvider::GetFromChannelArgs(args);
   if (xds_certificate_provider != nullptr) {
-    auto tls_credentials_options =
-        MakeRefCounted<grpc_tls_credentials_options>();
-    tls_credentials_options->set_certificate_provider(xds_certificate_provider);
-    if (xds_certificate_provider->ProvidesRootCerts()) {
-      tls_credentials_options->set_watch_root_cert(true);
+    std::string cluster_name =
+        grpc_channel_args_find_string(args, GRPC_ARG_XDS_CLUSTER_NAME);
+    GPR_ASSERT(cluster_name.data() != nullptr);
+    const bool watch_root =
+        xds_certificate_provider->ProvidesRootCerts(cluster_name);
+    const bool watch_identity =
+        xds_certificate_provider->ProvidesIdentityCerts(cluster_name);
+    if (watch_root || watch_identity) {
+      auto tls_credentials_options =
+          MakeRefCounted<grpc_tls_credentials_options>();
+      tls_credentials_options->set_certificate_provider(
+          xds_certificate_provider);
+      if (watch_root) {
+        tls_credentials_options->set_watch_root_cert(true);
+        tls_credentials_options->set_root_cert_name(cluster_name);
+      }
+      if (watch_identity) {
+        tls_credentials_options->set_watch_identity_pair(true);
+        tls_credentials_options->set_identity_cert_name(cluster_name);
+      }
+      tls_credentials_options->set_server_verification_option(
+          GRPC_TLS_SKIP_HOSTNAME_VERIFICATION);
+      auto* server_auth_check = new ServerAuthCheck(xds_certificate_provider,
+                                                    std::move(cluster_name));
+      tls_credentials_options->set_server_authorization_check_config(
+          MakeRefCounted<grpc_tls_server_authorization_check_config>(
+              server_auth_check, ServerAuthCheck::Schedule, nullptr,
+              ServerAuthCheck::Destroy));
+      // TODO(yashkt): Creating a new TlsCreds object each time we create a
+      // security connector means that the security connector's cmp() method
+      // returns unequal for each instance, which means that every time an LB
+      // policy updates, all the subchannels will be recreated.  This is
+      // going to lead to a lot of connection churn.  Instead, we should
+      // either (a) change the TLS security connector's cmp() method to be
+      // smarter somehow, so that it compares unequal only when the
+      // tls_credentials_options have changed, or (b) cache the TlsCreds
+      // objects in the XdsCredentials object so that we can reuse the
+      // same one when creating new security connectors, swapping out the
+      // TlsCreds object only when the tls_credentials_options change.
+      // Option (a) would probably be better, although it may require some
+      // structural changes to the security connector API.
+      auto tls_credentials =
+          MakeRefCounted<TlsCredentials>(std::move(tls_credentials_options));
+      return tls_credentials->create_security_connector(
+          std::move(call_creds), target_name, temp_args.args, new_args);
     }
-    if (xds_certificate_provider->ProvidesIdentityCerts()) {
-      tls_credentials_options->set_watch_identity_pair(true);
-    }
-    tls_credentials_options->set_server_verification_option(
-        GRPC_TLS_SKIP_HOSTNAME_VERIFICATION);
-    tls_credentials_options->set_server_authorization_check_config(
-        MakeRefCounted<grpc_tls_server_authorization_check_config>(
-            xds_certificate_provider->Ref().release(), ServerAuthCheckSchedule,
-            nullptr, ServerAuthCheckDestroy));
-    auto tls_credentials =
-        MakeRefCounted<TlsCredentials>(std::move(tls_credentials_options));
-    security_connector = tls_credentials->create_security_connector(
-        std::move(call_creds), target_name, temp_args, new_args);
-  } else {
-    GPR_ASSERT(fallback_credentials_ != nullptr);
-    security_connector = fallback_credentials_->create_security_connector(
-        std::move(call_creds), target_name, temp_args, new_args);
   }
-  if (temp_args != args) {
-    grpc_channel_args_destroy(temp_args);
-  }
-  return security_connector;
+  GPR_ASSERT(fallback_credentials_ != nullptr);
+  return fallback_credentials_->create_security_connector(
+      std::move(call_creds), target_name, temp_args.args, new_args);
 }
 
 //

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -5453,7 +5453,7 @@ class XdsSecurityTest : public BasicTest {
         }
       }
     }
-    EXPECT_TRUE(num_tries < kRetryCount);
+    EXPECT_LT(num_tries, kRetryCount);
   }
 
   std::string root_cert_;


### PR DESCRIPTION
Currently, the CDS policy creates a single `XdsCertificateProvider` object containing the certificate configuration for the entire cluster.  That provider gets passed down via channel args to all of the underlying subchannels.  This approach poses a problem for the aggregate cluster functionality being implemented by @donnadionne in #25078.  For an aggregate cluster, the cluster will be composed of more than one underlying cluster, each of which may have different certificate configuration, so we have to pass down a different configuration for different sets of subchannels.  This PR solves that problem by changing the `XdsCertificateProvider` to contain a map, so that it can contain a different certificate configuration for each cluster.

Previously, whenever the xDS certificate configuration changed, the CDS policy would create a new `XdsCertificateProvider` object containing the new config.  The new object would be passed down via channel args, and the new channel args would cause all of the subchannels to be recreated.  However, this approach will no longer work, because in the aggregate cluster case, if the certificate config changes for just one of the underlying clusters, we don't want to cause the subchannels to be recreated for _all_ clusters.  So instead, we will need to change the XdsCreds code to notice when the config for the cluster has changed and create a new security connector when that happens.

The latter change has not been fully implemented as part of this PR, because it turns out that there's a pre-existing bug: The XdsCreds code is creating a new TlsCreds object every time it creates a security connector, but the security connector's pointer to its channel creds object is part of its identity, so this causes the channel args to be different, which means that we're actually recreating the subchannels every single time there's an xDS update of any kind.  This clearly needs to be fixed anyway, so I've left a TODO for @yashykt to change the XdsCreds code to more intelligently decide when to change the security connector, which should be done only when the config for the cluster has changed.

For now, though, I have removed the code in the CDS policy that recreated the `XdsCertificateProvider` when a config changes.  Instead, it creates a single object and simply updates the map within that object as the configs for the underlying cluster change.