### PR TITLE
Fix unused variable error from PR #25401

### DIFF
--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -763,6 +763,7 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
   }
 
   void DoWork(void* tag, bool ok, bool resources) override {
+    (void)ok;
     SyncRequest* sync_req = static_cast<SyncRequest*>(tag);
 
     // Under the AllocatingRequestMatcher model we will never see an invalid tag


### PR DESCRIPTION
Currently causing a continuous build failure. See http://fusion/runanalysis/test/prod:grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_bazel_c_cpp_opt/prod:grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_bazel_c_cpp_opt/KOKORO/b7abf2c7-0d10-40cc-a006-ba3342c99db5/1613152745060/prod:grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_bazel_c_cpp_opt%20build%20%236527/Targets?target=grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_bazel_c_cpp_opt&drilldownTab=logs for a recent example.