### PR TITLE
Add conditional compilation logic for custom iomgr implementation

### DIFF
--- a/src/core/lib/iomgr/iomgr_custom.cc
+++ b/src/core/lib/iomgr/iomgr_custom.cc
@@ -20,6 +20,10 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+bool g_custom_iomgr_enabled = false;
+
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <grpc/support/thd_id.h>
 
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -49,8 +53,6 @@ static bool iomgr_platform_add_closure_to_background_poller(
   return false;
 }
 
-bool g_custom_iomgr_enabled = false;
-
 static grpc_iomgr_platform_vtable vtable = {
     iomgr_platform_init,
     iomgr_platform_flush,
@@ -72,8 +74,8 @@ void grpc_custom_iomgr_init(grpc_socket_vtable* socket,
   grpc_set_iomgr_platform_vtable(&vtable);
 }
 
-#ifdef GRPC_CUSTOM_SOCKET
 grpc_iomgr_platform_vtable* grpc_default_iomgr_platform_vtable() {
   return &vtable;
 }
-#endif
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/iomgr_custom.h
+++ b/src/core/lib/iomgr/iomgr_custom.h
@@ -21,6 +21,10 @@
 
 #include <grpc/support/port_platform.h>
 
+extern bool g_custom_iomgr_enabled;
+
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include "src/core/lib/iomgr/pollset_custom.h"
 #include "src/core/lib/iomgr/resolve_address_custom.h"
 #include "src/core/lib/iomgr/tcp_custom.h"
@@ -39,11 +43,10 @@ extern gpr_thd_id g_init_thread;
 #define GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD()
 #endif /* GRPC_CUSTOM_IOMGR_THREAD_CHECK */
 
-extern bool g_custom_iomgr_enabled;
-
 void grpc_custom_iomgr_init(grpc_socket_vtable* socket,
                             grpc_custom_resolver_vtable* resolver,
                             grpc_custom_timer_vtable* timer,
                             grpc_custom_poller_vtable* poller);
 
+#endif /* GRPC_CUSTOM_SOCKET */
 #endif /* GRPC_CORE_LIB_IOMGR_IOMGR_CUSTOM_H */

--- a/src/core/lib/iomgr/pollset_custom.cc
+++ b/src/core/lib/iomgr/pollset_custom.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <stddef.h>
 #include <string.h>
 
@@ -104,3 +106,5 @@ void grpc_custom_pollset_init(grpc_custom_poller_vtable* vtable) {
   poller_vtable = vtable;
   grpc_set_pollset_vtable(&custom_pollset_vtable);
 }
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/pollset_custom.h
+++ b/src/core/lib/iomgr/pollset_custom.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <stddef.h>
 
 typedef struct grpc_custom_poller_vtable {
@@ -32,4 +34,5 @@ typedef struct grpc_custom_poller_vtable {
 
 void grpc_custom_pollset_init(grpc_custom_poller_vtable* vtable);
 
+#endif /* GRPC_CUSTOM_SOCKET */
 #endif /* GRPC_CORE_LIB_IOMGR_POLLSET_CUSTOM_H */

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -18,6 +18,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include "src/core/lib/iomgr/resolve_address_custom.h"
 
 #include <string.h>
@@ -166,3 +168,5 @@ void grpc_custom_resolver_init(grpc_custom_resolver_vtable* impl) {
   resolve_address_vtable = impl;
   grpc_set_resolver_impl(&custom_resolver_vtable);
 }
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/resolve_address_custom.h
+++ b/src/core/lib/iomgr/resolve_address_custom.h
@@ -23,6 +23,8 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 
@@ -42,4 +44,5 @@ void grpc_custom_resolve_callback(grpc_custom_resolver* resolver,
 /* Internal APIs */
 void grpc_custom_resolver_init(grpc_custom_resolver_vtable* impl);
 
+#endif /* GRPC_CUSTOM_SOCKET */
 #endif /* GRPC_CORE_LIB_IOMGR_RESOLVE_ADDRESS_CUSTOM_H */

--- a/src/core/lib/iomgr/tcp_client_custom.cc
+++ b/src/core/lib/iomgr/tcp_client_custom.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <string.h>
 
 #include <grpc/support/alloc.h>
@@ -159,3 +161,5 @@ static void tcp_connect(grpc_closure* closure, grpc_endpoint** ep,
 }
 
 grpc_tcp_client_vtable custom_tcp_client_vtable = {tcp_connect};
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/tcp_custom.cc
+++ b/src/core/lib/iomgr/tcp_custom.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <limits.h>
 #include <string.h>
 
@@ -389,3 +391,5 @@ grpc_endpoint* custom_tcp_endpoint_create(grpc_custom_socket* socket,
 
   return &tcp->base;
 }
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/tcp_custom.h
+++ b/src/core/lib/iomgr/tcp_custom.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 
@@ -81,4 +83,5 @@ grpc_endpoint* custom_tcp_endpoint_create(grpc_custom_socket* socket,
                                           grpc_resource_quota* resource_quota,
                                           const char* peer_string);
 
+#endif /* GRPC_CUSTOM_SOCKET */
 #endif /* GRPC_CORE_LIB_IOMGR_TCP_CUSTOM_H */

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <assert.h>
 #include <string.h>
 
@@ -480,4 +482,6 @@ grpc_tcp_server_vtable custom_tcp_server_vtable = {
 
 #ifdef GRPC_UV_TEST
 grpc_tcp_server_vtable* default_tcp_server_vtable = &custom_tcp_server_vtable;
-#endif
+#endif /* GRPC_UV_TEST */
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/timer_custom.cc
+++ b/src/core/lib/iomgr/timer_custom.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/iomgr/port.h"
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
@@ -93,3 +95,5 @@ void grpc_custom_timer_init(grpc_custom_timer_vtable* impl) {
   custom_timer_impl = impl;
   grpc_set_timer_impl(&custom_timer_vtable);
 }
+
+#endif /* GRPC_CUSTOM_SOCKET */

--- a/src/core/lib/iomgr/timer_custom.h
+++ b/src/core/lib/iomgr/timer_custom.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#ifdef GRPC_CUSTOM_SOCKET
+
 #include "src/core/lib/iomgr/timer.h"
 
 typedef struct grpc_custom_timer {
@@ -40,4 +42,5 @@ void grpc_custom_timer_init(grpc_custom_timer_vtable* impl);
 
 void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error);
 
+#endif /* GRPC_CUSTOM_SOCKET */
 #endif /* GRPC_CORE_LIB_IOMGR_TIMER_CUSTOM_H */


### PR DESCRIPTION
Much of the `*_custom` iomgr code was compiled with gRPC regardless of
whether GRPC_UV or GRPC_CUSTOM_SOCKET were defined, in environments that
used Posix or Windows iomgr implementations for example. This custom
iomgr implementation relies on low-level networking types (`socklen_t`
for example) to be defined. In cases where the custom implementation was
not enabled at compile time, when the custom impl was compiled
regardless, these types were provided by whatever platform-specific
iomgr implementation was enabled. All current iomgr implementations
introduce these definitions so it hasn't posed a problem.

In trying to write a new kind of iomgr implementation without exposing
socket details to the broader gRPC codebase, the `*_custom` code still
required these types to exist, and they wouldn't necessarily need to
otherwise.

This work wraps the custom iomgr code in `#ifdef`s. As a side effect,
I'm curious if this will reduce the gRPC binary size a bit.
