### PR TITLE
LoadTest generator for OSS benchmarks framework.

### DIFF
--- a/tools/run_tests/performance/concat_yaml.py
+++ b/tools/run_tests/performance/concat_yaml.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright 2020 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper script to extract JSON scenario definitions from scenario_config.py
+# Useful to construct "ScenariosJSON" configuration accepted by the OSS benchmarks framework
+# See https://github.com/grpc/test-infra/blob/master/config/samples/cxx_example_loadtest.yaml
+
+import argparse
+import sys
+
+from typing import Iterable
+
+
+def gen_content_strings(input_files: Iterable[str]) -> Iterable[str]:
+    if not input_files:
+        return
+
+    with open(input_files[0]) as f:
+        yield f.read()
+
+    for input_file in input_files[1:]:
+        with open(input_file) as f:
+            content = f.read()
+        yield '---\n'
+        yield content
+
+
+def main() -> None:
+    argp = argparse.ArgumentParser(description='Concatenates YAML files.')
+    argp.add_argument('-i',
+                      '--inputs',
+                      action='extend',
+                      nargs='+',
+                      type=str,
+                      required=True,
+                      help='Input files.')
+    argp.add_argument(
+        '-o',
+        '--output',
+        type=str,
+        help='Concatenated output file. Output to stdout if not set.')
+    args = argp.parse_args()
+
+    with open(args.output, 'w') if args.output else sys.stdout as f:
+        for content in gen_content_strings(args.inputs):
+            print(content, file=f, sep='', end='')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper script to extract JSON scenario definitions from scenario_config.py
+# Useful to construct "ScenariosJSON" configuration accepted by the OSS benchmarks framework
+# See https://github.com/grpc/test-infra/blob/master/config/samples/cxx_example_loadtest.yaml
+
+
+import argparse
+import copy
+import datetime
+import json
+import os
+import string
+import sys
+
+from typing import Any, Dict, Iterable, Optional
+
+import yaml
+
+import scenario_config
+import scenario_config_exporter
+
+
+def default_loadtest_prefix() -> str:
+    """Constructs and returns a default prefix for LoadTest names."""
+    user = os.environ.get('USER', 'loadtest')
+    time_str = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    return user + time_str
+
+
+def validate_loadtest_name(name: str) -> None:
+    """Validates that a LoadTest name is in the expected format."""
+    base_name, _, suffix = name.partition('--')
+    if '--' in suffix:
+        raise ValueError(
+            'Multiple double dashes in LoadTest name: %s' % name)
+    elements = base_name.split('-')
+    if suffix:
+        elements.extend(suffix.split('-'))
+    for element in elements:
+        if not element.isalnum():
+            print(elements, file=sys.stderr)
+            raise ValueError(
+                'Invalid element in LoadTest name "%s": %s', name, element)
+
+
+def loadtest_name(prefix: str, scenario_name: str, run_index: str,
+                  queue_name: str) -> str:
+    """Constructs and returns a valid name for a LoadTest resource."""
+    elements = []
+    if prefix:
+        elements.append(prefix)
+    if run_index:
+        elements.append(run_index)
+    elements.append(scenario_name.replace('_', '-'))
+    if queue_name:
+        elements.extend(['', queue_name])
+    name = '-'.join(elements)
+    validate_loadtest_name(name)
+    return name
+
+
+def gen_run_indices(runs_per_test: int) -> Iterable[str]:
+    """Generates run indices for multiple runs, as formatted strings."""
+    if runs_per_test < 2:
+        yield ''
+        return
+    prefix_length = len('{:d}'.format(runs_per_test - 1))
+    prefix_fmt = '{{:{:d}d}}'.format(prefix_length)
+    for i in range(runs_per_test):
+        yield prefix_fmt.format(i)
+
+
+def gen_loadtest_configs(base_config: yaml.YAMLObject,
+                         scenarios: Iterable[Dict[str, Any]],
+                         loadtest_name_prefix: str = '',
+                         queue_name: str = '',
+                         runs_per_test: int = 1) -> Iterable[yaml.YAMLObject]:
+    """Generates LoadTest configurations as YAML objects."""
+    prefix = loadtest_name_prefix or default_loadtest_prefix()
+    for run_index in gen_run_indices(runs_per_test):
+        for scenario in scenarios:
+
+            name = loadtest_name(prefix, scenario['name'],
+                                 run_index, queue_name)
+            scenario_str = json.dumps({'scenarios': scenario}, indent="  ")
+            config = copy.deepcopy(base_config)
+            config['metadata']['name'] = name
+            config['spec']['scenariosJSON'] = scenario_str
+            yield config
+
+
+def parse_substitution_args(args: Optional[Iterable[str]]) -> Dict[str, str]:
+    """Parses arguments in the form key=value into a dictionary."""
+    d = dict()
+    if args is None:
+        return d
+    for arg in args:
+        key, equals, value = arg.partition('=')
+        if equals != '=':
+            raise ValueError('Expected key=value: ' + value)
+        d[key] = value
+    return d
+
+
+def configure_yaml() -> None:
+    """Configures the YAML library to dump data in the expected format."""
+    def str_presenter(dumper, data):
+        if '\n' in data:
+            return dumper.represent_scalar(
+                'tag:yaml.org,2002:str', data, style='|')
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+    yaml.add_representer(str, str_presenter)
+
+
+def main() -> None:
+    language_choices = sorted(scenario_config.LANGUAGES.keys())
+    argp = argparse.ArgumentParser(description='Generates load test configs.')
+    argp.add_argument('-l',
+                      '--language',
+                      choices=language_choices,
+                      required=True,
+                      help='Language to benchmark.')
+    argp.add_argument('-t',
+                      '--template',
+                      type=str,
+                      required=True,
+                      help='LoadTest configuration yaml file template.')
+    argp.add_argument('-s',
+                      '--substitutions',
+                      action='extend',
+                      nargs='+',
+                      type=str,
+                      help='Template substitutions in the form key=value.')
+    argp.add_argument('-p',
+                      '--prefix',
+                      type=str,
+                      default='',
+                      help='Test name prefix.')
+    argp.add_argument('-q',
+                      '--concurrency_queue',
+                      type=str,
+                      default='',
+                      help='Test runner concurrency queue.')
+    argp.add_argument('-r',
+                      '--regex',
+                      default='.*',
+                      type=str,
+                      help='Regex to select scenarios to run.')
+    argp.add_argument('--category',
+                      choices=['all', 'scalable', 'smoketest', 'sweep'],
+                      default='all',
+                      help='Select a category of tests to run.')
+    argp.add_argument(
+        '--client_language',
+        choices=language_choices,
+        help='Select only scenarios with a specified client language.')
+    argp.add_argument(
+        '--server_language',
+        choices=language_choices,
+        help='Select only scenarios with a specified server language.')
+    argp.add_argument('--runs_per_test',
+                      default=1,
+                      type=int,
+                      help='Number of copies to generate for each test.')
+    argp.add_argument('-o',
+                      '--output',
+                      type=str,
+                      help='Output file name. Output to stdout if not set.')
+    args = argp.parse_args()
+
+    substitution_args_dict = parse_substitution_args(args.substitutions)
+
+    with open(args.template) as f:
+        base_config = yaml.safe_load(string.Template(
+            f.read()).substitute(substitution_args_dict))
+
+    scenario_filter = scenario_config_exporter.scenario_filter(
+        scenario_name_regex=args.regex,
+        category=args.category,
+        client_language=args.client_language,
+        server_language=args.server_language)
+
+    scenarios = scenario_config_exporter.gen_scenarios(
+        args.language, scenario_filter)
+
+    configs = gen_loadtest_configs(
+        base_config, scenarios, loadtest_name_prefix=args.prefix,
+        queue_name=args.concurrency_queue, runs_per_test=args.runs_per_test)
+
+    configure_yaml()
+
+    with open(args.output, 'w') if args.output else sys.stdout as f:
+        yaml.dump_all(configs, stream=f)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/run_tests/performance/scenario_config_exporter.py
+++ b/tools/run_tests/performance/scenario_config_exporter.py
@@ -14,48 +14,169 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Helper script to extract JSON scenario definitions from scenario_config.py
-# Useful to construct "ScenariosJSON" configuration accepted by the OSS benchmarks framework
+# Library to extract scenario definitions from scenario_config.py
+#
+# Contains functions to filter, analyze and dump scenario definitions.
+#
+# This library is used in loadtest_config.py to generate the "scenariosJSON"
+# field in the format accepted by the OSS benchmarks framework.
 # See https://github.com/grpc/test-infra/blob/master/config/samples/cxx_example_loadtest.yaml
