### PR TITLE
Fix xds_end2end_test flakiness

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -5444,17 +5444,17 @@ class XdsSecurityTest : public BasicTest {
     }
     balancers_[0]->ads_service()->SetCdsResource(cluster);
     // The updates might take time to have an effect, so use a retry loop.
-    constexpr int kRetryCount = 10;
+    constexpr int kRetryCount = 100;
     int num_tries = 0;
     for (; num_tries < kRetryCount; num_tries++) {
       // Give some time for the updates to propagate.
       gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(100));
-      ShutdownBackend(0);
-      StartBackend(0);
-      ResetBackendCounters();
       if (test_expects_failure) {
-        Status status = SendRpc();
-        if (status.ok()) {
+        // Restart the servers to force a reconnection so that previously
+        // connected subchannels are not used for the RPC.
+        ShutdownBackend(0);
+        StartBackend(0);
+        if (SendRpc().ok()) {
           gpr_log(GPR_ERROR, "RPC succeeded. Failure expected. Trying again.");
           continue;
         }


### PR DESCRIPTION
Fixes b/174965558

After debugging this, it turned out that the reason for this failure is that the authenticated client identity did not match the expected client identity even with 10 retries. On digging further, turns out that in the round robin policy, on an update, the new subchannel list is only subbed in after it reports READY. In the failure cases, the previous subchannel list was still active and never got replaced. So, even though the channel itself got connected and was able to send RPCs, the RPCs were sent on subchannels from the old subchannel list which meant that certificates from previous updates were used from the connection, resulting in test failures when comparing the authenticated identity with the expected identity.
