### PR TITLE
Changed RPI build test to general ARM build test

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -243,7 +243,7 @@ $ cmake ../.. -DCMAKE_TOOLCHAIN_FILE=path/to/file
 $ make
 ```
 
-[Cross-compile example](test/distrib/cpp/run_distrib_test_cmake_arm_cross.sh)
+[Cross-compile example](test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh)
 
 ## Building with make on UNIX systems (deprecated)
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -243,7 +243,7 @@ $ cmake ../.. -DCMAKE_TOOLCHAIN_FILE=path/to/file
 $ make
 ```
 
-[Cross-compile example](test/distrib/cpp/run_distrib_test_raspberry_pi.sh)
+[Cross-compile example](test/distrib/cpp/run_distrib_test_cmake_arm_cross.sh)
 
 ## Building with make on UNIX systems (deprecated)
 

--- a/test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh
@@ -20,9 +20,6 @@ cd "$(dirname "$0")/../../.."
 # Install openssl (to use instead of boringssl)
 apt-get update && apt-get install -y libssl-dev
 
-# Install arm cross-compiler
-apt-get update && apt-get install -y g++-6-arm-linux-gnueabihf
-
 # Install CMake 3.16
 apt-get update && apt-get install -y wget
 wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.16.1/cmake-3.16.1-Linux-x86_64.sh
@@ -46,10 +43,10 @@ popd
 # Write a toolchain file to use for cross-compiling.
 cat > /tmp/toolchain.cmake <<'EOT'
 SET(CMAKE_SYSTEM_NAME Linux)
-SET(CMAKE_SYSTEM_PROCESSOR arm)
+SET(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_STAGING_PREFIX /tmp/stage)
-set(CMAKE_C_COMPILER /usr/bin/arm-linux-gnueabihf-gcc-6)
-set(CMAKE_CXX_COMPILER /usr/bin/arm-linux-gnueabihf-g++-6)
+set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc-6)
+set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++-6)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/test/distrib/cpp/run_distrib_test_cmake_arm_cross.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_arm_cross.sh
@@ -20,6 +20,9 @@ cd "$(dirname "$0")/../../.."
 # Install openssl (to use instead of boringssl)
 apt-get update && apt-get install -y libssl-dev
 
+# Install arm cross-compiler
+apt-get update && apt-get install -y g++-6-arm-linux-gnueabihf
+
 # Install CMake 3.16
 apt-get update && apt-get install -y wget
 wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.16.1/cmake-3.16.1-Linux-x86_64.sh
@@ -40,51 +43,52 @@ cmake \
 make -j4 install
 popd
 
-# Download raspberry pi toolchain.
-mkdir -p "/tmp/raspberrypi_root"
-pushd "/tmp/raspberrypi_root"
-git clone https://github.com/raspberrypi/tools raspberrypi-tools
-cd raspberrypi-tools && git checkout 4a335520900ce55e251ac4f420f52bf0b2ab6b1f && cd ..
-
 # Write a toolchain file to use for cross-compiling.
-cat > toolchain.cmake <<'EOT'
+cat > /tmp/toolchain.cmake <<'EOT'
 SET(CMAKE_SYSTEM_NAME Linux)
 SET(CMAKE_SYSTEM_PROCESSOR arm)
-set(devel_root /tmp/raspberrypi_root)
-set(CMAKE_STAGING_PREFIX ${devel_root}/stage)
-set(tool_root ${devel_root}/raspberrypi-tools/arm-bcm2708)
-set(CMAKE_SYSROOT ${tool_root}/arm-rpi-4.9.3-linux-gnueabihf/arm-linux-gnueabihf/sysroot)
-set(CMAKE_C_COMPILER ${tool_root}/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc)
-set(CMAKE_CXX_COMPILER ${tool_root}/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-g++)
+set(CMAKE_STAGING_PREFIX /tmp/stage)
+set(CMAKE_C_COMPILER /usr/bin/arm-linux-gnueabihf-gcc-6)
+set(CMAKE_CXX_COMPILER /usr/bin/arm-linux-gnueabihf-g++-6)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 EOT
-popd
 
