### PR TITLE
testing: allow 10m for first xds fault_injection case

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1706,6 +1706,7 @@ def test_fault_injection(gcp, original_backend_service, instance_group):
     ]
 
     try:
+        first_case = True
         for (testcase_name, client_config, expected_results) in test_cases:
             logger.info('starting case %s', testcase_name)
 
@@ -1725,6 +1726,9 @@ def test_fault_injection(gcp, original_backend_service, instance_group):
             # Each attempt takes 10 seconds; 20 attempts is equivalent to 200
             # second timeout.
             attempt_count = 20
+            if first_case:
+                attempt_count = 120
+                first_case = False
             before_stats = get_client_accumulated_stats()
             if not before_stats.stats_per_method:
                 raise ValueError(


### PR DESCRIPTION
This may be enough to fix some of the flakiness we've been seeing.

If the deletion/recreation of the backend service (to disable proxyless validation) is excessively slow, this would help.  The other test that does this, circuit breaking, has a 20m timer to wait for healthy backends afterwards.