### PR TITLE
Implement google-c2p resolver.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -332,6 +332,7 @@ grpc_cc_library(
             "grpc_lb_policy_xds_cluster_manager",
             "grpc_lb_policy_xds_cluster_resolver",
             "grpc_resolver_xds",
+            "grpc_resolver_c2p",
             "grpc_xds_server_config_fetcher",
         ],
     },
@@ -1815,6 +1816,19 @@ grpc_cc_library(
     name = "grpc_resolver_xds",
     srcs = [
         "src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc",
+    ],
+    language = "c++",
+    deps = [
+        "grpc_base",
+        "grpc_client_channel",
+        "grpc_xds_client",
+    ],
+)
+
+grpc_cc_library(
+    name = "grpc_resolver_c2p",
+    srcs = [
+        "src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc",
     ],
     language = "c++",
     deps = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -289,6 +289,7 @@ config("grpc_config") {
         "src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc",
         "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc",
         "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h",
+        "src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc",
         "src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc",
         "src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc",
         "src/core/ext/filters/client_channel/resolver/xds/xds_resolver.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1493,6 +1493,7 @@ add_library(grpc
   src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.cc
   src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
   src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+  src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
   src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
   src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
   src/core/ext/filters/client_channel/resolver_registry.cc

--- a/Makefile
+++ b/Makefile
@@ -1080,6 +1080,7 @@ LIBGRPC_SRC = \
     src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.cc \
     src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc \
     src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc \
+    src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc \
     src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc \
     src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc \
     src/core/ext/filters/client_channel/resolver_registry.cc \
@@ -2669,6 +2670,7 @@ src/core/ext/filters/client_channel/lb_policy/xds/cds.cc: $(OPENSSL_DEP)
 src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc: $(OPENSSL_DEP)
 src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc: $(OPENSSL_DEP)
 src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc: $(OPENSSL_DEP)
+src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc: $(OPENSSL_DEP)
 src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc: $(OPENSSL_DEP)
 src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc: $(OPENSSL_DEP)
 src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc: $(OPENSSL_DEP)

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -912,6 +912,7 @@ libs:
   - src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.cc
   - src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
   - src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+  - src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
   - src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
   - src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
   - src/core/ext/filters/client_channel/resolver_registry.cc

--- a/config.m4
+++ b/config.m4
@@ -85,6 +85,7 @@ if test "$PHP_GRPC" != "no"; then
     src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.cc \
     src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc \
     src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc \
+    src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc \
     src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc \
     src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc \
     src/core/ext/filters/client_channel/resolver_registry.cc \
@@ -1018,6 +1019,7 @@ if test "$PHP_GRPC" != "no"; then
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel/resolver/dns/c_ares)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel/resolver/dns/native)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel/resolver/fake)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel/resolver/google_c2p)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel/resolver/sockaddr)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_channel/resolver/xds)
   PHP_ADD_BUILD_DIR($ext_builddir/src/core/ext/filters/client_idle)

--- a/config.w32
+++ b/config.w32
@@ -52,6 +52,7 @@ if (PHP_GRPC != "no") {
     "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\dns_resolver_selection.cc " +
     "src\\core\\ext\\filters\\client_channel\\resolver\\dns\\native\\dns_resolver.cc " +
     "src\\core\\ext\\filters\\client_channel\\resolver\\fake\\fake_resolver.cc " +
+    "src\\core\\ext\\filters\\client_channel\\resolver\\google_c2p\\google_c2p_resolver.cc " +
     "src\\core\\ext\\filters\\client_channel\\resolver\\sockaddr\\sockaddr_resolver.cc " +
     "src\\core\\ext\\filters\\client_channel\\resolver\\xds\\xds_resolver.cc " +
     "src\\core\\ext\\filters\\client_channel\\resolver_registry.cc " +
@@ -1019,6 +1020,7 @@ if (PHP_GRPC != "no") {
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_channel\\resolver\\dns\\c_ares");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_channel\\resolver\\dns\\native");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_channel\\resolver\\fake");
+  FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_channel\\resolver\\google_c2p");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_channel\\resolver\\sockaddr");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_channel\\resolver\\xds");
   FSO.CreateFolder(base_dir+"\\ext\\grpc\\src\\core\\ext\\filters\\client_idle");

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -269,6 +269,7 @@ Pod::Spec.new do |s|
                       'src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc',
                       'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc',
                       'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h',
+                      'src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc',
                       'src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc',
                       'src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc',
                       'src/core/ext/filters/client_channel/resolver/xds/xds_resolver.h',

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -184,6 +184,7 @@ Gem::Specification.new do |s|
   s.files += %w( src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc )
   s.files += %w( src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc )
   s.files += %w( src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h )
