### PR TITLE
Remove GPR_BACKWARDS_COMPATIBILITY_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,19 +226,16 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_gRPC_C_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_gRPC_C_CXX_FLAGS}")
 
+if(_gRPC_PLATFORM_MAC)
+  # some C++11 constructs not supported before OS X 10.10
+  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
+endif()
+
 if(gRPC_USE_PROTO_LITE)
   set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf-lite")
   add_definitions("-DGRPC_USE_PROTO_LITE")
 else()
   set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf")
-endif()
-
-if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
-  add_definitions(-DGPR_BACKWARDS_COMPATIBILITY_MODE)
-  if(_gRPC_PLATFORM_MAC)
-    # some C++11 constructs not supported before OS X 10.10
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
-  endif()
 endif()
 
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -20,14 +20,6 @@
 #define GRPC_IMPL_CODEGEN_PORT_PLATFORM_H
 
 /*
- * Define GPR_BACKWARDS_COMPATIBILITY_MODE to try harder to be ABI
- * compatible with older platforms (currently only on Linux)
- * Causes:
- *  - some libc calls to be gotten via dlsym
- *  - some syscalls to be made directly
- */
-
-/*
  * Defines GPR_ABSEIL_SYNC to use synchronization features from Abseil
  */
 #ifndef GPR_ABSEIL_SYNC
@@ -393,18 +385,6 @@
 #error "Could not auto-detect platform"
 #endif
 #endif /* GPR_NO_AUTODETECT_PLATFORM */
-
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE)
-/*
- * For backward compatibility mode, reset _FORTIFY_SOURCE to prevent
- * a library from having non-standard symbols such as __asprintf_chk.
- * This helps non-glibc systems such as alpine using musl to find symbols.
- */
-#if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0
-#undef _FORTIFY_SOURCE
-#define _FORTIFY_SOURCE 0
-#endif
-#endif
 
 #if defined(__has_include)
 #if __has_include(<atomic>)

--- a/setup.py
+++ b/setup.py
@@ -320,9 +320,6 @@ if asm_key:
 else:
     DEFINE_MACROS += (('OPENSSL_NO_ASM', 1),)
 
-if not DISABLE_LIBC_COMPATIBILITY:
-    DEFINE_MACROS += (('GPR_BACKWARDS_COMPATIBILITY_MODE', 1),)
-
 if "win32" in sys.platform:
     # TODO(zyc): Re-enable c-ares on x64 and x86 windows after fixing the
     # ares_library_init compilation issue

--- a/src/core/lib/gpr/env_linux.cc
+++ b/src/core/lib/gpr/env_linux.cc
@@ -40,22 +40,7 @@
 
 char* gpr_getenv(const char* name) {
   char* result = nullptr;
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE)
-  typedef char* (*getenv_type)(const char*);
-  static getenv_type getenv_func = nullptr;
-  /* Check to see which getenv variant is supported (go from most
-   * to least secure) */
-  if (getenv_func == nullptr) {
-    const char* names[] = {"secure_getenv", "__secure_getenv", "getenv"};
-    for (size_t i = 0; i < GPR_ARRAY_SIZE(names); i++) {
-      getenv_func = (getenv_type)dlsym(RTLD_DEFAULT, names[i]);
-      if (getenv_func != nullptr) {
-        break;
-      }
-    }
-  }
-  result = getenv_func(name);
-#elif __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)
   result = secure_getenv(name);
 #else
   result = getenv(name);

--- a/src/core/lib/gpr/time_posix.cc
+++ b/src/core/lib/gpr/time_posix.cc
@@ -72,12 +72,7 @@ static gpr_timespec now_impl(gpr_clock_type clock_type) {
     gpr_precise_clock_now(&ret);
     return ret;
   } else {
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE) && defined(__linux__)
-    /* avoid ABI problems by invoking syscalls directly */
-    syscall(SYS_clock_gettime, clockid_for_gpr_clock[clock_type], &now);
-#else
     clock_gettime(clockid_for_gpr_clock[clock_type], &now);
-#endif
     return gpr_from_timespec(now, clock_type);
   }
 }

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -47,7 +47,6 @@ ENV['EMBED_ZLIB'] = 'true'
 ENV['EMBED_CARES'] = 'true'
 ENV['ARCH_FLAGS'] = RbConfig::CONFIG['ARCH_FLAG']
 ENV['ARCH_FLAGS'] = '-arch i386 -arch x86_64' if RUBY_PLATFORM =~ /darwin/
-ENV['CPPFLAGS'] = '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 
 output_dir = File.expand_path(RbConfig::CONFIG['topdir'])
 grpc_lib_dir = File.join(output_dir, 'libs', grpc_config)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -291,19 +291,16 @@
   set(CMAKE_C_FLAGS "<%text>${CMAKE_C_FLAGS} ${_gRPC_C_CXX_FLAGS}</%text>")
   set(CMAKE_CXX_FLAGS "<%text>${CMAKE_CXX_FLAGS} ${_gRPC_C_CXX_FLAGS}</%text>")
 
+  if(_gRPC_PLATFORM_MAC)
+    # some C++11 constructs not supported before OS X 10.10
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
+  endif()
+
   if(gRPC_USE_PROTO_LITE)
     set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf-lite")
     add_definitions("-DGRPC_USE_PROTO_LITE")
   else()
     set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf")
-  endif()
-
-  if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
-    add_definitions(-DGPR_BACKWARDS_COMPATIBILITY_MODE)
-    if(_gRPC_PLATFORM_MAC)
-      # some C++11 constructs not supported before OS X 10.10
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
-    endif()
   endif()
 
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)


### PR DESCRIPTION
As all prebuilt artifacts started leveraging `manylinux2010`, we don't need `GPR_BACKWARDS_COMPATIBILITY_MODE` which tried to change the way to communicate with the linux kernel in a more conservative way. This is not necessary anymore and it starts to work against us. (Recent case: https://github.com/grpc/grpc/issues/25386) We'd better stick with the standard way to use system functions so let's remove this option completely.