### PR TITLE
Re-generate Ruby protos

### DIFF
--- a/src/ruby/pb/src/proto/grpc/testing/messages_pb.rb
+++ b/src/ruby/pb/src/proto/grpc/testing/messages_pb.rb
@@ -82,10 +82,16 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       map :num_rpcs_started_by_method, :string, :int32, 1
       map :num_rpcs_succeeded_by_method, :string, :int32, 2
       map :num_rpcs_failed_by_method, :string, :int32, 3
+      map :stats_per_method, :string, :message, 4, "grpc.testing.LoadBalancerAccumulatedStatsResponse.MethodStats"
+    end
+    add_message "grpc.testing.LoadBalancerAccumulatedStatsResponse.MethodStats" do
+      optional :rpcs_started, :int32, 1
+      map :result, :int32, :int32, 2
     end
     add_message "grpc.testing.ClientConfigureRequest" do
       repeated :types, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
       repeated :metadata, :message, 2, "grpc.testing.ClientConfigureRequest.Metadata"
+      optional :timeout_sec, :int32, 3
     end
     add_message "grpc.testing.ClientConfigureRequest.Metadata" do
       optional :type, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
@@ -128,6 +134,7 @@ module Grpc
     LoadBalancerStatsResponse::RpcsByPeer = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsResponse.RpcsByPeer").msgclass
     LoadBalancerAccumulatedStatsRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsRequest").msgclass
     LoadBalancerAccumulatedStatsResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsResponse").msgclass
+    LoadBalancerAccumulatedStatsResponse::MethodStats = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsResponse.MethodStats").msgclass
     ClientConfigureRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest").msgclass
     ClientConfigureRequest::Metadata = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.Metadata").msgclass
     ClientConfigureRequest::RpcType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.RpcType").enummodule

--- a/src/ruby/qps/src/proto/grpc/testing/messages_pb.rb
+++ b/src/ruby/qps/src/proto/grpc/testing/messages_pb.rb
@@ -82,10 +82,16 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       map :num_rpcs_started_by_method, :string, :int32, 1
       map :num_rpcs_succeeded_by_method, :string, :int32, 2
       map :num_rpcs_failed_by_method, :string, :int32, 3
+      map :stats_per_method, :string, :message, 4, "grpc.testing.LoadBalancerAccumulatedStatsResponse.MethodStats"
+    end
+    add_message "grpc.testing.LoadBalancerAccumulatedStatsResponse.MethodStats" do
+      optional :rpcs_started, :int32, 1
+      map :result, :int32, :int32, 2
     end
     add_message "grpc.testing.ClientConfigureRequest" do
       repeated :types, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
       repeated :metadata, :message, 2, "grpc.testing.ClientConfigureRequest.Metadata"
+      optional :timeout_sec, :int32, 3
     end
     add_message "grpc.testing.ClientConfigureRequest.Metadata" do
       optional :type, :enum, 1, "grpc.testing.ClientConfigureRequest.RpcType"
@@ -128,6 +134,7 @@ module Grpc
     LoadBalancerStatsResponse::RpcsByPeer = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerStatsResponse.RpcsByPeer").msgclass
     LoadBalancerAccumulatedStatsRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsRequest").msgclass
     LoadBalancerAccumulatedStatsResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsResponse").msgclass
+    LoadBalancerAccumulatedStatsResponse::MethodStats = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.LoadBalancerAccumulatedStatsResponse.MethodStats").msgclass
     ClientConfigureRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest").msgclass
     ClientConfigureRequest::Metadata = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.Metadata").msgclass
     ClientConfigureRequest::RpcType = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("grpc.testing.ClientConfigureRequest.RpcType").enummodule


### PR DESCRIPTION
Ran `src/ruby/pb/generate_proto_ruby.sh` to re-generate the proto generated classes. Needed for some upcoming xds work.