### PR TITLE
setup.py: drop invalid gnu99 when compiling C++ files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ if EXTRA_ENV_COMPILE_ARGS is None:
             # available dynamically
             EXTRA_ENV_COMPILE_ARGS += ' /MT'
     elif "linux" in sys.platform:
-        EXTRA_ENV_COMPILE_ARGS += ' -std=gnu99 -fvisibility=hidden -fno-wrapv -fno-exceptions'
+        EXTRA_ENV_COMPILE_ARGS += ' -fvisibility=hidden -fno-wrapv -fno-exceptions'
     elif "darwin" in sys.platform:
         EXTRA_ENV_COMPILE_ARGS += ' -stdlib=libc++ -fvisibility=hidden -fno-wrapv -fno-exceptions'
 


### PR DESCRIPTION
gnu99 flag create an error when compiling C++ files.

cc1plus: warning: command line option '-std=gnu99' is valid for C/ObjC but not for C++

Signed-off-by: Clément Péron <peron.clem@gmail.com>

@yashykt
