### PR TITLE
Add max_frame_size support to fake TSI handshaker and fake HS service

### DIFF
--- a/src/core/tsi/fake_transport_security.cc
+++ b/src/core/tsi/fake_transport_security.cc
@@ -474,12 +474,21 @@ static void fake_zero_copy_grpc_protector_destroy(
   gpr_free(impl);
 }
 
+static tsi_result fake_zero_copy_grpc_protector_max_frame_size(
+    tsi_zero_copy_grpc_protector* self, size_t* max_frame_size) {
+  if (self == nullptr || max_frame_size == nullptr) return TSI_INVALID_ARGUMENT;
+  tsi_fake_zero_copy_grpc_protector* impl =
+      reinterpret_cast<tsi_fake_zero_copy_grpc_protector*>(self);
+  *max_frame_size = impl->max_frame_size;
+  return TSI_OK;
+}
+
 static const tsi_zero_copy_grpc_protector_vtable
     zero_copy_grpc_protector_vtable = {
         fake_zero_copy_grpc_protector_protect,
         fake_zero_copy_grpc_protector_unprotect,
         fake_zero_copy_grpc_protector_destroy,
-        nullptr /* fake_zero_copy_grpc_protector_max_frame_size */
+        fake_zero_copy_grpc_protector_max_frame_size,
 };
 
 /* --- tsi_handshaker_result methods implementation. ---*/

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
@@ -236,6 +236,7 @@ class FakeHandshakerService : public HandshakerService::Service {
     result.mutable_local_identity()->set_service_account("local_identity");
     string key(1024, '\0');
     result.set_key_data(key);
+    result.set_max_frame_size(16384);
     result.mutable_peer_rpc_versions()->mutable_max_rpc_version()->set_major(2);
     result.mutable_peer_rpc_versions()->mutable_max_rpc_version()->set_minor(1);
     result.mutable_peer_rpc_versions()->mutable_min_rpc_version()->set_major(2);

--- a/test/core/tsi/alts/fake_handshaker/handshaker.proto
+++ b/test/core/tsi/alts/fake_handshaker/handshaker.proto
@@ -95,6 +95,9 @@ message StartClientHandshakeReq {
 
   // (Optional) RPC protocol versions supported by the client.
   RpcProtocolVersions rpc_versions = 9;
+
+  // (Optional) Maximum frame size supported by the client.
+  uint32 max_frame_size = 10;
 }
 
 message ServerHandshakeParameters {
@@ -133,6 +136,9 @@ message StartServerHandshakeReq {
 
   // (Optional) RPC protocol versions supported by the server.
   RpcProtocolVersions rpc_versions = 6;
+
+  // (Optional) Maximum frame size supported by the server.
+  uint32 max_frame_size = 7;
 }
 
 message NextHandshakeMessageReq {
@@ -180,6 +186,9 @@ message HandshakerResult {
 
   // The RPC protocol versions supported by the peer.
   RpcProtocolVersions peer_rpc_versions = 7;
+
+  // The maximum frame size of the peer.
+  uint32 max_frame_size = 8;
 }
 
 message HandshakerStatus {


### PR DESCRIPTION
Fake TSI handshaker and HS services are used in envoy unit/integration tests. Recently we wanted to add the support of setting max_frame_size to envoy: https://github.com/envoyproxy/envoy/pull/15297#discussion_r587056089, which needs the changes in this PR to verify its behavior.