### PR TITLE
Enable timeout xds test for Ruby

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -62,10 +62,10 @@ touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
 
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
   tools/run_tests/run_xds_tests.py \
-    --test_case="all,path_matching,header_matching,circuit_breaking" \
+    --test_case="all,path_matching,header_matching,circuit_breaking,timeout" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
-    --source_image=projects/grpc-testing/global/images/xds-test-server-3 \
+    --source_image=projects/grpc-testing/global/images/xds-test-server-4 \
     --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
     --gcp_suffix=$(date '+%s') \
     --verbose \


### PR DESCRIPTION
Enable the `timeout` test case for Ruby xDS interop test. I have verified that it passed on my gcloud VM.

Need the cmdline argument `--xds_v3_support`, but it's already in the [shell script](https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh#L72). 