### PR TITLE
Update PHP's grpc_php_plugin instructions

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -161,21 +161,22 @@ You need the `grpc_php_plugin` to generate the PHP client stub classes. This
 plugin works with the main `protoc` binary to generate classes that you can
 import into your project.
 
-It should already been compiled when you run `make` from the root directory
-of this repo. The plugin can be found in the `bins/opt` directory. We are
-planning to provide a better way to download and install the plugin
-in the future.
-
-You can also just build the `grpc_php_plugin` by running:
+You can build `grpc_php_plugin` with `cmake`:
 
 ```sh
 $ git clone -b RELEASE_TAG_HERE https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
-$ make grpc_php_plugin
+$ mkdir -p cmake/build
+$ cd cmake/build
+$ cmake ../..
+$ make protoc grpc_php_plugin
 ```
 
-Alternatively, you can also build the `grpc_php_plugin` with `bazel` now:
+The commands above will make `protoc` and `grpc_php_plugin` available
+in `cmake/build/third_party/protobuf/protoc` and `cmake/build/grpc_php_plugin`.
+
+Alternatively, you can also build the `grpc_php_plugin` with `bazel`:
 
 ```sh
 $ bazel build @com_google_protobuf//:protoc


### PR DESCRIPTION
The protoc/grpc_php_plugin are no longer buildable with `make` starting from https://github.com/grpc/grpc/pull/24000 onwards.

See https://github.com/grpc/grpc/issues/25350. 
(This also needs to be fixed in grpc.io)

CC @chalin 