### PR TITLE
Configure keep-open RPCs with a large timeout to avoid DEADLINE_EXCEEDED influencing circuit breaking test

### DIFF
--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -264,11 +264,6 @@ class TestClient {
     AsyncClientCall* call = new AsyncClientCall;
     for (const auto& data : config.metadata) {
       call->context.AddMetadata(data.first, data.second);
-      // TODO(@donnadionne): move deadline to separate proto.
-      if (data.first == "rpc-behavior" && data.second == "keep-open") {
-        deadline =
-            std::chrono::system_clock::now() + std::chrono::seconds(INT_MAX);
-      }
     }
     call->context.set_deadline(deadline);
     call->saved_request_id = saved_request_id;

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1414,14 +1414,15 @@ def test_circuit_breaking(gcp, original_backend_service, instance_group,
             extra_backend_instances + more_extra_backend_instances,
             _WAIT_FOR_STATS_SEC)
 
-        # Make all calls keep-open.
+        # Make all calls keep-open. Set a large timeout to avoid RPCs
+        # closed by DEADLINE_EXCEEDED.
         configure_client([
             messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL,
             messages_pb2.ClientConfigureRequest.RpcType.EMPTY_CALL
         ], [(messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL,
              'rpc-behavior', 'keep-open'),
             (messages_pb2.ClientConfigureRequest.RpcType.EMPTY_CALL,
-             'rpc-behavior', 'keep-open')])
+             'rpc-behavior', 'keep-open')], timeout_sec=3600)
         wait_until_rpcs_in_flight(
             'UNARY_CALL', (_WAIT_FOR_BACKEND_SEC +
                            int(extra_backend_service_max_requests / args.qps)),

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1422,7 +1422,8 @@ def test_circuit_breaking(gcp, original_backend_service, instance_group,
         ], [(messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL,
              'rpc-behavior', 'keep-open'),
             (messages_pb2.ClientConfigureRequest.RpcType.EMPTY_CALL,
-             'rpc-behavior', 'keep-open')], timeout_sec=3600)
+             'rpc-behavior', 'keep-open')],
+                         timeout_sec=3600)
         wait_until_rpcs_in_flight(
             'UNARY_CALL', (_WAIT_FOR_BACKEND_SEC +
                            int(extra_backend_service_max_requests / args.qps)),


### PR DESCRIPTION
Test RPCs that are kept open end with DEADLINE_EXCEEDED after the default timeout (e.g., 30s in Ruby). Usually this shouldn't be a problem as 30s is long enough for making up to 1000 RPCs in-flight dynamically (with 100 QPS) at any point of time. But we did see some low ratio of flakiness in Ruby's test. Cpp test client had already made the hack for disabling "keep-open" RPCs. Now that the test driver can configure timeout via `Configure()`, we can just configure with a large value and eliminate the hack in Cpp test client.


/cc @donnadionne @menghanl @stanley-cheung

Also, please request for review as my write permission is revoked...