### PR TITLE
Add google storage URLs for all mirrored bazel dependencies

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -390,8 +390,8 @@ def grpc_deps():
             sha256 = "b7e13f0b4259e80c3070b583c2f39e53153085a6918718b1c710caf7037572b0",
             strip_prefix = "opencensus-proto-0.3.0/src",
             urls = [
-              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
-              "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
             ],
         )
 
@@ -401,8 +401,8 @@ def grpc_deps():
             sha256 = "e368733c9fb7f8489591ffaf269170d7658cc0cd1ee322b601512b769446d3c8",
             strip_prefix = "protoc-gen-validate-278964a8052f96a2f514add0298098f63fb7f47f",
             urls = [
-              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz",
-              "https://github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz",
+                "https://github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz",
             ],
         )
 

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -314,6 +314,7 @@ def grpc_deps():
             sha256 = "4423bef0ab15053dca0f723cbdaf4b48ab145e9d8158f02e33028c66fb1d20e0",
             strip_prefix = "data-plane-api-18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2",
             urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/data-plane-api/archive/18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2.tar.gz",
                 "https://github.com/envoyproxy/data-plane-api/archive/18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2.tar.gz",
             ],
         )

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -390,8 +390,8 @@ def grpc_deps():
             sha256 = "b7e13f0b4259e80c3070b583c2f39e53153085a6918718b1c710caf7037572b0",
             strip_prefix = "opencensus-proto-0.3.0/src",
             urls = [
-              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
-              "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
+              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
+              "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz",
             ],
         )
 
@@ -401,8 +401,8 @@ def grpc_deps():
             sha256 = "e368733c9fb7f8489591ffaf269170d7658cc0cd1ee322b601512b769446d3c8",
             strip_prefix = "protoc-gen-validate-278964a8052f96a2f514add0298098f63fb7f47f",
             urls = [
-              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz"
-              "https://github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz"
+              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz",
+              "https://github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz",
             ],
         )
 

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -368,6 +368,7 @@ def grpc_deps():
             sha256 = "a45019af4d3290f02eaeb1ce10990166978c807cb33a9692141a076ba46d1405",
             strip_prefix = "googleapis-82944da21578a53b74e547774cf62ed31a05b841",
             urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/googleapis/archive/82944da21578a53b74e547774cf62ed31a05b841.tar.gz",
                 "https://github.com/googleapis/googleapis/archive/82944da21578a53b74e547774cf62ed31a05b841.tar.gz",
             ],
         )
@@ -378,6 +379,7 @@ def grpc_deps():
             sha256 = "d987004a72697334a095bbaa18d615804a28280201a50ed6c234c40ccc41e493",
             strip_prefix = "bazel-gazelle-0.19.1",
             urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/bazel-gazelle/archive/v0.19.1.tar.gz",
                 "https://github.com/bazelbuild/bazel-gazelle/archive/v0.19.1.tar.gz",
             ],
         )
@@ -387,7 +389,10 @@ def grpc_deps():
             name = "opencensus_proto",
             sha256 = "b7e13f0b4259e80c3070b583c2f39e53153085a6918718b1c710caf7037572b0",
             strip_prefix = "opencensus-proto-0.3.0/src",
-            urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"],
+            urls = [
+              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
+              "https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz"
+            ],
         )
 
     if "com_envoyproxy_protoc_gen_validate" not in native.existing_rules():
@@ -395,7 +400,10 @@ def grpc_deps():
             name = "com_envoyproxy_protoc_gen_validate",
             sha256 = "e368733c9fb7f8489591ffaf269170d7658cc0cd1ee322b601512b769446d3c8",
             strip_prefix = "protoc-gen-validate-278964a8052f96a2f514add0298098f63fb7f47f",
-            urls = ["https://github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz"],
+            urls = [
+              "https://storage.googleapis.com/grpc-bazel-mirror/github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz"
+              "https://github.com/envoyproxy/protoc-gen-validate/archive/278964a8052f96a2f514add0298098f63fb7f47f.tar.gz"
+            ],
         )
 
     grpc_python_deps()


### PR DESCRIPTION
update_mirror.sh was already mirroring all GitHub archives in grpc_deps.bzl, so all of these files already existed.

Fixes #25709 