### PR TITLE
Make `go test`'s module-awareness behave as it did before go v1.16

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_http2/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_http2/build_interop.sh
@@ -27,5 +27,7 @@ ${name}')
 cp -r /var/local/jenkins/service_account $HOME || true
 
 # compile the tests
-(cd /var/local/git/grpc/tools/http2_interop && go test -c)
+(cd /var/local/git/grpc/tools/http2_interop && \
+  go env -w GO111MODULE=auto && \
+  go test -c)
 


### PR DESCRIPTION
Go v1.16 introduced module-aware commands by default. This version
upgrade broke our http2 interop tests (see #25660). Setting the go
environment variable `GO111MODULE` to "auto" makes go tools behave as
they did before the v1.16 change.

Docs on the flag: https://golang.org/ref/mod#mod-commands
Recent discussion on golang/go:
  https://github.com/golang/go/issues/31997#issuecomment-782864390

CC @markdroth 