### PR TITLE
Clarify Guarantees about grpc.Future Interface

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -489,7 +489,8 @@ class UnaryStreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
             An object that is both a Call for the RPC and an iterator of
             response values. Drawing response values from the returned
             Call-iterator may raise RpcError indicating termination of
-            the RPC with non-OK status.
+            the RPC with non-OK status. This object *should* also fulfill the
+            Future interface, though it may not.
         """
         raise NotImplementedError()
 
@@ -562,7 +563,8 @@ class StreamStreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
           An object that is both a Call for the RPC and an iterator of
           response values. Drawing response values from the returned
           Call-iterator may raise RpcError indicating termination of
-          the RPC with non-OK status.
+          the RPC with non-OK status. This object *should* also fulfill the
+          Future interface, though it may not.
         """
         raise NotImplementedError()
 
@@ -800,7 +802,8 @@ class UnaryStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
             An object that is both a Call for the RPC and an iterator of
             response values. Drawing response values from the returned
             Call-iterator may raise RpcError indicating termination of the
-            RPC with non-OK status.
+            RPC with non-OK status. This object also fulfills the Future
+            interface.
         """
         raise NotImplementedError()
 
@@ -939,7 +942,8 @@ class StreamStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
             An object that is both a Call for the RPC and an iterator of
             response values. Drawing response values from the returned
             Call-iterator may raise RpcError indicating termination of the
-            RPC with non-OK status.
+            RPC with non-OK status. This object also fulfills the Future
+            interface.
         """
         raise NotImplementedError()
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -799,11 +799,10 @@ class UnaryStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
             grpc.compression.Gzip. This is an EXPERIMENTAL option.
 
         Returns:
-            An object that is both a Call for the RPC and an iterator of
-            response values. Drawing response values from the returned
-            Call-iterator may raise RpcError indicating termination of the
-            RPC with non-OK status. This object also fulfills the Future
-            interface.
+            An object that is a Call for the RPC, an iterator of response
+            values, and a Future for the RPC. Drawing response values from the
+            returned Call-iterator may raise RpcError indicating termination of
+            the RPC with non-OK status.
         """
         raise NotImplementedError()
 
@@ -939,11 +938,10 @@ class StreamStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
             grpc.compression.Gzip. This is an EXPERIMENTAL option.
 
         Returns:
-            An object that is both a Call for the RPC and an iterator of
-            response values. Drawing response values from the returned
-            Call-iterator may raise RpcError indicating termination of the
-            RPC with non-OK status. This object also fulfills the Future
-            interface.
+            An object that is a Call for the RPC, an iterator of response
+            values, and a Future for the RPC. Drawing response values from the
+            returned Call-iterator may raise RpcError indicating termination of
+            the RPC with non-OK status.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Since the beginning, `grpc.UnaryStreamMultiCallable.__call__` and  `grpc.StreamStreamMultiCallable.__call__` have returned objects that fulfill three interfaces: iterator, Call, and Future. However, in the docstrings, only the first two of these interfaces are mentioned. Many of our users have come to depend on the fulfillment of the Future interface. We need to document the continued satisfaction of that interface as an API guarantee.

The same problem exists in the docstrings for the interceptors. However, the situation is fundamentally different there, as we are not in control of all interceptor implementations. There are likely some floating around that do *not* implement the Future interface. We amend the docstrings here to merely *recommend* that interceptor authors fulfill the Future interface.