### PR TITLE
Fix flake in ruby call creds timeout test

### DIFF
--- a/src/ruby/end2end/call_credentials_timeout_test.rb
+++ b/src/ruby/end2end/call_credentials_timeout_test.rb
@@ -61,6 +61,7 @@ def check_rpcs_still_possible(stub)
       begin
         stub.echo(Echo::EchoRequest.new(request: 'hello'), deadline: Time.now + 10)
         success = true
+        break
       rescue GRPC::BadStatus => e
         STDERR.puts "RPC received status: #{e}. Try again..."
       end

--- a/src/ruby/end2end/call_credentials_timeout_test.rb
+++ b/src/ruby/end2end/call_credentials_timeout_test.rb
@@ -49,7 +49,28 @@ def create_server_creds
     true) # force client auth
 end
 
-# rubocop:disable Metrics/AbcSize
+def check_rpcs_still_possible(stub)
+  # Expect three more RPCs to succeed. Use a retry loop because the server
+  # thread pool might still be busy processing the previous round of RPCs.
+  3.times do
+    timeout_seconds = 30
+    deadline = Time.now + timeout_seconds
+    success = false
+    while Time.now < deadline
+      STDERR.puts 'now perform another RPC and expect OK...'
+      begin
+        stub.echo(Echo::EchoRequest.new(request: 'hello'), deadline: Time.now + 10)
+        success = true
+      rescue GRPC::BadStatus => e
+        STDERR.puts "RPC received status: #{e}. Try again..."
+      end
+    end
+    unless success
+      fail "failed to complete a successful RPC within #{timeout_seconds} seconds"
+    end
+  end
+end
+
 # rubocop:disable Metrics/MethodLength
 def main
   server_runner = ServerRunner.new(EchoServerImpl)
@@ -119,13 +140,7 @@ def main
   unless got_at_least_one_failure.value
     fail 'expected at least one of the initial RPCs to fail'
   end
-  # Expect three more RPCs to succeed
-  STDERR.puts 'now perform another RPC and expect OK...'
-  stub.echo(Echo::EchoRequest.new(request: 'hello'), deadline: Time.now + 10)
-  STDERR.puts 'now perform another RPC and expect OK...'
-  stub.echo(Echo::EchoRequest.new(request: 'hello'), deadline: Time.now + 10)
-  STDERR.puts 'now perform another RPC and expect OK...'
-  stub.echo(Echo::EchoRequest.new(request: 'hello'), deadline: Time.now + 10)
+  check_rpcs_still_possible(stub)
   jwt_aud_uri_extraction_success_count_mu.synchronize do
     if jwt_aud_uri_extraction_success_count.value < 4
       fail "Expected auth metadata plugin callback to be ran with the jwt_aud_uri


### PR DESCRIPTION
Tentative fix for internal issue: b/179264590, where occasional flakes hit the following error:

```
perform a first few RPCs to try to get things into a bad state...
call creds plugin sleeping for 4 seconds
call creds plugin done with 4 second sleep
now perform another RPC and expect OK...
/var/local/git/grpc/src/ruby/lib/grpc/generic/active_call.rb:29:in `check_status': 8:No free threads in thread pool. debug_error_string:{"created":"@1611179389.298273286","description":"Error received from peer ipv6:[::1]:36645","file":"src/core/lib/surface/call.cc","file_line":1068,"grpc_message":"No free threads in thread pool","grpc_status":8} (GRPC::ResourceExhausted)
	from /var/local/git/grpc/src/ruby/lib/grpc/generic/active_call.rb:180:in `attach_status_results_and_complete_call'
	from /var/local/git/grpc/src/ruby/lib/grpc/generic/active_call.rb:376:in `request_response'
	from /var/local/git/grpc/src/ruby/lib/grpc/generic/client_stub.rb:178:in `block in request_response'
	from /var/local/git/grpc/src/ruby/lib/grpc/generic/interceptors.rb:170:in `intercept!'
	from /var/local/git/grpc/src/ruby/lib/grpc/generic/client_stub.rb:177:in `request_response'
	from /var/local/git/grpc/src/ruby/lib/grpc/generic/service.rb:171:in `block (3 levels) in rpc_stub_class'
	from src/ruby/end2end/call_credentials_timeout_test.rb:124:in `main'
	from src/ruby/end2end/call_credentials_timeout_test.rb:150:in `<main>'
E0120 21:49:49.344876238   12194 completion_queue.cc:279]    assertion failed: completed_head.next == reinterpret_cast<uintptr_t>(&completed_head)
Command terminated by signal 6
real 18.49
user 4.59
sys 2.32
```
