### PR TITLE
Mark that callback generic service is frequently-polled

### DIFF
--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -304,6 +304,10 @@ std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
     }
   }
 
+  if (callback_generic_service_ != nullptr) {
+    has_frequently_polled_cqs = true;
+  }
+
   const bool is_hybrid_server = has_sync_methods && has_frequently_polled_cqs;
 
   if (has_sync_methods) {


### PR DESCRIPTION
All callback CQs are frequently-polled but this was only being claimed for named services, not generic ones. As a result, a server with just a CallbackGenericService was not being allowed.
