### PR TITLE
[Aio] Add time_remaining method to ServicerContext

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -252,6 +252,12 @@ cdef class _ServicerContext:
         else:
             return {}
 
+    def time_remaining(self):
+        if self._rpc_state.details.deadline.seconds == _GPR_INF_FUTURE.seconds:
+            return None
+        else:
+            return max(_time_from_timespec(self._rpc_state.details.deadline) - time.time(), 0)
+
 
 cdef class _SyncServicerContext:
     """Sync servicer context for sync handler compatibility."""
@@ -310,6 +316,9 @@ cdef class _SyncServicerContext:
 
     def auth_context(self):
         return self._context.auth_context()
+
+    def time_remaining(self):
+        return self._context.time_remaining()
 
 
 async def _run_interceptor(object interceptors, object query_handler,

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -296,7 +296,6 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
           A map of strings to an iterable of bytes for each auth property.
         """
 
-    @abc.abstractmethod
     def time_remaining(self) -> float:
         """Describes the length of allowed time remaining for the RPC.
 

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -295,3 +295,13 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         Returns:
           A map of strings to an iterable of bytes for each auth property.
         """
+
+    @abc.abstractmethod
+    def time_remaining(self) -> float:
+        """Describes the length of allowed time remaining for the RPC.
+
+        Returns:
+          A nonnegative float indicating the length of allowed time in seconds
+          remaining for the RPC to complete before it is considered to have
+          timed out, or None if no deadline was specified for the RPC.
+        """

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -36,6 +36,7 @@
   "unit.secure_call_test.TestUnaryUnarySecureCall",
   "unit.server_interceptor_test.TestServerInterceptor",
   "unit.server_test.TestServer",
+  "unit.server_time_remaining_test.TestServerTimeRemaining",
   "unit.timeout_test.TestTimeout",
   "unit.wait_for_connection_test.TestWaitForConnection",
   "unit.wait_for_ready_test.TestWaitForReady"

--- a/src/python/grpcio_tests/tests_aio/unit/_common.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_common.py
@@ -21,6 +21,8 @@ from grpc.aio._metadata import Metadata
 
 from tests.unit.framework.common import test_constants
 
+ADHOC_METHOD = '/test/AdHoc'
+
 
 def seen_metadata(expected: Metadata, actual: Metadata):
     return not bool(set(tuple(expected)) - set(tuple(actual)))
@@ -97,3 +99,20 @@ class CountingResponseIterator:
 
     def __aiter__(self):
         return self._forward_responses()
+
+
+class AdhocGenericHandler(grpc.GenericRpcHandler):
+    """A generic handler to plugin testing server methods on the fly."""
+    _handler: grpc.RpcMethodHandler
+
+    def __init__(self):
+        self._handler = None
+
+    def set_adhoc_handler(self, handler: grpc.RpcMethodHandler):
+        self._handler = handler
+
+    def service(self, handler_call_details):
+        if handler_call_details.method == ADHOC_METHOD:
+            return self._handler
+        else:
+            return None

--- a/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
@@ -59,7 +59,6 @@ class TestServerTimeRemaining(AioTestBase):
         await self._channel.unary_unary(ADHOC_METHOD)(
             _REQUEST, timeout=_REQUEST_TIMEOUT_S)
         self.assertGreater(seen_time_remaining[0], _REQUEST_TIMEOUT_S / 2)
-        self.assertLess(seen_time_remaining[0], _REQUEST_TIMEOUT_S * 3 / 2)
         # Check if there is no timeout, the time_remaining will be None
         self._adhoc_handlers.set_adhoc_handler(log_time_remaining)
         await self._channel.unary_unary(ADHOC_METHOD)(_REQUEST)

--- a/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
@@ -1,0 +1,71 @@
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Testing the compatibility between AsyncIO stack and the old stack."""
+
+import asyncio
+import logging
+import unittest
+import datetime
+
+import grpc
+from grpc import aio
+
+from tests_aio.unit._common import ADHOC_METHOD, AdhocGenericHandler
+from tests_aio.unit._test_base import AioTestBase
+
+_REQUEST = b'\x09\x05'
+_REQUEST_TIMEOUT_S = datetime.timedelta(seconds=5).total_seconds()
+
+
+class TestServerTimeRemaining(AioTestBase):
+
+    async def setUp(self):
+        # Create async server
+        self._server = aio.server(options=(('grpc.so_reuseport', 0),))
+        self._adhoc_handlers = AdhocGenericHandler()
+        self._server.add_generic_rpc_handlers((self._adhoc_handlers,))
+        port = self._server.add_insecure_port('[::]:0')
+        address = 'localhost:%d' % port
+        await self._server.start()
+        # Create async channel
+        self._channel = aio.insecure_channel(address)
+
+    async def tearDown(self):
+        await self._channel.close()
+        await self._server.stop(None)
+
+    async def test_servicer_context_time_remaining(self):
+        seen_time_remaining = []
+
+        @grpc.unary_unary_rpc_method_handler
+        def log_time_remaining(request: bytes,
+                               context: grpc.ServicerContext) -> bytes:
+            seen_time_remaining.append(context.time_remaining())
+            return b""
+
+        # Check if the deadline propagates properly
+        self._adhoc_handlers.set_adhoc_handler(log_time_remaining)
+        await self._channel.unary_unary(ADHOC_METHOD)(
+            _REQUEST, timeout=_REQUEST_TIMEOUT_S)
+        self.assertGreater(seen_time_remaining[0], _REQUEST_TIMEOUT_S / 2)
+        self.assertLess(seen_time_remaining[0], _REQUEST_TIMEOUT_S * 3 / 2)
+        # Check if there is no timeout, the time_remaining will be None
+        self._adhoc_handlers.set_adhoc_handler(log_time_remaining)
+        await self._channel.unary_unary(ADHOC_METHOD)(_REQUEST)
+        self.assertIsNone(seen_time_remaining[1])
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_time_remaining_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The gRPC Authors
+# Copyright 2021 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Testing the compatibility between AsyncIO stack and the old stack."""
+"""Test the time_remaining() method of async ServicerContext."""
 
 import asyncio
 import logging


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/24325

This method is provided by sync gRPC Python, but not AsyncIO. We haven't found a valid use case in the past, until https://github.com/grpc/grpc/issues/24325 showed that it is needed for OpenCensus tracing. This PR should fill the gap.