### PR TITLE
Add missing security field to channelz Socket

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -363,10 +363,14 @@ static bool read_channel_args(grpc_chttp2_transport* t,
     }
   }
   if (channelz_enabled) {
+    auto sec = grpc_core::channelz::SocketNode::Security::GetFromChannelArgs(
+        channel_args);
     t->channelz_socket =
         grpc_core::MakeRefCounted<grpc_core::channelz::SocketNode>(
             std::string(grpc_endpoint_get_local_address(t->ep)), t->peer_string,
-            absl::StrFormat("%s %s", get_vtable()->name, t->peer_string));
+            absl::StrFormat("%s %s", get_vtable()->name, t->peer_string),
+            grpc_core::channelz::SocketNode::Security::GetFromChannelArgs(
+                channel_args));
   }
   return enable_bdp;
 }

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -363,8 +363,6 @@ static bool read_channel_args(grpc_chttp2_transport* t,
     }
   }
   if (channelz_enabled) {
-    auto sec = grpc_core::channelz::SocketNode::Security::GetFromChannelArgs(
-        channel_args);
     t->channelz_socket =
         grpc_core::MakeRefCounted<grpc_core::channelz::SocketNode>(
             std::string(grpc_endpoint_get_local_address(t->ep)), t->peer_string,

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -538,6 +538,9 @@ Json SocketNode::RenderJson() {
        }},
       {"data", std::move(data)},
   };
+  if(security_ != nullptr && security_->type != SocketNode::Security::ModelType::kUnset) {
+    object["security"] = security_->RenderJson();
+  }
   PopulateSocketAddressJson(&object, "remote", remote_.c_str());
   PopulateSocketAddressJson(&object, "local", local_.c_str());
   return object;

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -337,6 +337,75 @@ Json ServerNode::RenderJson() {
 }
 
 //
+// SocketNode::Security::Tls
+//
+
+Json SocketNode::Security::Tls::RenderJson() {
+  Json::Object data;
+  if (type == NameType::kStandardName) {
+    data["standard_name"] = name;
+  } else if (type == NameType::kOtherName) {
+    data["other_name"] = name;
+  }
+  if (!local_certificate.empty()) {
+    data["local_certificate"] = local_certificate;
+  }
+  if (!remote_certificate.empty()) {
+    data["remote_certificate"] = remote_certificate;
+  }
+  return data;
+}
+
+//
+// SocketNode::Security
+//
+
+Json SocketNode::Security::RenderJson() {
+  switch (type) {
+    case ModelType::kUnset:
+      return Json::Object();
+    case ModelType::kTls:
+      return tls->RenderJson();
+    case ModelType::kOther:
+      return *other;
+  }
+}
+
+namespace {
+
+void* SecurityArgCopy(void* p) {
+  SocketNode::Security* xds_certificate_provider =
+      static_cast<SocketNode::Security*>(p);
+  return xds_certificate_provider->Ref().release();
+}
+
+void SecurityArgDestroy(void* p) {
+  SocketNode::Security* xds_certificate_provider =
+      static_cast<SocketNode::Security*>(p);
+  xds_certificate_provider->Unref();
+}
+
+int SecurityArgCmp(void* p, void* q) { return GPR_ICMP(p, q); }
+
+const grpc_arg_pointer_vtable kChannelArgVtable = {
+    SecurityArgCopy, SecurityArgDestroy, SecurityArgCmp};
+
+}  // namespace
+
+grpc_arg SocketNode::Security::MakeChannelArg() const {
+  return grpc_channel_arg_pointer_create(
+      const_cast<char*>(GRPC_ARG_CHANNELZ_SECURITY),
+      const_cast<SocketNode::Security*>(this), &kChannelArgVtable);
+}
+
+RefCountedPtr<SocketNode::Security> SocketNode::Security::GetFromChannelArgs(
+    const grpc_channel_args* args) {
+  Security* security = grpc_channel_args_find_pointer<Security>(
+      args, GRPC_ARG_CHANNELZ_SECURITY);
+  return security != nullptr ? security->Ref() : nullptr;
+}
+
+//
 // SocketNode
 //
 
@@ -376,10 +445,12 @@ void PopulateSocketAddressJson(Json::Object* json, const char* name,
 
 }  // namespace
 
-SocketNode::SocketNode(std::string local, std::string remote, std::string name)
+SocketNode::SocketNode(std::string local, std::string remote, std::string name,
+                       RefCountedPtr<Security> security)
     : BaseNode(EntityType::kSocket, std::move(name)),
       local_(std::move(local)),
