### PR TITLE
Replaced slice_shard:gpr_mu with Mutex

### DIFF
--- a/src/core/lib/slice/slice_intern.cc
+++ b/src/core/lib/slice/slice_intern.cc
@@ -44,13 +44,13 @@
 using grpc_core::InternedSliceRefcount;
 
 typedef struct slice_shard {
-  grpc_core::Mutex* mu;
+  grpc_core::Mutex mu;
   InternedSliceRefcount** strs;
   size_t count;
   size_t capacity;
 } slice_shard;
 
-static slice_shard g_shards[SHARD_COUNT];
+static slice_shard* g_shards;
 
 struct static_metadata_hash_ent {
   uint32_t hash;
@@ -69,7 +69,7 @@ static bool g_forced_hash_seed = false;
 
 InternedSliceRefcount::~InternedSliceRefcount() {
   slice_shard* shard = &g_shards[SHARD_IDX(this->hash)];
-  MutexLock lock(shard->mu);
+  MutexLock lock(&shard->mu);
   InternedSliceRefcount** prev_next;
   InternedSliceRefcount* cur;
   for (prev_next = &shard->strs[TABLE_IDX(this->hash, shard->capacity)],
@@ -259,7 +259,7 @@ template <typename SliceArgs>
 static InternedSliceRefcount* FindOrCreateInternedSlice(uint32_t hash,
                                                         const SliceArgs& args) {
   slice_shard* shard = &g_shards[SHARD_IDX(hash)];
-  grpc_core::MutexLock lock(shard->mu);
+  grpc_core::MutexLock lock(&shard->mu);
   const size_t idx = TABLE_IDX(hash, shard->capacity);
   InternedSliceRefcount* s = MatchInternedSliceLocked(hash, idx, args);
   if (s == nullptr) {
@@ -311,9 +311,9 @@ void grpc_slice_intern_init(void) {
     grpc_core::g_hash_seed =
         static_cast<uint32_t>(gpr_now(GPR_CLOCK_REALTIME).tv_nsec);
   }
+  g_shards = new slice_shard[SHARD_COUNT];
   for (size_t i = 0; i < SHARD_COUNT; i++) {
     slice_shard* shard = &g_shards[i];
-    shard->mu = new grpc_core::Mutex();
     shard->count = 0;
     shard->capacity = INITIAL_SHARD_CAPACITY;
     shard->strs = static_cast<InternedSliceRefcount**>(
@@ -351,7 +351,6 @@ void grpc_slice_intern_init(void) {
 void grpc_slice_intern_shutdown(void) {
   for (size_t i = 0; i < SHARD_COUNT; i++) {
     slice_shard* shard = &g_shards[i];
-    delete shard->mu;
     /* TODO(ctiller): GPR_ASSERT(shard->count == 0); */
     if (shard->count != 0) {
       gpr_log(GPR_DEBUG, "WARNING: %" PRIuPTR " metadata strings were leaked",
@@ -370,4 +369,5 @@ void grpc_slice_intern_shutdown(void) {
     }
     gpr_free(shard->strs);
   }
+  delete[] g_shards;
 }


### PR DESCRIPTION
This is part of moving to Mutex and removing `grpc_core::MutexLockForGprMu`.