### PR TITLE
PHP: A exception has different names in PHP7 and PHP8

### DIFF
--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -64,9 +64,21 @@ class ChannelTest extends \PHPUnit\Framework\TestCase
         $xdsCreds = \Grpc\ChannelCredentials::createXds(null);
     }
 
-    public function testCreateXdsWithInvalidType() {
-        $this->expectException(\TypeError::class);
-        $xdsCreds = \Grpc\ChannelCredentials::createXds("invalid-type");
+    public function testCreateXdsWithInvalidType()
+    {
+        $expected = $this->logicalOr(
+            // PHP8
+            new \PHPUnit\Framework\Constraint\Exception(\InvalidArgumentException::class),
+            // PHP7
+            new \PHPUnit\Framework\Constraint\Exception(\TypeError::class)
+        );
+        try {
+            $xdsCreds = \Grpc\ChannelCredentials::createXds("invalid-type");
+        } catch (\Throwable $exception) {
+            $this->assertThat($exception, $expected);
+            return;
+        }
+        $this->assertThat(null, $expected);
     }
 
     public function testGetConnectivityState()


### PR DESCRIPTION
This exception has different names in PHP7 and PHP8.
in PHP 8: "InvalidArgumentException"
in PHP 7.2: "TypeError"

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
@stanley-cheung 