### PR TITLE
Fix rare race in SyncRequestThreadManager shutdown

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -840,6 +840,9 @@ void Server::CancelAllCalls() {
   {
     MutexLock lock(&mu_global_);
     broadcaster.FillChannelsLocked(GetChannelsLocked());
+    MutexLock call_lock(&mu_call_);
+    KillPendingWorkLocked(
+        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
   }
   broadcaster.BroadcastShutdown(
       /*send_goaway=*/false,


### PR DESCRIPTION
The SyncRequestThreadManager has multiple responsibilities: polling for work, invoking sync request method handlers, managing threads (as suggested by the name), and requesting new server RPCs. A new RPC will be requested each time an RPC is processed, unless the sync request thread manager is shutdown already. However, that's a potential algorithmic race since the core server is shutdown first (which prevents new matches) before the sync request thread manager is shutdown. As a result, we could create a situation where a new call has been requested after the core server has been shutdown and pending RPCs from it cancelled, which then can cause a new call to get stuck forever waiting for a match that will never come,  and thus will never post a tag on its CQ for completion.

The easiest solution to this is to let such calls get requested if they arise, but then force a cancellation of all calls before actually doing the wait process on the SyncRequestThreadManager. A better solution will be to completely eliminate sync RPC requests and use the same mechanism that we use in the callback API which is to only request a call when it is actually matched, but that can be resolved later.

Seen during detailed (1.2M tests) runs of #25169 
