### PR TITLE
Fix a typo in xDS bootstrap parsing

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -894,7 +894,7 @@ XdsClusterResolverLb::CreateChildPolicyConfigLocked() {
             locality_name_json["zone"] = locality_name->zone();
           }
           if (!locality_name->sub_zone().empty()) {
-            locality_name_json["subzone"] = locality_name->sub_zone();
+            locality_name_json["sub_zone"] = locality_name->sub_zone();
           }
           // Add weighted target entry.
           weighted_targets[locality_name->AsHumanReadableString()] =

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -763,7 +763,7 @@ void PopulateNode(const EncodingContext& context,
       PopulateMetadata(context, metadata, node->metadata.object_value());
     }
     if (!node->locality_region.empty() || !node->locality_zone.empty() ||
-        !node->locality_subzone.empty()) {
+        !node->locality_sub_zone.empty()) {
       envoy_config_core_v3_Locality* locality =
           envoy_config_core_v3_Node_mutable_locality(node_msg, context.arena);
       if (!node->locality_region.empty()) {
@@ -774,9 +774,9 @@ void PopulateNode(const EncodingContext& context,
         envoy_config_core_v3_Locality_set_zone(
             locality, StdStringToUpbString(node->locality_zone));
       }
-      if (!node->locality_subzone.empty()) {
+      if (!node->locality_sub_zone.empty()) {
         envoy_config_core_v3_Locality_set_sub_zone(
-            locality, StdStringToUpbString(node->locality_subzone));
+            locality, StdStringToUpbString(node->locality_sub_zone));
       }
     }
   }

--- a/src/core/ext/xds/xds_bootstrap.cc
+++ b/src/core/ext/xds/xds_bootstrap.cc
@@ -93,13 +93,14 @@ std::string BootstrapString(const XdsBootstrap& bootstrap) {
         "  locality={\n"
         "    region=\"%s\",\n"
         "    zone=\"%s\",\n"
-        "    subzone=\"%s\"\n"
+        "    sub_zone=\"%s\"\n"
         "  },\n"
         "  metadata=%s,\n"
         "},\n",
         bootstrap.node()->id, bootstrap.node()->cluster,
         bootstrap.node()->locality_region, bootstrap.node()->locality_zone,
-        bootstrap.node()->locality_subzone, bootstrap.node()->metadata.Dump()));
+        bootstrap.node()->locality_sub_zone,
+        bootstrap.node()->metadata.Dump()));
   }
   parts.push_back(absl::StrFormat(
       "servers=[\n"
@@ -455,13 +456,13 @@ grpc_error* XdsBootstrap::ParseLocality(Json* json) {
       node_->locality_zone = std::move(*it->second.mutable_string_value());
     }
   }
-  it = json->mutable_object()->find("subzone");
+  it = json->mutable_object()->find("sub_zone");
   if (it != json->mutable_object()->end()) {
     if (it->second.type() != Json::Type::STRING) {
       error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "\"subzone\" field is not a string"));
+          "\"sub_zone\" field is not a string"));
     } else {
-      node_->locality_subzone = std::move(*it->second.mutable_string_value());
+      node_->locality_sub_zone = std::move(*it->second.mutable_string_value());
     }
   }
   return GRPC_ERROR_CREATE_FROM_VECTOR("errors parsing \"locality\" object",

--- a/src/core/ext/xds/xds_bootstrap.h
+++ b/src/core/ext/xds/xds_bootstrap.h
@@ -54,7 +54,7 @@ class XdsBootstrap {
     std::string cluster;
     std::string locality_region;
     std::string locality_zone;
-    std::string locality_subzone;
+    std::string locality_sub_zone;
     Json metadata;
   };
 

--- a/src/core/ext/xds/xds_client_stats.h
+++ b/src/core/ext/xds/xds_client_stats.h
@@ -56,10 +56,10 @@ class XdsLocalityName : public RefCounted<XdsLocalityName> {
     }
   };
 
-  XdsLocalityName(std::string region, std::string zone, std::string subzone)
+  XdsLocalityName(std::string region, std::string zone, std::string sub_zone)
       : region_(std::move(region)),
         zone_(std::move(zone)),
-        sub_zone_(std::move(subzone)) {}
+        sub_zone_(std::move(sub_zone)) {}
 
   bool operator==(const XdsLocalityName& other) const {
     return region_ == other.region_ && zone_ == other.zone_ &&

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -101,7 +101,7 @@ TEST_P(XdsBootstrapTest, Basic) {
       "    \"locality\": {"
       "      \"region\": \"milky_way\","
       "      \"zone\": \"sol_system\","
-      "      \"subzone\": \"earth\","
+      "      \"sub_zone\": \"earth\","
       "      \"ignore\": {}"
       "    },"
       "    \"metadata\": {"
@@ -126,7 +126,7 @@ TEST_P(XdsBootstrapTest, Basic) {
   EXPECT_EQ(bootstrap.node()->cluster, "bar");
   EXPECT_EQ(bootstrap.node()->locality_region, "milky_way");
   EXPECT_EQ(bootstrap.node()->locality_zone, "sol_system");
-  EXPECT_EQ(bootstrap.node()->locality_subzone, "earth");
+  EXPECT_EQ(bootstrap.node()->locality_sub_zone, "earth");
   ASSERT_EQ(bootstrap.node()->metadata.type(), Json::Type::OBJECT);
   EXPECT_THAT(bootstrap.node()->metadata.object_value(),
               ::testing::ElementsAre(
@@ -387,7 +387,7 @@ TEST_P(XdsBootstrapTest, LocalityFieldsWrongType) {
       "    \"locality\":{"
       "      \"region\":0,"
       "      \"zone\":0,"
-      "      \"subzone\":0"
+      "      \"sub_zone\":0"
       "    }"
       "  }"
       "}";
@@ -400,7 +400,7 @@ TEST_P(XdsBootstrapTest, LocalityFieldsWrongType) {
                                        "errors parsing \"locality\" object.*"
                                        "\"region\" field is not a string.*"
                                        "\"zone\" field is not a string.*"
-                                       "\"subzone\" field is not a string"));
+                                       "\"sub_zone\" field is not a string"));
   GRPC_ERROR_UNREF(error);
 }
 

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -192,7 +192,7 @@ constexpr char kBootstrapFileV3[] =
     "    \"locality\": {\n"
     "      \"region\": \"corp\",\n"
     "      \"zone\": \"svl\",\n"
-    "      \"subzone\": \"mp3\"\n"
+    "      \"sub_zone\": \"mp3\"\n"
     "    }\n"
     "  },\n"
     "  \"certificate_providers\": {\n"
@@ -234,7 +234,7 @@ constexpr char kBootstrapFileV2[] =
     "    \"locality\": {\n"
     "      \"region\": \"corp\",\n"
     "      \"zone\": \"svl\",\n"
-    "      \"subzone\": \"mp3\"\n"
+    "      \"sub_zone\": \"mp3\"\n"
     "    }\n"
     "  }\n"
     "}\n";


### PR DESCRIPTION
It's `sub_zone` instead of `subzone` in `base.proto`: https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/core/v3/base.proto#L85.

This shouldn't affect interop tests, because we are not using the `sub_zone` field at all.

CC @markdroth 