### PR TITLE
Make ADS timeout increase from 500 to 2000

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -11078,7 +11078,7 @@ TEST_P(ClientStatusDiscoveryServiceTest, XdsConfigDumpClusterRequested) {
 class CsdsShortAdsTimeoutTest : public ClientStatusDiscoveryServiceTest {
   void SetUp() override {
     // Shorten the ADS subscription timeout to speed up the test run.
-    xds_resource_does_not_exist_timeout_ms_ = 500;
+    xds_resource_does_not_exist_timeout_ms_ = 2000;
     ClientStatusDiscoveryServiceTest::SetUp();
   }
 };


### PR DESCRIPTION
sponge/3d4de79e-c5bd-4cb8-a8aa-23db2f18d1a2

Under MSAN, the timeout 500ms might be too short that XdsClient unable to complete several round-trip of ADS to create corresponding CDS representation. This PR increases it to 2000. This is longer than the wait in REQUESTED client status test which appears to never be flaky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25844)
<!-- Reviewable:end -->
