### PR TITLE
Run Ruby xDS tests on Buster instead of Jessie

### DIFF
--- a/templates/tools/dockerfile/test/ruby_buster_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/ruby_buster_x64/Dockerfile.template
@@ -1,0 +1,38 @@
+%YAML 1.2
+--- |
+  # Copyright 2021 The gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM debian:buster
+  
+  <%include file="../../apt_get_basic.include"/>
+
+
+  RUN apt-get update && apt-get install -y ${'\\'}
+      python-all-dev ${'\\'}
+      python3-all-dev ${'\\'}
+      python-setuptools ${'\\'}
+      procps
+  
+  # Install Python packages from PyPI
+  RUN curl https://bootstrap.pypa.io/get-pip.py | python3
+  RUN pip install --upgrade pip==19.3.1
+  RUN pip install virtualenv==16.7.9
+  RUN pip install protobuf==3.5.2.post1 twisted==17.5.0
+
+  <%include file="../../gcp_api_libraries.include"/>
+  <%include file="../../ruby_deps.include"/>
+  <%include file="../../run_tests_addons.include"/>
+  # Define the default command.
+  CMD ["bash"]

--- a/tools/dockerfile/test/ruby_buster_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_buster_x64/Dockerfile
@@ -1,0 +1,89 @@
+# Copyright 2021 The gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:buster
+
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  gcc \
+  gcc-multilib \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#================
+# Build profiling
+RUN apt-get update && apt-get install -y time && apt-get clean
+
+
+
+RUN apt-get update && apt-get install -y \
+    python-all-dev \
+    python3-all-dev \
+    python-setuptools \
+    procps
+
+# Install Python packages from PyPI
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3
+RUN pip install --upgrade pip==19.3.1
+RUN pip install virtualenv==16.7.9
+RUN pip install protobuf==3.5.2.post1 twisted==17.5.0
+
+# Google Cloud platform API libraries
+RUN pip install --upgrade google-api-python-client oauth2client
+
+#==================
+# Ruby dependencies
+
+# Install rvm
+RUN apt-get update && apt-get install -y gnupg2
+RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN \curl -sSL https://get.rvm.io | bash -s stable
+
+# Install Ruby 2.5
+RUN /bin/bash -l -c "rvm install ruby-2.5"
+RUN /bin/bash -l -c "rvm use --default ruby-2.5"
+RUN /bin/bash -l -c "echo 'gem: --no-document' > ~/.gemrc"
+RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
+
+
+RUN mkdir /var/local/jenkins
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/internal_ci/linux/grpc_xds_ruby.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/ruby_jessie_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/ruby_buster_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh


### PR DESCRIPTION
Ruby xDS interop tests are running with Python 3.4 on v1.30.x  through v1.34.x, which seems to be having issues. This PR bumps the docker image to Jessie to update us to Python 3.7.

Backports are being generated with

```
tools/release/backport_pr.sh 25493 gnossen "$(seq 30 33 | xargs -n1 printf "v1.%s.x ")" "menghanl" -c "./tools/dockerfile/push_testing_images.sh"
```

Additions to the backport script will be merged to master in a forthcoming PR.