### PR TITLE
Fix required a higher minimum deployment target of Auth Sample Test

### DIFF
--- a/examples/objective-c/auth_sample/Podfile
+++ b/examples/objective-c/auth_sample/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 


### PR DESCRIPTION
Auth Sample can not be ran via Cocoapods because of the following error:
<img width="565" alt="Screen Shot 2021-03-16 at 3 10 41 PM" src="https://user-images.githubusercontent.com/64815511/111387364-d7cb1c80-866a-11eb-82cf-2511c2a1be21.png">

Increasing the target version to fix the issue.
