### PR TITLE
Include `GRPC::GenericService` from root namespace

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -80,7 +80,7 @@ void PrintService(const ServiceDescriptor* service, Printer* out) {
   // Write the indented class body.
   out->Indent();
   out->Print("\n");
-  out->Print("include GRPC::GenericService\n");
+  out->Print("include ::GRPC::GenericService\n");
   out->Print("\n");
   out->Print("self.marshal_class_method = :encode\n");
   out->Print("self.unmarshal_class_method = :decode\n");


### PR DESCRIPTION
@markdroth

This PR modifies the Ruby service generator to include the `GRPC::GenericService` module from the root namespace, i.e. it replaces:

```ruby
include GRPC::GenericService
```

with:
```ruby
include ::GRPC::GenericService
```

This is useful because otherwise, if you already have a submodule named `GRPC` in any of the class' parent modules, Ruby will use it instead of the grpc gem, e.g.:
```ruby
module MyApp
  module GRPC
    # presumably some GRPC related things in here
  end
end

# Generated by the protocol buffer compiler.
module MyApp
  module MyProtoService
    class Service
      include GRPC::GenericService # Ruby thinks this means MyApp::GRPC::GenericService
    end
  end
end
```