### PR TITLE
[Backport] Fix fault injection filter to still run trailing md closure even if no error

### DIFF
--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -465,9 +465,11 @@ void CallData::HijackedRecvTrailingMetadataReady(void* arg, grpc_error* error) {
   if (calld->abort_error_ != GRPC_ERROR_NONE) {
     error = grpc_error_add_child(GRPC_ERROR_REF(error),
                                  GRPC_ERROR_REF(calld->abort_error_));
-    Closure::Run(DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready_,
-                 error);
+  } else {
+    error = GRPC_ERROR_REF(error);
   }
+  Closure::Run(DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready_,
+               error);
 }
 
 }  // namespace


### PR DESCRIPTION
Backport of #25926 to `v1.37.x`.