### PR TITLE
Fix unused variables

### DIFF
--- a/src/core/lib/iomgr/parse_address.cc
+++ b/src/core/lib/iomgr/parse_address.cc
@@ -122,25 +122,25 @@ grpc_error* UnixAbstractSockaddrPopulate(absl::string_view path,
 
 #else  /* GRPC_HAVE_UNIX_SOCKET */
 
-bool grpc_parse_unix(const grpc_core::URI& uri,
-                     grpc_resolved_address* resolved_addr) {
+bool grpc_parse_unix(const grpc_core::URI& /* uri */,
+                     grpc_resolved_address* /* resolved_addr */) {
   abort();
 }
 
-bool grpc_parse_unix_abstract(const grpc_core::URI& uri,
-                              grpc_resolved_address* resolved_addr) {
+bool grpc_parse_unix_abstract(const grpc_core::URI& /* uri */,
+                              grpc_resolved_address* /* resolved_addr */) {
   abort();
 }
 
 namespace grpc_core {
 
-grpc_error* UnixSockaddrPopulate(absl::string_view path,
-                                 grpc_resolved_address* resolved_addr) {
+grpc_error* UnixSockaddrPopulate(absl::string_view /* path */,
+                                 grpc_resolved_address* /* resolved_addr */) {
   abort();
 }
 
-grpc_error* UnixAbstractSockaddrPopulate(absl::string_view path,
-                                         grpc_resolved_address* resolved_addr) {
+grpc_error* UnixAbstractSockaddrPopulate(
+    absl::string_view /* path */, grpc_resolved_address* /* resolved_addr */) {
   abort();
 }
 

--- a/src/core/lib/iomgr/unix_sockets_posix_noop.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix_noop.cc
@@ -26,7 +26,7 @@
 
 #include <grpc/support/log.h>
 
-void grpc_create_socketpair_if_unix(int sv[2]) {
+void grpc_create_socketpair_if_unix(int /* sv */[2]) {
   // TODO: Either implement this for the non-Unix socket case or make
   // sure that it is never called in any such case. Until then, leave an
   // assertion to notify if this gets called inadvertently
@@ -34,7 +34,7 @@ void grpc_create_socketpair_if_unix(int sv[2]) {
 }
 
 grpc_error* grpc_resolve_unix_domain_address(
-    const char* name, grpc_resolved_addresses** addresses) {
+    const char* /* name */, grpc_resolved_addresses** addresses) {
   *addresses = NULL;
   return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Unix domain sockets are not supported on Windows");
@@ -47,12 +47,15 @@ grpc_error* grpc_resolve_unix_abstract_domain_address(
       "Unix domain sockets are not supported on Windows");
 }
 
-int grpc_is_unix_socket(const grpc_resolved_address* addr) { return false; }
+int grpc_is_unix_socket(const grpc_resolved_address* /* addr */) {
+  return false;
+}
 
-void grpc_unlink_if_unix_domain_socket(const grpc_resolved_address* addr) {}
+void grpc_unlink_if_unix_domain_socket(
+    const grpc_resolved_address* /* addr */) {}
 
 std::string grpc_sockaddr_to_uri_unix_if_possible(
-    const grpc_resolved_address* addr) {
+    const grpc_resolved_address* /* addr */) {
   return "";
 }
 


### PR DESCRIPTION
I think these warnings should have shown up on a Windows build, but I
found them by other means (prep for EventEngine).