### PR TITLE
PHP: Fix windows build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1022,6 +1022,7 @@ if (PHP_GRPC != "no") {
     "/I"+configure_module_dirname+"\\third_party\\boringssl-with-bazel\\src\\include "+
     "/I"+configure_module_dirname+"\\third_party\\re2 "+
     "/I"+configure_module_dirname+"\\third_party\\upb "+
+    "/I"+configure_module_dirname+"\\third_party\\xxhash "+
     "/I"+configure_module_dirname+"\\third_party\\zlib ");
 
   base_dir = get_define('BUILD_DIR');

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -37,6 +37,7 @@
       "/I"+configure_module_dirname+"\\third_party\\boringssl-with-bazel\\src\\include "+
       "/I"+configure_module_dirname+"\\third_party\\re2 "+
       "/I"+configure_module_dirname+"\\third_party\\upb "+
+      "/I"+configure_module_dirname+"\\third_party\\xxhash "+
       "/I"+configure_module_dirname+"\\third_party\\zlib ");
   <%
     dirs = sorted(set(src[:src.rfind('/')] for src in srcs))


### PR DESCRIPTION
Error seen after trying to upload the `v1.37.0RC1` PECL extension. PHP + Windows is lacking a PR artifact test, so we always have to manually do this.

```
	"cl.exe" /D COMPILE_DL_GRPC /D GRPC_EXPORTS=1 /DOPENSSL_NO_ASM /D_GNU_SOURCE /DWIN32_LEAN_AND_MEAN /D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 /Iext\grpc /Iext\grpc\include /Iext\grpc\src\core\ext\upb-generated /Iext\grpc\src\core\ext\upbdefs-generated /Iext\grpc\src\php\ext\grpc /Iext\grpc\third_party\abseil-cpp /Iext\grpc\third_party\address_sorting\include /Iext\grpc\third_party\boringssl-with-bazel\src\include /Iext\grpc\third_party\re2 /Iext\grpc\third_party\upb /Iext\grpc\third_party\zlib /nologo /I . /I main /I Zend /I TSRM /I ext /D _WINDOWS /D WINDOWS=1 /D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _MBCS /W3 /D _USE_MATH_DEFINES /FD /wd4996 /Qspectre /guard:cf /Zc:inline /Gw /Zc:__cplusplus /MP /Zi /LD /MD /W3 /Ox /D NDebug /D NDEBUG /D ZEND_WIN32_FORCE_INLINE /GF /D ZEND_DEBUG=0 /I "C:\php-snap-build\php-src\php73\x64\deps\include" /D FD_SETSIZE=256 /DHAVE_ARGON2ID_HASH_RAW=1 /FoC:\php-snap-build\obj\7.3-nts-windows-vc15-x64\Release\ext\grpc\src\core\ext\filters\client_channel\resolver\xds\ /FpC:\php-snap-build\obj\7.3-nts-windows-vc15-x64\Release\ext\grpc\src\core\ext\filters\client_channel\resolver\xds\ /FRC:\php-snap-build\obj\7.3-nts-windows-vc15-x64\Release\ext\grpc\src\core\ext\filters\client_channel\resolver\xds\ /FdC:\php-snap-build\obj\7.3-nts-windows-vc15-x64\Release\ext\grpc\src\core\ext\filters\client_channel\resolver\xds\ /c ext\grpc\src\core\ext\filters\client_channel\resolver\xds\xds_resolver.cc
xds_resolver.cc
ext\grpc\src\core\ext\filters\client_channel\resolver\xds\xds_resolver.cc(26): fatal error C1083: Cannot open include file: 'xxhash.h': No such file or directory
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\cl.exe"' : return code '0x2'
Stop.
```

Original PR: #25645