### PR TITLE
[DO NOT MERGE] Update clang requirement in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ If you plan to build using CMake
 If you are a contributor and plan to build and run tests, install the following as well:
 ```sh
  $ # clang and LLVM C++ lib is only required for sanitizer builds
- $ [sudo] apt-get install clang-5.0 libc++-dev
+ $ [sudo] apt-get install clang libc++-dev
 ```
 
 ## MacOS


### PR DESCRIPTION
As of debian buster, package clang-5.0 is not accessible in the DebianStable package source. It appears to be available for Ubuntu
xenial and bionic (LTS). However, Clang stable is currently version 11. This commit removes the version requirement for the clang dependency.

This is meant to start a discussion, not to be merged AS-IS.
