### PR TITLE
Add use_strict_warning=true for mac-os bazel build

### DIFF
--- a/src/core/lib/gprpp/dual_ref_counted.h
+++ b/src/core/lib/gprpp/dual_ref_counted.h
@@ -170,8 +170,8 @@ class DualRefCounted : public Orphanable {
 #endif
     const uint64_t prev_ref_pair =
         refs_.FetchSub(MakeRefPair(0, 1), MemoryOrder::ACQ_REL);
-    const uint32_t weak_refs = GetWeakRefs(prev_ref_pair);
 #ifndef NDEBUG
+    const uint32_t weak_refs = GetWeakRefs(prev_ref_pair);
     const uint32_t strong_refs = GetStrongRefs(prev_ref_pair);
     if (trace != nullptr) {
       gpr_log(GPR_INFO, "%s:%p weak_unref %d -> %d (refs=%d)", trace, this,
@@ -192,8 +192,8 @@ class DualRefCounted : public Orphanable {
 #endif
     const uint64_t prev_ref_pair =
         refs_.FetchSub(MakeRefPair(0, 1), MemoryOrder::ACQ_REL);
-    const uint32_t weak_refs = GetWeakRefs(prev_ref_pair);
 #ifndef NDEBUG
+    const uint32_t weak_refs = GetWeakRefs(prev_ref_pair);
     const uint32_t strong_refs = GetStrongRefs(prev_ref_pair);
     if (trace_ != nullptr) {
       gpr_log(GPR_INFO, "%s:%p %s:%d weak_unref %d -> %d (refs=%d) %s", trace,

--- a/tools/remote_build/mac.bazelrc
+++ b/tools/remote_build/mac.bazelrc
@@ -33,3 +33,6 @@ build --project_id=grpc-testing
 
 # print output for tests that fail (default is "summary")
 build --test_output=errors
+
+# Enable strict warnings to keep it warning-free.
+build --define=use_strict_warning=true


### PR DESCRIPTION
Enabling `use_strict_warning=true` on MacOS build to keep mac specific code warning-free.