### PR TITLE
replace deprecated addProtoService

### DIFF
--- a/examples/node/dynamic_codegen/route_guide/route_guide_server.js
+++ b/examples/node/dynamic_codegen/route_guide/route_guide_server.js
@@ -218,7 +218,7 @@ function routeChat(call) {
  */
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(routeguide.RouteGuide.service, {
+  server.addService(routeguide.RouteGuide.service, {
     getFeature: getFeature,
     listFeatures: listFeatures,
     recordRoute: recordRoute,


### PR DESCRIPTION
Looks like the greeter example and the route_guide static example were all updated to use addService, but the dynamic example was not leading to a deprecation warning at run time. The documentation also uses the deprecated method, but is not part of this repo. I will open a separate PR to fix that so that the code and the documentation match.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
