### PR TITLE
Add parallel compilation to php distribtest

### DIFF
--- a/test/distrib/php/run_distrib_test.sh
+++ b/test/distrib/php/run_distrib_test.sh
@@ -20,6 +20,6 @@ cd "$(dirname "$0")"
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
 find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
-    MAKEFLAGS=-j4 xargs pecl install
+    MAKEFLAGS=-j xargs pecl install
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php

--- a/test/distrib/php/run_distrib_test.sh
+++ b/test/distrib/php/run_distrib_test.sh
@@ -20,6 +20,6 @@ cd "$(dirname "$0")"
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
 find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
-    xargs pecl install
+    MAKEFLAGS=-j4 xargs pecl install
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php

--- a/test/distrib/php/run_distrib_test_macos.sh
+++ b/test/distrib/php/run_distrib_test_macos.sh
@@ -20,6 +20,6 @@ cd "$(dirname "$0")"
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
 find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
-    xargs sudo pecl install
+    xargs sudo MAKEFLAGS=-j4 pecl install
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php

--- a/test/distrib/php/run_distrib_test_macos.sh
+++ b/test/distrib/php/run_distrib_test_macos.sh
@@ -20,6 +20,6 @@ cd "$(dirname "$0")"
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
 find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
-    xargs sudo MAKEFLAGS=-j4 pecl install
+    xargs sudo MAKEFLAGS=-j pecl install
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php


### PR DESCRIPTION
Fixes #25818.

Tested this by running the [prod:grpc/core/experimental/grpc_build_artifacts_multiplatform](https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod%3Agrpc%2Fcore%2Fexperimental%2Fgrpc_build_artifacts_multiplatform) job before and after the fix.

Before: [build artifacts](https://fusion2.corp.google.com/invocations/18b1a50e-837e-426c-ac7a-345cda471d17/targets/grpc%2Fcore%2Fexperimental%2Fgrpc_build_artifacts_multiplatform/log) -> [build packages](https://fusion2.corp.google.com/invocations/0bd06964-de15-46ff-88b8-5d36dd2dfb58/targets/grpc%2Fcore%2Fexperimental%2Fgrpc_build_packages_multiplatform/log) -> [distribtests multiplatform](https://fusion2.corp.google.com/invocations/d6ef1120-f7a7-416b-8a53-705148a9bff2/targets/grpc%2Fcore%2Fexperimental%2Fgrpc_distribtests_multiplatform/log) -> [macos distribtests](https://fusion2.corp.google.com/invocations/0f46f2a2-b11f-43c7-9e64-018cda074eb9/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_distribtests;config=default/log) -> `2021-03-28 02:05:04,803 TIMEOUT: distribtest.php7_macos_x64_None [pid=6221, time=901.6sec]` (Timed out, error).

After: [build artifacts](https://fusion2.corp.google.com/invocations/4fbecbcc-cc50-4cea-8393-5834d0f61a6c/targets/grpc%2Fcore%2Fexperimental%2Fgrpc_build_artifacts_multiplatform/log) -> [build packages](https://fusion2.corp.google.com/invocations/713ca7ca-56bc-48b4-a7df-db0a04a97686/targets/grpc%2Fcore%2Fexperimental%2Fgrpc_build_packages_multiplatform/log) -> [distribtests multiplatform](https://fusion2.corp.google.com/invocations/cc6ef727-e2b0-4f23-85e1-b154f405a323/targets/grpc%2Fcore%2Fexperimental%2Fgrpc_distribtests_multiplatform/log) -> [macos distribtests](https://fusion2.corp.google.com/invocations/eaa941ea-2858-4be5-a6e4-3d13cc3dbc0a/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_distribtests;config=default/log) -> `2021-03-28 01:46:56,887 PASSED: distribtest.php7_macos_x64_None [time=380.6sec, retries=0:0]`