### PR TITLE
Flag to build latest framework to ASP.NET Core interop tests

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -41,5 +41,5 @@
 
   # Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
   # Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
-  dotnet build --configuration Debug --output ./output/InteropTestsWebsite testassets/InteropTestsWebsite/InteropTestsWebsite.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
-  dotnet build --configuration Debug --output ./output/InteropTestsClient testassets/InteropTestsClient/InteropTestsClient.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
+  dotnet build --configuration Debug --output ./output/InteropTestsWebsite testassets/InteropTestsWebsite/InteropTestsWebsite.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git -p:LatestFramework=true
+  dotnet build --configuration Debug --output ./output/InteropTestsClient testassets/InteropTestsClient/InteropTestsClient.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git -p:LatestFramework=true

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -39,5 +39,5 @@ fi
 
 # Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
 # Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
-dotnet build --configuration Debug --output ./output/InteropTestsWebsite testassets/InteropTestsWebsite/InteropTestsWebsite.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
-dotnet build --configuration Debug --output ./output/InteropTestsClient testassets/InteropTestsClient/InteropTestsClient.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git
+dotnet build --configuration Debug --output ./output/InteropTestsWebsite testassets/InteropTestsWebsite/InteropTestsWebsite.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git -p:LatestFramework=true
+dotnet build --configuration Debug --output ./output/InteropTestsClient testassets/InteropTestsClient/InteropTestsClient.csproj -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git -p:LatestFramework=true


### PR DESCRIPTION
Add a flag to interop tests build script. When set only the latest framework will be built.

The flag currently does nothing but allows future changes to interop apps without breaking these tests.

@jtattermusch 
