### PR TITLE
Export files under third_party/py in bazel BUILD file

### DIFF
--- a/third_party/py/BUILD
+++ b/third_party/py/BUILD
@@ -1,0 +1,5 @@
+exports_files([
+    "BUILD.tpl",
+    "python_configure.bzl",
+    "variety.tpl"
+])


### PR DESCRIPTION
otherwise running in tensorflow code base:
`bazel query "deps(//external:local_config_python)" `

shows error like this:

```
ERROR: /home/mingzhao/g/tensorflow/WORKSPACE:19:14: every rule of type python_configure implicitly depends upon the target '@com_github_grpc_grpc//third_party/py:BUILD.tpl', but this target could not be found because of: no such target '@com_github_grpc_grpc//third_party/py:BUILD.tpl': target 'BUILD.tpl' not declared in package 'third_party/py'; however, a source file of this name exists.  (Perhaps add 'exports_files(["BUILD.tpl"])' to third_party/py/BUILD?) defined by /home/mingzhao/.cache/bazel/_bazel_mingzhao/b8418b6d51a5e225bcc1359ca8cb25de/external/com_github_grpc_grpc/third_party/py/BUILD
ERROR: /home/mingzhao/g/tensorflow/WORKSPACE:19:14: every rule of type python_configure implicitly depends upon the target '@com_github_grpc_grpc//third_party/py:variety.tpl', but this target could not be found because of: no such target '@com_github_grpc_grpc//third_party/py:variety.tpl': target 'variety.tpl' not declared in package 'third_party/py'; however, a source file of this name exists.  (Perhaps add 'exports_files(["variety.tpl"])' to third_party/py/BUILD?) defined by /home/mingzhao/.cache/bazel/_bazel_mingzhao/b8418b6d51a5e225bcc1359ca8cb25de/external/com_github_grpc_grpc/third_party/py/BUILD
ERROR: Evaluation of query "deps(//external:local_config_python)" failed: errors were encountered while computing transitive closure
```

After this fix:

```
 bazel query "deps(//external:local_config_python)"

//external:local_config_python
@com_github_grpc_grpc//third_party/py:variety.tpl
@com_github_grpc_grpc//third_party/py:BUILD.tpl
```



<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
