### PR TITLE
Update config selector for LDS update with no route config

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -741,6 +741,10 @@ void XdsResolver::OnListenerUpdate(XdsApi::LdsUpdate listener) {
   if (route_config_name_.empty()) {
     GPR_ASSERT(current_listener_.rds_update.has_value());
     OnRouteConfigUpdate(std::move(*current_listener_.rds_update));
+  } else {
+    // HCM may contain newer filter config. We need to propagate the update as
+    // config selector to the channel
+    GenerateResult();
   }
 }
 

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -732,6 +732,7 @@ void XdsResolver::OnListenerUpdate(XdsApi::LdsUpdate listener) {
     }
     route_config_name_ = std::move(listener.route_config_name);
     if (!route_config_name_.empty()) {
+      current_virtual_host_.Clear();
       auto watcher = absl::make_unique<RouteConfigWatcher>(Ref());
       route_config_watcher_ = watcher.get();
       xds_client_->WatchRouteConfigData(route_config_name_, std::move(watcher));

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -732,7 +732,7 @@ void XdsResolver::OnListenerUpdate(XdsApi::LdsUpdate listener) {
     }
     route_config_name_ = std::move(listener.route_config_name);
     if (!route_config_name_.empty()) {
-      current_virtual_host_.Clear();
+      current_virtual_host_.routes.clear();
       auto watcher = absl::make_unique<RouteConfigWatcher>(Ref());
       route_config_watcher_ = watcher.get();
       xds_client_->WatchRouteConfigData(route_config_name_, std::move(watcher));


### PR DESCRIPTION
There is a corner case: when LDS is updated without any route config, the filter config update is ignored.

I thought enabling RDS in LDS may affect the processing of LDS, but as discussed offline, our xDS client will religiously follow the in-effective LDS to handle route updates. And processing route update has nothing to do with processing the filter config update from LDS, except refreshing the config selector. This means LDS should have a new code path to handle filter config update in itself, as title.

Related: https://github.com/grpc/grpc/pull/24354