### PR TITLE
Format Channelz Address.TcpIpAddress.address as packed bytes

### DIFF
--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -439,13 +439,12 @@ void PopulateSocketAddressJson(Json::Object* json, const char* name,
     grpc_resolved_address resolved_host;
     grpc_string_to_sockaddr(&resolved_host, host.c_str(), port_num);
     std::string packed_host = grpc_sockaddr_get_packed_host(&resolved_host);
-    char* b64_host = grpc_base64_encode(packed_host.data(), packed_host.size(),
-                                        false, false);
+    std::string b64_host;
+    absl::Base64Escape(packed_host, &b64_host);
     data["tcpip_address"] = Json::Object{
         {"port", port_num},
         {"ip_address", b64_host},
     };
-    gpr_free(b64_host);
   } else if (uri.ok() && uri->scheme() == "unix") {
     data["uds_address"] = Json::Object{
         {"filename", uri->path()},

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -439,7 +439,8 @@ void PopulateSocketAddressJson(Json::Object* json, const char* name,
     grpc_resolved_address resolved_host;
     grpc_string_to_sockaddr(&resolved_host, host.c_str(), port_num);
     std::string packed_host = grpc_sockaddr_get_packed_host(&resolved_host);
-    char* b64_host = grpc_base64_encode(packed_host.data(), packed_host.size(), false, false);
+    char* b64_host = grpc_base64_encode(packed_host.data(), packed_host.size(),
+                                        false, false);
     data["tcpip_address"] = Json::Object{
         {"port", port_num},
         {"ip_address", b64_host},

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -439,8 +439,7 @@ void PopulateSocketAddressJson(Json::Object* json, const char* name,
     grpc_resolved_address resolved_host;
     grpc_string_to_sockaddr(&resolved_host, host.c_str(), port_num);
     std::string packed_host = grpc_sockaddr_get_packed_host(&resolved_host);
-    std::string b64_host;
-    absl::Base64Escape(packed_host, &b64_host);
+    std::string b64_host = absl::Base64Escape(packed_host);
     data["tcpip_address"] = Json::Object{
         {"port", port_num},
         {"ip_address", b64_host},

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -19,6 +19,8 @@
 #include <grpc/impl/codegen/port_platform.h>
 
 #include "src/core/lib/channel/channelz.h"
+#include "src/core/lib/iomgr/resolve_address.h"
+#include "src/core/lib/iomgr/sockaddr_utils.h"
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/strip.h"
@@ -434,7 +436,10 @@ void PopulateSocketAddressJson(Json::Object* json, const char* name,
     if (!port.empty()) {
       port_num = atoi(port.data());
     }
-    char* b64_host = grpc_base64_encode(host.data(), host.size(), false, false);
+    grpc_resolved_address resolved_host;
+    grpc_string_to_sockaddr(&resolved_host, host.c_str(), port_num);
+    std::string packed_host = grpc_sockaddr_get_packed_host(&resolved_host);
+    char* b64_host = grpc_base64_encode(packed_host.data(), packed_host.size(), false, false);
     data["tcpip_address"] = Json::Object{
         {"port", port_num},
         {"ip_address", b64_host},

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -294,3 +294,22 @@ int grpc_sockaddr_set_port(grpc_resolved_address* resolved_addr, int port) {
       return 0;
   }
 }
+
+std::string grpc_sockaddr_get_packed_host(const grpc_resolved_address* resolved_addr) {
+  const grpc_sockaddr* addr =
+          reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
+  if (addr->sa_family == GRPC_AF_INET) {
+    const grpc_sockaddr_in* addr4 =
+              reinterpret_cast<const grpc_sockaddr_in*>(addr);
+    const char* addr_bytes = reinterpret_cast<const char*>(&addr4->sin_addr);
+    return std::string(addr_bytes, 4);
+  } else if (addr->sa_family == GRPC_AF_INET6) {
+    const grpc_sockaddr_in6* addr6 =
+              reinterpret_cast<const grpc_sockaddr_in6*>(addr);
+    const char* addr_bytes = reinterpret_cast<const char*>(&addr6->sin6_addr);
+    return std::string(addr_bytes, 16);
+  } else {
+    GPR_ASSERT(false);
+  }
+}
+

--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -295,21 +295,21 @@ int grpc_sockaddr_set_port(grpc_resolved_address* resolved_addr, int port) {
   }
 }
 
-std::string grpc_sockaddr_get_packed_host(const grpc_resolved_address* resolved_addr) {
+std::string grpc_sockaddr_get_packed_host(
+    const grpc_resolved_address* resolved_addr) {
   const grpc_sockaddr* addr =
-          reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
+      reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
   if (addr->sa_family == GRPC_AF_INET) {
     const grpc_sockaddr_in* addr4 =
-              reinterpret_cast<const grpc_sockaddr_in*>(addr);
+        reinterpret_cast<const grpc_sockaddr_in*>(addr);
     const char* addr_bytes = reinterpret_cast<const char*>(&addr4->sin_addr);
     return std::string(addr_bytes, 4);
   } else if (addr->sa_family == GRPC_AF_INET6) {
     const grpc_sockaddr_in6* addr6 =
-              reinterpret_cast<const grpc_sockaddr_in6*>(addr);
+        reinterpret_cast<const grpc_sockaddr_in6*>(addr);
     const char* addr_bytes = reinterpret_cast<const char*>(&addr6->sin6_addr);
     return std::string(addr_bytes, 16);
   } else {
     GPR_ASSERT(false);
   }
 }
-

--- a/src/core/lib/iomgr/sockaddr_utils.h
+++ b/src/core/lib/iomgr/sockaddr_utils.h
@@ -77,6 +77,7 @@ const char* grpc_sockaddr_get_uri_scheme(const grpc_resolved_address* addr);
 
 int grpc_sockaddr_get_family(const grpc_resolved_address* resolved_addr);
 
-std::string grpc_sockaddr_get_packed_host(const grpc_resolved_address* resolved_addr);
+std::string grpc_sockaddr_get_packed_host(
+    const grpc_resolved_address* resolved_addr);
 
 #endif /* GRPC_CORE_LIB_IOMGR_SOCKADDR_UTILS_H */

--- a/src/core/lib/iomgr/sockaddr_utils.h
+++ b/src/core/lib/iomgr/sockaddr_utils.h
@@ -77,4 +77,6 @@ const char* grpc_sockaddr_get_uri_scheme(const grpc_resolved_address* addr);
 
 int grpc_sockaddr_get_family(const grpc_resolved_address* resolved_addr);
 
+std::string grpc_sockaddr_get_packed_host(const grpc_resolved_address* resolved_addr);
+
 #endif /* GRPC_CORE_LIB_IOMGR_SOCKADDR_UTILS_H */

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -350,6 +350,13 @@ class ChannelzServicerTest(unittest.TestCase):
             self.assertEqual(gsc_resp.subchannel.data.calls_succeeded,
                              gs_resp.socket.data.messages_received)
 
+            if gs_resp.socket.remote.HasField("tcpip_address"):
+                address = gs_resp.socket.remote.tcpip_address.ip_address
+                self.assertTrue(len(address) == 4 or len(address) == 16, address)
+            if gs_resp.socket.local.HasField("tcpip_address"):
+                address = gs_resp.socket.local.tcpip_address.ip_address
+                self.assertTrue(len(address) == 4 or len(address) == 16, address)
+
     def test_streaming_rpc(self):
         self._pairs = _generate_channel_server_pairs(1)
         # In C++, the argument for _send_successful_stream_stream is message length.
@@ -413,6 +420,8 @@ class ChannelzServicerTest(unittest.TestCase):
         gs_resp = self._channelz_stub.GetSocket(
             channelz_pb2.GetSocketRequest(
                 socket_id=gss_resp.server[0].listen_socket[0].socket_id))
+
+
         # If the RPC call failed, it will raise a grpc.RpcError
         # So, if there is no exception raised, considered pass
 

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -352,10 +352,12 @@ class ChannelzServicerTest(unittest.TestCase):
 
             if gs_resp.socket.remote.HasField("tcpip_address"):
                 address = gs_resp.socket.remote.tcpip_address.ip_address
-                self.assertTrue(len(address) == 4 or len(address) == 16, address)
+                self.assertTrue(
+                    len(address) == 4 or len(address) == 16, address)
             if gs_resp.socket.local.HasField("tcpip_address"):
                 address = gs_resp.socket.local.tcpip_address.ip_address
-                self.assertTrue(len(address) == 4 or len(address) == 16, address)
+                self.assertTrue(
+                    len(address) == 4 or len(address) == 16, address)
 
     def test_streaming_rpc(self):
         self._pairs = _generate_channel_server_pairs(1)
@@ -420,7 +422,6 @@ class ChannelzServicerTest(unittest.TestCase):
         gs_resp = self._channelz_stub.GetSocket(
             channelz_pb2.GetSocketRequest(
                 socket_id=gss_resp.server[0].listen_socket[0].socket_id))
-
 
         # If the RPC call failed, it will raise a grpc.RpcError
         # So, if there is no exception raised, considered pass

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -47,6 +47,7 @@
 
 #include <gtest/gtest.h>
 
+using grpc::channelz::v1::Address;
 using grpc::channelz::v1::GetChannelRequest;
 using grpc::channelz::v1::GetChannelResponse;
 using grpc::channelz::v1::GetServerRequest;
@@ -65,6 +66,14 @@ using grpc::channelz::v1::GetTopChannelsResponse;
 namespace grpc {
 namespace testing {
 namespace {
+
+static bool ValidateAddress(const Address& address) {
+  if (address.address_case() != Address::kTcpipAddress) {
+    return true;
+  }
+  return address.tcpip_address().ip_address().size() == 4 || address.tcpip_address().ip_address().size() == 16; 
+
+}
 
 // Proxy service supports N backends. Sends RPC to backend dictated by
 // request->backend_channel_idx().
@@ -787,6 +796,8 @@ TEST_P(ChannelzServerTest, GetServerSocketsTest) {
   s = channelz_stub_->GetSocket(&get_socket_context, get_socket_request,
                                 &get_socket_response);
   EXPECT_TRUE(s.ok()) << "s.error_message() = " << s.error_message();
+  EXPECT_TRUE(ValidateAddress(get_socket_response.socket().remote()));
+  EXPECT_TRUE(ValidateAddress(get_socket_response.socket().local()));
   switch (GetParam()) {
     case CredentialsType::kInsecure:
       EXPECT_FALSE(get_socket_response.socket().has_security());
@@ -898,6 +909,9 @@ TEST_P(ChannelzServerTest, GetServerListenSocketsTest) {
   s = channelz_stub_->GetSocket(&get_socket_context_1, get_socket_request,
                                 &get_socket_response);
   EXPECT_TRUE(s.ok()) << "s.error_message() = " << s.error_message();
+
+  EXPECT_TRUE(ValidateAddress(get_socket_response.socket().remote()));
+  EXPECT_TRUE(ValidateAddress(get_socket_response.socket().local()));
   if (listen_socket_size == 2) {
     get_socket_request.set_socket_id(
         get_server_response.server(0).listen_socket(1).socket_id());

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -71,8 +71,8 @@ static bool ValidateAddress(const Address& address) {
   if (address.address_case() != Address::kTcpipAddress) {
     return true;
   }
-  return address.tcpip_address().ip_address().size() == 4 || address.tcpip_address().ip_address().size() == 16; 
-
+  return address.tcpip_address().ip_address().size() == 4 ||
+         address.tcpip_address().ip_address().size() == 16;
 }
 
 // Proxy service supports N backends. Sends RPC to backend dictated by


### PR DESCRIPTION
According to [the channelz spec](https://github.com/grpc/grpc-proto/blob/cdd9ed5c3d3f87aef62f373b93361cf7bddc620d/grpc/channelz/v1/channelz.proto#L300), the `Address.TcpIpAddress.address` field is "either the IPv4 or IPv6 address in bytes" and it will "be either 4 bytes or 16 bytes in length". The Java implementation and [`gdebug`](https://github.com/grpc/grpc-experiments/blob/2ec1d0aeb5503188169c9cd7992b8db4a6472365/gdebug/web/channelzui/src/app/utils.ts#L181) both conform to this. However, Core currently returns a human-readable string for this field. This PR switches Core to return packed bytes instead.

I suspect this will require a cherry pick.