### PR TITLE
Follow-up from #24965

### DIFF
--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2219,6 +2219,7 @@ RefCountedPtr<XdsClient> XdsClient::GetOrCreate(grpc_error** error) {
     if (xds_client != nullptr) return xds_client;
   }
   auto xds_client = MakeRefCounted<XdsClient>(error);
+  if (*error != GRPC_ERROR_NONE) return nullptr;
   g_xds_client = xds_client.get();
   return xds_client;
 }

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2213,14 +2213,17 @@ void XdsClientGlobalShutdown() {
 }
 
 RefCountedPtr<XdsClient> XdsClient::GetOrCreate(grpc_error** error) {
-  MutexLock lock(g_mu);
-  if (g_xds_client != nullptr) {
-    auto xds_client = g_xds_client->RefIfNonZero();
-    if (xds_client != nullptr) return xds_client;
+  RefCountedPtr<XdsClient> xds_client;
+  {
+    MutexLock lock(g_mu);
+    if (g_xds_client != nullptr) {
+      auto xds_client = g_xds_client->RefIfNonZero();
+      if (xds_client != nullptr) return xds_client;
+    }
+    xds_client = MakeRefCounted<XdsClient>(error);
+    if (*error != GRPC_ERROR_NONE) return nullptr;
+    g_xds_client = xds_client.get();
   }
-  auto xds_client = MakeRefCounted<XdsClient>(error);
-  if (*error != GRPC_ERROR_NONE) return nullptr;
-  g_xds_client = xds_client.get();
   return xds_client;
 }
 

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -88,7 +88,11 @@ class XdsClient : public DualRefCounted<XdsClient> {
   explicit XdsClient(grpc_error** error);
   ~XdsClient() override;
 
-  const XdsBootstrap* bootstrap() const { return bootstrap_.get(); }
+  const XdsBootstrap& bootstrap() const {
+    // bootstrap_ is guaranteed to be non-null since XdsClient::GetOrCreate()
+    // would return a null object if bootstrap_ was null.
+    return *bootstrap_;
+  }
 
   CertificateProviderStore& certificate_provider_store() {
     return *certificate_provider_store_;

--- a/src/core/ext/xds/xds_server_config_fetcher.cc
+++ b/src/core/ext/xds/xds_server_config_fetcher.cc
@@ -49,7 +49,7 @@ class XdsServerConfigFetcher : public grpc_server_config_fetcher {
         std::move(watcher), args, xds_client_);
     auto* listener_watcher_ptr = listener_watcher.get();
     listening_address = absl::StrReplaceAll(
-        xds_client_->bootstrap()->server_listener_resource_name_template(),
+        xds_client_->bootstrap().server_listener_resource_name_template(),
         {{"%s", listening_address}});
     xds_client_->WatchListenerData(listening_address,
                                    std::move(listener_watcher));
@@ -272,7 +272,7 @@ grpc_server_config_fetcher* grpc_server_config_fetcher_xds_create() {
     return nullptr;
   }
   if (xds_client->bootstrap()
-          ->server_listener_resource_name_template()
+          .server_listener_resource_name_template()
           .empty()) {
     gpr_log(GPR_ERROR,
             "server_listener_resource_name_template not provided in bootstrap "


### PR DESCRIPTION
Follow-up from #24965. (Missed the comment on returning a const ref for `bootstrap_` on approval due to auto-merge)