### PR TITLE
Simplify build.yaml's  "deps_linkage" logic

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5003,6 +5003,7 @@ targets:
   uses_polling: false
 - name: bm_callback_streaming_ping_pong
   build: test
+  run: false
   language: c++
   headers:
   - test/cpp/microbenchmarks/callback_streaming_ping_pong.h
@@ -5033,6 +5034,7 @@ targets:
   - posix
 - name: bm_callback_unary_ping_pong
   build: test
+  run: false
   language: c++
   headers:
   - test/cpp/microbenchmarks/callback_test_service.h

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -1419,7 +1419,6 @@ libs:
   - absl/container:flat_hash_set
   - absl/container:flat_hash_map
   baselib: true
-  deps_linkage: static
   dll: true
   generate_plugin_registry: true
   secure: true
@@ -1435,7 +1434,6 @@ libs:
   - gpr
   - address_sorting
   - upb
-  deps_linkage: static
   dll: only
 - name: grpc_test_util
   build: private
@@ -2100,7 +2098,6 @@ libs:
   - absl/container:inlined_vector
   - absl/container:flat_hash_map
   baselib: true
-  deps_linkage: static
   dll: true
   generate_plugin_registry: true
   secure: false

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -970,25 +970,12 @@
     lib_deps = ' $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)'
     mingw_libs = ''
     mingw_lib_deps = ' $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)'
-    if lib.get('deps_linkage', None) == 'static':
-      for dep in lib.get('deps', []):
-        if is_absl_lib(dep): continue
-        lib_archive = '$(LIBDIR)/$(CONFIG)/lib' + dep + '.a'
-        common = common + ' ' + lib_archive
-        lib_deps = lib_deps + ' ' + lib_archive
-        mingw_lib_deps = mingw_lib_deps + ' ' + lib_archive
-    else:
-      for dep in lib.get('deps', []):
-        if is_absl_lib(dep): continue
-        dep_lib = None
-        for dl in libs:
-          if dl.name == dep:
-            dep_lib = dl
-        assert dep_lib, 'lib %s not found (in %s)' % (dep, lib.name)
-        link_libs = link_libs + ' -l' + dep
-        lib_deps = lib_deps + ' $(LIBDIR)/$(CONFIG)/lib' + dep + '.$(SHARED_EXT_' + lang_to_var[dep_lib.language] + ')'
-        mingw_libs = mingw_libs + ' -l' + dep + '$(SHARED_VERSION_' + lang_to_var[dep_lib.language] + ')-dll'
-        mingw_lib_deps = mingw_lib_deps + ' $(LIBDIR)/$(CONFIG)/' + dep + '$(SHARED_VERSION_' + lang_to_var[dep_lib.language] + ').$(SHARED_EXT_' + lang_to_var[dep_lib.language] + ')'
+    for dep in lib.get('deps', []):
+      if is_absl_lib(dep): continue
+      lib_archive = '$(LIBDIR)/$(CONFIG)/lib' + dep + '.a'
+      common = common + ' ' + lib_archive
+      lib_deps = lib_deps + ' ' + lib_archive
+      mingw_lib_deps = mingw_lib_deps + ' ' + lib_archive
 
     security = lib.get('secure', 'check')
     if security == True:

--- a/templates/README.md
+++ b/templates/README.md
@@ -82,9 +82,6 @@ baselib: boolean,         # this is a low level library that has system
 filegroups:               # list of filegroups to merge to that project
                           # note that this will be expanded automatically
 deps:                     # list of libraries this target depends on
-deps_linkage: "..."       # "static"  or "dynamic". Used by the Makefile only to
-                          # determine the way dependencies are linkned. Defaults
-                          # to "dynamic".
 dll: "..."                # see below.
 ```
 

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -645,7 +645,6 @@ _BUILD_EXTRA_METADATA = {
         'build': 'all',
         'baselib': True,
         'secure': True,
-        'deps_linkage': 'static',
         'dll': True,
         'generate_plugin_registry': True
     },
@@ -679,7 +678,6 @@ _BUILD_EXTRA_METADATA = {
     'grpc_csharp_ext': {
         'language': 'c',
         'build': 'all',
-        'deps_linkage': 'static',
         'dll': 'only'
     },
     'grpc_unsecure': {
@@ -687,7 +685,6 @@ _BUILD_EXTRA_METADATA = {
         'build': 'all',
         'baselib': True,
         'secure': False,
-        'deps_linkage': 'static',
         'dll': True,
         'generate_plugin_registry': True
     },


### PR DESCRIPTION
this is part of ongoing effort to reduce the amount of extra build metadata that's provided from outside of bazel BUILD file.
(Ideally all the metadata would be extracted from the bazel BUILD - but now we provide quite a bit of extra info through the `_BUILD_EXTRA_METADATA` dictionary).

deps_linkage was added here https://github.com/grpc/grpc/pull/23335 but since then, the number of targets in Makefile was reduced quite a bit and all the targets there are now actually using deps_linkage=static and the flag is no longer useful.