### PR TITLE
Ruby: Add limited Apple Silicon (arm64-darwin20) support

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -45,8 +45,16 @@ if RUBY_PLATFORM =~ /darwin/
 ENV['EMBED_OPENSSL'] = 'true'
 ENV['EMBED_ZLIB'] = 'true'
 ENV['EMBED_CARES'] = 'true'
+
 ENV['ARCH_FLAGS'] = RbConfig::CONFIG['ARCH_FLAG']
-ENV['ARCH_FLAGS'] = '-arch i386 -arch x86_64' if RUBY_PLATFORM =~ /darwin/
+if RUBY_PLATFORM =~ /darwin/
+  if RUBY_PLATFORM =~ /arm64/
+    ENV['ARCH_FLAGS'] = '-arch arm64'
+  else
+    ENV['ARCH_FLAGS'] = '-arch i386 -arch x86_64'
+  end
+end
+
 ENV['CPPFLAGS'] = '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 
 output_dir = File.expand_path(RbConfig::CONFIG['topdir'])


### PR DESCRIPTION
Discussion: #24846 

#### Changes

This PR adds `-arch arm64` to ARCH_FLAGS on [extconf.rb](https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/extconf.rb). Although this doesn't generate either universal grpc_c.bundle or platform specific binary, it at least allows native complication of gem on Apple Silicon systems when used with `force_ruby_platform` Bundler flag. 

#### Details

Since Apple Silicon came out, there were many native gems which worked with a workaround to force complication of native extensions. By adding `force_ruby_platform` flag, bundler ignores included extension and builds from source.

```bash
bundle config set force_ruby_platform true

# or for local repo only:
bundle config set --local force_ruby_platform true
```

However, when I tried using grpc gem with it, it didn't work. Notably, I was encountering the issue described by [this comment](https://github.com/grpc/grpc/issues/24846#issuecomment-772697816):

```bash
dyld: lazy symbol binding failed: Symbol not found: _grpc_set_ssl_roots_override_callback    
  Referenced from: /.../gems/grpc-1.35.0/src/ruby/lib/grpc/grpc_c.bundle
  Expected in: flat namespace

dyld: Symbol not found: _grpc_set_ssl_roots_override_callback
  Referenced from: /.../gems/2.7.0/gems/grpc-1.35.0/src/ruby/lib/grpc/grpc_c.bundle
  Expected in: flat namespace

zsh: abort
``` 

---

After adding `-arch arm64` to ARCH_FLAGS, I set `force_ruby_platform` to true, hooked everything up to self-hosted GitHub Actions runner (which is ARM Mac system running latest macOS), and ran `rake compile`. It runs smoothly, and when I try to load gem, it works without returning any dyld errors.

<img width="752" alt="107640304-6be54500-6cb5-11eb-9506-e61f9e2b0d36" src="https://user-images.githubusercontent.com/291078/107641869-7ef91480-6cb7-11eb-8a59-86179f64e5ae.png">
 
You can check the compile and test I did using GitHub Actions:
- **[Workflow file](https://github.com/premist/grpc/blob/premist/fork-init/.github/workflows/build.yml)**
- **[Workflow output](https://github.com/premist/grpc/runs/1879714275)** (check 'Quick test' and 'Suite')

---

As mentioned earlier, it doesn't seem to generate universal bundle or arch-specific files (but I might be wrong). Therefore I assume more build related changes are needed, as well as build environment changes to either natively compile to arm64 or cross compile on Intel Mac.  

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
