### PR TITLE
Fix broken nightly build and publish due to MacOS x86 protoc deprecation

### DIFF
--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -49,7 +49,7 @@ for zip_dir in protoc_windows_{x86,x64}
 do
   zip -jr "$PROTOC_PLUGINS_ZIPPED_PACKAGES/grpc-$zip_dir-$GRPC_VERSION.zip" "$INPUT_ARTIFACTS/$zip_dir/"*
 done
-for tar_dir in protoc_{linux,macos}_{x86,x64}
+for tar_dir in protoc_linux_x86 protoc_linux_x64 protoc_macos_x64
 do
   chmod +x "$INPUT_ARTIFACTS/$tar_dir"/*
   tar -cvzf "$PROTOC_PLUGINS_ZIPPED_PACKAGES/grpc-$tar_dir-$GRPC_VERSION.tar.gz" -C "$INPUT_ARTIFACTS/$tar_dir" .


### PR DESCRIPTION
The grpc_publish_packages.sh build script has been broken since 2020-12-03 due
to commit 010d9f302, after which protoc artifacts for MacOS x86 were no
longer being built. See #24870. The internal log for the
`grpc/core/nightly/grpc_publish_packages` job show failures for `chmod +x
<nothing>`.

As pointed out in #25210, https://packages.grpc.io/ has not been updated
since 2020-12-02. This should fix the build.