### PR TITLE
Modify build_python.sh because get-pip.py has moved.

### DIFF
--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -153,7 +153,7 @@ fi
 # See https://github.com/grpc/grpc/issues/14815 for more context. We cannot rely
 # on pip to upgrade itself because if pip is too old, it may not have the required
 # TLS version to run `pip install`.
-curl https://bootstrap.pypa.io/get-pip.py | $VENV_PYTHON
+curl https://bootstrap.pypa.io/2.7/get-pip.py | $VENV_PYTHON
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
 # Python gets confused when parsing paths.


### PR DESCRIPTION
Over the weekend, several builds failed:
grpc/core/master/linux/grpc_build_abseil-cpp_at_head
master/linux/grpc_build_boringssl_at_head
etc...

All errors seem to point to:
+ VENV_PYTHON=/var/local/git/grpc/py27_native/bin/python2.7
+ curl https://bootstrap.pypa.io/get-pip.py
+ /var/local/git/grpc/py27_native/bin/python2.7
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1883k  100 1883k    0     0  6848k      0 --:--:-- --:--:-- --:--:-- 6848k
Traceback (most recent call last):
  File "<stdin>", line 24226, in <module>
  File "<stdin>", line 199, in main
  File "<stdin>", line 82, in bootstrap
  File "/tmp/tmpOBM481/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax

According to https://stackoverflow.com/questions/65866417/pip-install-failing-on-python2, it seems that get-pip.py has moved.

So i updated the script.
