### PR TITLE
[C#] Add buildTransitive directory to NuGet package

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -48,6 +48,10 @@
       <PackagePath>build/net45/</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="buildTransitive\net45\Grpc.Core.targets">
+      <PackagePath>buildTransitive/net45/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/csharp/Grpc.Core/buildTransitive/net45/Grpc.Core.targets
+++ b/src/csharp/Grpc.Core/buildTransitive/net45/Grpc.Core.targets
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Ensure projects which depend on projects which depend on Grpc.Core recieve this build logic. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\net45\Grpc.Core.targets" />
+</Project>

--- a/src/csharp/Grpc.Core/buildTransitive/net45/Grpc.Core.targets
+++ b/src/csharp/Grpc.Core/buildTransitive/net45/Grpc.Core.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Ensure projects which depend on projects which depend on Grpc.Core recieve this build logic. -->
+  <!-- Ensure projects which depend on projects which depend on Grpc.Core receive this build logic. -->
+  <!-- We still need both "build" and "buildTransitive" directories since "buildTransitive" is only supported starting from nuget 5.0 -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\net45\Grpc.Core.targets" />
 </Project>


### PR DESCRIPTION
This change adds the buildTransitive directory to the NuGet package. This allows projects which depend on projects which depend on Grpc.Core, but don't build on Grpc.Core directly, to receive the build logic from Grpc.Core, which is required to copy native runtime dependencies for .NET Framework projects.

Fixes #25285

@jtattermusch
