### PR TITLE
Add gRPC 1.36.3 to the interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -111,6 +111,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
+            ('v1.36.2', ReleaseInfo()),
         ]),
     'go':
         OrderedDict([
@@ -314,6 +315,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo(runtimes=['python'])),
             ('v1.34.0', ReleaseInfo(runtimes=['python'])),
             ('v1.35.0', ReleaseInfo(runtimes=['python'])),
+            ('v1.36.2', ReleaseInfo(runtimes=['python'])),
         ]),
     'node':
         OrderedDict([
@@ -378,6 +380,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
+            ('v1.36.2', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([
@@ -415,6 +418,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
+            ('v1.36.2', ReleaseInfo()),
         ]),
     'csharp':
         OrderedDict([
@@ -457,5 +461,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
+            ('v1.36.2', ReleaseInfo()),
         ]),
 }

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -111,7 +111,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
-            ('v1.36.2', ReleaseInfo()),
+            ('v1.36.3', ReleaseInfo()),
         ]),
     'go':
         OrderedDict([
@@ -315,7 +315,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo(runtimes=['python'])),
             ('v1.34.0', ReleaseInfo(runtimes=['python'])),
             ('v1.35.0', ReleaseInfo(runtimes=['python'])),
-            ('v1.36.2', ReleaseInfo(runtimes=['python'])),
+            ('v1.36.3', ReleaseInfo(runtimes=['python'])),
         ]),
     'node':
         OrderedDict([
@@ -380,7 +380,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
-            ('v1.36.2', ReleaseInfo()),
+            ('v1.36.3', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([
@@ -418,7 +418,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
-            ('v1.36.2', ReleaseInfo()),
+            ('v1.36.3', ReleaseInfo()),
         ]),
     'csharp':
         OrderedDict([
@@ -461,6 +461,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.33.2', ReleaseInfo()),
             ('v1.34.0', ReleaseInfo()),
             ('v1.35.0', ReleaseInfo()),
-            ('v1.36.2', ReleaseInfo()),
+            ('v1.36.3', ReleaseInfo()),
         ]),
 }


### PR DESCRIPTION
The image generation was complicated by several Python dependencies.

v1.36.1 includes a patch to Core DirectPath https://github.com/grpc/grpc/pull/25569; v1.36.2 includes some infra fixes; v1.36.3 includes https://github.com/grpc/grpc/pull/25690 and infra fixes.