### PR TITLE
Add v1.37.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -184,6 +184,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.34.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.35.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.36.0', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.37.0', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
```
easwars@minefield:grpc $ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.11
DIGEST        TAGS     TIMESTAMP            VULNERABILITIES
9afd0aa3c841  v1.37.0  2021-04-07T12:56:32  CRITICAL=9,HIGH=48,LOW=376,MEDIUM=175
d45f0322911e  v1.36.1  2021-03-25T16:26:42  CRITICAL=9,HIGH=48,LOW=376,MEDIUM=175
cff1a18ad29d  v1.36.0  2021-02-24T16:10:11  CRITICAL=10,HIGH=49,LOW=382,MEDIUM=183
6b95185e4fee  v1.35.0  2021-01-13T16:18:58  CRITICAL=17,HIGH=90,LOW=430,MEDIUM=309
3205ca9f1a6c  v1.34.0  2020-12-02T14:49:06  CRITICAL=17,HIGH=91,LOW=430,MEDIUM=311
d47039978f43  v1.32.0  2020-10-20T16:23:04  CRITICAL=10,HIGH=49,LOW=382,MEDIUM=186
54df3f093d5e  v1.31.1  2020-10-20T16:21:27  CRITICAL=10,HIGH=49,LOW=382,MEDIUM=186
c614c0444639  v1.33.1  2020-10-20T16:16:37  CRITICAL=10,HIGH=49,LOW=382,MEDIUM=186
ad86b3ed2e8d  v1.30.0  2020-07-30T11:08:52  CRITICAL=9,HIGH=48,LOW=378,MEDIUM=183
b15169a571cc  v1.31.0  2020-07-30T11:06:34  CRITICAL=9,HIGH=33,LOW=289,MEDIUM=103
```
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
@jtattermusch 