### PR TITLE
Make returning a local reference a compilation error

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -9,6 +9,8 @@ build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
 
 build:dbg --compilation_mode=dbg
+build:dbg --copt=-Werror=return-local-addr
+build:dbg --copt=-Werror=return-stack-address
 
 build:windows_opt --compilation_mode=opt
 build:windows_dbg --compilation_mode=dbg

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -9,7 +9,6 @@ build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
 
 build:dbg --compilation_mode=dbg
-build:dbg --copt=-Werror=return-local-addr
 build:dbg --copt=-Werror=return-stack-address
 
 build:windows_opt --compilation_mode=opt


### PR DESCRIPTION
As title.

I just sunk hours debugging a segfault caused by returning a local reference. Turns out, the sanitizers and other tooling are not yet capable of pointing out a complex version of returning a local reference.

This PR makes simple version of returning a local reference/stack reference an error. The compiler will be able to catch cases like:

```cc
#include <vector>

struct Happy {
    std::vector<int> ints;
};

const std::vector<int>& be_happy() {
    Happy h;
    return h.ints;
}

int main() {
    const std::vector<int>& local_ints = be_happy();
}
```

However, if the code decided to wrap the local reference with a thin abstraction, the compiler will stop complaining and it will inevitably crash at runtime:

```cc
#include <vector>

class Happy {
  public:
    const std::vector<int>& ints() {return ints_;}
  private:
    std::vector<int> ints_;
};

const std::vector<int>& be_happy() {
    Happy h;
    return h.ints();
}

int main() {
    const std::vector<int>& local_ints = be_happy();
}

```

At least, I hope these two flags can help someone else one-day.

---

Related https://github.com/grpc/grpc/pull/25038

I hit this bug with ProtoBuf, that even if a local reference of a ProtoBuf message is returned, the ProtoBuf message still has some value left un-cleaned. For example, I can check the size of repeated fields, and it returns a right answer deterministically. But it will crash if I try to get the values out of the ProtoBuf message.

Credit to someone randomly mentioning this case in group chat @nicolasnoble