### PR TITLE
[Fuchsia] Disable C-ARES resolver

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -366,6 +366,7 @@
 #define GPR_ARCH_32 1
 #endif /* _LP64 */
 #elif defined(__Fuchsia__)
+#define GRPC_ARES 0
 #define GPR_FUCHSIA 1
 #define GPR_ARCH_64 1
 #define GPR_PLATFORM_STRING "fuchsia"


### PR DESCRIPTION
C-ARES does not work on Fuchsia, and is causing DNS solution failures.
We are disabling C-ARES so that we fall back to the native resolver.

Issue: #25446




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
