### PR TITLE
Fix xds_end2end_test for ipv6 only platforms

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -6192,10 +6192,10 @@ class XdsEnabledServerTest : public XdsEnd2endTest {
 TEST_P(XdsEnabledServerTest, Basic) {
   Listener listener;
   listener.set_name(
-      absl::StrCat("grpc/server?xds.resource.listening_address=127.0.0.1:",
-                   backends_[0]->port()));
+      absl::StrCat("grpc/server?xds.resource.listening_address=",
+                   ipv6_only_ ? "[::1]:" : "127.0.0.1:", backends_[0]->port()));
   listener.mutable_address()->mutable_socket_address()->set_address(
-      "127.0.0.1");
+      ipv6_only_ ? "::1" : "127.0.0.1");
   listener.mutable_address()->mutable_socket_address()->set_port_value(
       backends_[0]->port());
   listener.add_filter_chains();
@@ -6211,8 +6211,8 @@ TEST_P(XdsEnabledServerTest, Basic) {
 TEST_P(XdsEnabledServerTest, BadLdsUpdateNoApiListenerNorAddress) {
   Listener listener;
   listener.set_name(
-      absl::StrCat("grpc/server?xds.resource.listening_address=127.0.0.1:",
-                   backends_[0]->port()));
+      absl::StrCat("grpc/server?xds.resource.listening_address=",
+                   ipv6_only_ ? "[::1]:" : "127.0.0.1:", backends_[0]->port()));
   listener.add_filter_chains();
   balancers_[0]->ads_service()->SetLdsResource(listener);
   CheckRpcSendFailure(1, RpcOptions().set_wait_for_ready(true));
@@ -6226,11 +6226,11 @@ TEST_P(XdsEnabledServerTest, BadLdsUpdateNoApiListenerNorAddress) {
 TEST_P(XdsEnabledServerTest, BadLdsUpdateBothApiListenerAndAddress) {
   Listener listener;
   listener.set_name(
-      absl::StrCat("grpc/server?xds.resource.listening_address=127.0.0.1:",
-                   backends_[0]->port()));
+      absl::StrCat("grpc/server?xds.resource.listening_address=",
+                   ipv6_only_ ? "[::1]:" : "127.0.0.1:", backends_[0]->port()));
   balancers_[0]->ads_service()->SetLdsResource(listener);
   listener.mutable_address()->mutable_socket_address()->set_address(
-      "127.0.0.1");
+      ipv6_only_ ? "::1" : "127.0.0.1");
   listener.mutable_address()->mutable_socket_address()->set_port_value(
       backends_[0]->port());
   auto* filter_chain = listener.add_filter_chains();
@@ -6485,11 +6485,11 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
 TEST_P(XdsServerSecurityTest, TlsConfigurationWithoutRootProviderInstance) {
   Listener listener;
   listener.set_name(
-      absl::StrCat("grpc/server?xds.resource.listening_address=127.0.0.1:",
-                   backends_[0]->port()));
+      absl::StrCat("grpc/server?xds.resource.listening_address=",
+                   ipv6_only_ ? "[::1]:" : "127.0.0.1:", backends_[0]->port()));
   balancers_[0]->ads_service()->SetLdsResource(listener);
   auto* socket_address = listener.mutable_address()->mutable_socket_address();
-  socket_address->set_address("127.0.0.1");
+  socket_address->set_address(ipv6_only_ ? "::1" : "127.0.0.1");
   socket_address->set_port_value(backends_[0]->port());
   auto* filter_chain = listener.add_filter_chains();
   auto* transport_socket = filter_chain->mutable_transport_socket();


### PR DESCRIPTION
Forward fix for #25283 to handle Ipv6 only platforms.