### PR TITLE
Fix unused parameter warnings

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -47,7 +47,6 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wno-missing-field-initializers",
     "-Wno-sign-compare",
     "-Wno-unused-function",
-    "-Wno-unused-parameter",
 ]
 
 GRPC_DEFAULT_COPTS = select({

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1047,7 +1047,7 @@ class LoadBalancedCall {
 
 // Channel arg pointer vtable for GRPC_ARG_CLIENT_CHANNEL_DATA.
 void* ChannelDataArgCopy(void* p) { return p; }
-void ChannelDataArgDestroy(void* p) {}
+void ChannelDataArgDestroy(void* /*p*/) {}
 int ChannelDataArgCmp(void* p, void* q) { return GPR_ICMP(p, q); }
 const grpc_arg_pointer_vtable kChannelDataArgPointerVtable = {
     ChannelDataArgCopy, ChannelDataArgDestroy, ChannelDataArgCmp};
@@ -1079,10 +1079,10 @@ class DynamicTerminationFilterChannelData {
   }
 
   // Will never be called.
-  static void StartTransportOp(grpc_channel_element* elem,
-                               grpc_transport_op* op) {}
-  static void GetChannelInfo(grpc_channel_element* elem,
-                             const grpc_channel_info* info) {}
+  static void StartTransportOp(grpc_channel_element* /*elem*/,
+                               grpc_transport_op* /*op*/) {}
+  static void GetChannelInfo(grpc_channel_element* /*elem*/,
+                             const grpc_channel_info* /*info*/) {}
 
   ChannelData* chand() const { return chand_; }
   RefCountedPtr<ServerRetryThrottleData> retry_throttle_data() const {
@@ -1117,7 +1117,7 @@ class DynamicTerminationFilterCallData {
   }
 
   static void Destroy(grpc_call_element* elem,
-                      const grpc_call_final_info* final_info,
+                      const grpc_call_final_info* /*final_info*/,
                       grpc_closure* then_schedule_closure) {
     auto* calld =
         static_cast<DynamicTerminationFilterCallData*>(elem->call_data);

--- a/src/core/ext/filters/client_channel/config_selector.h
+++ b/src/core/ext/filters/client_channel/config_selector.h
@@ -106,7 +106,7 @@ class DefaultConfigSelector : public ConfigSelector {
 
   // Only comparing the ConfigSelector itself, not the underlying
   // service config, so we always return true.
-  bool Equals(const ConfigSelector* other) const override { return true; }
+  bool Equals(const ConfigSelector* /*other*/) const override { return true; }
 
   CallConfig GetCallConfig(GetCallConfigArgs args) override {
     CallConfig call_config;

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1259,12 +1259,10 @@ ServerAddressList ExtractBalancerAddresses(const grpc_channel_args& args) {
  * stream for the reception of load balancing updates.
  *
  * Inputs:
- *   - \a addresses: corresponding to the balancers.
  *   - \a response_generator: in order to propagate updates from the resolver
  *   above the grpclb policy.
  *   - \a args: other args inherited from the grpclb policy. */
 grpc_channel_args* BuildBalancerChannelArgs(
-    const ServerAddressList& addresses,
     FakeResolverResponseGenerator* response_generator,
     const grpc_channel_args* args) {
   // Channel args to remove.
@@ -1313,7 +1311,7 @@ grpc_channel_args* BuildBalancerChannelArgs(
       args, args_to_remove, GPR_ARRAY_SIZE(args_to_remove), args_to_add.data(),
       args_to_add.size());
   // Make any necessary modifications for security.
-  return ModifyGrpclbBalancerChannelArgs(addresses, new_args);
+  return ModifyGrpclbBalancerChannelArgs(new_args);
 }
 
 //
@@ -1464,8 +1462,8 @@ void GrpcLb::ProcessAddressesAndChannelArgsLocked(
       &args, args_to_remove, GPR_ARRAY_SIZE(args_to_remove), &new_arg, 1);
   // Construct args for balancer channel.
   ServerAddressList balancer_addresses = ExtractBalancerAddresses(args);
-  grpc_channel_args* lb_channel_args = BuildBalancerChannelArgs(
-      balancer_addresses, response_generator_.get(), &args);
+  grpc_channel_args* lb_channel_args =
+      BuildBalancerChannelArgs(response_generator_.get(), &args);
   // Create balancer channel if needed.
   if (lb_channel_ == nullptr) {
     std::string uri_str = absl::StrCat("fake:///", server_name_);

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
@@ -24,8 +24,7 @@
 
 namespace grpc_core {
 
-grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
-    const ServerAddressList& /*addresses*/, grpc_channel_args* args) {
+grpc_channel_args* ModifyGrpclbBalancerChannelArgs(grpc_channel_args* args) {
   return args;
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h
@@ -33,8 +33,7 @@ namespace grpc_core {
 /// Takes ownership of \a args.
 ///
 /// Caller takes ownership of the returned args.
-grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
-    const ServerAddressList& addresses, grpc_channel_args* args);
+grpc_channel_args* ModifyGrpclbBalancerChannelArgs(grpc_channel_args* args);
 
 grpc_channel* CreateGrpclbBalancerChannel(const char* target_uri,
                                           const grpc_channel_args& args);

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -40,7 +40,7 @@
 namespace grpc_core {
 
 grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
-    const ServerAddressList& addresses, grpc_channel_args* args) {
+    const ServerAddressList& /*addresses*/, grpc_channel_args* args) {
   absl::InlinedVector<const char*, 1> args_to_remove;
   absl::InlinedVector<grpc_arg, 1> args_to_add;
   // Substitute the channel credentials with a version without call

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -39,8 +39,7 @@
 
 namespace grpc_core {
 
-grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
-    const ServerAddressList& /*addresses*/, grpc_channel_args* args) {
+grpc_channel_args* ModifyGrpclbBalancerChannelArgs(grpc_channel_args* args) {
   absl::InlinedVector<const char*, 1> args_to_remove;
   absl::InlinedVector<grpc_arg, 1> args_to_add;
   // Substitute the channel credentials with a version without call

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -497,7 +497,7 @@ class PickFirstFactory : public LoadBalancingPolicyFactory {
   const char* name() const override { return kPickFirst; }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const Json& json, grpc_error** /*error*/) const override {
+      const Json& /*json*/, grpc_error** /*error*/) const override {
     return MakeRefCounted<PickFirstConfig>();
   }
 };

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -1236,7 +1236,7 @@ class XdsClusterResolverLbFactory : public LoadBalancingPolicyFactory {
     }
 
     OrphanablePtr<LoadBalancingPolicy> CreateLoadBalancingPolicy(
-        const char* name, LoadBalancingPolicy::Args args) const override {
+        const char* /*name*/, LoadBalancingPolicy::Args args) const override {
       return MakeOrphanable<XdsClusterResolverLb>(xds_client_, std::move(args));
     }
 

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -150,7 +150,7 @@ class UnixResolverFactory : public ResolverFactory {
     return CreateSockaddrResolver(std::move(args), grpc_parse_unix);
   }
 
-  std::string GetDefaultAuthority(const URI& uri) const override {
+  std::string GetDefaultAuthority(const URI& /*uri*/) const override {
     return "localhost";
   }
 

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -72,7 +72,7 @@ grpc_error* ServerLoadReportingChannelData::Init(
 
 void ServerLoadReportingCallData::Destroy(
     grpc_call_element* elem, const grpc_call_final_info* final_info,
-    grpc_closure* then_call_closure) {
+    grpc_closure* /*then_call_closure*/) {
   ServerLoadReportingChannelData* chand =
       reinterpret_cast<ServerLoadReportingChannelData*>(elem->channel_data);
   // Only record an end if we've recorded its corresponding start, which is
@@ -265,7 +265,7 @@ void ServerLoadReportingCallData::RecvInitialMetadataReady(void* arg,
 }
 
 grpc_error* ServerLoadReportingCallData::Init(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+    grpc_call_element* elem, const grpc_call_element_args* /*args*/) {
   service_method_ = grpc_empty_slice();
   GRPC_CLOSURE_INIT(&recv_initial_metadata_ready_, RecvInitialMetadataReady,
                     elem, grpc_schedule_on_exec_ctx);

--- a/src/core/ext/transport/chttp2/client/chttp2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/chttp2_connector.cc
@@ -220,7 +220,7 @@ void Chttp2Connector::OnReceiveSettings(void* arg, grpc_error* error) {
   self->Unref();
 }
 
-void Chttp2Connector::OnTimeout(void* arg, grpc_error* error) {
+void Chttp2Connector::OnTimeout(void* arg, grpc_error* /*error*/) {
   Chttp2Connector* self = static_cast<Chttp2Connector*>(arg);
   {
     MutexLock lock(&self->mu_);

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -93,7 +93,7 @@ class Chttp2ServerListener : public Server::ListenerInterface {
     explicit ConfigFetcherWatcher(Chttp2ServerListener* listener)
         : listener_(listener) {}
 
-    void UpdateConfig(grpc_channel_args* args) override {
+    void UpdateConfig(grpc_channel_args* /*args*/) override {
       {
         MutexLock lock(&listener_->mu_);
         grpc_channel_args_destroy(listener_->args_);

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -93,7 +93,7 @@ class Chttp2ServerListener : public Server::ListenerInterface {
     explicit ConfigFetcherWatcher(Chttp2ServerListener* listener)
         : listener_(listener) {}
 
-    void UpdateConfig(grpc_channel_args* /*args*/) override {
+    void UpdateConfig(grpc_channel_args* args) override {
       {
         MutexLock lock(&listener_->mu_);
         grpc_channel_args_destroy(listener_->args_);

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2.cc
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2.cc
@@ -30,7 +30,7 @@
 namespace {
 
 grpc_channel_args* ModifyArgsForConnection(grpc_channel_args* args,
-                                           grpc_error** error) {
+                                           grpc_error** /*error*/) {
   return args;
 }
 

--- a/src/core/ext/transport/cronet/transport/cronet_api_dummy.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_api_dummy.cc
@@ -32,51 +32,55 @@ library, so we can build it in all environments */
 #else
 /* Dummy implementation of cronet API just to test for build-ability */
 bidirectional_stream* bidirectional_stream_create(
-    stream_engine* engine, void* annotation,
-    bidirectional_stream_callback* callback) {
+    stream_engine* /*engine*/, void* /*annotation*/,
+    bidirectional_stream_callback* /*callback*/) {
   GPR_ASSERT(0);
   return nullptr;
 }
 
-int bidirectional_stream_destroy(bidirectional_stream* stream) {
+int bidirectional_stream_destroy(bidirectional_stream* /*stream*/) {
   GPR_ASSERT(0);
   return 0;
 }
 
-int bidirectional_stream_start(bidirectional_stream* stream, const char* url,
-                               int priority, const char* method,
-                               const bidirectional_stream_header_array* headers,
-                               bool end_of_stream) {
+int bidirectional_stream_start(
+    bidirectional_stream* /*stream*/, const char* /*url*/, int /*priority*/,
+    const char* /*method*/,
+    const bidirectional_stream_header_array* /*headers*/,
+    bool /*end_of_stream*/) {
   GPR_ASSERT(0);
   return 0;
 }
 
-int bidirectional_stream_read(bidirectional_stream* stream, char* buffer,
-                              int capacity) {
+int bidirectional_stream_read(bidirectional_stream* /*stream*/,
+                              char* /*buffer*/, int /*capacity*/) {
   GPR_ASSERT(0);
   return 0;
 }
 
-int bidirectional_stream_write(bidirectional_stream* stream, const char* buffer,
-                               int count, bool end_of_stream) {
+int bidirectional_stream_write(bidirectional_stream* /*stream*/,
+                               const char* /*buffer*/, int /*count*/,
+                               bool /*end_of_stream*/) {
   GPR_ASSERT(0);
   return 0;
 }
 
-void bidirectional_stream_cancel(bidirectional_stream* stream) {
+void bidirectional_stream_cancel(bidirectional_stream* /*stream*/) {
   GPR_ASSERT(0);
 }
 
-void bidirectional_stream_disable_auto_flush(bidirectional_stream* stream,
-                                             bool disable_auto_flush) {
+void bidirectional_stream_disable_auto_flush(bidirectional_stream* /*stream*/,
+                                             bool /*disable_auto_flush*/) {
   GPR_ASSERT(0);
 }
 
 void bidirectional_stream_delay_request_headers_until_flush(
-    bidirectional_stream* stream, bool delay_headers_until_flush) {
+    bidirectional_stream* /*stream*/, bool /*delay_headers_until_flush*/) {
   GPR_ASSERT(0);
 }
 
-void bidirectional_stream_flush(bidirectional_stream* stream) { GPR_ASSERT(0); }
+void bidirectional_stream_flush(bidirectional_stream* /*stream*/) {
+  GPR_ASSERT(0);
+}
 
 #endif /* GRPC_COMPILE_WITH_CRONET */

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -1420,19 +1420,20 @@ inline stream_obj::~stream_obj() {
 }
 
 static int init_stream(grpc_transport* gt, grpc_stream* gs,
-                       grpc_stream_refcount* refcount, const void* server_data,
-                       grpc_core::Arena* arena) {
+                       grpc_stream_refcount* refcount,
+                       const void* /*server_data*/, grpc_core::Arena* arena) {
   new (gs) stream_obj(gt, gs, refcount, arena);
   return 0;
 }
 
-static void set_pollset_do_nothing(grpc_transport* gt, grpc_stream* gs,
-                                   grpc_pollset* pollset) {}
+static void set_pollset_do_nothing(grpc_transport* /*gt*/, grpc_stream* /*gs*/,
+                                   grpc_pollset* /*pollset*/) {}
 
-static void set_pollset_set_do_nothing(grpc_transport* gt, grpc_stream* gs,
-                                       grpc_pollset_set* pollset_set) {}
+static void set_pollset_set_do_nothing(grpc_transport* /*gt*/,
+                                       grpc_stream* /*gs*/,
+                                       grpc_pollset_set* /*pollset_set*/) {}
 
-static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
+static void perform_stream_op(grpc_transport* /*gt*/, grpc_stream* gs,
                               grpc_transport_stream_op_batch* op) {
   CRONET_LOG(GPR_DEBUG, "perform_stream_op");
   if (op->send_initial_metadata &&
@@ -1466,7 +1467,7 @@ static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
   execute_from_storage(s);
 }
 
-static void destroy_stream(grpc_transport* gt, grpc_stream* gs,
+static void destroy_stream(grpc_transport* /*gt*/, grpc_stream* gs,
                            grpc_closure* then_schedule_closure) {
   stream_obj* s = reinterpret_cast<stream_obj*>(gs);
   s->~stream_obj();
@@ -1474,11 +1475,11 @@ static void destroy_stream(grpc_transport* gt, grpc_stream* gs,
                           GRPC_ERROR_NONE);
 }
 
-static void destroy_transport(grpc_transport* gt) {}
+static void destroy_transport(grpc_transport* /*gt*/) {}
 
-static grpc_endpoint* get_endpoint(grpc_transport* gt) { return nullptr; }
+static grpc_endpoint* get_endpoint(grpc_transport* /*gt*/) { return nullptr; }
 
-static void perform_op(grpc_transport* gt, grpc_transport_op* op) {}
+static void perform_op(grpc_transport* /*gt*/, grpc_transport_op* /*op*/) {}
 
 static const grpc_transport_vtable grpc_cronet_vtable = {
     sizeof(stream_obj),
@@ -1494,7 +1495,7 @@ static const grpc_transport_vtable grpc_cronet_vtable = {
 
 grpc_transport* grpc_create_cronet_transport(void* engine, const char* target,
                                              const grpc_channel_args* args,
-                                             void* reserved) {
+                                             void* /*reserved*/) {
   grpc_cronet_transport* ct = static_cast<grpc_cronet_transport*>(
       gpr_malloc(sizeof(grpc_cronet_transport)));
   if (!ct) {

--- a/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h
+++ b/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h
@@ -93,7 +93,7 @@ class GoogleMeshCaCertificateProviderFactory
                                   grpc_error** error) override;
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<CertificateProviderFactory::Config> config) override {
+      RefCountedPtr<CertificateProviderFactory::Config> /*config*/) override {
     // TODO(yashykt) : To be implemented
     return nullptr;
   }

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -1389,8 +1389,8 @@ grpc_error* LdsResponseParseClient(
 
 grpc_error* LdsResponseParseServer(
     upb_arena* arena, const envoy_config_listener_v3_Listener* listener,
-    const std::string& listener_name,
-    const envoy_config_core_v3_Address* address,
+    const std::string& /*listener_name*/,
+    const envoy_config_core_v3_Address* /*address*/,
     XdsApi::LdsUpdate* lds_update) {
   lds_update->type = XdsApi::LdsUpdate::ListenerType::kTcpListener;
   // TODO(yashykt): Support filter chain match.

--- a/src/core/ext/xds/xds_bootstrap.cc
+++ b/src/core/ext/xds/xds_bootstrap.cc
@@ -48,8 +48,8 @@ bool XdsChannelCredsRegistry::IsSupported(const std::string& creds_type) {
          creds_type == "fake";
 }
 
-bool XdsChannelCredsRegistry::IsValidConfig(const std::string& creds_type,
-                                            const Json& config) {
+bool XdsChannelCredsRegistry::IsValidConfig(const std::string& /*creds_type*/,
+                                            const Json& /*config*/) {
   // Currently, none of the creds types actually take a config, but we
   // ignore whatever might be specified in the bootstrap file for
   // forward compatibility reasons.
@@ -58,7 +58,7 @@ bool XdsChannelCredsRegistry::IsValidConfig(const std::string& creds_type,
 
 RefCountedPtr<grpc_channel_credentials>
 XdsChannelCredsRegistry::MakeChannelCreds(const std::string& creds_type,
-                                          const Json& config) {
+                                          const Json& /*config*/) {
   if (creds_type == "google_default") {
     return grpc_google_default_credentials_create(nullptr);
   } else if (creds_type == "insecure") {

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -226,7 +226,7 @@ class Delete<T, true> {
 template <typename T>
 class Delete<T, false> {
  public:
-  explicit Delete(T* t) {}
+  explicit Delete(T* /*t*/) {}
 };
 }  // namespace internal
 

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -63,6 +63,7 @@ grpc_error* grpc_set_socket_zerocopy(int fd) {
   }
   return GRPC_ERROR_NONE;
 #else
+  (void)fd;
   return GRPC_OS_ERROR(ENOSYS, "setsockopt(SO_ZEROCOPY)");
 #endif
 }

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -1241,11 +1241,11 @@ static void tcp_handle_error(void* arg /* grpc_tcp */, grpc_error* error) {
 
 #else  /* GRPC_LINUX_ERRQUEUE */
 static TcpZerocopySendRecord* tcp_get_send_zerocopy_record(
-    grpc_tcp* tcp, grpc_slice_buffer* buf) {
+    grpc_tcp* /*tcp*/, grpc_slice_buffer* /*buf*/) {
   return nullptr;
 }
 
-static void ZerocopyDisableAndWaitForRemaining(grpc_tcp* tcp) {}
+static void ZerocopyDisableAndWaitForRemaining(grpc_tcp* /*tcp*/) {}
 
 static bool tcp_write_with_timestamps(grpc_tcp* /*tcp*/, struct msghdr* /*msg*/,
                                       size_t /*sending_length*/,
@@ -1391,8 +1391,8 @@ static bool do_tcp_flush_zerocopy(grpc_tcp* tcp, TcpZerocopySendRecord* record,
 
 static void UnrefMaybePutZerocopySendRecord(grpc_tcp* tcp,
                                             TcpZerocopySendRecord* record,
-                                            uint32_t seq,
-                                            const char* /* tag */) {
+                                            uint32_t /*seq*/,
+                                            const char* /*tag*/) {
   if (record->Unref()) {
     tcp->tcp_zerocopy_send_ctx.PutSendRecord(record);
   }

--- a/src/core/lib/security/authorization/mock_cel/activation.h
+++ b/src/core/lib/security/authorization/mock_cel/activation.h
@@ -48,7 +48,7 @@ class Activation : public BaseActivation {
   Activation& operator=(const Activation&) = delete;
 
   // Insert value into Activation.
-  void InsertValue(absl::string_view name, const CelValue& value) {}
+  void InsertValue(absl::string_view /*name*/, const CelValue& /*value*/) {}
 };
 
 }  // namespace mock_cel

--- a/src/core/lib/security/authorization/mock_cel/cel_value.h
+++ b/src/core/lib/security/authorization/mock_cel/cel_value.h
@@ -61,23 +61,25 @@ class CelValue {
   // We rely on copy elision to avoid extra copying.
   static CelValue CreateNull() { return CelValue(nullptr); }
 
-  static CelValue CreateInt64(int64_t value) { return CreateNull(); }
+  static CelValue CreateInt64(int64_t /*value*/) { return CreateNull(); }
 
-  static CelValue CreateUint64(uint64_t value) { return CreateNull(); }
+  static CelValue CreateUint64(uint64_t /*value*/) { return CreateNull(); }
 
-  static CelValue CreateStringView(absl::string_view value) {
+  static CelValue CreateStringView(absl::string_view /*value*/) {
     return CreateNull();
   }
 
-  static CelValue CreateString(const std::string* str) { return CreateNull(); }
+  static CelValue CreateString(const std::string* /*str*/) {
+    return CreateNull();
+  }
 
-  static CelValue CreateMap(const CelMap* value) { return CreateNull(); }
+  static CelValue CreateMap(const CelMap* /*value*/) { return CreateNull(); }
 
  private:
   // Constructs CelValue wrapping value supplied as argument.
   // Value type T should be supported by specification of ValueHolder.
   template <class T>
-  explicit CelValue(T value) {}
+  explicit CelValue(T /*value*/) {}
 };
 
 // CelMap implementation that uses STL map container as backing storage.
@@ -86,7 +88,7 @@ class ContainerBackedMapImpl : public CelMap {
   ContainerBackedMapImpl() = default;
 
   static std::unique_ptr<CelMap> Create(
-      absl::Span<std::pair<CelValue, CelValue>> key_values) {
+      absl::Span<std::pair<CelValue, CelValue>> /*key_values*/) {
     return absl::make_unique<ContainerBackedMapImpl>();
   }
 };

--- a/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
@@ -120,7 +120,7 @@ AwsExternalAccountCredentials::AwsExternalAccountCredentials(
 }
 
 void AwsExternalAccountCredentials::RetrieveSubjectToken(
-    HTTPRequestContext* ctx, const Options& options,
+    HTTPRequestContext* ctx, const Options& /*options*/,
     std::function<void(std::string, grpc_error*)> cb) {
   if (ctx == nullptr) {
     FinishRetrieveSubjectToken(

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.cc
@@ -91,7 +91,7 @@ FileExternalAccountCredentials::FileExternalAccountCredentials(
 }
 
 void FileExternalAccountCredentials::RetrieveSubjectToken(
-    HTTPRequestContext* ctx, const Options& options,
+    HTTPRequestContext* /*ctx*/, const Options& /*options*/,
     std::function<void(std::string, grpc_error*)> cb) {
   struct SliceWrapper {
     ~SliceWrapper() { grpc_slice_unref_internal(slice); }

--- a/src/core/lib/security/credentials/external/url_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/url_external_account_credentials.cc
@@ -112,7 +112,7 @@ UrlExternalAccountCredentials::UrlExternalAccountCredentials(
 }
 
 void UrlExternalAccountCredentials::RetrieveSubjectToken(
-    HTTPRequestContext* ctx, const Options& options,
+    HTTPRequestContext* ctx, const Options& /*options*/,
     std::function<void(std::string, grpc_error*)> cb) {
   if (ctx == nullptr) {
     FinishRetrieveSubjectToken(

--- a/src/core/lib/security/credentials/fake/fake_credentials.cc
+++ b/src/core/lib/security/credentials/fake/fake_credentials.cc
@@ -59,7 +59,7 @@ class grpc_fake_server_credentials final : public grpc_server_credentials {
   ~grpc_fake_server_credentials() override = default;
 
   grpc_core::RefCountedPtr<grpc_server_security_connector>
-  create_security_connector(const grpc_channel_args* args) override {
+  create_security_connector(const grpc_channel_args* /*args*/) override {
     return grpc_fake_server_security_connector_create(this->Ref());
   }
 };

--- a/src/core/lib/security/security_connector/insecure/insecure_security_connector.cc
+++ b/src/core/lib/security/security_connector/insecure/insecure_security_connector.cc
@@ -51,14 +51,14 @@ RefCountedPtr<grpc_auth_context> TestOnlyMakeInsecureAuthContext() {
 // check_call_host and cancel_check_call_host are no-ops since we want to
 // provide an insecure channel.
 bool InsecureChannelSecurityConnector::check_call_host(
-    absl::string_view host, grpc_auth_context* auth_context,
-    grpc_closure* on_call_host_checked, grpc_error** error) {
+    absl::string_view /*host*/, grpc_auth_context* /*auth_context*/,
+    grpc_closure* /*on_call_host_checked*/, grpc_error** error) {
   *error = GRPC_ERROR_NONE;
   return true;
 }
 
 void InsecureChannelSecurityConnector::cancel_check_call_host(
-    grpc_closure* on_call_host_checked, grpc_error* error) {
+    grpc_closure* /*on_call_host_checked*/, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 
@@ -76,7 +76,7 @@ void InsecureChannelSecurityConnector::add_handshakers(
 }
 
 void InsecureChannelSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* ep,
+    tsi_peer peer, grpc_endpoint* /*ep*/,
     RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   *auth_context = MakeAuthContext();
@@ -104,7 +104,7 @@ void InsecureServerSecurityConnector::add_handshakers(
 }
 
 void InsecureServerSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* ep,
+    tsi_peer peer, grpc_endpoint* /*ep*/,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   *auth_context = MakeAuthContext();

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -513,7 +513,7 @@ grpc_resource_user* CreateDefaultResourceUser(const grpc_channel_args* args) {
 }
 
 RefCountedPtr<channelz::ServerNode> CreateChannelzNode(
-    Server* /*server*/, const grpc_channel_args* args) {
+    const grpc_channel_args* args) {
   RefCountedPtr<channelz::ServerNode> channelz_node;
   if (grpc_channel_args_find_bool(args, GRPC_ARG_ENABLE_CHANNELZ,
                                   GRPC_ENABLE_CHANNELZ_DEFAULT)) {
@@ -534,7 +534,7 @@ RefCountedPtr<channelz::ServerNode> CreateChannelzNode(
 Server::Server(const grpc_channel_args* args)
     : channel_args_(grpc_channel_args_copy(args)),
       default_resource_user_(CreateDefaultResourceUser(args)),
-      channelz_node_(CreateChannelzNode(this, args)) {}
+      channelz_node_(CreateChannelzNode(args)) {}
 
 Server::~Server() {
   grpc_channel_args_destroy(channel_args_);

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -513,7 +513,7 @@ grpc_resource_user* CreateDefaultResourceUser(const grpc_channel_args* args) {
 }
 
 RefCountedPtr<channelz::ServerNode> CreateChannelzNode(
-    Server* server, const grpc_channel_args* args) {
+    Server* /*server*/, const grpc_channel_args* args) {
   RefCountedPtr<channelz::ServerNode> channelz_node;
   if (grpc_channel_args_find_bool(args, GRPC_ARG_ENABLE_CHANNELZ,
                                   GRPC_ENABLE_CHANNELZ_DEFAULT)) {

--- a/src/core/lib/transport/metadata.cc
+++ b/src/core/lib/transport/metadata.cc
@@ -673,6 +673,10 @@ void grpc_mdelem_do_unref(grpc_mdelem gmd DEBUG_ARGS) {
 
 void grpc_mdelem_on_final_unref(grpc_mdelem_data_storage storage, void* ptr,
                                 uint32_t hash DEBUG_ARGS) {
+#ifndef NDEBUG
+  (void)file;
+  (void)line;
+#endif
   switch (storage) {
     case GRPC_MDELEM_STORAGE_EXTERNAL:
     case GRPC_MDELEM_STORAGE_STATIC:

--- a/src/core/tsi/fake_transport_security.cc
+++ b/src/core/tsi/fake_transport_security.cc
@@ -490,7 +490,7 @@ struct fake_handshaker_result {
   size_t unused_bytes_size;
 };
 static tsi_result fake_handshaker_result_extract_peer(
-    const tsi_handshaker_result* self, tsi_peer* peer) {
+    const tsi_handshaker_result* /*self*/, tsi_peer* peer) {
   /* Construct a tsi_peer with 1 property: certificate type, security_level. */
   tsi_result result = tsi_construct_peer(2, peer);
   if (result != TSI_OK) return result;

--- a/src/cpp/ext/filters/census/channel_filter.cc
+++ b/src/cpp/ext/filters/census/channel_filter.cc
@@ -22,8 +22,8 @@
 
 namespace grpc {
 
-grpc_error* CensusChannelData::Init(grpc_channel_element* elem,
-                                    grpc_channel_element_args* args) {
+grpc_error* CensusChannelData::Init(grpc_channel_element* /*elem*/,
+                                    grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -152,9 +152,9 @@ grpc_error* CensusClientCallData::Init(grpc_call_element* elem,
   return GRPC_ERROR_NONE;
 }
 
-void CensusClientCallData::Destroy(grpc_call_element* elem,
+void CensusClientCallData::Destroy(grpc_call_element* /*elem*/,
                                    const grpc_call_final_info* final_info,
-                                   grpc_closure* then_call_closure) {
+                                   grpc_closure* /*then_call_closure*/) {
   const uint64_t request_size = GetOutgoingDataSize(final_info);
   const uint64_t response_size = GetIncomingDataSize(final_info);
   double latency_ms = absl::ToDoubleMilliseconds(absl::Now() - start_time_);

--- a/src/cpp/ext/filters/census/context.cc
+++ b/src/cpp/ext/filters/census/context.cc
@@ -28,8 +28,9 @@ using ::opencensus::tags::TagMap;
 using ::opencensus::trace::Span;
 using ::opencensus::trace::SpanContext;
 
-void GenerateServerContext(absl::string_view tracing, absl::string_view stats,
-                           absl::string_view primary_role,
+void GenerateServerContext(absl::string_view tracing,
+                           absl::string_view /*stats*/,
+                           absl::string_view /*primary_role*/,
                            absl::string_view method, CensusContext* context) {
   // Destruct the current CensusContext to free the Span memory before
   // overwriting it below.
@@ -77,7 +78,7 @@ size_t TraceContextSerialize(const ::opencensus::trace::SpanContext& context,
                                       tracing_buf_size);
 }
 
-size_t StatsContextSerialize(size_t max_tags_len, grpc_slice* tags) {
+size_t StatsContextSerialize(size_t /*max_tags_len*/, grpc_slice* /*tags*/) {
   // TODO(unknown): Add implementation. Waiting on stats tagging to be added.
   return 0;
 }

--- a/src/cpp/ext/filters/census/context.cc
+++ b/src/cpp/ext/filters/census/context.cc
@@ -28,10 +28,8 @@ using ::opencensus::tags::TagMap;
 using ::opencensus::trace::Span;
 using ::opencensus::trace::SpanContext;
 
-void GenerateServerContext(absl::string_view tracing,
-                           absl::string_view /*stats*/,
-                           absl::string_view /*primary_role*/,
-                           absl::string_view method, CensusContext* context) {
+void GenerateServerContext(absl::string_view tracing, absl::string_view method,
+                           CensusContext* context) {
   // Destruct the current CensusContext to free the Span memory before
   // overwriting it below.
   context->~CensusContext();

--- a/src/cpp/ext/filters/census/context.h
+++ b/src/cpp/ext/filters/census/context.h
@@ -96,9 +96,8 @@ size_t ServerStatsDeserialize(const char* buf, size_t buf_size,
 // Deserialize the incoming SpanContext and generate a new server context based
 // on that. This new span will never be a root span. This should only be called
 // with a blank CensusContext as it overwrites it.
-void GenerateServerContext(absl::string_view tracing, absl::string_view stats,
-                           absl::string_view primary_role,
-                           absl::string_view method, CensusContext* context);
+void GenerateServerContext(absl::string_view tracing, absl::string_view method,
+                           CensusContext* context);
 
 // Creates a new client context that is by default a new root context.
 // If the current context is the default context then the newly created

--- a/src/cpp/ext/filters/census/server_filter.cc
+++ b/src/cpp/ext/filters/census/server_filter.cc
@@ -103,19 +103,8 @@ void CensusServerCallData::OnDoneRecvInitialMetadataCb(void* user_data,
     size_t tracing_str_len = GRPC_SLICE_IS_EMPTY(sml.tracing_slice)
                                  ? 0
                                  : GRPC_SLICE_LENGTH(sml.tracing_slice);
-    const char* census_str = GRPC_SLICE_IS_EMPTY(sml.census_proto)
-                                 ? ""
-                                 : reinterpret_cast<const char*>(
-                                       GRPC_SLICE_START_PTR(sml.census_proto));
-    size_t census_str_len = GRPC_SLICE_IS_EMPTY(sml.census_proto)
-                                ? 0
-                                : GRPC_SLICE_LENGTH(sml.census_proto);
-
     GenerateServerContext(absl::string_view(tracing_str, tracing_str_len),
-                          absl::string_view(census_str, census_str_len),
-                          /*primary_role*/ "", calld->qualified_method_,
-                          &calld->context_);
-
+                          calld->qualified_method_, &calld->context_);
     grpc_slice_unref_internal(sml.tracing_slice);
     grpc_slice_unref_internal(sml.census_proto);
     grpc_slice_unref_internal(sml.path);

--- a/src/cpp/ext/filters/census/server_filter.cc
+++ b/src/cpp/ext/filters/census/server_filter.cc
@@ -179,9 +179,9 @@ grpc_error* CensusServerCallData::Init(grpc_call_element* elem,
   return GRPC_ERROR_NONE;
 }
 
-void CensusServerCallData::Destroy(grpc_call_element* elem,
+void CensusServerCallData::Destroy(grpc_call_element* /*elem*/,
                                    const grpc_call_final_info* final_info,
-                                   grpc_closure* then_call_closure) {
+                                   grpc_closure* /*then_call_closure*/) {
   const uint64_t request_size = GetOutgoingDataSize(final_info);
   const uint64_t response_size = GetIncomingDataSize(final_info);
   double elapsed_time_ms = absl::ToDoubleMilliseconds(elapsed_time_);

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -362,7 +362,7 @@ void LoadReporterAsyncServiceImpl::ReportLoadHandler::Shutdown(
 
 void LoadReporterAsyncServiceImpl::ReportLoadHandler::OnFinishDone(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::shared_ptr<ReportLoadHandler> self, bool ok) {
+    std::shared_ptr<ReportLoadHandler> /*self*/, bool ok) {
   if (ok) {
     gpr_log(GPR_INFO,
             "[LRS %p] Load reporting finished (lb_id_: %s, handler: %p).",

--- a/src/cpp/server/load_reporter/load_reporting_service_server_builder_plugin.cc
+++ b/src/cpp/server/load_reporter/load_reporting_service_server_builder_plugin.cc
@@ -51,7 +51,7 @@ void LoadReportingServiceServerBuilderPlugin::InitServer(
 }
 
 void LoadReportingServiceServerBuilderPlugin::Finish(
-    grpc::ServerInitializer* si) {
+    grpc::ServerInitializer* /*si*/) {
   service_->StartThread();
   service_.reset();
 }

--- a/src/cpp/server/load_reporter/load_reporting_service_server_builder_plugin.h
+++ b/src/cpp/server/load_reporter/load_reporting_service_server_builder_plugin.h
@@ -44,8 +44,8 @@ class LoadReportingServiceServerBuilderPlugin : public ServerBuilderPlugin {
   // Starts the load reporter service.
   void Finish(ServerInitializer* si) override;
 
-  void ChangeArguments(const std::string& name, void* value) override {}
-  void UpdateChannelArguments(grpc::ChannelArguments* args) override {}
+  void ChangeArguments(const std::string& /*name*/, void* /*value*/) override {}
+  void UpdateChannelArguments(grpc::ChannelArguments* /*args*/) override {}
   bool has_sync_methods() const override;
   bool has_async_methods() const override;
 

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -573,6 +573,11 @@ static grpc_call_error grpcsharp_call_start_batch_nop(grpc_call* call,
                                                       const grpc_op* ops,
                                                       size_t nops, void* tag,
                                                       void* reserved) {
+  (void)call;
+  (void)ops;
+  (void)nops;
+  (void)tag;
+  (void)reserved;
   return GRPC_CALL_OK;
 }
 
@@ -654,6 +659,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcsharp_test_call_start_unary_echo(
     grpc_call* call, grpcsharp_batch_context* ctx,
     grpc_slice_buffer* send_buffer, uint32_t write_flags,
     grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags) {
+  (void)call;
+  (void)write_flags;
+  (void)initial_metadata_flags;
   // prepare as if we were performing a normal RPC.
   grpc_byte_buffer* send_message =
       grpcsharp_create_byte_buffer_from_stolen_slices(send_buffer);
@@ -1136,6 +1144,10 @@ static int grpcsharp_get_metadata_handler(
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t* num_creds_md, grpc_status_code* status,
     const char** error_details) {
+  (void)creds_md;
+  (void)num_creds_md;
+  (void)status;
+  (void)error_details;
   // the "context" object and its contents are only guaranteed to live until
   // this handler returns (which could result in use-after-free for async
   // handling of the callback), so the C# counterpart of this handler

--- a/test/core/client_channel/certificate_provider_registry_test.cc
+++ b/test/core/client_channel/certificate_provider_registry_test.cc
@@ -33,12 +33,12 @@ class FakeCertificateProviderFactory1 : public CertificateProviderFactory {
   const char* name() const override { return "fake1"; }
 
   RefCountedPtr<Config> CreateCertificateProviderConfig(
-      const Json& config_json, grpc_error** error) override {
+      const Json& /*config_json*/, grpc_error** /*error*/) override {
     return nullptr;
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<Config> config) override {
+      RefCountedPtr<Config> /*config*/) override {
     return nullptr;
   }
 };
@@ -48,12 +48,12 @@ class FakeCertificateProviderFactory2 : public CertificateProviderFactory {
   const char* name() const override { return "fake2"; }
 
   RefCountedPtr<Config> CreateCertificateProviderConfig(
-      const Json& config_json, grpc_error** error) override {
+      const Json& /*config_json*/, grpc_error** /*error*/) override {
     return nullptr;
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<Config> config) override {
+      RefCountedPtr<Config> /*config*/) override {
     return nullptr;
   }
 };

--- a/test/core/end2end/cq_verifier.cc
+++ b/test/core/end2end/cq_verifier.cc
@@ -304,9 +304,9 @@ void cq_verify_empty_timeout(cq_verifier* v, int timeout_sec) {
 void cq_verify_empty(cq_verifier* v) { cq_verify_empty_timeout(v, 1); }
 
 void cq_maybe_expect_completion(cq_verifier* v, const char* file, int line,
-                                void* tag, bool /*success*/, bool* seen) {
-  v->maybe_expectations.emplace_back(file, line, GRPC_OP_COMPLETE, tag, true,
-                                     true, seen);
+                                void* tag, bool success, bool* seen) {
+  v->maybe_expectations.emplace_back(file, line, GRPC_OP_COMPLETE, tag,
+                                     true /* check_success */, success, seen);
 }
 
 static void add(cq_verifier* v, const char* file, int line,

--- a/test/core/end2end/cq_verifier.cc
+++ b/test/core/end2end/cq_verifier.cc
@@ -304,7 +304,7 @@ void cq_verify_empty_timeout(cq_verifier* v, int timeout_sec) {
 void cq_verify_empty(cq_verifier* v) { cq_verify_empty_timeout(v, 1); }
 
 void cq_maybe_expect_completion(cq_verifier* v, const char* file, int line,
-                                void* tag, bool success, bool* seen) {
+                                void* tag, bool /*success*/, bool* seen) {
   v->maybe_expectations.emplace_back(file, line, GRPC_OP_COMPLETE, tag, true,
                                      true, seen);
 }

--- a/test/core/network_benchmarks/low_level_ping_pong.cc
+++ b/test/core/network_benchmarks/low_level_ping_pong.cc
@@ -232,7 +232,7 @@ static int set_socket_nonblocking(thread_args* args) {
   return 0;
 }
 
-static int do_nothing(thread_args* args) { return 0; }
+static int do_nothing(thread_args* /*args*/) { return 0; }
 
 #ifdef __linux__
 /* Special case for epoll, where we need to create the fd ahead of time. */

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -1670,17 +1670,17 @@ struct fake_call_creds : public grpc_call_credentials {
 
   ~fake_call_creds() override { GRPC_MDELEM_UNREF(dummy_md_); }
 
-  bool get_request_metadata(grpc_polling_entity* pollent,
-                            grpc_auth_metadata_context context,
+  bool get_request_metadata(grpc_polling_entity* /*pollent*/,
+                            grpc_auth_metadata_context /*context*/,
                             grpc_credentials_mdelem_array* md_array,
-                            grpc_closure* on_request_metadata,
-                            grpc_error** error) override {
+                            grpc_closure* /*on_request_metadata*/,
+                            grpc_error** /*error*/) override {
     grpc_credentials_mdelem_array_add(md_array, dummy_md_);
     return true;
   }
 
-  void cancel_get_request_metadata(grpc_credentials_mdelem_array* md_array,
-                                   grpc_error* error) override {}
+  void cancel_get_request_metadata(grpc_credentials_mdelem_array* /*md_array*/,
+                                   grpc_error* /*error*/) override {}
 
  private:
   grpc_mdelem dummy_md_;
@@ -1983,7 +1983,7 @@ static void test_auth_metadata_context(void) {
 
 static void validate_external_account_creds_token_exchage_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
-    bool expect_actor_token) {
+    bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
   GPR_ASSERT(body != nullptr);
   GPR_ASSERT(body_size != 0);
@@ -2021,7 +2021,7 @@ static void validate_external_account_creds_token_exchage_request(
 static void
 validate_external_account_creds_token_exchage_request_with_url_encode(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
-    bool expect_actor_token) {
+    bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
   GPR_ASSERT(body != nullptr);
   GPR_ASSERT(body_size != 0);
@@ -2051,7 +2051,7 @@ validate_external_account_creds_token_exchage_request_with_url_encode(
 static void
 validate_external_account_creds_service_account_impersonation_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
-    bool expect_actor_token) {
+    bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
   GPR_ASSERT(body != nullptr);
   GPR_ASSERT(body_size != 0);
@@ -2097,8 +2097,8 @@ static int external_account_creds_httpcli_post_success(
 
 static int
 external_account_creds_httpcli_post_failure_token_exchange_response_missing_access_token(
-    const grpc_httpcli_request* request, const char* body, size_t body_size,
-    grpc_millis /*deadline*/, grpc_closure* on_done,
+    const grpc_httpcli_request* request, const char* /*body*/,
+    size_t /*body_size*/, grpc_millis /*deadline*/, grpc_closure* on_done,
     grpc_httpcli_response* response) {
   if (strcmp(request->http.path, "/token") == 0) {
     *response = http_response(200,
@@ -2139,7 +2139,7 @@ static int url_external_account_creds_httpcli_get_success(
 
 static void validate_aws_external_account_creds_token_exchage_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
-    bool expect_actor_token) {
+    bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
   GPR_ASSERT(body != nullptr);
   GPR_ASSERT(body_size != 0);
@@ -2212,7 +2212,7 @@ class TestExternalAccountCredentials final
 
  protected:
   void RetrieveSubjectToken(
-      HTTPRequestContext* ctx, const Options& options,
+      HTTPRequestContext* /*ctx*/, const Options& /*options*/,
       std::function<void(std::string, grpc_error*)> cb) override {
     cb("test_subject_token", GRPC_ERROR_NONE);
   }

--- a/test/core/security/grpc_tls_certificate_distributor_test.cc
+++ b/test/core/security/grpc_tls_certificate_distributor_test.cc
@@ -562,8 +562,8 @@ TEST_F(GrpcTlsCertificateDistributorTest, ResetCallbackToNull) {
 
 TEST_F(GrpcTlsCertificateDistributorTest, SetKeyMaterialsInCallback) {
   distributor_.SetWatchStatusCallback([this](std::string cert_name,
-                                             bool root_being_watched,
-                                             bool identity_being_watched) {
+                                             bool /*root_being_watched*/,
+                                             bool /*identity_being_watched*/) {
     distributor_.SetKeyMaterials(
         cert_name, kRootCert1Contents,
         MakeCertKeyPairs(kIdentityCert1PrivateKey, kIdentityCert1Contents));
@@ -913,8 +913,8 @@ TEST_F(GrpcTlsCertificateDistributorTest, WatchErroredCertInfoBySetError) {
 
 TEST_F(GrpcTlsCertificateDistributorTest, SetErrorForCertInCallback) {
   distributor_.SetWatchStatusCallback([this](std::string cert_name,
-                                             bool root_being_watched,
-                                             bool identity_being_watched) {
+                                             bool /*root_being_watched*/,
+                                             bool /*identity_being_watched*/) {
     this->distributor_.SetErrorForCert(
         cert_name, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
         GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
@@ -59,7 +59,7 @@ class FakeHandshakerService : public HandshakerService::Service {
       : expected_max_concurrent_rpcs_(expected_max_concurrent_rpcs) {}
 
   Status DoHandshake(
-      ServerContext* server_context,
+      ServerContext* /*server_context*/,
       ServerReaderWriter<HandshakerResp, HandshakerReq>* stream) override {
     ConcurrentRpcsCheck concurrent_rpcs_check(this);
     Status status;

--- a/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
@@ -440,10 +440,10 @@ static void schedule_request_success_test() {
   destroy_config(config);
 }
 
-static void tsi_cb_assert_tsi_internal_error(tsi_result status, void* user_data,
-                                             const unsigned char* bytes_to_send,
-                                             size_t bytes_to_send_size,
-                                             tsi_handshaker_result* result) {
+static void tsi_cb_assert_tsi_internal_error(
+    tsi_result status, void* /*user_data*/,
+    const unsigned char* /*bytes_to_send*/, size_t /*bytes_to_send_size*/,
+    tsi_handshaker_result* /*result*/) {
   GPR_ASSERT(status == TSI_INTERNAL_ERROR);
 }
 

--- a/test/core/tsi/ssl_session_cache_test.cc
+++ b/test/core/tsi/ssl_session_cache_test.cc
@@ -72,8 +72,8 @@ class SessionTracker {
     return tsi::SslSessionPtr(cb(ssl_context_));
   }
 
-  static void DestroyExData(void* parent, void* ptr, CRYPTO_EX_DATA* ad,
-                            int index, long argl, void* argp) {
+  static void DestroyExData(void* /*parent*/, void* ptr, CRYPTO_EX_DATA* /*ad*/,
+                            int /*index*/, long /*argl*/, void* /*argp*/) {
     SessionExDataId* data = static_cast<SessionExDataId*>(ptr);
     data->tracker->alive_sessions_.erase(data->id);
     delete data;

--- a/test/core/util/eval_args_mock_endpoint.cc
+++ b/test/core/util/eval_args_mock_endpoint.cc
@@ -36,15 +36,16 @@ class EvalArgsMockEndpoint {
     base_.vtable = &vtable_;
   }
   grpc_endpoint* base() const { return const_cast<grpc_endpoint*>(&base_); }
-  static void Read(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                   grpc_closure* cb, bool unused) {}
-  static void Write(grpc_endpoint* ep, grpc_slice_buffer* slices,
-                    grpc_closure* cb, void* unused) {}
-  static void AddToPollset(grpc_endpoint* ep, grpc_pollset* unused) {}
-  static void AddToPollsetSet(grpc_endpoint* ep, grpc_pollset_set* unused) {}
-  static void DeleteFromPollsetSet(grpc_endpoint* ep,
-                                   grpc_pollset_set* unused) {}
-  static void Shutdown(grpc_endpoint* ep, grpc_error* why) {}
+  static void Read(grpc_endpoint* /*ep*/, grpc_slice_buffer* /*slices*/,
+                   grpc_closure* /*cb*/, bool /*unused*/) {}
+  static void Write(grpc_endpoint* /*ep*/, grpc_slice_buffer* /*slices*/,
+                    grpc_closure* /*cb*/, void* /*unused*/) {}
+  static void AddToPollset(grpc_endpoint* /*ep*/, grpc_pollset* /*unused*/) {}
+  static void AddToPollsetSet(grpc_endpoint* /*ep*/,
+                              grpc_pollset_set* /*unused*/) {}
+  static void DeleteFromPollsetSet(grpc_endpoint* /*ep*/,
+                                   grpc_pollset_set* /*unused*/) {}
+  static void Shutdown(grpc_endpoint* /*ep*/, grpc_error* /*why*/) {}
   static void Destroy(grpc_endpoint* ep) {
     EvalArgsMockEndpoint* m = reinterpret_cast<EvalArgsMockEndpoint*>(ep);
     delete m;
@@ -60,12 +61,12 @@ class EvalArgsMockEndpoint {
     return m->local_address_;
   }
 
-  static grpc_resource_user* GetResourceUser(grpc_endpoint* ep) {
+  static grpc_resource_user* GetResourceUser(grpc_endpoint* /*ep*/) {
     return nullptr;
   }
 
-  static int GetFd(grpc_endpoint* unused) { return -1; }
-  static bool CanTrackErr(grpc_endpoint* unused) { return false; }
+  static int GetFd(grpc_endpoint* /*unused*/) { return -1; }
+  static bool CanTrackErr(grpc_endpoint* /*unused*/) { return false; }
 
  private:
   static constexpr grpc_endpoint_vtable vtable_ = {

--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -153,7 +153,7 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms) {
           GPR_TIMESPAN));
 }
 
-void grpc_test_init(int argc, char** argv) {
+void grpc_test_init(int /*argc*/, char** argv) {
   grpc_core::testing::InitializeStackTracer(argv[0]);
   absl::FailureSignalHandlerOptions options;
   absl::InstallFailureSignalHandler(options);

--- a/test/core/xds/certificate_provider_store_test.cc
+++ b/test/core/xds/certificate_provider_store_test.cc
@@ -57,13 +57,13 @@ class FakeCertificateProviderFactory1 : public CertificateProviderFactory {
   const char* name() const override { return "fake1"; }
 
   RefCountedPtr<CertificateProviderFactory::Config>
-  CreateCertificateProviderConfig(const Json& config_json,
-                                  grpc_error** error) override {
+  CreateCertificateProviderConfig(const Json& /*config_json*/,
+                                  grpc_error** /*error*/) override {
     return MakeRefCounted<Config>();
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<CertificateProviderFactory::Config> config) override {
+      RefCountedPtr<CertificateProviderFactory::Config> /*config*/) override {
     return MakeRefCounted<FakeCertificateProvider>();
   }
 };
@@ -80,13 +80,13 @@ class FakeCertificateProviderFactory2 : public CertificateProviderFactory {
   const char* name() const override { return "fake2"; }
 
   RefCountedPtr<CertificateProviderFactory::Config>
-  CreateCertificateProviderConfig(const Json& config_json,
-                                  grpc_error** error) override {
+  CreateCertificateProviderConfig(const Json& /*config_json*/,
+                                  grpc_error** /*error*/) override {
     return MakeRefCounted<Config>();
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<CertificateProviderFactory::Config> config) override {
+      RefCountedPtr<CertificateProviderFactory::Config> /*config*/) override {
     return MakeRefCounted<FakeCertificateProvider>();
   }
 };

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -507,7 +507,7 @@ class FakeCertificateProviderFactory : public CertificateProviderFactory {
   }
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
-      RefCountedPtr<CertificateProviderFactory::Config> config) override {
+      RefCountedPtr<CertificateProviderFactory::Config> /*config*/) override {
     return nullptr;
   }
 };

--- a/test/cpp/end2end/nonblocking_test.cc
+++ b/test/cpp/end2end/nonblocking_test.cc
@@ -212,6 +212,8 @@ int main(int argc, char** argv) {
   gpr_tls_destroy(&g_is_nonblocking_poll);
   return ret;
 #else   // GRPC_POSIX_SOCKET
+  (void)argc;
+  (void)argv;
   return 0;
 #endif  // GRPC_POSIX_SOCKET
 }

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -895,8 +895,7 @@ class AdsServiceImpl : public std::enable_shared_from_this<AdsServiceImpl> {
                                     &subscription_state, &resource_state,
                                     update_queue) ||
             ClientNeedsResourceUpdate(resource_type_state, resource_state,
-                                      client_resource_type_version,
-                                      &subscription_state)) {
+                                      client_resource_type_version)) {
           gpr_log(GPR_INFO, "ADS[%p]: Sending update for type=%s name=%s", this,
                   request.type_url().c_str(), resource_name.c_str());
           resources_added_to_response.emplace(resource_name);
@@ -942,11 +941,9 @@ class AdsServiceImpl : public std::enable_shared_from_this<AdsServiceImpl> {
       auto& resource_name_map = resource_type_state.resource_name_map;
       auto it = subscription_name_map.find(resource_name);
       if (it != subscription_name_map.end()) {
-        SubscriptionState& subscription_state = it->second;
         ResourceState& resource_state = resource_name_map[resource_name];
         if (ClientNeedsResourceUpdate(resource_type_state, resource_state,
-                                      sent_state->resource_type_version,
-                                      &subscription_state)) {
+                                      sent_state->resource_type_version)) {
           gpr_log(GPR_INFO, "ADS[%p]: Sending update for type=%s name=%s", this,
                   resource_type.c_str(), resource_name.c_str());
           response->emplace();
@@ -1060,8 +1057,7 @@ class AdsServiceImpl : public std::enable_shared_from_this<AdsServiceImpl> {
   // the resource.
   static bool ClientNeedsResourceUpdate(
       const ResourceTypeState& resource_type_state,
-      const ResourceState& resource_state, int client_resource_type_version,
-      SubscriptionState* /*subscription_state*/) {
+      const ResourceState& resource_state, int client_resource_type_version) {
     return client_resource_type_version <
                resource_type_state.resource_type_version &&
            resource_state.resource_type_version <=

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1050,7 +1050,7 @@ class AdsServiceImpl : public std::enable_shared_from_this<AdsServiceImpl> {
     }
 
     static void CheckBuildVersion(
-        const ::envoy::service::discovery::v3::DiscoveryRequest& request) {}
+        const ::envoy::service::discovery::v3::DiscoveryRequest& /*request*/) {}
 
     AdsServiceImpl* parent_;
     const bool is_v2_;
@@ -1061,7 +1061,7 @@ class AdsServiceImpl : public std::enable_shared_from_this<AdsServiceImpl> {
   static bool ClientNeedsResourceUpdate(
       const ResourceTypeState& resource_type_state,
       const ResourceState& resource_state, int client_resource_type_version,
-      SubscriptionState* subscription_state) {
+      SubscriptionState* /*subscription_state*/) {
     return client_resource_type_version <
                resource_type_state.resource_type_version &&
            resource_state.resource_type_version <=
@@ -1449,15 +1449,15 @@ class FakeCertificateProviderFactory
   const char* name() const override { return name_; }
 
   grpc_core::RefCountedPtr<grpc_core::CertificateProviderFactory::Config>
-  CreateCertificateProviderConfig(const grpc_core::Json& config_json,
-                                  grpc_error** error) override {
+  CreateCertificateProviderConfig(const grpc_core::Json& /*config_json*/,
+                                  grpc_error** /*error*/) override {
     return grpc_core::MakeRefCounted<Config>(name_);
   }
 
   grpc_core::RefCountedPtr<grpc_tls_certificate_provider>
   CreateCertificateProvider(
       grpc_core::RefCountedPtr<grpc_core::CertificateProviderFactory::Config>
-          config) override {
+      /*config*/) override {
     if (*cert_data_map_ == nullptr) return nullptr;
     return grpc_core::MakeRefCounted<FakeCertificateProvider>(**cert_data_map_);
   }

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -51,7 +51,7 @@ static const auto TEST_TAG_KEY = TagKey::Register("my_key");
 static const auto TEST_TAG_VALUE = "my_value";
 
 class EchoServer final : public EchoTestService::Service {
-  ::grpc::Status Echo(::grpc::ServerContext* context,
+  ::grpc::Status Echo(::grpc::ServerContext* /*context*/,
                       const EchoRequest* request,
                       EchoResponse* response) override {
     if (request->param().expected_error().code() == 0) {

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -367,7 +367,7 @@ class LoadBalancerStatsServiceImpl : public LoadBalancerStatsService::Service {
   explicit LoadBalancerStatsServiceImpl(StatsWatchers* stats_watchers)
       : stats_watchers_(stats_watchers) {}
 
-  Status GetClientStats(ServerContext* context,
+  Status GetClientStats(ServerContext* /*context*/,
                         const LoadBalancerStatsRequest* request,
                         LoadBalancerStatsResponse* response) override {
     int start_id;
@@ -390,8 +390,8 @@ class LoadBalancerStatsServiceImpl : public LoadBalancerStatsService::Service {
   }
 
   Status GetClientAccumulatedStats(
-      ServerContext* context,
-      const LoadBalancerAccumulatedStatsRequest* request,
+      ServerContext* /*context*/,
+      const LoadBalancerAccumulatedStatsRequest* /*request*/,
       LoadBalancerAccumulatedStatsResponse* response) override {
     std::lock_guard<std::mutex> lock(stats_watchers_->mu);
     stats_watchers_->global_watcher->GetCurrentRpcStats(response,
@@ -410,9 +410,9 @@ class XdsUpdateClientConfigureServiceImpl
       RpcConfigurationsQueue* rpc_configs_queue)
       : rpc_configs_queue_(rpc_configs_queue) {}
 
-  Status Configure(ServerContext* context,
+  Status Configure(ServerContext* /*context*/,
                    const ClientConfigureRequest* request,
-                   ClientConfigureResponse* response) override {
+                   ClientConfigureResponse* /*response*/) override {
     std::map<int, std::vector<std::pair<std::string, std::string>>>
         metadata_map;
     for (const auto& data : request->metadata()) {

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -52,7 +52,7 @@ class TestServiceImpl : public TestService::Service {
  public:
   explicit TestServiceImpl(const std::string& i) : hostname_(i) {}
 
-  Status UnaryCall(ServerContext* context, const SimpleRequest* request,
+  Status UnaryCall(ServerContext* context, const SimpleRequest* /*request*/,
                    SimpleResponse* response) override {
     response->set_server_id(absl::GetFlag(FLAGS_server_id));
     response->set_hostname(hostname_);
@@ -60,8 +60,8 @@ class TestServiceImpl : public TestService::Service {
     return Status::OK;
   }
 
-  Status EmptyCall(ServerContext* context, const Empty* request,
-                   Empty* response) override {
+  Status EmptyCall(ServerContext* context, const Empty* /*request*/,
+                   Empty* /*response*/) override {
     context->AddInitialMetadata("hostname", hostname_);
     return Status::OK;
   }

--- a/test/cpp/microbenchmarks/bm_opencensus_plugin.cc
+++ b/test/cpp/microbenchmarks/bm_opencensus_plugin.cc
@@ -34,7 +34,7 @@ absl::once_flag once;
 void RegisterOnce() { absl::call_once(once, grpc::RegisterOpenCensusPlugin); }
 
 class EchoServer final : public grpc::testing::EchoTestService::Service {
-  grpc::Status Echo(grpc::ServerContext* context,
+  grpc::Status Echo(grpc::ServerContext* /*context*/,
                     const grpc::testing::EchoRequest* request,
                     grpc::testing::EchoResponse* response) override {
     if (request->param().expected_error().code() == 0) {

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -64,9 +64,9 @@ std::string output_json("output.json");
 
 // Creata an echo server
 class EchoServerImpl final : public grpc::testing::TestService::Service {
-  Status EmptyCall(::grpc::ServerContext* context,
-                   const grpc::testing::Empty* request,
-                   grpc::testing::Empty* response) override {
+  Status EmptyCall(::grpc::ServerContext* /*context*/,
+                   const grpc::testing::Empty* /*request*/,
+                   grpc::testing::Empty* /*response*/) override {
     return Status::OK;
   }
 };

--- a/test/cpp/util/grpc_tool_test.cc
+++ b/test/cpp/util/grpc_tool_test.cc
@@ -184,7 +184,8 @@ class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
     return Status::OK;
   }
 
-  Status CheckDeadlineSet(ServerContext* context, const SimpleRequest* request,
+  Status CheckDeadlineSet(ServerContext* context,
+                          const SimpleRequest* /*request*/,
                           StringValue* response) override {
     response->set_message(context->deadline() !=
                                   std::chrono::system_clock::time_point::max()
@@ -196,7 +197,7 @@ class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
   // Check if deadline - current time <= timeout
   // If deadline set, timeout + current time should be an upper bound for it
   Status CheckDeadlineUpperBound(ServerContext* context,
-                                 const SimpleRequest* request,
+                                 const SimpleRequest* /*request*/,
                                  StringValue* response) override {
     auto seconds = std::chrono::duration_cast<std::chrono::seconds>(
         context->deadline() - std::chrono::system_clock::now());


### PR DESCRIPTION
- Removing `-Wno-unused-parameter`.
- Fixing all lines causing `unused parameter`
  - C++: commenting out parameters
  - C: using `(void)arg`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25134)
<!-- Reviewable:end -->