-      remote_(std::move(remote)) {}
+      remote_(std::move(remote)),
+      security_(std::move(security)) {}
 
 void SocketNode::RecordStreamStartedFromLocal() {
   streams_started_.FetchAdd(1, MemoryOrder::RELAXED);

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -206,6 +206,11 @@ RefCountedPtr<channelz::SocketNode::Security>
 MakeChannelzSecurityFromAuthContext(grpc_auth_context* auth_context) {
   RefCountedPtr<channelz::SocketNode::Security> security =
       MakeRefCounted<channelz::SocketNode::Security>();
+  // TODO(yashykt): Currently, we are assuming TLS by default and are only able
+  // to fill in the remote certificate but we should ideally be able to fill in
+  // other fields in
+  // https://github.com/grpc/grpc/blob/fcd43e90304862a823316b224ee733d17a8cfd90/src/proto/grpc/channelz/channelz.proto#L326
+  // from grpc_auth_context.
   security->type = channelz::SocketNode::Security::ModelType::kTls;
   security->tls = absl::make_optional<channelz::SocketNode::Security::Tls>();
   grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -29,6 +29,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/channel/handshaker.h"
 #include "src/core/lib/channel/handshaker_registry.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
@@ -199,6 +200,26 @@ void SecurityHandshaker::HandshakeFailedLocked(grpc_error* error) {
   ExecCtx::Run(DEBUG_LOCATION, on_handshake_done_, error);
 }
 
+namespace {
+
+RefCountedPtr<channelz::SocketNode::Security>
+MakeChannelzSecurityFromAuthContext(grpc_auth_context* auth_context) {
+  RefCountedPtr<channelz::SocketNode::Security> security =
+      MakeRefCounted<channelz::SocketNode::Security>();
+  security->type = channelz::SocketNode::Security::ModelType::kTls;
+  security->tls = absl::make_optional<channelz::SocketNode::Security::Tls>();
+  grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(
+      auth_context, GRPC_X509_PEM_CERT_PROPERTY_NAME);
+  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
+  if (prop != nullptr) {
+    security->tls->remote_certificate =
+        std::string(prop->value, prop->value_length);
+  }
+  return security;
+}
+
+}  // namespace
+
 void SecurityHandshaker::OnPeerCheckedInner(grpc_error* error) {
   MutexLock lock(&mu_);
   if (error != GRPC_ERROR_NONE || is_shutdown_) {
@@ -251,9 +272,13 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error* error) {
   tsi_handshaker_result_destroy(handshaker_result_);
   handshaker_result_ = nullptr;
   // Add auth context to channel args.
-  grpc_arg auth_context_arg = grpc_auth_context_to_arg(auth_context_.get());
+  absl::InlinedVector<grpc_arg, 2> args_to_add;
+  args_to_add.push_back(grpc_auth_context_to_arg(auth_context_.get()));
+  auto security = MakeChannelzSecurityFromAuthContext(auth_context_.get());
+  args_to_add.push_back(security->MakeChannelArg());
   grpc_channel_args* tmp_args = args_->args;
-  args_->args = grpc_channel_args_copy_and_add(tmp_args, &auth_context_arg, 1);
+  args_->args = grpc_channel_args_copy_and_add(tmp_args, args_to_add.data(),
+                                               args_to_add.size());
   grpc_channel_args_destroy(tmp_args);
   // Invoke callback.
   ExecCtx::Run(DEBUG_LOCATION, on_handshake_done_, GRPC_ERROR_NONE);

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -240,6 +240,13 @@ grpc_cc_library(
 grpc_cc_test(
     name = "channelz_service_test",
     srcs = ["channelz_service_test.cc"],
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:client.key",
+        "//src/core/tsi/test_creds:client.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
     external_deps = [
         "gtest",
     ],

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -175,6 +175,11 @@ std::shared_ptr<grpc::ServerCredentials> GetServerCredentials(
   return grpc::experimental::TlsServerCredentials(options);
 }
 
+std::string RemoveWhitespaces(std::string input) {
+  input.erase(remove_if(input.begin(), input.end(), isspace), input.end());
+  return input;
+}
+
 class ChannelzServerTest : public ::testing::TestWithParam<CredentialsType> {
  public:
   ChannelzServerTest() {}
@@ -677,8 +682,9 @@ TEST_P(ChannelzServerTest, ManySubchannelsAndSockets) {
         EXPECT_TRUE(get_socket_resp.socket().has_security());
         EXPECT_TRUE(get_socket_resp.socket().security().has_tls());
         EXPECT_EQ(
-            get_socket_resp.socket().security().tls().remote_certificate(),
-            ReadFile(kServerCertPath));
+            RemoveWhitespaces(
+                get_socket_resp.socket().security().tls().remote_certificate()),
+            RemoveWhitespaces(ReadFile(kServerCertPath)));
         break;
     }
   }
@@ -740,9 +746,11 @@ TEST_P(ChannelzServerTest, StreamingRPC) {
     case CredentialsType::kMtls:
       EXPECT_TRUE(get_socket_response.socket().has_security());
       EXPECT_TRUE(get_socket_response.socket().security().has_tls());
-      EXPECT_EQ(
-          get_socket_response.socket().security().tls().remote_certificate(),
-          ReadFile(kServerCertPath));
+      EXPECT_EQ(RemoveWhitespaces(get_socket_response.socket()
+                                      .security()
+                                      .tls()
+                                      .remote_certificate()),
+                RemoveWhitespaces(ReadFile(kServerCertPath)));
       break;
   }
 }
@@ -788,9 +796,11 @@ TEST_P(ChannelzServerTest, GetServerSocketsTest) {
       EXPECT_TRUE(get_socket_response.socket().has_security());
       EXPECT_TRUE(get_socket_response.socket().security().has_tls());
       if (GetParam() == CredentialsType::kMtls) {
-        EXPECT_EQ(
-            get_socket_response.socket().security().tls().remote_certificate(),
-            ReadFile(kClientCertPath));
+        EXPECT_EQ(RemoveWhitespaces(get_socket_response.socket()
+                                        .security()
+                                        .tls()
+                                        .remote_certificate()),
+                  RemoveWhitespaces(ReadFile(kClientCertPath)));
       } else {
         EXPECT_TRUE(get_socket_response.socket()
                         .security()


### PR DESCRIPTION
As per https://github.com/grpc/grpc/blob/fcd43e90304862a823316b224ee733d17a8cfd90/src/proto/grpc/channelz/channelz.proto#L240, `Sockets` should expose security information.

Currently, we are able to get the remote's peer certificate from `grpc_auth_context` once the security handshake is done, but we don't have any other information. This PR exposes the remote's peer certificates as part of the channelz's Socket information.

cc @markdroth @ZhenLian

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25593)
<!-- Reviewable:end -->
