### PR TITLE
xds-k8s driver: exclude from tests suites

### DIFF
--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -86,7 +86,7 @@ _WHITELIST_DICT = {
     '^test/distrib/php/': [_PHP_TEST_SUITE],
     '^test/distrib/python/': [_PYTHON_TEST_SUITE],
     '^test/distrib/ruby/': [_RUBY_TEST_SUITE],
-    '^tools/run_tests/xds_k8s_test_driver': [],
+    '^tools/run_tests/xds_k8s_test_driver/': [],
     '^vsprojects/': [_WINDOWS_TEST_SUITE],
     'composer\.json$': [_PHP_TEST_SUITE],
     'config\.m4$': [_PHP_TEST_SUITE],

--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -86,6 +86,7 @@ _WHITELIST_DICT = {
     '^test/distrib/php/': [_PHP_TEST_SUITE],
     '^test/distrib/python/': [_PYTHON_TEST_SUITE],
     '^test/distrib/ruby/': [_RUBY_TEST_SUITE],
+    '^tools/run_tests/xds_k8s_test_driver': [],
     '^vsprojects/': [_WINDOWS_TEST_SUITE],
     'composer\.json$': [_PHP_TEST_SUITE],
     'config\.m4$': [_PHP_TEST_SUITE],


### PR DESCRIPTION
[xds-k8s test driver](https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver) is isolated from the grpc source, no need to run expensive Portability Tests builds.