### PR TITLE
fix: escape protoc delimiter in comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3693,6 +3693,7 @@ target_link_libraries(grpc_plugin_support
   ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::strings
 )
 
 foreach(_hdr

--- a/src/compiler/BUILD
+++ b/src/compiler/BUILD
@@ -69,6 +69,7 @@ grpc_cc_library(
         "schema_interface.h",
     ],
     external_deps = [
+        "absl/strings",
         "protobuf_clib",
     ],
     language = "c++",

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/str_replace.h"
+
 #include "src/compiler/config.h"
 
 namespace grpc_generator {
@@ -245,9 +247,9 @@ inline std::string GenerateCommentsWithPrefix(
     if (elem.empty()) {
       oss << prefix << "\n";
     } else if (elem[0] == ' ') {
-      oss << prefix << elem << "\n";
+      oss << prefix << absl::StrReplaceAll(elem, {{"$", "$$"}}) << "\n";
     } else {
-      oss << prefix << " " << elem << "\n";
+      oss << prefix << " " << absl::StrReplaceAll(elem, {{"$", "$$"}}) << "\n";
     }
   }
   return oss.str();


### PR DESCRIPTION


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
