### PR TITLE
Allow v2 Router filter with v3 xDS

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -365,7 +365,8 @@ XdsResolver::XdsConfigSelector::XdsConfigSelector(
     }
   }
   // Populate filter list.
-  if (XdsFaultInjectionEnabled()) {
+  if (XdsFaultInjectionEnabled() &&
+      resolver_->xds_client_->bootstrap()->server().ShouldUseV3()) {
     bool found_router = false;
     for (const auto& http_filter :
          resolver_->current_listener_.http_connection_manager.http_filters) {

--- a/src/core/ext/xds/xds_http_filters.cc
+++ b/src/core/ext/xds/xds_http_filters.cc
@@ -24,6 +24,8 @@
 
 namespace grpc_core {
 
+const char* kXdsHttpV2RouterFilterConfigName =
+    "envoy.config.filter.http.router.v2.Router";
 const char* kXdsHttpRouterFilterConfigName =
     "envoy.extensions.filters.http.router.v3.Router";
 
@@ -100,6 +102,8 @@ void XdsHttpFilterRegistry::PopulateSymtab(upb_symtab* symtab) {
 void XdsHttpFilterRegistry::Init() {
   g_filters = new FilterOwnerList;
   g_filter_registry = new FilterRegistryMap;
+  RegisterFilter(absl::make_unique<XdsHttpRouterFilter>(),
+                 {kXdsHttpV2RouterFilterConfigName});
   RegisterFilter(absl::make_unique<XdsHttpRouterFilter>(),
                  {kXdsHttpRouterFilterConfigName});
   RegisterFilter(absl::make_unique<XdsHttpFaultFilter>(),

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -3292,7 +3292,7 @@ TEST_P(LdsTest, HttpFiltersEnabled) {
   gpr_unsetenv("GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION");
 }
 
-// Filter support is v3 only, but the xDS server may send v2 filters
+// Filter support is v3 only, but we should not fail v2 xDS.
 TEST_P(LdsTest, AllowV2RouterFilter) {
   gpr_setenv("GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION", "true");
   SetNextResolutionForLbChannelAllBalancers();

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2595,12 +2595,7 @@ try:
         client_env['GRPC_XDS_BOOTSTRAP'] = bootstrap_path
         client_env['GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING'] = 'true'
         client_env['GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT'] = 'true'
-        # Temporarily turn off fault injection, because HTTPFault filter isn't
-        # handled correctly yet in CPP and Go. And setting would break all the
-        # other tests. Uncomment the following line when the support is
-        # complete.
-        #
-        # client_env['GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION'] = 'true'
+        client_env['GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION'] = 'true'
         test_results = {}
         failed_tests = []
         for test_case in args.test_case:


### PR DESCRIPTION
```
I0310 20:52:36.838374923   23959 xds_client.cc:814]          [xds_client 0x7f6ebc01cdb0] sending ADS request: type=type.googleapis.com/envoy.config.listener.v3.Listener version= nonce= error="No Error" resources=grpc-test1615409294-chengyuanzhang:8107

...

D0310 20:54:28.855433800   23964 xds_api.cc:994]             [xds_client 0x7f6ebc01cdb0] received response: version_info: "1615409665135813785"
resources: {
  type_url: "type.googleapis.com/envoy.api.v2.Listener"
  value: "\n\'grpc-test1615409294-chengyuanzhang:8107\232\001\210\003\n\205\003\n`type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager\022\240\002\022\017trafficdirector\032f\n\002\032\000\022`URL_MAP/830293263384_test-map1615409294-chengyuanzhang_0_grpc-test1615409294-chengyuanzhang:8107*P\n\013envoy.fault\"A\n?type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault*S\n\014envoy.router\"C\n=type.googleapis.com/envoy.config.filter.http.router.v2.Router\022\002 \001"
}
type_url: "type.googleapis.com/envoy.api.v2.Listener"
nonce: "2"
 
D0310 20:54:28.855483277   23964 xds_api.cc:1011]            [xds_client 0x7f6ebc01cdb0] HttpConnectionManager: stat_prefix: "trafficdirector"
rds: {
  config_source: {
    ads: {
    }
  }
  route_config_name: "URL_MAP/830293263384_test-map1615409294-chengyuanzhang_0_grpc-test1615409294-chengyuanzhang:8107"
}
http_filters: {
  name: "envoy.fault"
  typed_config: {
    type_url: "type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault"
  }
}
http_filters: {
  name: "envoy.router"
  typed_config: {
    type_url: "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
    value: " \001"
  }
}
```

The gRPC client asks for v3 xDS configs, but the control plane returns v2 resources including the v2 Router filter. Before this PR, Core doesn't accept that.

Even though Router filter isn't essential for gRPC, but we mimic Envoy's behavior to rejects all RPCs if Router filter is not presented, causing issues like https://github.com/grpc/grpc/pull/25676 b/182443801.