### PR TITLE
Restore callback microbenchmarks but make them manual for now

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -362,8 +362,10 @@ grpc_cc_test(
         "bm_callback_unary_ping_pong.cc",
     ],
     tags = [
+        "manual",
         "no_mac",
         "no_windows",
+        "notap",
     ],
     deps = [":callback_unary_ping_pong_h"],
 )
@@ -387,8 +389,10 @@ grpc_cc_test(
         "bm_callback_streaming_ping_pong.cc",
     ],
     tags = [
-        "no_mac",  # to emulate "excluded_poll_engines: poll"
+        "manual",
+        "no_mac",
         "no_windows",
+        "notap",
     ],
     deps = [":callback_streaming_ping_pong_h"],
 )

--- a/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
@@ -34,7 +34,7 @@ static void StreamingPingPongMsgSizeArgs(benchmark::internal::Benchmark* b) {
   b->Args({0, 1});
   b->Args({0, 2});
 
-  for (int msg_size = 1; msg_size <= 16 * 1024 * 1024; msg_size *= 8) {
+  for (int msg_size = 1; msg_size <= 128 * 1024 * 1024; msg_size *= 8) {
     b->Args({msg_size, 1});
     b->Args({msg_size, 2});
   }

--- a/test/cpp/microbenchmarks/bm_callback_unary_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_callback_unary_ping_pong.cc
@@ -31,7 +31,7 @@ namespace testing {
 // internal microbenchmarking tooling
 static void SweepSizesArgs(benchmark::internal::Benchmark* b) {
   b->Args({0, 0});
-  for (int i = 1; i <= 16 * 1024 * 1024; i *= 8) {
+  for (int i = 1; i <= 128 * 1024 * 1024; i *= 8) {
     // First argument is the message size of request
     // Second argument is the message size of response
     b->Args({i, 0});

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3520,46 +3520,6 @@
     "flaky": false,
     "gtest": false,
     "language": "c++",
-    "name": "bm_callback_streaming_ping_pong",
-    "platforms": [
-      "linux",
-      "posix"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": true,
-    "ci_platforms": [
-      "linux",
-      "posix"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": false,
-    "language": "c++",
-    "name": "bm_callback_unary_ping_pong",
-    "platforms": [
-      "linux",
-      "posix"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": true,
-    "ci_platforms": [
-      "linux",
-      "posix"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": false,
-    "language": "c++",
     "name": "bm_channel",
     "platforms": [
       "linux",


### PR DESCRIPTION
While the callback alternative implementation goes through performance debugging, remove these microbenchmarks from the test suites so as to avoid flakes on presubmit and at import. Previous attempts to avoid timeouts by reducing benchmark size were insufficient, so just disable them for now and restore their original message size.