### PR TITLE
Move platform-specific sockaddr logic out of port_platform for EventEngine

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -131,6 +131,7 @@ GRPC_PUBLIC_HDRS = [
 GRPC_PUBLIC_EVENT_ENGINE_HDRS = [
     "include/grpc/event_engine/channel_args.h",
     "include/grpc/event_engine/event_engine.h",
+    "include/grpc/event_engine/port.h",
     "include/grpc/event_engine/slice_allocator.h",
 ]
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -201,6 +201,7 @@ config("grpc_config") {
         "include/grpc/compression.h",
         "include/grpc/event_engine/channel_args.h",
         "include/grpc/event_engine/event_engine.h",
+        "include/grpc/event_engine/port.h",
         "include/grpc/event_engine/slice_allocator.h",
         "include/grpc/fork.h",
         "include/grpc/grpc.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2086,6 +2086,7 @@ foreach(_hdr
   include/grpc/compression.h
   include/grpc/event_engine/channel_args.h
   include/grpc/event_engine/event_engine.h
+  include/grpc/event_engine/port.h
   include/grpc/event_engine/slice_allocator.h
   include/grpc/fork.h
   include/grpc/grpc.h
@@ -2638,6 +2639,7 @@ foreach(_hdr
   include/grpc/compression.h
   include/grpc/event_engine/channel_args.h
   include/grpc/event_engine/event_engine.h
+  include/grpc/event_engine/port.h
   include/grpc/event_engine/slice_allocator.h
   include/grpc/fork.h
   include/grpc/grpc.h

--- a/Makefile
+++ b/Makefile
@@ -1599,6 +1599,7 @@ PUBLIC_HEADERS_C += \
     include/grpc/compression.h \
     include/grpc/event_engine/channel_args.h \
     include/grpc/event_engine/event_engine.h \
+    include/grpc/event_engine/port.h \
     include/grpc/event_engine/slice_allocator.h \
     include/grpc/fork.h \
     include/grpc/grpc.h \
@@ -2001,6 +2002,7 @@ PUBLIC_HEADERS_C += \
     include/grpc/compression.h \
     include/grpc/event_engine/channel_args.h \
     include/grpc/event_engine/event_engine.h \
+    include/grpc/event_engine/port.h \
     include/grpc/event_engine/slice_allocator.h \
     include/grpc/fork.h \
     include/grpc/grpc.h \

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -370,6 +370,7 @@ libs:
   - include/grpc/compression.h
   - include/grpc/event_engine/channel_args.h
   - include/grpc/event_engine/event_engine.h
+  - include/grpc/event_engine/port.h
   - include/grpc/event_engine/slice_allocator.h
   - include/grpc/fork.h
   - include/grpc/grpc.h
@@ -1582,6 +1583,7 @@ libs:
   - include/grpc/compression.h
   - include/grpc/event_engine/channel_args.h
   - include/grpc/event_engine/event_engine.h
+  - include/grpc/event_engine/port.h
   - include/grpc/event_engine/slice_allocator.h
   - include/grpc/fork.h
   - include/grpc/grpc.h

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -55,6 +55,7 @@ Gem::Specification.new do |s|
   s.files += %w( include/grpc/compression.h )
   s.files += %w( include/grpc/event_engine/channel_args.h )
   s.files += %w( include/grpc/event_engine/event_engine.h )
+  s.files += %w( include/grpc/event_engine/port.h )
   s.files += %w( include/grpc/event_engine/slice_allocator.h )
   s.files += %w( include/grpc/fork.h )
   s.files += %w( include/grpc/grpc.h )

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -23,8 +23,8 @@
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 
-#include "grpc/event_engine/port.h"
 #include "grpc/event_engine/channel_args.h"
+#include "grpc/event_engine/port.h"
 #include "grpc/event_engine/slice_allocator.h"
 
 // TODO(hork): explicitly define lifetimes and ownership of all objects.

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -23,6 +23,7 @@
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 
+#include "grpc/event_engine/port.h"
 #include "grpc/event_engine/channel_args.h"
 #include "grpc/event_engine/slice_allocator.h"
 

--- a/include/grpc/event_engine/port.h
+++ b/include/grpc/event_engine/port.h
@@ -1,0 +1,37 @@
+// Copyright 2021 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GRPC_EVENT_ENGINE_PORT_H
+#define GRPC_EVENT_ENGINE_PORT_H
+
+// Platform-specific sockaddr includes
+#ifdef GRPC_UV
+#include <uv.h>
+#elif defined(GPR_ANDROID) || defined(GPR_LINUX) || defined(GPR_APPLE) ||   \
+    defined(GPR_FREEBSD) || defined(GPR_OPENBSD) || defined(GPR_SOLARIS) || \
+    defined(GPR_AIX) || defined(GPR_NACL) || defined(GPR_FUCHSIA) ||        \
+    defined(GRPC_POSIX_SOCKET)
+#define GRPC_EVENT_ENGINE_POSIX
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#elif defined(GPR_WINDOWS)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+// must be included after the above
+#include <mswsock.h>
+#else
+#error UNKNOWN PLATFORM
+#endif
+
+#endif  // GRPC_EVENT_ENGINE_PORT_H

--- a/include/grpc/event_engine/port.h
+++ b/include/grpc/event_engine/port.h
@@ -14,6 +14,8 @@
 #ifndef GRPC_EVENT_ENGINE_PORT_H
 #define GRPC_EVENT_ENGINE_PORT_H
 
+#include <grpc/support/port_platform.h>
+
 // Platform-specific sockaddr includes
 #ifdef GRPC_UV
 #include <uv.h>

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -659,24 +659,4 @@ typedef unsigned __int64 uint64_t;
 #define __STDC_FORMAT_MACROS
 #endif
 
-// Platform-specific sockaddr includes
-#ifdef GRPC_UV
-#include <uv.h>
-#elif defined(GPR_ANDROID) || defined(GPR_LINUX) || defined(GPR_APPLE) ||   \
-    defined(GPR_FREEBSD) || defined(GPR_OPENBSD) || defined(GPR_SOLARIS) || \
-    defined(GPR_AIX) || defined(GPR_NACL) || defined(GPR_FUCHSIA) ||        \
-    defined(GRPC_POSIX_SOCKET)
-#define GRPC_EVENT_ENGINE_POSIX
-#include <netdb.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#elif defined(GPR_WINDOWS)
-#include <winsock2.h>
-#include <ws2tcpip.h>
-// must be included after the above
-#include <mswsock.h>
-#else
-#error UNKNOWN PLATFORM
-#endif
-
 #endif /* GRPC_IMPL_CODEGEN_PORT_PLATFORM_H */

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,7 @@
     <file baseinstalldir="/" name="include/grpc/compression.h" role="src" />
     <file baseinstalldir="/" name="include/grpc/event_engine/channel_args.h" role="src" />
     <file baseinstalldir="/" name="include/grpc/event_engine/event_engine.h" role="src" />
+    <file baseinstalldir="/" name="include/grpc/event_engine/port.h" role="src" />
     <file baseinstalldir="/" name="include/grpc/event_engine/slice_allocator.h" role="src" />
     <file baseinstalldir="/" name="include/grpc/fork.h" role="src" />
     <file baseinstalldir="/" name="include/grpc/grpc.h" role="src" />

--- a/src/core/lib/event_engine/sockaddr.cc
+++ b/src/core/lib/event_engine/sockaddr.cc
@@ -15,8 +15,8 @@
 
 #include <string.h>
 
-#include "grpc/event_engine/port.h"
 #include "grpc/event_engine/event_engine.h"
+#include "grpc/event_engine/port.h"
 #include "grpc/support/log.h"
 
 namespace grpc_event_engine {

--- a/src/core/lib/event_engine/sockaddr.cc
+++ b/src/core/lib/event_engine/sockaddr.cc
@@ -15,6 +15,7 @@
 
 #include <string.h>
 
+#include "grpc/event_engine/port.h"
 #include "grpc/event_engine/event_engine.h"
 #include "grpc/support/log.h"
 

--- a/tools/doxygen/Doxyfile.c++
+++ b/tools/doxygen/Doxyfile.c++
@@ -883,6 +883,7 @@ include/grpc/census.h \
 include/grpc/compression.h \
 include/grpc/event_engine/channel_args.h \
 include/grpc/event_engine/event_engine.h \
+include/grpc/event_engine/port.h \
 include/grpc/event_engine/slice_allocator.h \
 include/grpc/fork.h \
 include/grpc/grpc.h \

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -883,6 +883,7 @@ include/grpc/census.h \
 include/grpc/compression.h \
 include/grpc/event_engine/channel_args.h \
 include/grpc/event_engine/event_engine.h \
+include/grpc/event_engine/port.h \
 include/grpc/event_engine/slice_allocator.h \
 include/grpc/fork.h \
 include/grpc/grpc.h \

--- a/tools/doxygen/Doxyfile.core
+++ b/tools/doxygen/Doxyfile.core
@@ -813,6 +813,7 @@ include/grpc/census.h \
 include/grpc/compression.h \
 include/grpc/event_engine/channel_args.h \
 include/grpc/event_engine/event_engine.h \
+include/grpc/event_engine/port.h \
 include/grpc/event_engine/slice_allocator.h \
 include/grpc/fork.h \
 include/grpc/grpc.h \

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -813,6 +813,7 @@ include/grpc/census.h \
 include/grpc/compression.h \
 include/grpc/event_engine/channel_args.h \
 include/grpc/event_engine/event_engine.h \
+include/grpc/event_engine/port.h \
 include/grpc/event_engine/slice_allocator.h \
 include/grpc/fork.h \
 include/grpc/grpc.h \


### PR DESCRIPTION
A fix for issues brought about by #25795, regarding includes in port_platform.h. This is currently blocking the import.

CC: @markdroth, @nicolasnoble 