### PR TITLE
Update bazel io_bazel_rules_python to 0.1.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,15 +81,9 @@ rbe_autoconfig(
     ),
 )
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+load("@io_bazel_rules_python//python:pip.bzl", "pip_install")
 
-pip_import(
+pip_install(
     name = "grpc_python_dependencies",
     requirements = "@com_github_grpc_grpc//:requirements.bazel.txt",
 )
-
-load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
-
-pip_repositories()
-
-pip_install()

--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -36,8 +36,8 @@ def grpc_python_deps():
     if "io_bazel_rules_python" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_python",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
-            sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
+            sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
         )
 
     if "rules_python" not in native.existing_rules():


### PR DESCRIPTION
Looks like this is required for a successful upgrade of third_party/protobuf: https://github.com/grpc/grpc/pull/25131#issuecomment-758726911
More context: https://github.com/grpc/grpc/pull/24723#issuecomment-726484839

Creating a separate PR with this change to ensure that this change is safe.
https://github.com/bazelbuild/rules_python/releases/tag/0.1.0