### PR TITLE
Cherry-pick PR #25429 "Add ruby 3.0 support for mac binary packages" to 1.37.x

### DIFF
--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -17,15 +17,15 @@ set -ex
 
 rm -rf ~/.rake-compiler
 
-CROSS_RUBY=$(mktemp tmpfile.XXXXXXXX)
+CROSS_RUBY="$(pwd)/$(mktemp tmpfile.XXXXXXXX)"
 
-curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.1.0/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
+curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.1.1/tasks/bin/cross-ruby.rake > "$CROSS_RUBY"
 
 # See https://github.com/grpc/grpc/issues/12161 for verconf.h patch details
 patch "$CROSS_RUBY" << EOF
---- cross-ruby.rake	2018-04-10 11:32:16.000000000 -0700
-+++ patched	2018-04-10 11:40:25.000000000 -0700
-@@ -133,8 +133,10 @@
+--- cross-ruby.rake	2021-03-05 12:04:09.898286632 -0800
++++ patched	2021-03-05 12:05:35.594318962 -0800
+@@ -111,10 +111,11 @@
      "--host=#{MINGW_HOST}",
      "--target=#{MINGW_TARGET}",
      "--build=#{RUBY_BUILD}",
@@ -34,12 +34,14 @@ patch "$CROSS_RUBY" << EOF
 +    '--disable-shared',
      '--disable-install-doc',
 +    '--without-gmp',
-     '--with-ext='
+     '--with-ext=',
+-    'LDFLAGS=-pipe -s',
    ]
  
-@@ -151,6 +153,7 @@
+   # Force Winsock2 for Ruby 1.8, 1.9 defaults to it
+@@ -130,6 +131,7 @@
  # make
- file "#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/ruby.exe" => ["#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/Makefile"] do |t|
+ file "#{build_dir}/ruby.exe" => ["#{build_dir}/Makefile"] do |t|
    chdir File.dirname(t.prerequisites.first) do
 +    sh "test -s verconf.h || rm -f verconf.h"  # if verconf.h has size 0, make sure it gets re-built by make
      sh MAKE
@@ -49,22 +51,44 @@ EOF
 
 MAKE="make -j8"
 
+# Install ruby 3.0.0 for rake-compiler
+# Download ruby 3.0.0 sources outside of the cross-ruby.rake file, since the
+# latest rake-compiler/v1.1.1 cross-ruby.rake file requires tar.bz2 source
+# files.
+# TODO(apolcyn): remove this hack when tar.bz2 sources are available for ruby
+# 3.0.0 in https://ftp.ruby-lang.org/pub/ruby/3.0/. Also see
+# https://stackoverflow.com/questions/65477613/rvm-where-is-ruby-3-0-0.
 set +x # rvm commands are very verbose
 source ~/.rvm/scripts/rvm
+echo "rvm use 3.0.0"
+rvm use 3.0.0
+set -x
+RUBY_3_0_0_TAR="${HOME}/.rake-compiler/sources/ruby-3.0.0.tar.gz"
+mkdir -p "$(dirname $RUBY_3_0_0_TAR)"
+curl -L "https://ftp.ruby-lang.org/pub/ruby/3.0/$(basename $RUBY_3_0_0_TAR)" -o "$RUBY_3_0_0_TAR"
+ccache -c
+ruby --version | grep 'ruby 3.0.0'
+rake -f "$CROSS_RUBY" cross-ruby VERSION=3.0.0 HOST=x86_64-darwin11 MAKE="$MAKE" SOURCE="$RUBY_3_0_0_TAR"
+echo "installed ruby 3.0.0 build targets"
+# Install ruby 2.7.0 for rake-compiler
+set +x
+echo "rvm use 2.7.0"
 rvm use 2.7.0
 set -x
 ruby --version | grep 'ruby 2.7.0'
-for v in 2.7.0 ; do
-  ccache -c
-  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
-done
+ccache -c
+rake -f "$CROSS_RUBY" cross-ruby VERSION=2.7.0 HOST=x86_64-darwin11 MAKE="$MAKE"
+echo "installed ruby 2.7.0 build targets"
+# Install ruby 2.4-2.6 for rake-compiler
 set +x
+echo "rvm use 2.5.0"
 rvm use 2.5.0
 set -x
 ruby --version | grep 'ruby 2.5.0'
-for v in 2.6.0 2.5.0 2.4.0 2.3.0 2.2.2 ; do
+for v in 2.6.0 2.5.0 2.4.0 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
+  echo "installed ruby $v build targets"
 done
 
 sed 's/x86_64-darwin-11/universal-darwin/' ~/.rake-compiler/config.yml > "$CROSS_RUBY"

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -46,9 +46,21 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_RUBY}" == "true" ]
 then
+  # Fetch keys per https://rvm.io/rvm/install
+  # Force use of an IPv4 key server to avoid running into https://github.com/rvm/rvm/issues/4215
+  gpg_recv_keys_success=0
+  for ((i=0;i<5;i++)); do
+    KEYSERVER_IPV4_ADDRESS="$(host pool.sks-keyservers.net | grep 'has address' | head -n1 | awk '{print $4}')"
+    gpg --keyserver "hkp://${KEYSERVER_IPV4_ADDRESS}" --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+      && gpg_recv_keys_success=1
+    [[ "$gpg_recv_keys_success" == 1 ]] && break
+    sleep 3
+  done
+  [[ "$gpg_recv_keys_success" == 1 ]] || exit 1
+  rvm get stable # Per https://stackoverflow.com/questions/65477613/rvm-where-is-ruby-3-0-0
   source $HOME/.rvm/scripts/rvm
-  for RUBY_VERSION in 2.5.0 2.7.0; do
-    time rvm install "$RUBY_VERSION"
+  for RUBY_VERSION in 2.5.0 2.7.0 3.0.0; do
+    time rvm install "ruby-${RUBY_VERSION}"
     time gem install bundler -v 1.17.3 --no-document
     time gem install rake-compiler --no-document
   done;


### PR DESCRIPTION
Cherry-picks https://github.com/grpc/grpc/pull/25429

cc @dazuma

Kicked off a full package build in https://fusion2.corp.google.com/invocations/7d2128b7-feb7-4a9c-9a6f-851e0c67be98/targets