+#
+# It can also be used to dump scenarios to files, and to count scenarios by
+# language.
+#
+# Example usage:
+#
+# scenario_config.py --export_scenarios -l cxx -f cxx_scenario_ -r '.*' \
+#     --category=scalable
+#
+# scenario_config.py --count_scenarios
 
+import argparse
+import collections
 import json
 import re
-import scenario_config
 import sys
 
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
-def get_json_scenarios(language_name, scenario_name_regex='.*', category='all'):
-    """Returns list of scenarios that match given constraints."""
-    result = []
-    scenarios = scenario_config.LANGUAGES[language_name].scenarios()
-    for scenario_json in scenarios:
-        if re.search(scenario_name_regex, scenario_json['name']):
-            # if the 'CATEGORIES' key is missing, treat scenario as part of 'scalable' and 'smoketest'
-            # this matches the behavior of run_performance_tests.py
-            scenario_categories = scenario_json.get('CATEGORIES',
-                                                    ['scalable', 'smoketest'])
-            # TODO(jtattermusch): consider adding filtering for 'CLIENT_LANGUAGE' and 'SERVER_LANGUAGE'
-            # fields, before the get stripped away.
-            if category in scenario_categories or category == 'all':
-                scenario_json_stripped = scenario_config.remove_nonproto_fields(
-                    scenario_json)
-                result.append(scenario_json_stripped)
-    return result
+import scenario_config
 
 
-def dump_to_json_files(json_scenarios, filename_prefix='scenario_dump_'):
-    """Dump a list of json scenarios to json files"""
-    for scenario in json_scenarios:
-        filename = "%s%s.json" % (filename_prefix, scenario['name'])
-        print('Writing file %s' % filename, file=sys.stderr)
+def gen_scenario_languages() -> Iterable[Tuple[str, str, str]]:
+    """Generates tuples containing the languages specified in each scenario."""
+    for language in scenario_config.LANGUAGES:
+        for scenario in scenario_config.LANGUAGES[language].scenarios():
+            client_language = scenario.get('ÇLIENT_LANGUAGE')
+            server_language = scenario.get('SERVER_LANGUAGE')
+            yield (language, client_language, server_language)
+
+
+def scenario_filter(
+        scenario_name_regex: str = '.*', category: str = 'all',
+        client_language: Optional[str] = None,
+        server_language: Optional[str] = None
+) -> Callable[[Dict[str, Any]], bool]:
+    """Returns a function to filter scenarios to process."""
+
+    def filter_scenario(scenario: Dict[str, Any]) -> bool:
+        """Filters scenarios that match specified criteria."""
+        if not re.search(scenario_name_regex, scenario["name"]):
+            return False
+        # if the 'CATEGORIES' key is missing, treat scenario as part of
+        # 'scalable' and 'smoketest'. This matches the behavior of
+        # run_performance_tests.py.
+        scenario_categories = scenario.get('CATEGORIES',
+                                           ['scalable', 'smoketest'])
+        if category not in scenario_categories and category != 'all':
+            return False
+
+        scenario_client_language = scenario.get('CLIENT_LANGUAGE')
+        if client_language != scenario_client_language:
+            if scenario_client_language:
+                return False
+
+        scenario_server_language = scenario.get('SERVER_LANGUAGE')
+        if server_language != scenario_server_language:
+            if scenario_client_language:
+                return False
+
+        return True
+
+    return filter_scenario
+
+
+def gen_scenarios(language_name: str,
+                  scenario_filter_function: Callable[[Dict[str, Any]], bool]
+                  ) -> Iterable[Dict[str, Any]]:
+    """Generates scenarios that match a given filter function."""
+    return map(scenario_config.remove_nonproto_fields,
+               filter(scenario_filter_function,
+                      scenario_config.LANGUAGES[language_name].scenarios()))
+
+
+def dump_to_json_files(scenarios: Iterable[Dict[str, Any]],
+                       filename_prefix: str) -> None:
+    """Dumps a list of scenarios to JSON files"""
+    count = 0
+    for scenario in scenarios:
+        filename = '{}{}.json'.format(filename_prefix, scenario['name'])
+        print('Writing file {}'.format(filename), file=sys.stderr)
         with open(filename, 'w') as outfile:
