### PR TITLE
Ruby: Document the units for channel timeouts

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -82,7 +82,7 @@ module GRPC
     #     should be created with an insecure connection. Note: this argument is
     #     ignored if the channel_override argument is provided.
     # @param channel_override [Core::Channel] a pre-created channel
-    # @param timeout [Number] the default timeout to use in requests
+    # @param timeout [Number] the default timeout to use in requests, in fractional seconds.
     # @param propagate_mask [Number] A bitwise combination of flags in
     #     GRPC::Core::PropagateMasks. Indicates how data should be propagated
     #     from parent server calls to child client calls if this client is being


### PR DESCRIPTION
It is not clear that this is seconds, rather than millis or something else.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
