### PR TITLE
Provide runtime/framework info in gRPC C# user agent string

### DIFF
--- a/src/csharp/Grpc.Core.Tests/Internal/UserAgentStringProviderTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/UserAgentStringProviderTest.cs
@@ -1,0 +1,63 @@
+#region Copyright notice and license
+
+// Copyright 2021 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Internal.Tests
+{
+    public class UserAgentStringProviderTest
+    {
+        [Test]
+        public void BasicTest()
+        {
+            Assert.AreEqual("grpc-csharp/1.0 (.NET Framework 4.6.1; CLR 1.2.3.4; net45; x64)",
+                new UserAgentStringProvider("1.0", ".NET Framework 4.6.1", "1.2.3.4", "net45", CommonPlatformDetection.CpuArchitecture.X64).GrpcCsharpUserAgentString);
+            Assert.AreEqual("grpc-csharp/1.0 (CLR 1.2.3.4; net45; x64)",
+                new UserAgentStringProvider("1.0", null, "1.2.3.4", "net45", CommonPlatformDetection.CpuArchitecture.X64).GrpcCsharpUserAgentString);
+            Assert.AreEqual("grpc-csharp/1.0 (.NET Framework 4.6.1; net45; x64)",
+                new UserAgentStringProvider("1.0", ".NET Framework 4.6.1", null, "net45", CommonPlatformDetection.CpuArchitecture.X64).GrpcCsharpUserAgentString);
+            Assert.AreEqual("grpc-csharp/1.0 (.NET Framework 4.6.1; CLR 1.2.3.4; x64)",
+                new UserAgentStringProvider("1.0", ".NET Framework 4.6.1", "1.2.3.4", null, CommonPlatformDetection.CpuArchitecture.X64).GrpcCsharpUserAgentString);
+        }
+
+        [Test]
+        public void ArchitectureTest()
+        {
+            Assert.AreEqual("grpc-csharp/1.0 (.NET Framework 4.6.1; CLR 1.2.3.4; net45; arm64)",
+                new UserAgentStringProvider("1.0", ".NET Framework 4.6.1", "1.2.3.4", "net45", CommonPlatformDetection.CpuArchitecture.Arm64).GrpcCsharpUserAgentString);
+
+            // unknown architecture
+            Assert.AreEqual("grpc-csharp/1.0 (.NET Framework 4.6.1; CLR 1.2.3.4; net45)",
+                new UserAgentStringProvider("1.0", ".NET Framework 4.6.1", "1.2.3.4", "net45", CommonPlatformDetection.CpuArchitecture.Unknown).GrpcCsharpUserAgentString);
+        }
+
+        [Test]
+        public void FrameworkDescriptionTest()
+        {
+            Assert.AreEqual("grpc-csharp/1.0 (Mono 6.12.0.93; x64)",
+                new UserAgentStringProvider("1.0", "Mono 6.12.0.93 (2020-02/620cf538206 Tue Aug 25 14:04:52 EDT 2020)", null, null, CommonPlatformDetection.CpuArchitecture.X64).GrpcCsharpUserAgentString);
+
+            Assert.AreEqual("grpc-csharp/1.0 (x64)",
+                new UserAgentStringProvider("1.0", "(some invalid framework description)", null, null, CommonPlatformDetection.CpuArchitecture.X64).GrpcCsharpUserAgentString);
+        }
+    }
+}

--- a/src/csharp/Grpc.Core.Tests/UserAgentStringTest.cs
+++ b/src/csharp/Grpc.Core.Tests/UserAgentStringTest.cs
@@ -50,10 +50,10 @@ namespace Grpc.Core.Tests
             helper = new MockServiceHelper(Host);
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
-                var userAgentString = context.RequestHeaders.First(m => (m.Key == "user-agent")).Value;
+                var userAgentString = context.RequestHeaders.GetValue("user-agent");
                 var parts = userAgentString.Split(new [] {' '}, 2);
-                Assert.AreEqual(string.Format("grpc-csharp/{0}", VersionInfo.CurrentVersion), parts[0]);
-                Assert.IsTrue(parts[1].StartsWith("grpc-c/"));
+                Assert.AreEqual($"grpc-csharp/{VersionInfo.CurrentVersion}", parts[0]);
+                Assert.That(parts[1], Does.Match(@"\(.*\) grpc-c/.*"));
                 return Task.FromResult("PASS");
             });
 
