### PR TITLE
[Aio] Gracefully handle RPCs ends pre-maturely

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -140,7 +140,7 @@ cdef class _AioCall(GrpcCallWrapper):
         if self._initial_metadata is None:
             self._set_initial_metadata(_IMMUTABLE_EMPTY_METADATA)
 
-        for waiter in _waiters_status:
+        for waiter in self._waiters_status:
             if not waiter.done():
                 waiter.set_result(None)
         self._waiters_status = []
@@ -162,7 +162,7 @@ cdef class _AioCall(GrpcCallWrapper):
         # set.
         self._initial_metadata = initial_metadata
 
-        for waiter in _waiters_initial_metadata:
+        for waiter in self._waiters_initial_metadata:
             if not waiter.done():
                 waiter.set_result(None)
         self._waiters_initial_metadata = []

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -134,37 +134,38 @@ cdef class _AioCall(GrpcCallWrapper):
     cdef void _set_status(self, AioRpcStatus status) except *:
         cdef list waiters
 
+        # No more waiters should be expected since status has been set.
         self._status = status
 
         if self._initial_metadata is None:
             self._set_initial_metadata(_IMMUTABLE_EMPTY_METADATA)
 
-        # No more waiters should be expected since status
-        # has been set.
-        waiters = self._waiters_status
-        self._waiters_status = None
-
-        for waiter in waiters:
+        for waiter in _waiters_status:
             if not waiter.done():
                 waiter.set_result(None)
+        self._waiters_status = []
 
         for callback in self._done_callbacks:
             callback()
 
     cdef void _set_initial_metadata(self, tuple initial_metadata) except *:
+        if self._initial_metadata is not None:
+            # Some gRPC calls might end before the initial metadata arrived in
+            # the Call object. That causes this method to be invoked twice: 1.
+            # filled with an empty metadata; 2. updated with the actual user
+            # provided metadata.
+            return
+
         cdef list waiters
 
+        # No more waiters should be expected since initial metadata has been
+        # set.
         self._initial_metadata = initial_metadata
 
-        # No more waiters should be expected since initial metadata
-        # has been set.
-        waiters = self._waiters_initial_metadata
-        self._waiters_initial_metadata = None
-
-        for waiter in waiters:
+        for waiter in _waiters_initial_metadata:
             if not waiter.done():
                 waiter.set_result(None)
-
+        self._waiters_initial_metadata = []
 
     def add_done_callback(self, callback):
         if self.done():


### PR DESCRIPTION
In cases like cancellation/broken gRPC traffic, the RPC might end very quickly that the user provided initial metadata haven't been set yet. That triggers a bug in existing code to generate an error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/local/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/var/local/git/grpc/src/python/grpcio_tests/tests_aio/unit/_test_base.py", line 31, in wrapper
    return loop.run_until_complete(f(*args, **kwargs))
  File "/usr/local/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "/var/local/git/grpc/src/python/grpcio_tests/tests_aio/interop/local_interop_test.py", line 73, in test_empty_stream
    self._stub, None)
  File "/usr/local/lib/python3.6/asyncio/coroutines.py", line 129, in throw
    return self.gen.throw(type, value, traceback)
  File "/var/local/git/grpc/src/python/grpcio_tests/tests_aio/interop/methods.py", line 449, in test_interoperability
    await method(stub)
  File "/usr/local/lib/python3.6/asyncio/coroutines.py", line 129, in throw
    return self.gen.throw(type, value, traceback)
  File "/var/local/git/grpc/src/python/grpcio_tests/tests_aio/interop/methods.py", line 247, in _empty_stream
    assert await call.read() == aio.EOF
  File "/usr/local/lib/python3.6/asyncio/coroutines.py", line 129, in throw
    return self.gen.throw(type, value, traceback)
  File "/var/local/git/grpc/py36_asyncio/lib/python3.6/site-packages/grpc/aio/_call.py", line 353, in read
    response_message = await self._read()
  File "/usr/local/lib/python3.6/asyncio/coroutines.py", line 129, in throw
    return self.gen.throw(type, value, traceback)
  File "/var/local/git/grpc/py36_asyncio/lib/python3.6/site-packages/grpc/aio/_call.py", line 331, in _read
    await self._preparation
  File "/usr/local/lib/python3.6/asyncio/coroutines.py", line 126, in send
    return self.gen.send(value)
  File "/var/local/git/grpc/py36_asyncio/lib/python3.6/site-packages/grpc/aio/_call.py", line 624, in _prepare_rpc
    self._metadata, self._metadata_sent_observer)
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi", line 499, in initiate_stream_stream
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi", line 164, in grpc._cython.cygrpc._AioCall._set_initial_metadata
TypeError: 'NoneType' object is not iterable
```

Fixes https://github.com/grpc/grpc/issues/25873

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25884)
<!-- Reviewable:end -->
