### PR TITLE
Raise custom exception on abort

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -80,6 +80,10 @@ def _details(state):
     return b'' if state.details is None else state.details
 
 
+class AbortException(Exception):
+    pass
+
+
 class _HandlerCallDetails(
         collections.namedtuple('_HandlerCallDetails', (
             'method',
@@ -316,7 +320,7 @@ class _Context(grpc.ServicerContext):
             self._state.code = code
             self._state.details = _common.encode(details)
             self._state.aborted = True
-            raise Exception()
+            raise AbortException()
 
     def abort_with_status(self, status):
         self._state.trailing_metadata = status.trailing_metadata


### PR DESCRIPTION
@markdroth

I'd like to make an action on abort in an interceptor, but [a raw `Exception` is raised on abort](https://github.com/grpc/grpc/blob/0539a63274cd73288ec13fea16fa855b01c73e61/src/python/grpcio/grpc/_server.py#L319), which is hard to distinguish from other exceptions. Please consider raising a custom exception so we can handle it.

I'm using the following interceptor for now.

```python
import functools
import logging

import grpc
from grpc.experimental import wrap_server_method_handler

logger = logging.getLogger(__name__)


def handle_exception(e, context) -> None:
    # This is a workaround to catch an abortion, but using private variable `_state` is not good.
    if hasattr(context, "_state") and context._state.aborted:
        raise Exception()

    error_context = None
    if isinstance(e, NotImplementedError):
        error_context = (grpc.StatusCode.UNIMPLEMENTED, "Not implemented")

    if error_context is not None:
        context.abort(error_context[0], error_context[1])

    logger.exception(e)
    context.abort(grpc.StatusCode.INTERNAL, "Internal server error")


def _wrapper(behavior):
    @functools.wraps(behavior)
    def wrapper(request, context):
        try:
            response = behavior(request, context)
        except Exception as e:
            handle_exception(e, context)
            return
        return response

    return wrapper


class ExceptionHandlerServerInterceptor(ServerInterceptor):
    def intercept_service(self, continuation, handler_call_details):
        return wrap_server_method_handler(_wrapper, continuation(handler_call_details))
```