### PR TITLE
xds-k8s driver: increase timeouts for k8s cleanup operations

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -84,8 +84,10 @@ class KubernetesNamespace:
     DELETE_GRACE_PERIOD_SEC: int = 5
     WAIT_SHORT_TIMEOUT_SEC: int = 60
     WAIT_SHORT_SLEEP_SEC: int = 1
-    WAIT_LONG_TIMEOUT_SEC: int = 240
-    WAIT_LONG_SLEEP_SEC: int = 5
+    WAIT_MEDIUM_TIMEOUT_SEC: int = 5 * 60
+    WAIT_MEDIUM_SLEEP_SEC: int = 10
+    WAIT_LONG_TIMEOUT_SEC: int = 10 * 60
+    WAIT_LONG_SLEEP_SEC: int = 30
 
     def __init__(self, api: KubernetesApiManager, name: str):
         self.name = name
@@ -234,8 +236,8 @@ class KubernetesNamespace:
             self,
             name,
             count=1,
-            timeout_sec=WAIT_LONG_TIMEOUT_SEC,
-            wait_sec=WAIT_LONG_SLEEP_SEC):
+            timeout_sec=WAIT_MEDIUM_TIMEOUT_SEC,
+            wait_sec=WAIT_MEDIUM_SLEEP_SEC):
 
         @retrying.retry(
             retry_on_result=lambda r: not self._replicas_available(r, count),
@@ -253,8 +255,8 @@ class KubernetesNamespace:
 
     def wait_for_deployment_deleted(self,
                                     deployment_name: str,
-                                    timeout_sec=WAIT_SHORT_TIMEOUT_SEC,
-                                    wait_sec=WAIT_SHORT_SLEEP_SEC):
+                                    timeout_sec=WAIT_MEDIUM_TIMEOUT_SEC,
+                                    wait_sec=WAIT_MEDIUM_SLEEP_SEC):
 
         @retrying.retry(retry_on_result=lambda r: r is not None,
                         stop_max_delay=timeout_sec * 1000,


### PR DESCRIPTION
* Added `WAIT_MEDIUM_TIMEOUT_SEC`: 5 minutes, sleep 10s - used for waiting on deployment start/delete
* Increased `WAIT_LONG_TIMEOUT_SEC`: 10 minutes, sleep 30s - used for waiting on namespace to be deleted

Ref b/178776925