### PR TITLE
Pin all Bazel pypi dependencies

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -1,15 +1,15 @@
 # GRPC Python setup requirements
-coverage>=4.0
-cython>=0.29.8
-enum34>=1.0.4
+coverage==4.5.4
+cython==0.29.21
+enum34==1.1.10
 protobuf>=3.5.0.post1, < 4.0dev
-six>=1.10
-wheel>=0.29
-futures>=2.2.0
-google-auth>=1.17.2
+six==1.15.0
+wheel==0.36.2
+futures==3.1.1
+google-auth==1.24.0
 oauth2client==4.1.0
-requests>=2.14.2
-urllib3>=1.23
+requests==2.25.1
+urllib3==1.26.3
 chardet==3.0.4
 certifi==2017.4.17
 idna==2.7


### PR DESCRIPTION
We're currently seeing a continuous breakage on master:

```
fastbuild/bin/src/python/grpcio_tests/tests/interop/_secure_intraop_test.python3.runfiles/pypi__google_auth_1_25_0/google/auth/crypt/rsa.py", line 20, in <module>
    from google.auth.crypt import _cryptography_rsa
  File "/root/.cache/bazel/_bazel_root/d2dc70c3d9da3fab488ba0dcbbd35051/sandbox/processwrapper-sandbox/2817/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/interop/_secure_intraop_test.python3.runfiles/pypi__google_auth_1_25_0/google/auth/crypt/_cryptography_rsa.py", line 22, in <module>
    import cryptography.exceptions
ModuleNotFoundError: No module named 'cryptography'
```

The beginning of this breakage coincides with the release of [`google-auth` 1.25.0](https://pypi.org/project/google-auth/1.25.0/). This PR pins back not only `google-auth`, but all dependencies except `protobuf`, since this is the one runtime dependency listed in that file.

This fixes b/179401729

**EDIT**: Fixes https://github.com/grpc/grpc/pull/25355