### PR TITLE
xds-k8s driver: remove "Client subchannel must have no sockets" check

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -160,7 +160,8 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
                     try:
                         subchannel = self.find_subchannel_with_state(
                             channel, state, **rpc_params)
-                        logger.info('Found subchannel in state %s: %s', state,
+                        logger.info('Found subchannel in state %s: %s',
+                                    _ChannelzChannelState.Name(state),
                                     subchannel)
                     except self.NotFound as e:
                         # Otherwise, keep searching.

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -457,9 +457,6 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
                        1,
                        msg="Client channel must have exactly one subchannel "
                        "in state TRANSIENT_FAILURE.")
-        sockets = list(
-            test_client.channelz.list_subchannels_sockets(subchannels[0]))
-        self.assertEmpty(sockets, msg="Client subchannel must have no sockets")
 
     @staticmethod
     def getConnectedSockets(


### PR DESCRIPTION
- Remove "Client subchannel must have no sockets" assertion from negative PSM Security tests to cover an edge case with the check being executed after test client established the connection, but test server hasn't rejected it yet. Ref b/180327778
- Minor: fix log message. Use full state name instead of numeric enum value, f.e. `Found subchannel in state 4` -> `Found subchannel in state TRANSIENT_FAILURE`
