### PR TITLE
refactor!: change error_details functions to templates

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -462,7 +462,6 @@ grpc_cc_library(
     standalone = True,
     deps = [
         "grpc++",
-        "//src/proto/grpc/status:status_proto",
     ],
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3039,12 +3039,7 @@ if(gRPC_INSTALL)
 endif()
 
 
-if(gRPC_BUILD_CODEGEN)
 add_library(grpc++_error_details
-  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.pb.cc
-  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.grpc.pb.cc
-  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.pb.h
-  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.grpc.pb.h
   src/cpp/util/error_details.cc
 )
 
@@ -3097,9 +3092,7 @@ foreach(_hdr
     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
   )
 endforeach()
-endif()
 
-if(gRPC_BUILD_CODEGEN)
 
 if(gRPC_INSTALL)
   install(TARGETS grpc++_error_details EXPORT gRPCTargets
@@ -3109,7 +3102,6 @@ if(gRPC_INSTALL)
   )
 endif()
 
-endif()
 
 if(gRPC_BUILD_CODEGEN)
 add_library(grpc++_reflection
@@ -10804,6 +10796,10 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(error_details_test
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/status/status.grpc.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.pb.h

--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,6 @@ let package = Package(
         "src/cpp/server/load_reporter/",
         "src/cpp/util/core_stats.cc",
         "src/cpp/util/core_stats.h",
-        "src/cpp/util/error_details.cc",
       ],
       sources: [
         "src/cpp/",

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2395,7 +2395,6 @@ libs:
   - include/grpcpp/support/error_details.h
   headers: []
   src:
-  - src/proto/grpc/status/status.proto
   - src/cpp/util/error_details.cc
   deps:
   - grpc++
@@ -5896,6 +5895,7 @@ targets:
   language: c++
   headers: []
   src:
+  - src/proto/grpc/status/status.proto
   - src/proto/grpc/testing/echo_messages.proto
   - test/cpp/util/error_details_test.cc
   deps:

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -1471,7 +1471,6 @@
         'upb',
       ],
       'sources': [
-        'src/proto/grpc/status/status.proto',
         'src/cpp/util/error_details.cc',
       ],
     },

--- a/src/cpp/util/error_details.cc
+++ b/src/cpp/util/error_details.cc
@@ -17,34 +17,3 @@
  */
 
 #include <grpcpp/support/error_details.h>
-
-#include "src/proto/grpc/status/status.pb.h"
-
-namespace grpc {
-
-grpc::Status ExtractErrorDetails(const grpc::Status& from,
-                                 ::google::rpc::Status* to) {
-  if (to == nullptr) {
-    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "");
-  }
-  if (!to->ParseFromString(from.error_details())) {
-    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "");
-  }
-  return grpc::Status::OK;
-}
-
-grpc::Status SetErrorDetails(const ::google::rpc::Status& from,
-                             grpc::Status* to) {
-  if (to == nullptr) {
-    return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "");
-  }
-  grpc::StatusCode code = grpc::StatusCode::UNKNOWN;
-  if (from.code() >= grpc::StatusCode::OK &&
-      from.code() <= grpc::StatusCode::UNAUTHENTICATED) {
-    code = static_cast<grpc::StatusCode>(from.code());
-  }
-  *to = grpc::Status(code, from.message(), from.SerializeAsString());
-  return grpc::Status::OK;
-}
-
-}  // namespace grpc

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -290,6 +290,7 @@ grpc_cc_test(
     ],
     deps = [
         "//:grpc++_error_details",
+        "//src/proto/grpc/status:status_proto",
         "//src/proto/grpc/testing:echo_messages_proto",
         "//test/core/util:grpc_test_util",
     ],


### PR DESCRIPTION
BREAKING CHANGE for the `grpc++_error_details` build target.

release notes: yes

This PR fixes internal tracking bug b/170952273. The summary of that bug is that customers can experience ODR violations when linking with `grpc++_error_details`, which includes a definition for `status.pb.h`, and `google-cloud-cpp`, which also includes definitions for `status.pb.h`. After discussing this issue with `google-cloud-cpp` owners and `grpc` owners, we believe the one official `status.proto` definition should be the one at https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto, and that's the one compiled by `google-cloud-cpp`. 

This PR removes the compiled `status.proto` code from the `grpc++_error_details` library. The user-facing functions in `error_details.h` are now function templates so that they do not require a build dep on `status.proto`. However, this change requires that any _user_ who does want to use these functions must provide their own definition of `status.proto` to link with.

@veblush @yang-g

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25196)
<!-- Reviewable:end -->
