### PR TITLE
Fix the generated_projects.sh again

### DIFF
--- a/tools/buildgen/generate_projects.sh
+++ b/tools/buildgen/generate_projects.sh
@@ -20,7 +20,7 @@ export TEST=${TEST:-false}
 
 YAML_OK=$(python3 -c "import yaml; print(yaml.__version__.split('.') >= ['5', '4', '1'])")
 
-if [[ ${YAML_OK} != "True" ]]; then
+if [[ "${YAML_OK}" != "True" ]]; then
   python3 -m pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
 fi
 


### PR DESCRIPTION
```
+ tools/buildgen/generate_projects.sh
tools/buildgen/generate_projects.sh: 23: tools/buildgen/generate_projects.sh: [[: not found
```

Previous PR overlooked one possibility that the Python command returns nothing in stdout.