### PR TITLE
[Backport] Relax ruby test check on protobuf error message 

### DIFF
--- a/src/ruby/spec/errors_spec.rb
+++ b/src/ruby/spec/errors_spec.rb
@@ -131,7 +131,7 @@ describe GRPC::BadStatus do
 
       error_msg = 'parse error: to_rpc_status failed'
       error_desc = '<Google::Protobuf::ParseError> ' \
-        'Error occurred during parsing: Invalid wire type'
+        'Error occurred during parsing'
 
       # Check that the parse error was logged correctly
       log_contents = @log_output.read


### PR DESCRIPTION
#25507

The Ruby tests failed the same ProtoBuf output error on the v1.36.x branch.