### PR TITLE
Add support for additional protoc arguments in Grpc.Tools

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
@@ -141,6 +141,15 @@ namespace Grpc.Tools.Tests
         }
 
         [Test]
+        public void AdditionalProtocArguments()
+        {
+            _task.AdditionalProtocArguments = new[] { "--experimental_allow_proto3_optional" };
+            ExecuteExpectSuccess();
+            Assert.That(_task.LastResponseFile,
+                Does.Contain("--experimental_allow_proto3_optional"));
+        }
+
+        [Test]
         public void DirectoryArgumentsSlashTrimmed()
         {
             _task.GrpcPluginExe = "/foo/grpcgen";

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -279,6 +279,12 @@ namespace Grpc.Tools
         public string[] OutputOptions { get; set; }
 
         /// <summary>
+        /// Additional arguments that will be passed unmodified to protoc (and before any file names).
+        /// For example, "--experimental_allow_proto3_optional"
+        /// </summary>
+        public string[] AdditionalProtocArguments { get; set; }
+
+        /// <summary>
         /// Full path to the gRPC plugin executable. If specified, gRPC generation
         /// is enabled for the files.
         /// Switch: --plugin=protoc-gen-grpc=
@@ -428,6 +434,15 @@ namespace Grpc.Tools
             }
             cmd.AddSwitchMaybe("dependency_out", DependencyOut);
             cmd.AddSwitchMaybe("error_format", "msvs");
+
+            if (AdditionalProtocArguments != null)
+            {
+                foreach (var additionalProtocOption in AdditionalProtocArguments)
+                {
+                    cmd.AddArg(additionalProtocOption);
+                }
+            }
+
             foreach (var proto in Protobuf)
             {
                 cmd.AddArg(proto.ItemSpec);

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -288,6 +288,7 @@
       GrpcPluginExe="%(_Protobuf_OutOfDateProto.GrpcPluginExe)"
       GrpcOutputDir="%(_Protobuf_OutOfDateProto.GrpcOutputDir)"
       GrpcOutputOptions="%(_Protobuf_OutOfDateProto._GrpcOutputOptions)"
+      AdditionalProtocArguments="%(_Protobuf_OutOfDateProto.AdditionalProtocArguments)"
     >
       <Output TaskParameter="GeneratedFiles" ItemName="_Protobuf_GeneratedFiles"/>
     </ProtoCompile>


### PR DESCRIPTION
Using "optional" presence tracking in proto3 (before protobuf 3.15)
required the `--experimental_allow_proto3_optional` protoc option
but there was no existing Grpc.Tools feature that would allow specifying
these arguments.

This commit adds an optional `Protobuf.AdditionalProtocArguments` option
that allows you to specify arbitrary protoc arguments. For example:

```
<Protobuf Include="**\*.proto" CompileOutputs="true" AdditionalProtocArguments="--experimental_allow_proto3_optional" />
```
Fixes #22975

@jtattermusch 
