### PR TITLE
Add internal API for setting fallback xDS bootstrap contents.

### DIFF
--- a/src/core/ext/xds/xds_bootstrap.h
+++ b/src/core/ext/xds/xds_bootstrap.h
@@ -67,10 +67,13 @@ class XdsBootstrap {
     bool ShouldUseV3() const;
   };
 
+  // Normally locates the bootstrap file via an env var.  If no env var
+  // is set, fallback_config will be used instead (if non-null).
   // If *error is not GRPC_ERROR_NONE after returning, then there was an
   // error reading the file.
   static std::unique_ptr<XdsBootstrap> ReadFromFile(XdsClient* client,
                                                     TraceFlag* tracer,
+                                                    const char* fallback_config,
                                                     grpc_error** error);
 
   // Do not instantiate directly -- use ReadFromFile() above instead.

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -329,6 +329,9 @@ class XdsClient : public DualRefCounted<XdsClient> {
 namespace internal {
 void SetXdsChannelArgsForTest(grpc_channel_args* args);
 void UnsetGlobalXdsClientForTest();
+// Sets bootstrap config to be used when no env var is set.
+// Takes ownership of config.
+void SetXdsFallbackBootstrapConfig(char* config);
 }  // namespace internal
 
 }  // namespace grpc_core


### PR DESCRIPTION
This will be used by the C2P resolver.