### PR TITLE
explicitly cast GRPC_MILLIS_INF_FUTURE to avoid warnings.

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -58,7 +58,7 @@ static grpc_millis timespan_to_millis_round_down(gpr_timespec ts) {
   double x = GPR_MS_PER_SEC * static_cast<double>(ts.tv_sec) +
              static_cast<double>(ts.tv_nsec) / GPR_NS_PER_MS;
   if (x < 0) return 0;
-  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
+  if (x > static_cast<double>(GRPC_MILLIS_INF_FUTURE)) return GRPC_MILLIS_INF_FUTURE;
   return static_cast<grpc_millis>(x);
 }
 
@@ -72,7 +72,7 @@ static grpc_millis timespan_to_millis_round_up(gpr_timespec ts) {
              static_cast<double>(GPR_NS_PER_SEC - 1) /
                  static_cast<double>(GPR_NS_PER_SEC);
   if (x < 0) return 0;
-  if (x > GRPC_MILLIS_INF_FUTURE) return GRPC_MILLIS_INF_FUTURE;
+  if (x > static_cast<double>(GRPC_MILLIS_INF_FUTURE)) return GRPC_MILLIS_INF_FUTURE;
   return static_cast<grpc_millis>(x);
 }
 


### PR DESCRIPTION
Recent versions of clang warn about implicit conversions that introduce
rounding errors. This change silences these warnings by explicitly
indicating that we intend this rounding to take place.

Removes warnings identified https://github.com/grpc/grpc/issues/23249

@yashykt
