### PR TITLE
Made update_mirror.sh skip the existing files

### DIFF
--- a/bazel/update_mirror.sh
+++ b/bazel/update_mirror.sh
@@ -34,13 +34,18 @@ trap cleanup EXIT
 function upload {
   local file="$1"
 
-  echo "Downloading https://${file}"
-  curl -L --fail --output "${tmpdir}/archive" "https://${file}"
+  if gsutil stat "gs://grpc-bazel-mirror/${file}" > /dev/null
+  then
+    echo "Skipping ${file}"
+  else
+    echo "Downloading https://${file}"
+    curl -L --fail --output "${tmpdir}/archive" "https://${file}"
 
-  echo "Uploading https://${file} to https://storage.googleapis.com/grpc-bazel-mirror/${file}"
-  gsutil cp -n "${tmpdir}/archive" "gs://grpc-bazel-mirror/${file}"  # "-n" will skip existing files
+    echo "Uploading https://${file} to https://storage.googleapis.com/grpc-bazel-mirror/${file}"
+    gsutil cp "${tmpdir}/archive" "gs://grpc-bazel-mirror/${file}"
 
-  rm -rf "${tmpdir}/archive"
+    rm -rf "${tmpdir}/archive"
+  fi
 }
 
 # How to check that all mirror URLs work:


### PR DESCRIPTION
Made update_mirror.sh skip the existing files, which is the most case. It will quickly upload the one needed only.