### PR TITLE
Remove TCP transmit zerocopy shutdown when removing TCP endpoint from pollset.

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -1639,7 +1639,6 @@ static void tcp_add_to_pollset_set(grpc_endpoint* ep,
 static void tcp_delete_from_pollset_set(grpc_endpoint* ep,
                                         grpc_pollset_set* pollset_set) {
   grpc_tcp* tcp = reinterpret_cast<grpc_tcp*>(ep);
-  ZerocopyDisableAndWaitForRemaining(tcp);
   grpc_pollset_set_del_fd(pollset_set, tcp->em_fd);
 }
 


### PR DESCRIPTION
Previously, we disabled TCP transmit zerocopy and waited for all pending
completions when removing a TCP endpoint from a pollset. However, certain
transports may do this and then re-add the endpoint to a pollset, in which case
zerocopy is no longer active.

Instead, here we only shutdown zerocopy if the socket is being torn down.

