### PR TITLE
Fix fault injection filter to still run trailing md closure even if no error

### DIFF
--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -468,9 +468,11 @@ void CallData::HijackedRecvTrailingMetadataReady(void* arg, grpc_error* error) {
   if (calld->abort_error_ != GRPC_ERROR_NONE) {
     error = grpc_error_add_child(GRPC_ERROR_REF(error),
                                  GRPC_ERROR_REF(calld->abort_error_));
-    Closure::Run(DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready_,
-                 error);
+  } else {
+    error = GRPC_ERROR_REF(error);
   }
+  Closure::Run(DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready_,
+               error);
 }
 
 }  // namespace


### PR DESCRIPTION
Attempt to fix the issue seen in https://github.com/grpc/grpc/pull/25696#issuecomment-805615408. A short summary is that, after turning on the `GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION` env var, PHP cannot complete 1 RPC in the xDS v3 tests. The `grpc_completion_queue_pluck()` call to get the UnaryCall response message is stuck and does not return.

Yash noticed that in the fault injection filter, if `calld->abort_error_ == GRPC_ERROR_NONE`, then the `original_recv_trailing_metadata_ready_` closure were not run.

This may not be the right fix but I'd like to see if this fixes the problem I have been seeing with the PHP + v3 xds tests failing. So far, for the `ping_pong` test, with this fix, I am able to get the RPCs to complete normally now.