### PR TITLE
Fix sign compare warning

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -45,7 +45,6 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wno-deprecated-declarations",
     "-Wno-format",
     "-Wno-missing-field-initializers",
-    "-Wno-sign-compare",
     "-Wno-unused-function",
 ]
 

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -200,7 +200,7 @@ void ServerLoadReportingCallData::StoreClientIpAndLrToken(const char* lr_token,
     strncpy(cur_pos, lr_token, lr_token_len);
   }
   GPR_ASSERT(cur_pos + lr_token_len - client_ip_and_lr_token_ ==
-             client_ip_and_lr_token_len_);
+             long(client_ip_and_lr_token_len_));
 }
 
 grpc_filtered_mdelem ServerLoadReportingCallData::RecvInitialMetadataFilter(

--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -316,7 +316,7 @@ void ExternalAccountCredentials::OnExchangeTokenInternal(grpc_error* error) {
           std::string(ctx_->response.body, ctx_->response.body_length).c_str());
       metadata_req_->response.hdrs = static_cast<grpc_http_header*>(
           gpr_malloc(sizeof(grpc_http_header) * ctx_->response.hdr_count));
-      for (int i = 0; i < ctx_->response.hdr_count; i++) {
+      for (size_t i = 0; i < ctx_->response.hdr_count; i++) {
         metadata_req_->response.hdrs[i].key =
             gpr_strdup(ctx_->response.hdrs[i].key);
         metadata_req_->response.hdrs[i].value =
@@ -443,7 +443,7 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
   metadata_req_->response.body_length = body.length();
   metadata_req_->response.hdrs = static_cast<grpc_http_header*>(
       gpr_malloc(sizeof(grpc_http_header) * ctx_->response.hdr_count));
-  for (int i = 0; i < ctx_->response.hdr_count; i++) {
+  for (size_t i = 0; i < ctx_->response.hdr_count; i++) {
     metadata_req_->response.hdrs[i].key =
         gpr_strdup(ctx_->response.hdrs[i].key);
     metadata_req_->response.hdrs[i].value =

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -417,7 +417,7 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMiddleUuidCheck) {
   Json& array = (*parsed_json.mutable_object())["channel"];
   ValidateJsonArraySize(array, kNumChannels - kMidQuery + 1);
   std::vector<intptr_t> uuids = GetUuidListFromArray(array.array_value());
-  for (int i = 0; i < uuids.size(); ++i) {
+  for (size_t i = 0; i < uuids.size(); ++i) {
     EXPECT_EQ(static_cast<intptr_t>(kMidQuery + i), uuids[i]);
   }
 }
@@ -439,7 +439,7 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsNoHitUuid) {
   Json& array = (*parsed_json.mutable_object())["channel"];
   ValidateJsonArraySize(array, 10);
   std::vector<intptr_t> uuids = GetUuidListFromArray(array.array_value());
-  for (int i = 0; i < uuids.size(); ++i) {
+  for (size_t i = 0; i < uuids.size(); ++i) {
     EXPECT_EQ(static_cast<intptr_t>(51 + i), uuids[i]);
   }
 }

--- a/test/core/gprpp/examine_stack_test.cc
+++ b/test/core/gprpp/examine_stack_test.cc
@@ -72,7 +72,7 @@ TEST(ExamineStackTest, AbseilStackProvider) {
   EXPECT_NE(stack_trace, absl::nullopt);
   gpr_log(GPR_INFO, "stack_trace=%s", stack_trace->c_str());
 #if !defined(NDEBUG) && !defined(GPR_MUSL_LIBC_COMPAT)
-  EXPECT_TRUE(stack_trace->find("GetCurrentStackTrace") != -1);
+  EXPECT_TRUE(stack_trace->find("GetCurrentStackTrace") != std::string::npos);
 #endif
 }
 

--- a/test/core/iomgr/stranded_event_test.cc
+++ b/test/core/iomgr/stranded_event_test.cc
@@ -395,7 +395,7 @@ TEST(Pollers, TestReadabilityNotificationsDontGetStrandedOnOneCq) {
         {
           grpc_core::MutexLock lock(&ping_pong_round_mu);
           ping_pong_round_cv.Broadcast();
-          while (ping_pong_round != i) {
+          while (int(ping_pong_round) != i) {
             ping_pong_round_cv.Wait(&ping_pong_round_mu);
           }
         }

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -450,7 +450,7 @@ class FakeTcpServer {
           0x00,                   // flags
           0x00, 0x00, 0x00, 0x00  // stream identifier
       };
-      if (total_bytes_sent_ < kEmptyHttp2SettingsFrame.size()) {
+      if (total_bytes_sent_ < int(kEmptyHttp2SettingsFrame.size())) {
         int bytes_to_send = kEmptyHttp2SettingsFrame.size() - total_bytes_sent_;
         int bytes_sent =
             send(fd_, kEmptyHttp2SettingsFrame.data() + total_bytes_sent_,
@@ -463,7 +463,7 @@ class FakeTcpServer {
           GPR_ASSERT(0);
         } else if (bytes_sent > 0) {
           total_bytes_sent_ += bytes_sent;
-          GPR_ASSERT(total_bytes_sent_ <= kEmptyHttp2SettingsFrame.size());
+          GPR_ASSERT(total_bytes_sent_ <= int(kEmptyHttp2SettingsFrame.size()));
         }
       }
     }

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -952,7 +952,7 @@ void ssl_tsi_test_extract_cert_chain() {
   STACK_OF(X509_INFO)* certInfos =
       PEM_X509_INFO_read_bio(bio, nullptr, nullptr, nullptr);
   GPR_ASSERT(certInfos != nullptr);
-  for (int i = 0; i < sk_X509_INFO_num(certInfos); i++) {
+  for (size_t i = 0; i < sk_X509_INFO_num(certInfos); i++) {
     X509_INFO* certInfo = sk_X509_INFO_value(certInfos, i);
     if (certInfo->x509 != nullptr) {
       GPR_ASSERT(sk_X509_push(cert_chain, certInfo->x509) != 0);

--- a/test/core/util/reconnect_server.cc
+++ b/test/core/util/reconnect_server.cc
@@ -62,7 +62,7 @@ static void on_connect(void* arg, grpc_endpoint* tcp,
                        grpc_tcp_server_acceptor* acceptor) {
   gpr_free(acceptor);
   absl::string_view peer;
-  int last_colon;
+  absl::string_view::size_type last_colon;
   reconnect_server* server = static_cast<reconnect_server*>(arg);
   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
   timestamp_list* new_tail;

--- a/test/core/util/stack_tracer_test.cc
+++ b/test/core/util/stack_tracer_test.cc
@@ -31,7 +31,7 @@ TEST(StackTracerTest, Basic) {
   std::string stack_trace = grpc_core::testing::GetCurrentStackTrace();
   gpr_log(GPR_INFO, "stack_trace=%s", stack_trace.c_str());
 #if !defined(NDEBUG) && !defined(GPR_MUSL_LIBC_COMPAT)
-  EXPECT_TRUE(stack_trace.find("Basic") != -1);
+  EXPECT_TRUE(stack_trace.find("Basic") != std::string::npos);
 #endif
 }
 

--- a/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
+++ b/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
@@ -110,7 +110,7 @@ TEST(DestroyGrpclbChannelWithActiveConnectStressTest,
   for (int i = 0; i < kNumThreads; i++) {
     threads.emplace_back(new std::thread(TryConnectAndDestroy));
   }
-  for (int i = 0; i < threads.size(); i++) {
+  for (size_t i = 0; i < threads.size(); i++) {
     threads[i]->join();
   }
   grpc_shutdown();

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -433,7 +433,7 @@ TEST_P(ClientCallbackEnd2endTest, SimpleRpcUnderLockNested) {
           rpc_state[index].done = true;
           rpc_state[index].cv.notify_all();
           // Call the next level of nesting if possible
-          if (index + 1 < rpc_state.size()) {
+          if (index + 1 < int(rpc_state.size())) {
             nested_call(index + 1);
           }
         });

--- a/test/cpp/end2end/server_load_reporting_end2end_test.cc
+++ b/test/cpp/end2end/server_load_reporting_end2end_test.cc
@@ -96,7 +96,7 @@ class ServerLoadReportingEnd2endTest : public ::testing::Test {
     auto stub = EchoTestService::NewStub(
         grpc::CreateChannel(server_address_, InsecureChannelCredentials()));
     std::string lb_token = lb_id + lb_tag;
-    for (int i = 0; i < num_requests; ++i) {
+    for (size_t i = 0; i < num_requests; ++i) {
       ClientContext ctx;
       if (!lb_token.empty()) ctx.AddMetadata(GRPC_LB_TOKEN_MD_KEY, lb_token);
       EchoRequest request;

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -147,7 +147,7 @@ static void postprocess_scenario_result(ScenarioResult* result) {
   // all clients
   double qps = 0;
   double client_system_cpu_load = 0, client_user_cpu_load = 0;
-  for (size_t i = 0; i < result->client_stats_size(); i++) {
+  for (int i = 0; i < result->client_stats_size(); i++) {
     auto client_stat = result->client_stats(i);
     qps += client_stat.latencies().count() / client_stat.time_elapsed();
     client_system_cpu_load +=
@@ -158,7 +158,7 @@ static void postprocess_scenario_result(ScenarioResult* result) {
   // Calculate cpu load for each server and then aggregate results for all
   // servers
   double server_system_cpu_load = 0, server_user_cpu_load = 0;
-  for (size_t i = 0; i < result->server_stats_size(); i++) {
+  for (int i = 0; i < result->server_stats_size(); i++) {
     auto server_stat = result->server_stats(i);
     server_system_cpu_load +=
         server_stat.time_system() / server_stat.time_elapsed();


### PR DESCRIPTION
Enabled `sign-compare` and fixed the existing warnings.