### PR TITLE
PHP: add initializing start batch message buffer

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -294,7 +294,7 @@ PHP_METHOD(Call, startBatch) {
   grpc_status_code status;
   grpc_slice recv_status_details = grpc_empty_slice();
   grpc_slice send_status_details = grpc_empty_slice();
-  grpc_byte_buffer *message;
+  grpc_byte_buffer *message = NULL;
   int cancelled;
   grpc_call_error error;
 

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -289,6 +289,20 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
         $status = $call->getStatus();
         $this->assertSame(\Grpc\STATUS_OK, $status->code);
     }
+
+    public function testReuseCall()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("start_batch was called incorrectly");
+        $div_arg = new Math\DivArgs();
+        $div_arg->setDividend(7);
+        $div_arg->setDivisor(4);
+        $call = self::$client->Div($div_arg, [], ['timeout' => 1000000]);
+
+        list($response, $status) = $call->wait();
+        $this->assertSame(\Grpc\STATUS_OK, $status->code);
+        list($response, $status) = $call->wait();
+    }
 }
 
 class DummyInvalidClient extends \Grpc\BaseStub


### PR DESCRIPTION
a simpler fix of PR #24914, to avoid SEGFAULT on buffer destroy, if a unary call is called twice. 

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@stanley-cheung 
