### PR TITLE
Add description of the core_banned_functions check

### DIFF
--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -13,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Explicitly ban select functions from being used in src/core/**.
+
+Most of these functions have internal versions that should be used instead."""
 
 import os
 import sys


### PR DESCRIPTION
Spot checking the banned functions, it appears there are internal versions that should be used instead, with a few different reasons and implementations:

* Some public methods declare an ExecCtx (e.g., grpc_resource_quota_ref vs grpc_resource_quota_ref_internal)
* Some have macros that should be used instead (e.g., grpc_error_ref vs GRPC_ERROR_REF, which adds debug info if compiled with the right flag).

This script could be used for other purposes, since it's just text matching across all non-header files in src/core, but this docstring captures its current purpose.