### PR TITLE
Add abseil thread annotations to grpcpp/sync

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -350,6 +350,7 @@ grpc_cc_library(
     name = "grpc++_public_hdrs",
     hdrs = GRPCXX_PUBLIC_HDRS,
     external_deps = [
+        "absl/synchronization",
         "protobuf_headers",
     ],
 )
@@ -376,6 +377,7 @@ grpc_cc_library(
         "src/cpp/server/secure_server_credentials.h",
     ],
     external_deps = [
+        "absl/synchronization",
         "protobuf_headers",
     ],
     language = "c++",
@@ -514,6 +516,9 @@ grpc_cc_library(
     name = "grpc++_internal_hdrs_only",
     hdrs = [
         "include/grpcpp/impl/codegen/sync.h",
+    ],
+    external_deps = [
+        "absl/synchronization",
     ],
     language = "c++",
     deps = [
@@ -2303,6 +2308,7 @@ grpc_cc_library(
     srcs = GRPCXX_SRCS,
     hdrs = GRPCXX_HDRS,
     external_deps = [
+        "absl/synchronization",
         "protobuf_headers",
     ],
     language = "c++",
@@ -2320,6 +2326,7 @@ grpc_cc_library(
     srcs = GRPCXX_SRCS,
     hdrs = GRPCXX_HDRS,
     external_deps = [
+        "absl/synchronization",
         "protobuf_headers",
     ],
     language = "c++",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1513,6 +1513,7 @@ config("grpc_config") {
         ":gpr",
         ":address_sorting",
         ":upb",
+        ":absl/synchronization:synchronization",
     ]
     
     public_configs = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2784,6 +2784,7 @@ target_link_libraries(grpc++
   gpr
   address_sorting
   upb
+  absl::synchronization
 )
 
 foreach(_hdr
@@ -3446,6 +3447,7 @@ target_link_libraries(grpc++_unsecure
   gpr
   address_sorting
   upb
+  absl::synchronization
 )
 
 foreach(_hdr

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2377,6 +2377,7 @@ libs:
   - gpr
   - address_sorting
   - upb
+  - absl/synchronization:synchronization
   baselib: true
 - name: grpc++_alts
   build: all
@@ -2728,6 +2729,7 @@ libs:
   - gpr
   - address_sorting
   - upb
+  - absl/synchronization:synchronization
   baselib: true
   secure: false
 - name: grpc_plugin_support

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -1399,6 +1399,7 @@
         'gpr',
         'address_sorting',
         'upb',
+        'absl/synchronization:synchronization',
       ],
       'sources': [
         'src/cpp/client/channel_cc.cc',
@@ -1555,6 +1556,7 @@
         'gpr',
         'address_sorting',
         'upb',
+        'absl/synchronization:synchronization',
       ],
       'sources': [
         'src/cpp/client/channel_cc.cc',

--- a/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM alpine:3.9
+  FROM alpine:3.11
   
   # Install Git and basic packages.
   RUN apk update && apk add ${'\\'}
@@ -32,9 +32,8 @@
     make ${'\\'}
     perl ${'\\'}
     strace ${'\\'}
-    python-dev ${'\\'}
-    py-pip ${'\\'}
-    py-yaml ${'\\'}
+    python2-dev ${'\\'}
+    py2-pip ${'\\'}
     unzip ${'\\'}
     wget ${'\\'}
     zip
@@ -42,11 +41,12 @@
   # Install Python packages from PyPI
   RUN pip install --upgrade pip==19.3.1
   RUN pip install virtualenv
-  RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.15.0 twisted==17.5.0
-  
+  RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+  RUN pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
+
   # Google Cloud platform API libraries
-  RUN pip install --upgrade google-api-python-client
-  
+  RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0
+
   <%include file="../../run_tests_addons.include"/>
   
   # Define the default command.

--- a/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
@@ -26,6 +26,13 @@ wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.
 sh cmake-linux.sh -- --skip-license --prefix=/usr
 rm cmake-linux.sh
 
+# Install absl (absl won't be installed down below)
+mkdir -p "third_party/abseil-cpp/cmake/build"
+pushd "third_party/abseil-cpp/cmake/build"
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ../..
+make -j4 install
+popd
+
 # Install gRPC and its dependencies
 mkdir -p "cmake/build"
 pushd "cmake/build"
@@ -33,6 +40,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DgRPC_INSTALL=ON \
   -DgRPC_BUILD_TESTS=OFF \
+  -DgRPC_ABSL_PROVIDER=package \
   -DgRPC_SSL_PROVIDER=package \
   ../..
 make -j4 install

--- a/test/distrib/cpp/run_distrib_test_cmake_module_install_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install_pkgconfig.sh
@@ -26,6 +26,13 @@ wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.
 sh cmake-linux.sh -- --skip-license --prefix=/usr
 rm cmake-linux.sh
 
+# Install absl (absl won't be installed down below)
+mkdir -p "third_party/abseil-cpp/cmake/build"
+pushd "third_party/abseil-cpp/cmake/build"
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ../..
+make -j4 install
+popd
+
 # Install gRPC and its dependencies
 mkdir -p "cmake/build"
 pushd "cmake/build"
@@ -33,6 +40,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DgRPC_INSTALL=ON \
   -DgRPC_BUILD_TESTS=OFF \
+  -DgRPC_ABSL_PROVIDER=package \
   -DgRPC_SSL_PROVIDER=package \
   ../..
 make -j4 install

--- a/tools/dockerfile/distribtest/python_dev_alpine3.7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_alpine3.7_x64/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.9
+FROM alpine:3.11
 
-RUN apk add --update build-base linux-headers python python-dev py-pip
+RUN apk add --update build-base linux-headers python python2-dev py2-pip
 
 RUN pip install --upgrade pip==19.3.1
 

--- a/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.9
+FROM alpine:3.11
 
 # Install Git and basic packages.
 RUN apk update && apk add \
@@ -30,9 +30,8 @@ RUN apk update && apk add \
   make \
   perl \
   strace \
-  python-dev \
-  py-pip \
-  py-yaml \
+  python2-dev \
+  py2-pip \
   unzip \
   wget \
   zip
@@ -40,10 +39,11 @@ RUN apk update && apk add \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
 
 # Google Cloud platform API libraries
-RUN pip install --upgrade google-api-python-client
+RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0
 
 
 RUN mkdir /var/local/jenkins

--- a/tools/dockerfile/test/python_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/python_alpine_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.9
+FROM alpine:3.11
 
 # Install Git and basic packages.
 RUN apk update && apk add \
@@ -30,8 +30,8 @@ RUN apk update && apk add \
   make \
   perl \
   strace \
-  python-dev \
-  py-pip \
+  python2-dev \
+  py2-pip \
   unzip \
   wget \
   zip
@@ -39,10 +39,10 @@ RUN apk update && apk add \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.15.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0
 
 # Google Cloud platform API libraries
-RUN pip install --upgrade google-api-python-client oauth2client
+RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0
 
 RUN mkdir -p /var/local/jenkins
 


### PR DESCRIPTION
Adding clang thread annotations to grpcpp/sync/mutex so that it can benefit from clang thread analysis. This is a follow-up of https://github.com/grpc/grpc/pull/25325 which did the same thing for core/sync/mutex.
 
This PR does two things;
- Updating the existing grpcpp mutex to have annotation and abseil-compatibility.
- Updating the existing tests to support abseil dependency in the public headers of gRPC C++.