### PR TITLE
Fix access to empty list in proto

### DIFF
--- a/src/ruby/pb/test/xds_client.rb
+++ b/src/ruby/pb/test/xds_client.rb
@@ -114,7 +114,7 @@ class ConfigureTarget < Grpc::Testing::XdsUpdateClientConfigureService::Service
 
   def configure(req, _call)
     metadata_to_send = {}
-    req['metadata'].each do |m|
+    req.metadata.each do |m|
       rpc = m.type
       if !metadata_to_send.key?(rpc)
         metadata_to_send[rpc] = {}


### PR DESCRIPTION
Fixes #25505, b/180674033 and b/180662355.

Instead of `req['metadata'].each`, we should access the repeated field as a list `req.metadata.each`.


Error message:
```
WARN -- : undefined method `each' for nil:NilClass (NoMethodError)
src/ruby/pb/test/xds_client.rb:117:in `configure'
```