### PR TITLE
More informative result from check_submodules.sh

### DIFF
--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -24,23 +24,23 @@ cd "$(dirname "$0")/../../.."
 submodules=$(mktemp /tmp/submXXXXXX)
 want_submodules=$(mktemp /tmp/submXXXXXX)
 
-git submodule | awk '{ print $1 }' | sort > "$submodules"
-cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
- 997aaf3a28308eba1b9156aa35ab7bca9688e9f6 third_party/abseil-cpp (heads/master)
- 73d4d5e8d6d449fc8663765a42aa8aeeee844489 third_party/benchmark (v1.5.2)
- 73594cde8c9a52a102c4341c244c833aa61b9c06 third_party/bloaty (remotes/origin/wide-14-g73594cd)
- 1a7359455220f7010def8c63f7c7e041ce6707c6 third_party/boringssl-with-bazel (remotes/origin/master-with-bazel)
- e982924acee7f7313b4baa4ee5ec000c5e373c30 third_party/cares/cares (cares-1_15_0)
- 18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2 third_party/envoy-api (remotes/origin/main)
- 82944da21578a53b74e547774cf62ed31a05b841 third_party/googleapis (common-protos-1_3_1-915-g80ed4d0bb)
- c9ccac7cb7345901884aabf5d1a786cfa6e2f397 third_party/googletest (6e2f397)
- 15ae750151ac9341e5945eb38f8982d59fb99201 third_party/libuv (v1.34.0)
- 4aa53e15cbf1a47bc9087e6cfdca214c1eea4e89 third_party/opencensus-proto (v0.3.0)
- d7e943b8d2bc444a8c770644e73d090b486f8b37 third_party/protobuf (v3.15.2)
- 872b28c457822ed9c2a5405da3c33f386ac0e86f third_party/protoc-gen-validate (v0.4.1)
- aecba11114cf1fac5497aeb844b6966106de3eb6 third_party/re2 (heads/master)
- cc1b757b3eddccaaaf0743cbb107742bb7e3ee4f third_party/udpa (heads/master)
- cacf7f1d4e3d44d871b605da3b647f07d718623f third_party/zlib (v1.2.11)
+git submodule | awk '{ print $2 "\t" $1 }' | sort > "$submodules"
+cat << EOF | sort > "$want_submodules"
+third_party/abseil-cpp	997aaf3a28308eba1b9156aa35ab7bca9688e9f6
+third_party/benchmark	73d4d5e8d6d449fc8663765a42aa8aeeee844489
+third_party/bloaty	73594cde8c9a52a102c4341c244c833aa61b9c06
+third_party/boringssl-with-bazel	1a7359455220f7010def8c63f7c7e041ce6707c6
+third_party/cares/cares	e982924acee7f7313b4baa4ee5ec000c5e373c30
+third_party/envoy-api	18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2
+third_party/googleapis	82944da21578a53b74e547774cf62ed31a05b841
+third_party/googletest	c9ccac7cb7345901884aabf5d1a786cfa6e2f397
+third_party/libuv	15ae750151ac9341e5945eb38f8982d59fb99201
+third_party/opencensus-proto	4aa53e15cbf1a47bc9087e6cfdca214c1eea4e89
+third_party/protobuf	d7e943b8d2bc444a8c770644e73d090b486f8b37
+third_party/protoc-gen-validate	872b28c457822ed9c2a5405da3c33f386ac0e86f
+third_party/re2	aecba11114cf1fac5497aeb844b6966106de3eb6
+third_party/udpa	cc1b757b3eddccaaaf0743cbb107742bb7e3ee4f
+third_party/zlib	cacf7f1d4e3d44d871b605da3b647f07d718623f
 EOF
 
 diff -u "$submodules" "$want_submodules"

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -24,23 +24,23 @@ cd "$(dirname "$0")/../../.."
 submodules=$(mktemp /tmp/submXXXXXX)
 want_submodules=$(mktemp /tmp/submXXXXXX)
 
-git submodule | awk '{ print $2 "\t" $1 }' | sort > "$submodules"
+git submodule | awk '{ print $2 " " $1 }' | sort > "$submodules"
 cat << EOF | sort > "$want_submodules"
-third_party/abseil-cpp	997aaf3a28308eba1b9156aa35ab7bca9688e9f6
-third_party/benchmark	73d4d5e8d6d449fc8663765a42aa8aeeee844489
-third_party/bloaty	73594cde8c9a52a102c4341c244c833aa61b9c06
-third_party/boringssl-with-bazel	1a7359455220f7010def8c63f7c7e041ce6707c6
-third_party/cares/cares	e982924acee7f7313b4baa4ee5ec000c5e373c30
-third_party/envoy-api	18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2
-third_party/googleapis	82944da21578a53b74e547774cf62ed31a05b841
-third_party/googletest	c9ccac7cb7345901884aabf5d1a786cfa6e2f397
-third_party/libuv	15ae750151ac9341e5945eb38f8982d59fb99201
-third_party/opencensus-proto	4aa53e15cbf1a47bc9087e6cfdca214c1eea4e89
-third_party/protobuf	d7e943b8d2bc444a8c770644e73d090b486f8b37
-third_party/protoc-gen-validate	872b28c457822ed9c2a5405da3c33f386ac0e86f
-third_party/re2	aecba11114cf1fac5497aeb844b6966106de3eb6
-third_party/udpa	cc1b757b3eddccaaaf0743cbb107742bb7e3ee4f
-third_party/zlib	cacf7f1d4e3d44d871b605da3b647f07d718623f
+third_party/abseil-cpp 997aaf3a28308eba1b9156aa35ab7bca9688e9f6
+third_party/benchmark 73d4d5e8d6d449fc8663765a42aa8aeeee844489
+third_party/bloaty 73594cde8c9a52a102c4341c244c833aa61b9c06
+third_party/boringssl-with-bazel 1a7359455220f7010def8c63f7c7e041ce6707c6
+third_party/cares/cares e982924acee7f7313b4baa4ee5ec000c5e373c30
+third_party/envoy-api 18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2
+third_party/googleapis 82944da21578a53b74e547774cf62ed31a05b841
+third_party/googletest c9ccac7cb7345901884aabf5d1a786cfa6e2f397
+third_party/libuv 15ae750151ac9341e5945eb38f8982d59fb99201
+third_party/opencensus-proto 4aa53e15cbf1a47bc9087e6cfdca214c1eea4e89
+third_party/protobuf d7e943b8d2bc444a8c770644e73d090b486f8b37
+third_party/protoc-gen-validate 872b28c457822ed9c2a5405da3c33f386ac0e86f
+third_party/re2 aecba11114cf1fac5497aeb844b6966106de3eb6
+third_party/udpa cc1b757b3eddccaaaf0743cbb107742bb7e3ee4f
+third_party/zlib cacf7f1d4e3d44d871b605da3b647f07d718623f
 EOF
 
 diff -u "$submodules" "$want_submodules"


### PR DESCRIPTION
When `check_submodules.sh` returns errors, it now shows the name of submodule along with the expected commit-id like

```
 third_party/envoy-api	18b54850c9b7ba29a4ab67cbd7ed7eab7b0bbdb2
-third_party/googleapis	82944da21578a53b74e547774cf62ed31a05b841
+third_party/googleapis	92944da21578a53b74e547774cf62ed31a05b841
 third_party/googletest	c9ccac7cb7345901884aabf5d1a786cfa6e2f397
```

Also this removes misleading annotated tags from the expected submodule because they haven't been updated.