### PR TITLE
Add g_gli_initializer to server_context

### DIFF
--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -62,6 +62,7 @@ ClientContext::ClientContext()
       propagate_from_call_(nullptr),
       compression_algorithm_(GRPC_COMPRESS_NONE),
       initial_metadata_corked_(false) {
+  g_gli_initializer.summon();
   g_client_callbacks->DefaultConstructor(this);
 }
 

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -28,6 +28,7 @@
 #include <grpc/support/log.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/completion_queue.h>
+#include <grpcpp/impl/grpc_library.h>
 #include <grpcpp/support/server_callback.h>
 #include <grpcpp/support/time.h>
 
@@ -36,6 +37,8 @@
 #include "src/core/lib/surface/call.h"
 
 namespace grpc {
+
+static internal::GrpcLibraryInitializer g_gli_initializer;
 
 // CompletionOp
 
@@ -233,7 +236,9 @@ bool ServerContextBase::CompletionOp::FinalizeResult(void** tag, bool* status) {
 // ServerContextBase body
 
 ServerContextBase::ServerContextBase()
-    : deadline_(gpr_inf_future(GPR_CLOCK_REALTIME)) {}
+    : deadline_(gpr_inf_future(GPR_CLOCK_REALTIME)) {
+  g_gli_initializer.summon();
+}
 
 ServerContextBase::ServerContextBase(gpr_timespec deadline,
                                      grpc_metadata_array* arr)


### PR DESCRIPTION
server_context also needs to have a static `GrpcLibraryInitializer` variable to make sure that g_core_codegen_interface is properly instantiated so that MetadataMap::Destroy can work without segfault.

Fixes #22551