### PR TITLE
Add usage note about immediately-Set alarms

### DIFF
--- a/include/grpcpp/alarm.h
+++ b/include/grpcpp/alarm.h
@@ -56,6 +56,10 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   /// Once the alarm expires (at \a deadline) or it's cancelled (see \a Cancel),
   /// an event with tag \a tag will be added to \a cq. If the alarm expired, the
   /// event's success bit will be true, false otherwise (ie, upon cancellation).
+  //
+  // USAGE NOTE: This is frequently used to inject arbitrary tags into \a cq by
+  // setting an immediate deadline. Such usage allows synchronizing an external
+  // event with an application's \a grpc::CompletionQueue::Next loop.
   template <typename T>
   void Set(::grpc::CompletionQueue* cq, const T& deadline, void* tag) {
     SetInternal(cq, ::grpc::TimePoint<T>(deadline).raw_time(), tag);


### PR DESCRIPTION
This is a common usage pattern and we should just document that this is the "standard" way of doing things since we do get questions about this topic from time to time.

Cc @jacobsa