### PR TITLE
Set error message when a data frame with END_STREAM is received on client

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -297,7 +297,11 @@ grpc_error* grpc_chttp2_data_parser_parse(void* /*parser*/,
   }
 
   if (is_last && s->received_last_frame) {
-    grpc_chttp2_mark_stream_closed(t, s, true, false, GRPC_ERROR_NONE);
+    grpc_chttp2_mark_stream_closed(
+        t, s, true, false,
+        t->is_client ? GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+                           "Data frame with END_STREAM flag received")
+                     : GRPC_ERROR_NONE);
   }
 
   return GRPC_ERROR_NONE;


### PR DESCRIPTION
This PR improves error logging for the case when a data frame with END_STREAM is received on client. (A gRPC client expects trailers with the status after the data frames.)