### PR TITLE
ruby: use x86_64 binary on M1 macs

### DIFF
--- a/src/ruby/tools/platform_check.rb
+++ b/src/ruby/tools/platform_check.rb
@@ -29,7 +29,12 @@ module PLATFORM
   end
 
   def PLATFORM.architecture
-    case RbConfig::CONFIG['host_cpu']
+    host_cpu = RbConfig::CONFIG['host_cpu']
+
+    # When we're on arm in macOS, we can rely on Rosetta and use the x86_64 binary
+    return 'x86_64' if RbConfig::CONFIG['host_os'] =~ /darwin/ && host_cpu =~ /arm/
+
+    case host_cpu
       when /x86_64/
         'x86_64'
       else


### PR DESCRIPTION
On M1 macs we can rely on rosetta. Right now architecture defaults to 32-bit for those machines, which doesn't work

Related to https://github.com/grpc/grpc/issues/25755

cc @jtattermusch