### PR TITLE
Remove CAS loops in global subchannel pool and simplify subchannel refcounting

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_factory.h
+++ b/src/core/ext/filters/client_channel/client_channel_factory.h
@@ -32,7 +32,8 @@ class ClientChannelFactory {
   virtual ~ClientChannelFactory() = default;
 
   // Creates a subchannel with the specified args.
-  virtual Subchannel* CreateSubchannel(const grpc_channel_args* args) = 0;
+  virtual RefCountedPtr<Subchannel> CreateSubchannel(
+      const grpc_channel_args* args) = 0;
 
   // Returns a channel arg containing the specified factory.
   static grpc_arg CreateChannelArg(ClientChannelFactory* factory);

--- a/src/core/ext/filters/client_channel/global_subchannel_pool.cc
+++ b/src/core/ext/filters/client_channel/global_subchannel_pool.cc
@@ -27,16 +27,6 @@ namespace grpc_core {
 #define GRPC_REGISTER_SUBCHANNEL_CALM_DOWN_AFTER_ATTEMPTS 100
 #define GRPC_REGISTER_SUBCHANNEL_CALM_DOWN_MICROS 10
 
-GlobalSubchannelPool::GlobalSubchannelPool() {
-  subchannel_map_ = grpc_avl_create(&subchannel_avl_vtable_);
-  gpr_mu_init(&mu_);
-}
-
-GlobalSubchannelPool::~GlobalSubchannelPool() {
-  gpr_mu_destroy(&mu_);
-  grpc_avl_unref(subchannel_map_, nullptr);
-}
-
 void GlobalSubchannelPool::Init() {
   instance_ = new RefCountedPtr<GlobalSubchannelPool>(
       MakeRefCounted<GlobalSubchannelPool>());
@@ -57,145 +47,37 @@ RefCountedPtr<GlobalSubchannelPool> GlobalSubchannelPool::instance() {
   return *instance_;
 }
 
-Subchannel* GlobalSubchannelPool::RegisterSubchannel(SubchannelKey* key,
-                                                     Subchannel* constructed) {
-  Subchannel* c = nullptr;
-  // Compare and swap (CAS) loop:
-  for (int attempt_count = 0; c == nullptr; attempt_count++) {
-    // Ref the shared map to have a local copy.
-    gpr_mu_lock(&mu_);
-    grpc_avl old_map = grpc_avl_ref(subchannel_map_, nullptr);
-    gpr_mu_unlock(&mu_);
-    // Check to see if a subchannel already exists.
-    c = static_cast<Subchannel*>(grpc_avl_get(old_map, key, nullptr));
-    if (c != nullptr) {
-      // The subchannel already exists. Try to reuse it.
-      c = GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(c, "subchannel_register+reuse");
-      if (c != nullptr) {
-        GRPC_SUBCHANNEL_UNREF(constructed,
-                              "subchannel_register+found_existing");
-        // Exit the CAS loop without modifying the shared map.
-      } else {
-        // Reuse of the subchannel failed, so retry CAS loop
-        if (attempt_count >=
-            GRPC_REGISTER_SUBCHANNEL_CALM_DOWN_AFTER_ATTEMPTS) {
-          // GRPC_SUBCHANNEL_REF_FROM_WEAK_REF returning nullptr means that the
-          // subchannel we got is no longer valid and it's going to be removed
-          // from the AVL tree soon. Spinning here excesively here can actually
-          // prevent another thread from removing the subchannel, basically
-          // resulting in a live lock. See b/157516542 for more details.
-          // TODO(jtattermusch): the entire ref-counting mechanism for
-          // subchannels should be overhaulded, but the current workaround
-          // is fine for short-term.
-          // TODO(jtattermusch): gpr does not support thread yield operation,
-          // so a very short wait is the best we can do.
-          gpr_sleep_until(gpr_time_add(
-              gpr_now(GPR_CLOCK_REALTIME),
-              gpr_time_from_micros(GRPC_REGISTER_SUBCHANNEL_CALM_DOWN_MICROS,
-                                   GPR_TIMESPAN)));
-        }
-      }
-    } else {
-      // There hasn't been such subchannel. Add one.
-      // Note that we should ref the old map first because grpc_avl_add() will
-      // unref it while we still need to access it later.
-      grpc_avl new_map = grpc_avl_add(
-          grpc_avl_ref(old_map, nullptr), new SubchannelKey(*key),
-          GRPC_SUBCHANNEL_WEAK_REF(constructed, "subchannel_register+new"),
-          nullptr);
-      // Try to publish the change to the shared map. It may happen (but
-      // unlikely) that some other thread has changed the shared map, so compare
-      // to make sure it's unchanged before swapping. Retry if it's changed.
-      gpr_mu_lock(&mu_);
-      if (old_map.root == subchannel_map_.root) {
-        GPR_SWAP(grpc_avl, new_map, subchannel_map_);
-        c = constructed;
-      }
-      gpr_mu_unlock(&mu_);
-      grpc_avl_unref(new_map, nullptr);
-    }
-    grpc_avl_unref(old_map, nullptr);
+RefCountedPtr<Subchannel> GlobalSubchannelPool::RegisterSubchannel(
+    const SubchannelKey& key, RefCountedPtr<Subchannel> constructed) {
+  MutexLock lock(&mu_);
+  auto it = subchannel_map_.find(key);
+  if (it != subchannel_map_.end()) {
+    RefCountedPtr<Subchannel> existing = it->second->RefIfNonZero();
+    if (existing != nullptr) return existing;
   }
-  return c;
-}
-
-void GlobalSubchannelPool::UnregisterSubchannel(SubchannelKey* key) {
-  bool done = false;
-  // Compare and swap (CAS) loop:
-  while (!done) {
-    // Ref the shared map to have a local copy.
-    gpr_mu_lock(&mu_);
-    grpc_avl old_map = grpc_avl_ref(subchannel_map_, nullptr);
-    gpr_mu_unlock(&mu_);
-    // Remove the subchannel.
-    // Note that we should ref the old map first because grpc_avl_remove() will
-    // unref it while we still need to access it later.
-    grpc_avl new_map =
-        grpc_avl_remove(grpc_avl_ref(old_map, nullptr), key, nullptr);
-    // Try to publish the change to the shared map. It may happen (but
-    // unlikely) that some other thread has changed the shared map, so compare
-    // to make sure it's unchanged before swapping. Retry if it's changed.
-    gpr_mu_lock(&mu_);
-    if (old_map.root == subchannel_map_.root) {
-      GPR_SWAP(grpc_avl, new_map, subchannel_map_);
-      done = true;
-    }
-    gpr_mu_unlock(&mu_);
-    grpc_avl_unref(new_map, nullptr);
-    grpc_avl_unref(old_map, nullptr);
-  }
-}
-
-Subchannel* GlobalSubchannelPool::FindSubchannel(SubchannelKey* key) {
-  // Lock, and take a reference to the subchannel map.
-  // We don't need to do the search under a lock as AVL's are immutable.
-  gpr_mu_lock(&mu_);
-  grpc_avl index = grpc_avl_ref(subchannel_map_, nullptr);
-  gpr_mu_unlock(&mu_);
-  Subchannel* c = static_cast<Subchannel*>(grpc_avl_get(index, key, nullptr));
-  if (c != nullptr) c = GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(c, "found_from_pool");
-  grpc_avl_unref(index, nullptr);
-  return c;
+  subchannel_map_[key] = constructed.get();
+  return constructed;
 }
 
 RefCountedPtr<GlobalSubchannelPool>* GlobalSubchannelPool::instance_ = nullptr;
 
-namespace {
-
-void sck_avl_destroy(void* p, void* /*user_data*/) {
-  SubchannelKey* key = static_cast<SubchannelKey*>(p);
-  delete key;
+void GlobalSubchannelPool::UnregisterSubchannel(const SubchannelKey& key,
+                                                Subchannel* subchannel) {
+  MutexLock lock(&mu_);
+  auto it = subchannel_map_.find(key);
+  // delete only if key hasn't been re-registered to a different subchannel
+  // between strong-unreffing and unregistration of subchannel.
+  if (it != subchannel_map_.end() && it->second == subchannel) {
+    subchannel_map_.erase(it);
+  }
 }
 
-void* sck_avl_copy(void* p, void* /*unused*/) {
-  const SubchannelKey* key = static_cast<const SubchannelKey*>(p);
-  auto* new_key = new SubchannelKey(*key);
-  return static_cast<void*>(new_key);
+RefCountedPtr<Subchannel> GlobalSubchannelPool::FindSubchannel(
+    const SubchannelKey& key) {
+  MutexLock lock(&mu_);
+  auto it = subchannel_map_.find(key);
+  if (it == subchannel_map_.end()) return nullptr;
+  return it->second->RefIfNonZero();
 }
-
-long sck_avl_compare(void* a, void* b, void* /*unused*/) {
-  const SubchannelKey* key_a = static_cast<const SubchannelKey*>(a);
-  const SubchannelKey* key_b = static_cast<const SubchannelKey*>(b);
-  return key_a->Cmp(*key_b);
-}
-
-void scv_avl_destroy(void* p, void* /*user_data*/) {
-  GRPC_SUBCHANNEL_WEAK_UNREF((Subchannel*)p, "global_subchannel_pool");
-}
-
-void* scv_avl_copy(void* p, void* /*unused*/) {
-  GRPC_SUBCHANNEL_WEAK_REF((Subchannel*)p, "global_subchannel_pool");
-  return p;
-}
-
-}  // namespace
-
-const grpc_avl_vtable GlobalSubchannelPool::subchannel_avl_vtable_ = {
-    sck_avl_destroy,  // destroy_key
-    sck_avl_copy,     // copy_key
-    sck_avl_compare,  // compare_keys
-    scv_avl_destroy,  // destroy_value
-    scv_avl_copy      // copy_value
-};
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/global_subchannel_pool.h
+++ b/src/core/ext/filters/client_channel/global_subchannel_pool.h
@@ -21,7 +21,10 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <map>
+
 #include "src/core/ext/filters/client_channel/subchannel_pool_interface.h"
+#include "src/core/lib/gprpp/sync.h"
 
 namespace grpc_core {
 
@@ -33,8 +36,8 @@ namespace grpc_core {
 class GlobalSubchannelPool final : public SubchannelPoolInterface {
  public:
   // The ctor and dtor are not intended to use directly.
-  GlobalSubchannelPool();
-  ~GlobalSubchannelPool() override;
+  GlobalSubchannelPool() {}
+  ~GlobalSubchannelPool() override {}
 
   // Should be called exactly once at filter initialization time.
   static void Init();
@@ -45,22 +48,24 @@ class GlobalSubchannelPool final : public SubchannelPoolInterface {
   static RefCountedPtr<GlobalSubchannelPool> instance();
 
   // Implements interface methods.
-  Subchannel* RegisterSubchannel(SubchannelKey* key,
-                                 Subchannel* constructed) override;
-  void UnregisterSubchannel(SubchannelKey* key) override;
-  Subchannel* FindSubchannel(SubchannelKey* key) override;
+  RefCountedPtr<Subchannel> RegisterSubchannel(
+      const SubchannelKey& key, RefCountedPtr<Subchannel> constructed) override
+      ABSL_LOCKS_EXCLUDED(mu_);
+  void UnregisterSubchannel(const SubchannelKey& key,
+                            Subchannel* subchannel) override
+      ABSL_LOCKS_EXCLUDED(mu_);
+  RefCountedPtr<Subchannel> FindSubchannel(const SubchannelKey& key) override
+      ABSL_LOCKS_EXCLUDED(mu_);
 
  private:
   // The singleton instance. (It's a pointer to RefCountedPtr so that this
   // non-local static object can be trivially destructible.)
   static RefCountedPtr<GlobalSubchannelPool>* instance_;
 
-  // The vtable for subchannel operations in an AVL tree.
-  static const grpc_avl_vtable subchannel_avl_vtable_;
   // A map from subchannel key to subchannel.
-  grpc_avl subchannel_map_;
+  std::map<SubchannelKey, Subchannel*> subchannel_map_ ABSL_GUARDED_BY(mu_);
   // To protect subchannel_map_.
-  gpr_mu mu_;
+  Mutex mu_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/local_subchannel_pool.h
+++ b/src/core/ext/filters/client_channel/local_subchannel_pool.h
@@ -21,6 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <map>
+
 #include "src/core/ext/filters/client_channel/subchannel_pool_interface.h"
 
 namespace grpc_core {
@@ -34,22 +36,21 @@ namespace grpc_core {
 // Thread-unsafe.
 class LocalSubchannelPool final : public SubchannelPoolInterface {
  public:
-  LocalSubchannelPool();
-  ~LocalSubchannelPool() override;
+  LocalSubchannelPool() {}
+  ~LocalSubchannelPool() override {}
 
   // Implements interface methods.
   // Thread-unsafe. Intended to be invoked within the client_channel work
   // serializer.
-  Subchannel* RegisterSubchannel(SubchannelKey* key,
-                                 Subchannel* constructed) override;
-  void UnregisterSubchannel(SubchannelKey* key) override;
-  Subchannel* FindSubchannel(SubchannelKey* key) override;
+  RefCountedPtr<Subchannel> RegisterSubchannel(
+      const SubchannelKey& key, RefCountedPtr<Subchannel> constructed) override;
+  void UnregisterSubchannel(const SubchannelKey& key,
+                            Subchannel* subchannel) override;
+  RefCountedPtr<Subchannel> FindSubchannel(const SubchannelKey& key) override;
 
  private:
-  // The vtable for subchannel operations in an AVL tree.
-  static const grpc_avl_vtable subchannel_avl_vtable_;
   // A map from subchannel key to subchannel.
-  grpc_avl subchannel_map_;
+  std::map<SubchannelKey, Subchannel*> subchannel_map_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/subchannel_pool_interface.cc
+++ b/src/core/ext/filters/client_channel/subchannel_pool_interface.cc
@@ -49,8 +49,19 @@ SubchannelKey& SubchannelKey::operator=(const SubchannelKey& other) {
   return *this;
 }
 
-int SubchannelKey::Cmp(const SubchannelKey& other) const {
-  return grpc_channel_args_compare(args_, other.args_);
+SubchannelKey::SubchannelKey(SubchannelKey&& other) noexcept {
+  args_ = other.args_;
+  other.args_ = nullptr;
+}
+
+SubchannelKey& SubchannelKey::operator=(SubchannelKey&& other) noexcept {
+  args_ = other.args_;
+  other.args_ = nullptr;
+  return *this;
+}
+
+bool SubchannelKey::operator<(const SubchannelKey& other) const {
+  return grpc_channel_args_compare(args_, other.args_) < 0;
 }
 
 void SubchannelKey::Init(

--- a/src/core/ext/filters/client_channel/subchannel_pool_interface.h
+++ b/src/core/ext/filters/client_channel/subchannel_pool_interface.h
@@ -41,11 +41,11 @@ class SubchannelKey {
   // Copyable.
   SubchannelKey(const SubchannelKey& other);
   SubchannelKey& operator=(const SubchannelKey& other);
-  // Not movable.
-  SubchannelKey(SubchannelKey&&) = delete;
-  SubchannelKey& operator=(SubchannelKey&&) = delete;
+  // Movable
+  SubchannelKey(SubchannelKey&&) noexcept;
+  SubchannelKey& operator=(SubchannelKey&&) noexcept;
 
-  int Cmp(const SubchannelKey& other) const;
+  bool operator<(const SubchannelKey& other) const;
 
  private:
   // Initializes the subchannel key with the given \a args and the function to
@@ -72,15 +72,17 @@ class SubchannelPoolInterface : public RefCounted<SubchannelPoolInterface> {
   // Registers a subchannel against a key. Returns the subchannel registered
   // with \a key, which may be different from \a constructed because we reuse
   // (instead of update) any existing subchannel already registered with \a key.
-  virtual Subchannel* RegisterSubchannel(SubchannelKey* key,
-                                         Subchannel* constructed) = 0;
+  virtual RefCountedPtr<Subchannel> RegisterSubchannel(
+      const SubchannelKey& key, RefCountedPtr<Subchannel> constructed) = 0;
 
   // Removes the registered subchannel found by \a key.
-  virtual void UnregisterSubchannel(SubchannelKey* key) = 0;
+  virtual void UnregisterSubchannel(const SubchannelKey& key,
+                                    Subchannel* subchannel) = 0;
 
   // Finds the subchannel registered for the given subchannel key. Returns NULL
   // if no such channel exists. Thread-safe.
-  virtual Subchannel* FindSubchannel(SubchannelKey* key) = 0;
+  virtual RefCountedPtr<Subchannel> FindSubchannel(
+      const SubchannelKey& key) = 0;
 
   // Creates a channel arg from \a subchannel pool.
   static grpc_arg CreateChannelArg(SubchannelPoolInterface* subchannel_pool);

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -37,10 +37,11 @@ namespace grpc_core {
 
 class Chttp2InsecureClientChannelFactory : public ClientChannelFactory {
  public:
-  Subchannel* CreateSubchannel(const grpc_channel_args* args) override {
+  RefCountedPtr<Subchannel> CreateSubchannel(
+      const grpc_channel_args* args) override {
     grpc_channel_args* new_args =
         grpc_default_authority_add_if_not_present(args);
-    Subchannel* s =
+    RefCountedPtr<Subchannel> s =
         Subchannel::Create(MakeOrphanable<Chttp2Connector>(), new_args);
     grpc_channel_args_destroy(new_args);
     return s;

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -43,14 +43,15 @@ namespace grpc_core {
 
 class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
  public:
-  Subchannel* CreateSubchannel(const grpc_channel_args* args) override {
+  RefCountedPtr<Subchannel> CreateSubchannel(
+      const grpc_channel_args* args) override {
     grpc_channel_args* new_args = GetSecureNamingChannelArgs(args);
     if (new_args == nullptr) {
       gpr_log(GPR_ERROR,
               "Failed to create channel args during subchannel creation.");
       return nullptr;
     }
-    Subchannel* s =
+    RefCountedPtr<Subchannel> s =
         Subchannel::Create(MakeOrphanable<Chttp2Connector>(), new_args);
     grpc_channel_args_destroy(new_args);
     return s;

--- a/src/core/lib/gprpp/dual_ref_counted.h
+++ b/src/core/lib/gprpp/dual_ref_counted.h
@@ -195,7 +195,7 @@ class DualRefCounted : public Orphanable {
 #ifndef NDEBUG
     const uint32_t weak_refs = GetWeakRefs(prev_ref_pair);
     const uint32_t strong_refs = GetStrongRefs(prev_ref_pair);
-    if (trace_ != nullptr) {
+    if (trace != nullptr) {
       gpr_log(GPR_INFO, "%s:%p %s:%d weak_unref %d -> %d (refs=%d) %s", trace,
               this, location.file(), location.line(), weak_refs, weak_refs - 1,
               strong_refs, reason);

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -318,7 +318,7 @@ static void DoNothing(void* /*arg*/, grpc_error* /*error*/) {}
 
 class FakeClientChannelFactory : public grpc_core::ClientChannelFactory {
  public:
-  grpc_core::Subchannel* CreateSubchannel(
+  grpc_core::RefCountedPtr<grpc_core::Subchannel> CreateSubchannel(
       const grpc_channel_args* /*args*/) override {
     return nullptr;
   }


### PR DESCRIPTION
The primary change here is to replace the CAS loops in the global subchannel pool with mutex synchronization. As detailed in b/178127983, in a certain use case involving a very large number of channels and a high degree of parallelism, we spend very large amounts of time (sometimes nearly all CPU cores of CPU for many minutes) in `GlobalSubchannelPool::Register` and `Unregister`, with excessive spinning in the subchannel AVL tree CAS loops. This caused slowness, timeouts, etc.

This PR replaces the CAS loops with a single mutex lock, replaces the AVL tree with `std::map`, and revises `Subchannel` ref counting to inherit from `DualRefCounted`.

Note that there's one subtlety related to replacing the CAS loop with a single mutex lock, which is that we don't want the following to happen:
1) Thread 1 creates subchannel X
2) Thread 1 strong-unref's subchannel X
3) Thread 2 attempts to create a subchannel with equivalent arguments to X. Subchannel X has no strong-refs remaining, so it creates a new subchannel Y (with equivalent arguments to X) and inserts it into the pool.
4) Subchannel X is `Orphan`'d, and unregisters subchannel X from the pool. This unintentionally unregisters the still-active subchannel Y since they share the same key.
5) Thread 3 inserts a new subchannel Z, which also has the same key as X and Y. Subchannel Z is inserted into the pool because no other equivalent subchannels are registered. There are now two active subchannels (Y and Z), which share the same channel arguments, even though they're supposed to be using the global pool.

The simple fix was to make manipulation of subchannel strong-refs be atomic with global subchannel pool registration/unregistration. So, the `SubchannelRef` interface was added to allow the global subchannel pool to ensure this, while not interfering with the local subchannel pool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25485)
<!-- Reviewable:end -->
