### PR TITLE
fix: examples/node/ undeclared variable error

### DIFF
--- a/examples/node/static_codegen/greeter_client.js
+++ b/examples/node/static_codegen/greeter_client.js
@@ -16,6 +16,7 @@
  *
  */
 
+var parseArgs = require('minimist');
 var messages = require('./helloworld_pb');
 var services = require('./helloworld_grpc_pb');
 


### PR DESCRIPTION
ReferenceError: parseArgs is not defined


@nicolasnoble