-# Build and install gRPC for raspberry pi.
-# This build will use the host architecture copies of protoc and
-# grpc_cpp_plugin that we built earlier because we installed them
-# to a location in our PATH (/usr/local/bin).
-mkdir -p "cmake/raspberrypi_build"
-pushd "cmake/raspberrypi_build"
-cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/raspberrypi_root/toolchain.cmake \
+# Build and install absl (absl won't be installed down below)
+mkdir -p "third_party/abseil-cpp/cmake/build_arm"
+pushd "third_party/abseil-cpp/cmake/build_arm"
+cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/toolchain.cmake \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=/tmp/raspberrypi_root/grpc_install \
+      -DCMAKE_INSTALL_PREFIX=/tmp/install \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
       ../..
 make -j4 install
 popd
 
-# Build helloworld example for raspberry pi.
+# Build and install gRPC for ARM.
+# This build will use the host architecture copies of protoc and
+# grpc_cpp_plugin that we built earlier because we installed them
+# to a location in our PATH (/usr/local/bin).
+mkdir -p "cmake/build_arm"
+pushd "cmake/build_arm"
+cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/toolchain.cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/tmp/install \
+      ../..
+make -j4 install
+popd
+
+# Build helloworld example for ARM.
 # As above, it will find and use protoc and grpc_cpp_plugin
 # for the host architecture.
-mkdir -p "examples/cpp/helloworld/cmake/raspberrypi_build"
-pushd "examples/cpp/helloworld/cmake/raspberrypi_build"
-cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/raspberrypi_root/toolchain.cmake \
+mkdir -p "examples/cpp/helloworld/cmake/build_arm"
+pushd "examples/cpp/helloworld/cmake/build_arm"
+cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/toolchain.cmake \
       -DCMAKE_BUILD_TYPE=Release \
-      -DProtobuf_DIR=/tmp/raspberrypi_root/stage/lib/cmake/protobuf \
-      -DgRPC_DIR=/tmp/raspberrypi_root/stage/lib/cmake/grpc \
+      -DProtobuf_DIR=/tmp/stage/lib/cmake/protobuf \
+      -DgRPC_DIR=/tmp/stage/lib/cmake/grpc \
       ../..
 make
 popd

--- a/tools/dockerfile/distribtest/cpp_stretch_aarch64_cross_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/cpp_stretch_aarch64_cross_x64/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+# gRPC C++ dependencies based on https://github.com/grpc/grpc/blob/master/BUILDING.md
+RUN apt-get update && apt-get install -y build-essential autoconf libtool pkg-config && apt-get clean
+
+# debian stretch has cmake 3.7: https://packages.debian.org/stretch/cmake
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+# C++ distribtests are setup in a way that requires git
+RUN apt-get update && apt-get install -y git && apt-get clean
+
+# aarch cross-compiler
+RUN apt-get update && apt-get install -y g++-6-aarch64-linux-gnu
+
+CMD ["bash"]

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -326,7 +326,8 @@ def targets():
         CppDistribTest('linux', 'x64', 'stretch',
                        'cmake_module_install_pkgconfig'),
         CppDistribTest('linux', 'x64', 'stretch', 'cmake_pkgconfig'),
-        CppDistribTest('linux', 'x64', 'stretch', 'cmake_arm_cross'),
+        CppDistribTest('linux', 'x64', 'stretch_aarch64_cross',
+                       'cmake_aarch64_cross'),
         CppDistribTest('windows', 'x86', testcase='cmake'),
         CppDistribTest('windows', 'x86', testcase='cmake_as_externalproject'),
         # C#

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -326,7 +326,7 @@ def targets():
         CppDistribTest('linux', 'x64', 'stretch',
                        'cmake_module_install_pkgconfig'),
         CppDistribTest('linux', 'x64', 'stretch', 'cmake_pkgconfig'),
-        CppDistribTest('linux', 'x64', 'stretch', 'raspberry_pi'),
+        CppDistribTest('linux', 'x64', 'stretch', 'cmake_arm_cross'),
         CppDistribTest('windows', 'x86', testcase='cmake'),
         CppDistribTest('windows', 'x86', testcase='cmake_as_externalproject'),
         # C#


### PR DESCRIPTION
Changing the existing cmake build test for Raspberry Pi to the general ARM build test because the tool chain that existing test uses hasn't updated (e.g. gcc 4.9). Instead, it's repurposed to test the build on general ARM, which allows it to use gcc 6.x.

[grpc_build_artifacts_multiplatform](https://fusion2.corp.google.com/invocations/21fae796-5ccb-41ef-9ad1-ce9bf672819d): passed