### PR TITLE
Option to disable local_certificate check from PSM security tests

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -36,6 +36,12 @@ _FORCE_CLEANUP = flags.DEFINE_bool(
     "force_cleanup",
     default=False,
     help="Force resource cleanup, even if not created by this test run")
+# TODO(yashkt): We will no longer need this flag once Core exposes local certs
+# from channelz
+_CHECK_LOCAL_CERTS = flags.DEFINE_bool(
+    "check_local_certs",
+    default=False,
+    help="Security Tests also check the value of local certs")
 flags.adopt_module_key_flags(xds_flags)
 flags.adopt_module_key_flags(xds_k8s_flags)
 
@@ -83,6 +89,7 @@ class XdsKubernetesTestCase(absltest.TestCase):
         cls.force_cleanup = _FORCE_CLEANUP.value
         cls.debug_use_port_forwarding = \
             xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
+        cls.check_local_certs = _CHECK_LOCAL_CERTS.value
 
         # Resource managers
         cls.k8s_api_manager = k8s.KubernetesApiManager(
@@ -340,28 +347,28 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         server_tls, client_tls = server_security.tls, client_security.tls
 
         # Confirm regular TLS: server local cert == client remote cert
-        # TODO(yashykt): Re-enable when Core's channelz exposes local certs.
-        # self.assertNotEmpty(server_tls.local_certificate,
-        #                     msg="(mTLS) Server local certificate is missing")
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(mTLS) Client remote certificate is missing")
-        # self.assertEqual(
-        #     server_tls.local_certificate,
-        #     client_tls.remote_certificate,
-        #     msg="(mTLS) Server local certificate must match client's "
-        #     "remote certificate")
+        if cls.check_local_certs:
+            self.assertNotEmpty(server_tls.local_certificate,
+                                msg="(mTLS) Server local certificate is missing")
+            self.assertEqual(
+                server_tls.local_certificate,
+                client_tls.remote_certificate,
+                msg="(mTLS) Server local certificate must match client's "
+                "remote certificate")
 
         # mTLS: server remote cert == client local cert
         self.assertNotEmpty(server_tls.remote_certificate,
                             msg="(mTLS) Server remote certificate is missing")
-        # TODO(yashykt): Re-enable when Core's channelz exposes local certs.
-        # self.assertNotEmpty(client_tls.local_certificate,
-        #                     msg="(mTLS) Client local certificate is missing")
-        # self.assertEqual(
-        #     server_tls.remote_certificate,
-        #     client_tls.local_certificate,
-        #     msg="(mTLS) Server remote certificate must match client's "
-        #     "local certificate")
+        if cls.check_local_certs:
+            self.assertNotEmpty(client_tls.local_certificate,
+                                msg="(mTLS) Client local certificate is missing")
+            self.assertEqual(
+                server_tls.remote_certificate,
+                client_tls.local_certificate,
+                msg="(mTLS) Server remote certificate must match client's "
+                "local certificate")
 
     def assertSecurityTls(self, client_security: grpc_channelz.Security,
                           server_security: grpc_channelz.Security):
@@ -374,15 +381,15 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         server_tls, client_tls = server_security.tls, client_security.tls
 
         # Regular TLS: server local cert == client remote cert
-        # TODO(yashykt): Re-enable when Core's channelz exposes local certs.
-        # self.assertNotEmpty(server_tls.local_certificate,
-        #                     msg="(TLS) Server local certificate is missing")
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(TLS) Client remote certificate is missing")
-        # self.assertEqual(server_tls.local_certificate,
-        #                  client_tls.remote_certificate,
-        #                  msg="(TLS) Server local certificate must match client "
-        #                  "remote certificate")
+        if cls.check_local_certs:
+            self.assertNotEmpty(server_tls.local_certificate,
+                                msg="(TLS) Server local certificate is missing")
+            self.assertEqual(server_tls.local_certificate,
+                             client_tls.remote_certificate,
+                             msg="(TLS) Server local certificate must match client "
+                             "remote certificate")
 
         # mTLS must not be used
         self.assertEmpty(

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -350,8 +350,9 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(mTLS) Client remote certificate is missing")
         if cls.check_local_certs:
-            self.assertNotEmpty(server_tls.local_certificate,
-                                msg="(mTLS) Server local certificate is missing")
+            self.assertNotEmpty(
+                server_tls.local_certificate,
+                msg="(mTLS) Server local certificate is missing")
             self.assertEqual(
                 server_tls.local_certificate,
                 client_tls.remote_certificate,
@@ -362,8 +363,9 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         self.assertNotEmpty(server_tls.remote_certificate,
                             msg="(mTLS) Server remote certificate is missing")
         if cls.check_local_certs:
-            self.assertNotEmpty(client_tls.local_certificate,
-                                msg="(mTLS) Client local certificate is missing")
+            self.assertNotEmpty(
+                client_tls.local_certificate,
+                msg="(mTLS) Client local certificate is missing")
             self.assertEqual(
                 server_tls.remote_certificate,
                 client_tls.local_certificate,
@@ -386,10 +388,11 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         if cls.check_local_certs:
             self.assertNotEmpty(server_tls.local_certificate,
                                 msg="(TLS) Server local certificate is missing")
-            self.assertEqual(server_tls.local_certificate,
-                             client_tls.remote_certificate,
-                             msg="(TLS) Server local certificate must match client "
-                             "remote certificate")
+            self.assertEqual(
+                server_tls.local_certificate,
+                client_tls.remote_certificate,
+                msg="(TLS) Server local certificate must match client "
+                "remote certificate")
 
         # mTLS must not be used
         self.assertEmpty(

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -40,7 +40,7 @@ _FORCE_CLEANUP = flags.DEFINE_bool(
 # from channelz
 _CHECK_LOCAL_CERTS = flags.DEFINE_bool(
     "check_local_certs",
-    default=False,
+    default=True,
     help="Security Tests also check the value of local certs")
 flags.adopt_module_key_flags(xds_flags)
 flags.adopt_module_key_flags(xds_k8s_flags)

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -340,26 +340,28 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         server_tls, client_tls = server_security.tls, client_security.tls
 
         # Confirm regular TLS: server local cert == client remote cert
-        self.assertNotEmpty(server_tls.local_certificate,
-                            msg="(mTLS) Server local certificate is missing")
+        # TODO(yashykt): Re-enable when Core's channelz exposes local certs.
+        # self.assertNotEmpty(server_tls.local_certificate,
+        #                     msg="(mTLS) Server local certificate is missing")
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(mTLS) Client remote certificate is missing")
-        self.assertEqual(
-            server_tls.local_certificate,
-            client_tls.remote_certificate,
-            msg="(mTLS) Server local certificate must match client's "
-            "remote certificate")
+        # self.assertEqual(
+        #     server_tls.local_certificate,
+        #     client_tls.remote_certificate,
+        #     msg="(mTLS) Server local certificate must match client's "
+        #     "remote certificate")
 
         # mTLS: server remote cert == client local cert
         self.assertNotEmpty(server_tls.remote_certificate,
                             msg="(mTLS) Server remote certificate is missing")
-        self.assertNotEmpty(client_tls.local_certificate,
-                            msg="(mTLS) Client local certificate is missing")
-        self.assertEqual(
-            server_tls.remote_certificate,
-            client_tls.local_certificate,
-            msg="(mTLS) Server remote certificate must match client's "
-            "local certificate")
+        # TODO(yashykt): Re-enable when Core's channelz exposes local certs.
+        # self.assertNotEmpty(client_tls.local_certificate,
+        #                     msg="(mTLS) Client local certificate is missing")
+        # self.assertEqual(
+        #     server_tls.remote_certificate,
+        #     client_tls.local_certificate,
+        #     msg="(mTLS) Server remote certificate must match client's "
+        #     "local certificate")
 
     def assertSecurityTls(self, client_security: grpc_channelz.Security,
                           server_security: grpc_channelz.Security):
@@ -372,14 +374,15 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         server_tls, client_tls = server_security.tls, client_security.tls
 
         # Regular TLS: server local cert == client remote cert
-        self.assertNotEmpty(server_tls.local_certificate,
-                            msg="(TLS) Server local certificate is missing")
+        # TODO(yashykt): Re-enable when Core's channelz exposes local certs.
+        # self.assertNotEmpty(server_tls.local_certificate,
+        #                     msg="(TLS) Server local certificate is missing")
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(TLS) Client remote certificate is missing")
-        self.assertEqual(server_tls.local_certificate,
-                         client_tls.remote_certificate,
-                         msg="(TLS) Server local certificate must match client "
-                         "remote certificate")
+        # self.assertEqual(server_tls.local_certificate,
+        #                  client_tls.remote_certificate,
+        #                  msg="(TLS) Server local certificate must match client "
+        #                  "remote certificate")
 
         # mTLS must not be used
         self.assertEmpty(


### PR DESCRIPTION
After https://github.com/grpc/grpc/pull/25593, Core will be able to expose the Security field for channelz Sockets but it is only capable of exposing remote's certificates. For our purposes, simply checking that the remote certificates have been populated should be enough to verify whether we are configured with Insecure/TLS/mTLS.

This check can be re-enabled after Core exposes local certificates too.
cc @easwars 