### PR TITLE
Changed GRPCPP_ABSEIL_SYNC to GPR_ABSEIL_SYNC

### DIFF
--- a/include/grpcpp/impl/codegen/sync.h
+++ b/include/grpcpp/impl/codegen/sync.h
@@ -46,7 +46,7 @@
 namespace grpc {
 namespace internal {
 
-#ifdef GRPCPP_ABSEIL_SYNC
+#ifdef GPR_ABSEIL_SYNC
 
 using Mutex = absl::Mutex;
 using MutexLock = absl::MutexLock;
@@ -141,7 +141,7 @@ class CondVar {
   gpr_cv cv_;
 };
 
-#endif  // GRPCPP_ABSEIL_SYNC
+#endif  // GPR_ABSEIL_SYNC
 
 template <typename Predicate>
 static void WaitUntil(CondVar* cv, Mutex* mu, Predicate pred) {


### PR DESCRIPTION
Changed gRPC C++ Mutex to be an alias of Abseil's one when `GPR_ABSEIL_SYNC` is defined instead of `GRPCPP_ABSEIL_SYNC`. It doesn't give much benefit to have two different macros controlling this so let's combine them into one.