### PR TITLE
Update dart to 2.12 release

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/dart:2.12-beta
+FROM google/dart:2.12
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
@stanley-cheung this should fix #25652.

Tried `tools/run_tests/run_interop_tests.py -l dart -s java --use_docker` locally and it fails before this change and passes after this change
