### PR TITLE
make tools/bazel wrapper work on arm64

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -55,6 +55,9 @@ case $(uname -sm) in
   "Linux x86_64")
     suffix=linux-x86_64
     ;;
+  "Linux aarch64")
+    suffix=linux-arm64
+    ;;
   "Darwin x86_64")
     suffix=darwin-x86_64
     ;;


### PR DESCRIPTION
bazel publishes binary distribution for arm64, so this just works (and it makes building on arm hardware easier).