+  s.files += %w( src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc )
   s.files += %w( src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc )
   s.files += %w( src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc )
   s.files += %w( src/core/ext/filters/client_channel/resolver/xds/xds_resolver.h )

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -499,6 +499,7 @@
         'src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.cc',
         'src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc',
         'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc',
+        'src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc',
         'src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc',
         'src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc',
         'src/core/ext/filters/client_channel/resolver_registry.cc',

--- a/package.xml
+++ b/package.xml
@@ -164,6 +164,7 @@
     <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc" role="src" />
     <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc" role="src" />
     <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h" role="src" />
+    <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc" role="src" />
     <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc" role="src" />
     <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc" role="src" />
     <file baseinstalldir="/" name="src/core/ext/filters/client_channel/resolver/xds/xds_resolver.h" role="src" />

--- a/src/core/ext/filters/client_channel/resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver.cc
@@ -29,13 +29,10 @@ namespace grpc_core {
 // Resolver
 //
 
-Resolver::Resolver(std::shared_ptr<WorkSerializer> work_serializer,
-                   std::unique_ptr<ResultHandler> result_handler)
+Resolver::Resolver()
     : InternallyRefCounted(GRPC_TRACE_FLAG_ENABLED(grpc_trace_resolver_refcount)
                                ? "Resolver"
-                               : nullptr),
-      work_serializer_(std::move(work_serializer)),
-      result_handler_(std::move(result_handler)) {}
+                               : nullptr) {}
 
 //
 // Resolver::Result

--- a/src/core/ext/filters/client_channel/resolver.h
+++ b/src/core/ext/filters/client_channel/resolver.h
@@ -125,21 +125,10 @@ class Resolver : public InternallyRefCounted<Resolver> {
   }
 
  protected:
-  Resolver(std::shared_ptr<WorkSerializer> work_serializer,
-           std::unique_ptr<ResultHandler> result_handler);
+  Resolver();
 
   /// Shuts down the resolver.
   virtual void ShutdownLocked() = 0;
