### PR TITLE
Fix invalid use of python's traceback.print_exc

### DIFF
--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -65,8 +65,8 @@ def _access_token():
                     'exp': time.time() + 60
                 }
                 break
-            except (KeyError, ValueError) as e:
-                traceback.print_exc(e)
+            except (KeyError, ValueError):
+                traceback.print_exc()
                 print('HTTP Status %d %s' % (resp.status_code, resp.reason))
                 print("Fetch access token from Github API failed:")
                 print(resp.text)


### PR DESCRIPTION
The exception is being interpreted as a `limit` (int) to cap the number
of stack trace entries to print.

https://docs.python.org/3/library/traceback.html#traceback.print_exc

Problem also appeared in https://github.com/grpc/grpc/pull/25704

Fixes #25425