### PR TITLE
extract_metadata_from_bazel_xml.py changes from #25272

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -176,14 +176,14 @@ config("grpc_config") {
         "src/core/lib/profiling/timers.h",
     ]
     deps = [
-        ":absl/types:optional",
-        ":absl/time:time",
-        ":absl/synchronization:synchronization",
-        ":absl/strings:strings",
-        ":absl/strings:str_format",
-        ":absl/status:status",
-        ":absl/memory:memory",
         ":absl/base:base",
+        ":absl/memory:memory",
+        ":absl/status:status",
+        ":absl/strings:str_format",
+        ":absl/strings:strings",
+        ":absl/synchronization:synchronization",
+        ":absl/time:time",
+        ":absl/types:optional",
     ]
     
     public_configs = [
@@ -1239,17 +1239,14 @@ config("grpc_config") {
     ]
     deps = [
         "//third_party/zlib",
+        ":absl/container:flat_hash_map",
+        ":absl/container:inlined_vector",
+        ":absl/functional:bind_front",
+        ":absl/status:statusor",
         ":gpr",
+        "//third_party/boringssl",
         ":address_sorting",
         ":upb",
-        "//third_party/boringssl",
-        ":absl/types:optional",
-        ":absl/strings:strings",
-        ":absl/status:statusor",
-        ":absl/status:status",
-        ":absl/functional:bind_front",
-        ":absl/container:inlined_vector",
-        ":absl/container:flat_hash_map",
         "//third_party/cares",
         ":address_sorting",
     ]
@@ -1517,11 +1514,6 @@ config("grpc_config") {
     deps = [
         "//third_party/protobuf:protobuf_lite",
         ":grpc",
-        ":gpr",
-        ":address_sorting",
-        ":upb",
-        "//third_party/boringssl",
-        ":absl/synchronization:synchronization",
     ]
     
     public_configs = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1164,11 +1164,6 @@ target_include_directories(end2end_nosec_tests
 target_link_libraries(end2end_nosec_tests
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -1300,11 +1295,6 @@ target_include_directories(end2end_tests
 target_link_libraries(end2end_tests
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -1389,14 +1379,14 @@ target_include_directories(gpr
 )
 target_link_libraries(gpr
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::optional
-  absl::time
-  absl::synchronization
-  absl::strings
-  absl::str_format
-  absl::status
-  absl::memory
   absl::base
+  absl::memory
+  absl::status
+  absl::str_format
+  absl::strings
+  absl::synchronization
+  absl::time
+  absl::optional
 )
 if(_gRPC_PLATFORM_ANDROID)
   target_link_libraries(gpr
@@ -2044,17 +2034,14 @@ target_link_libraries(grpc
   ${_gRPC_RE2_LIBRARIES}
   ${_gRPC_UPB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flat_hash_map
+  absl::inlined_vector
+  absl::bind_front
+  absl::statusor
   gpr
+  ${_gRPC_SSL_LIBRARIES}
   address_sorting
   upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::optional
-  absl::strings
-  absl::statusor
-  absl::status
-  absl::bind_front
-  absl::inlined_vector
-  absl::flat_hash_map
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc "-framework CoreFoundation")
@@ -2130,10 +2117,6 @@ target_include_directories(grpc_csharp_ext
 target_link_libraries(grpc_csharp_ext
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -2197,14 +2180,10 @@ target_include_directories(grpc_test_util
 )
 target_link_libraries(grpc_test_util
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::symbolize
-  absl::stacktrace
   absl::failure_signal_handler
+  absl::stacktrace
+  absl::symbolize
+  grpc
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc_test_util "-framework CoreFoundation")
@@ -2270,13 +2249,10 @@ target_include_directories(grpc_test_util_unsecure
 )
 target_link_libraries(grpc_test_util_unsecure
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_unsecure
-  gpr
-  address_sorting
-  upb
-  absl::symbolize
-  absl::stacktrace
   absl::failure_signal_handler
+  absl::stacktrace
+  absl::symbolize
+  grpc_unsecure
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc_test_util_unsecure "-framework CoreFoundation")
@@ -2605,15 +2581,12 @@ target_link_libraries(grpc_unsecure
   ${_gRPC_RE2_LIBRARIES}
   ${_gRPC_UPB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flat_hash_map
+  absl::inlined_vector
+  absl::statusor
   gpr
   address_sorting
   upb
-  absl::optional
-  absl::strings
-  absl::statusor
-  absl::status
-  absl::inlined_vector
-  absl::flat_hash_map
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc_unsecure "-framework CoreFoundation")
@@ -2707,14 +2680,10 @@ target_include_directories(benchmark_helpers
 target_link_libraries(benchmark_helpers
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
-  grpc++_unsecure
-  grpc_unsecure
-  grpc++_test_config
-  gpr
-  address_sorting
-  upb
   ${_gRPC_BENCHMARK_LIBRARIES}
+  grpc++_unsecure
+  grpc_test_util_unsecure
+  grpc++_test_config
 )
 
 endif()
@@ -2809,11 +2778,6 @@ target_link_libraries(grpc++
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::synchronization
 )
 
 foreach(_hdr
@@ -3060,11 +3024,6 @@ target_link_libraries(grpc++_alts
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 foreach(_hdr
@@ -3126,11 +3085,6 @@ target_link_libraries(grpc++_error_details
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 foreach(_hdr
@@ -3198,11 +3152,6 @@ target_link_libraries(grpc++_reflection
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 foreach(_hdr
@@ -3272,11 +3221,6 @@ target_link_libraries(grpc++_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 foreach(_hdr
@@ -3338,8 +3282,8 @@ target_include_directories(grpc++_test_config
 target_link_libraries(grpc++_test_config
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
   absl::flags_parse
+  gpr
 )
 
 
@@ -3395,14 +3339,9 @@ target_include_directories(grpc++_test_util
 target_link_libraries(grpc++_test_util
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
   absl::flags
+  grpc++
+  grpc_test_util
 )
 
 
@@ -3486,10 +3425,6 @@ target_link_libraries(grpc++_unsecure
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_unsecure
-  gpr
-  address_sorting
-  upb
-  absl::synchronization
 )
 
 foreach(_hdr
@@ -3808,11 +3743,6 @@ target_link_libraries(grpcpp_channelz
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 foreach(_hdr
@@ -4027,11 +3957,6 @@ target_include_directories(algorithm_test
 target_link_libraries(algorithm_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4059,11 +3984,6 @@ target_include_directories(alloc_test
 target_link_libraries(alloc_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4091,11 +4011,6 @@ target_include_directories(alpn_test
 target_link_libraries(alpn_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4124,11 +4039,6 @@ target_include_directories(alts_counter_test
 target_link_libraries(alts_counter_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4157,11 +4067,6 @@ target_include_directories(alts_crypt_test
 target_link_libraries(alts_crypt_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4190,11 +4095,6 @@ target_include_directories(alts_crypter_test
 target_link_libraries(alts_crypter_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4224,11 +4124,6 @@ target_include_directories(alts_frame_protector_test
 target_link_libraries(alts_frame_protector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4257,11 +4152,6 @@ target_include_directories(alts_grpc_record_protocol_test
 target_link_libraries(alts_grpc_record_protocol_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4290,11 +4180,6 @@ target_include_directories(alts_handshaker_client_test
 target_link_libraries(alts_handshaker_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4323,11 +4208,6 @@ target_include_directories(alts_iovec_record_protocol_test
 target_link_libraries(alts_iovec_record_protocol_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4355,11 +4235,6 @@ target_include_directories(alts_security_connector_test
 target_link_libraries(alts_security_connector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4388,11 +4263,6 @@ target_include_directories(alts_tsi_handshaker_test
 target_link_libraries(alts_tsi_handshaker_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4421,11 +4291,6 @@ target_include_directories(alts_tsi_utils_test
 target_link_libraries(alts_tsi_utils_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4454,11 +4319,6 @@ target_include_directories(alts_zero_copy_grpc_protector_test
 target_link_libraries(alts_zero_copy_grpc_protector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4486,11 +4346,6 @@ target_include_directories(arena_test
 target_link_libraries(arena_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4518,11 +4373,6 @@ target_include_directories(auth_context_test
 target_link_libraries(auth_context_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4550,11 +4400,6 @@ target_include_directories(avl_test
 target_link_libraries(avl_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4582,11 +4427,6 @@ target_include_directories(b64_test
 target_link_libraries(b64_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4615,11 +4455,6 @@ target_include_directories(bad_server_response_test
 target_link_libraries(bad_server_response_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4649,11 +4484,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(bad_ssl_alpn_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -4684,11 +4514,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(bad_ssl_cert_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -4717,11 +4542,6 @@ target_include_directories(bin_decoder_test
 target_link_libraries(bin_decoder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4749,11 +4569,6 @@ target_include_directories(bin_encoder_test
 target_link_libraries(bin_encoder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4781,11 +4596,6 @@ target_include_directories(buffer_list_test
 target_link_libraries(buffer_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4813,11 +4623,6 @@ target_include_directories(channel_args_test
 target_link_libraries(channel_args_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4845,11 +4650,6 @@ target_include_directories(channel_create_test
 target_link_libraries(channel_create_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4877,11 +4677,6 @@ target_include_directories(channel_stack_builder_test
 target_link_libraries(channel_stack_builder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4909,11 +4704,6 @@ target_include_directories(channel_stack_test
 target_link_libraries(channel_stack_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4941,11 +4731,6 @@ target_include_directories(check_gcp_environment_linux_test
 target_link_libraries(check_gcp_environment_linux_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -4973,11 +4758,6 @@ target_include_directories(check_gcp_environment_windows_test
 target_link_libraries(check_gcp_environment_windows_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5006,11 +4786,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(client_ssl_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5039,11 +4814,6 @@ target_include_directories(cmdline_test
 target_link_libraries(cmdline_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5072,11 +4842,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(combiner_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5105,11 +4870,6 @@ target_include_directories(completion_queue_threading_test
 target_link_libraries(completion_queue_threading_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5137,11 +4897,6 @@ target_include_directories(compression_test
 target_link_libraries(compression_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5169,11 +4924,6 @@ target_include_directories(concurrent_connectivity_test
 target_link_libraries(concurrent_connectivity_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5202,11 +4952,6 @@ target_include_directories(connection_refused_test
 target_link_libraries(connection_refused_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5234,11 +4979,6 @@ target_include_directories(cpu_test
 target_link_libraries(cpu_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5266,11 +5006,6 @@ target_include_directories(dns_resolver_connectivity_using_ares_test
 target_link_libraries(dns_resolver_connectivity_using_ares_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5298,11 +5033,6 @@ target_include_directories(dns_resolver_connectivity_using_native_test
 target_link_libraries(dns_resolver_connectivity_using_native_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5330,11 +5060,6 @@ target_include_directories(dns_resolver_cooldown_test
 target_link_libraries(dns_resolver_cooldown_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5362,11 +5087,6 @@ target_include_directories(dns_resolver_test
 target_link_libraries(dns_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5396,11 +5116,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(dualstack_socket_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5430,11 +5145,6 @@ target_include_directories(endpoint_pair_test
 target_link_libraries(endpoint_pair_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5462,11 +5172,6 @@ target_include_directories(env_test
 target_link_libraries(env_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5495,11 +5200,6 @@ target_include_directories(error_test
 target_link_libraries(error_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5528,11 +5228,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(ev_epollex_linux_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5561,11 +5256,6 @@ target_include_directories(fake_resolver_test
 target_link_libraries(fake_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5594,11 +5284,6 @@ target_include_directories(fake_transport_security_test
 target_link_libraries(fake_transport_security_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5627,11 +5312,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(fd_conservation_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5661,11 +5341,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(fd_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5699,11 +5374,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(fling_stream_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5737,11 +5407,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(fling_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5771,11 +5436,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(fork_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -5808,11 +5468,6 @@ target_include_directories(format_request_test
 target_link_libraries(format_request_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5841,11 +5496,6 @@ target_include_directories(frame_handler_test
 target_link_libraries(frame_handler_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5874,11 +5524,6 @@ target_include_directories(goaway_server_test
 target_link_libraries(goaway_server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5906,11 +5551,6 @@ target_include_directories(grpc_alts_credentials_options_test
 target_link_libraries(grpc_alts_credentials_options_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5938,11 +5578,6 @@ target_include_directories(grpc_byte_buffer_reader_test
 target_link_libraries(grpc_byte_buffer_reader_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -5970,11 +5605,6 @@ target_include_directories(grpc_completion_queue_test
 target_link_libraries(grpc_completion_queue_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6002,11 +5632,6 @@ target_include_directories(grpc_ipv6_loopback_available_test
 target_link_libraries(grpc_ipv6_loopback_available_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6036,11 +5661,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(handshake_server_with_readahead_handshaker_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -6070,11 +5690,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(handshake_verify_peer_options_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -6103,11 +5718,6 @@ target_include_directories(histogram_test
 target_link_libraries(histogram_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6135,11 +5745,6 @@ target_include_directories(host_port_test
 target_link_libraries(host_port_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6167,11 +5772,6 @@ target_include_directories(hpack_encoder_test
 target_link_libraries(hpack_encoder_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6199,11 +5799,6 @@ target_include_directories(hpack_parser_test
 target_link_libraries(hpack_parser_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6231,11 +5826,6 @@ target_include_directories(hpack_table_test
 target_link_libraries(hpack_table_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6268,11 +5858,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(httpcli_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -6306,11 +5891,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(httpscli_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -6339,12 +5919,6 @@ target_include_directories(inproc_callback_test
 target_link_libraries(inproc_callback_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   end2end_tests
-  grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6373,11 +5947,6 @@ target_include_directories(invalid_call_argument_test
 target_link_libraries(invalid_call_argument_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6405,11 +5974,6 @@ target_include_directories(json_token_test
 target_link_libraries(json_token_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6437,11 +6001,6 @@ target_include_directories(jwt_verifier_test
 target_link_libraries(jwt_verifier_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6470,11 +6029,6 @@ target_include_directories(lame_client_test
 target_link_libraries(lame_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6502,11 +6056,6 @@ target_include_directories(load_file_test
 target_link_libraries(load_file_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6534,11 +6083,6 @@ target_include_directories(manual_constructor_test
 target_link_libraries(manual_constructor_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6566,11 +6110,6 @@ target_include_directories(message_compress_test
 target_link_libraries(message_compress_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6598,11 +6137,6 @@ target_include_directories(metadata_test
 target_link_libraries(metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6630,11 +6164,6 @@ target_include_directories(minimal_stack_is_minimal_test
 target_link_libraries(minimal_stack_is_minimal_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6662,11 +6191,6 @@ target_include_directories(mpmcqueue_test
 target_link_libraries(mpmcqueue_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6695,11 +6219,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(mpscq_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -6729,11 +6248,6 @@ target_include_directories(multiple_server_queues_test
 target_link_libraries(multiple_server_queues_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6761,11 +6275,6 @@ target_include_directories(murmur_hash_test
 target_link_libraries(murmur_hash_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6794,11 +6303,6 @@ target_include_directories(no_server_test
 target_link_libraries(no_server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6826,11 +6330,6 @@ target_include_directories(num_external_connectivity_watchers_test
 target_link_libraries(num_external_connectivity_watchers_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6858,11 +6357,6 @@ target_include_directories(parse_address_test
 target_link_libraries(parse_address_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6891,11 +6385,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(parse_address_with_named_scope_id_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -6928,11 +6417,6 @@ target_include_directories(parser_test
 target_link_libraries(parser_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6960,11 +6444,6 @@ target_include_directories(percent_encoding_test
 target_link_libraries(percent_encoding_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -6992,11 +6471,6 @@ target_include_directories(public_headers_must_be_c89
 target_link_libraries(public_headers_must_be_c89
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7025,11 +6499,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(resolve_address_using_ares_resolver_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7058,11 +6527,6 @@ target_include_directories(resolve_address_using_ares_resolver_test
 target_link_libraries(resolve_address_using_ares_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7091,11 +6555,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(resolve_address_using_native_resolver_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7124,11 +6583,6 @@ target_include_directories(resolve_address_using_native_resolver_test
 target_link_libraries(resolve_address_using_native_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7156,11 +6610,6 @@ target_include_directories(resource_quota_test
 target_link_libraries(resource_quota_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7188,11 +6637,6 @@ target_include_directories(secure_channel_create_test
 target_link_libraries(secure_channel_create_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7221,11 +6665,6 @@ target_include_directories(secure_endpoint_test
 target_link_libraries(secure_endpoint_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7253,11 +6692,6 @@ target_include_directories(security_connector_test
 target_link_libraries(security_connector_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7285,11 +6719,6 @@ target_include_directories(sequential_connectivity_test
 target_link_libraries(sequential_connectivity_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7319,11 +6748,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(server_ssl_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7352,11 +6776,6 @@ target_include_directories(server_test
 target_link_libraries(server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7384,11 +6803,6 @@ target_include_directories(slice_buffer_test
 target_link_libraries(slice_buffer_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7416,11 +6830,6 @@ target_include_directories(slice_string_helpers_test
 target_link_libraries(slice_string_helpers_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7448,11 +6857,6 @@ target_include_directories(sockaddr_resolver_test
 target_link_libraries(sockaddr_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7480,11 +6884,6 @@ target_include_directories(sockaddr_utils_test
 target_link_libraries(sockaddr_utils_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7513,11 +6912,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(socket_utils_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7546,11 +6940,6 @@ target_include_directories(spinlock_test
 target_link_libraries(spinlock_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7578,11 +6967,6 @@ target_include_directories(ssl_credentials_test
 target_link_libraries(ssl_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7612,11 +6996,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(ssl_transport_security_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7645,11 +7024,6 @@ target_include_directories(status_conversion_test
 target_link_libraries(status_conversion_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7677,11 +7051,6 @@ target_include_directories(stream_compression_test
 target_link_libraries(stream_compression_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7709,11 +7078,6 @@ target_include_directories(stream_map_test
 target_link_libraries(stream_map_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7741,11 +7105,6 @@ target_include_directories(stream_owned_slice_test
 target_link_libraries(stream_owned_slice_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7773,11 +7132,6 @@ target_include_directories(string_test
 target_link_libraries(string_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7805,11 +7159,6 @@ target_include_directories(sync_test
 target_link_libraries(sync_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7838,11 +7187,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(tcp_client_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7873,11 +7217,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(tcp_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7907,11 +7246,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(tcp_server_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -7940,11 +7274,6 @@ target_include_directories(test_core_gpr_time_test
 target_link_libraries(test_core_gpr_time_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -7972,11 +7301,6 @@ target_include_directories(test_core_security_credentials_test
 target_link_libraries(test_core_security_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8004,11 +7328,6 @@ target_include_directories(test_core_slice_slice_test
 target_link_libraries(test_core_slice_slice_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8036,11 +7355,6 @@ target_include_directories(thd_test
 target_link_libraries(thd_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8068,11 +7382,6 @@ target_include_directories(threadpool_test
 target_link_libraries(threadpool_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8100,11 +7409,6 @@ target_include_directories(time_averaged_stats_test
 target_link_libraries(time_averaged_stats_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8132,11 +7436,6 @@ target_include_directories(timeout_encoding_test
 target_link_libraries(timeout_encoding_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8164,11 +7463,6 @@ target_include_directories(timer_heap_test
 target_link_libraries(timer_heap_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8196,11 +7490,6 @@ target_include_directories(timer_list_test
 target_link_libraries(timer_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8228,11 +7517,6 @@ target_include_directories(tls_test
 target_link_libraries(tls_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8260,11 +7544,6 @@ target_include_directories(transport_security_common_api_test
 target_link_libraries(transport_security_common_api_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8292,11 +7571,6 @@ target_include_directories(transport_security_test
 target_link_libraries(transport_security_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8325,11 +7599,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(udp_server_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -8358,11 +7627,6 @@ target_include_directories(useful_test
 target_link_libraries(useful_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8390,11 +7654,6 @@ target_include_directories(varint_test
 target_link_libraries(varint_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8430,15 +7689,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(address_sorting_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
-    grpc_test_util
-    grpc++
     grpc++_test_config
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
+    grpc++_test_util
   )
 
 
@@ -8478,13 +7730,9 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(address_sorting_test_unsecure
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util_unsecure
     grpc++_unsecure
-    grpc_unsecure
+    grpc_test_util_unsecure
     grpc++_test_config
-    gpr
-    address_sorting
-    upb
   )
 
 
@@ -8521,12 +7769,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(alarm_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util_unsecure
     grpc++_unsecure
-    grpc_unsecure
-    gpr
-    address_sorting
-    upb
+    grpc_test_util_unsecure
   )
 
 
@@ -8573,13 +7817,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(alts_concurrent_connectivity_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
     grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
+    grpc_test_util
   )
 
 
@@ -8615,15 +7854,8 @@ target_include_directories(alts_util_test
 target_link_libraries(alts_util_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
   grpc++_alts
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -8679,13 +7911,6 @@ target_link_libraries(async_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8721,13 +7946,6 @@ target_link_libraries(auth_property_iterator_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8765,13 +7983,8 @@ target_include_directories(authorization_engine_test
 target_link_libraries(authorization_engine_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
   absl::flat_hash_set
+  grpc_test_util
 )
 
 
@@ -8807,11 +8020,6 @@ target_link_libraries(aws_request_signer_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8847,11 +8055,6 @@ target_link_libraries(backoff_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8889,11 +8092,6 @@ target_link_libraries(bad_streaming_id_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8931,11 +8129,6 @@ target_link_libraries(badreq_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -8972,11 +8165,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -9014,14 +8202,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9059,14 +8239,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9104,14 +8276,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9149,14 +8313,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9198,14 +8354,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9247,14 +8395,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9292,14 +8432,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9337,14 +8469,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9382,14 +8506,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9427,14 +8543,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9472,14 +8580,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9517,14 +8617,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9562,14 +8654,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9607,14 +8691,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9652,14 +8728,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9696,16 +8764,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(bm_fullstack_trickle
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
     absl::flags
+    benchmark_helpers
   )
 
 
@@ -9743,14 +8803,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9788,14 +8840,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9833,14 +8877,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9878,14 +8914,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9923,14 +8951,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     benchmark_helpers
-    grpc_test_util_unsecure
-    grpc++_unsecure
-    grpc_unsecure
-    grpc++_test_config
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_BENCHMARK_LIBRARIES}
   )
 
 
@@ -9967,13 +8987,6 @@ target_link_libraries(byte_buffer_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10009,11 +9022,6 @@ target_link_libraries(byte_stream_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10050,15 +9058,8 @@ target_include_directories(cancel_ares_query_test
 target_link_libraries(cancel_ares_query_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -10094,11 +9095,6 @@ target_link_libraries(certificate_provider_registry_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10134,11 +9130,6 @@ target_link_libraries(certificate_provider_store_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10187,13 +9178,6 @@ target_link_libraries(cfstream_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10228,13 +9212,8 @@ target_include_directories(channel_arguments_test
 target_link_libraries(channel_arguments_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10269,13 +9248,8 @@ target_include_directories(channel_filter_test
 target_link_libraries(channel_filter_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10315,13 +9289,8 @@ target_include_directories(channel_trace_test
 target_link_libraries(channel_trace_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10356,13 +9325,8 @@ target_include_directories(channelz_registry_test
 target_link_libraries(channelz_registry_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10412,13 +9376,6 @@ target_link_libraries(channelz_service_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpcpp_channelz
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10458,13 +9415,8 @@ target_include_directories(channelz_test
 target_link_libraries(channelz_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10522,14 +9474,6 @@ target_link_libraries(cli_call_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -10579,13 +9523,6 @@ target_link_libraries(client_callback_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10643,13 +9580,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -10700,13 +9630,6 @@ target_link_libraries(client_interceptors_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10765,13 +9688,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -10807,13 +9723,8 @@ target_include_directories(codegen_test_full
 target_link_libraries(codegen_test_full
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10848,13 +9759,8 @@ target_include_directories(codegen_test_minimal
 target_link_libraries(codegen_test_minimal
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -10892,11 +9798,6 @@ target_link_libraries(connection_prefix_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10932,11 +9833,6 @@ target_link_libraries(connectivity_state_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -10985,13 +9881,6 @@ target_link_libraries(context_allocator_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11027,11 +9916,6 @@ target_link_libraries(context_list_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11080,13 +9964,6 @@ target_link_libraries(delegating_channel_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11122,13 +9999,6 @@ target_link_libraries(destroy_grpclb_channel_with_active_connect_stress_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11164,11 +10034,6 @@ target_link_libraries(dual_ref_counted_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11206,11 +10071,6 @@ target_link_libraries(duplicate_header_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11263,15 +10123,8 @@ target_include_directories(end2end_test
 target_link_libraries(end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
   grpc++_test
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -11316,12 +10169,6 @@ target_link_libraries(error_details_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_error_details
   grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11359,11 +10206,6 @@ target_link_libraries(evaluate_args_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11399,11 +10241,6 @@ target_link_libraries(eventmanager_libuv_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11440,13 +10277,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
-    absl::symbolize
-    absl::stacktrace
   )
 
 
@@ -11495,13 +10325,6 @@ target_link_libraries(exception_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11537,11 +10360,6 @@ target_link_libraries(file_watcher_certificate_provider_factory_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11593,13 +10411,6 @@ target_link_libraries(filter_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11648,13 +10459,6 @@ target_link_libraries(flaky_network_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11706,13 +10510,6 @@ target_link_libraries(generic_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11749,11 +10546,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -11790,11 +10582,6 @@ target_link_libraries(global_config_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11831,11 +10618,6 @@ target_link_libraries(google_mesh_ca_certificate_provider_factory_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -11880,14 +10662,9 @@ target_include_directories(grpc_cli
 target_link_libraries(grpc_cli
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -12196,11 +10973,6 @@ target_link_libraries(grpc_tls_certificate_distributor_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12236,11 +11008,6 @@ target_link_libraries(grpc_tls_certificate_provider_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12276,11 +11043,6 @@ target_link_libraries(grpc_tls_credentials_options_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12334,16 +11096,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(grpc_tool_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
     grpc++_reflection
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
-    absl::flags
+    grpc++_test_util
   )
 
 
@@ -12384,13 +11138,6 @@ target_link_libraries(grpclb_api_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12448,13 +11195,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -12491,12 +11231,6 @@ target_link_libraries(h2_ssl_session_reuse_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   end2end_tests
-  grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12534,11 +11268,6 @@ target_link_libraries(head_of_line_blocking_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12576,11 +11305,6 @@ target_link_libraries(headers_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12638,13 +11362,6 @@ target_link_libraries(health_service_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12691,16 +11408,8 @@ target_include_directories(http2_client
 target_link_libraries(http2_client
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
+  grpc++_test_util
 )
 
 
@@ -12753,13 +11462,6 @@ target_link_libraries(hybrid_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12795,11 +11497,6 @@ target_link_libraries(init_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12837,11 +11534,6 @@ target_link_libraries(initial_settings_frame_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12877,11 +11569,6 @@ target_link_libraries(insecure_security_connector_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -12931,16 +11618,8 @@ target_include_directories(interop_client
 target_link_libraries(interop_client
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
+  grpc++_test_util
 )
 
 
@@ -12989,16 +11668,8 @@ target_include_directories(interop_server
 target_link_libraries(interop_server
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
+  grpc++_test_util
 )
 
 
@@ -13034,16 +11705,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(interop_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
-    grpc_test_util
-    grpc++
     grpc++_test_config
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
-    absl::flags
+    grpc++_test_util
   )
 
 
@@ -13080,11 +11743,6 @@ target_link_libraries(json_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13122,11 +11780,6 @@ target_link_libraries(large_metadata_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13165,13 +11818,8 @@ target_include_directories(lb_get_cpu_stats_test
 target_link_libraries(lb_get_cpu_stats_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -13207,13 +11855,8 @@ target_include_directories(lb_load_data_store_test
 target_link_libraries(lb_load_data_store_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -13249,11 +11892,6 @@ target_link_libraries(linux_system_roots_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13289,11 +11927,6 @@ target_link_libraries(log_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13329,11 +11962,6 @@ target_link_libraries(matchers_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13382,13 +12010,6 @@ target_link_libraries(message_allocator_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13439,15 +12060,8 @@ target_include_directories(mock_test
 target_link_libraries(mock_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
   grpc++_test
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -13495,13 +12109,6 @@ target_link_libraries(nonblocking_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13536,13 +12143,8 @@ target_include_directories(noop-benchmark
 target_link_libraries(noop-benchmark
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
   ${_gRPC_BENCHMARK_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -13578,11 +12180,6 @@ target_link_libraries(orphanable_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13620,11 +12217,6 @@ target_link_libraries(out_of_bounds_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13660,11 +12252,6 @@ target_link_libraries(pid_controller_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13713,13 +12300,6 @@ target_link_libraries(port_sharing_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -13772,15 +12352,8 @@ target_include_directories(proto_server_reflection_test
 target_link_libraries(proto_server_reflection_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
   grpc++_reflection
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -13815,13 +12388,8 @@ target_include_directories(proto_utils_test
 target_link_libraries(proto_utils_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -13902,16 +12470,8 @@ target_include_directories(qps_json_driver
 target_link_libraries(qps_json_driver
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
+  grpc++_test_util
 )
 
 
@@ -13984,16 +12544,8 @@ target_include_directories(qps_worker
 target_link_libraries(qps_worker
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
+  grpc++_test_util
 )
 
 
@@ -14046,13 +12598,6 @@ target_link_libraries(raw_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14091,11 +12636,6 @@ target_link_libraries(rbac_translator_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14131,11 +12671,6 @@ target_link_libraries(ref_counted_ptr_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14171,11 +12706,6 @@ target_link_libraries(ref_counted_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14212,11 +12742,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -14253,11 +12778,6 @@ target_link_libraries(retry_throttle_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14293,13 +12813,6 @@ target_link_libraries(secure_auth_context_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14352,13 +12865,6 @@ target_link_libraries(server_builder_plugin_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14406,12 +12912,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(server_builder_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util_unsecure
     grpc++_unsecure
-    grpc_unsecure
-    gpr
-    address_sorting
-    upb
+    grpc_test_util_unsecure
   )
 
 
@@ -14460,12 +12962,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(server_builder_with_socket_mutator_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util_unsecure
     grpc++_unsecure
-    grpc_unsecure
-    gpr
-    address_sorting
-    upb
+    grpc_test_util_unsecure
   )
 
 
@@ -14502,11 +13000,6 @@ target_link_libraries(server_chttp2_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14541,15 +13034,8 @@ target_include_directories(server_context_test_spouse_test
 target_link_libraries(server_context_test_spouse_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
   grpc++_test
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -14597,13 +13083,6 @@ target_link_libraries(server_early_return_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14653,13 +13132,6 @@ target_link_libraries(server_interceptors_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14697,11 +13169,6 @@ target_link_libraries(server_registered_method_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14749,12 +13216,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(server_request_call_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util_unsecure
     grpc++_unsecure
-    grpc_unsecure
-    gpr
-    address_sorting
-    upb
+    grpc_test_util_unsecure
   )
 
 
@@ -14808,13 +13271,6 @@ target_link_libraries(service_config_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14850,11 +13306,6 @@ target_link_libraries(service_config_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14890,11 +13341,6 @@ target_link_libraries(settings_timeout_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14946,13 +13392,6 @@ target_link_libraries(shutdown_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -14990,11 +13429,6 @@ target_link_libraries(simple_request_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15031,12 +13465,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
-    absl::symbolize
   )
 
 
@@ -15073,11 +13501,6 @@ target_link_libraries(stat_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15113,11 +13536,6 @@ target_link_libraries(static_metadata_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15153,11 +13571,6 @@ target_link_libraries(stats_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15193,11 +13606,6 @@ target_link_libraries(status_metadata_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15233,11 +13641,6 @@ target_link_libraries(status_util_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15275,11 +13678,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -15333,13 +13731,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -15375,13 +13766,8 @@ target_include_directories(string_ref_test
 target_link_libraries(string_ref_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -15416,13 +13802,8 @@ target_include_directories(test_cpp_client_credentials_test
 target_link_libraries(test_cpp_client_credentials_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -15457,13 +13838,8 @@ target_include_directories(test_cpp_server_credentials_test
 target_link_libraries(test_cpp_server_credentials_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -15499,13 +13875,6 @@ target_link_libraries(test_cpp_util_slice_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15541,13 +13910,6 @@ target_link_libraries(test_cpp_util_time_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15582,15 +13944,8 @@ target_include_directories(thread_manager_test
 target_link_libraries(thread_manager_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -15643,13 +13998,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -15686,13 +14034,8 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(time_jump_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
     grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
+    grpc_test_util
   )
 
 
@@ -15729,11 +14072,6 @@ target_link_libraries(time_util_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15768,13 +14106,8 @@ target_include_directories(timer_test
 target_link_libraries(timer_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
   grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc_test_util
 )
 
 
@@ -15810,11 +14143,6 @@ target_link_libraries(tls_security_connector_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15850,15 +14178,8 @@ target_include_directories(too_many_pings_test
 target_link_libraries(too_many_pings_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
-  grpc_test_util
-  grpc++
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
+  grpc++_test_util
 )
 
 
@@ -15896,11 +14217,6 @@ target_link_libraries(unknown_frame_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15936,11 +14252,6 @@ target_link_libraries(uri_parser_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -15978,11 +14289,6 @@ target_link_libraries(window_overflow_bad_client_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -16019,11 +14325,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc_test_util
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -16094,15 +14395,10 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(writes_per_rpc_test
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
-    absl::symbolize
-    absl::stacktrace
     absl::failure_signal_handler
+    absl::stacktrace
+    absl::symbolize
+    grpc++
   )
 
 
@@ -16139,11 +14435,6 @@ target_link_libraries(xds_bootstrap_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -16179,11 +14470,6 @@ target_link_libraries(xds_certificate_provider_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -16232,13 +14518,6 @@ target_link_libraries(xds_credentials_end2end_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util
-  grpc_test_util
-  grpc++
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -16274,11 +14553,6 @@ target_link_libraries(xds_credentials_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
 )
 
 
@@ -16440,13 +14714,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTOBUF_LIBRARIES}
     ${_gRPC_ALLTARGETS_LIBRARIES}
     grpc++_test_util
-    grpc_test_util
-    grpc++
-    grpc
-    gpr
-    address_sorting
-    upb
-    ${_gRPC_SSL_LIBRARIES}
   )
 
 
@@ -16494,15 +14761,10 @@ target_include_directories(xds_interop_client
 target_link_libraries(xds_interop_client
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc++
-  grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
   absl::flags
+  grpc++
+  grpc_test_util
+  grpc++_test_config
 )
 
 
@@ -16554,15 +14816,10 @@ target_include_directories(xds_interop_server
 target_link_libraries(xds_interop_server
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc++
-  grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
   absl::flags
+  grpc++
+  grpc_test_util
+  grpc++_test_config
 )
 
 
@@ -16598,14 +14855,9 @@ target_include_directories(alts_credentials_fuzzer_one_entry
 target_link_libraries(alts_credentials_fuzzer_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16641,14 +14893,9 @@ target_include_directories(client_fuzzer_one_entry
 target_link_libraries(client_fuzzer_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16684,14 +14931,9 @@ target_include_directories(hpack_parser_fuzzer_test_one_entry
 target_link_libraries(hpack_parser_fuzzer_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16727,14 +14969,9 @@ target_include_directories(http_request_fuzzer_test_one_entry
 target_link_libraries(http_request_fuzzer_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16770,14 +15007,9 @@ target_include_directories(http_response_fuzzer_test_one_entry
 target_link_libraries(http_response_fuzzer_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16813,14 +15045,9 @@ target_include_directories(json_fuzzer_test_one_entry
 target_link_libraries(json_fuzzer_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16856,14 +15083,9 @@ target_include_directories(nanopb_fuzzer_response_test_one_entry
 target_link_libraries(nanopb_fuzzer_response_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16899,14 +15121,9 @@ target_include_directories(nanopb_fuzzer_serverlist_test_one_entry
 target_link_libraries(nanopb_fuzzer_serverlist_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16942,14 +15159,9 @@ target_include_directories(percent_decode_fuzzer_one_entry
 target_link_libraries(percent_decode_fuzzer_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -16985,14 +15197,9 @@ target_include_directories(percent_encode_fuzzer_one_entry
 target_link_libraries(percent_encode_fuzzer_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -17028,14 +15235,9 @@ target_include_directories(server_fuzzer_one_entry
 target_link_libraries(server_fuzzer_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -17071,14 +15273,9 @@ target_include_directories(ssl_server_fuzzer_one_entry
 target_link_libraries(ssl_server_fuzzer_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -17114,14 +15311,9 @@ target_include_directories(uri_fuzzer_test_one_entry
 target_link_libraries(uri_fuzzer_test_one_entry
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
   grpc_test_util
   grpc++_test_config
-  grpc
-  gpr
-  address_sorting
-  upb
-  ${_gRPC_SSL_LIBRARIES}
-  absl::flags
 )
 
 
@@ -17185,7 +15377,7 @@ generate_pkgconfig(
   "gRPC platform support library"
   "${gRPC_CORE_VERSION}"
   ""
-  "-lgpr -labsl_status -labsl_cord -labsl_str_format_internal -labsl_synchronization -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_stacktrace -labsl_debugging_internal -labsl_malloc_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_bad_optional_access -labsl_raw_logging_internal -labsl_log_severity"
+  "-lgpr -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_status -labsl_cord -labsl_str_format_internal -labsl_bad_optional_access -labsl_symbolize -labsl_strings -labsl_strings_internal -labsl_int128 -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_throw_delegate -labsl_base -labsl_spinlock_wait -labsl_raw_logging_internal -labsl_log_severity"
   ""
   "gpr.pc")
 
@@ -17195,7 +15387,7 @@ generate_pkgconfig(
   "high performance general RPC framework"
   "${gRPC_CORE_VERSION}"
   "gpr openssl"
-  "-lgrpc -laddress_sorting -lre2 -lupb -lcares -lz -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_exponential_biased -labsl_hash -labsl_city -labsl_statusor -labsl_bad_variant_access -labsl_status -labsl_cord -labsl_str_format_internal -labsl_synchronization -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_stacktrace -labsl_debugging_internal -labsl_malloc_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_bad_optional_access -labsl_raw_logging_internal -labsl_log_severity"
+  "-lgrpc -laddress_sorting -lre2 -lupb -lcares -lz -labsl_statusor -labsl_status -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_exponential_biased -labsl_cord -labsl_str_format_internal -labsl_hash -labsl_bad_variant_access -labsl_bad_optional_access -labsl_strings -labsl_strings_internal -labsl_base -labsl_spinlock_wait -labsl_int128 -labsl_city -labsl_throw_delegate -labsl_raw_logging_internal -labsl_log_severity"
   ""
   "grpc.pc")
 
@@ -17205,7 +15397,7 @@ generate_pkgconfig(
   "high performance general RPC framework without SSL"
   "${gRPC_CORE_VERSION}"
   "gpr"
-  "-lgrpc_unsecure -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_exponential_biased -labsl_hash -labsl_city -labsl_statusor -labsl_bad_variant_access -labsl_status -labsl_cord -labsl_str_format_internal -labsl_synchronization -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_stacktrace -labsl_debugging_internal -labsl_malloc_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_bad_optional_access -labsl_raw_logging_internal -labsl_log_severity"
+  "-lgrpc_unsecure -labsl_statusor -labsl_status -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_exponential_biased -labsl_cord -labsl_str_format_internal -labsl_hash -labsl_bad_variant_access -labsl_bad_optional_access -labsl_strings -labsl_strings_internal -labsl_base -labsl_spinlock_wait -labsl_int128 -labsl_city -labsl_throw_delegate -labsl_raw_logging_internal -labsl_log_severity"
   ""
   "grpc_unsecure.pc")
 
@@ -17215,7 +15407,7 @@ generate_pkgconfig(
   "C++ wrapper for gRPC"
   "${gRPC_CPP_VERSION}"
   "grpc"
-  "-lgrpc++ -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_exponential_biased -labsl_hash -labsl_city -labsl_statusor -labsl_bad_variant_access -labsl_status -labsl_cord -labsl_str_format_internal -labsl_synchronization -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_stacktrace -labsl_debugging_internal -labsl_malloc_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_bad_optional_access -labsl_raw_logging_internal -labsl_log_severity"
+  "-lgrpc++ -labsl_statusor -labsl_status -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_exponential_biased -labsl_cord -labsl_str_format_internal -labsl_hash -labsl_bad_variant_access -labsl_bad_optional_access -labsl_strings -labsl_strings_internal -labsl_base -labsl_spinlock_wait -labsl_int128 -labsl_city -labsl_throw_delegate -labsl_raw_logging_internal -labsl_log_severity"
   ""
   "grpc++.pc")
 
@@ -17225,6 +15417,6 @@ generate_pkgconfig(
   "C++ wrapper for gRPC without SSL"
   "${gRPC_CPP_VERSION}"
   "grpc_unsecure"
-  "-lgrpc++_unsecure -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_exponential_biased -labsl_hash -labsl_city -labsl_statusor -labsl_bad_variant_access -labsl_status -labsl_cord -labsl_str_format_internal -labsl_synchronization -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_stacktrace -labsl_debugging_internal -labsl_malloc_internal -labsl_time -labsl_time_zone -labsl_civil_time -labsl_strings -labsl_strings_internal -labsl_throw_delegate -labsl_int128 -labsl_base -labsl_spinlock_wait -labsl_bad_optional_access -labsl_raw_logging_internal -labsl_log_severity"
+  "-lgrpc++_unsecure -labsl_statusor -labsl_status -labsl_raw_hash_set -labsl_hashtablez_sampler -labsl_synchronization -labsl_time -labsl_time_zone -labsl_civil_time -labsl_graphcycles_internal -labsl_symbolize -labsl_demangle_internal -labsl_malloc_internal -labsl_stacktrace -labsl_debugging_internal -labsl_exponential_biased -labsl_cord -labsl_str_format_internal -labsl_hash -labsl_bad_variant_access -labsl_bad_optional_access -labsl_strings -labsl_strings_internal -labsl_base -labsl_spinlock_wait -labsl_int128 -labsl_city -labsl_throw_delegate -labsl_raw_logging_internal -labsl_log_severity"
   ""
   "grpc++_unsecure.pc")

--- a/Makefile
+++ b/Makefile
@@ -1651,17 +1651,7 @@ PUBLIC_HEADERS_C += \
 LIBGRPC_CSHARP_EXT_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC_CSHARP_EXT_SRC))))
 
 
-ifeq ($(NO_SECURE),true)
-
-# You can't build secure libraries if you don't have OpenSSL.
-
-$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a: openssl_dep_error
-
-$(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): openssl_dep_error
-
-else
-
-$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a: $(ZLIB_DEP) $(OPENSSL_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)  $(LIBGRPC_CSHARP_EXT_OBJS) 
+$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a: $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)  $(LIBGRPC_CSHARP_EXT_OBJS) 
 	$(E) "[AR]      Creating $@"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a
@@ -1673,29 +1663,25 @@ endif
 
 
 ifeq ($(SYSTEM),MINGW32)
-$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE)-dll.a -o $(LIBDIR)/$(CONFIG)/grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_DEP)
+$(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE): $(LIBGRPC_CSHARP_EXT_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(RE2_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP) $(LIBDIR)/$(CONFIG)/libgrpc.a
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
 ifeq ($(SYSTEM),Darwin)
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 else
-	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_csharp_ext.so.15 -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libupb.a $(OPENSSL_MERGE_LIBS) $(LDLIBS_SECURE) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpc_csharp_ext.so.15 -o $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBGRPC_CSHARP_EXT_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc.a $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(RE2_MERGE_LIBS) $(UPB_MERGE_LIBS) $(GRPC_ABSEIL_MERGE_LIBS) $(LDLIBS)
 	$(Q) ln -sf $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).so.15
 	$(Q) ln -sf $(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext$(SHARED_VERSION_CORE).so
 endif
 endif
 
-endif
-
-ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
 -include $(LIBGRPC_CSHARP_EXT_OBJS:.o=.dep)
-endif
 endif
 # end of build recipe for library "grpc_csharp_ext"
 
@@ -2926,7 +2912,6 @@ src/core/tsi/ssl/session_cache/ssl_session_openssl.cc: $(OPENSSL_DEP)
 src/core/tsi/ssl_transport_security.cc: $(OPENSSL_DEP)
 src/core/tsi/transport_security.cc: $(OPENSSL_DEP)
 src/core/tsi/transport_security_grpc.cc: $(OPENSSL_DEP)
-src/csharp/ext/grpc_csharp_ext.c: $(OPENSSL_DEP)
 endif
 
 .PHONY: all strip tools dep_error openssl_dep_error openssl_dep_message git_update stop buildtests buildtests_c buildtests_cxx test test_c test_cxx install install_c install_cxx install_csharp install-static install-certs strip strip-shared strip-static strip_c strip-shared_c strip-static_c strip_cxx strip-shared_cxx strip-static_cxx dep_c dep_cxx bins_dep_c bins_dep_cxx clean

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -116,11 +116,6 @@ libs:
   - test/core/end2end/tests/write_buffering_at_end.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: end2end_tests
   build: private
   language: c
@@ -226,11 +221,6 @@ libs:
   - test/core/end2end/tests/write_buffering_at_end.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: gpr
   build: all
   language: c
@@ -356,14 +346,14 @@ libs:
   - src/core/lib/profiling/basic_timers.cc
   - src/core/lib/profiling/stap_timers.cc
   deps:
-  - absl/types:optional
-  - absl/time:time
-  - absl/synchronization:synchronization
-  - absl/strings:strings
-  - absl/strings:str_format
-  - absl/status:status
-  - absl/memory:memory
   - absl/base:base
+  - absl/memory:memory
+  - absl/status:status
+  - absl/strings:str_format
+  - absl/strings:strings
+  - absl/synchronization:synchronization
+  - absl/time:time
+  - absl/types:optional
 - name: grpc
   build: all
   language: c
@@ -1412,17 +1402,14 @@ libs:
   - src/core/tsi/transport_security.cc
   - src/core/tsi/transport_security_grpc.cc
   deps:
+  - absl/container:flat_hash_map
+  - absl/container:inlined_vector
+  - absl/functional:bind_front
+  - absl/status:statusor
   - gpr
+  - libssl
   - address_sorting
   - upb
-  - libssl
-  - absl/types:optional
-  - absl/strings:strings
-  - absl/status:statusor
-  - absl/status:status
-  - absl/functional:bind_front
-  - absl/container:inlined_vector
-  - absl/container:flat_hash_map
   baselib: true
   generate_plugin_registry: true
 - name: grpc_csharp_ext
@@ -1434,10 +1421,6 @@ libs:
   - src/csharp/ext/grpc_csharp_ext.c
   deps:
   - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_test_util
   build: private
   language: c
@@ -1489,14 +1472,10 @@ libs:
   - test/core/util/tracer_util.cc
   - test/core/util/trickle_endpoint.cc
   deps:
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/debugging:symbolize
-  - absl/debugging:stacktrace
   - absl/debugging:failure_signal_handler
+  - absl/debugging:stacktrace
+  - absl/debugging:symbolize
+  - grpc
 - name: grpc_test_util_unsecure
   build: private
   language: c
@@ -1546,13 +1525,10 @@ libs:
   - test/core/util/tracer_util.cc
   - test/core/util/trickle_endpoint.cc
   deps:
-  - grpc_unsecure
-  - gpr
-  - address_sorting
-  - upb
-  - absl/debugging:symbolize
-  - absl/debugging:stacktrace
   - absl/debugging:failure_signal_handler
+  - absl/debugging:stacktrace
+  - absl/debugging:symbolize
+  - grpc_unsecure
 - name: grpc_unsecure
   build: all
   language: c
@@ -2095,15 +2071,12 @@ libs:
   - src/core/lib/uri/uri_parser.cc
   - src/core/plugin_registry/grpc_unsecure_plugin_registry.cc
   deps:
+  - absl/container:flat_hash_map
+  - absl/container:inlined_vector
+  - absl/status:statusor
   - gpr
   - address_sorting
   - upb
-  - absl/types:optional
-  - absl/strings:strings
-  - absl/status:statusor
-  - absl/status:status
-  - absl/container:inlined_vector
-  - absl/container:flat_hash_map
   baselib: true
   generate_plugin_registry: true
 - name: benchmark_helpers
@@ -2120,14 +2093,10 @@ libs:
   - src/proto/grpc/testing/simple_messages.proto
   - test/cpp/microbenchmarks/helpers.cc
   deps:
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
   - benchmark
+  - grpc++_unsecure
+  - grpc_test_util_unsecure
+  - grpc++_test_config
   defaults: benchmark
 - name: grpc++
   build: all
@@ -2383,11 +2352,6 @@ libs:
   - src/cpp/util/time_cc.cc
   deps:
   - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/synchronization:synchronization
   baselib: true
 - name: grpc++_alts
   build: all
@@ -2401,11 +2365,6 @@ libs:
   - src/cpp/common/alts_util.cc
   deps:
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   baselib: true
 - name: grpc++_error_details
   build: all
@@ -2418,11 +2377,6 @@ libs:
   - src/cpp/util/error_details.cc
   deps:
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc++_reflection
   build: all
   language: c++
@@ -2437,11 +2391,6 @@ libs:
   - src/cpp/ext/proto_server_reflection_plugin.cc
   deps:
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc++_test
   build: private
   language: c++
@@ -2457,11 +2406,6 @@ libs:
   - src/cpp/client/channel_test_peer.cc
   deps:
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc++_test_config
   build: private
   language: c++
@@ -2471,8 +2415,8 @@ libs:
   src:
   - test/cpp/util/test_config_cc.cc
   deps:
-  - gpr
   - absl/flags:parse
+  - gpr
 - name: grpc++_test_util
   build: private
   language: c++
@@ -2495,14 +2439,9 @@ libs:
   - test/cpp/util/subprocess.cc
   - test/cpp/util/test_credentials_provider.cc
   deps:
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   - absl/flags:flag
+  - grpc++
+  - grpc_test_util
 - name: grpc++_unsecure
   build: all
   language: c++
@@ -2742,10 +2681,6 @@ libs:
   - src/cpp/util/time_cc.cc
   deps:
   - grpc_unsecure
-  - gpr
-  - address_sorting
-  - upb
-  - absl/synchronization:synchronization
   baselib: true
 - name: grpc_plugin_support
   build: protoc
@@ -2799,11 +2734,6 @@ libs:
   - src/cpp/server/channelz/channelz_service_plugin.cc
   deps:
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 targets:
 - name: algorithm_test
   build: test
@@ -2813,11 +2743,6 @@ targets:
   - test/core/compression/algorithm_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: alloc_test
   build: test
@@ -2827,11 +2752,6 @@ targets:
   - test/core/gpr/alloc_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: alpn_test
   build: test
@@ -2841,11 +2761,6 @@ targets:
   - test/core/transport/chttp2/alpn_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_counter_test
   build: test
   language: c
@@ -2856,11 +2771,6 @@ targets:
   - test/core/tsi/alts/frame_protector/alts_counter_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_crypt_test
   build: test
   language: c
@@ -2871,11 +2781,6 @@ targets:
   - test/core/tsi/alts/crypt/gsec_test_util.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_crypter_test
   build: test
   language: c
@@ -2886,11 +2791,6 @@ targets:
   - test/core/tsi/alts/frame_protector/alts_crypter_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_frame_protector_test
   build: test
   language: c
@@ -2903,11 +2803,6 @@ targets:
   - test/core/tsi/transport_security_test_lib.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_grpc_record_protocol_test
   build: test
   language: c
@@ -2918,11 +2813,6 @@ targets:
   - test/core/tsi/alts/zero_copy_frame_protector/alts_grpc_record_protocol_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_handshaker_client_test
   build: test
   language: c
@@ -2933,11 +2823,6 @@ targets:
   - test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_iovec_record_protocol_test
   build: test
   language: c
@@ -2948,11 +2833,6 @@ targets:
   - test/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_security_connector_test
   build: test
   language: c
@@ -2961,11 +2841,6 @@ targets:
   - test/core/security/alts_security_connector_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_tsi_handshaker_test
   build: test
   language: c
@@ -2976,11 +2851,6 @@ targets:
   - test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_tsi_utils_test
   build: test
   language: c
@@ -2991,11 +2861,6 @@ targets:
   - test/core/tsi/alts/handshaker/alts_tsi_utils_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: alts_zero_copy_grpc_protector_test
   build: test
   language: c
@@ -3006,11 +2871,6 @@ targets:
   - test/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: arena_test
   build: test
   language: c
@@ -3019,11 +2879,6 @@ targets:
   - test/core/gpr/arena_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: auth_context_test
   build: test
@@ -3033,11 +2888,6 @@ targets:
   - test/core/security/auth_context_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: avl_test
   build: test
@@ -3047,11 +2897,6 @@ targets:
   - test/core/avl/avl_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: b64_test
   build: test
@@ -3061,11 +2906,6 @@ targets:
   - test/core/slice/b64_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: bad_server_response_test
   build: test
@@ -3077,11 +2917,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: bad_ssl_alpn_test
   build: test
   language: c
@@ -3092,11 +2927,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3111,11 +2941,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3128,11 +2953,6 @@ targets:
   - test/core/transport/chttp2/bin_decoder_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: bin_encoder_test
   build: test
@@ -3142,11 +2962,6 @@ targets:
   - test/core/transport/chttp2/bin_encoder_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: buffer_list_test
   build: test
@@ -3156,11 +2971,6 @@ targets:
   - test/core/iomgr/buffer_list_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: channel_args_test
   build: test
   language: c
@@ -3169,11 +2979,6 @@ targets:
   - test/core/channel/channel_args_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: channel_create_test
   build: test
@@ -3183,11 +2988,6 @@ targets:
   - test/core/surface/channel_create_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: channel_stack_builder_test
   build: test
   language: c
@@ -3196,11 +2996,6 @@ targets:
   - test/core/channel/channel_stack_builder_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: channel_stack_test
   build: test
   language: c
@@ -3209,11 +3004,6 @@ targets:
   - test/core/channel/channel_stack_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: check_gcp_environment_linux_test
   build: test
@@ -3223,11 +3013,6 @@ targets:
   - test/core/security/check_gcp_environment_linux_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: check_gcp_environment_windows_test
   build: test
   language: c
@@ -3236,11 +3021,6 @@ targets:
   - test/core/security/check_gcp_environment_windows_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: client_ssl_test
   build: test
   language: c
@@ -3249,11 +3029,6 @@ targets:
   - test/core/handshake/client_ssl.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3266,11 +3041,6 @@ targets:
   - test/core/util/cmdline_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: combiner_test
   build: test
@@ -3280,11 +3050,6 @@ targets:
   - test/core/iomgr/combiner_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3298,11 +3063,6 @@ targets:
   - test/core/surface/completion_queue_threading_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: compression_test
   build: test
   language: c
@@ -3311,11 +3071,6 @@ targets:
   - test/core/compression/compression_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: concurrent_connectivity_test
   build: test
@@ -3325,11 +3080,6 @@ targets:
   - test/core/surface/concurrent_connectivity_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: connection_refused_test
   build: test
   language: c
@@ -3340,11 +3090,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: cpu_test
   build: test
   language: c
@@ -3353,11 +3098,6 @@ targets:
   - test/core/gpr/cpu_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: dns_resolver_connectivity_using_ares_test
   build: test
@@ -3367,11 +3107,6 @@ targets:
   - test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   args:
   - --resolver=ares
 - name: dns_resolver_connectivity_using_native_test
@@ -3382,11 +3117,6 @@ targets:
   - test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   args:
   - --resolver=native
 - name: dns_resolver_cooldown_test
@@ -3397,11 +3127,6 @@ targets:
   - test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: dns_resolver_test
   build: test
   language: c
@@ -3410,11 +3135,6 @@ targets:
   - test/core/client_channel/resolvers/dns_resolver_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: dualstack_socket_test
   build: test
   language: c
@@ -3425,11 +3145,6 @@ targets:
   - test/core/end2end/dualstack_socket_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3444,11 +3159,6 @@ targets:
   - test/core/iomgr/endpoint_tests.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: env_test
   build: test
   language: c
@@ -3457,11 +3167,6 @@ targets:
   - test/core/gpr/env_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: error_test
   build: test
@@ -3473,11 +3178,6 @@ targets:
   - test/core/iomgr/error_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: ev_epollex_linux_test
   build: test
@@ -3487,11 +3187,6 @@ targets:
   - test/core/iomgr/ev_epollex_linux_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3504,11 +3199,6 @@ targets:
   - test/core/client_channel/resolvers/fake_resolver_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: fake_transport_security_test
   build: test
   language: c
@@ -3519,11 +3209,6 @@ targets:
   - test/core/tsi/transport_security_test_lib.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: fd_conservation_posix_test
   build: test
   language: c
@@ -3532,11 +3217,6 @@ targets:
   - test/core/iomgr/fd_conservation_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3549,11 +3229,6 @@ targets:
   - test/core/iomgr/fd_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3571,11 +3246,6 @@ targets:
   - test/core/fling/fling_stream_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3593,11 +3263,6 @@ targets:
   - test/core/fling/fling_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3610,11 +3275,6 @@ targets:
   - test/core/gprpp/fork_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3633,11 +3293,6 @@ targets:
   - test/core/http/format_request_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: frame_handler_test
   build: test
   language: c
@@ -3648,11 +3303,6 @@ targets:
   - test/core/tsi/alts/frame_protector/frame_handler_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: goaway_server_test
   build: test
   language: c
@@ -3663,11 +3313,6 @@ targets:
   - test/core/end2end/goaway_server_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_alts_credentials_options_test
   build: test
   language: c
@@ -3676,11 +3321,6 @@ targets:
   - test/core/security/grpc_alts_credentials_options_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_byte_buffer_reader_test
   build: test
   language: c
@@ -3689,11 +3329,6 @@ targets:
   - test/core/surface/byte_buffer_reader_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: grpc_completion_queue_test
   build: test
@@ -3703,11 +3338,6 @@ targets:
   - test/core/surface/completion_queue_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_ipv6_loopback_available_test
   build: test
   language: c
@@ -3716,11 +3346,6 @@ targets:
   - test/core/iomgr/grpc_ipv6_loopback_available_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: handshake_server_with_readahead_handshaker_test
   build: test
   language: c
@@ -3731,11 +3356,6 @@ targets:
   - test/core/handshake/server_ssl_common.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3748,11 +3368,6 @@ targets:
   - test/core/handshake/verify_peer_options.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3765,11 +3380,6 @@ targets:
   - test/core/util/histogram_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: host_port_test
   build: test
@@ -3779,11 +3389,6 @@ targets:
   - test/core/gprpp/host_port_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: hpack_encoder_test
   build: test
@@ -3793,11 +3398,6 @@ targets:
   - test/core/transport/chttp2/hpack_encoder_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: hpack_parser_test
   build: test
@@ -3807,11 +3407,6 @@ targets:
   - test/core/transport/chttp2/hpack_parser_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: hpack_table_test
   build: test
@@ -3821,11 +3416,6 @@ targets:
   - test/core/transport/chttp2/hpack_table_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: httpcli_test
   build: test
@@ -3840,11 +3430,6 @@ targets:
   - test/core/http/httpcli_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3862,11 +3447,6 @@ targets:
   - test/core/http/httpscli_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -3879,12 +3459,6 @@ targets:
   - test/core/end2end/inproc_callback_test.cc
   deps:
   - end2end_tests
-  - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: invalid_call_argument_test
   build: test
@@ -3896,11 +3470,6 @@ targets:
   - test/core/end2end/invalid_call_argument_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: json_token_test
   build: test
   language: c
@@ -3909,11 +3478,6 @@ targets:
   - test/core/security/json_token_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: jwt_verifier_test
   build: test
@@ -3923,11 +3487,6 @@ targets:
   - test/core/security/jwt_verifier_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: lame_client_test
   build: test
@@ -3939,11 +3498,6 @@ targets:
   - test/core/surface/lame_client_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: load_file_test
   build: test
   language: c
@@ -3952,11 +3506,6 @@ targets:
   - test/core/iomgr/load_file_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: manual_constructor_test
   build: test
@@ -3966,11 +3515,6 @@ targets:
   - test/core/gprpp/manual_constructor_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: message_compress_test
   build: test
@@ -3980,11 +3524,6 @@ targets:
   - test/core/compression/message_compress_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: metadata_test
   build: test
@@ -3994,11 +3533,6 @@ targets:
   - test/core/transport/metadata_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: minimal_stack_is_minimal_test
   build: test
   language: c
@@ -4007,11 +3541,6 @@ targets:
   - test/core/channel/minimal_stack_is_minimal_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: mpmcqueue_test
   build: test
@@ -4021,11 +3550,6 @@ targets:
   - test/core/iomgr/mpmcqueue_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: mpscq_test
   build: test
@@ -4035,11 +3559,6 @@ targets:
   - test/core/gprpp/mpscq_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4055,11 +3574,6 @@ targets:
   - test/core/end2end/multiple_server_queues_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: murmur_hash_test
   build: test
   language: c
@@ -4068,11 +3582,6 @@ targets:
   - test/core/gpr/murmur_hash_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: no_server_test
   build: test
@@ -4084,11 +3593,6 @@ targets:
   - test/core/end2end/no_server_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: num_external_connectivity_watchers_test
   build: test
   language: c
@@ -4097,11 +3601,6 @@ targets:
   - test/core/surface/num_external_connectivity_watchers_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: parse_address_test
   build: test
   language: c
@@ -4110,11 +3609,6 @@ targets:
   - test/core/iomgr/parse_address_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: parse_address_with_named_scope_id_test
   build: test
   language: c
@@ -4123,11 +3617,6 @@ targets:
   - test/core/iomgr/parse_address_with_named_scope_id_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4146,11 +3635,6 @@ targets:
   - test/core/http/parser_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: percent_encoding_test
   build: test
@@ -4160,11 +3644,6 @@ targets:
   - test/core/slice/percent_encoding_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: public_headers_must_be_c89
   build: test
@@ -4174,11 +3653,6 @@ targets:
   - test/core/surface/public_headers_must_be_c89.c
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: resolve_address_using_ares_resolver_posix_test
   build: test
   language: c
@@ -4187,11 +3661,6 @@ targets:
   - test/core/iomgr/resolve_address_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   args:
   - --resolver=ares
   platforms:
@@ -4206,11 +3675,6 @@ targets:
   - test/core/iomgr/resolve_address_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   args:
   - --resolver=ares
 - name: resolve_address_using_native_resolver_posix_test
@@ -4221,11 +3685,6 @@ targets:
   - test/core/iomgr/resolve_address_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   args:
   - --resolver=native
   platforms:
@@ -4240,11 +3699,6 @@ targets:
   - test/core/iomgr/resolve_address_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   args:
   - --resolver=native
 - name: resource_quota_test
@@ -4255,11 +3709,6 @@ targets:
   - test/core/iomgr/resource_quota_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: secure_channel_create_test
   build: test
   language: c
@@ -4268,11 +3717,6 @@ targets:
   - test/core/surface/secure_channel_create_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: secure_endpoint_test
   build: test
   language: c
@@ -4283,11 +3727,6 @@ targets:
   - test/core/security/secure_endpoint_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: security_connector_test
   build: test
   language: c
@@ -4296,11 +3735,6 @@ targets:
   - test/core/security/security_connector_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: sequential_connectivity_test
   build: test
   run: false
@@ -4310,11 +3744,6 @@ targets:
   - test/core/surface/sequential_connectivity_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_ssl_test
   build: test
   language: c
@@ -4325,11 +3754,6 @@ targets:
   - test/core/handshake/server_ssl_common.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4342,11 +3766,6 @@ targets:
   - test/core/surface/server_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: slice_buffer_test
   build: test
   language: c
@@ -4355,11 +3774,6 @@ targets:
   - test/core/slice/slice_buffer_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: slice_string_helpers_test
   build: test
@@ -4369,11 +3783,6 @@ targets:
   - test/core/slice/slice_string_helpers_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: sockaddr_resolver_test
   build: test
@@ -4383,11 +3792,6 @@ targets:
   - test/core/client_channel/resolvers/sockaddr_resolver_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: sockaddr_utils_test
   build: test
   language: c
@@ -4396,11 +3800,6 @@ targets:
   - test/core/iomgr/sockaddr_utils_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: socket_utils_test
   build: test
   language: c
@@ -4409,11 +3808,6 @@ targets:
   - test/core/iomgr/socket_utils_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4426,11 +3820,6 @@ targets:
   - test/core/gpr/spinlock_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: ssl_credentials_test
   build: test
@@ -4440,11 +3829,6 @@ targets:
   - test/core/security/ssl_credentials_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: ssl_transport_security_test
   build: test
   language: c
@@ -4455,11 +3839,6 @@ targets:
   - test/core/tsi/transport_security_test_lib.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4472,11 +3851,6 @@ targets:
   - test/core/transport/status_conversion_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: stream_compression_test
   build: test
@@ -4486,11 +3860,6 @@ targets:
   - test/core/compression/stream_compression_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: stream_map_test
   build: test
@@ -4500,11 +3869,6 @@ targets:
   - test/core/transport/chttp2/stream_map_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: stream_owned_slice_test
   build: test
   language: c
@@ -4513,11 +3877,6 @@ targets:
   - test/core/transport/stream_owned_slice_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: string_test
   build: test
@@ -4527,11 +3886,6 @@ targets:
   - test/core/gpr/string_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: sync_test
   build: test
@@ -4541,11 +3895,6 @@ targets:
   - test/core/gpr/sync_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: tcp_client_posix_test
   build: test
@@ -4555,11 +3904,6 @@ targets:
   - test/core/iomgr/tcp_client_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4574,11 +3918,6 @@ targets:
   - test/core/iomgr/tcp_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4590,11 +3929,6 @@ targets:
   - test/core/iomgr/tcp_server_posix_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4607,11 +3941,6 @@ targets:
   - test/core/gpr/time_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: test_core_security_credentials_test
   build: test
@@ -4621,11 +3950,6 @@ targets:
   - test/core/security/credentials_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: test_core_slice_slice_test
   build: test
   language: c
@@ -4634,11 +3958,6 @@ targets:
   - test/core/slice/slice_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: thd_test
   build: test
@@ -4648,11 +3967,6 @@ targets:
   - test/core/gprpp/thd_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: threadpool_test
   build: test
@@ -4662,11 +3976,6 @@ targets:
   - test/core/iomgr/threadpool_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: time_averaged_stats_test
   build: test
@@ -4676,11 +3985,6 @@ targets:
   - test/core/iomgr/time_averaged_stats_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: timeout_encoding_test
   build: test
@@ -4690,11 +3994,6 @@ targets:
   - test/core/transport/timeout_encoding_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: timer_heap_test
   build: test
@@ -4704,11 +4003,6 @@ targets:
   - test/core/iomgr/timer_heap_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: timer_list_test
   build: test
@@ -4718,11 +4012,6 @@ targets:
   - test/core/iomgr/timer_list_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: tls_test
   build: test
@@ -4732,11 +4021,6 @@ targets:
   - test/core/gpr/tls_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: transport_security_common_api_test
   build: test
@@ -4746,11 +4030,6 @@ targets:
   - test/core/tsi/alts/handshaker/transport_security_common_api_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: transport_security_test
   build: test
   language: c
@@ -4759,11 +4038,6 @@ targets:
   - test/core/tsi/transport_security_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: udp_server_test
   build: test
   language: c
@@ -4772,11 +4046,6 @@ targets:
   - test/core/iomgr/udp_server_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -4789,11 +4058,6 @@ targets:
   - test/core/gpr/useful_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: varint_test
   build: test
@@ -4803,11 +4067,6 @@ targets:
   - test/core/transport/chttp2/varint_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: address_sorting_test
   gtest: true
@@ -4817,15 +4076,8 @@ targets:
   src:
   - test/cpp/naming/address_sorting_test.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
   platforms:
   - linux
   - posix
@@ -4844,13 +4096,9 @@ targets:
   - test/cpp/util/string_ref_helper.cc
   - test/cpp/util/subprocess.cc
   deps:
-  - grpc_test_util_unsecure
   - grpc++_unsecure
-  - grpc_unsecure
+  - grpc_test_util_unsecure
   - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
   platforms:
   - linux
   - posix
@@ -4863,12 +4111,8 @@ targets:
   src:
   - test/cpp/common/alarm_test.cc
   deps:
-  - grpc_test_util_unsecure
   - grpc++_unsecure
-  - grpc_unsecure
-  - gpr
-  - address_sorting
-  - upb
+  - grpc_test_util_unsecure
   platforms:
   - linux
   - posix
@@ -4887,13 +4131,8 @@ targets:
   - test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
   - test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   platforms:
   - linux
   - posix
@@ -4905,14 +4144,9 @@ targets:
   - test/core/security/alts_credentials_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/security/corpus/alts_credentials_corpus
   maxlen: 2048
@@ -4924,15 +4158,8 @@ targets:
   src:
   - test/cpp/common/alts_util_test.cc
   deps:
-  - grpc++_test_util
   - grpc++_alts
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: async_end2end_test
   gtest: true
   build: test
@@ -4947,13 +4174,6 @@ targets:
   - test/cpp/end2end/async_end2end_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: auth_property_iterator_test
   gtest: true
   build: test
@@ -4963,13 +4183,6 @@ targets:
   - test/cpp/common/auth_property_iterator_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: authorization_engine_test
   gtest: true
@@ -4991,13 +4204,8 @@ targets:
   - src/core/lib/security/authorization/rbac_policy.cc
   - test/core/security/authorization_engine_test.cc
   deps:
-  - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   - absl/container:flat_hash_set
+  - grpc_test_util
 - name: aws_request_signer_test
   gtest: true
   build: test
@@ -5007,11 +4215,6 @@ targets:
   - test/core/security/aws_request_signer_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: backoff_test
   gtest: true
   build: test
@@ -5021,11 +4224,6 @@ targets:
   - test/core/backoff/backoff_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: bad_streaming_id_bad_client_test
   gtest: true
@@ -5040,11 +4238,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: badreq_bad_client_test
   gtest: true
   build: test
@@ -5058,11 +4251,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: bdp_estimator_test
   gtest: true
   build: test
@@ -5072,11 +4260,6 @@ targets:
   - test/core/transport/bdp_estimator_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -5090,14 +4273,6 @@ targets:
   - test/cpp/microbenchmarks/bm_alarm.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5111,14 +4286,6 @@ targets:
   - test/cpp/microbenchmarks/bm_arena.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5133,14 +4300,6 @@ targets:
   - test/cpp/microbenchmarks/bm_byte_buffer.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5155,14 +4314,6 @@ targets:
   - test/cpp/microbenchmarks/bm_call_create.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5187,14 +4338,6 @@ targets:
   - test/cpp/util/subprocess.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5218,14 +4361,6 @@ targets:
   - test/cpp/util/subprocess.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5239,14 +4374,6 @@ targets:
   - test/cpp/microbenchmarks/bm_channel.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5261,14 +4388,6 @@ targets:
   - test/cpp/microbenchmarks/bm_chttp2_hpack.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5283,14 +4402,6 @@ targets:
   - test/cpp/microbenchmarks/bm_chttp2_transport.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5304,14 +4415,6 @@ targets:
   - test/cpp/microbenchmarks/bm_closure.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5325,14 +4428,6 @@ targets:
   - test/cpp/microbenchmarks/bm_cq.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5346,14 +4441,6 @@ targets:
   - test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5368,14 +4455,6 @@ targets:
   - test/cpp/microbenchmarks/bm_error.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5391,14 +4470,6 @@ targets:
   - test/cpp/microbenchmarks/bm_fullstack_streaming_ping_pong.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5413,14 +4484,6 @@ targets:
   - test/cpp/microbenchmarks/bm_fullstack_streaming_pump.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5434,16 +4497,8 @@ targets:
   src:
   - test/cpp/microbenchmarks/bm_fullstack_trickle.cc
   deps:
-  - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   - absl/flags:flag
+  - benchmark_helpers
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5459,14 +4514,6 @@ targets:
   - test/cpp/microbenchmarks/bm_fullstack_unary_ping_pong.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5480,14 +4527,6 @@ targets:
   - test/cpp/microbenchmarks/bm_metadata.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5502,14 +4541,6 @@ targets:
   - test/cpp/microbenchmarks/bm_pollset.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5524,14 +4555,6 @@ targets:
   - test/cpp/microbenchmarks/bm_threadpool.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5547,14 +4570,6 @@ targets:
   - test/cpp/microbenchmarks/bm_timer.cc
   deps:
   - benchmark_helpers
-  - grpc_test_util_unsecure
-  - grpc++_unsecure
-  - grpc_unsecure
-  - grpc++_test_config
-  - gpr
-  - address_sorting
-  - upb
-  - benchmark
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5570,13 +4585,6 @@ targets:
   - test/cpp/util/byte_buffer_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: byte_stream_test
   gtest: true
@@ -5587,11 +4595,6 @@ targets:
   - test/core/transport/byte_stream_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: cancel_ares_query_test
   gtest: true
@@ -5605,15 +4608,8 @@ targets:
   - test/cpp/naming/cancel_ares_query_test.cc
   - test/cpp/naming/dns_test_util.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: certificate_provider_registry_test
   gtest: true
   build: test
@@ -5623,11 +4619,6 @@ targets:
   - test/core/client_channel/certificate_provider_registry_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: certificate_provider_store_test
   gtest: true
   build: test
@@ -5637,11 +4628,6 @@ targets:
   - test/core/xds/certificate_provider_store_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: cfstream_test
   gtest: true
   build: test
@@ -5657,13 +4643,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: channel_arguments_test
   gtest: true
   build: test
@@ -5672,13 +4651,8 @@ targets:
   src:
   - test/cpp/common/channel_arguments_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: channel_filter_test
   gtest: true
@@ -5688,13 +4662,8 @@ targets:
   src:
   - test/cpp/common/channel_filter_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: channel_trace_test
   gtest: true
@@ -5707,13 +4676,8 @@ targets:
   - test/core/channel/channel_trace_test.cc
   - test/cpp/util/channel_trace_proto_helper.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: channelz_registry_test
   gtest: true
   build: test
@@ -5722,13 +4686,8 @@ targets:
   src:
   - test/core/channel/channelz_registry_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: channelz_service_test
   gtest: true
@@ -5745,13 +4704,6 @@ targets:
   deps:
   - grpcpp_channelz
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: channelz_test
   gtest: true
   build: test
@@ -5763,13 +4715,8 @@ targets:
   - test/core/channel/channelz_test.cc
   - test/cpp/util/channel_trace_proto_helper.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: cli_call_test
   gtest: true
   build: test
@@ -5796,14 +4743,6 @@ targets:
   - test/cpp/util/service_describer.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
 - name: client_callback_end2end_test
   gtest: true
   build: test
@@ -5820,13 +4759,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: client_channel_stress_test
   gtest: true
   build: test
@@ -5844,13 +4776,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -5863,14 +4788,9 @@ targets:
   - test/core/end2end/fuzzers/client_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/end2end/fuzzers/client_fuzzer_corpus
   dict: test/core/end2end/fuzzers/hpack.dictionary
@@ -5891,13 +4811,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: client_lb_end2end_test
   gtest: true
   build: test
@@ -5917,13 +4830,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -5936,13 +4842,8 @@ targets:
   src:
   - test/cpp/codegen/codegen_test_full.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: codegen_test_minimal
   gtest: true
@@ -5952,13 +4853,8 @@ targets:
   src:
   - test/cpp/codegen/codegen_test_minimal.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: connection_prefix_bad_client_test
   gtest: true
@@ -5973,11 +4869,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: connectivity_state_test
   gtest: true
   build: test
@@ -5987,11 +4878,6 @@ targets:
   - test/core/transport/connectivity_state_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: context_allocator_end2end_test
   gtest: true
   build: test
@@ -6006,13 +4892,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: context_list_test
   gtest: true
   build: test
@@ -6022,11 +4901,6 @@ targets:
   - test/core/transport/chttp2/context_list_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: delegating_channel_test
   gtest: true
@@ -6042,13 +4916,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: destroy_grpclb_channel_with_active_connect_stress_test
   gtest: true
   build: test
@@ -6058,13 +4925,6 @@ targets:
   - test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: dual_ref_counted_test
   gtest: true
   build: test
@@ -6074,11 +4934,6 @@ targets:
   - test/core/gprpp/dual_ref_counted_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: duplicate_header_bad_client_test
   gtest: true
   build: test
@@ -6092,11 +4947,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: end2end_test
   gtest: true
   build: test
@@ -6114,15 +4964,8 @@ targets:
   - test/cpp/end2end/interceptors_util.cc
   - test/cpp/end2end/test_service_impl.cc
   deps:
-  - grpc++_test_util
   - grpc++_test
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: error_details_test
   gtest: true
   build: test
@@ -6135,12 +4978,6 @@ targets:
   deps:
   - grpc++_error_details
   - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: evaluate_args_test
   gtest: true
   build: test
@@ -6154,11 +4991,6 @@ targets:
   - test/core/security/evaluate_args_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: eventmanager_libuv_test
   gtest: true
   build: test
@@ -6168,11 +5000,6 @@ targets:
   - test/core/iomgr/poller/eventmanager_libuv_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: examine_stack_test
   gtest: true
@@ -6183,13 +5010,6 @@ targets:
   - test/core/gprpp/examine_stack_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/debugging:symbolize
-  - absl/debugging:stacktrace
   platforms:
   - linux
   - posix
@@ -6207,13 +5027,6 @@ targets:
   - test/cpp/end2end/exception_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: file_watcher_certificate_provider_factory_test
   gtest: true
   build: test
@@ -6223,11 +5036,6 @@ targets:
   - test/core/xds/file_watcher_certificate_provider_factory_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: filter_end2end_test
   gtest: true
   build: test
@@ -6241,13 +5049,6 @@ targets:
   - test/cpp/end2end/filter_end2end_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: flaky_network_test
   gtest: true
   build: test
@@ -6263,13 +5064,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: generic_end2end_test
   gtest: true
   build: test
@@ -6283,13 +5077,6 @@ targets:
   - test/cpp/end2end/generic_end2end_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: global_config_env_test
   gtest: true
   build: test
@@ -6299,11 +5086,6 @@ targets:
   - test/core/gprpp/global_config_env_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -6318,11 +5100,6 @@ targets:
   - test/core/gprpp/global_config_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: google_mesh_ca_certificate_provider_factory_test
   gtest: true
@@ -6335,11 +5112,6 @@ targets:
   - test/core/xds/google_mesh_ca_certificate_provider_factory_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_cli
   build: test
   run: false
@@ -6362,14 +5134,9 @@ targets:
   - test/cpp/util/proto_reflection_descriptor_database.cc
   - test/cpp/util/service_describer.cc
   deps:
+  - absl/flags:flag
   - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
 - name: grpc_cpp_plugin
   build: protoc
   language: c++
@@ -6435,11 +5202,6 @@ targets:
   - test/core/security/grpc_tls_certificate_distributor_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_tls_certificate_provider_test
   gtest: true
   build: test
@@ -6449,11 +5211,6 @@ targets:
   - test/core/security/grpc_tls_certificate_provider_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_tls_credentials_options_test
   gtest: true
   build: test
@@ -6463,11 +5220,6 @@ targets:
   - test/core/security/grpc_tls_credentials_options_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpc_tool_test
   gtest: true
   build: test
@@ -6492,16 +5244,8 @@ targets:
   - test/cpp/util/proto_reflection_descriptor_database.cc
   - test/cpp/util/service_describer.cc
   deps:
-  - grpc++_test_util
   - grpc++_reflection
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
   platforms:
   - linux
   - posix
@@ -6516,13 +5260,6 @@ targets:
   - test/cpp/grpclb/grpclb_api_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: grpclb_end2end_test
   gtest: true
   build: test
@@ -6540,13 +5277,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -6560,12 +5290,6 @@ targets:
   - test/core/end2end/h2_ssl_session_reuse_test.cc
   deps:
   - end2end_tests
-  - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: head_of_line_blocking_bad_client_test
   gtest: true
   build: test
@@ -6579,11 +5303,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: headers_bad_client_test
   gtest: true
   build: test
@@ -6597,11 +5316,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: health_service_end2end_test
   gtest: true
   build: test
@@ -6620,13 +5334,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: hpack_parser_fuzzer_test
   build: fuzzer
   language: c++
@@ -6635,14 +5342,9 @@ targets:
   - test/core/transport/chttp2/hpack_parser_fuzzer_test.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/transport/chttp2/hpack_parser_corpus
   dict: test/core/end2end/fuzzers/hpack.dictionary
@@ -6658,16 +5360,8 @@ targets:
   - src/proto/grpc/testing/test.proto
   - test/cpp/interop/http2_client.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
 - name: http_request_fuzzer_test
   build: fuzzer
   language: c++
@@ -6676,14 +5370,9 @@ targets:
   - test/core/http/request_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/http/request_corpus
   maxlen: 2048
@@ -6695,14 +5384,9 @@ targets:
   - test/core/http/response_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/http/response_corpus
   maxlen: 2048
@@ -6721,13 +5405,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: init_test
   gtest: true
   build: test
@@ -6737,11 +5414,6 @@ targets:
   - test/core/surface/init_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: initial_settings_frame_bad_client_test
   gtest: true
@@ -6756,11 +5428,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: insecure_security_connector_test
   gtest: true
   build: test
@@ -6770,11 +5437,6 @@ targets:
   - test/core/security/insecure_security_connector_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: interop_client
   build: test
   run: false
@@ -6792,16 +5454,8 @@ targets:
   - test/cpp/interop/client_helper.cc
   - test/cpp/interop/interop_client.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
 - name: interop_server
   build: test
   run: false
@@ -6816,16 +5470,8 @@ targets:
   - test/cpp/interop/interop_server_bootstrap.cc
   - test/cpp/interop/server_helper.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
 - name: interop_test
   build: test
   language: c++
@@ -6833,16 +5479,8 @@ targets:
   src:
   - test/cpp/interop/interop_test.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
   platforms:
   - linux
   - posix
@@ -6855,14 +5493,9 @@ targets:
   - test/core/json/fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/json/corpus
   maxlen: 512
@@ -6875,11 +5508,6 @@ targets:
   - test/core/json/json_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: large_metadata_bad_client_test
   gtest: true
@@ -6894,11 +5522,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: lb_get_cpu_stats_test
   gtest: true
   build: test
@@ -6912,13 +5535,8 @@ targets:
   - src/cpp/server/load_reporter/get_cpu_stats_windows.cc
   - test/cpp/server/load_reporter/get_cpu_stats_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: lb_load_data_store_test
   gtest: true
   build: test
@@ -6930,13 +5548,8 @@ targets:
   - src/cpp/server/load_reporter/load_data_store.cc
   - test/cpp/server/load_reporter/load_data_store_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: linux_system_roots_test
   gtest: true
   build: test
@@ -6946,11 +5559,6 @@ targets:
   - test/core/security/linux_system_roots_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: log_test
   gtest: true
   build: test
@@ -6960,11 +5568,6 @@ targets:
   - test/core/gpr/log_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: matchers_test
   gtest: true
@@ -6975,11 +5578,6 @@ targets:
   - test/core/security/matchers_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: message_allocator_end2end_test
   gtest: true
   build: test
@@ -6994,13 +5592,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: mock_test
   gtest: true
   build: test
@@ -7013,15 +5604,8 @@ targets:
   - src/proto/grpc/testing/simple_messages.proto
   - test/cpp/end2end/mock_test.cc
   deps:
-  - grpc++_test_util
   - grpc++_test
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: nanopb_fuzzer_response_test
   build: fuzzer
   language: c++
@@ -7030,14 +5614,9 @@ targets:
   - test/core/nanopb/fuzzer_response.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/nanopb/corpus_response
   maxlen: 128
@@ -7049,14 +5628,9 @@ targets:
   - test/core/nanopb/fuzzer_serverlist.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/nanopb/corpus_serverlist
   maxlen: 128
@@ -7072,13 +5646,6 @@ targets:
   - test/cpp/end2end/nonblocking_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: noop-benchmark
   build: test
   language: c++
@@ -7086,13 +5653,8 @@ targets:
   src:
   - test/cpp/microbenchmarks/noop-benchmark.cc
   deps:
-  - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   - benchmark
+  - grpc_test_util
   benchmark: true
   defaults: benchmark
 - name: orphanable_test
@@ -7104,11 +5666,6 @@ targets:
   - test/core/gprpp/orphanable_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: out_of_bounds_bad_client_test
   gtest: true
   build: test
@@ -7122,11 +5679,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: percent_decode_fuzzer
   build: fuzzer
   language: c++
@@ -7135,14 +5687,9 @@ targets:
   - test/core/slice/percent_decode_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/slice/percent_decode_corpus
   maxlen: 32
@@ -7154,14 +5701,9 @@ targets:
   - test/core/slice/percent_encode_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/slice/percent_encode_corpus
   maxlen: 32
@@ -7174,11 +5716,6 @@ targets:
   - test/core/transport/pid_controller_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: port_sharing_end2end_test
   gtest: true
   build: test
@@ -7193,13 +5730,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: proto_server_reflection_test
   gtest: true
   build: test
@@ -7216,15 +5746,8 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   - test/cpp/util/proto_reflection_descriptor_database.cc
   deps:
-  - grpc++_test_util
   - grpc++_reflection
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: proto_utils_test
   gtest: true
   build: test
@@ -7233,13 +5756,8 @@ targets:
   src:
   - test/cpp/codegen/proto_utils_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: qps_json_driver
   build: test
@@ -7284,16 +5802,8 @@ targets:
   - test/cpp/qps/server_sync.cc
   - test/cpp/qps/usage_timer.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
 - name: qps_worker
   build: test
   run: false
@@ -7328,16 +5838,8 @@ targets:
   - test/cpp/qps/usage_timer.cc
   - test/cpp/qps/worker.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
+  - grpc++_test_util
 - name: raw_end2end_test
   gtest: true
   build: test
@@ -7353,13 +5855,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: rbac_translator_test
   gtest: true
   build: test
@@ -7375,11 +5870,6 @@ targets:
   - test/core/security/rbac_translator_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: ref_counted_ptr_test
   gtest: true
   build: test
@@ -7389,11 +5879,6 @@ targets:
   - test/core/gprpp/ref_counted_ptr_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: ref_counted_test
   gtest: true
   build: test
@@ -7403,11 +5888,6 @@ targets:
   - test/core/gprpp/ref_counted_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: remove_stream_from_stalled_lists_test
   gtest: true
   build: test
@@ -7417,11 +5897,6 @@ targets:
   - test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -7435,11 +5910,6 @@ targets:
   - test/core/client_channel/retry_throttle_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: secure_auth_context_test
   gtest: true
@@ -7450,13 +5920,6 @@ targets:
   - test/cpp/common/secure_auth_context_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_builder_plugin_test
   gtest: true
   build: test
@@ -7472,13 +5935,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_builder_test
   gtest: true
   build: test
@@ -7490,12 +5946,8 @@ targets:
   - src/proto/grpc/testing/simple_messages.proto
   - test/cpp/server/server_builder_test.cc
   deps:
-  - grpc_test_util_unsecure
   - grpc++_unsecure
-  - grpc_unsecure
-  - gpr
-  - address_sorting
-  - upb
+  - grpc_test_util_unsecure
   platforms:
   - linux
   - posix
@@ -7511,12 +5963,8 @@ targets:
   - src/proto/grpc/testing/simple_messages.proto
   - test/cpp/server/server_builder_with_socket_mutator_test.cc
   deps:
-  - grpc_test_util_unsecure
   - grpc++_unsecure
-  - grpc_unsecure
-  - gpr
-  - address_sorting
-  - upb
+  - grpc_test_util_unsecure
   platforms:
   - linux
   - posix
@@ -7530,11 +5978,6 @@ targets:
   - test/core/surface/server_chttp2_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_context_test_spouse_test
   gtest: true
   build: test
@@ -7543,15 +5986,8 @@ targets:
   src:
   - test/cpp/test/server_context_test_spouse_test.cc
   deps:
-  - grpc++_test_util
   - grpc++_test
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: server_early_return_test
   gtest: true
   build: test
@@ -7564,13 +6000,6 @@ targets:
   - test/cpp/end2end/server_early_return_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_fuzzer
   build: fuzzer
   language: c++
@@ -7579,14 +6008,9 @@ targets:
   - test/core/end2end/fuzzers/server_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/end2end/fuzzers/server_fuzzer_corpus
   dict: test/core/end2end/fuzzers/hpack.dictionary
@@ -7607,13 +6031,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_registered_method_bad_client_test
   gtest: true
   build: test
@@ -7627,11 +6044,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: server_request_call_test
   gtest: true
   build: test
@@ -7643,12 +6055,8 @@ targets:
   - src/proto/grpc/testing/simple_messages.proto
   - test/cpp/server/server_request_call_test.cc
   deps:
-  - grpc_test_util_unsecure
   - grpc++_unsecure
-  - grpc_unsecure
-  - gpr
-  - address_sorting
-  - upb
+  - grpc_test_util_unsecure
   platforms:
   - linux
   - posix
@@ -7668,13 +6076,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: service_config_test
   gtest: true
   build: test
@@ -7684,11 +6085,6 @@ targets:
   - test/core/client_channel/service_config_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: settings_timeout_test
   gtest: true
   build: test
@@ -7699,11 +6095,6 @@ targets:
   - test/core/transport/chttp2/settings_timeout_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: shutdown_test
   gtest: true
   build: test
@@ -7717,13 +6108,6 @@ targets:
   - test/cpp/end2end/shutdown_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: simple_request_bad_client_test
   gtest: true
   build: test
@@ -7737,11 +6121,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: ssl_server_fuzzer
   build: fuzzer
   language: c++
@@ -7750,14 +6129,9 @@ targets:
   - test/core/security/ssl_server_fuzzer.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/security/corpus/ssl_server_corpus
   maxlen: 2048
@@ -7770,12 +6144,6 @@ targets:
   - test/core/util/stack_tracer_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/debugging:symbolize
   platforms:
   - linux
   - posix
@@ -7790,11 +6158,6 @@ targets:
   - test/core/gprpp/stat_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: static_metadata_test
   gtest: true
@@ -7805,11 +6168,6 @@ targets:
   - test/core/transport/static_metadata_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: stats_test
   gtest: true
   build: test
@@ -7819,11 +6177,6 @@ targets:
   - test/core/debug/stats_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: status_metadata_test
   gtest: true
@@ -7834,11 +6187,6 @@ targets:
   - test/core/transport/status_metadata_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: status_util_test
   gtest: true
@@ -7849,11 +6197,6 @@ targets:
   - test/core/channel/status_util_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: stranded_event_test
   gtest: true
@@ -7866,11 +6209,6 @@ targets:
   - test/core/iomgr/stranded_event_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -7888,13 +6226,6 @@ targets:
   - test/cpp/end2end/streaming_throughput_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -7907,13 +6238,8 @@ targets:
   src:
   - test/cpp/util/string_ref_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   uses_polling: false
 - name: test_cpp_client_credentials_test
   gtest: true
@@ -7923,13 +6249,8 @@ targets:
   src:
   - test/cpp/client/credentials_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: test_cpp_server_credentials_test
   gtest: true
   build: test
@@ -7938,13 +6259,8 @@ targets:
   src:
   - test/cpp/server/credentials_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: test_cpp_util_slice_test
   gtest: true
   build: test
@@ -7954,13 +6270,6 @@ targets:
   - test/cpp/util/slice_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: test_cpp_util_time_test
   gtest: true
@@ -7971,13 +6280,6 @@ targets:
   - test/cpp/util/time_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: thread_manager_test
   gtest: true
@@ -7987,15 +6289,8 @@ targets:
   src:
   - test/cpp/thread_manager/thread_manager_test.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: thread_stress_test
   gtest: true
   build: test
@@ -8009,13 +6304,6 @@ targets:
   - test/cpp/end2end/thread_stress_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -8029,13 +6317,8 @@ targets:
   src:
   - test/cpp/common/time_jump_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
   platforms:
   - linux
   - posix
@@ -8049,11 +6332,6 @@ targets:
   - test/core/gprpp/time_util_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   uses_polling: false
 - name: timer_test
   gtest: true
@@ -8063,13 +6341,8 @@ targets:
   src:
   - test/cpp/common/timer_test.cc
   deps:
-  - grpc_test_util
   - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc_test_util
 - name: tls_security_connector_test
   gtest: true
   build: test
@@ -8079,11 +6352,6 @@ targets:
   - test/core/security/tls_security_connector_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: too_many_pings_test
   gtest: true
   build: test
@@ -8094,15 +6362,8 @@ targets:
   - test/core/end2end/cq_verifier.cc
   - test/core/transport/chttp2/too_many_pings_test.cc
   deps:
-  - grpc++_test_util
-  - grpc_test_util
-  - grpc++
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
+  - grpc++_test_util
 - name: unknown_frame_bad_client_test
   gtest: true
   build: test
@@ -8116,11 +6377,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: uri_fuzzer_test
   build: fuzzer
   language: c++
@@ -8129,14 +6385,9 @@ targets:
   - test/core/uri/uri_fuzzer_test.cc
   - test/core/util/fuzzer_corpus_test.cc
   deps:
+  - absl/flags:flag
   - grpc_test_util
   - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/flags:flag
   corpus_dirs:
   - test/core/uri/uri_corpus
   maxlen: 128
@@ -8149,11 +6400,6 @@ targets:
   - test/core/uri/uri_parser_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: window_overflow_bad_client_test
   gtest: true
   build: test
@@ -8167,11 +6413,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: work_serializer_test
   gtest: true
   build: test
@@ -8181,11 +6422,6 @@ targets:
   - test/core/iomgr/work_serializer_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -8243,15 +6479,10 @@ targets:
   - test/core/util/trickle_endpoint.cc
   - test/cpp/performance/writes_per_rpc_test.cc
   deps:
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
-  - absl/debugging:symbolize
-  - absl/debugging:stacktrace
   - absl/debugging:failure_signal_handler
+  - absl/debugging:stacktrace
+  - absl/debugging:symbolize
+  - grpc++
   platforms:
   - linux
   - posix
@@ -8265,11 +6496,6 @@ targets:
   - test/core/xds/xds_bootstrap_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: xds_certificate_provider_test
   gtest: true
   build: test
@@ -8279,11 +6505,6 @@ targets:
   - test/core/xds/xds_certificate_provider_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: xds_credentials_end2end_test
   gtest: true
   build: test
@@ -8298,13 +6519,6 @@ targets:
   - test/cpp/end2end/xds_credentials_end2end_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: xds_credentials_test
   gtest: true
   build: test
@@ -8314,11 +6528,6 @@ targets:
   - test/core/security/xds_credentials_test.cc
   deps:
   - grpc_test_util
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
 - name: xds_end2end_test
   gtest: true
   build: test
@@ -8362,13 +6571,6 @@ targets:
   - test/cpp/end2end/xds_end2end_test.cc
   deps:
   - grpc++_test_util
-  - grpc_test_util
-  - grpc++
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   platforms:
   - linux
   - posix
@@ -8384,15 +6586,10 @@ targets:
   - src/proto/grpc/testing/test.proto
   - test/cpp/interop/xds_interop_client.cc
   deps:
-  - grpc_test_util
-  - grpc++
-  - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   - absl/flags:flag
+  - grpc++
+  - grpc_test_util
+  - grpc++_test_config
 - name: xds_interop_server
   build: test
   run: false
@@ -8407,13 +6604,8 @@ targets:
   - test/cpp/end2end/test_health_check_service_impl.cc
   - test/cpp/interop/xds_interop_server.cc
   deps:
-  - grpc_test_util
-  - grpc++
-  - grpc++_test_config
-  - grpc
-  - gpr
-  - address_sorting
-  - upb
-  - libssl
   - absl/flags:flag
+  - grpc++
+  - grpc_test_util
+  - grpc++_test_config
 tests: []

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -178,10 +178,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc_test_util',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'test/core/end2end/cq_verifier.cc',
@@ -280,10 +276,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc_test_util',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'test/core/end2end/cq_verifier.cc',
@@ -382,14 +374,14 @@
       'target_name': 'gpr',
       'type': 'static_library',
       'dependencies': [
-        'absl/types:optional',
-        'absl/time:time',
-        'absl/synchronization:synchronization',
-        'absl/strings:strings',
-        'absl/strings:str_format',
-        'absl/status:status',
-        'absl/memory:memory',
         'absl/base:base',
+        'absl/memory:memory',
+        'absl/status:status',
+        'absl/strings:str_format',
+        'absl/strings:strings',
+        'absl/synchronization:synchronization',
+        'absl/time:time',
+        'absl/types:optional',
       ],
       'sources': [
         'src/core/lib/gpr/alloc.cc',
@@ -443,16 +435,13 @@
       'target_name': 'grpc',
       'type': 'static_library',
       'dependencies': [
+        'absl/container:flat_hash_map',
+        'absl/container:inlined_vector',
+        'absl/functional:bind_front',
+        'absl/status:statusor',
         'gpr',
         'address_sorting',
         'upb',
-        'absl/types:optional',
-        'absl/strings:strings',
-        'absl/status:statusor',
-        'absl/status:status',
-        'absl/functional:bind_front',
-        'absl/container:inlined_vector',
-        'absl/container:flat_hash_map',
       ],
       'sources': [
         'src/core/ext/filters/census/grpc_context.cc',
@@ -1001,9 +990,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'src/csharp/ext/grpc_csharp_ext.c',
@@ -1013,13 +999,10 @@
       'target_name': 'grpc_test_util',
       'type': 'static_library',
       'dependencies': [
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
-        'absl/debugging:symbolize',
-        'absl/debugging:stacktrace',
         'absl/debugging:failure_signal_handler',
+        'absl/debugging:stacktrace',
+        'absl/debugging:symbolize',
+        'grpc',
       ],
       'sources': [
         'test/core/util/cmdline.cc',
@@ -1051,13 +1034,10 @@
       'target_name': 'grpc_test_util_unsecure',
       'type': 'static_library',
       'dependencies': [
-        'grpc_unsecure',
-        'gpr',
-        'address_sorting',
-        'upb',
-        'absl/debugging:symbolize',
-        'absl/debugging:stacktrace',
         'absl/debugging:failure_signal_handler',
+        'absl/debugging:stacktrace',
+        'absl/debugging:symbolize',
+        'grpc_unsecure',
       ],
       'sources': [
         'test/core/util/cmdline.cc',
@@ -1088,15 +1068,12 @@
       'target_name': 'grpc_unsecure',
       'type': 'static_library',
       'dependencies': [
+        'absl/container:flat_hash_map',
+        'absl/container:inlined_vector',
+        'absl/status:statusor',
         'gpr',
         'address_sorting',
         'upb',
-        'absl/types:optional',
-        'absl/strings:strings',
-        'absl/status:statusor',
-        'absl/status:status',
-        'absl/container:inlined_vector',
-        'absl/container:flat_hash_map',
       ],
       'sources': [
         'src/core/ext/filters/census/grpc_context.cc',
@@ -1385,14 +1362,10 @@
       'target_name': 'benchmark_helpers',
       'type': 'static_library',
       'dependencies': [
-        'grpc_test_util_unsecure',
-        'grpc++_unsecure',
-        'grpc_unsecure',
-        'grpc++_test_config',
-        'gpr',
-        'address_sorting',
-        'upb',
         'benchmark',
+        'grpc++_unsecure',
+        'grpc_test_util_unsecure',
+        'grpc++_test_config',
       ],
       'sources': [
         'src/proto/grpc/testing/echo.proto',
@@ -1406,10 +1379,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
-        'absl/synchronization:synchronization',
       ],
       'sources': [
         'src/cpp/client/channel_cc.cc',
@@ -1469,10 +1438,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc++',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'src/cpp/common/alts_context.cc',
@@ -1484,10 +1449,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc++',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'src/cpp/util/error_details.cc',
@@ -1498,10 +1459,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc++',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'src/proto/grpc/reflection/v1alpha/reflection.proto',
@@ -1514,10 +1471,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc++',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'src/cpp/client/channel_test_peer.cc',
@@ -1527,8 +1480,8 @@
       'target_name': 'grpc++_test_config',
       'type': 'static_library',
       'dependencies': [
-        'gpr',
         'absl/flags:parse',
+        'gpr',
       ],
       'sources': [
         'test/cpp/util/test_config_cc.cc',
@@ -1538,13 +1491,9 @@
       'target_name': 'grpc++_test_util',
       'type': 'static_library',
       'dependencies': [
-        'grpc_test_util',
-        'grpc++',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
         'absl/flags:flag',
+        'grpc++',
+        'grpc_test_util',
       ],
       'sources': [
         'test/core/end2end/data/client_certs.cc',
@@ -1563,10 +1512,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc_unsecure',
-        'gpr',
-        'address_sorting',
-        'upb',
-        'absl/synchronization:synchronization',
       ],
       'sources': [
         'src/cpp/client/channel_cc.cc',
@@ -1631,10 +1576,6 @@
       'type': 'static_library',
       'dependencies': [
         'grpc++',
-        'grpc',
-        'gpr',
-        'address_sorting',
-        'upb',
       ],
       'sources': [
         'src/proto/grpc/channelz/channelz.proto',

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2020 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,14 +34,36 @@ import subprocess
 import yaml
 import xml.etree.ElementTree as ET
 import os
+import collections
 import sys
+import re
+from typing import List, Any, Dict, Optional, Iterable
+
 import build_cleaner
 
-_ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../..'))
-os.chdir(_ROOT)
+PROJECT_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..',
+                            '..')
+os.chdir(PROJECT_ROOT)
+
+BuildMetadata = Dict[str, Any]
+BuildDict = Dict[str, BuildMetadata]
+BuildYaml = Dict[str, Any]
+
+# Map from the external repository's labels to their path prefixes.
+EXTERNAL_LIB_LABEL_PATH_MAP = dict(
+    envoy_api='third_party/envoy-api/',
+    com_google_googleapis='third_party/googleapis/',
+    com_github_cncf_udpa='third_party/udpa/',
+    com_envoyproxy_protoc_gen_validate='third_party/protoc-gen-validate/',
+    opencensus_proto='third_party/opencensus-proto/src/')
+# The external repositories that we are currently able to support the metadata
+# extraction. We aim to support arbitrary external libraries in the long term.
+# This variable should be removed eventually.
+RE_MATCH_SUPPORTED_EXTERNAL_LIBS = re.compile(
+    f'^@({"|".join(EXTERNAL_LIB_LABEL_PATH_MAP.keys())}).*$')
 
 
-def _bazel_query_xml_tree(query):
+def _bazel_query_xml_tree(query: str) -> ET.Element:
     """Get xml output of bazel query invocation, parsed as XML tree"""
     output = subprocess.check_output(
         ['tools/bazel', 'query', '--noimplicit_deps', '--output', 'xml', query])
@@ -90,7 +112,7 @@ def _extract_rules_from_bazel_xml(xml_tree):
             rule_name = rule_dict['name']
             if rule_clazz in [
                     'cc_library', 'cc_binary', 'cc_test', 'cc_proto_library',
-                    'proto_library'
+                    'proto_library', 'cc_proto_gen_validate'
             ]:
                 if rule_name in result:
                     raise Exception('Rule %s already present' % rule_name)
@@ -98,14 +120,16 @@ def _extract_rules_from_bazel_xml(xml_tree):
     return result
 
 
-def _get_bazel_label(target_name):
+def _get_bazel_label(target_name: str) -> str:
+    if target_name.startswith('@'):
+        return target_name
     if ':' in target_name:
         return '//%s' % target_name
     else:
         return '//:%s' % target_name
 
 
-def _extract_source_file_path(label):
+def _extract_source_file_path(label: str) -> str:
     """Gets relative path to source file from bazel deps listing"""
     if label.startswith('//'):
         label = label[len('//'):]
@@ -117,7 +141,7 @@ def _extract_source_file_path(label):
     return label
 
 
-def _extract_public_headers(bazel_rule):
+def _extract_public_headers(bazel_rule: BuildMetadata) -> List[str]:
     """Gets list of public headers from a bazel rule"""
     result = []
     for dep in bazel_rule['hdrs']:
@@ -126,7 +150,7 @@ def _extract_public_headers(bazel_rule):
     return list(sorted(result))
 
 
-def _extract_nonpublic_headers(bazel_rule):
+def _extract_nonpublic_headers(bazel_rule: BuildMetadata) -> List[str]:
     """Gets list of non-public headers from a bazel rule"""
     result = []
     for dep in bazel_rule['hdrs']:
@@ -136,22 +160,50 @@ def _extract_nonpublic_headers(bazel_rule):
     return list(sorted(result))
 
 
-def _extract_sources(bazel_rule):
+def _extract_sources(bazel_rule: BuildMetadata) -> List[str]:
     """Gets list of source files from a bazel rule"""
     result = []
-    for dep in bazel_rule['srcs']:
-        if dep.startswith('//') and (dep.endswith('.cc') or dep.endswith('.c')
-                                     or dep.endswith('.proto')):
-            result.append(_extract_source_file_path(dep))
+    for src in bazel_rule['srcs']:
+        if src.endswith('.cc') or src.endswith('.c') or src.endswith('.proto'):
+            if src.startswith('//'):
+                # This source file is local to gRPC
+                result.append(_extract_source_file_path(src))
+            elif RE_MATCH_SUPPORTED_EXTERNAL_LIBS.match(src):
+                # This source file is external, and we need to translate the
+                # @REPO_NAME to a valid path prefix. At this stage, we need
+                # to check repo name, since the label/path mapping is not
+                # available in BUILD files.
+                external_library_name = RE_MATCH_SUPPORTED_EXTERNAL_LIBS.match(
+                    src).group(1)
+                result.append(
+                    src.replace(
+                        f"@{external_library_name}//",
+                        EXTERNAL_LIB_LABEL_PATH_MAP[external_library_name]).
+                    replace(':', "/"))
+            else:
+                # We don't know how to map these labels to a concrete source
+                # file path, so let's skip them.
+                pass
     return list(sorted(result))
 
 
-def _extract_deps(bazel_rule):
+def _extract_deps(bazel_rule: BuildMetadata,
+                  bazel_rules: BuildDict) -> List[str]:
     """Gets list of deps from from a bazel rule"""
-    return list(sorted(bazel_rule['deps']))
+    deps = set(bazel_rule['deps'])
+    for src in bazel_rule['srcs']:
+        if not src.endswith('.cc') and not src.endswith(
+                '.c') and not src.endswith('.proto'):
+            if src in bazel_rules:
+                # This label doesn't point to a source file, but another Bazel
+                # target. This is required for :pkg_cc_proto_validate targets,
+                # and it's generally allowed by Bazel.
+                deps.add(src)
+    return list(sorted(list(deps)))
 
 
-def _create_target_from_bazel_rule(target_name, bazel_rules):
+def _create_target_from_bazel_rule(target_name: str,
+                                   bazel_rules: BuildDict) -> BuildMetadata:
     """Create build.yaml-like target definition from bazel metadata"""
     bazel_rule = bazel_rules[_get_bazel_label(target_name)]
 
@@ -164,71 +216,16 @@ def _create_target_from_bazel_rule(target_name, bazel_rules):
         '_PUBLIC_HEADERS_BAZEL': _extract_public_headers(bazel_rule),
         '_HEADERS_BAZEL': _extract_nonpublic_headers(bazel_rule),
         '_SRC_BAZEL': _extract_sources(bazel_rule),
-        '_DEPS_BAZEL': _extract_deps(bazel_rule),
+        '_DEPS_BAZEL': _extract_deps(bazel_rule, bazel_rules),
+        'public_headers': bazel_rule['_COLLAPSED_PUBLIC_HEADERS'],
+        'headers': bazel_rule['_COLLAPSED_HEADERS'],
+        'src': bazel_rule['_COLLAPSED_SRCS'],
+        'deps': bazel_rule['_COLLAPSED_DEPS'],
     }
     return result
 
 
-def _sort_by_build_order(lib_names, lib_dict, deps_key_name, verbose=False):
-    """Sort library names to form correct build order. Use metadata from lib_dict"""
-    # we find correct build order by performing a topological sort
-    # expected output: if library B depends on A, A should be listed first
-
-    # all libs that are not in the dictionary are considered external.
-    external_deps = list(
-        sorted([lib_name for lib_name in lib_names if lib_name not in lib_dict
-               ]))
-    if verbose:
-        print('topo_ordering ' + str(lib_names))
-        print('    external_deps ' + str(external_deps))
-
-    result = list(external_deps)  # external deps will be listed first
-    while len(result) < len(lib_names):
-        more_results = []
-        for lib in lib_names:
-            if lib not in result:
-                dep_set = set(lib_dict[lib].get(deps_key_name, []))
-                dep_set = dep_set.intersection(lib_names)
-                # if lib only depends on what's already built, add it to the results
-                if not dep_set.difference(set(result)):
-                    more_results.append(lib)
-        if not more_results:
-            raise Exception(
-                'Cannot sort topologically, there seems to be a cyclic dependency'
-            )
-        if verbose:
-            print('    adding ' + str(more_results))
-        result = result + list(
-            sorted(more_results
-                  ))  # when build order doesn't matter, sort lexicographically
-    return result
-
-
-# TODO(jtattermusch): deduplicate with transitive_dependencies.py (which has a slightly different logic)
-def _populate_transitive_deps(bazel_rules):
-    """Add 'transitive_deps' field for each of the rules"""
-    transitive_deps = {}
-    for rule_name in bazel_rules.keys():
-        transitive_deps[rule_name] = set(bazel_rules[rule_name]['deps'])
-
-    while True:
-        deps_added = 0
-        for rule_name in bazel_rules.keys():
-            old_deps = transitive_deps[rule_name]
-            new_deps = set(old_deps)
-            for dep_name in old_deps:
-                new_deps.update(transitive_deps.get(dep_name, set()))
-            deps_added += len(new_deps) - len(old_deps)
-            transitive_deps[rule_name] = new_deps
-        # if none of the transitive dep sets has changed, we're done
-        if deps_added == 0:
-            break
-
-    for rule_name, bazel_rule in bazel_rules.items():
-        bazel_rule['transitive_deps'] = list(sorted(transitive_deps[rule_name]))
-
-
-def _external_dep_name_from_bazel_dependency(bazel_dep):
+def _external_dep_name_from_bazel_dependency(bazel_dep: str) -> Optional[str]:
     """Returns name of dependency if external bazel dependency is provided or None"""
     if bazel_dep.startswith('@com_google_absl//'):
         # special case for add dependency on one of the absl libraries (there is not just one absl library)
@@ -247,118 +244,204 @@ def _external_dep_name_from_bazel_dependency(bazel_dep):
         return None
 
 
-def _expand_intermediate_deps(target_dict, public_dep_names, bazel_rules):
-    # Some of the libraries defined by bazel won't be exposed in build.yaml
-    # We call these "intermediate" dependencies. This method expands
-    # the intermediate deps for given target (populates library's
-    # headers, sources and dicts as if the intermediate dependency never existed)
+def _deduplicate_append(target: List[str], pending: List[str]) -> None:
+    """Append the list without duplicated items in place.
+    
+    Expected to be used to create a order-stable dependency list.
+    """
+    seen = set(target)
+    for dep in pending:
+        if dep not in seen:
+            target.append(dep)
 
-    # use this dictionary to translate from bazel labels to dep names
+
+def _compute_transitive_metadata(
+        rule_name: str, bazel_rules: Any,
+        bazel_label_to_dep_name: Dict[str, str]) -> None:
+    """Computes the final build metadata for Bazel target with rule_name.
+
+    The dependencies that will appear on the deps list are:
+
+    * Public build targets including binaries and tests;
+    * External targets, like absl, re2.
+
+    All other intermediate dependencies will be merged, which means their
+    source file, headers, etc. will be collected into one build target. This
+    step of processing will greatly reduce the complexity of the generated
+    build specifications for other build systems, like CMake, Make, setuptools.
+
+    The final build metadata are:
+    * _TRANSITIVE_DEPS: all the transitive dependencies including intermediate
+                        targets;
+    * _COLLAPSED_DEPS:  dependencies that fits our requirement above, and it
+                        will remove duplicated items and produce the shortest
+                        possible dependency list in alphabetical order;
+    * _COLLAPSED_SRCS:  the merged source files;
+    * _COLLAPSED_PUBLIC_HEADERS: the merged public headers;
+    * _COLLAPSED_HEADERS: the merged non-public headers;
+    * _EXCLUDE_DEPS: transitive dependencies of public deps that this build
+      target depends on, and they will be excluded in the final build metadata.
+
+    For the collapsed_deps, the algorithm improved cases like:
+
+    The result in the past:
+        end2end_tests -> [grpc_test_util, grpc, gpr, address_sorting, upb]
+        grpc_test_util -> [grpc, gpr, address_sorting, upb, ...]
+        grpc -> [gpr, address_sorting, upb, ...]
+    
+    The result of the algorithm:
+        end2end_tests -> [grpc_test_util]
+        grpc_test_util -> [grpc]
+        grpc -> [gpr, address_sorting, upb, ...]
+    """
+    bazel_rule = bazel_rules[rule_name]
+    direct_deps = _extract_deps(bazel_rule, bazel_rules)
+    transitive_deps = []
+    # We care about the order of dependencies list, so it will be a list.
+    collapsed_deps = set()
+    # We don't care about the order of srcs and headers, they will be sorted.
+    collapsed_srcs = set(_extract_sources(bazel_rule))
+    collapsed_public_headers = set(_extract_public_headers(bazel_rule))
+    collapsed_headers = set(_extract_nonpublic_headers(bazel_rule))
+    exclude_deps = set()
+
+    for dep in direct_deps:
+        external_dep_name_maybe = _external_dep_name_from_bazel_dependency(dep)
+
+        if dep in bazel_rules:
+            # Suppress expanding absl libs; expanding absl deps are technically
+            # correct but creates too much noise
+            if external_dep_name_maybe is None or not external_dep_name_maybe.startswith(
+                    'absl'):
+                if "_PROCESSING_DONE" not in bazel_rules[dep]:
+                    # This item is not processed before, compute now
+                    _compute_transitive_metadata(dep, bazel_rules,
+                                                 bazel_label_to_dep_name)
+                _deduplicate_append(
+                    transitive_deps,
+                    bazel_rules[dep].get('_TRANSITIVE_DEPS', []))
+                collapsed_deps.update(
+                    collapsed_deps, bazel_rules[dep].get('_COLLAPSED_DEPS', []))
+                exclude_deps.update(bazel_rules[dep].get('_EXCLUDE_DEPS', []))
+
+        # This dep is a public target, add it as a dependency
+        if dep in bazel_label_to_dep_name:
+            _deduplicate_append(transitive_deps, [bazel_label_to_dep_name[dep]])
+            collapsed_deps.update(collapsed_deps,
+                                  [bazel_label_to_dep_name[dep]])
+            # Add all the transitive deps of our every public dep to exclude
+            # list since we want to avoid building sources that are already
+            # built our dependencies
+            exclude_deps.update(bazel_rules[dep]['_TRANSITIVE_DEPS'])
+            exclude_deps.add(dep)
+            continue
+
+        # This dep is an external target, add it as a dependency
+        if external_dep_name_maybe is not None:
+            _deduplicate_append(transitive_deps, [external_dep_name_maybe])
+            collapsed_deps.update(collapsed_deps, [external_dep_name_maybe])
+            continue
+
+    # Direct dependencies are part of transitive dependencies
+    _deduplicate_append(transitive_deps, direct_deps)
+
+    # Remove intermediate targets that our public dependencies already depend
+    # on. This is the step that further shorten the deps list.
+    collapsed_deps = list(
+        filter(lambda x: x not in exclude_deps, collapsed_deps))
+
+    # Compute the final source files and headers for this build target whose
+    # name is `rule_name` (input argument of this function).
+    #
+    # Imaging a public target PX has transitive deps [IA, IB, PY, IC, PZ]. PX,
+    # PY and PZ are public build targets. And IA, IB, IC are intermediate
+    # targets. In addition, PY depends on IC.
+    #
+    # Translate the condition into dependency graph:
+    #   PX -> [IA, IB, PY, IC, PZ]
+    #   PY -> [IC]
+    #   Public targets: [PX, PY, PZ]
+    #
+    # The collapsed dependencies of PX: [PY, PZ].
+    # The excluded dependencies of X: [PY, IC, PZ].
+    # (IC is excluded as a dependency of PX. It is already included in PY, hence
+    # it would be redundant to include it again.)
+    #
+    # Target PX should include source files and headers of [PX, IA, IB] as final
+    # build metadata.
+    for dep in transitive_deps:
+        if dep not in exclude_deps:
+            if dep in bazel_rules:
+                collapsed_srcs.update(_extract_sources(bazel_rules[dep]))
+                collapsed_public_headers.update(
+                    _extract_public_headers(bazel_rules[dep]))
+                collapsed_headers.update(
+                    _extract_nonpublic_headers(bazel_rules[dep]))
+
+    # This item is a "visited" flag
+    bazel_rule['_PROCESSING_DONE'] = True
+    # Following items are described in the docstinrg.
+    bazel_rule['_TRANSITIVE_DEPS'] = transitive_deps
+    bazel_rule['_COLLAPSED_DEPS'] = list(sorted(collapsed_deps))
+    bazel_rule['_COLLAPSED_SRCS'] = list(sorted(collapsed_srcs))
+    bazel_rule['_COLLAPSED_PUBLIC_HEADERS'] = list(
+        sorted(collapsed_public_headers))
+    bazel_rule['_COLLAPSED_HEADERS'] = list(sorted(collapsed_headers))
+    bazel_rule['_EXCLUDE_DEPS'] = list(sorted(exclude_deps))
+
+
+# TODO(jtattermusch): deduplicate with transitive_dependencies.py (which has a slightly different logic)
+# TODO(jtattermusch): This is done to avoid introducing too many intermediate
+# libraries into the build.yaml-based builds (which might in cause issues
+# building language-specific artifacts) and also because the libraries
+# in build.yaml-based build are generally considered units of distributions
+# (= public libraries that are visible to the user and are installable),
+# while in bazel builds it is customary to define larger number of smaller
+# "sublibraries". The need for elision (and expansion)
+# of intermediate libraries can be re-evaluated in the future.
+def _populate_transitive_metadata(bazel_rules: Any,
+                                  public_dep_names: Iterable[str]) -> None:
+    """Add 'transitive_deps' field for each of the rules"""
+    # Create the map between Bazel label and public dependency name
     bazel_label_to_dep_name = {}
     for dep_name in public_dep_names:
         bazel_label_to_dep_name[_get_bazel_label(dep_name)] = dep_name
 
-    target_name = target_dict['name']
-    bazel_deps = target_dict['_DEPS_BAZEL']
-
-    # initial values
-    public_headers = set(target_dict['_PUBLIC_HEADERS_BAZEL'])
-    headers = set(target_dict['_HEADERS_BAZEL'])
-    src = set(target_dict['_SRC_BAZEL'])
-    deps = set()
-
-    expansion_blocklist = set()
-    to_expand = set(bazel_deps)
-    while to_expand:
-
-        # start with the last dependency to be built
-        build_order = _sort_by_build_order(list(to_expand), bazel_rules,
-                                           'transitive_deps')
-
-        bazel_dep = build_order[-1]
-        to_expand.remove(bazel_dep)
-
-        is_public = bazel_dep in bazel_label_to_dep_name
-        external_dep_name_maybe = _external_dep_name_from_bazel_dependency(
-            bazel_dep)
-
-        if is_public:
-            # this is not an intermediate dependency we so we add it
-            # to the list of public dependencies to the list, in the right format
-            deps.add(bazel_label_to_dep_name[bazel_dep])
-
-            # we do not want to expand any intermediate libraries that are already included
-            # by the dependency we just added
-            expansion_blocklist.update(
-                bazel_rules[bazel_dep]['transitive_deps'])
-
-        elif external_dep_name_maybe:
-            deps.add(external_dep_name_maybe)
-
-        elif bazel_dep.startswith(
-                '//external:') or not bazel_dep.startswith('//'):
-            # all the other external deps can be skipped
-            pass
-
-        elif bazel_dep in expansion_blocklist:
-            # do not expand if a public dependency that depends on this has already been expanded
-            pass
-
-        else:
-            if bazel_dep in bazel_rules:
-                # this is an intermediate library, expand it
-                public_headers.update(
-                    _extract_public_headers(bazel_rules[bazel_dep]))
-                headers.update(
-                    _extract_nonpublic_headers(bazel_rules[bazel_dep]))
-                src.update(_extract_sources(bazel_rules[bazel_dep]))
-
-                new_deps = _extract_deps(bazel_rules[bazel_dep])
-                to_expand.update(new_deps)
-            else:
-                raise Exception(bazel_dep + ' not in bazel_rules')
-
-    # make the 'deps' field transitive, but only list non-intermediate deps and selected external deps
-    bazel_transitive_deps = bazel_rules[_get_bazel_label(
-        target_name)]['transitive_deps']
-    for transitive_bazel_dep in bazel_transitive_deps:
-        public_name = bazel_label_to_dep_name.get(transitive_bazel_dep, None)
-        if public_name:
-            deps.add(public_name)
-        external_dep_name_maybe = _external_dep_name_from_bazel_dependency(
-            transitive_bazel_dep)
-        if external_dep_name_maybe:
-            # expanding all absl libraries is technically correct but creates too much noise
-            if not external_dep_name_maybe.startswith('absl'):
-                deps.add(external_dep_name_maybe)
-
-    target_dict['public_headers'] = list(sorted(public_headers))
-    target_dict['headers'] = list(sorted(headers))
-    target_dict['src'] = list(sorted(src))
-    target_dict['deps'] = list(sorted(deps))
+    # Make sure we reached all the Bazel rules
+    # TODO(lidiz) potentially we could only update a subset of rules
+    for rule_name in bazel_rules:
+        if '_PROCESSING_DONE' not in bazel_rules[rule_name]:
+            _compute_transitive_metadata(rule_name, bazel_rules,
+                                         bazel_label_to_dep_name)
 
 
-def _generate_build_metadata(build_extra_metadata, bazel_rules):
+def update_test_metadata_with_transitive_metadata(
+        all_extra_metadata: BuildDict, bazel_rules: BuildDict) -> None:
+    """Patches test build metadata with transitive metadata."""
+    for lib_name, lib_dict in all_extra_metadata.items():
+        # Skip if it isn't not an test
+        if lib_dict.get('build') != 'test' or lib_dict.get('_TYPE') != 'target':
+            continue
+
+        bazel_rule = bazel_rules[_get_bazel_label(lib_name)]
+
+        if '//external:benchmark' in bazel_rule['_TRANSITIVE_DEPS']:
+            lib_dict['benchmark'] = True
+            lib_dict['defaults'] = 'benchmark'
+
+        if '//external:gtest' in bazel_rule['_TRANSITIVE_DEPS']:
+            lib_dict['gtest'] = True
+            lib_dict['language'] = 'c++'
+
+
+def _generate_build_metadata(build_extra_metadata: BuildDict,
+                             bazel_rules: BuildDict) -> BuildDict:
     """Generate build metadata in build.yaml-like format bazel build metadata and build.yaml-specific "extra metadata"."""
     lib_names = list(build_extra_metadata.keys())
     result = {}
 
     for lib_name in lib_names:
         lib_dict = _create_target_from_bazel_rule(lib_name, bazel_rules)
-
-        # Figure out the final list of headers and sources for given target.
-        # While this is mostly based on bazel build metadata, build.yaml does
-        # not necessarily expose all the targets that are present in bazel build.
-        # These "intermediate dependencies" might get flattened.
-        # TODO(jtattermusch): This is done to avoid introducing too many intermediate
-        # libraries into the build.yaml-based builds (which might in cause issues
-        # building language-specific artifacts) and also because the libraries
-        # in build.yaml-based build are generally considered units of distributions
-        # (= public libraries that are visible to the user and are installable),
-        # while in bazel builds it is customary to define larger number of smaller
-        # "sublibraries". The need for elision (and expansion)
-        # of intermediate libraries can be re-evaluated in the future.
-        _expand_intermediate_deps(lib_dict, lib_names, bazel_rules)
 
         # populate extra properties from the build.yaml-specific "extra metadata"
         lib_dict.update(build_extra_metadata.get(lib_name, {}))
@@ -376,8 +459,8 @@ def _generate_build_metadata(build_extra_metadata, bazel_rules):
         if to_name:
             # store lib under the new name and also change its 'name' property
             if to_name in result:
-                raise Exception('Cannot rename target ' + lib_name + ', ' +
-                                to_name + ' already exists.')
+                raise Exception('Cannot rename target ' + str(lib_name) + ', ' +
+                                str(to_name) + ' already exists.')
             lib_dict = result.pop(lib_name)
             lib_dict['name'] = to_name
             result[to_name] = lib_dict
@@ -389,15 +472,10 @@ def _generate_build_metadata(build_extra_metadata, bazel_rules):
                     for dep in lib_dict_to_update['deps']
                 ])
 
-    # make sure deps are listed in reverse topological order (e.g. "grpc gpr" and not "gpr grpc")
-    for lib_dict in result.values():
-        lib_dict['deps'] = list(
-            reversed(_sort_by_build_order(lib_dict['deps'], result, 'deps')))
-
     return result
 
 
-def _convert_to_build_yaml_like(lib_dict):
+def _convert_to_build_yaml_like(lib_dict: BuildMetadata) -> BuildYaml:
     lib_names = [
         lib_name for lib_name in list(lib_dict.keys())
         if lib_dict[lib_name].get('_TYPE', 'library') == 'library'
@@ -440,7 +518,7 @@ def _convert_to_build_yaml_like(lib_dict):
     return build_yaml_like
 
 
-def _extract_cc_tests(bazel_rules):
+def _extract_cc_tests(bazel_rules: BuildDict) -> List[str]:
     """Gets list of cc_test tests from bazel rules"""
     result = []
     for bazel_rule in bazel_rules.values():
@@ -452,7 +530,7 @@ def _extract_cc_tests(bazel_rules):
     return list(sorted(result))
 
 
-def _exclude_unwanted_cc_tests(tests):
+def _exclude_unwanted_cc_tests(tests: List[str]) -> List[str]:
     """Filters out bazel tests that we don't want to run with other build systems or we cannot build them reasonably"""
 
     # most qps tests are autogenerated, we are fine without them
@@ -518,7 +596,8 @@ def _exclude_unwanted_cc_tests(tests):
     return tests
 
 
-def _generate_build_extra_metadata_for_tests(tests, bazel_rules):
+def _generate_build_extra_metadata_for_tests(
+        tests: List[str], bazel_rules: BuildDict) -> BuildDict:
     """For given tests, generate the "extra metadata" that we need for our "build.yaml"-like output. The extra metadata is generated from the bazel rule metadata by using a bunch of heuristics."""
     test_metadata = {}
     for test in tests:
@@ -567,19 +646,11 @@ def _generate_build_extra_metadata_for_tests(tests, bazel_rules):
                 platforms.append('windows')
             test_dict['platforms'] = platforms
 
-        if '//external:benchmark' in bazel_rule['transitive_deps']:
-            test_dict['benchmark'] = True
-            test_dict['defaults'] = 'benchmark'
-
         cmdline_args = bazel_rule['args']
         if cmdline_args:
             test_dict['args'] = list(cmdline_args)
 
-        uses_gtest = '//external:gtest' in bazel_rule['transitive_deps']
-        if uses_gtest:
-            test_dict['gtest'] = True
-
-        if test.startswith('test/cpp') or uses_gtest:
+        if test.startswith('test/cpp'):
             test_dict['language'] = 'c++'
 
         elif test.startswith('test/core'):
@@ -615,7 +686,7 @@ def _generate_build_extra_metadata_for_tests(tests, bazel_rules):
     return test_metadata
 
 
-def _detect_and_print_issues(build_yaml_like):
+def _detect_and_print_issues(build_yaml_like: BuildYaml) -> None:
     """Try detecting some unusual situations and warn about them."""
     for tgt in build_yaml_like['targets']:
         if tgt['build'] == 'test':
@@ -968,6 +1039,8 @@ _BAZEL_DEPS_QUERIES = [
     'deps("//:all")',
     'deps("//src/compiler/...")',
     'deps("//src/proto/...")',
+    # The ^ is needed to differentiate proto_library from go_proto_library
+    'deps(kind("^proto_library", @envoy_api//envoy/...))',
 ]
 
 # Step 1: run a bunch of "bazel query --output xml" queries to collect
@@ -986,14 +1059,6 @@ bazel_rules = {}
 for query in _BAZEL_DEPS_QUERIES:
     bazel_rules.update(
         _extract_rules_from_bazel_xml(_bazel_query_xml_tree(query)))
-
-# Step 1a: Knowing the transitive closure of dependencies will make
-# the postprocessing simpler, so compute the info for all our rules.
-#
-# Example:
-# '//:grpc' : { ...,
-#               'transitive_deps': ['//:gpr_base', ...] }
-_populate_transitive_deps(bazel_rules)
 
 # Step 2: Extract the known bazel cc_test tests. While most tests
 # will be buildable with other build systems just fine, some of these tests
@@ -1049,7 +1114,25 @@ all_extra_metadata.update(_BUILD_EXTRA_METADATA)
 all_extra_metadata.update(
     _generate_build_extra_metadata_for_tests(tests, bazel_rules))
 
-# Step 4: Generate the final metadata for all the targets.
+# Step 4: Compute the build metadata that will be used in the final build.yaml.
+# The final build metadata includes transitive dependencies, and sources/headers
+# expanded without intermediate dependencies.
+# Example:
+# '//:grpc' : { ...,
+#               '_TRANSITIVE_DEPS': ['//:gpr_base', ...],
+#               '_COLLAPSED_DEPS': ['gpr', ...],
+#               '_COLLAPSED_SRCS': [...],
+#               '_COLLAPSED_PUBLIC_HEADERS': [...],
+#               '_COLLAPSED_HEADERS': [...]
+#             }
+_populate_transitive_metadata(bazel_rules, all_extra_metadata.keys())
+
+# Step 4a: Update the existing test metadata with the updated build metadata.
+# Certain build metadata of certain test targets depend on the transitive
+# metadata that wasn't available earlier.
+update_test_metadata_with_transitive_metadata(all_extra_metadata, bazel_rules)
+
+# Step 5: Generate the final metadata for all the targets.
 # This is done by combining the bazel build metadata and the "extra metadata"
 # we obtained in the previous step.
 # In this step, we also perform some interesting massaging of the target metadata
@@ -1079,7 +1162,7 @@ all_extra_metadata.update(
 #            ... }
 all_targets_dict = _generate_build_metadata(all_extra_metadata, bazel_rules)
 
-# Step 5: convert the dictionary with all the targets to a dict that has
+# Step 6: convert the dictionary with all the targets to a dict that has
 # the desired "build.yaml"-like layout.
 # TODO(jtattermusch): We use the custom "build.yaml"-like layout because
 # currently all other build systems use that format as their source of truth.
@@ -1096,7 +1179,7 @@ build_yaml_like = _convert_to_build_yaml_like(all_targets_dict)
 # detect and report some suspicious situations we've seen before
 _detect_and_print_issues(build_yaml_like)
 
-# Step 6: Store the build_autogenerated.yaml in a deterministic (=sorted)
+# Step 7: Store the build_autogenerated.yaml in a deterministic (=sorted)
 # and cleaned-up form.
 # A basic overview of the resulting "build.yaml"-like format is here:
 # https://github.com/grpc/grpc/blob/master/templates/README.md

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -268,8 +268,8 @@ def _compute_transitive_metadata(
     * _COLLAPSED_SRCS:  the merged source files;
     * _COLLAPSED_PUBLIC_HEADERS: the merged public headers;
     * _COLLAPSED_HEADERS: the merged non-public headers;
-    * _EXCLUDE_DEPS: transitive dependencies of public deps that this build
-      target depends on, and they will be excluded in the final build metadata.
+    * _EXCLUDE_DEPS: intermediate targets to exclude when performing collapsing
+      of sources and dependencies. 
 
     For the collapsed_deps, the algorithm improved cases like:
 
@@ -329,7 +329,7 @@ def _compute_transitive_metadata(
     # Direct dependencies are part of transitive dependencies
     transitive_deps.update(direct_deps)
 
-    # Calculate transitive public deps
+    # Calculate transitive public deps (needed for collapsing sources)
     transitive_public_deps = set(
         filter(lambda x: x in bazel_label_to_dep_name, transitive_deps))
 

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -296,10 +296,8 @@ def _compute_transitive_metadata(
         external_dep_name_maybe = _external_dep_name_from_bazel_dependency(dep)
 
         if dep in bazel_rules:
-            # Suppress expanding absl libs; expanding absl deps are technically
-            # correct but creates too much noise
-            if external_dep_name_maybe is None or not external_dep_name_maybe.startswith(
-                    'absl'):
+            # Descend recursively, but no need to do that for external deps
+            if external_dep_name_maybe is None:
                 if "_PROCESSING_DONE" not in bazel_rules[dep]:
                     # This item is not processed before, compute now
                     _compute_transitive_metadata(dep, bazel_rules,


### PR DESCRIPTION
The extract_metadata_from_bazel_xml.py changes from #25272,
but with some extra fixes and improvements (see individual changes commit-by-commit).

The original PR is too big to review properly (and several things are being done at once so it's really hard to make sense of things). After separating the code, I was able to spot some issues and I fixed them.