-            # the dump file should have {"scenarios" : []} as the top level element
+            # The dump file should have {"scenarios" : []} as the top level
+            # element, when embedded in a LoadTest configuration YAML file.
             json.dump({'scenarios': [scenario]}, outfile, indent=2)
+        count += 1
+    print('Wrote {} scenarios'.format(count), file=sys.stderr)
+
+
+def main() -> None:
+    language_choices = sorted(scenario_config.LANGUAGES.keys())
+    argp = argparse.ArgumentParser(description='Exports scenarios to files.')
+    argp.add_argument('--export_scenarios',
+                      nargs='?',
+                      const=True,
+                      default=False,
+                      type=bool,
+                      help='Export scenarios to JSON files.')
+    argp.add_argument('--count_scenarios',
+                      nargs='?',
+                      const=True,
+                      default=False,
+                      type=bool,
+                      help='Count scenarios for all test languages.')
+    argp.add_argument('-l',
+                      '--language',
+                      choices=language_choices,
+                      help='Language to export.')
+    argp.add_argument('-f',
+                      '--filename_prefix',
+                      default='scenario_dump_',
+                      type=str,
+                      help='Prefix for exported JSON file names.')
+    argp.add_argument('-r',
+                      '--regex',
+                      default='.*',
+                      type=str,
+                      help='Regex to select scenarios to run.')
+    argp.add_argument('--category',
+                      default='all',
+                      choices=['all', 'scalable', 'smoketest', 'sweep'],
+                      help='Select scenarios for a category of tests.')
+    argp.add_argument(
+        '--client_language',
+        choices=language_choices,
+        help='Select only scenarios with a specified client language.')
+    argp.add_argument(
+        '--server_language',
+        choices=language_choices,
+        help='Select only scenarios with a specified server language.')
+    args = argp.parse_args()
+
+    if args.export_scenarios and not args.language:
+        print('Dumping scenarios requires a specified language.',
+              file=sys.stderr)
+        argp.print_usage(file=sys.stderr)
+        return
+
+    if args.export_scenarios:
+        s_filter = scenario_filter(
+            scenario_name_regex=args.regex,
+            category=args.category,
+            client_language=args.client_language,
+            server_language=args.server_language)
+        scenarios = gen_scenarios(args.language, s_filter)
+        dump_to_json_files(scenarios, args.filename_prefix)
+
+    if args.count_scenarios:
+        print('Scenario count for all languages:', file=sys.stderr)
+        print('{:>5}  {:16} {:8} {:8}'.format(
+            'Count', 'Language', 'Client', 'Server'), file=sys.stdout)
+        c = collections.Counter(gen_scenario_languages())
+        for ((l, cl, sl), count) in c.most_common():
+            print('{count:5}  {l:16} {cl:8} {sl:8}'.format(
+                l=l, cl=str(cl), sl=str(sl), count=count), file=sys.stdout)
 
 
 if __name__ == "__main__":
-    # example usage: extract C# scenarios and dump them as .json files
-    scenarios = get_json_scenarios('csharp',
-                                   scenario_name_regex='.*',
-                                   category='scalable')
-    dump_to_json_files(scenarios, 'scenario_dump_')
+    main()


### PR DESCRIPTION
This change adds a LoadTest configuration generator for the OSS
benchmarks framework. The output of the generator is a multipart
YAML file that specifies uniquely named LoadTest resources that
can be applied to a kubernetes cluster.

For the benchmarks framework, see  https://github.com/github/test-infra.

