### PR TITLE
Enable backport of unmerged PRs

### DIFF
--- a/tools/release/backport_pr.sh
+++ b/tools/release/backport_pr.sh
@@ -29,9 +29,8 @@ display_usage () {
 USAGE: $0 PR_ID GITHUB_USER BACKPORT_BRANCHES REVIEWERS [-c PER_BACKPORT_COMMAND]
    PR_ID: The ID of the PR to be backported.
    GITHUB_USER: Your GitHub username.
-   BACKPORT_BRANCHES: A space-separated list of branches to which the
-     source PR will be backported.
-   REVIEWERS: A comma-separated list of users to add as both reviewer and assignee. >/dev/stderr
+   BACKPORT_BRANCHES: A space-separated list of branches to which the source PR will be backported.
+   REVIEWERS: A comma-separated list of users to add as both reviewer and assignee.
    PER_BACKPORT_COMMAND : An optional command to run after cherrypicking the PR to the target branch.
      If you use this option, ensure your working directory is clean, as "git add -A" will be used to
      incorporate any generated files. Try running "git clean -xdff" beforehand.
@@ -51,7 +50,7 @@ if [ "$#" -lt "4" ]; then
   display_usage
 fi
 
-PR_NUMBER="$1"
+PR_ID="$1"
 GITHUB_USER="$2"
 BACKPORT_BRANCHES="$3"
 REVIEWERS="$4"
@@ -95,7 +94,7 @@ printf "\n"
 
 PR_DATA=$(curl -s -u "$GITHUB_USER:$GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/grpc/grpc/pulls/$PR_NUMBER")
+          "https://api.github.com/repos/grpc/grpc/pulls/$PR_ID")
 
 STATE=$(echo "$PR_DATA" | jq -r '.state')
 if [ "$STATE" != "open" ]; then
@@ -125,7 +124,7 @@ for BACKPORT_BRANCH in $BACKPORT_BRANCHES; do
 
   git checkout "origin/$BACKPORT_BRANCH"
 
-  BRANCH_NAME="backport_${PR_NUMBER}_to_${BACKPORT_BRANCH}"
+  BRANCH_NAME="backport_${PR_ID}_to_${BACKPORT_BRANCH}"
 
   # To make the script idempotent.
   git branch -D "$BRANCH_NAME" || true
