### PR TITLE
Remove async mark for set_trailing_metadata interface

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -193,7 +193,7 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         """
 
     @abc.abstractmethod
-    async def set_trailing_metadata(self, trailing_metadata: Metadata) -> None:
+    def set_trailing_metadata(self, trailing_metadata: Metadata) -> None:
         """Sends the trailing metadata for the RPC.
 
         This method need not be called by implementations if they have no


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/25813.

This method is a simple setter. I think I made a mistake before to mark it as "async".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25814)
<!-- Reviewable:end -->
