### PR TITLE
also build python3.6 aarch64 manylinux2014 wheel

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -387,6 +387,7 @@ def targets():
         PythonArtifact('manylinux2010', 'x86', 'cp37-cp37m'),
         PythonArtifact('manylinux2010', 'x86', 'cp38-cp38'),
         PythonArtifact('manylinux2010', 'x86', 'cp39-cp39'),
+        PythonArtifact('manylinux2014', 'aarch64', 'cp36-cp36m'),
         PythonArtifact('manylinux2014', 'aarch64', 'cp37-cp37m'),
         PythonArtifact('manylinux2014', 'aarch64', 'cp38-cp38'),
         PythonArtifact('manylinux2014', 'aarch64', 'cp39-cp39'),


### PR DESCRIPTION
arm64 linux wheel for python3.6 was requested here: https://github.com/grpc/grpc/issues/21283#issuecomment-815537778

(python3.6 is still supported for the next 8 months. After that we can remove the python3.6 wheel again).