@@ -71,9 +71,10 @@ namespace Grpc.Core.Tests
                 channelOptions: new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "XYZ") });
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
-                var userAgentString = context.RequestHeaders.First(m => (m.Key == "user-agent")).Value;
+                var userAgentString = context.RequestHeaders.GetValue("user-agent");
                 var parts = userAgentString.Split(new[] { ' ' }, 3);
                 Assert.AreEqual("XYZ", parts[0]);
+                Assert.AreEqual($"grpc-csharp/{VersionInfo.CurrentVersion}", parts[1]);
                 return Task.FromResult("PASS");
             });
 

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -318,8 +318,7 @@ namespace Grpc.Core
                 userAgentString = option.StringValue + " ";
             };
 
-            // TODO(jtattermusch): it would be useful to also provide .NET/mono version.
-            userAgentString += string.Format("grpc-csharp/{0}", VersionInfo.CurrentVersion);
+            userAgentString += UserAgentStringProvider.DefaultInstance.GrpcCsharpUserAgentString;
 
             options[ChannelOptions.PrimaryUserAgentString] = new ChannelOption(key, userAgentString);
         }

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -47,6 +47,8 @@ namespace Grpc.Core.Internal
         static readonly bool isMono;
         static readonly bool isNet5OrHigher;
         static readonly bool isNetCore;
+        static readonly string frameworkDescription;
+        static readonly string clrVersion;
         static readonly string unityApplicationPlatform;
         static readonly bool isXamarin;
         static readonly bool isXamarinIOS;
@@ -72,6 +74,8 @@ namespace Grpc.Core.Internal
             isNet5OrHigher = false;
             isNetCore = false;
 #endif
+            frameworkDescription = TryGetFrameworkDescription();
+            clrVersion = TryGetClrVersion();
 
             // Detect mono runtime
             isMono = Type.GetType("Mono.Runtime") != null;
@@ -123,6 +127,18 @@ namespace Grpc.Core.Internal
         /// true if running on .NET 5+, false otherwise.
         /// </summary>
         public static bool IsNet5OrHigher => isNet5OrHigher;
+
+        /// <summary>
+        /// Contains <c>RuntimeInformation.FrameworkDescription</c> if the property is available on current TFM.
+        /// <c>null</c> otherwise.
+        /// </summary>
+        public static string FrameworkDescription => frameworkDescription;
+
+        /// <summary>
+        /// Contains the version of common language runtime obtained from <c>Environment.Version</c>
+        /// if the property is available on current TFM. <c>null</c> otherwise.
+        /// </summary>
+        public static string ClrVersion => clrVersion;
 
         /// <summary>
         /// true if running on .NET Core (CoreCLR) or NET 5+, false otherwise.
@@ -182,6 +198,56 @@ namespace Grpc.Core.Internal
                 // and we are going to interpret this as "not running on Unity".
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Returns description of the framework this process is running on.
+        /// Value is based on <c>RuntimeInformation.FrameworkDescription</c>.
+        /// </summary>
+        static string TryGetFrameworkDescription()
+        {
+#if NETSTANDARD
+            return RuntimeInformation.FrameworkDescription;
+#else
+            // on full .NET framework we are targeting net45, and the property is only available starting from .NET Framework 4.7.1+
+            // try obtaining the value by reflection since we might be running on a newer framework even though we're targeting
+            // an older one.
+            var runtimeInformationClass = Type.GetType("System.Runtime.InteropServices.RuntimeInformation");
+            var frameworkDescriptionProperty = runtimeInformationClass?.GetTypeInfo().GetProperty("FrameworkDescription", BindingFlags.Static | BindingFlags.Public);
+            return frameworkDescriptionProperty?.GetValue(null)?.ToString();
+#endif
+        }
+
+        /// <summary>
+        /// Returns version of the common language runtime this process is running on.
+        /// Value is based on <c>Environment.Version</c>.
+        /// </summary>
+        static string TryGetClrVersion()
+        {
+#if NETSTANDARD1_5
+            return null;
+#else
+            return Environment.Version.ToString();
+#endif
+        }
+
+        /// <summary>
+        /// Returns the TFM of the Grpc.Core assembly.
+        /// </summary>
+        public static string GetGrpcCoreTargetFrameworkMoniker()
+        {
+#if NETSTANDARD1_5
+            return "netstandard1.5";
+#elif NETSTANDARD2_0
+            return "netstandard2.0";
+#elif NET45
+            return "net45";
+#else
+            // The TFM is determined at compile time.
+            // The is intentionally no "default" return clause here so that
+            // if the set of TFMs we build for changes and this method is not updated accordingly,
+            // it will result in compilation error.
+#endif
         }
     }
 }

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -183,32 +183,5 @@ namespace Grpc.Core.Internal
                 return null;
             }
         }
