### PR TITLE
Use URI form of address for channelz listen node

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -604,7 +604,7 @@ grpc_error* Chttp2ServerListener::Create(Server* server,
     // Create channelz node.
     if (grpc_channel_args_find_bool(args, GRPC_ARG_ENABLE_CHANNELZ,
                                     GRPC_ENABLE_CHANNELZ_DEFAULT)) {
-      std::string string_address = grpc_sockaddr_to_string(addr, false);
+      std::string string_address = grpc_sockaddr_to_uri(addr);
       listener->channelz_listen_socket_ =
           MakeRefCounted<channelz::ListenSocketNode>(
               string_address.c_str(),


### PR DESCRIPTION
With `grpc_sockaddr_to_string`, we were losing information on the type of the resolved address when parsing the string as an URI, which resulted in the channelz node using `other_address` field instead of formatting it as a `tcpip_address`