### PR TITLE
xds-k8s: Use latest TD bootstrap supporting new secrets dir

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,4 +1,4 @@
 --namespace=interop-psm-security
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:8af4336691ba23683ee3e280275894959dc47c4c
+--td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:2558ec79df06984ed0d37e9e69f34688ffe301bb
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/pull/16