-
-        [DllImport("libc")]
-        static extern int uname(IntPtr buf);
-
-        static string GetUname()
-        {
-            var buffer = Marshal.AllocHGlobal(8192);
-            try
-            {
-                if (uname(buffer) == 0)
-                {
-                    return Marshal.PtrToStringAnsi(buffer);
-                }
-                return string.Empty;
-            }
-            catch
-            {
-                return string.Empty;
-            }
-            finally
-            {
-                if (buffer != IntPtr.Zero)
-                {
-                    Marshal.FreeHGlobal(buffer);
-                }
-            }
-        }
     }
 }

--- a/src/csharp/Grpc.Core/Internal/UserAgentStringProvider.cs
+++ b/src/csharp/Grpc.Core/Internal/UserAgentStringProvider.cs
@@ -1,0 +1,114 @@
+#region Copyright notice and license
+
+// Copyright 2021 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Grpc.Core.Internal
+{
+    /// <summary>
+    /// Helps constructing the grpc-csharp component of the user agent string.
+    /// </summary>
+    internal class UserAgentStringProvider
+    {
+        static readonly UserAgentStringProvider defaultInstance;
+        readonly string userAgentString;
+
+        static UserAgentStringProvider()
+        {
+            defaultInstance = new UserAgentStringProvider(VersionInfo.CurrentVersion, PlatformApis.FrameworkDescription, PlatformApis.ClrVersion, PlatformApis.GetGrpcCoreTargetFrameworkMoniker(), PlatformApis.ProcessArchitecture);
+        }
+
+        public static UserAgentStringProvider DefaultInstance => defaultInstance;
+
+        public string GrpcCsharpUserAgentString => userAgentString;
+
+        public UserAgentStringProvider(string grpcCsharpVersion, string frameworkDescription, string clrVersion, string tfm, CommonPlatformDetection.CpuArchitecture arch)
+        {
+            var detailComponents = new List<string>();
+
+            string sanitizedFrameworkDescription = SanitizeFrameworkDescription(frameworkDescription);
+            if (sanitizedFrameworkDescription != null)
+            {
+                detailComponents.Add(sanitizedFrameworkDescription);
+            }
+
+            if (clrVersion != null)
+            {
+                detailComponents.Add($"CLR {clrVersion}");
+            }
+
+            if (tfm != null)
+            {
+                detailComponents.Add(tfm);
+            }
+
+            string architectureString = TryGetArchitectureString(arch);
+            if (architectureString != null)
+            {
+                detailComponents.Add(architectureString);
+            }
+
+            // TODO(jtattermusch): consider adding details about running under unity / xamarin etc.
+            var details = string.Join("; ", detailComponents);
+            userAgentString = $"grpc-csharp/{grpcCsharpVersion} ({details})";
+        }
+
+        static string TryGetArchitectureString(CommonPlatformDetection.CpuArchitecture arch)
+        {
+            switch (arch)
+            {
+                case CommonPlatformDetection.CpuArchitecture.X86:
+                  return "x86";
+                case CommonPlatformDetection.CpuArchitecture.X64:
+                  return "x64";
+                case CommonPlatformDetection.CpuArchitecture.Arm64:
+                  return "arm64";
+                default:
+                  return null;
+            }
+        }
+
+        static string SanitizeFrameworkDescription(string frameworkDescription)
+        {
+            if (frameworkDescription == null)
+            {
+                return null;
+            }
+
+            // Some platforms return more details in the FrameworkDescription string than we want.
+            // e.g. on mono, we will get something like "Mono 6.12.0.93 (2020-02/620cf538206 Tue Aug 25 14:04:52 EDT 2020)"
+            // For user agent string, we only want basic info on framework name and its version.
+            var parts = new List<string>(frameworkDescription.Split(' '));
+            
+            int i = 0;
+            for  (; i < parts.Count; i++)
+            {
+                var part = parts[i];
+                if (!Regex.IsMatch(part, @"^[-.,+@A-Za-z0-9]*$"))
+                {
+                    // stop once we find first part that's not framework name or version
+                    break;
+                }
+            }
+
+            var result = string.Join(" ", parts.GetRange(0, i));
+            return !string.IsNullOrEmpty(result) ? result : null;
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Internal/UserAgentStringProvider.cs
+++ b/src/csharp/Grpc.Core/Internal/UserAgentStringProvider.cs
@@ -71,17 +71,11 @@ namespace Grpc.Core.Internal
 
         static string TryGetArchitectureString(CommonPlatformDetection.CpuArchitecture arch)
         {
-            switch (arch)
+            if (arch == CommonPlatformDetection.CpuArchitecture.Unknown)
             {
-                case CommonPlatformDetection.CpuArchitecture.X86:
-                  return "x86";
-                case CommonPlatformDetection.CpuArchitecture.X64:
-                  return "x64";
-                case CommonPlatformDetection.CpuArchitecture.Arm64:
-                  return "arm64";
-                default:
-                  return null;
+                return null;
             }
+            return arch.ToString().ToLowerInvariant();
         }
 
         static string SanitizeFrameworkDescription(string frameworkDescription)

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -17,6 +17,7 @@
     "Grpc.Core.Internal.Tests.SliceBufferSafeHandleTest",
     "Grpc.Core.Internal.Tests.SliceTest",
     "Grpc.Core.Internal.Tests.TimespecTest",
+    "Grpc.Core.Internal.Tests.UserAgentStringProviderTest",
     "Grpc.Core.Internal.Tests.WellKnownStringsTest",
     "Grpc.Core.Tests.AppDomainUnloadTest",
     "Grpc.Core.Tests.AuthContextTest",


### PR DESCRIPTION
Make the user-agent string generated by the grpc-csharp client more useful by including info about the .NET Framework version in use, TFM, process architecture etc.


Example values of user-agent string:

- MacOS:
Mono:
`grpc-csharp/2.38.0-dev (Mono 5.20.1.19; CLR 4.0.30319.42000; net45; x64) grpc-c/16.0.0 (osx; chttp2)`
.NET Core
`grpc-csharp/2.38.0-dev (.NET Core 4.6.27617.05; CLR 4.0.30319.42000; netstandard2.0; x64) grpc-c/16.0.0 (osx; chttp2)`

- Linux:
Mono:
`grpc-csharp/2.38.0-dev (Mono 6.12.0.122; CLR 4.0.30319.42000; net45; x64) grpc-c/16.0.0 (linux; chttp2)`
.NET Core
`grpc-csharp/2.38.0-dev (.NET Core 4.6.27019.06; CLR 4.0.30319.42000; netstandard2.0; x64) grpc-c/16.0.0 (linux; chttp2)`

- Windows:
.NET Framework ("full framework")
`grpc-csharp/2.38.0-dev (.NET Framework 4.7.3163.0; CLR 4.0.30319.42000; net45; x64) grpc-c/16.0.0 (windows; chttp2)`
.NET Core:
`grpc-csharp/2.38.0-dev (.NET Core 4.6.27317.03; CLR 4.0.30319.42000; netstandard2.0; x64) grpc-c/16.0.0 (windows; chttp2)`

- Values on .NET Core 3.x and newer:
`grpc-csharp/2.38.0-dev (.NET Core 3.1.8; CLR 3.1.8; netstandard2.0; x64) grpc-c/16.0.0 (osx; chttp2)`
`grpc-csharp/2.38.0-dev (.NET 5.0.0; CLR 5.0.0; netstandard2.0; x64) grpc-c/16.0.0 (osx; chttp2)`


Known limitations:
- Detecting .NET framework version is a tricky subject, especially for older framework versions. This PR tries to get the best signal possible without resorting to tricky and fragile logic of "fixing" wrong info provided by some of the framework versions.
- Note that for .NET Core 2.x, the RuntimeInformation.FrameworkDescription reports wrong version (it should be 2.x), but that's a [known bug](https://github.com/dotnet/BenchmarkDotNet/issues/448) that is fixed in .NET Core 3.x.  This wrong value on 2.x can still be interpreted correctly since no other supported .NET Core version reports 4.x. Also, .NET Core 2.x will be end of life in summer 2021.  
- "FrameworkDescription" is only available starting from .NET Framework 4.7.1+ (released in 2017).  For the legacy .NET Frameworks 4.5, 4.6 and 4.6.1, an approximation of framework version can be determined from the CLR version. That seems fair enough, considering those framework versions are ancient today (and hopefully no one is using them anymore).

