### PR TITLE
Fix child process port allocation in ruby end-to-end tests

### DIFF
--- a/src/ruby/end2end/channel_closing_client.rb
+++ b/src/ruby/end2end/channel_closing_client.rb
@@ -30,11 +30,11 @@ class ChannelClosingClientController < ClientControl::ClientController::Service
 end
 
 def main
-  client_control_port = ''
+  parent_controller_port = ''
   server_port = ''
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do |p|
-      client_control_port = p
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
@@ -46,7 +46,8 @@ def main
 
   srv = new_rpc_server_for_testing
   thd = Thread.new do
-    srv.add_http2_port("0.0.0.0:#{client_control_port}", :this_port_is_insecure)
+    port = srv.add_http2_port('localhost:0', :this_port_is_insecure)
+    report_controller_port_to_parent(parent_controller_port, port)
     srv.handle(ChannelClosingClientController.new(ch))
     srv.run
   end

--- a/src/ruby/end2end/channel_closing_test.rb
+++ b/src/ruby/end2end/channel_closing_test.rb
@@ -24,8 +24,8 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  control_stub, client_pid = start_client('channel_closing_client.rb',
-                                          server_port)
+  client_controller = ClientController.new(
+    'channel_closing_client.rb', server_port)
   # sleep to allow time for the client to get into
   # the middle of a "watch connectivity state" call
   sleep 3
@@ -34,7 +34,7 @@ def main
     Timeout.timeout(20) do
       loop do
         begin
-          control_stub.shutdown(ClientControl::Void.new)
+          client_controller.stub.shutdown(ClientControl::Void.new)
           break
         rescue GRPC::BadStatus => e
           STDERR.puts "control_stub.shutdown RPC received error:|#{e}|. " \
@@ -42,12 +42,12 @@ def main
           "so we'll retry the RPC"
         end
       end
-      Process.wait(client_pid)
+      Process.wait(client_controller.client_pid)
     end
   rescue Timeout::Error
-    STDERR.puts "timeout wait for client pid #{client_pid}"
-    Process.kill('SIGKILL', client_pid)
-    Process.wait(client_pid)
+    STDERR.puts "timeout wait for client pid #{client_controller.client_pid}"
+    Process.kill('SIGKILL', client_controller.client_pid)
+    Process.wait(client_controller.client_pid)
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. It likely hangs when a ' \
       'channel is closed while connectivity is watched'

--- a/src/ruby/end2end/channel_state_client.rb
+++ b/src/ruby/end2end/channel_state_client.rb
@@ -17,15 +17,17 @@
 require_relative './end2end_common'
 
 def main
+  parent_controller_port = ''
   server_port = ''
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do
-      STDERR.puts 'client_control_port ignored'
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
     end
   end.parse!
+  report_controller_port_to_parent(parent_controller_port, 0)
 
   ch = GRPC::Core::Channel.new("localhost:#{server_port}", {},
                                :this_channel_is_insecure)

--- a/src/ruby/end2end/channel_state_test.rb
+++ b/src/ruby/end2end/channel_state_test.rb
@@ -23,18 +23,19 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  _, client_pid = start_client('channel_state_client.rb', server_port)
+  client_controller = ClientController.new(
+    'channel_state_client.rb', server_port)
   # sleep to allow time for the client to get into
   # the middle of a "watch connectivity state" call
   sleep 3
-  Process.kill('SIGTERM', client_pid)
+  Process.kill('SIGTERM', client_controller.client_pid)
 
   begin
-    Timeout.timeout(10) { Process.wait(client_pid) }
+    Timeout.timeout(10) { Process.wait(client_controller.client_pid) }
   rescue Timeout::Error
-    STDERR.puts "timeout wait for client pid #{client_pid}"
-    Process.kill('SIGKILL', client_pid)
-    Process.wait(client_pid)
+    STDERR.puts "timeout wait for client pid #{client_controller.client_pid}"
+    Process.kill('SIGKILL', client_controller.client_pid)
+    Process.wait(client_controller.client_pid)
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. ' \
            'It likely hangs when ended abruptly'

--- a/src/ruby/end2end/client_memory_usage_client.rb
+++ b/src/ruby/end2end/client_memory_usage_client.rb
@@ -18,17 +18,19 @@ require_relative './end2end_common'
 require 'objspace'
 
 def main
+  parent_controller_port = ''
   server_port = ''
   loop_count = 200
 
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do
-      STDERR.puts 'client_control_port ignored'
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
     end
   end.parse!
