### PR TITLE
xds-k8s: Update to TD bootstrap with server_listener_resource_name_template support

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,4 +1,4 @@
 --namespace=interop-psm-security
---td_bootstrap_image=gcr.io/trafficdirector-prod/td-grpc-bootstrap:0.10.0
+--td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:8af4336691ba23683ee3e280275894959dc47c4c
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0


### PR DESCRIPTION
Related:
* https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/pull/14
* https://github.com/grpc/grpc-java/pull/7978


