### PR TITLE
Apply the xds-specific Bazel rule to admin API

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2630,7 +2630,7 @@ grpc_cc_library_xds(
     alwayslink = 1,
 )
 
-grpc_cc_library(
+grpc_cc_library_xds(
     name = "grpcpp_admin",
     srcs = [
         "src/cpp/server/admin/admin_services.cc",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -874,7 +874,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_test_xds(
     name = "admin_services_end2end_test",
     srcs = ["admin_services_end2end_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/admin_services_end2end_test.cc
+++ b/test/cpp/end2end/admin_services_end2end_test.cc
@@ -21,13 +21,15 @@
 
 #include "absl/strings/str_cat.h"
 
-#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 
 #include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
+
+#ifndef DISABLED_XDS_PROTO_IN_CC
+#include <grpcpp/ext/admin_services.h>
 
 namespace grpc {
 namespace testing {
@@ -94,6 +96,8 @@ TEST_F(AdminServicesTest, XdsDisabled) {
 
 }  // namespace testing
 }  // namespace grpc
+
+#endif  // DISABLED_XDS_PROTO_IN_CC
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);


### PR DESCRIPTION
The xDS protos are not supported by internal C++ yet. So, we need to use the new Bazel rule to hide targets that depends on xDS protos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25799)
<!-- Reviewable:end -->
