### PR TITLE
xds-k8s driver: do not override wait for deployment timeout_sec

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -240,8 +240,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
             secure_mode=secure_mode)
 
         self._wait_deployment_with_available_replicas(self.deployment_name,
-                                                      replica_count,
-                                                      timeout_sec=120)
+                                                      replica_count)
 
         # Wait for pods running
         pods = self.k8s_namespace.list_deployment_pods(self.deployment)


### PR DESCRIPTION
Now that the default timeout is increased in #25203, use the default timeout.