### PR TITLE
Remove an incorrect debug assertion

### DIFF
--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -811,8 +811,9 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
     void* tag;
     bool ok;
     while (server_cq_->Next(&tag, &ok)) {
-      GPR_DEBUG_ASSERT(false);
-      gpr_log(GPR_ERROR, "SyncRequest seen during shutdown");
+      // Drain the item and don't do any work on it. It is possible to see this
+      // if there is an explicit call to Wait that is not part of the actual
+      // Shutdown.
     }
   }
 


### PR DESCRIPTION
This assertion was triggered during server shutdown with an explicit Wait call thereafter (b/180458132) . This is actually correct if uncommon usage, so we should not be asserting.

