### PR TITLE
Improve the run_xds_tests logging

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -42,7 +42,8 @@ from src.proto.grpc.testing import test_pb2_grpc
 
 logger = logging.getLogger()
 console_handler = logging.StreamHandler()
-formatter = logging.Formatter(fmt='%(asctime)s: %(levelname)-8s %(message)s')
+formatter = logging.Formatter(
+    fmt='%(module)s:%(asctime)s: %(levelname)-8s %(message)s')
 console_handler.setFormatter(formatter)
 logger.handlers = []
 logger.addHandler(console_handler)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -48,6 +48,9 @@ logger.handlers = []
 logger.addHandler(console_handler)
 logger.setLevel(logging.WARNING)
 
+original_grpc_trace = os.environ.pop('GRPC_TRACE')
+original_grpc_verbosity = os.environ.pop('GRPC_VERBOSITY')
+
 _TEST_CASES = [
     'backends_restart',
     'change_backend_service',
@@ -2580,6 +2583,10 @@ try:
 
     if args.test_case:
         client_env = dict(os.environ)
+        if original_grpc_trace:
+            client_env['GRPC_TRACE'] = original_grpc_trace
+        if original_grpc_verbosity:
+            client_env['GRPC_VERBOSITY'] = original_grpc_verbosity
         bootstrap_server_features = []
         if gcp.service_port == _DEFAULT_SERVICE_PORT:
             server_uri = service_host_name

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -43,7 +43,7 @@ from src.proto.grpc.testing import test_pb2_grpc
 logger = logging.getLogger()
 console_handler = logging.StreamHandler()
 formatter = logging.Formatter(
-    fmt='%(module)s:%(asctime)s: %(levelname)-8s %(message)s')
+    fmt='%(name)s:%(asctime)s: %(levelname)-8s %(message)s')
 console_handler.setFormatter(formatter)
 logger.handlers = []
 logger.addHandler(console_handler)


### PR DESCRIPTION
1. For wrapper languages, don't print Core traces for test driver, just pass the trace flags to client;
2. Suppress GCP client's debug logging about URLs, like `2021-04-02 18:46:25,077: DEBUG    URL being requested: POST https://compute.googleapis.com/compute/v1/projects/grpc-testing/zones/us-central1-a/instanceGroupManagers?alt=json`;
3. Print ClientStats as JSON instead, which is more info-condense.

For example, the entire build log of a wrapper language (see [C# log](https://fusion2.corp.google.com/invocations/d3ffa637-6c52-4560-a653-627f3e0aef5a/targets/grpc%2Fcore%2Fv1.31.x%2Fbranch%2Flinux%2Fgrpc_xds_csharp/log)) is easily > 20000 lines, with this PR, it can reduce to <9000 lines. That means the bug triage person can browse the log at 200% efficiency now 🐶 .

I can backport it to older releases, if needed. Manually tested, passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25871)
<!-- Reviewable:end -->