-
-  std::shared_ptr<WorkSerializer> work_serializer() const {
-    return work_serializer_;
-  }
-
-  ResultHandler* result_handler() const { return result_handler_.get(); }
-
- private:
-  std::shared_ptr<WorkSerializer> work_serializer_;
-  std::unique_ptr<ResultHandler> result_handler_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -91,10 +91,20 @@ class AresDnsResolver : public Resolver {
   std::string name_to_resolve_;
   /// channel args
   grpc_channel_args* channel_args_;
-  /// whether to request the service config
-  bool request_service_config_;
+  std::shared_ptr<WorkSerializer> work_serializer_;
+  std::unique_ptr<ResultHandler> result_handler_;
   /// pollset_set to drive the name resolution process
   grpc_pollset_set* interested_parties_;
+
+  /// whether to request the service config
+  bool request_service_config_;
+  // whether or not to enable SRV DNS queries
+  bool enable_srv_queries_;
+  // timeout in milliseconds for active DNS queries
+  int query_timeout_ms_;
+  /// min interval between DNS requests
+  grpc_millis min_time_between_resolutions_;
+
   /// closures used by the work_serializer
   grpc_closure on_next_resolution_;
   grpc_closure on_resolved_;
@@ -105,8 +115,6 @@ class AresDnsResolver : public Resolver {
   /// next resolution timer
   bool have_next_resolution_timer_ = false;
   grpc_timer next_resolution_timer_;
-  /// min interval between DNS requests
-  grpc_millis min_time_between_resolutions_;
   /// timestamp of last DNS request
   grpc_millis last_resolution_timestamp_ = -1;
   /// retry backoff state
@@ -119,14 +127,25 @@ class AresDnsResolver : public Resolver {
   char* service_config_json_ = nullptr;
   // has shutdown been initiated
   bool shutdown_initiated_ = false;
-  // timeout in milliseconds for active DNS queries
-  int query_timeout_ms_;
-  // whether or not to enable SRV DNS queries
-  bool enable_srv_queries_;
 };
 
 AresDnsResolver::AresDnsResolver(ResolverArgs args)
-    : Resolver(std::move(args.work_serializer), std::move(args.result_handler)),
+    : dns_server_(args.uri.authority()),
+      name_to_resolve_(absl::StripPrefix(args.uri.path(), "/")),
+      channel_args_(grpc_channel_args_copy(args.args)),
+      work_serializer_(std::move(args.work_serializer)),
+      result_handler_(std::move(args.result_handler)),
+      interested_parties_(grpc_pollset_set_create()),
+      request_service_config_(!grpc_channel_args_find_bool(
+          channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION, true)),
+      enable_srv_queries_(grpc_channel_args_find_bool(
+          channel_args_, GRPC_ARG_DNS_ENABLE_SRV_QUERIES, false)),
+      query_timeout_ms_(grpc_channel_args_find_integer(
+          channel_args_, GRPC_ARG_DNS_ARES_QUERY_TIMEOUT_MS,
+          {GRPC_DNS_ARES_DEFAULT_QUERY_TIMEOUT_MS, 0, INT_MAX})),
+      min_time_between_resolutions_(grpc_channel_args_find_integer(
+          channel_args_, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS,
+          {1000 * 30, 0, INT_MAX})),
       backoff_(
           BackOff::Options()
               .set_initial_backoff(GRPC_DNS_INITIAL_CONNECT_BACKOFF_SECONDS *
@@ -134,37 +153,14 @@ AresDnsResolver::AresDnsResolver(ResolverArgs args)
               .set_multiplier(GRPC_DNS_RECONNECT_BACKOFF_MULTIPLIER)
               .set_jitter(GRPC_DNS_RECONNECT_JITTER)
               .set_max_backoff(GRPC_DNS_RECONNECT_MAX_BACKOFF_SECONDS * 1000)) {
-  // Closure Initialization
+  // Closure initialization.
   GRPC_CLOSURE_INIT(&on_next_resolution_, OnNextResolution, this,
                     grpc_schedule_on_exec_ctx);
   GRPC_CLOSURE_INIT(&on_resolved_, OnResolved, this, grpc_schedule_on_exec_ctx);
-  // Get name to resolve from URI path.
-  name_to_resolve_ = std::string(absl::StripPrefix(args.uri.path(), "/"));
-  // Get DNS server from URI authority.
-  dns_server_ = args.uri.authority();
-  channel_args_ = grpc_channel_args_copy(args.args);
-  // Disable service config option
-  const grpc_arg* arg = grpc_channel_args_find(
-      channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION);
-  request_service_config_ = !grpc_channel_arg_get_bool(arg, true);
-  // Min time b/t resolutions option
-  arg = grpc_channel_args_find(channel_args_,
-                               GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
-  min_time_between_resolutions_ =
-      grpc_channel_arg_get_integer(arg, {1000 * 30, 0, INT_MAX});
-  // Enable SRV queries option
-  arg = grpc_channel_args_find(channel_args_, GRPC_ARG_DNS_ENABLE_SRV_QUERIES);
-  enable_srv_queries_ = grpc_channel_arg_get_bool(arg, false);
-  interested_parties_ = grpc_pollset_set_create();
+  // Polling linkage.
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);
   }
-
-  const grpc_arg* query_timeout_ms_arg =
-      grpc_channel_args_find(channel_args_, GRPC_ARG_DNS_ARES_QUERY_TIMEOUT_MS);
-  query_timeout_ms_ = grpc_channel_arg_get_integer(
-      query_timeout_ms_arg,
-      {GRPC_DNS_ARES_DEFAULT_QUERY_TIMEOUT_MS, 0, INT_MAX});
 }
 
 AresDnsResolver::~AresDnsResolver() {
@@ -205,8 +201,8 @@ void AresDnsResolver::ShutdownLocked() {
 void AresDnsResolver::OnNextResolution(void* arg, grpc_error* error) {
   AresDnsResolver* r = static_cast<AresDnsResolver*>(arg);
   GRPC_ERROR_REF(error);  // ref owned by lambda
-  r->work_serializer()->Run([r, error]() { r->OnNextResolutionLocked(error); },
-                            DEBUG_LOCATION);
+  r->work_serializer_->Run([r, error]() { r->OnNextResolutionLocked(error); },
+                           DEBUG_LOCATION);
 }
 
 void AresDnsResolver::OnNextResolutionLocked(grpc_error* error) {
@@ -317,8 +313,8 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
 void AresDnsResolver::OnResolved(void* arg, grpc_error* error) {
   AresDnsResolver* r = static_cast<AresDnsResolver*>(arg);
   GRPC_ERROR_REF(error);  // ref owned by lambda
-  r->work_serializer()->Run([r, error]() { r->OnResolvedLocked(error); },
-                            DEBUG_LOCATION);
+  r->work_serializer_->Run([r, error]() { r->OnResolvedLocked(error); },
+                           DEBUG_LOCATION);
 }
 
 void AresDnsResolver::OnResolvedLocked(grpc_error* error) {
@@ -355,7 +351,7 @@ void AresDnsResolver::OnResolvedLocked(grpc_error* error) {
     }
     result.args = grpc_channel_args_copy_and_add(channel_args_, new_args.data(),
                                                  new_args.size());
-    result_handler()->ReturnResult(std::move(result));
+    result_handler_->ReturnResult(std::move(result));
     addresses_.reset();
     balancer_addresses_.reset();
     // Reset backoff state so that we start from the beginning when the
@@ -366,7 +362,7 @@ void AresDnsResolver::OnResolvedLocked(grpc_error* error) {
                          grpc_error_string(error));
     std::string error_message =
         absl::StrCat("DNS resolution failed for service: ", name_to_resolve_);
-    result_handler()->ReturnError(grpc_error_set_int(
+    result_handler_->ReturnError(grpc_error_set_int(
         GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(error_message.c_str(),
                                                          &error, 1),
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));
@@ -436,7 +432,7 @@ void AresDnsResolver::StartResolvingLocked() {
       interested_parties_, &on_resolved_, &addresses_,
       enable_srv_queries_ ? &balancer_addresses_ : nullptr,
       request_service_config_ ? &service_config_json_ : nullptr,
-      query_timeout_ms_, work_serializer());
+      query_timeout_ms_, work_serializer_);
   last_resolution_timestamp_ = grpc_core::ExecCtx::Get()->Now();
   GRPC_CARES_TRACE_LOG("resolver:%p Started resolving. pending_request_:%p",
                        this, pending_request_);

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -77,6 +77,8 @@ class NativeDnsResolver : public Resolver {
   std::string name_to_resolve_;
   /// channel args
   grpc_channel_args* channel_args_ = nullptr;
+  std::shared_ptr<WorkSerializer> work_serializer_;
+  std::unique_ptr<ResultHandler> result_handler_;
   /// pollset_set to drive the name resolution process
   grpc_pollset_set* interested_parties_ = nullptr;
   /// are we shutting down?
@@ -99,7 +101,14 @@ class NativeDnsResolver : public Resolver {
 };
 
 NativeDnsResolver::NativeDnsResolver(ResolverArgs args)
-    : Resolver(std::move(args.work_serializer), std::move(args.result_handler)),
+    : name_to_resolve_(absl::StripPrefix(args.uri.path(), "/")),
+      channel_args_(grpc_channel_args_copy(args.args)),
+      work_serializer_(std::move(args.work_serializer)),
+      result_handler_(std::move(args.result_handler)),
+      interested_parties_(grpc_pollset_set_create()),
+      min_time_between_resolutions_(grpc_channel_args_find_integer(
+          channel_args_, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS,
+          {1000 * 30, 0, INT_MAX})),
       backoff_(
           BackOff::Options()
               .set_initial_backoff(GRPC_DNS_INITIAL_CONNECT_BACKOFF_SECONDS *
@@ -107,13 +116,6 @@ NativeDnsResolver::NativeDnsResolver(ResolverArgs args)
               .set_multiplier(GRPC_DNS_RECONNECT_BACKOFF_MULTIPLIER)
               .set_jitter(GRPC_DNS_RECONNECT_JITTER)
               .set_max_backoff(GRPC_DNS_RECONNECT_MAX_BACKOFF_SECONDS * 1000)) {
-  name_to_resolve_ = std::string(absl::StripPrefix(args.uri.path(), "/"));
-  channel_args_ = grpc_channel_args_copy(args.args);
-  const grpc_arg* arg = grpc_channel_args_find(
-      args.args, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
-  min_time_between_resolutions_ =
-      grpc_channel_arg_get_integer(arg, {1000 * 30, 0, INT_MAX});
-  interested_parties_ = grpc_pollset_set_create();
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);
   }
@@ -149,8 +151,8 @@ void NativeDnsResolver::ShutdownLocked() {
 void NativeDnsResolver::OnNextResolution(void* arg, grpc_error* error) {
   NativeDnsResolver* r = static_cast<NativeDnsResolver*>(arg);
   GRPC_ERROR_REF(error);  // ref owned by lambda
-  r->work_serializer()->Run([r, error]() { r->OnNextResolutionLocked(error); },
-                            DEBUG_LOCATION);
+  r->work_serializer_->Run([r, error]() { r->OnNextResolutionLocked(error); },
+                           DEBUG_LOCATION);
 }
 
 void NativeDnsResolver::OnNextResolutionLocked(grpc_error* error) {
@@ -165,8 +167,8 @@ void NativeDnsResolver::OnNextResolutionLocked(grpc_error* error) {
 void NativeDnsResolver::OnResolved(void* arg, grpc_error* error) {
   NativeDnsResolver* r = static_cast<NativeDnsResolver*>(arg);
   GRPC_ERROR_REF(error);  // owned by lambda
-  r->work_serializer()->Run([r, error]() { r->OnResolvedLocked(error); },
-                            DEBUG_LOCATION);
+  r->work_serializer_->Run([r, error]() { r->OnResolvedLocked(error); },
+                           DEBUG_LOCATION);
 }
 
 void NativeDnsResolver::OnResolvedLocked(grpc_error* error) {
@@ -186,7 +188,7 @@ void NativeDnsResolver::OnResolvedLocked(grpc_error* error) {
     }
     grpc_resolved_addresses_destroy(addresses_);
     result.args = grpc_channel_args_copy(channel_args_);
-    result_handler()->ReturnResult(std::move(result));
+    result_handler_->ReturnResult(std::move(result));
     // Reset backoff state so that we start from the beginning when the
     // next request gets triggered.
     backoff_.Reset();
@@ -196,7 +198,7 @@ void NativeDnsResolver::OnResolvedLocked(grpc_error* error) {
     // Return transient error.
     std::string error_message =
         absl::StrCat("DNS resolution failed for service: ", name_to_resolve_);
-    result_handler()->ReturnError(grpc_error_set_int(
+    result_handler_->ReturnError(grpc_error_set_int(
         GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(error_message.c_str(),
                                                          &error, 1),
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));

--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -1,0 +1,360 @@
+//
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/ext/filters/client_channel/resolver_registry.h"
+#include "src/core/ext/xds/xds_client.h"
+#include "src/core/lib/gpr/env.h"
+#include "src/core/lib/http/httpcli.h"
+#include "src/core/lib/iomgr/polling_entity.h"
+#include "src/core/lib/security/credentials/alts/check_gcp_environment.h"
+
+namespace grpc_core {
+
+namespace {
+
+class GoogleCloud2ProdResolver : public Resolver {
+ public:
+  explicit GoogleCloud2ProdResolver(ResolverArgs args);
+
+  void StartLocked() override;
+  void RequestReresolutionLocked() override;
+  void ResetBackoffLocked() override;
+  void ShutdownLocked() override;
+
+ private:
+  // Represents an HTTP request to the metadata server.
+  class MetadataQuery : public InternallyRefCounted<MetadataQuery> {
+   public:
+    MetadataQuery(RefCountedPtr<GoogleCloud2ProdResolver> resolver,
+                  const char* path, grpc_polling_entity* pollent);
+    ~MetadataQuery() override;
+
+    void Orphan() override;
+
+   private:
+    static void OnHttpRequestDone(void* arg, grpc_error* error);
+
+    void MaybeCallOnDone(grpc_error* error);
+
+    // If error is not GRPC_ERROR_NONE, then it's not safe to look at response.
+    virtual void OnDone(GoogleCloud2ProdResolver* resolver,
+                        const grpc_http_response* response,
+                        grpc_error* error) = 0;
+
+    RefCountedPtr<GoogleCloud2ProdResolver> resolver_;
+    grpc_httpcli_context context_;
+    grpc_httpcli_response response_;
+    grpc_closure on_done_;
+    Atomic<bool> on_done_called_{false};
+  };
+
+  // A metadata server query to get the zone.
+  class ZoneQuery : public MetadataQuery {
+   public:
+    ZoneQuery(RefCountedPtr<GoogleCloud2ProdResolver> resolver,
+              grpc_polling_entity* pollent);
+
+   private:
+    void OnDone(GoogleCloud2ProdResolver* resolver,
+                const grpc_http_response* response, grpc_error* error) override;
+  };
+
+  // A metadata server query to get the IPv6 address.
+  class IPv6Query : public MetadataQuery {
+   public:
+    IPv6Query(RefCountedPtr<GoogleCloud2ProdResolver> resolver,
+              grpc_polling_entity* pollent);
+
+   private:
+    void OnDone(GoogleCloud2ProdResolver* resolver,
+                const grpc_http_response* response, grpc_error* error) override;
+  };
+
+  void ZoneQueryDone(std::string zone);
+  void IPv6QueryDone(bool ipv6_supported);
+  void StartXdsResolver();
+
+  std::shared_ptr<WorkSerializer> work_serializer_;
+  grpc_polling_entity pollent_;
+  bool using_dns_ = false;
+  OrphanablePtr<Resolver> child_resolver_;
+
+  OrphanablePtr<ZoneQuery> zone_query_;
+  absl::optional<std::string> zone_;
+
+  OrphanablePtr<IPv6Query> ipv6_query_;
+  absl::optional<bool> supports_ipv6_;
+};
+
+//
+// GoogleCloud2ProdResolver::MetadataQuery
+//
+
+GoogleCloud2ProdResolver::MetadataQuery::MetadataQuery(
+    RefCountedPtr<GoogleCloud2ProdResolver> resolver, const char* path,
+    grpc_polling_entity* pollent)
+    : resolver_(std::move(resolver)) {
+  grpc_httpcli_context_init(&context_);
+  // Start HTTP request.
+  GRPC_CLOSURE_INIT(&on_done_, OnHttpRequestDone, this, nullptr);
+  Ref().release();  // Ref held by callback.
+  grpc_httpcli_request request;
+  memset(&request, 0, sizeof(grpc_httpcli_request));
+  grpc_http_header header = {const_cast<char*>("Metadata-Flavor"),
+                             const_cast<char*>("Google")};
+  request.host = const_cast<char*>("metadata.google.internal");
+  request.http.path = const_cast<char*>(path);
+  request.http.hdr_count = 1;
+  request.http.hdrs = &header;
+  grpc_resource_quota* resource_quota =
+      grpc_resource_quota_create("c2p_resolver");
+  grpc_httpcli_get(&context_, pollent, resource_quota, &request,
+                   ExecCtx::Get()->Now() + 10000,  // 10s timeout
+                   &on_done_, &response_);
+  grpc_resource_quota_unref_internal(resource_quota);
+}
+
+GoogleCloud2ProdResolver::MetadataQuery::~MetadataQuery() {
+  grpc_httpcli_context_destroy(&context_);
+}
+
+void GoogleCloud2ProdResolver::MetadataQuery::Orphan() {
+  // TODO(roth): Once the HTTP client library supports cancellation,
+  // use that here.
+  MaybeCallOnDone(GRPC_ERROR_CANCELLED);
+  Unref();
+}
+
+void GoogleCloud2ProdResolver::MetadataQuery::OnHttpRequestDone(
+    void* arg, grpc_error* error) {
+  auto* self = static_cast<MetadataQuery*>(arg);
+  self->MaybeCallOnDone(error);
+  grpc_http_response_destroy(&self->response_);
+  self->Unref();
+}
+
+void GoogleCloud2ProdResolver::MetadataQuery::MaybeCallOnDone(
+    grpc_error* error) {
+  bool expected = false;
+  if (on_done_called_.CompareExchangeStrong(
+          &expected, true, MemoryOrder::RELAXED, MemoryOrder::RELAXED)) {
+    // Hop back into WorkSerializer.
+    Ref().release();  // Ref held by callback.
+    resolver_->work_serializer_->Run(
+        [this, error]() {
+          OnDone(resolver_.get(), &response_, error);
+          Unref();
+        },
+        DEBUG_LOCATION);
+  } else {
+    GRPC_ERROR_UNREF(error);
+  }
+}
+
+//
+// GoogleCloud2ProdResolver::ZoneQuery
+//
+
+GoogleCloud2ProdResolver::ZoneQuery::ZoneQuery(
+    RefCountedPtr<GoogleCloud2ProdResolver> resolver,
+    grpc_polling_entity* pollent)
+    : MetadataQuery(std::move(resolver), "/computeMetadata/v1/instance/zone",
+                    pollent) {}
+
+void GoogleCloud2ProdResolver::ZoneQuery::OnDone(
+    GoogleCloud2ProdResolver* resolver, const grpc_http_response* response,
+    grpc_error* error) {
+  if (error != GRPC_ERROR_NONE) {
+    gpr_log(GPR_ERROR, "error fetching zone from metadata server: %s",
+            grpc_error_string(error));
+  }
+  std::string zone;
+  if (error == GRPC_ERROR_NONE && response->status == 200) {
+    absl::string_view body(response->body, response->body_length);
+    size_t i = body.find_last_of('/');
+    if (i == body.npos) {
+      gpr_log(GPR_ERROR, "could not parse zone from metadata server: %s",
+              std::string(body).c_str());
+    } else {
+      zone = std::string(body.substr(i));
+    }
+  }
+  resolver->ZoneQueryDone(std::move(zone));
+  GRPC_ERROR_UNREF(error);
+}
+
+//
+// GoogleCloud2ProdResolver::IPv6Query
+//
+
+GoogleCloud2ProdResolver::IPv6Query::IPv6Query(
+    RefCountedPtr<GoogleCloud2ProdResolver> resolver,
+    grpc_polling_entity* pollent)
+    : MetadataQuery(std::move(resolver),
+                    "/computeMetadata/v1/instance/network-interfaces/0/ipv6s",
+                    pollent) {}
+
+void GoogleCloud2ProdResolver::IPv6Query::OnDone(
+    GoogleCloud2ProdResolver* resolver, const grpc_http_response* response,
+    grpc_error* error) {
+  if (error != GRPC_ERROR_NONE) {
+    gpr_log(GPR_ERROR, "error fetching IPv6 address from metadata server: %s",
+            grpc_error_string(error));
+  }
+  resolver->IPv6QueryDone(error == GRPC_ERROR_NONE && response->status == 200);
+  GRPC_ERROR_UNREF(error);
+}
+
+//
+// GoogleCloud2ProdResolver
+//
+
+GoogleCloud2ProdResolver::GoogleCloud2ProdResolver(ResolverArgs args)
+    : work_serializer_(std::move(args.work_serializer)),
+      pollent_(grpc_polling_entity_create_from_pollset_set(args.pollset_set)) {
+  absl::string_view name_to_resolve = absl::StripPrefix(args.uri.path(), "/");
+  // If we're not running on GCP, we can't use DirectPath, so delegate
+  // to the DNS resolver.
+  if (!grpc_alts_is_running_on_gcp() ||
+      // If the client is already using xDS, we can't use it here, because
+      // they may be talking to a completely different xDS server than we
+      // want to.
+      // TODO(roth): When we implement xDS federation, remove this constraint.
+      UniquePtr<char>(gpr_getenv("GRPC_XDS_BOOTSTRAP")) != nullptr ||
+      UniquePtr<char>(gpr_getenv("GRPC_XDS_BOOTSTRAP_CONFIG")) != nullptr) {
+    using_dns_ = true;
+    child_resolver_ = ResolverRegistry::CreateResolver(
+        absl::StrCat("dns:", name_to_resolve).c_str(), args.args,
+        args.pollset_set, work_serializer_, std::move(args.result_handler));
+    GPR_ASSERT(child_resolver_ != nullptr);
+    return;
+  }
+  // Create xds resolver.
+  child_resolver_ = ResolverRegistry::CreateResolver(
+      absl::StrCat("xds:", name_to_resolve).c_str(), args.args,
+      args.pollset_set, work_serializer_, std::move(args.result_handler));
+  GPR_ASSERT(child_resolver_ != nullptr);
+}
+
+void GoogleCloud2ProdResolver::StartLocked() {
+  if (using_dns_) {
+    child_resolver_->StartLocked();
+    return;
+  }
+  // Using xDS.  Start metadata server queries.
+  zone_query_ = MakeOrphanable<ZoneQuery>(Ref(), &pollent_);
+  ipv6_query_ = MakeOrphanable<IPv6Query>(Ref(), &pollent_);
+}
+
+void GoogleCloud2ProdResolver::RequestReresolutionLocked() {
+  if (child_resolver_ != nullptr) {
+    child_resolver_->RequestReresolutionLocked();
+  }
+}
+
+void GoogleCloud2ProdResolver::ResetBackoffLocked() {
+  if (child_resolver_ != nullptr) {
+    child_resolver_->ResetBackoffLocked();
+  }
+}
+
+void GoogleCloud2ProdResolver::ShutdownLocked() {
+  zone_query_.reset();
+  ipv6_query_.reset();
+  child_resolver_.reset();
+}
+
+void GoogleCloud2ProdResolver::ZoneQueryDone(std::string zone) {
+  zone_query_.reset();
+  zone_ = std::move(zone);
+  if (supports_ipv6_.has_value()) StartXdsResolver();
+}
+
+void GoogleCloud2ProdResolver::IPv6QueryDone(bool ipv6_supported) {
+  ipv6_query_.reset();
+  supports_ipv6_ = ipv6_supported;
+  if (zone_.has_value()) StartXdsResolver();
+}
+
+void GoogleCloud2ProdResolver::StartXdsResolver() {
+  // Construct bootstrap JSON.
+  Json::Object node = {
+      {"id", "C2P"},
+      {"locality",
+       Json::Object{
+           {"zone", *zone_},
+       }},
+  };
+  if (*supports_ipv6_) {
+    node["metadata"] = Json::Object{
+        {"TRAFFICDIRECTOR_DIRECTPATH_C2P_IPV6_CAPABLE", true},
+    };
+  }
+  Json bootstrap = Json::Object{
+      {"xds_servers",
+       Json::Array{
+           Json::Object{
+               {"server_uri", "directpath-trafficdirector.googleapis.com"},
+               {"channel_creds",
+                Json::Array{
+                    Json::Object{
+                        {"type", "google_default"},
+                    },
+                }},
+           },
+       }},
+      {"node", std::move(node)},
+  };
+  // Inject bootstrap JSON as fallback config.
+  internal::SetXdsFallbackBootstrapConfig(bootstrap.Dump().c_str());
+  // Now start xDS resolver.
+  child_resolver_->StartLocked();
+}
+
+//
+// Factory
+//
+
+class GoogleCloud2ProdResolverFactory : public ResolverFactory {
+ public:
+  bool IsValidUri(const URI& uri) const override {
+    if (GPR_UNLIKELY(!uri.authority().empty())) {
+      gpr_log(GPR_ERROR, "google-c2p URI scheme does not support authorities");
+      return false;
+    }
+    return true;
+  }
+
+  OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
+    if (!IsValidUri(args.uri)) return nullptr;
+    return MakeOrphanable<GoogleCloud2ProdResolver>(std::move(args));
+  }
+
+  const char* scheme() const override { return "google-c2p"; }
+};
+
+}  // namespace
+
+void GoogleCloud2ProdResolverInit() {
+  ResolverRegistry::Builder::RegisterResolverFactory(
+      absl::make_unique<GoogleCloud2ProdResolverFactory>());
+}
+
+void GoogleCloud2ProdResolverShutdown() {}
+
+}  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -35,7 +35,6 @@
 #include "src/core/lib/iomgr/parse_address.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/unix_sockets_posix.h"
-#include "src/core/lib/iomgr/work_serializer.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/slice/slice_string_helpers.h"
 
@@ -53,13 +52,14 @@ class SockaddrResolver : public Resolver {
   void ShutdownLocked() override {}
 
  private:
+  std::unique_ptr<ResultHandler> result_handler_;
   ServerAddressList addresses_;
   const grpc_channel_args* channel_args_ = nullptr;
 };
 
 SockaddrResolver::SockaddrResolver(ServerAddressList addresses,
                                    ResolverArgs args)
-    : Resolver(std::move(args.work_serializer), std::move(args.result_handler)),
+    : result_handler_(std::move(args.result_handler)),
       addresses_(std::move(addresses)),
       channel_args_(grpc_channel_args_copy(args.args)) {}
 
@@ -73,7 +73,7 @@ void SockaddrResolver::StartLocked() {
   // TODO(roth): Use std::move() once channel args is converted to C++.
   result.args = channel_args_;
   channel_args_ = nullptr;
-  result_handler()->ReturnResult(std::move(result));
+  result_handler_->ReturnResult(std::move(result));
 }
 
 //

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2228,10 +2228,10 @@ void UnsetGlobalXdsClientForTest() {
   g_xds_client = nullptr;
 }
 
-void SetXdsFallbackBootstrapConfig(char* config) {
+void SetXdsFallbackBootstrapConfig(const char* config) {
   MutexLock lock(g_mu);
   gpr_free(g_fallback_bootstrap_config);
-  g_fallback_bootstrap_config = config;
+  g_fallback_bootstrap_config = gpr_strdup(config);
 }
 
 }  // namespace internal

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -330,8 +330,8 @@ namespace internal {
 void SetXdsChannelArgsForTest(grpc_channel_args* args);
 void UnsetGlobalXdsClientForTest();
 // Sets bootstrap config to be used when no env var is set.
-// Takes ownership of config.
-void SetXdsFallbackBootstrapConfig(char* config);
+// Does not take ownership of config.
+void SetXdsFallbackBootstrapConfig(const char* config);
 }  // namespace internal
 
 }  // namespace grpc_core

--- a/src/core/plugin_registry/grpc_plugin_registry.cc
+++ b/src/core/plugin_registry/grpc_plugin_registry.cc
@@ -82,6 +82,10 @@ void grpc_lb_policy_xds_cluster_manager_init(void);
 void grpc_lb_policy_xds_cluster_manager_shutdown(void);
 void grpc_resolver_xds_init(void);
 void grpc_resolver_xds_shutdown(void);
+namespace grpc_core {
+void GoogleCloud2ProdResolverInit();
+void GoogleCloud2ProdResolverShutdown();
+}
 #endif
 
 void grpc_register_built_in_plugins(void) {
@@ -142,5 +146,7 @@ void grpc_register_built_in_plugins(void) {
                        grpc_lb_policy_xds_cluster_manager_shutdown);
   grpc_register_plugin(grpc_resolver_xds_init,
                        grpc_resolver_xds_shutdown);
+  grpc_register_plugin(grpc_core::GoogleCloud2ProdResolverInit,
+                       grpc_core::GoogleCloud2ProdResolverShutdown);
 #endif
 }

--- a/src/python/grpcio/grpc_core_dependencies.py
+++ b/src/python/grpcio/grpc_core_dependencies.py
@@ -61,6 +61,7 @@ CORE_SOURCE_FILES = [
     'src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.cc',
     'src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc',
     'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc',
+    'src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc',
     'src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc',
     'src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc',
     'src/core/ext/filters/client_channel/resolver_registry.cc',

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -1119,6 +1119,7 @@ src/core/ext/filters/client_channel/resolver/dns/dns_resolver_selection.h \
 src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc \
 src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc \
 src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h \
+src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc \
 src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc \
 src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc \
 src/core/ext/filters/client_channel/resolver/xds/xds_resolver.h \

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -947,6 +947,7 @@ src/core/ext/filters/client_channel/resolver/dns/native/README.md \
 src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc \
 src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc \
 src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h \
+src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc \
 src/core/ext/filters/client_channel/resolver/sockaddr/README.md \
 src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc \
 src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc \


### PR DESCRIPTION
As part of this, I've changed the `Resolver` API such that the base class no longer takes ownership of the `WorkSerializer` or `ResultHandler`.  That will require internal changes, so I'll put together a cherry-pick for that once we're happy with this PR.

I don't really have a good way to test the C2P resolver, but I'm hoping that you can put together an interop test that will cover it.