### PR TITLE
use boringssl asm optimizations in aarch64 wheel source build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -303,10 +303,13 @@ asm_key = ''
 if BUILD_WITH_BORING_SSL_ASM and not BUILD_WITH_SYSTEM_OPENSSL:
     LINUX_X86_64 = 'linux-x86_64'
     LINUX_ARM = 'linux-arm'
+    LINUX_AARCH64 = 'linux-aarch64'
     if LINUX_X86_64 == util.get_platform():
         asm_key = 'crypto_linux_x86_64'
     elif LINUX_ARM == util.get_platform():
         asm_key = 'crypto_linux_arm'
+    elif LINUX_AARCH64 == util.get_platform():
+        asm_key = 'crypto_linux_aarch64'
     elif "mac" in util.get_platform() and "x86_64" in util.get_platform():
         asm_key = 'crypto_mac_x86_64'
     else:


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/25451 (note that this will only fix the wheel when building python wheels from source, more work is needed to include asm optimizations in the binary wheels)

Supersedes https://github.com/grpc/grpc/pull/25162

note that the grpc_core_dependencies.py already contains the assembly files for linux aarch64
https://github.com/grpc/grpc/blob/6102f67adeccb95afb32c2cef4198e50a5d77ee0/src/python/grpcio/grpc_core_dependencies.py#L1070
