### PR TITLE
Fixed missing-field-initializers

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -43,7 +43,6 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wvla",
     # Exceptions but will be removed
     "-Wno-deprecated-declarations",
-    "-Wno-missing-field-initializers",
     "-Wno-unused-function",
 ]
 

--- a/src/core/ext/xds/xds_client_stats.cc
+++ b/src/core/ext/xds/xds_client_stats.cc
@@ -137,7 +137,8 @@ XdsClusterLocalityStats::GetSnapshotAndReset() {
                        // not related to a single reporting interval.
                        total_requests_in_progress_.Load(MemoryOrder::RELAXED),
                        GetAndResetCounter(&total_error_requests_),
-                       GetAndResetCounter(&total_issued_requests_)};
+                       GetAndResetCounter(&total_issued_requests_),
+                       {}};
   MutexLock lock(&backend_metrics_mu_);
   snapshot.backend_metrics = std::move(backend_metrics_);
   return snapshot;


### PR DESCRIPTION
Enabled `missing-field-initializers` and fixed the existing warnings.