### PR TITLE
Updated clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,48 +1,124 @@
 ---
-# Disable abseil-no-namespace: https://bugs.llvm.org/show_bug.cgi?id=47947
+# Note on checks are disabled on purpose
+#
+# - abseil-no-namespace
+#   https://bugs.llvm.org/show_bug.cgi?id=47947
+#
+# - bugprone-reserved-identifier
+#   Some macros need to be defined for portability purpose; e.g. _BSD_SOURCE.
+#
+# - google-upgrade-googletest-case
+#   This requires googletest 1.10 which is higher than ones installed on many linux distributions.
+#
+# - modernize-redundant-void-arg
+#   Some source should be strictly C99 and func(void) should be used.
+#
+# Note on checks which will be enabled in future. These are good to have but
+# it's not activated yet due to the existing issues with the checks.
+# Once those issues are clear, these checks can be enabled later.
+#
+# - bugprone-branch-clone
+# - bugprone-infinite-loop
+# - bugprone-narrowing-conversions
+# - bugprone-not-null-terminated-result
+# - bugprone-signed-char-misuse
+# - bugprone-sizeof-expression
+# - bugprone-too-small-loop-variable
+# - bugprone-unhandled-self-assignment
+# - clang-diagnostic-deprecated-declarations
+# - clang-diagnostic-unused-function
+# - google-readability-avoid-underscore-in-googletest-name
+# - google-runtime-int
+# - google-runtime-references
+# - modernize-avoid-bind
+# - modernize-deprecated-headers
+# - modernize-loop-convert
+# - modernize-pass-by-value
+# - modernize-raw-string-literal
+# - modernize-return-braced-init-list
+# - modernize-use-auto
+# - modernize-use-default-member-init
+# - modernize-use-emplace
+# - modernize-use-equals-default
+# - modernize-use-equals-delete
+# - modernize-use-using
+# - performance-no-automatic-move
+# - performance-unnecessary-copy-initialization
+# - performance-unnecessary-value-param
+# - readability-const-return-type
+# - readability-delete-null-pointer
+# - readability-else-after-return
+# - readability-implicit-bool-conversion
+# - readability-redundant-declaration
+# - readability-simplify-boolean-expr
+# - readability-static-definition-in-anonymous-namespace
+#
 Checks: '-*,
   abseil-*,
   -abseil-no-namespace,
   bugprone-*,
+  -bugprone-branch-clone,
+  -bugprone-infinite-loop,
   -bugprone-narrowing-conversions,
+  -bugprone-not-null-terminated-result,
+  -bugprone-reserved-identifier,
+  -bugprone-signed-char-misuse,
+  -bugprone-sizeof-expression,
   -bugprone-too-small-loop-variable,
-  performance-*,
-  -performance-unnecessary-copy-initialization,
-  -performance-unnecessary-value-param,
+  -bugprone-unhandled-self-assignment,
   google-*,
+  -google-readability-avoid-underscore-in-googletest-name,
   -google-runtime-int,
   -google-runtime-references,
+  -google-upgrade-googletest-case,
+  performance-*,
+  -performance-no-automatic-move,
+  -performance-unnecessary-copy-initialization,
+  -performance-unnecessary-value-param,
+  clang-diagnostic-deprecated-register,
+  clang-diagnostic-expansion-to-defined,
+  clang-diagnostic-ignored-attributes,
+  clang-diagnostic-non-pod-varargs,
+  clang-diagnostic-shadow-field,
+  clang-diagnostic-shift-sign-overflow,
+  clang-diagnostic-tautological-undefined-compare,
+  clang-diagnostic-thread-safety*,
+  clang-diagnostic-undefined-bool-conversion,
+  clang-diagnostic-unreachable-code,
+  clang-diagnostic-unreachable-code-loop-increment,
+  clang-diagnostic-unused-const-variable,
+  clang-diagnostic-unused-lambda-capture,
+  clang-diagnostic-unused-local-typedef,
+  clang-diagnostic-unused-private-field,
+  clang-diagnostic-user-defined-warnings,
   misc-definitions-in-headers,
   misc-static-assert,
   misc-unconventional-assign-operator,
   misc-uniqueptr-reset-release,
   misc-unused-alias-decls,
   misc-unused-using-decls,
+  modernize-make-shared,
   modernize-make-unique,
-  -modernize-redundant-void-arg,
   modernize-replace-auto-ptr,
+  modernize-replace-random-shuffle,
   modernize-shrink-to-fit,
+  modernize-unary-static-assert,
   modernize-use-bool-literals,
+  modernize-use-noexcept,
   modernize-use-nullptr,
   modernize-use-override,
+  modernize-use-transparent-functors,
   readability-container-size-empty,
   readability-deleted-default,
   readability-function-size,
   readability-inconsistent-declaration-parameter-name,
+  readability-misleading-indentation,
+  readability-misplaced-array-index,
   readability-redundant-control-flow,
+  readability-redundant-function-ptr-dereference,
   readability-redundant-smartptr-get,
   readability-string-compare,
-
-  -bugprone-branch-clone,
-  -bugprone-infinite-loop,
-  -bugprone-not-null-terminated-result,
-  -bugprone-reserved-identifier,
-  -bugprone-signed-char-misuse,
-  -bugprone-sizeof-expression,
-  -bugprone-unhandled-self-assignment,
-  -google-readability-avoid-underscore-in-googletest-name,
-  -google-upgrade-googletest-case,
-  -performance-no-automatic-move'
+  readability-uniqueptr-delete-release'
 WarningsAsErrors: '*'
 CheckOptions:
   - key:    readability-function-size.StatementThreshold


### PR DESCRIPTION
As https://github.com/grpc/grpc/pull/25590 upgrading clang-tidy to 11 got merged, new rules which the internal CI uses are added. Checks which have problems with gRPC source are disabled and those will be added in future after fixing the issues.