### PR TITLE
Added portability test with openssl 1.0.2

### DIFF
--- a/templates/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile.template
@@ -1,0 +1,39 @@
+%YAML 1.2
+--- |
+  # Copyright 2015 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM debian:buster
+  
+  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../python_deps.include"/>
+  <%include file="../../gcp_api_libraries.include"/>
+  <%include file="../../cxx_deps.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../run_tests_addons.include"/>
+
+  # Install openssl 1.0.2 from source
+  RUN apt-get update && apt-get install -y build-essential zlib1g-dev
+  RUN cd /tmp && ${"\\"}
+      wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && ${"\\"}
+      tar -xf openssl-1.0.2u.tar.gz && ${"\\"}
+      cd openssl-1.0.2u && ${"\\"}
+      ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && ${"\\"}
+      make -j 4 && ${"\\"}
+      make install && ${"\\"}
+      rm -rf /tmp/openssl-1.0.2u*
+  ENV OPENSSL_ROOT_DIR=/usr/local/ssl
+
+  # Define the default command.
+  CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile.template
@@ -1,6 +1,6 @@
 %YAML 1.2
 --- |
-  # Copyright 2015 gRPC authors.
+  # Copyright 2021 the gRPC authors.
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
   # you may not use this file except in compliance with the License.

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -956,7 +956,11 @@ void ssl_tsi_test_extract_cert_chain() {
     X509_INFO* certInfo = sk_X509_INFO_value(certInfos, i);
     if (certInfo->x509 != nullptr) {
       GPR_ASSERT(sk_X509_push(cert_chain, certInfo->x509) != 0);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
       X509_up_ref(certInfo->x509);
+#else
+      certInfo->x509->references += 1;
+#endif
     }
   }
   tsi_peer_property chain_property;

--- a/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2021 the gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile
@@ -1,0 +1,98 @@
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:buster
+
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  gcc \
+  gcc-multilib \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#================
+# Build profiling
+RUN apt-get update && apt-get install -y time && apt-get clean
+
+#====================
+# Python dependencies
+
+# Install dependencies
+
+RUN apt-get update && apt-get install -y \
+    python-all-dev \
+    python3-all-dev \
+    python-setuptools
+
+# Install Python packages from PyPI
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+RUN pip install --upgrade pip==19.3.1
+RUN pip install virtualenv==16.7.9
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+
+# Google Cloud platform API libraries
+RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0
+
+#=================
+# C++ dependencies
+RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
+
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+
+RUN mkdir /var/local/jenkins
+
+
+# Install openssl 1.0.2 from source
+RUN apt-get update && apt-get install -y build-essential zlib1g-dev
+RUN cd /tmp && \
+    wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && \
+    tar -xf openssl-1.0.2u.tar.gz && \
+    cd openssl-1.0.2u && \
+    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
+    make -j 4 && \
+    make install && \
+    rm -rf /tmp/openssl-1.0.2u*
+ENV OPENSSL_ROOT_DIR=/usr/local/ssl
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -485,6 +485,10 @@ class CLanguage(object):
             return ('ubuntu1804', [])
         elif compiler == 'gcc8.3':
             return ('buster', [])
+        elif compiler == 'gcc8.3_openssl102':
+            return ('buster_openssl102', [
+                "-DgRPC_SSL_PROVIDER=package",
+            ])
         elif compiler == 'gcc_musl':
             return ('alpine', [])
         elif compiler == 'clang4.0':
@@ -1424,6 +1428,7 @@ argp.add_argument(
         'gcc5.3',
         'gcc7.4',
         'gcc8.3',
+        'gcc8.3_openssl102',
         'gcc_musl',
         'clang4.0',
         'clang5.0',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -266,8 +266,8 @@ def _create_portability_test_jobs(extra_args=[],
 
     # portability C and C++ on x64
     for compiler in [
-            'gcc4.9', 'gcc5.3', 'gcc7.4', 'gcc8.3', 'gcc_musl', 'clang4.0',
-            'clang5.0'
+            'gcc4.9', 'gcc5.3', 'gcc7.4', 'gcc8.3', 'gcc8.3_openssl102',
+            'gcc_musl', 'clang4.0', 'clang5.0'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],
                                     configs=['dbg'],


### PR DESCRIPTION
Adding a new portability test with openssl 1.0.2. OpenSSL 1.0.2 is out of support but it's still worth having tests because openssl variants such as libressl are OpenSSL 1.0.x compatible.

[grpc/core/master/linux/grpc_portability](https://fusion2.corp.google.com/invocations/64471576-f02a-4576-b786-a425f0b59426)

Fixes #24960