### PR TITLE
xds-k8s Fix NameError name 'cls' is not defined

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -349,7 +349,7 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         # Confirm regular TLS: server local cert == client remote cert
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(mTLS) Client remote certificate is missing")
-        if cls.check_local_certs:
+        if self.check_local_certs:
             self.assertNotEmpty(
                 server_tls.local_certificate,
                 msg="(mTLS) Server local certificate is missing")
@@ -362,7 +362,7 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         # mTLS: server remote cert == client local cert
         self.assertNotEmpty(server_tls.remote_certificate,
                             msg="(mTLS) Server remote certificate is missing")
-        if cls.check_local_certs:
+        if self.check_local_certs:
             self.assertNotEmpty(
                 client_tls.local_certificate,
                 msg="(mTLS) Client local certificate is missing")
@@ -385,7 +385,7 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
         # Regular TLS: server local cert == client remote cert
         self.assertNotEmpty(client_tls.remote_certificate,
                             msg="(TLS) Client remote certificate is missing")
-        if cls.check_local_certs:
+        if self.check_local_certs:
             self.assertNotEmpty(server_tls.local_certificate,
                                 msg="(TLS) Server local certificate is missing")
             self.assertEqual(


### PR DESCRIPTION
Regression introduced to the driver in https://github.com/grpc/grpc/pull/25595.
Invocation example:  https://source.cloud.google.com/results/invocations/408b4af1-21ea-44bc-b24f-212b027d0d96/targets/grpc%2Fjava%2Fmaster%2Fbranch%2Fxds-k8s%2Fsecurity_test/tests
Error: NameError: name 'cls' is not defined
ref b/181846049