### PR TITLE
xds testing: set fault injection env var, so the test can be turned on

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2595,12 +2595,7 @@ try:
         client_env['GRPC_XDS_BOOTSTRAP'] = bootstrap_path
         client_env['GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING'] = 'true'
         client_env['GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT'] = 'true'
-        # Temporarily turn off fault injection, because HTTPFault filter isn't
-        # handled correctly yet in CPP and Go. And setting would break all the
-        # other tests. Uncomment the following line when the support is
-        # complete.
-        #
-        # client_env['GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION'] = 'true'
+        client_env['GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION'] = 'true'
         test_results = {}
         failed_tests = []
         for test_case in args.test_case:


### PR DESCRIPTION
This reverts #25676

Note that this doesn't turn on the tests. The tests needs to be turned on in the kokoro shell scripts.