### PR TITLE
[Backport] Bump xDS Interop Tests to Python 3

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -23,7 +23,7 @@ ${name}')
 cd /var/local/git/grpc
 
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV"
+virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio-tools google-api-python-client google-auth-httplib2 oauth2client

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -23,7 +23,7 @@ ${name}')
 cd /var/local/git/grpc
 
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV"
+virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio grpcio-tools google-api-python-client google-auth-httplib2 oauth2client

--- a/tools/internal_ci/linux/grpc_xds_csharp_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_csharp_test_in_docker.sh
@@ -23,7 +23,7 @@ ${name}')
 cd /var/local/git/grpc
 
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV"
+virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio grpcio-tools google-api-python-client google-auth-httplib2 oauth2client

--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -23,7 +23,7 @@ ${name}')
 cd /var/local/git/grpc
 
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV"
+virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio-tools google-api-python-client google-auth-httplib2 oauth2client

--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -23,7 +23,7 @@ ${name}')
 cd /var/local/git/grpc
 
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV"
+virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio-tools google-api-python-client google-auth-httplib2 oauth2client


### PR DESCRIPTION
*This is an automatically generated backport of #25456.*

This PR updates all xDS interop tests to run the test runner on a Python 3.X interpreter. The build was recently broken when a minor version release of the `rsa` package (a transitive dependency) dropped support for Python 2.7. Theoretically, this bump in interpreter version is all that should be required, but it's possible that there's some incompatibility between the new interpreter version and the test runner code.

I won't merge until my manual test finishes, but it looks promising, so I want to get presubmits running.

Generated with: `find tools/internal_ci/linux/ -name '*xds*docker*sh' | xargs sed -i 's/virtualenv "\$VIRTUAL_ENV"/virtualenv "\$VIRTUAL_ENV" -p python3/g'`