### PR TITLE
Remove grpc_authorization_engine default dependency to avoid large RE2 binary footprint.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -337,7 +337,6 @@ grpc_cc_library(
     },
     standalone = True,
     deps = [
-        "grpc_authorization_engine",
         "grpc_common",
         "grpc_lb_policy_grpclb_secure",
         "grpc_secure",


### PR DESCRIPTION
grpc_authorization_engine target includes RE2, which has a large binary footprint. 

This PR removes grpc_authorization_target from gRPC when we choose to build gRPC without xDS.