### PR TITLE
Fix flakey time diff assertion in resolver cooldown test

### DIFF
--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -31,8 +31,6 @@
 #include "test/core/util/test_config.h"
 
 constexpr int kMinResolutionPeriodMs = 1000;
-// Provide some slack when checking intervals, to allow for test timing issues.
-constexpr int kMinResolutionPeriodForCheckMs = 900;
 
 extern grpc_address_resolver_vtable* grpc_resolve_address_impl;
 static grpc_address_resolver_vtable* default_resolve_address;
@@ -76,9 +74,16 @@ static void test_resolve_address_impl(const char* name,
   } else {
     grpc_millis now =
         grpc_timespec_to_millis_round_up(gpr_now(GPR_CLOCK_MONOTONIC));
-    GPR_ASSERT(now - last_resolution_time >= kMinResolutionPeriodForCheckMs);
+    GPR_ASSERT(now - last_resolution_time >= kMinResolutionPeriodMs);
     last_resolution_time = now;
   }
+  // For correct time diff comparisons, make sure that any subsequent calls
+  // to grpc_core::ExecCtx::Get()->Now() on this thread don't return a time
+  // which is earlier than that returned by the call(s) to
+  // gpr_now(GPR_CLOCK_MONOTONIC) within this function. This is important
+  // because the resolver's last_resolution_timestamp_ will be taken from
+  // grpc_core::ExecCtx::Get()->Now() right after this returns.
+  grpc_core::ExecCtx::Get()->InvalidateNow();
 }
 
 static grpc_error* test_blocking_resolve_address_impl(
@@ -109,14 +114,21 @@ static grpc_ares_request* test_dns_lookup_ares_locked(
   gpr_log(GPR_DEBUG,
           "last_resolution_time:%" PRId64 " now:%" PRId64
           " min_time_between:%d",
-          last_resolution_time, now, kMinResolutionPeriodForCheckMs);
+          last_resolution_time, now, kMinResolutionPeriodMs);
   if (last_resolution_time == 0) {
     last_resolution_time =
         grpc_timespec_to_millis_round_up(gpr_now(GPR_CLOCK_MONOTONIC));
   } else {
-    GPR_ASSERT(now - last_resolution_time >= kMinResolutionPeriodForCheckMs);
+    GPR_ASSERT(now - last_resolution_time >= kMinResolutionPeriodMs);
     last_resolution_time = now;
   }
+  // For correct time diff comparisons, make sure that any subsequent calls
+  // to grpc_core::ExecCtx::Get()->Now() on this thread don't return a time
+  // which is earlier than that returned by the call(s) to
+  // gpr_now(GPR_CLOCK_MONOTONIC) within this function. This is important
+  // because the resolver's last_resolution_timestamp_ will be taken from
+  // grpc_core::ExecCtx::Get()->Now() right after this returns.
+  grpc_core::ExecCtx::Get()->InvalidateNow();
   return result;
 }
 


### PR DESCRIPTION
This is a pre-req for submitting https://github.com/grpc/grpc/pull/25108, which is hitting this flake very frequently under msan.

Because of `ExecCtx` time caching, the time that `last_resolution_timestamp_` is set to in https://github.com/grpc/grpc/blob/4dc84aea46396cde21d13813efcf8ca3b2fda692/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc#L431 can actually be <i>earlier</i> than the time set to the cooldown test's `last_resolution_time` field in https://github.com/grpc/grpc/blob/4dc84aea46396cde21d13813efcf8ca3b2fda692/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc#L107, even though the resolver's `last_resolution_timestamp_` is written to afterwards, and even though both are using the same monotonic clock. As a result, the test and the c-ares resolver can get out of sync as to how much time they think has elapsed between resolutions.

This change fixes the comparison by invalidating the time cache before returning. I believe this makes the 10% error margin no longer needed.

