### PR TITLE
PHP: Fix PHPUnit 8 warnings of gen code test

### DIFF
--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -70,19 +70,32 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
     public function testMetadata()
     {
         $div_arg = new Math\DivArgs();
+        $div_arg->setDividend(7);
+        $div_arg->setDivisor(4);
         $call = self::$client->Div($div_arg, ['somekey' => ['abc123']]);
+        // $this->assertNotNull($call);
+        list($response, $status) = $call->wait();
+        $this->assertSame(\Grpc\STATUS_OK, $status->code);
     }
 
     public function testMetadataKey()
     {
         $div_arg = new Math\DivArgs();
+        $div_arg->setDividend(7);
+        $div_arg->setDivisor(4);
         $call = self::$client->Div($div_arg, ['somekey_-1' => ['abc123']]);
+        list($response, $status) = $call->wait();
+        $this->assertSame(\Grpc\STATUS_OK, $status->code);
     }
 
     public function testMetadataKeyWithDot()
     {
         $div_arg = new Math\DivArgs();
+        $div_arg->setDividend(7);
+        $div_arg->setDivisor(4);
         $call = self::$client->Div($div_arg, ['someKEY._-1' => ['abc123']]);
+        list($response, $status) = $call->wait();
+        $this->assertSame(\Grpc\STATUS_OK, $status->code);
     }
 
     public function testMetadataInvalidKey()
@@ -170,6 +183,7 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
             'grpc.primary_user_agent' => 'testUserAgent',
         ]);
+        $this->assertTrue(TRUE); // to avoid no assert warning
     }
 
     public function testWriteFlags()

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -52,21 +52,17 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(is_string(self::$client->getTarget()));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testClose()
     {
+        $this->expectException(\InvalidArgumentException::class);
         self::$client->close();
         $div_arg = new Math\DivArgs();
         $call = self::$client->Div($div_arg);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMetadata()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $div_arg = new Math\DivArgs();
         $call = self::$client->Div($div_arg, [' ' => 'abc123']);
     }
@@ -89,11 +85,9 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
         $call = self::$client->Div($div_arg, ['someKEY._-1' => ['abc123']]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testMetadataInvalidKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $div_arg = new Math\DivArgs();
         $call = self::$client->Div($div_arg, ['(somekey)' => ['abc123']]);
     }
@@ -152,11 +146,9 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(\Grpc\STATUS_CANCELLED, $status->code);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidMethodName()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $invalid_client = new DummyInvalidClient('host', [
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ]);
@@ -164,11 +156,10 @@ abstract class AbstractGeneratedCodeTest extends \PHPUnit\Framework\TestCase
         $invalid_client->InvalidUnaryCall($div_arg);
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testMissingCredentials()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("The opts['credentials'] key is now required.");
         $invalid_client = new DummyInvalidClient('host', [
         ]);
     }


### PR DESCRIPTION
Fix warnings of generated code tests.
This is one of clean up tasks for migrating to PHPUnit 8.

@stanley-cheung

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