+  report_controller_port_to_parent(parent_controller_port, 0)
 
   loop_count.times do
     stub = Echo::EchoServer::Stub.new("localhost:#{server_port}", :this_channel_is_insecure)

--- a/src/ruby/end2end/client_memory_usage_test.rb
+++ b/src/ruby/end2end/client_memory_usage_test.rb
@@ -21,9 +21,10 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  _, client_pid = start_client('client_memory_usage_client.rb', server_port)
+  client_controller = ClientController.new(
+    'client_memory_usage_client.rb', server_port)
 
-  Process.wait(client_pid)
+  Process.wait(client_controller.client_pid)
 
   client_exit_code = $CHILD_STATUS
   if client_exit_code != 0

--- a/src/ruby/end2end/forking_client_client.rb
+++ b/src/ruby/end2end/forking_client_client.rb
@@ -19,10 +19,11 @@
 require_relative './end2end_common'
 
 def main
+  parent_controller_port = ''
   server_port = ''
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do
-      STDERR.puts 'client control port not used'
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
@@ -46,7 +47,9 @@ def main
     raise 'Timed out waiting for client process. ' \
       'It likely hangs when using gRPC after loading it and then forking'
   end
-
+  # don't report the port until now so as to not use grpc before forking
+  report_controller_port_to_parent(parent_controller_port, 0)
+  # check exit status of forked process
   client_exit_code = $CHILD_STATUS
   fail "forked process failed #{client_exit_code}" if client_exit_code != 0
 end

--- a/src/ruby/end2end/forking_client_test.rb
+++ b/src/ruby/end2end/forking_client_test.rb
@@ -21,17 +21,17 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  _, client_pid = start_client('forking_client_client.rb',
-                               server_port)
+  client_controller = ClientController.new(
+    'forking_client_client.rb', server_port)
 
   begin
     Timeout.timeout(10) do
-      Process.wait(client_pid)
+      Process.wait(client_controller.client_pid)
     end
   rescue Timeout::Error
-    STDERR.puts "timeout wait for client pid #{client_pid}"
-    Process.kill('SIGKILL', client_pid)
-    Process.wait(client_pid)
+    STDERR.puts "timeout wait for client pid #{client_controller.client_pid}"
+    Process.kill('SIGKILL', client_controller.client_pid)
+    Process.wait(client_controller.client_pid)
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. ' \
       'It likely hangs when requiring grpc, then forking, then using grpc '

--- a/src/ruby/end2end/graceful_sig_handling_client.rb
+++ b/src/ruby/end2end/graceful_sig_handling_client.rb
@@ -30,21 +30,20 @@ class SigHandlingClientController < ClientControl::ClientController::Service
 end
 
 def main
-  client_control_port = ''
+  parent_controller_port = ''
   server_port = ''
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do |p|
-      client_control_port = p
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
     end
   end.parse!
 
-  # Allow a few seconds to be safe.
   srv = new_rpc_server_for_testing
-  srv.add_http2_port("0.0.0.0:#{client_control_port}",
-                     :this_port_is_insecure)
+  port = srv.add_http2_port('localhost:0',
+                            :this_port_is_insecure)
   stub = Echo::EchoServer::Stub.new("localhost:#{server_port}",
                                     :this_channel_is_insecure)
   control_service = SigHandlingClientController.new(stub)
@@ -53,8 +52,8 @@ def main
     srv.run_till_terminated_or_interrupted(['int'])
   end
   srv.wait_till_running
-  # send a first RPC to notify the parent process that we've started
-  stub.echo(Echo::EchoRequest.new(request: 'client/child started'))
+  # notify the parent process that we're ready to receive signals
+  report_controller_port_to_parent(parent_controller_port, port)
   server_thread.join
 end
 

--- a/src/ruby/end2end/graceful_sig_stop_client.rb
+++ b/src/ruby/end2end/graceful_sig_stop_client.rb
@@ -45,11 +45,11 @@ class SigHandlingClientController < ClientControl::ClientController::Service
 end
 
 def main
-  client_control_port = ''
+  parent_controller_port = ''
   server_port = ''
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do |p|
-      client_control_port = p
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
@@ -59,8 +59,8 @@ def main
   # The "shutdown" RPC should end very quickly.
   # Allow a few seconds to be safe.
   srv = new_rpc_server_for_testing(poll_period: 3)
-  srv.add_http2_port("0.0.0.0:#{client_control_port}",
-                     :this_port_is_insecure)
+  port = srv.add_http2_port('localhost:0',
+                            :this_port_is_insecure)
   stub = Echo::EchoServer::Stub.new("localhost:#{server_port}",
                                     :this_channel_is_insecure)
   control_service = SigHandlingClientController.new(srv, stub)
