### PR TITLE
make Grpc C# work on aarch64 linux

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -36,6 +36,10 @@
       <PackagePath>runtimes/linux-x64/native/libgrpc_csharp_ext.x64.so</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="..\nativelibs\csharp_ext_linux_aarch64\libgrpc_csharp_ext.so">
+      <PackagePath>runtimes/linux-arm64/native/libgrpc_csharp_ext.arm64.so</PackagePath>
+      <Pack>true</Pack>
+    </Content>
     <Content Include="..\nativelibs\csharp_ext_windows_x64\grpc_csharp_ext.dll">
       <PackagePath>runtimes/win-x64/native/grpc_csharp_ext.x64.dll</PackagePath>
       <Pack>true</Pack>

--- a/src/csharp/Grpc.Core/Internal/CommonPlatformDetection.cs
+++ b/src/csharp/Grpc.Core/Internal/CommonPlatformDetection.cs
@@ -1,0 +1,129 @@
+#region Copyright notice and license
+
+// Copyright 2021 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Grpc.Core.Internal
+{
+    /// <summary>
+    /// This source file is shared by both Grpc.Core and Grpc.Tools to avoid duplication
+    /// of platform detection code.
+    /// </summary>
+    internal static class CommonPlatformDetection
+    {
+        public enum OSKind { Unknown, Windows, Linux, MacOSX };
+        public enum CpuArchitecture { Unknown, X86, X64, Arm64 };
+
+        public static OSKind GetOSKind()
+        {
+#if NETSTANDARD || NETCORE
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return OSKind.Windows;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return OSKind.Linux;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSKind.MacOSX;
+            }
+            else
+            {
+                return OSKind.Unknown;
+            }
+#else
+            var platform = Environment.OSVersion.Platform;
+            if (platform == PlatformID.Win32NT || platform == PlatformID.Win32S || platform == PlatformID.Win32Windows)
+            {
+                return OSKind.Windows;
+            }
+            else if (platform == PlatformID.Unix && GetUname() == "Darwin")
+            {
+                // PlatformID.MacOSX is never returned, commonly used trick is to identify Mac is by using uname.
+                return OSKind.MacOSX;
+            }
+            else if (platform == PlatformID.Unix)
+            {
+                // on legacy .NET Framework, our detection options are limited, so we treat
+                // all other unix systems as Linux.
+                return OSKind.Linux;
+            }
+            else
+            {
+                return OSKind.Unknown;
+            }
+#endif
+        }
+
+        public static CpuArchitecture GetProcessArchitecture()
+        {
+#if NETSTANDARD || NETCORE  
+            switch (RuntimeInformation.ProcessArchitecture)
+            {
+                case Architecture.X86:
+                    return CpuArchitecture.X86;
+                case Architecture.X64:
+                    return CpuArchitecture.X64;
+                case Architecture.Arm64:
+                    return CpuArchitecture.Arm64;
+                // We do not support other architectures,
+                // so we simply return "unrecognized".
+                default: 
+                   return CpuArchitecture.Unknown;
+            }
+#else
+            // on legacy .NET Framework, RuntimeInformation is not available
+            // but our choice of supported architectures there
+            // is also very limited, so we simply take our best guess.
+            return Environment.Is64BitProcess ? CpuArchitecture.X64 : CpuArchitecture.X86;
+#endif
+        }
+
+        [DllImport("libc")]
+        static extern int uname(IntPtr buf);
+
+        // This code is copied from Grpc.Core/PlatformApis.cs
+        static string GetUname()
+        {
+            var buffer = Marshal.AllocHGlobal(8192);
+            try
+            {
+                if (uname(buffer) == 0)
+                {
+                    return Marshal.PtrToStringAnsi(buffer);
+                }
+                return string.Empty;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -136,7 +136,7 @@ namespace Grpc.Core.Internal
             // but DllImport("grpc_csharp_ext.x64.dll") does, so we need a special case for that.
             // See https://github.com/dotnet/coreclr/pull/17505 (fixed in .NET Core 3.1+)
             bool useDllSuffix = PlatformApis.IsWindows;
-            if (PlatformApis.Is64Bit)
+            if (PlatformApis.ProcessArchitecture == CommonPlatformDetection.CpuArchitecture.X64)
             {
                 if (useDllSuffix)
                 {
@@ -144,13 +144,21 @@ namespace Grpc.Core.Internal
                 }
                 return new NativeMethods(new NativeMethods.DllImportsFromSharedLib_x64());
             }
-            else
+            else if (PlatformApis.ProcessArchitecture == CommonPlatformDetection.CpuArchitecture.X86)
             {
                 if (useDllSuffix)
                 {
                     return new NativeMethods(new NativeMethods.DllImportsFromSharedLib_x86_dll());
                 }
                 return new NativeMethods(new NativeMethods.DllImportsFromSharedLib_x86());
+            }
+            else if (PlatformApis.ProcessArchitecture == CommonPlatformDetection.CpuArchitecture.Arm64)
+            {
+                return new NativeMethods(new NativeMethods.DllImportsFromSharedLib_arm64());
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unsupported architecture \"{PlatformApis.ProcessArchitecture}\".");
             }
         }
 
@@ -285,16 +293,18 @@ namespace Grpc.Core.Internal
             throw new InvalidOperationException("Unsupported platform.");
         }
 