@@ -147,7 +146,7 @@ for BACKPORT_BRANCH in $BACKPORT_BRANCHES; do
   fi
 
   BACKPORT_PR=$(hub pull-request -p -m "[Backport] $PR_TITLE" \
-                  -m "*Beep boop. This is an automatically generated backport of #${PR_NUMBER}.*" \
+                  -m "*Beep boop. This is an automatically generated backport of #${PR_ID}.*" \
                   -m "$PR_DESCRIPTION" \
                   -l "$LABELS" \
                   -b "$GITHUB_USER:$BACKPORT_BRANCH" \

--- a/tools/release/backport_pr.sh
+++ b/tools/release/backport_pr.sh
@@ -25,18 +25,20 @@ ensure_command () {
 }
 
 display_usage () {
-  echo "USAGE: $0 PR_ID GITHUB_USER BACKPORT_BRANCHES REVIEWERS [-c PER_BACKPORT_COMMAND]" >/dev/stderr
-  echo "   PR_ID: The ID of the PR to be backported." >/dev/stderr
-  echo "   GITHUB_USER: Your GitHub username." >/dev/stderr
-  echo "   BACKPORT_BRANCHES: A space-separated list of branches to which the " >/dev/stderr
-  echo "     source PR will be backported." >/dev/stderr
-  echo "   REVIEWERS: A comma-separated list of users to add as both reviewer and assignee." >/dev/stderr
-  echo "   PER_BACKPORT_COMMAND : An optional command to run after cherrypicking the PR to the target branch." >/dev/stderr
-  echo "     If you use this option, ensure your working directory is clean, as `git add -A` will be used to " >/dev/stderr
-  echo "     incorporate any generated files. Try running `git clean -xdff` beforehand." >/dev/stderr
-  echo "" >/dev/stderr
-  echo "Example: $0 25456 gnossen \"v1.30.x v1.31.x v1.32.x v1.33.x v1.34.x v1.35.x v1.36.x\" \"menghanl,gnossen\"" >/dev/stderr
-  echo "Example: $0 25493 gnossen \"\$(seq 30 33 | xargs -n1 printf \"v1.%s.x \")\" \"menghanl\" -c ./tools/dockerfile/push_testing_images.sh" >/dev/stderr
+  cat << EOF >/dev/stderr
+USAGE: $0 PR_ID GITHUB_USER BACKPORT_BRANCHES REVIEWERS [-c PER_BACKPORT_COMMAND]
+   PR_ID: The ID of the PR to be backported.
+   GITHUB_USER: Your GitHub username.
+   BACKPORT_BRANCHES: A space-separated list of branches to which the
+     source PR will be backported.
+   REVIEWERS: A comma-separated list of users to add as both reviewer and assignee. >/dev/stderr
+   PER_BACKPORT_COMMAND : An optional command to run after cherrypicking the PR to the target branch.
+     If you use this option, ensure your working directory is clean, as "git add -A" will be used to
+     incorporate any generated files. Try running "git clean -xdff" beforehand.
+
+Example: $0 25456 gnossen "v1.30.x v1.31.x v1.32.x v1.33.x v1.34.x v1.35.x v1.36.x" "menghanl,gnossen"
+Example: $0 25493 gnossen "\$(seq 30 33 | xargs -n1 printf 'v1.%s.x ')" "menghanl" -c ./tools/dockerfile/push_testing_images.sh
+EOF
   exit 1
 }
 

--- a/tools/release/backport_pr.sh
+++ b/tools/release/backport_pr.sh
@@ -95,9 +95,10 @@ PR_DATA=$(curl -s -u "$GITHUB_USER:$GITHUB_TOKEN" \
           "https://api.github.com/repos/grpc/grpc/pulls/$PR_NUMBER")
 
 STATE=$(echo "$PR_DATA" | jq -r '.state')
-if [ "$STATE" == "merged" ]; then
+if [ "$STATE" != "open" ]; then
   TARGET_COMMITS=$(echo "$PR_DATA" | jq -r '.merge_commit_sha')
-  FETCH_HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.repo.default_branch')
+  FETCH_HEAD_REF=$(echo "$PR_DATA" | jq -r '.base.ref')
+  SOURCE_REPO=$(echo "$PR_DATA" | jq -r '.base.repo.full_name')
 else
   COMMITS_URL=$(echo "$PR_DATA" | jq -r '.commits_url')
   COMMITS_DATA=$(curl -s -u "$GITHUB_USER:$GITHUB_TOKEN" \
@@ -105,8 +106,8 @@ else
                  "$COMMITS_URL")
   TARGET_COMMITS=$(echo "$COMMITS_DATA" | jq -r '. | map(.sha) | join(" ")')
   FETCH_HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.sha')
+  SOURCE_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')
 fi
-SOURCE_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')
 PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
 PR_DESCRIPTION=$(echo "$PR_DATA" | jq -r '.body')
 LABELS=$(echo "$PR_DATA" | jq -r '.labels | map(.name) | join(",")')

--- a/tools/release/backport_pr.sh
+++ b/tools/release/backport_pr.sh
@@ -25,11 +25,12 @@ ensure_command () {
 }
 
 display_usage () {
-  echo "USAGE: $0 PR_NUMBER GITHUB_USER BACKPORT_BRANCHES REVIEWERS [-c PER_BACKPORT_COMMAND]" >/dev/stderr
-  echo "   PR_NUMBER: The number for the PR to be backported." >/dev/stderr
+  echo "USAGE: $0 PR_ID GITHUB_USER BACKPORT_BRANCHES REVIEWERS [-c PER_BACKPORT_COMMAND]" >/dev/stderr
+  echo "   PR_ID: The ID of the PR to be backported." >/dev/stderr
   echo "   GITHUB_USER: Your GitHub username." >/dev/stderr
-  echo "   BACKPORT_BRANCHES: A space-separated list of branches to which to backport." >/dev/stderr
-  echo "   REVIEWERS: A comma-separated list of users add as reviewers and assignees." >/dev/stderr
+  echo "   BACKPORT_BRANCHES: A space-separated list of branches to which the " >/dev/stderr
+  echo "     source PR will be backported." >/dev/stderr
+  echo "   REVIEWERS: A comma-separated list of users to add as both reviewer and assignee." >/dev/stderr
   echo "   PER_BACKPORT_COMMAND : An optional command to run after cherrypicking the PR to the target branch." >/dev/stderr
   echo "     If you use this option, ensure your working directory is clean, as `git add -A` will be used to " >/dev/stderr
   echo "     incorporate any generated files. Try running `git clean -xdff` beforehand." >/dev/stderr

--- a/tools/release/backport_pr.sh
+++ b/tools/release/backport_pr.sh
@@ -24,10 +24,57 @@ ensure_command () {
   fi
 }
 
+display_usage () {
+  echo "USAGE: $0 PR_NUMBER GITHUB_USER BACKPORT_BRANCHES REVIEWERS [-c PER_BACKPORT_COMMAND]" >/dev/stderr
+  echo "   PR_NUMBER: The number for the PR to be backported." >/dev/stderr
+  echo "   GITHUB_USER: Your GitHub username." >/dev/stderr
+  echo "   BACKPORT_BRANCHES: A space-separated list of branches to which to backport." >/dev/stderr
+  echo "   REVIEWERS: A comma-separated list of users add as reviewers and assignees." >/dev/stderr
+  echo "   PER_BACKPORT_COMMAND : An optional command to run after cherrypicking the PR to the target branch." >/dev/stderr
+  echo "     If you use this option, ensure your working directory is clean, as `git add -A` will be used to " >/dev/stderr
+  echo "     incorporate any generated files. Try running `git clean -xdff` beforehand." >/dev/stderr
+  echo "" >/dev/stderr
+  echo "Example: $0 25456 gnossen \"v1.30.x v1.31.x v1.32.x v1.33.x v1.34.x v1.35.x v1.36.x\" \"menghanl,gnossen\"" >/dev/stderr
+  echo "Example: $0 25493 gnossen \"\$(seq 30 33 | xargs -n1 printf \"v1.%s.x \")\" \"menghanl\" -c ./tools/dockerfile/push_testing_images.sh" >/dev/stderr
+  exit 1
+}
+
 ensure_command "curl"
 ensure_command "egrep"
 ensure_command "hub"
 ensure_command "jq"
+
+if [ "$#" -lt "4" ]; then
+  display_usage
+fi
+
+PR_NUMBER="$1"
+GITHUB_USER="$2"
+BACKPORT_BRANCHES="$3"
+REVIEWERS="$4"
+shift 4
+
+PER_BACKPORT_COMMAND=""
+while getopts "c:" OPT; do
+  case "$OPT" in
+    c )
+      PER_BACKPORT_COMMAND="$OPTARG"
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" >/dev/stderr
+      display_usage
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument." >/dev/stderr
+      display_usage
+      ;;
+  esac
+done
+
+if [[ ! -z "$(git status --porcelain)" && ! -z "$PER_BACKPORT_COMMAND" ]]; then
+  echo "Your working directory is not clean. Try running `git clean -xdff`. Warning: This is irreversible." > /dev/stderr
+  exit 1
+fi
 
 if [ -z "$GITHUB_TOKEN" ]; then
   echo "A GitHub token is required to run this script. See " \
@@ -36,47 +83,41 @@ if [ -z "$GITHUB_TOKEN" ]; then
   exit 1
 fi
 
-if [ "$#" != "4" ]; then
-  echo "USAGE: $0 PR_NUMBER GITHUB_USER BACKPORT_BRANCHES REVIEWERS" >/dev/stderr
-  echo "   PR_NUMBER: The number for the PR to be backported." >/dev/stderr
-  echo "   GITHUB_USER: Your GitHub username." >/dev/stderr
-  echo "   BACKPORT_BRANCHES: A space-separated list of branches to which to backport." >/dev/stderr
-  echo "   REVIEWERS: A comma-separated list of users add as reviewers and assignees." >/dev/stderr
-  echo "" >/dev/stderr
-  echo "Example: $0 25456 gnossen \"v1.30.x v1.31.x v1.32.x v1.33.x v1.34.x v1.35.x v1.36.x\" \"menghanl,gnossen\""
-  exit 1
-fi
-
-echo "This script will create a collection of backport PRs. Make sure the PR to" \
-       " backport has already been merged. You will probably " \
-       " have to touch your gnubby a frustrating number of times. C'est la vie."
+echo "This script will create a collection of backport PRs. You will probably " \
+       "have to touch your gnubby a frustrating number of times. C'est la vie."
 printf "Press any key to continue."
 read -r RESPONSE </dev/tty
 printf "\n"
 
-PR_NUMBER="$1"
-GITHUB_USER="$2"
-
-BACKPORT_BRANCHES="$3"
-
-REVIEWERS="$4"
 
 PR_DATA=$(curl -s -u "$GITHUB_USER:$GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/grpc/grpc/pulls/$PR_NUMBER")
 
-MERGE_COMMIT=$(echo "$PR_DATA" | jq -r '.merge_commit_sha')
+STATE=$(echo "$PR_DATA" | jq -r '.state')
+if [ "$STATE" == "merged" ]; then
+  TARGET_COMMITS=$(echo "$PR_DATA" | jq -r '.merge_commit_sha')
+  FETCH_HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.repo.default_branch')
+else
+  COMMITS_URL=$(echo "$PR_DATA" | jq -r '.commits_url')
+  COMMITS_DATA=$(curl -s -u "$GITHUB_USER:$GITHUB_TOKEN" \
+                 -H "Accept: application/vnd.github.v3+json" \
+                 "$COMMITS_URL")
+  TARGET_COMMITS=$(echo "$COMMITS_DATA" | jq -r '. | map(.sha) | join(" ")')
+  FETCH_HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.sha')
+fi
+SOURCE_REPO=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')
 PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
 PR_DESCRIPTION=$(echo "$PR_DATA" | jq -r '.body')
 LABELS=$(echo "$PR_DATA" | jq -r '.labels | map(.name) | join(",")')
 
 set -x
 
-git fetch origin
+git fetch "git@github.com:$SOURCE_REPO.git" "$FETCH_HEAD_REF"
 
 BACKPORT_PRS=""
 for BACKPORT_BRANCH in $BACKPORT_BRANCHES; do
-  echo "Backporting $MERGE_COMMIT to $BACKPORT_BRANCH."
+  echo "Backporting $TARGET_COMMITS to $BACKPORT_BRANCH."
 
   git checkout "origin/$BACKPORT_BRANCH"
 
@@ -87,12 +128,25 @@ for BACKPORT_BRANCH in $BACKPORT_BRANCHES; do
   git checkout "$BACKPORT_BRANCH"
   git checkout -b "$BRANCH_NAME"
 
-  git cherry-pick -m 1 "$MERGE_COMMIT"
+  for TARGET_COMMIT in $TARGET_COMMITS; do
+    git cherry-pick -m 1 "$TARGET_COMMIT"
+  done
+
+  if [[ ! -z "$PER_BACKPORT_COMMAND" ]]; then
+    git submodule update --init --recursive
+
+    # To remove dangling submodules.
+    git clean -xdff
+    eval "$PER_BACKPORT_COMMAND"
+    git add -A
+    git commit --amend --no-edit
+  fi
+
   BACKPORT_PR=$(hub pull-request -p -m "[Backport] $PR_TITLE" \
                   -m "*Beep boop. This is an automatically generated backport of #${PR_NUMBER}.*" \
                   -m "$PR_DESCRIPTION" \
                   -l "$LABELS" \
-                  -b "$BACKPORT_BRANCH" \
+                  -b "$GITHUB_USER:$BACKPORT_BRANCH" \
                   -r "$REVIEWERS" \
                   -a "$REVIEWERS" | tail -n 1)
   BACKPORT_PRS+="$BACKPORT_PR\n"


### PR DESCRIPTION
This PR enabled the backport of https://github.com/grpc/grpc/pull/25493. It adds two features:

 - The ability to backport unmerged PRs (including those with multiple commits)
 - The ability to run a script after cherry-picking the desired commits, including scripts that generate files.

It also fixes a bug where the script previously created PRs on the `grpc/grpc` repo instead of on the user's fork.