### PR TITLE
Update dotnet sdk5 docker image to avoid nuget download error in C# .NET 5 distribtest

### DIFF
--- a/tools/dockerfile/distribtest/csharp_dotnet5_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_dotnet5_x64/Dockerfile
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# "5.0" tag uses debian buster
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+# "5.0.x" tag uses debian buster
+# we use the full version number to make docker image version updates explicit
+FROM mcr.microsoft.com/dotnet/sdk:5.0.103
 
 RUN apt-get update && apt-get install -y unzip && apt-get clean
 


### PR DESCRIPTION
Fixes internal b/178903415

The C# .NET5 distribtests are currently broken with
```
  Determining projects to restore...
/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj : error NU3028: Package 'Microsoft.AspNetCore.App.Runtime.linux-x64 5.0.0-rc.2.20475.17' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj : error NU3037: Package 'Microsoft.AspNetCore.App.Runtime.linux-x64 5.0.0-rc.2.20475.17' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.
/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj : error NU3028: Package 'Microsoft.AspNetCore.App.Runtime.linux-x64 5.0.0-rc.2.20475.17' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj : error NU3028: Package 'Microsoft.NETCore.App.Runtime.linux-x64 5.0.0-rc.2.20475.5' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj : error NU3037: Package 'Microsoft.NETCore.App.Runtime.linux-x64 5.0.0-rc.2.20475.5' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.
/var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj : error NU3028: Package 'Microsoft.NETCore.App.Runtime.linux-x64 5.0.0-rc.2.20475.5' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
  Failed to restore /var/local/git/grpc/test/distrib/csharp/DistribTest/DistribTestDotNet.csproj (in 2.15 sec).
+ FAILED=true
```

The root cause seems to be https://github.com/NuGet/Announcements/issues/49
Since the distribtest is using the official dotnet SDK image, it is enough to just fetch a fresh version of it to get this fixed.
