### PR TITLE
back-port: add env var protection for google-c2p resolver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -19,6 +19,7 @@
 #include "src/core/ext/filters/client_channel/resolver_registry.h"
 #include "src/core/ext/xds/xds_client.h"
 #include "src/core/lib/gpr/env.h"
+#include "src/core/lib/gpr/string.h"
 #include "src/core/lib/http/httpcli.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/security/credentials/alts/check_gcp_environment.h"
@@ -353,8 +354,14 @@ class GoogleCloud2ProdResolverFactory : public ResolverFactory {
 }  // namespace
 
 void GoogleCloud2ProdResolverInit() {
-  ResolverRegistry::Builder::RegisterResolverFactory(
-      absl::make_unique<GoogleCloud2ProdResolverFactory>());
+  // TODO(roth): Remove env var protection once this code is proven stable.
+  UniquePtr<char> value(gpr_getenv("GRPC_EXPERIMENTAL_GOOGLE_C2P_RESOLVER"));
+  bool parsed_value;
+  bool parse_succeeded = gpr_parse_bool_value(value.get(), &parsed_value);
+  if (parse_succeeded && parsed_value) {
+    ResolverRegistry::Builder::RegisterResolverFactory(
+        absl::make_unique<GoogleCloud2ProdResolverFactory>());
+  }
 }
 
 void GoogleCloud2ProdResolverShutdown() {}


### PR DESCRIPTION
Back-porting #25548 to v1.36.x.