### PR TITLE
Use AllocatingRequestMatcher for C++ sync server

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -375,7 +375,7 @@ class Server::AllocatingRequestMatcherBatch
                    cq(), static_cast<void*>(call_info.tag), nullptr, nullptr) ==
                GRPC_CALL_OK);
     RequestedCall* rc = new RequestedCall(
-        static_cast<void*>(call_info.tag), cq(), call_info.call,
+        static_cast<void*>(call_info.tag), call_info.cq, call_info.call,
         call_info.initial_metadata, call_info.details);
     calld->SetState(CallData::CallState::ACTIVATED);
     calld->Publish(cq_idx(), rc);
@@ -399,14 +399,12 @@ class Server::AllocatingRequestMatcherRegistered
   void MatchOrQueue(size_t /*start_request_queue_index*/,
                     CallData* calld) override {
     RegisteredCallAllocation call_info = allocator_();
-    GPR_ASSERT(
-        server()->ValidateServerRequest(cq(), static_cast<void*>(call_info.tag),
-                                        call_info.optional_payload,
-                                        registered_method_) == GRPC_CALL_OK);
+    GPR_ASSERT(server()->ValidateServerRequest(
+                   cq(), call_info.tag, call_info.optional_payload,
+                   registered_method_) == GRPC_CALL_OK);
     RequestedCall* rc = new RequestedCall(
-        static_cast<void*>(call_info.tag), cq(), call_info.call,
-        call_info.initial_metadata, registered_method_, call_info.deadline,
-        call_info.optional_payload);
+        call_info.tag, call_info.cq, call_info.call, call_info.initial_metadata,
+        registered_method_, call_info.deadline, call_info.optional_payload);
     calld->SetState(CallData::CallState::ACTIVATED);
     calld->Publish(cq_idx(), rc);
   }

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -49,21 +49,23 @@ class Server : public InternallyRefCounted<Server> {
   // An object to represent the most relevant characteristics of a
   // newly-allocated call object when using an AllocatingRequestMatcherBatch.
   struct BatchCallAllocation {
-    grpc_experimental_completion_queue_functor* tag;
+    void* tag;
     grpc_call** call;
     grpc_metadata_array* initial_metadata;
     grpc_call_details* details;
+    grpc_completion_queue* cq;
   };
 
   // An object to represent the most relevant characteristics of a
   // newly-allocated call object when using an
   // AllocatingRequestMatcherRegistered.
   struct RegisteredCallAllocation {
-    grpc_experimental_completion_queue_functor* tag;
+    void* tag;
     grpc_call** call;
     grpc_metadata_array* initial_metadata;
     gpr_timespec* deadline;
     grpc_byte_buffer** optional_payload;
+    grpc_completion_queue* cq;
   };
 
   /// Interface for listeners.


### PR DESCRIPTION
This simplifies SyncRequestThreadManager and prevents a rare shutdown race exposed on #25169 . It also simplifies SyncRequest since there is no longer a distinction between a created/allocated request and an actually active one. Merging this will allow #25169 to actually move forward (1.2M runs completed on that without any races).

One functional change in this is that if there is a sync server, unimplemented RPCs will only be registered as sync requests and not also as async. In practice, this shouldn't affect anything since unimplemented RPCs are not performance-critical and the sync server will always poll for them if they come in.