### PR TITLE
xds-k8s: Update GKE workload certificates: fix annotation

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     app: ${deployment_name}
     owner: xds-k8s-interop-test
-  annotations:
-    security.cloud.google.com/use-workload-certificates: ""
 spec:
   replicas: 1
   selector:
@@ -19,6 +17,8 @@ spec:
       labels:
         app: ${deployment_name}
         owner: xds-k8s-interop-test
+      annotations:
+        security.cloud.google.com/use-workload-certificates: ""
     spec:
       serviceAccountName: ${service_account_name}
       containers:

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     app: ${deployment_name}
     owner: xds-k8s-interop-test
-  annotations:
-    security.cloud.google.com/use-workload-certificates: ""
 spec:
   replicas: ${replica_count}
   selector:
@@ -16,6 +14,8 @@ spec:
       app: ${deployment_name}
   template:
     metadata:
+      annotations:
+        security.cloud.google.com/use-workload-certificates: ""
       labels:
         app: ${deployment_name}
         owner: xds-k8s-interop-test


### PR DESCRIPTION
Fixes a configuration mistake made in #25875.  
Annotation `security.cloud.google.com/use-workload-certificates` must be decalared in the pod metadata, not in deployment metadata.