### PR TITLE
Add v1.36.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -182,6 +182,7 @@ LANG_RELEASE_MATRIX = {
              ReleaseInfo(runtimes=['go1.11'], testcases_file='go__v1.20.0')),
             ('v1.34.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.35.0', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.36.0', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION

```
gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_"$GO_VERSION"
DIGEST        TAGS     TIMESTAMP            VULNERABILITIES
cff1a18ad29d  v1.36.0  2021-02-24T16:10:11  CRITICAL=10,HIGH=46,LOW=359,MEDIUM=168
6b95185e4fee  v1.35.0  2021-01-13T16:18:58  CRITICAL=17,HIGH=87,LOW=414,MEDIUM=293
3205ca9f1a6c  v1.34.0  2020-12-02T14:49:06  CRITICAL=17,HIGH=88,LOW=414,MEDIUM=295
d47039978f43  v1.32.0  2020-10-20T16:23:04  CRITICAL=10,HIGH=46,LOW=359,MEDIUM=171
54df3f093d5e  v1.31.1  2020-10-20T16:21:27  CRITICAL=10,HIGH=46,LOW=359,MEDIUM=171
c614c0444639  v1.33.1  2020-10-20T16:16:37  CRITICAL=10,HIGH=46,LOW=359,MEDIUM=171
ad86b3ed2e8d  v1.30.0  2020-07-30T11:08:52  CRITICAL=9,HIGH=45,LOW=355,MEDIUM=168
b15169a571cc  v1.31.0  2020-07-30T11:06:34  CRITICAL=9,HIGH=33,LOW=289,MEDIUM=103
1f0372707b7f  v1.29.0  2020-04-21T15:56:17  CRITICAL=9,HIGH=46,LOW=368,MEDIUM=178
afe0d55d0862  v1.28.1  2020-04-06T14:44:50  CRITICAL=12,HIGH=24,LOW=301,MEDIUM=82
```