### PR TITLE
xds-k8s driver: Change Endpint Config Selector type to GRPC_SERVER

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -389,7 +389,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
             "metadataLabels": endpoint_matcher_labels
         }
         config = {
-            "type": "SIDECAR_PROXY",
+            "type": "GRPC_SERVER",
             "httpFilters": {},
             "trafficPortSelector": port_selector,
             "endpointMatcher": {


### PR DESCRIPTION
Changes `EndpointConfigSelector` type from `SIDECAR_PROXY` to `GRPC_SERVER`. Ref b/178523040.