-        // Currently, only Intel platform is supported.
         private static string GetArchitectureString()
         {
-            if (PlatformApis.Is64Bit)
+            switch (PlatformApis.ProcessArchitecture)
             {
-                return "x64";
-            }
-            else
-            {
-                return "x86";
+                case CommonPlatformDetection.CpuArchitecture.X86:
+                  return "x86";
+                case CommonPlatformDetection.CpuArchitecture.X64:
+                  return "x64";
+                case CommonPlatformDetection.CpuArchitecture.Arm64:
+                  return "arm64";
+                default:
+                  throw new InvalidOperationException($"Unsupported architecture \"{PlatformApis.ProcessArchitecture}\".");
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
@@ -681,6 +681,114 @@ namespace Grpc.Core.Internal
             this.grpcsharp_test_call_start_unary_echo = DllImportsFromSharedLib_x64.grpcsharp_test_call_start_unary_echo;
         }
 
+        public NativeMethods(DllImportsFromSharedLib_arm64 unusedInstance)
+        {
+            this.grpcsharp_init = DllImportsFromSharedLib_arm64.grpcsharp_init;
+            this.grpcsharp_shutdown = DllImportsFromSharedLib_arm64.grpcsharp_shutdown;
+            this.grpcsharp_version_string = DllImportsFromSharedLib_arm64.grpcsharp_version_string;
+            this.grpcsharp_batch_context_create = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_create;
+            this.grpcsharp_batch_context_recv_initial_metadata = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_initial_metadata;
+            this.grpcsharp_batch_context_recv_message_length = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_message_length;
+            this.grpcsharp_batch_context_recv_message_next_slice_peek = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_message_next_slice_peek;
+            this.grpcsharp_batch_context_recv_status_on_client_status = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_status_on_client_status;
+            this.grpcsharp_batch_context_recv_status_on_client_details = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_status_on_client_details;
+            this.grpcsharp_batch_context_recv_status_on_client_error_string = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_status_on_client_error_string;
+            this.grpcsharp_batch_context_recv_status_on_client_trailing_metadata = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_status_on_client_trailing_metadata;
+            this.grpcsharp_batch_context_recv_close_on_server_cancelled = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_recv_close_on_server_cancelled;
+            this.grpcsharp_batch_context_reset = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_reset;
+            this.grpcsharp_batch_context_destroy = DllImportsFromSharedLib_arm64.grpcsharp_batch_context_destroy;
+            this.grpcsharp_request_call_context_create = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_create;
+            this.grpcsharp_request_call_context_call = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_call;
+            this.grpcsharp_request_call_context_method = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_method;
+            this.grpcsharp_request_call_context_host = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_host;
+            this.grpcsharp_request_call_context_deadline = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_deadline;
+            this.grpcsharp_request_call_context_request_metadata = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_request_metadata;
+            this.grpcsharp_request_call_context_reset = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_reset;
+            this.grpcsharp_request_call_context_destroy = DllImportsFromSharedLib_arm64.grpcsharp_request_call_context_destroy;
+            this.grpcsharp_composite_call_credentials_create = DllImportsFromSharedLib_arm64.grpcsharp_composite_call_credentials_create;
+            this.grpcsharp_call_credentials_release = DllImportsFromSharedLib_arm64.grpcsharp_call_credentials_release;
+            this.grpcsharp_call_cancel = DllImportsFromSharedLib_arm64.grpcsharp_call_cancel;
+            this.grpcsharp_call_cancel_with_status = DllImportsFromSharedLib_arm64.grpcsharp_call_cancel_with_status;
+            this.grpcsharp_call_start_unary = DllImportsFromSharedLib_arm64.grpcsharp_call_start_unary;
+            this.grpcsharp_call_start_client_streaming = DllImportsFromSharedLib_arm64.grpcsharp_call_start_client_streaming;
+            this.grpcsharp_call_start_server_streaming = DllImportsFromSharedLib_arm64.grpcsharp_call_start_server_streaming;
+            this.grpcsharp_call_start_duplex_streaming = DllImportsFromSharedLib_arm64.grpcsharp_call_start_duplex_streaming;
+            this.grpcsharp_call_send_message = DllImportsFromSharedLib_arm64.grpcsharp_call_send_message;
+            this.grpcsharp_call_send_close_from_client = DllImportsFromSharedLib_arm64.grpcsharp_call_send_close_from_client;
+            this.grpcsharp_call_send_status_from_server = DllImportsFromSharedLib_arm64.grpcsharp_call_send_status_from_server;
+            this.grpcsharp_call_recv_message = DllImportsFromSharedLib_arm64.grpcsharp_call_recv_message;
+            this.grpcsharp_call_recv_initial_metadata = DllImportsFromSharedLib_arm64.grpcsharp_call_recv_initial_metadata;
+            this.grpcsharp_call_start_serverside = DllImportsFromSharedLib_arm64.grpcsharp_call_start_serverside;
+            this.grpcsharp_call_send_initial_metadata = DllImportsFromSharedLib_arm64.grpcsharp_call_send_initial_metadata;
+            this.grpcsharp_call_set_credentials = DllImportsFromSharedLib_arm64.grpcsharp_call_set_credentials;
+            this.grpcsharp_call_get_peer = DllImportsFromSharedLib_arm64.grpcsharp_call_get_peer;
+            this.grpcsharp_call_destroy = DllImportsFromSharedLib_arm64.grpcsharp_call_destroy;
+            this.grpcsharp_channel_args_create = DllImportsFromSharedLib_arm64.grpcsharp_channel_args_create;
+            this.grpcsharp_channel_args_set_string = DllImportsFromSharedLib_arm64.grpcsharp_channel_args_set_string;
+            this.grpcsharp_channel_args_set_integer = DllImportsFromSharedLib_arm64.grpcsharp_channel_args_set_integer;
+            this.grpcsharp_channel_args_destroy = DllImportsFromSharedLib_arm64.grpcsharp_channel_args_destroy;
+            this.grpcsharp_override_default_ssl_roots = DllImportsFromSharedLib_arm64.grpcsharp_override_default_ssl_roots;
+            this.grpcsharp_ssl_credentials_create = DllImportsFromSharedLib_arm64.grpcsharp_ssl_credentials_create;
+            this.grpcsharp_composite_channel_credentials_create = DllImportsFromSharedLib_arm64.grpcsharp_composite_channel_credentials_create;
+            this.grpcsharp_channel_credentials_release = DllImportsFromSharedLib_arm64.grpcsharp_channel_credentials_release;
+            this.grpcsharp_insecure_channel_create = DllImportsFromSharedLib_arm64.grpcsharp_insecure_channel_create;
+            this.grpcsharp_secure_channel_create = DllImportsFromSharedLib_arm64.grpcsharp_secure_channel_create;
+            this.grpcsharp_channel_create_call = DllImportsFromSharedLib_arm64.grpcsharp_channel_create_call;
+            this.grpcsharp_channel_check_connectivity_state = DllImportsFromSharedLib_arm64.grpcsharp_channel_check_connectivity_state;
+            this.grpcsharp_channel_watch_connectivity_state = DllImportsFromSharedLib_arm64.grpcsharp_channel_watch_connectivity_state;
+            this.grpcsharp_channel_get_target = DllImportsFromSharedLib_arm64.grpcsharp_channel_get_target;
+            this.grpcsharp_channel_destroy = DllImportsFromSharedLib_arm64.grpcsharp_channel_destroy;
+            this.grpcsharp_sizeof_grpc_event = DllImportsFromSharedLib_arm64.grpcsharp_sizeof_grpc_event;
+            this.grpcsharp_completion_queue_create_async = DllImportsFromSharedLib_arm64.grpcsharp_completion_queue_create_async;
+            this.grpcsharp_completion_queue_create_sync = DllImportsFromSharedLib_arm64.grpcsharp_completion_queue_create_sync;
+            this.grpcsharp_completion_queue_shutdown = DllImportsFromSharedLib_arm64.grpcsharp_completion_queue_shutdown;
+            this.grpcsharp_completion_queue_next = DllImportsFromSharedLib_arm64.grpcsharp_completion_queue_next;
+            this.grpcsharp_completion_queue_pluck = DllImportsFromSharedLib_arm64.grpcsharp_completion_queue_pluck;
+            this.grpcsharp_completion_queue_destroy = DllImportsFromSharedLib_arm64.grpcsharp_completion_queue_destroy;
+            this.gprsharp_free = DllImportsFromSharedLib_arm64.gprsharp_free;
+            this.grpcsharp_metadata_array_create = DllImportsFromSharedLib_arm64.grpcsharp_metadata_array_create;
+            this.grpcsharp_metadata_array_add = DllImportsFromSharedLib_arm64.grpcsharp_metadata_array_add;
+            this.grpcsharp_metadata_array_count = DllImportsFromSharedLib_arm64.grpcsharp_metadata_array_count;
+            this.grpcsharp_metadata_array_get_key = DllImportsFromSharedLib_arm64.grpcsharp_metadata_array_get_key;
+            this.grpcsharp_metadata_array_get_value = DllImportsFromSharedLib_arm64.grpcsharp_metadata_array_get_value;
+            this.grpcsharp_metadata_array_destroy_full = DllImportsFromSharedLib_arm64.grpcsharp_metadata_array_destroy_full;
+            this.grpcsharp_redirect_log = DllImportsFromSharedLib_arm64.grpcsharp_redirect_log;
+            this.grpcsharp_native_callback_dispatcher_init = DllImportsFromSharedLib_arm64.grpcsharp_native_callback_dispatcher_init;
+            this.grpcsharp_metadata_credentials_create_from_plugin = DllImportsFromSharedLib_arm64.grpcsharp_metadata_credentials_create_from_plugin;
+            this.grpcsharp_metadata_credentials_notify_from_plugin = DllImportsFromSharedLib_arm64.grpcsharp_metadata_credentials_notify_from_plugin;
+            this.grpcsharp_ssl_server_credentials_create = DllImportsFromSharedLib_arm64.grpcsharp_ssl_server_credentials_create;
+            this.grpcsharp_server_credentials_release = DllImportsFromSharedLib_arm64.grpcsharp_server_credentials_release;
+            this.grpcsharp_server_create = DllImportsFromSharedLib_arm64.grpcsharp_server_create;
+            this.grpcsharp_server_register_completion_queue = DllImportsFromSharedLib_arm64.grpcsharp_server_register_completion_queue;
+            this.grpcsharp_server_add_insecure_http2_port = DllImportsFromSharedLib_arm64.grpcsharp_server_add_insecure_http2_port;
+            this.grpcsharp_server_add_secure_http2_port = DllImportsFromSharedLib_arm64.grpcsharp_server_add_secure_http2_port;
+            this.grpcsharp_server_start = DllImportsFromSharedLib_arm64.grpcsharp_server_start;
+            this.grpcsharp_server_request_call = DllImportsFromSharedLib_arm64.grpcsharp_server_request_call;
+            this.grpcsharp_server_cancel_all_calls = DllImportsFromSharedLib_arm64.grpcsharp_server_cancel_all_calls;
+            this.grpcsharp_server_shutdown_and_notify_callback = DllImportsFromSharedLib_arm64.grpcsharp_server_shutdown_and_notify_callback;
+            this.grpcsharp_server_destroy = DllImportsFromSharedLib_arm64.grpcsharp_server_destroy;
+            this.grpcsharp_call_auth_context = DllImportsFromSharedLib_arm64.grpcsharp_call_auth_context;
+            this.grpcsharp_auth_context_peer_identity_property_name = DllImportsFromSharedLib_arm64.grpcsharp_auth_context_peer_identity_property_name;
+            this.grpcsharp_auth_context_property_iterator = DllImportsFromSharedLib_arm64.grpcsharp_auth_context_property_iterator;
+            this.grpcsharp_auth_property_iterator_next = DllImportsFromSharedLib_arm64.grpcsharp_auth_property_iterator_next;
+            this.grpcsharp_auth_context_release = DllImportsFromSharedLib_arm64.grpcsharp_auth_context_release;
+            this.grpcsharp_slice_buffer_create = DllImportsFromSharedLib_arm64.grpcsharp_slice_buffer_create;
+            this.grpcsharp_slice_buffer_adjust_tail_space = DllImportsFromSharedLib_arm64.grpcsharp_slice_buffer_adjust_tail_space;
+            this.grpcsharp_slice_buffer_slice_count = DllImportsFromSharedLib_arm64.grpcsharp_slice_buffer_slice_count;
+            this.grpcsharp_slice_buffer_slice_peek = DllImportsFromSharedLib_arm64.grpcsharp_slice_buffer_slice_peek;
+            this.grpcsharp_slice_buffer_reset_and_unref = DllImportsFromSharedLib_arm64.grpcsharp_slice_buffer_reset_and_unref;
+            this.grpcsharp_slice_buffer_destroy = DllImportsFromSharedLib_arm64.grpcsharp_slice_buffer_destroy;
+            this.gprsharp_now = DllImportsFromSharedLib_arm64.gprsharp_now;
+            this.gprsharp_inf_future = DllImportsFromSharedLib_arm64.gprsharp_inf_future;
+            this.gprsharp_inf_past = DllImportsFromSharedLib_arm64.gprsharp_inf_past;
+            this.gprsharp_convert_clock_type = DllImportsFromSharedLib_arm64.gprsharp_convert_clock_type;
+            this.gprsharp_sizeof_timespec = DllImportsFromSharedLib_arm64.gprsharp_sizeof_timespec;
+            this.grpcsharp_test_callback = DllImportsFromSharedLib_arm64.grpcsharp_test_callback;
+            this.grpcsharp_test_nop = DllImportsFromSharedLib_arm64.grpcsharp_test_nop;
+            this.grpcsharp_test_override_method = DllImportsFromSharedLib_arm64.grpcsharp_test_override_method;
+            this.grpcsharp_test_call_start_unary_echo = DllImportsFromSharedLib_arm64.grpcsharp_test_call_start_unary_echo;
+        }
+
         public NativeMethods(DllImportsFromSharedLib_x86_dll unusedInstance)
         {
             this.grpcsharp_init = DllImportsFromSharedLib_x86_dll.grpcsharp_init;
@@ -1974,6 +2082,326 @@ namespace Grpc.Core.Internal
         internal class DllImportsFromSharedLib_x64
         {
             private const string ImportName = "grpc_csharp_ext.x64";
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_init();
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_shutdown();
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_version_string();
+            
+            [DllImport(ImportName)]
+            public static extern BatchContextSafeHandle grpcsharp_batch_context_create();
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_batch_context_recv_initial_metadata(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_batch_context_recv_message_length(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern int grpcsharp_batch_context_recv_message_next_slice_peek(BatchContextSafeHandle ctx, out UIntPtr sliceLen, out IntPtr sliceDataPtr);
+            
+            [DllImport(ImportName)]
+            public static extern StatusCode grpcsharp_batch_context_recv_status_on_client_status(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_batch_context_recv_status_on_client_details(BatchContextSafeHandle ctx, out UIntPtr detailsLength);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_batch_context_recv_status_on_client_error_string(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_batch_context_recv_status_on_client_trailing_metadata(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern int grpcsharp_batch_context_recv_close_on_server_cancelled(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_batch_context_reset(BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_batch_context_destroy(IntPtr ctx);
+            
+            [DllImport(ImportName)]
+            public static extern RequestCallContextSafeHandle grpcsharp_request_call_context_create();
+            
+            [DllImport(ImportName)]
+            public static extern CallSafeHandle grpcsharp_request_call_context_call(RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_request_call_context_method(RequestCallContextSafeHandle ctx, out UIntPtr methodLength);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_request_call_context_host(RequestCallContextSafeHandle ctx, out UIntPtr hostLength);
+            
+            [DllImport(ImportName)]
+            public static extern Timespec grpcsharp_request_call_context_deadline(RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_request_call_context_request_metadata(RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_request_call_context_reset(RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_request_call_context_destroy(IntPtr ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallCredentialsSafeHandle grpcsharp_composite_call_credentials_create(CallCredentialsSafeHandle creds1, CallCredentialsSafeHandle creds2);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_call_credentials_release(IntPtr credentials);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_cancel(CallSafeHandle call);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_cancel_with_status(CallSafeHandle call, StatusCode status, string description);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_start_unary(CallSafeHandle call, BatchContextSafeHandle ctx, SliceBufferSafeHandle sendBuffer, WriteFlags writeFlags, MetadataArraySafeHandle metadataArray, CallFlags metadataFlags);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_start_client_streaming(CallSafeHandle call, BatchContextSafeHandle ctx, MetadataArraySafeHandle metadataArray, CallFlags metadataFlags);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_start_server_streaming(CallSafeHandle call, BatchContextSafeHandle ctx, SliceBufferSafeHandle sendBuffer, WriteFlags writeFlags, MetadataArraySafeHandle metadataArray, CallFlags metadataFlags);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_start_duplex_streaming(CallSafeHandle call, BatchContextSafeHandle ctx, MetadataArraySafeHandle metadataArray, CallFlags metadataFlags);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_send_message(CallSafeHandle call, BatchContextSafeHandle ctx, SliceBufferSafeHandle sendBuffer, WriteFlags writeFlags, int sendEmptyInitialMetadata);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_send_close_from_client(CallSafeHandle call, BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_send_status_from_server(CallSafeHandle call, BatchContextSafeHandle ctx, StatusCode statusCode, IntPtr statusMessage, UIntPtr statusMessageLen, MetadataArraySafeHandle metadataArray, int sendEmptyInitialMetadata, SliceBufferSafeHandle optionalSendBuffer, WriteFlags writeFlags);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_recv_message(CallSafeHandle call, BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_recv_initial_metadata(CallSafeHandle call, BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_start_serverside(CallSafeHandle call, BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_send_initial_metadata(CallSafeHandle call, BatchContextSafeHandle ctx, MetadataArraySafeHandle metadataArray);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_call_set_credentials(CallSafeHandle call, CallCredentialsSafeHandle credentials);
+            
+            [DllImport(ImportName)]
+            public static extern CStringSafeHandle grpcsharp_call_get_peer(CallSafeHandle call);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_call_destroy(IntPtr call);
+            
+            [DllImport(ImportName)]
+            public static extern ChannelArgsSafeHandle grpcsharp_channel_args_create(UIntPtr numArgs);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_channel_args_set_string(ChannelArgsSafeHandle args, UIntPtr index, string key, string value);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_channel_args_set_integer(ChannelArgsSafeHandle args, UIntPtr index, string key, int value);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_channel_args_destroy(IntPtr args);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
+            
+            [DllImport(ImportName)]
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
+            
+            [DllImport(ImportName)]
+            public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_channel_credentials_release(IntPtr credentials);
+            
+            [DllImport(ImportName)]
+            public static extern ChannelSafeHandle grpcsharp_insecure_channel_create(string target, ChannelArgsSafeHandle channelArgs);
+            
+            [DllImport(ImportName)]
+            public static extern ChannelSafeHandle grpcsharp_secure_channel_create(ChannelCredentialsSafeHandle credentials, string target, ChannelArgsSafeHandle channelArgs);
+            
+            [DllImport(ImportName)]
+            public static extern CallSafeHandle grpcsharp_channel_create_call(ChannelSafeHandle channel, CallSafeHandle parentCall, ContextPropagationFlags propagationMask, CompletionQueueSafeHandle cq, string method, string host, Timespec deadline);
+            
+            [DllImport(ImportName)]
+            public static extern ChannelState grpcsharp_channel_check_connectivity_state(ChannelSafeHandle channel, int tryToConnect);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_channel_watch_connectivity_state(ChannelSafeHandle channel, ChannelState lastObservedState, Timespec deadline, CompletionQueueSafeHandle cq, BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CStringSafeHandle grpcsharp_channel_get_target(ChannelSafeHandle call);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_channel_destroy(IntPtr channel);
+            
+            [DllImport(ImportName)]
+            public static extern int grpcsharp_sizeof_grpc_event();
+            
+            [DllImport(ImportName)]
+            public static extern CompletionQueueSafeHandle grpcsharp_completion_queue_create_async();
+            
+            [DllImport(ImportName)]
+            public static extern CompletionQueueSafeHandle grpcsharp_completion_queue_create_sync();
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_completion_queue_shutdown(CompletionQueueSafeHandle cq);
+            
+            [DllImport(ImportName)]
+            public static extern CompletionQueueEvent grpcsharp_completion_queue_next(CompletionQueueSafeHandle cq);
+            
+            [DllImport(ImportName)]
+            public static extern CompletionQueueEvent grpcsharp_completion_queue_pluck(CompletionQueueSafeHandle cq, IntPtr tag);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_completion_queue_destroy(IntPtr cq);
+            
+            [DllImport(ImportName)]
+            public static extern void gprsharp_free(IntPtr ptr);
+            
+            [DllImport(ImportName)]
+            public static extern MetadataArraySafeHandle grpcsharp_metadata_array_create(UIntPtr capacity);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_metadata_array_add(MetadataArraySafeHandle array, string key, byte[] value, UIntPtr valueLength);
+            
+            [DllImport(ImportName)]
+            public static extern UIntPtr grpcsharp_metadata_array_count(IntPtr metadataArray);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_metadata_array_get_key(IntPtr metadataArray, UIntPtr index, out UIntPtr keyLength);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_metadata_array_get_value(IntPtr metadataArray, UIntPtr index, out UIntPtr valueLength);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_metadata_array_destroy_full(IntPtr array);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_redirect_log(GprLogDelegate callback);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_native_callback_dispatcher_init(NativeCallbackDispatcherCallback dispatcher);
+            
+            [DllImport(ImportName)]
+            public static extern CallCredentialsSafeHandle grpcsharp_metadata_credentials_create_from_plugin(IntPtr nativeCallbackTag);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_metadata_credentials_notify_from_plugin(IntPtr callbackPtr, IntPtr userData, MetadataArraySafeHandle metadataArray, StatusCode statusCode, string errorDetails);
+            
+            [DllImport(ImportName)]
+            public static extern ServerCredentialsSafeHandle grpcsharp_ssl_server_credentials_create(string pemRootCerts, string[] keyCertPairCertChainArray, string[] keyCertPairPrivateKeyArray, UIntPtr numKeyCertPairs, SslClientCertificateRequestType clientCertificateRequest);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_server_credentials_release(IntPtr credentials);
+            
+            [DllImport(ImportName)]
+            public static extern ServerSafeHandle grpcsharp_server_create(ChannelArgsSafeHandle args);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_server_register_completion_queue(ServerSafeHandle server, CompletionQueueSafeHandle cq);
+            
+            [DllImport(ImportName)]
+            public static extern int grpcsharp_server_add_insecure_http2_port(ServerSafeHandle server, string addr);
+            
+            [DllImport(ImportName)]
+            public static extern int grpcsharp_server_add_secure_http2_port(ServerSafeHandle server, string addr, ServerCredentialsSafeHandle creds);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_server_start(ServerSafeHandle server);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_server_request_call(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_server_cancel_all_calls(ServerSafeHandle server);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_server_shutdown_and_notify_callback(ServerSafeHandle server, CompletionQueueSafeHandle cq, BatchContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_server_destroy(IntPtr server);
+            
+            [DllImport(ImportName)]
+            public static extern AuthContextSafeHandle grpcsharp_call_auth_context(CallSafeHandle call);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_auth_context_peer_identity_property_name(AuthContextSafeHandle authContext);
+            
+            [DllImport(ImportName)]
+            public static extern AuthContextSafeHandle.NativeAuthPropertyIterator grpcsharp_auth_context_property_iterator(AuthContextSafeHandle authContext);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_auth_property_iterator_next(ref AuthContextSafeHandle.NativeAuthPropertyIterator iterator);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_auth_context_release(IntPtr authContext);
+            
+            [DllImport(ImportName)]
+            public static extern SliceBufferSafeHandle grpcsharp_slice_buffer_create();
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_slice_buffer_adjust_tail_space(SliceBufferSafeHandle sliceBuffer, UIntPtr availableTailSpace, UIntPtr requestedTailSpace);
+            
+            [DllImport(ImportName)]
+            public static extern UIntPtr grpcsharp_slice_buffer_slice_count(SliceBufferSafeHandle sliceBuffer);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_slice_buffer_slice_peek(SliceBufferSafeHandle sliceBuffer, UIntPtr index, out UIntPtr sliceLen, out IntPtr sliceDataPtr);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_slice_buffer_reset_and_unref(SliceBufferSafeHandle sliceBuffer);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_slice_buffer_destroy(IntPtr sliceBuffer);
+            
+            [DllImport(ImportName)]
+            public static extern Timespec gprsharp_now(ClockType clockType);
+            
+            [DllImport(ImportName)]
+            public static extern Timespec gprsharp_inf_future(ClockType clockType);
+            
+            [DllImport(ImportName)]
+            public static extern Timespec gprsharp_inf_past(ClockType clockType);
+            
+            [DllImport(ImportName)]
+            public static extern Timespec gprsharp_convert_clock_type(Timespec t, ClockType targetClock);
+            
+            [DllImport(ImportName)]
+            public static extern int gprsharp_sizeof_timespec();
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_test_callback([MarshalAs(UnmanagedType.FunctionPtr)] NativeCallbackTestDelegate callback);
+            
+            [DllImport(ImportName)]
+            public static extern IntPtr grpcsharp_test_nop(IntPtr ptr);
+            
+            [DllImport(ImportName)]
+            public static extern void grpcsharp_test_override_method(string methodName, string variant);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_test_call_start_unary_echo(CallSafeHandle call, BatchContextSafeHandle ctx, SliceBufferSafeHandle sendBuffer, WriteFlags writeFlags, MetadataArraySafeHandle metadataArray, CallFlags metadataFlags);
+        }
+
+        /// <summary>
+        /// grpc_csharp_ext used as a shared library (with arm64 suffix)
+        /// </summary>
+        internal class DllImportsFromSharedLib_arm64
+        {
+            private const string ImportName = "grpc_csharp_ext.arm64";
             
             [DllImport(ImportName)]
             public static extern void grpcsharp_init();

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -54,27 +54,26 @@ namespace Grpc.Core.Internal
 
         static PlatformApis()
         {
-#if NETSTANDARD
-            isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            isMacOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-            isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#if NETSTANDARD2_0
-            isNet5OrHigher = Environment.Version.Major >= 5;
-#else
-            // assume that on .NET 5+, the netstandard2.0 TFM is going to be selected.
+            // Detect OS
+            var osKind = CommonPlatformDetection.GetOSKind();
+            isLinux = osKind == CommonPlatformDetection.OSKind.Linux;
+            isMacOSX = osKind == CommonPlatformDetection.OSKind.MacOSX;
+            isWindows = osKind == CommonPlatformDetection.OSKind.Windows;
+
+#if NETSTANDARD1_5
+            // assume that on .NET 5+, the netstandard2.0 or newer TFM is always going to be selected
+            // so for netstandard1.5 we assume we are never on .NET5+
             isNet5OrHigher = false;
-#endif
+            isNetCore = isNet5OrHigher || RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+#elif NETSTANDARD
+            isNet5OrHigher = Environment.Version.Major >= 5;
             isNetCore = isNet5OrHigher || RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
 #else
-            var platform = Environment.OSVersion.Platform;
-
-            // PlatformID.MacOSX is never returned, commonly used trick is to identify Mac is by using uname.
-            isMacOSX = (platform == PlatformID.Unix && GetUname() == "Darwin");
-            isLinux = (platform == PlatformID.Unix && !isMacOSX);
-            isWindows = (platform == PlatformID.Win32NT || platform == PlatformID.Win32S || platform == PlatformID.Win32Windows);
             isNet5OrHigher = false;
             isNetCore = false;
 #endif
+
+            // Detect mono runtime
             isMono = Type.GetType("Mono.Runtime") != null;
 
             // Unity
@@ -131,6 +130,8 @@ namespace Grpc.Core.Internal
         public static bool IsNetCore => isNetCore;
 
         public static bool Is64Bit => IntPtr.Size == 8;
+
+        public static CommonPlatformDetection.CpuArchitecture ProcessArchitecture => CommonPlatformDetection.GetProcessArchitecture();
 
         /// <summary>
         /// Returns <c>UnityEngine.Application.platform</c> as a string.

--- a/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
@@ -68,6 +68,16 @@ namespace Grpc.Tools.Tests
         }
 
         [Test]
+        public void CpuIsArm64()
+        {
+            if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+            {
+                _cpuMatched++;
+                Assert.AreEqual("arm64", _task.Cpu);
+            }
+        }
+
+        [Test]
         public void OsIsWindows()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/csharp/Grpc.Tools/Common.cs
+++ b/src/csharp/Grpc.Tools/Common.cs
@@ -43,7 +43,7 @@ namespace Grpc.Tools
         public enum OsKind { Unknown, Windows, Linux, MacOsX };
         public static readonly OsKind Os;
 
-        public enum CpuKind { Unknown, X86, X64 };
+        public enum CpuKind { Unknown, X86, X64, Arm64 };
         public static readonly CpuKind Cpu;
 
         // This is not necessarily true, but good enough. BCL lacks a per-FS
@@ -65,6 +65,7 @@ namespace Grpc.Tools
             {
                 case CommonPlatformDetection.CpuArchitecture.X86: Cpu = CpuKind.X86; break;
                 case CommonPlatformDetection.CpuArchitecture.X64: Cpu = CpuKind.X64; break;
+                case CommonPlatformDetection.CpuArchitecture.Arm64: Cpu = CpuKind.Arm64; break;
                 default: Cpu = CpuKind.Unknown; break;
             }
         }

--- a/src/csharp/Grpc.Tools/Common.cs
+++ b/src/csharp/Grpc.Tools/Common.cs
@@ -40,35 +40,14 @@ namespace Grpc.Tools
     // A few flags used to control the behavior under various platforms.
     internal static class Platform
     {
-        public enum OsKind { Unknown, Windows, Linux, MacOsX };
-        public static readonly OsKind Os;
+        public static readonly CommonPlatformDetection.OSKind Os = CommonPlatformDetection.GetOSKind();
 
-        public enum CpuKind { Unknown, X86, X64, Arm64 };
-        public static readonly CpuKind Cpu;
+        public static readonly CommonPlatformDetection.CpuArchitecture Cpu = CommonPlatformDetection.GetProcessArchitecture();
 
         // This is not necessarily true, but good enough. BCL lacks a per-FS
         // API to determine file case sensitivity.
-        public static bool IsFsCaseInsensitive => Os == OsKind.Windows;
-        public static bool IsWindows => Os == OsKind.Windows;
-
-        static Platform()
-        {
-            switch (CommonPlatformDetection.GetOSKind())
-            {
-                case CommonPlatformDetection.OSKind.Windows: Os = OsKind.Windows; break;
-                case CommonPlatformDetection.OSKind.Linux: Os = OsKind.Linux; break;
-                case CommonPlatformDetection.OSKind.MacOSX: Os = OsKind.MacOsX; break;
-                default: Os = OsKind.Unknown; break;
-            }
-
-            switch (CommonPlatformDetection.GetProcessArchitecture())
-            {
-                case CommonPlatformDetection.CpuArchitecture.X86: Cpu = CpuKind.X86; break;
-                case CommonPlatformDetection.CpuArchitecture.X64: Cpu = CpuKind.X64; break;
-                case CommonPlatformDetection.CpuArchitecture.Arm64: Cpu = CpuKind.Arm64; break;
-                default: Cpu = CpuKind.Unknown; break;
-            }
-        }
+        public static bool IsFsCaseInsensitive => Os == CommonPlatformDetection.OSKind.Windows;
+        public static bool IsWindows => Os == CommonPlatformDetection.OSKind.Windows;
     };
 
     // Exception handling helpers.

--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -47,6 +47,11 @@ Linux and MacOS. Managed runtime is supplied separately in the Grpc.Core package
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- include common code for platform detection to avoid duplicating the logic -->
+    <Compile Include="..\Grpc.Core\Internal\CommonPlatformDetection.cs" Link="CommonPlatformDetection.cs" />
+  </ItemGroup>
+
   <ItemGroup Label="NuGet package assets">
     <None Pack="true" PackagePath="build\" Include="build\**\*.xml; build\**\*.props; build\**\*.targets;" />
 
@@ -62,6 +67,7 @@ Linux and MacOS. Managed runtime is supplied separately in the Grpc.Core package
     <_Asset PackagePath="tools/windows_x64/" Include="$(Assets_ProtoCompiler)windows_x64/protoc.exe" />
     <_Asset PackagePath="tools/linux_x86/" Include="$(Assets_ProtoCompiler)linux_x86/protoc" />
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_ProtoCompiler)linux_x64/protoc" />
+    <_Asset PackagePath="tools/linux_arm64/" Include="$(Assets_ProtoCompiler)linux_aarch64/protoc" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_ProtoCompiler)macos_x64/protoc" /> <!-- GPB: macosx-->
 
     <!-- gRPC assets (for Grpc.Tools) -->
@@ -69,6 +75,7 @@ Linux and MacOS. Managed runtime is supplied separately in the Grpc.Core package
     <_Asset PackagePath="tools/windows_x64/" Include="$(Assets_GrpcPlugins)protoc_windows_x64/grpc_csharp_plugin.exe" />
     <_Asset PackagePath="tools/linux_x86/" Include="$(Assets_GrpcPlugins)protoc_linux_x86/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_GrpcPlugins)protoc_linux_x64/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/linux_arm64/" Include="$(Assets_GrpcPlugins)protoc_linux_aarch64/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_GrpcPlugins)protoc_macos_x64/grpc_csharp_plugin" />
 
     <None Include="@(_Asset)" Pack="true" Visible="false" />

--- a/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
+++ b/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Grpc.Core.Internal;
 
 namespace Grpc.Tools
 {
@@ -45,17 +46,17 @@ namespace Grpc.Tools
         {
             switch (Platform.Os)
             {
-                case Platform.OsKind.Linux: Os = "linux"; break;
-                case Platform.OsKind.MacOsX: Os = "macosx"; break;
-                case Platform.OsKind.Windows: Os = "windows"; break;
+                case CommonPlatformDetection.OSKind.Linux: Os = "linux"; break;
+                case CommonPlatformDetection.OSKind.MacOSX: Os = "macosx"; break;
+                case CommonPlatformDetection.OSKind.Windows: Os = "windows"; break;
                 default: Os = ""; break;
             }
 
             switch (Platform.Cpu)
             {
-                case Platform.CpuKind.X86: Cpu = "x86"; break;
-                case Platform.CpuKind.X64: Cpu = "x64"; break;
-                case Platform.CpuKind.Arm64: Cpu = "arm64"; break;
+                case CommonPlatformDetection.CpuArchitecture.X86: Cpu = "x86"; break;
+                case CommonPlatformDetection.CpuArchitecture.X64: Cpu = "x64"; break;
+                case CommonPlatformDetection.CpuArchitecture.Arm64: Cpu = "arm64"; break;
                 default: Cpu = ""; break;
             }
             return true;

--- a/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
+++ b/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
@@ -34,7 +34,7 @@ namespace Grpc.Tools
         public string Os { get; set; }
 
         /// <summary>
-        /// Return one of 'x64' or 'x86'.
+        /// Return one of 'x64', 'x86', 'arm64'.
         /// If the CPU is unknown, the property is not set.
         /// </summary>
         [Output]
@@ -55,6 +55,7 @@ namespace Grpc.Tools
             {
                 case Platform.CpuKind.X86: Cpu = "x86"; break;
                 case Platform.CpuKind.X64: Cpu = "x64"; break;
+                case Platform.CpuKind.Arm64: Cpu = "arm64"; break;
                 default: Cpu = ""; break;
             }
             return true;

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -83,7 +83,7 @@
 
     <Error Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' and '$(PROTOBUF_PROTOC)' == ''
                         and ( '$(Protobuf_ToolsOs)' == '' or '$(Protobuf_ToolsCpu)' == '' ) "
-      Text="Google.Protobuf.Tools cannot determine host OS and CPU.&#10;Use environment variables PROTOBUF_TOOLS_OS={linux|macosx|windows} and PROTOBUF_TOOLS_CPU={x86|x64} to try the closest match to your system.&#10;You may also set PROTOBUF_PROTOC to specify full path to the host-provided compiler (v3.5+ is required)." />
+      Text="Google.Protobuf.Tools cannot determine host OS and CPU.&#10;Use environment variables PROTOBUF_TOOLS_OS={linux|macosx|windows} and PROTOBUF_TOOLS_CPU={x86|x64|arm64} to try the closest match to your system.&#10;You may also set PROTOBUF_PROTOC to specify full path to the host-provided compiler (v3.5+ is required)." />
   </Target>
 
   <!--================================================================================

--- a/templates/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs.template
+++ b/templates/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs.template
@@ -77,6 +77,13 @@
               % endfor
           }
 
+          public NativeMethods(DllImportsFromSharedLib_arm64 unusedInstance)
+          {
+              % for method in get_native_methods():
+              this.${method['name']} = DllImportsFromSharedLib_arm64.${method['name']};
+              % endfor
+          }
+
           public NativeMethods(DllImportsFromSharedLib_x86_dll unusedInstance)
           {
               % for method in get_native_methods():
@@ -146,6 +153,19 @@
           internal class DllImportsFromSharedLib_x64
           {
               private const string ImportName = "grpc_csharp_ext.x64";
+              % for method in get_native_methods():
+              
+              [DllImport(ImportName)]
+              public static extern ${method['returntype']} ${method['name']}(${method['params']});
+              % endfor
+          }
+
+          /// <summary>
+          /// grpc_csharp_ext used as a shared library (with arm64 suffix)
+          /// </summary>
+          internal class DllImportsFromSharedLib_arm64
+          {
+              private const string ImportName = "grpc_csharp_ext.arm64";
               % for method in get_native_methods():
               
               [DllImport(ImportName)]

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -260,30 +260,16 @@ class CSharpExtArtifact:
                                   use_workspace=True)
         else:
             if self.platform == 'linux':
-                cmake_arch_option = ''  # x64 is the default architecture
-                if self.arch == 'x86':
-                    # TODO(jtattermusch): more work needed to enable
-                    # boringssl assembly optimizations for 32-bit linux.
-                    # Problem: currently we are building the artifact under
-                    # 32-bit docker image, but CMAKE_SYSTEM_PROCESSOR is still
-                    # set to x86_64, so the resulting boringssl binary
-                    # would have undefined symbols.
-                    cmake_arch_option = '-DOPENSSL_NO_ASM=ON'
                 return create_docker_jobspec(
                     self.name,
                     'tools/dockerfile/grpc_artifact_centos6_{}'.format(
                         self.arch),
-                    'tools/run_tests/artifacts/build_artifact_csharp.sh',
-                    environ={'CMAKE_ARCH_OPTION': cmake_arch_option})
+                    'tools/run_tests/artifacts/build_artifact_csharp.sh')
             else:
-                cmake_arch_option = ''  # x64 is the default architecture
-                if self.arch == 'x86':
-                    cmake_arch_option = '-DCMAKE_OSX_ARCHITECTURES=i386'
                 return create_jobspec(
                     self.name,
                     ['tools/run_tests/artifacts/build_artifact_csharp.sh'],
-                    timeout_seconds=45 * 60,
-                    environ={'CMAKE_ARCH_OPTION': cmake_arch_option},
+                    timeout_seconds=45 * 60,,
                     use_workspace=True)
 
     def __str__(self):

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -260,16 +260,20 @@ class CSharpExtArtifact:
                                   use_workspace=True)
         else:
             if self.platform == 'linux':
+                dockerfile_dir = 'tools/dockerfile/grpc_artifact_centos6_{}'.format(
+                    self.arch)
+                if self.arch == 'aarch64':
+                    # for aarch64, use a dockcross manylinux image that will
+                    # give us both ready to use crosscompiler and sufficient backward compatibility
+                    dockerfile_dir = 'tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64'
                 return create_docker_jobspec(
-                    self.name,
-                    'tools/dockerfile/grpc_artifact_centos6_{}'.format(
-                        self.arch),
+                    self.name, dockerfile_dir,
                     'tools/run_tests/artifacts/build_artifact_csharp.sh')
             else:
                 return create_jobspec(
                     self.name,
                     ['tools/run_tests/artifacts/build_artifact_csharp.sh'],
-                    timeout_seconds=45 * 60,,
+                    timeout_seconds=45 * 60,
                     use_workspace=True)
 
     def __str__(self):
@@ -354,6 +358,7 @@ def targets():
         ProtocArtifact('windows', 'x64'),
         ProtocArtifact('windows', 'x86'),
         CSharpExtArtifact('linux', 'x64'),
+        CSharpExtArtifact('linux', 'aarch64'),
         CSharpExtArtifact('macos', 'x64'),
         CSharpExtArtifact('windows', 'x64'),
         CSharpExtArtifact('windows', 'x86'),

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -325,11 +325,16 @@ class ProtocArtifact:
         if self.platform != 'windows':
             environ = {'CXXFLAGS': '', 'LDFLAGS': ''}
             if self.platform == 'linux':
+                dockerfile_dir = 'tools/dockerfile/grpc_artifact_centos6_{}'.format(
+                    self.arch)
+                if self.arch == 'aarch64':
+                    # for aarch64, use a dockcross manylinux image that will
+                    # give us both ready to use crosscompiler and sufficient backward compatibility
+                    dockerfile_dir = 'tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64'
                 environ['LDFLAGS'] += ' -static-libgcc -static-libstdc++ -s'
                 return create_docker_jobspec(
                     self.name,
-                    'tools/dockerfile/grpc_artifact_centos6_{}'.format(
-                        self.arch),
+                    dockerfile_dir,
                     'tools/run_tests/artifacts/build_artifact_protoc.sh',
                     environ=environ)
             else:
@@ -358,6 +363,7 @@ def targets():
     return [
         ProtocArtifact('linux', 'x64'),
         ProtocArtifact('linux', 'x86'),
+        ProtocArtifact('linux', 'aarch64'),
         ProtocArtifact('macos', 'x64'),
         ProtocArtifact('windows', 'x64'),
         ProtocArtifact('windows', 'x86'),

--- a/tools/run_tests/artifacts/build_artifact_csharp.sh
+++ b/tools/run_tests/artifacts/build_artifact_csharp.sh
@@ -23,7 +23,6 @@ cd cmake/build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DgRPC_BACKWARDS_COMPATIBILITY_MODE=ON \
       -DgRPC_BUILD_TESTS=OFF \
-      "${CMAKE_ARCH_OPTION}" \
       ../..
 
 make grpc_csharp_ext -j2


### PR DESCRIPTION
Based on https://github.com/grpc/grpc/pull/25716

- build aarch64 artifacts for both grpc_csharp_ext and codegen binaries
- refactor and deduplicate code in platform detection in Grpc.Core and Grpc.Tools
- update native extension loading logic in Grpc.Core to support Arm64
- update Grpc.Tools to support Arm64