### PR TITLE
Fix protobuf status error

### DIFF
--- a/test/cpp/qps/parse_json.cc
+++ b/test/cpp/qps/parse_json.cc
@@ -34,7 +34,7 @@ void ParseJson(const std::string& json, const std::string& type,
   auto status = JsonToBinaryString(
       type_resolver.get(), "type.googleapis.com/" + type, json, &binary);
   if (!status.ok()) {
-    std::string errmsg(status.error_message());
+    std::string errmsg(status.message());
     gpr_log(GPR_ERROR, "Failed to convert json to binary: errcode=%d msg=%s",
             status.code(), errmsg.c_str());
     gpr_log(GPR_ERROR, "JSON: %s", json.c_str());


### PR DESCRIPTION
Fixed `prod:grpc/core/master/linux/grpc_build_protobuf_at_head`

```
/var/local/git/grpc/test/cpp/qps/parse_json.cc: In function 'void grpc::testing::ParseJson(const string&, const string&, google::protobuf::Message*)':
/var/local/git/grpc/test/cpp/qps/parse_json.cc:37:31: error: 'class google::protobuf::util::status_internal::Status' has no member named 'error_message'
     std::string errmsg(status.error_message());
```

Related with https://github.com/protocolbuffers/protobuf/pull/8354
