### PR TITLE
Remove BUILD file comment causing problems on import.

### DIFF
--- a/src/proto/grpc/auth/v1/BUILD
+++ b/src/proto/grpc/auth/v1/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])  # Apache v2
+licenses(["notice"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 


### PR DESCRIPTION
This comment is causing a lint check failure internally.