### PR TITLE
Reduce max size of bm_callback_streaming_ping_pong messages

### DIFF
--- a/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
@@ -34,7 +34,7 @@ static void StreamingPingPongMsgSizeArgs(benchmark::internal::Benchmark* b) {
   b->Args({0, 1});
   b->Args({0, 2});
 
-  for (int msg_size = 1; msg_size <= 128 * 1024 * 1024; msg_size *= 8) {
+  for (int msg_size = 1; msg_size <= 16 * 1024 * 1024; msg_size *= 8) {
     b->Args({msg_size, 1});
     b->Args({msg_size, 2});
   }


### PR DESCRIPTION
Match unary to prevent timeouts while callback alternative performance debugging is undergoing.