### PR TITLE
Use linkstatic for test libraries that contain main()

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -78,7 +78,8 @@ def grpc_cc_library(
         alwayslink = 0,
         data = [],
         use_cfstream = False,
-        tags = []):
+        tags = [],
+        linkstatic = False):
     copts = []
     if use_cfstream:
         copts = if_mac(["-DGRPC_CFSTREAM"])
@@ -122,6 +123,7 @@ def grpc_cc_library(
         alwayslink = alwayslink,
         data = data,
         tags = tags,
+        linkstatic = linkstatic,
     )
 
 def grpc_proto_plugin(name, srcs = [], deps = []):

--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -126,6 +126,7 @@ grpc_cc_library(
         "absl/flags:flag",
         "gtest",
     ],
+    linkstatic = True,
     tags = ["no_windows"],
     deps = [
         ":grpc_test_util",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -220,6 +220,7 @@ grpc_cc_library(
     external_deps = [
         "gtest",
     ],
+    linkstatic = True,
     deps = [
         ":interceptors_util",
         ":test_service_impl",


### PR DESCRIPTION
For tests that have their "main" method in a shared library, set that shared library to `linkstatic = True` since  when building with bazel & clang on aarch64, tests like this get mysteriously broken.

Workaround for https://github.com/grpc/grpc/issues/25288

Before merging this, the `linkstatic` arg support also needs to be added to grpc_cc_library internally