### PR TITLE
Use Realtime instead of Monotonic time for CSDS

### DIFF
--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -3520,7 +3520,7 @@ google_protobuf_Timestamp* GrpcMillisToTimestamp(const EncodingContext& context,
                                                  grpc_millis value) {
   google_protobuf_Timestamp* timestamp =
       google_protobuf_Timestamp_new(context.arena);
-  gpr_timespec timespec = grpc_millis_to_timespec(value, GPR_CLOCK_MONOTONIC);
+  gpr_timespec timespec = grpc_millis_to_timespec(value, GPR_CLOCK_REALTIME);
   google_protobuf_Timestamp_set_seconds(timestamp, timespec.tv_sec);
   google_protobuf_Timestamp_set_nanos(timestamp, timespec.tv_nsec);
   return timestamp;


### PR DESCRIPTION
This needs a backport. Found by @menghanl.

After the update, the timestamp is back to normal instead of `"last_updated": "1970-01-21T22:53:48.202451705Z",`.

```json
{
 "config": [
  {
   "node": {
    "id": "xds_end2end_test",
    "cluster": "test",
    "metadata": {
     "foo": "bar"
    },
    "locality": {
     "region": "corp",
     "zone": "svl",
     "subZone": "mp3"
    },
    "userAgentName": "gRPC C-core linux",
    "userAgentVersion": "15.0.0",
    "clientFeatures": [
     "envoy.lb.does_not_support_overprovisioning"
    ]
   },
   "xdsConfig": [
    {
     "clusterConfig": {
      "versionInfo": "1",
      "dynamicActiveClusters": [
       {
        "versionInfo": "1",
        "cluster": {
         "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
         "name": "cluster_name",
         "type": "EDS",
         "edsClusterConfig": {
          "edsConfig": {
           "ads": {}
          },
          "serviceName": "eds_service_name"
         }
        },
        "lastUpdated": "2021-03-31T22:39:41.965670143Z",
        "clientStatus": "ACKED"
       }
      ]
     }
    },
    {
     "endpointConfig": {
      "dynamicEndpointConfigs": [
       {
        "versionInfo": "1",
        "endpointConfig": {
         "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
         "clusterName": "eds_service_name",
         "endpoints": [
          {
           "locality": {
            "region": "xds_default_locality_region",
            "zone": "xds_default_locality_zone",
            "subZone": "locality0"
           },
           "lbEndpoints": [
            {
             "endpoint": {
              "address": {
               "socketAddress": {
                "address": "127.0.0.1",
                "portValue": 19123
               }
              }
             }
            }
           ],
           "loadBalancingWeight": 3
          }
         ]
        },
        "lastUpdated": "2021-03-31T22:39:41.976670220Z",
        "clientStatus": "ACKED"
       }
      ]
     }
    },
    {
     "listenerConfig": {
      "versionInfo": "1",
      "dynamicListeners": [
       {
        "name": "server.example.com",
        "activeState": {
         "versionInfo": "1",
         "listener": {
          "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
          "name": "server.example.com",
          "apiListener": {
           "apiListener": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "rds": {
             "configSource": {
              "ads": {}
             },
             "routeConfigName": "route_config_name"
            },
            "httpFilters": [
             {
              "name": "router",
              "typedConfig": {
               "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
              }
             }
            ]
           }
          }
         },
         "lastUpdated": "2021-03-31T22:39:41.943670219Z"
        },
        "clientStatus": "ACKED"
       }
      ]
     }
    },
    {
     "routeConfig": {
      "dynamicRouteConfigs": [
       {
        "versionInfo": "1",
        "routeConfig": {
         "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
         "name": "route_config_name",
         "virtualHosts": [
          {
           "domains": [
            "*"
           ],
           "routes": [
            {
             "match": {
              "prefix": ""
             },
             "route": {
              "cluster": "cluster_name"
             }
            }
           ]
          }
         ]
        },
        "lastUpdated": "2021-03-31T22:39:41.954670206Z",
        "clientStatus": "ACKED"
       }
      ]
     }
    }
   ]
  }
 ]
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25857)
<!-- Reviewable:end -->
