### PR TITLE
Expose raw gRPC method name on ActiveCall

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -43,7 +43,7 @@ module GRPC
     include Core::TimeConsts
     include Core::CallOps
     extend Forwardable
-    attr_reader :deadline, :metadata_sent, :metadata_to_send, :peer, :peer_cert
+    attr_reader :deadline, :metadata_sent, :metadata_to_send, :peer, :peer_cert, :method
     def_delegators :@call, :cancel, :metadata, :write_flag, :write_flag=,
                    :trailing_metadata, :status
 
@@ -85,11 +85,12 @@ module GRPC
     # @param started [true|false] indicates that metadata was sent
     # @param metadata_received [true|false] indicates if metadata has already
     #     been received. Should always be true for server calls
-    def initialize(call, marshal, unmarshal, deadline, started: true,
+    def initialize(call, marshal, unmarshal, deadline, method = nil, started: true,
                    metadata_received: false, metadata_to_send: nil)
       fail(TypeError, '!Core::Call') unless call.is_a? Core::Call
       @call = call
       @deadline = deadline
+      @method = method
       @marshal = marshal
       @unmarshal = unmarshal
       @metadata_received = metadata_received
@@ -639,7 +640,7 @@ module GRPC
 
     # SingleReqView limits access to an ActiveCall's methods for use in server
     # handlers that receive just one request.
-    SingleReqView = view_class(:cancelled?, :deadline, :metadata,
+    SingleReqView = view_class(:cancelled?, :deadline, :metadata, :method,
                                :output_metadata, :peer, :peer_cert,
                                :send_initial_metadata,
                                :metadata_to_send,
@@ -648,7 +649,7 @@ module GRPC
 
     # MultiReqView limits access to an ActiveCall's methods for use in
     # server client_streamer handlers.
-    MultiReqView = view_class(:cancelled?, :deadline,
+    MultiReqView = view_class(:cancelled?, :deadline, :method,
                               :each_remote_read, :metadata, :output_metadata,
                               :peer, :peer_cert,
                               :send_initial_metadata,

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -499,16 +499,17 @@ module GRPC
 
       # Create the ActiveCall. Indicate that metadata hasnt been sent yet.
       GRPC.logger.info("deadline is #{an_rpc.deadline}; (now=#{Time.now})")
-      rpc_desc = rpc_descs[an_rpc.method.to_sym]
+      mth = an_rpc.method.to_sym
+      rpc_desc = rpc_descs[mth]
       c = ActiveCall.new(an_rpc.call,
                          rpc_desc.marshal_proc,
                          rpc_desc.unmarshal_proc(:input),
                          an_rpc.deadline,
+                         mth,
                          metadata_received: true,
                          started: false,
                          metadata_to_send: connect_md)
       c.attach_peer_cert(an_rpc.call.peer_cert)
-      mth = an_rpc.method.to_sym
       [c, mth]
     end
 

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -75,7 +75,7 @@ describe GRPC::ActiveCall do
       it 'exposes a fixed subset of the ActiveCall.methods' do
         want = %w(cancelled?, deadline, each_remote_read, metadata, \
                   shutdown, peer, peer_cert, send_initial_metadata, \
-                  initial_metadata_sent)
+                  initial_metadata_sent, method)
         v = @client_call.multi_req_view
         want.each do |w|
           expect(v.methods.include?(w))
@@ -87,7 +87,7 @@ describe GRPC::ActiveCall do
       it 'exposes a fixed subset of the ActiveCall.methods' do
         want = %w(cancelled?, deadline, metadata, shutdown, \
                   send_initial_metadata, metadata_to_send, \
-                  merge_metadata_to_send, initial_metadata_sent)
+                  method, merge_metadata_to_send, initial_metadata_sent)
         v = @client_call.single_req_view
         want.each do |w|
           expect(v.methods.include?(w))


### PR DESCRIPTION
This is useful in interceptors, for logging the request.

@nicolasnoble
