### PR TITLE
Fix KeyError Introduced in https://github.com/grpc/grpc/pull/25871

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -50,8 +50,8 @@ logger.addHandler(console_handler)
 logger.setLevel(logging.WARNING)
 
 # Suppress excessive logs for gRPC Python
-original_grpc_trace = os.environ.pop('GRPC_TRACE')
-original_grpc_verbosity = os.environ.pop('GRPC_VERBOSITY')
+original_grpc_trace = os.environ.pop('GRPC_TRACE', None)
+original_grpc_verbosity = os.environ.pop('GRPC_VERBOSITY', None)
 # Suppress not-essential logs for GCP clients
 logging.getLogger('google_auth_httplib2').setLevel(logging.WARNING)
 logging.getLogger('googleapiclient.discovery').setLevel(logging.WARNING)


### PR DESCRIPTION
Fixes the following error:

```
+ python3 grpc/tools/run_tests/run_xds_tests.py --test_case=all,path_matching,header_matching,circuit_breaking,timeout,fault_injection --project_id=grpc-testing --project_num=830293263384 --source_image=projects/grpc-testing/global/images/xds-test-server-4 --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server --gcp_suffix=1617668358 --verbose '--client_cmd=grpc-go/interop/xds/client/client       --server=xds:///{server_uri}       --stats_port={stats_port}       --qps={qps}       {fail_on_failed_rpc}       {rpcs_to_send}       {metadata_to_send}'
Traceback (most recent call last):
  File "grpc/tools/run_tests/run_xds_tests.py", line 53, in <module>
    original_grpc_trace = os.environ.pop('GRPC_TRACE')
  File "/usr/lib/python3.4/_collections_abc.py", line 546, in pop
    value = self[key]
  File "/usr/lib/python3.4/os.py", line 633, in __getitem__
    raise KeyError(key) from None
KeyError: 'GRPC_TRACE'
```

I'll do a manual run of one of the failing jobs before merging.