### PR TITLE
Enable GPR_ABSEIL_SYNC on Apple environment

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -31,12 +31,7 @@
  * Defines GPR_ABSEIL_SYNC to use synchronization features from Abseil
  */
 #ifndef GPR_ABSEIL_SYNC
-#if defined(__APPLE__)
-// This is disabled on Apple platforms because macos/grpc_basictests_c_cpp
-// fails with this. https://github.com/grpc/grpc/issues/23661
-#else
 #define GPR_ABSEIL_SYNC 1
-#endif
 #endif  // GPR_ABSEIL_SYNC
 
 /* Get windows.h included everywhere (we need it) */


### PR DESCRIPTION
Trying to enable GPR_ABSEIL_SYNC on Apple again since gRPC got the latest Abseil (see https://github.com/grpc/grpc/pull/25835) which fixed the mysterious OSX TLS issue with their Mutex. I tried to enable this before (https://github.com/grpc/grpc/pull/23372) but failed due to OSX tests that got to fail more often. (Notably `macos/grpc_basictests_c_cpp` needs to be monitored carefully because it became super flaky with the past trial. ref:https://github.com/grpc/grpc/pull/24774). Currently its failure rate is 6/30.)