### PR TITLE
Remove unnecessary internal pollset set in c-ares DNS resolver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -135,7 +135,7 @@ AresDnsResolver::AresDnsResolver(ResolverArgs args)
       channel_args_(grpc_channel_args_copy(args.args)),
       work_serializer_(std::move(args.work_serializer)),
       result_handler_(std::move(args.result_handler)),
-      interested_parties_(grpc_pollset_set_create()),
+      interested_parties_(args.pollset_set),
       request_service_config_(!grpc_channel_args_find_bool(
           channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION, true)),
       enable_srv_queries_(grpc_channel_args_find_bool(
@@ -157,15 +157,10 @@ AresDnsResolver::AresDnsResolver(ResolverArgs args)
   GRPC_CLOSURE_INIT(&on_next_resolution_, OnNextResolution, this,
                     grpc_schedule_on_exec_ctx);
   GRPC_CLOSURE_INIT(&on_resolved_, OnResolved, this, grpc_schedule_on_exec_ctx);
-  // Polling linkage.
-  if (args.pollset_set != nullptr) {
-    grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);
-  }
 }
 
 AresDnsResolver::~AresDnsResolver() {
   GRPC_CARES_TRACE_LOG("resolver:%p destroying AresDnsResolver", this);
-  grpc_pollset_set_destroy(interested_parties_);
   grpc_channel_args_destroy(channel_args_);
 }
 


### PR DESCRIPTION
Noticed while working on https://github.com/grpc/grpc/pull/25108

The resolver holds a ref on it's channel stack via the resolver's `ResultHandler`, which assures that the pollset set passed to the resolver will outlive it. So creating a new pollset set and linking it to the client channel's pollset set is unnecessary.

Note that if this wasn't true and the resolver could somehow outlive the client channel stack's pollset set, creating a pollset set within the resolver and referencing the client channel's pollset set would be unsafe anyways, since the pointer from resolver's pollset set to client channel's could become invalid.