### PR TITLE
Exclude Arm64 for simulator

### DIFF
--- a/src/objective-c/CronetFramework.podspec
+++ b/src/objective-c/CronetFramework.podspec
@@ -74,4 +74,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = "Cronet.framework"
   s.public_header_files = "Cronet.framework/Headers/**/*{.h}"
   s.source_files = "Cronet.framework/Headers/**/*{.h}"
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/src/objective-c/GRPCClient/private/GRPCCore/ChannelArgsUtil.h
+++ b/src/objective-c/GRPCClient/private/GRPCCore/ChannelArgsUtil.h
@@ -28,9 +28,9 @@ void GRPCFreeChannelArgs(grpc_channel_args* channel_args);
  * in the
  * @c dictionary. Keys must be @c NSString, @c NSNumber, or a pointer. If the
  * value responds to
- * @c @selector(UTF8String) then it will be mapped to @c GRPC_ARG_STRING. If the
+ * @c selector(UTF8String) then it will be mapped to @c GRPC_ARG_STRING. If the
  * value responds to
- * @c @selector(intValue), it will be mapped to @c GRPC_ARG_INTEGER. Otherwise,
+ * @c selector(intValue), it will be mapped to @c GRPC_ARG_INTEGER. Otherwise,
  * if the value is not nil, it is mapped as a pointer. The caller of this
  * function is responsible for calling
  * @c GRPCFreeChannelArgs to free the @c grpc_channel_args struct.


### PR DESCRIPTION
- Xcode 12 supported to build arm64 for Mac simulator, but `CronetFramework` is a vendor_framework vendored_framework missing the Arm Mac simulator slice.
- `@c @select()` is invalid in Xcode12 now.