### PR TITLE
Fix format

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -43,7 +43,6 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wvla",
     # Exceptions but will be removed
     "-Wno-deprecated-declarations",
-    "-Wno-format",
     "-Wno-missing-field-initializers",
     "-Wno-sign-compare",
     "-Wno-unused-function",

--- a/src/cpp/server/load_reporter/load_reporter.cc
+++ b/src/cpp/server/load_reporter/load_reporter.cc
@@ -18,6 +18,7 @@
 
 #include <grpc/impl/codegen/port_platform.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <chrono>
@@ -227,7 +228,7 @@ std::string LoadReporter::GenerateLbId() {
     GPR_ASSERT(lb_id >= 0);
     // Convert to padded hex string for a 32-bit LB ID. E.g, "0000ca5b".
     char buf[kLbIdLength + 1];
-    snprintf(buf, sizeof(buf), "%08lx", lb_id);
+    snprintf(buf, sizeof(buf), "%08" PRIx64, lb_id);
     std::string lb_id_str(buf, kLbIdLength);
     // The client may send requests with LB ID that has never been allocated
     // by this load reporter. Those IDs are tracked and will be skipped when

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -18,6 +18,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <inttypes.h>
+
 #include "absl/memory/memory.h"
 
 #include "src/cpp/server/load_reporter/load_reporter_async_service_impl.h"
@@ -216,12 +218,12 @@ void LoadReporterAsyncServiceImpl::ReportLoadHandler::OnReadDone(
       load_report_interval_ms_ =
           static_cast<unsigned long>(load_report_interval.seconds() * 1000 +
                                      load_report_interval.nanos() / 1000);
-      gpr_log(
-          GPR_INFO,
-          "[LRS %p] Initial request received. Start load reporting (load "
-          "balanced host: %s, interval: %lu ms, lb_id_: %s, handler: %p)...",
-          service_, load_balanced_hostname_.c_str(), load_report_interval_ms_,
-          lb_id_.c_str(), this);
+      gpr_log(GPR_INFO,
+              "[LRS %p] Initial request received. Start load reporting (load "
+              "balanced host: %s, interval: %" PRIu64
+              " ms, lb_id_: %s, handler: %p)...",
+              service_, load_balanced_hostname_.c_str(),
+              load_report_interval_ms_, lb_id_.c_str(), this);
       SendReport(self, true /* ok */);
       // Expect this read to fail.
       {


### PR DESCRIPTION
Enabled `format` warning and fixed the existing warnings.