@@ -69,8 +69,8 @@ def main
     srv.run_till_terminated_or_interrupted(['int'])
   end
   srv.wait_till_running
-  # send a first RPC to notify the parent process that we've started
-  stub.echo(Echo::EchoRequest.new(request: 'client/child started'))
+  # notify the parent process that we're ready
+  report_controller_port_to_parent(parent_controller_port, port)
   server_thread.join
   control_service.join_shutdown_thread
 end

--- a/src/ruby/end2end/killed_client_thread_client.rb
+++ b/src/ruby/end2end/killed_client_thread_client.rb
@@ -20,15 +20,17 @@
 require_relative './end2end_common'
 
 def main
+  parent_controller_port = ''
   server_port = ''
   OptionParser.new do |opts|
-    opts.on('--client_control_port=P', String) do
-      STDERR.puts 'client control port not used'
+    opts.on('--parent_controller_port=P', String) do |p|
+      parent_controller_port = p
     end
     opts.on('--server_port=P', String) do |p|
       server_port = p
     end
   end.parse!
+  report_controller_port_to_parent(parent_controller_port, 0)
 
   thd = Thread.new do
     stub = Echo::EchoServer::Stub.new("localhost:#{server_port}",

--- a/src/ruby/end2end/lib/client_control_pb.rb
+++ b/src/ruby/end2end/lib/client_control_pb.rb
@@ -4,14 +4,20 @@
 require 'google/protobuf'
 
 Google::Protobuf::DescriptorPool.generated_pool.build do
-  add_message "client_control.DoEchoRpcRequest" do
-    optional :request, :string, 1
-  end
-  add_message "client_control.Void" do
+  add_file("client_control.proto", :syntax => :proto3) do
+    add_message "client_control.DoEchoRpcRequest" do
+      optional :request, :string, 1
+    end
+    add_message "client_control.Void" do
+    end
+    add_message "client_control.Port" do
+      optional :port, :int32, 1
+    end
   end
 end
 
 module ClientControl
-  DoEchoRpcRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("client_control.DoEchoRpcRequest").msgclass
-  Void = Google::Protobuf::DescriptorPool.generated_pool.lookup("client_control.Void").msgclass
+  DoEchoRpcRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("client_control.DoEchoRpcRequest").msgclass
+  Void = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("client_control.Void").msgclass
+  Port = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("client_control.Port").msgclass
 end

--- a/src/ruby/end2end/lib/client_control_services_pb.rb
+++ b/src/ruby/end2end/lib/client_control_services_pb.rb
@@ -29,8 +29,22 @@ module ClientControl
       self.unmarshal_class_method = :decode
       self.service_name = 'client_control.ClientController'
 
-      rpc :DoEchoRpc, DoEchoRpcRequest, Void
-      rpc :Shutdown, Void, Void
+      rpc :DoEchoRpc, ::ClientControl::DoEchoRpcRequest, ::ClientControl::Void
+      rpc :Shutdown, ::ClientControl::Void, ::ClientControl::Void
+    end
+
+    Stub = Service.rpc_stub_class
+  end
+  module ParentController
+    class Service
+
+      include GRPC::GenericService
+
+      self.marshal_class_method = :encode
+      self.unmarshal_class_method = :decode
+      self.service_name = 'client_control.ParentController'
+
+      rpc :SetClientControllerPort, ::ClientControl::Port, ::ClientControl::Void
     end
 
     Stub = Service.rpc_stub_class

--- a/src/ruby/end2end/lib/echo_pb.rb
+++ b/src/ruby/end2end/lib/echo_pb.rb
@@ -4,15 +4,17 @@
 require 'google/protobuf'
 
 Google::Protobuf::DescriptorPool.generated_pool.build do
-  add_message "echo.EchoRequest" do
-    optional :request, :string, 1
-  end
-  add_message "echo.EchoReply" do
-    optional :response, :string, 1
+  add_file("echo.proto", :syntax => :proto3) do
+    add_message "echo.EchoRequest" do
+      optional :request, :string, 1
+    end
+    add_message "echo.EchoReply" do
+      optional :response, :string, 1
+    end
   end
 end
 
 module Echo
-  EchoRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("echo.EchoRequest").msgclass
-  EchoReply = Google::Protobuf::DescriptorPool.generated_pool.lookup("echo.EchoReply").msgclass
+  EchoRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("echo.EchoRequest").msgclass
+  EchoReply = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("echo.EchoReply").msgclass
 end

--- a/src/ruby/end2end/lib/echo_services_pb.rb
+++ b/src/ruby/end2end/lib/echo_services_pb.rb
@@ -29,7 +29,7 @@ module Echo
       self.unmarshal_class_method = :decode
       self.service_name = 'echo.EchoServer'
 
-      rpc :Echo, EchoRequest, EchoReply
+      rpc :Echo, ::Echo::EchoRequest, ::Echo::EchoReply
     end
 
     Stub = Service.rpc_stub_class

--- a/src/ruby/end2end/protos/client_control.proto
+++ b/src/ruby/end2end/protos/client_control.proto
@@ -26,3 +26,11 @@ message DoEchoRpcRequest {
 }
 
 message Void{}
+
+service ParentController {
+  rpc SetClientControllerPort(Port) returns (Void) {}
+}
+
+message Port {
+  int32 port = 1;
+}

--- a/src/ruby/end2end/sig_handling_test.rb
+++ b/src/ruby/end2end/sig_handling_test.rb
@@ -25,19 +25,20 @@ def main
   server_runner = ServerRunner.new(echo_service)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  control_stub, client_pid = start_client('sig_handling_client.rb', server_port)
-  # use receipt of one RPC to indicate that the child process is
-  # ready
-  echo_service.wait_for_first_rpc_received(20)
+  client_controller = ClientController.new(
+    'sig_handling_client.rb', server_port)
   count = 0
   while count < 5
-    control_stub.do_echo_rpc(
+    client_controller.stub.do_echo_rpc(
       ClientControl::DoEchoRpcRequest.new(request: 'hello'))
-    Process.kill('SIGTERM', client_pid)
-    Process.kill('SIGINT', client_pid)
+    Process.kill('SIGTERM', client_controller.client_pid)
+    Process.kill('SIGINT', client_controller.client_pid)
     count += 1
   end
-  cleanup(control_stub, client_pid, server_runner)
+  client_controller.stub.shutdown(ClientControl::Void.new)
+  Process.wait(client_controller.client_pid)
+  fail "client exit code: #{$CHILD_STATUS}" unless $CHILD_STATUS.to_i.zero?
+  server_runner.stop
 end
 
 main

--- a/src/ruby/end2end/sig_int_during_channel_watch_test.rb
+++ b/src/ruby/end2end/sig_int_during_channel_watch_test.rb
@@ -25,23 +25,20 @@ def main
   server_runner = ServerRunner.new(echo_service)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  _, client_pid = start_client('sig_int_during_channel_watch_client.rb',
-                               server_port)
-  # use receipt of one RPC to indicate that the child process is
-  # ready for a SIGINT
-  echo_service.wait_for_first_rpc_received(20)
+  client_controller = ClientController.new(
+    'sig_int_during_channel_watch_client.rb', server_port)
   # give time for the client to get into the middle
   # of a channel state watch call
   sleep 1
-  Process.kill('SIGINT', client_pid)
+  Process.kill('SIGINT', client_controller.client_pid)
   begin
     Timeout.timeout(10) do
-      Process.wait(client_pid)
+      Process.wait(client_controller.client_pid)
     end
   rescue Timeout::Error
-    STDERR.puts "timeout wait for client pid #{client_pid}"
-    Process.kill('SIGKILL', client_pid)
-    Process.wait(client_pid)
+    STDERR.puts "timeout wait for client pid #{client_controller.client_pid}"
+    Process.kill('SIGKILL', client_controller.client_pid)
+    Process.wait(client_controller.client_pid)
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. It likely hangs when a ' \
       'SIGINT is sent while there is an active connectivity_state call'


### PR DESCRIPTION
Should fix internal issues: b/179264584, b/171057074, b/178198736

The current port allocation for child process in multi-process based ruby end to end tests works with a hack, see: https://github.com/grpc/grpc/blob/8b2bd69ef370b7eec08647662022c6012e62a0a0/src/ruby/end2end/end2end_common.rb#L111 - this works by:
1) allocating a port on a socket in the parent process
2) saving the port number
3) closing the socket
4) passing the port number to the child process and binding the child process server to this port number, hoping that the port number is still free. This is of course inherently incorrect, since the port can be reallocated before binding in the child process.

This refactors all of these tests to pick the child port in the child process, and then report that port number to the parent process via an RPC. The new `ClientController` class will spawn a child process and then wait for the child process to report a port number back to it.

This machinery also gives us a nice way to synchronize the parent process with when the child process is "ready" for the test to proceed, so this PR gets rid of some now unnecessary RPCs that were previously used for this purpose.


