### PR TITLE
Reduce Grpc.Core nuget size by generating separate .so with/without debug symbols for grpc_csharp_ext

### DIFF
--- a/src/csharp/Grpc.Core.NativeDebug/Grpc.Core.NativeDebug.csproj
+++ b/src/csharp/Grpc.Core.NativeDebug/Grpc.Core.NativeDebug.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Authors>The gRPC Authors</Authors>
     <Copyright>Copyright 2015 The gRPC Authors</Copyright>
-    <Description>Debug symbols for the native library contained in Grpc.Core</Description>
+    <Description>Debug symbols for the grpc_csharp_ext native library contained in Grpc.Core</Description>
     <PackageIconUrl>https://github.com/grpc/grpc.github.io/raw/master/img/grpc_square_reverse_4x.png</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/grpc/grpc</PackageProjectUrl>
@@ -18,6 +18,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\nativelibs\csharp_ext_linux_x64\libgrpc_csharp_ext.dbginfo.so">
+      <PackagePath>runtimes/linux-x64/native/libgrpc_csharp_ext.x64.dbginfo.so</PackagePath>
+      <Pack>true</Pack>
+    </None>
+    <None Include="..\nativelibs\csharp_ext_linux_aarch64\libgrpc_csharp_ext.dbginfo.so">
+      <PackagePath>runtimes/linux-arm64/native/libgrpc_csharp_ext.arm64.dbginfo.so</PackagePath>
+      <Pack>true</Pack>
+    </None>
     <None Include="..\nativelibs\csharp_ext_windows_x86\grpc_csharp_ext.dll">
       <PackagePath>runtimes/win-x86/native/grpc_csharp_ext.x86.dll</PackagePath>
       <Pack>true</Pack>

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64/Dockerfile
@@ -26,3 +26,10 @@ RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
 RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
 RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython
 RUN /opt/python/cp39-cp39/bin/pip install --upgrade cython
+
+# the dockcross docker image sets variables like CC, CXX etc.
+# to point to the crosscompilation toolchain, but doesn't set corresponding
+# variables for the "strip" and "objcopy" tools.
+# see https://github.com/dockcross/dockcross/blob/4349cb4999401cbf22a90f46f5052d29be240e50/manylinux2014-aarch64/Dockerfile.in#L23
+ENV STRIP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip \
+    OBJCOPY=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-objcopy

--- a/tools/internal_ci/linux/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/linux/grpc_build_artifacts.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_artifacts.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/run_tests/artifacts/build_artifact_csharp.sh
+++ b/tools/run_tests/artifacts/build_artifact_csharp.sh
@@ -29,13 +29,17 @@ make grpc_csharp_ext -j2
 
 if [ -f "libgrpc_csharp_ext.so" ]
 then
+    # in case we are in a crosscompilation environment
+    STRIP=${STRIP:-strip}
+    OBJCOPY=${OBJCOPY:-objcopy}
+    
     # The .so file with all debug symbols is too large to
     # package in the default nuget package.
     # But we still want to keep the version with symbols
     # to include it in a special "debug" package.
     cp libgrpc_csharp_ext.so libgrpc_csharp_ext.dbginfo.so
-    strip --strip-unneeded libgrpc_csharp_ext.so
-    objcopy --add-gnu-debuglink=libgrpc_csharp_ext.dbginfo.so libgrpc_csharp_ext.so
+    ${STRIP} --strip-unneeded libgrpc_csharp_ext.so
+    ${OBJCOPY} --add-gnu-debuglink=libgrpc_csharp_ext.dbginfo.so libgrpc_csharp_ext.so
 fi
 
 cd ../..

--- a/tools/run_tests/artifacts/build_artifact_csharp.sh
+++ b/tools/run_tests/artifacts/build_artifact_csharp.sh
@@ -26,7 +26,19 @@ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       ../..
 
 make grpc_csharp_ext -j2
+
+if [ -f "libgrpc_csharp_ext.so" ]
+then
+    # The .so file with all debug symbols is too large to
+    # package in the default nuget package.
+    # But we still want to keep the version with symbols
+    # to include it in a special "debug" package.
+    cp libgrpc_csharp_ext.so libgrpc_csharp_ext.dbginfo.so
+    strip --strip-unneeded libgrpc_csharp_ext.so
+    objcopy --add-gnu-debuglink=libgrpc_csharp_ext.dbginfo.so libgrpc_csharp_ext.so
+fi
+
 cd ../..
 
 mkdir -p "${ARTIFACTS_OUT}"
-cp cmake/build/libgrpc_csharp_ext.so "${ARTIFACTS_OUT}" || cp cmake/build/libgrpc_csharp_ext.dylib "${ARTIFACTS_OUT}"
+cp cmake/build/libgrpc_csharp_ext.so cmake/build/libgrpc_csharp_ext.dbginfo.so "${ARTIFACTS_OUT}" || cp cmake/build/libgrpc_csharp_ext.dylib "${ARTIFACTS_OUT}"


### PR DESCRIPTION
This should lead to significant reduction of Grpc.Core nuget's size.

The Grpc.Core package will from now on contain stripped version of grpc_csharp_ext.so. The non-stripped version with all the debug symbols will be made available through the Grpc.Core.NativeDebug package.

Related issue: https://github.com/grpc/grpc/issues/25598