### PR TITLE
Fix race at server shutdown between actual shutdown and MatchOrQueue

### DIFF
--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -388,6 +388,10 @@ class Server : public InternallyRefCounted<Server> {
   std::unique_ptr<RequestMatcherInterface> unregistered_request_matcher_;
 
   std::atomic_bool shutdown_flag_{false};
+  // Don't complete the shutdown until there are no blocking refs. Start with 1
+  // ref released during shutdown call, but also take a ref while the server
+  // needs to remain alive, e.g., during AllocatingRequestMatcher use.
+  std::atomic_int shutdown_blocking_refs_{1};
   bool shutdown_published_ = false;
   std::vector<ShutdownTag> shutdown_tags_;
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -356,17 +356,18 @@ class Server::SyncRequest final : public grpc::internal::CompletionQueueTag {
   }
 
   ~SyncRequest() override {
+    // The destructor should only cleanup those objects created in the
+    // constructor, since some paths may or may not actually go through the
+    // Run stage where other objects are allocated.
     if (has_request_payload_ && request_payload_) {
       grpc_byte_buffer_destroy(request_payload_);
     }
-    wrapped_call_.Destroy();
-    ctx_.Destroy();
-
     if (call_details_ != nullptr) {
       grpc_call_details_destroy(call_details_);
       delete call_details_;
     }
     grpc_metadata_array_destroy(&request_metadata_);
+    server_->UnrefWithPossibleNotify();
   }
 
   bool FinalizeResult(void** /*tag*/, bool* status) override {
@@ -424,26 +425,35 @@ class Server::SyncRequest final : public grpc::internal::CompletionQueueTag {
   }
 
   void ContinueRunAfterInterception() {
-    {
-      ctx_->ctx.BeginCompletionOp(&*wrapped_call_, nullptr, nullptr);
-      global_callbacks_->PreSynchronousRequest(&ctx_->ctx);
-      auto* handler = resources_ ? method_->handler()
-                                 : server_->resource_exhausted_handler_.get();
-      handler->RunHandler(grpc::internal::MethodHandler::HandlerParameter(
-          &*wrapped_call_, &ctx_->ctx, deserialized_request_, request_status_,
-          nullptr, nullptr));
-      global_callbacks_->PostSynchronousRequest(&ctx_->ctx);
+    ctx_->ctx.BeginCompletionOp(&*wrapped_call_, nullptr, nullptr);
+    global_callbacks_->PreSynchronousRequest(&ctx_->ctx);
+    auto* handler = resources_ ? method_->handler()
+                               : server_->resource_exhausted_handler_.get();
+    handler->RunHandler(grpc::internal::MethodHandler::HandlerParameter(
+        &*wrapped_call_, &ctx_->ctx, deserialized_request_, request_status_,
+        nullptr, nullptr));
+    global_callbacks_->PostSynchronousRequest(&ctx_->ctx);
 
-      cq_.Shutdown();
+    cq_.Shutdown();
 
-      grpc::internal::CompletionQueueTag* op_tag =
-          ctx_->ctx.GetCompletionOpTag();
-      cq_.TryPluck(op_tag, gpr_inf_future(GPR_CLOCK_REALTIME));
+    grpc::internal::CompletionQueueTag* op_tag = ctx_->ctx.GetCompletionOpTag();
+    cq_.TryPluck(op_tag, gpr_inf_future(GPR_CLOCK_REALTIME));
 
-      /* Ensure the cq_ is shutdown */
-      grpc::PhonyTag ignored_tag;
-      GPR_ASSERT(cq_.Pluck(&ignored_tag) == false);
-    }
+    // Ensure the cq_ is shutdown
+    grpc::PhonyTag ignored_tag;
+    GPR_ASSERT(cq_.Pluck(&ignored_tag) == false);
+
+    // Cleanup structures allocated during Run/ContinueRunAfterInterception
+    wrapped_call_.Destroy();
+    ctx_.Destroy();
+
+    delete this;
+  }
+
+  // For requests that must be only cleaned up but not actually Run
+  void Cleanup() {
+    cq_.Shutdown();
+    grpc_call_unref(call_);
     delete this;
   }
 
@@ -459,6 +469,7 @@ class Server::SyncRequest final : public grpc::internal::CompletionQueueTag {
 
   template <class CallAllocation>
   void CommonSetup(CallAllocation* data) {
+    server_->Ref();
     grpc_metadata_array_init(&request_metadata_);
     data->tag = static_cast<void*>(this);
     data->call = &call_;
@@ -473,7 +484,7 @@ class Server::SyncRequest final : public grpc::internal::CompletionQueueTag {
   grpc_call_details* call_details_ = nullptr;
   gpr_timespec deadline_;
   grpc_metadata_array request_metadata_;
-  grpc_byte_buffer* request_payload_;
+  grpc_byte_buffer* request_payload_ = nullptr;
   grpc::CompletionQueue cq_;
   grpc::Status request_status_;
   std::shared_ptr<GlobalCallbacks> global_callbacks_;
@@ -811,9 +822,9 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
     void* tag;
     bool ok;
     while (server_cq_->Next(&tag, &ok)) {
-      // Drain the item and don't do any work on it. It is possible to see this
-      // if there is an explicit call to Wait that is not part of the actual
-      // Shutdown.
+      // This problem can arise if the server CQ gets a request queued to it
+      // before it gets shutdown but then pulls it after shutdown.
+      static_cast<SyncRequest*>(tag)->Cleanup();
     }
   }
 
@@ -1227,6 +1238,9 @@ void Server::ShutdownInternal(gpr_timespec deadline) {
   // Else in case of SHUTDOWN or GOT_EVENT, it means that the server has
   // successfully shutdown
 
+  // Drop the shutdown ref and wait for all other refs to drop as well.
+  UnrefAndWaitLocked();
+
   // Shutdown all ThreadManagers. This will try to gracefully stop all the
   // threads in the ThreadManagers (once they process any inflight requests)
   for (const auto& value : sync_req_mgrs_) {
@@ -1237,9 +1251,6 @@ void Server::ShutdownInternal(gpr_timespec deadline) {
   for (const auto& value : sync_req_mgrs_) {
     value->Wait();
   }
-
-  // Drop the shutdown ref and wait for all other refs to drop as well.
-  UnrefAndWaitLocked();
 
   // Shutdown the callback CQ. The CQ is owned by its own shutdown tag, so it
   // will delete itself at true shutdown.


### PR DESCRIPTION
This race has been seen in one internal test when

1. T1 starts an AcceptStream but gets paused before hitting MatchOrQueue
2. T2 starts a shutdown
3. T1 finally calls the MatchOrQueue

This can manifest in various problems, such as
1. An RPC can be posted after the server is supposedly shutdown, causing a leak
2. An RPC is attempted to be posted after the CQ is shutdown, causing an assertion failure

This PR prevents the core server from posting a shutdown tag until any MatchOrQueue's in progress have actually completed (note that the RPC doesn't have to complete, just the queueing). This converts the existing atomic shutdown flag to an atomic counter that incorporates both whether shutdown has been called (low bit) and how many in-progress MatchOrQueues exist (upper bits). The C++ API server is also changed to ref count sync RPCs just as it currently ref counts callback RPCs, and only start shutting down the SyncRequestThreadManagers after all sync and callback RPCs are complete.

@markdroth Can you review this overall?
@soheilhy Can you check if the atomics look good?

After this PR, the test passes 1.2M runs in various configs without any flakes.

TESTED=all tests green here, internal presubmits clean, TGP clean, 1.2M runs of test that had been seeing flakes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25541)
<!-- Reviewable:end -->
