### PR TITLE
Switch to dart 2.12 to fix interop tests

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/dart:2.10
+FROM google/dart:2.12-beta
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Together with https://github.com/grpc/grpc-dart/pull/448 this should fix https://github.com/grpc/grpc-dart/issues/440, at least interop tests pass locally:

```
~/work/grpc$ tools/run_tests/run_interop_tests.py -l dart -s java --use_docker
...
PASSED: cloud_to_cloud:dart:java_server:large_unary:tls [time=5.4sec, retries=0:0]
PASSED: cloud_to_cloud:dart:java_server:unimplemented_service:tls [time=2.2sec, retries=0:0]
SUCCESS: All tests passed
...