### PR TITLE
PHP: remove experimental from Interceptor API

### DIFF
--- a/src/php/lib/Grpc/CallInvoker.php
+++ b/src/php/lib/Grpc/CallInvoker.php
@@ -21,7 +21,6 @@ namespace Grpc;
 /**
  * CallInvoker is used to pass the self defined channel into the stub,
  * while intercept each RPC with the channel accessible.
- * THIS IS AN EXPERIMENTAL API.
  */
 interface CallInvoker
 {

--- a/src/php/lib/Grpc/DefaultCallInvoker.php
+++ b/src/php/lib/Grpc/DefaultCallInvoker.php
@@ -20,7 +20,6 @@ namespace Grpc;
 
 /**
  * Default call invoker in the gRPC stub.
- * THIS IS AN EXPERIMENTAL API.
  */
 class DefaultCallInvoker implements CallInvoker
 {

--- a/src/php/lib/Grpc/Interceptor.php
+++ b/src/php/lib/Grpc/Interceptor.php
@@ -23,7 +23,6 @@ namespace Grpc;
  * Represents an interceptor that intercept RPC invocations before call starts.
  * There is one proposal related to the argument $deserialize under the review.
  * The proposal link is https://github.com/grpc/proposal/pull/86.
- * This is an EXPERIMENTAL API.
  */
 class Interceptor
 {


### PR DESCRIPTION
The PHP Interceptor API has been live and stable since 2018. Removing the `experimental` tag in code comments.