### PR TITLE
xds-k8s driver: switch Backend Health Check from TCP to GRPC

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
@@ -69,8 +69,10 @@ def main(argv):
 
     if _CMD.value == 'run':
         logger.info('Run server, secure_mode=%s', _SECURE.value)
-        server_runner.run(test_port=xds_flags.SERVER_PORT.value,
-                          secure_mode=_SECURE.value)
+        server_runner.run(
+            test_port=xds_flags.SERVER_PORT.value,
+            maintenance_port=xds_flags.SERVER_MAINTENANCE_PORT.value,
+            secure_mode=_SECURE.value)
 
     elif _CMD.value == 'cleanup':
         logger.info('Cleanup server')

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -126,6 +126,9 @@ class XdsTestServer(framework.rpc.grpc.GrpcApp):
 
 
 class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
+    DEFAULT_TEST_PORT = 8080
+    DEFAULT_MAINTENANCE_PORT = 8080
+    DEFAULT_SECURE_MODE_MAINTENANCE_PORT = 8081
 
     def __init__(self,
                  k8s_namespace,
@@ -176,7 +179,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
 
     def run(self,
             *,
-            test_port=8080,
+            test_port=DEFAULT_TEST_PORT,
             maintenance_port=None,
             secure_mode=False,
             server_id=None,
@@ -190,7 +193,11 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         # maintenance services can be reached independently from the security
         # configuration under test.
         if maintenance_port is None:
-            maintenance_port = test_port if not secure_mode else test_port + 1
+            if not secure_mode:
+                maintenance_port = self.DEFAULT_MAINTENANCE_PORT
+            else:
+                maintenance_port = self.DEFAULT_SECURE_MODE_MAINTENANCE_PORT
+
         if secure_mode and maintenance_port == test_port:
             raise ValueError('port and maintenance_port must be different '
                              'when running test server in secure mode')

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -37,7 +37,16 @@ SERVER_NAME = flags.DEFINE_string("server_name",
                                   help="Server deployment and service name")
 SERVER_PORT = flags.DEFINE_integer("server_port",
                                    default=8080,
+                                   lower_bound=0,
+                                   upper_bound=65535,
                                    help="Server test port")
+SERVER_MAINTENANCE_PORT = flags.DEFINE_integer(
+    "server_maintenance_port",
+    lower_bound=0,
+    upper_bound=65535,
+    default=None,
+    help="Server port running maintenance services: health check, channelz, etc"
+)
 SERVER_XDS_HOST = flags.DEFINE_string("server_xds_host",
                                       default='xds-test-server',
                                       help="Test server xDS hostname")

--- a/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
@@ -109,7 +109,8 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         been received as confirmed by the TD team.
         """
         # Create backend service
-        self.td.setup_backend_for_grpc()
+        self.td.setup_backend_for_grpc(
+            health_check_port=self.server_maintenance_port)
 
         # Start server and attach its NEGs to the backend service, but
         # until they become healthy.
@@ -145,7 +146,8 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         The order of operations is the same as in `test_mtls_error`.
         """
         # Create backend service
-        self.td.setup_backend_for_grpc()
+        self.td.setup_backend_for_grpc(
+            health_check_port=self.server_maintenance_port)
 
         # Start server and attach its NEGs to the backend service, but
         # until they become healthy.


### PR DESCRIPTION
* In PSM Security tests, use insecure maintenance port in Backend Service health check settings
* This will allow us to switch from TCP health check to GRPC health check

ref b/179929401