### PR TITLE
Explain include/grpc++ vs include/grpcpp

### DIFF
--- a/include/grpc++/README.md
+++ b/include/grpc++/README.md
@@ -1,0 +1,7 @@
+# include/grpc++
+
+This was the original directory name for all C++ header files but it
+conflicted with the naming scheme required for some build systems. It
+is superseded by `include/grpcpp` but the old directory structure is
+still present to avoid breaking code that used the old include files.
+All new include files are only in `include/grpcpp`.


### PR DESCRIPTION

The include path changed and wasn't explained.
