### PR TITLE
Enable channelz for xds_interop_client and xds_interop_server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14924,7 +14924,7 @@ target_link_libraries(xds_interop_client
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   absl::flags
-  grpc++
+  grpcpp_channelz
   grpc_test_util
   grpc++_test_config
 )
@@ -14979,7 +14979,7 @@ target_link_libraries(xds_interop_server
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   absl::flags
-  grpc++
+  grpcpp_channelz
   grpc_test_util
   grpc++_test_config
 )

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -6677,7 +6677,7 @@ targets:
   - test/cpp/interop/xds_interop_client.cc
   deps:
   - absl/flags:flag
-  - grpc++
+  - grpcpp_channelz
   - grpc_test_util
   - grpc++_test_config
 - name: xds_interop_server
@@ -6695,7 +6695,7 @@ targets:
   - test/cpp/interop/xds_interop_server.cc
   deps:
   - absl/flags:flag
-  - grpc++
+  - grpcpp_channelz
   - grpc_test_util
   - grpc++_test_config
 tests: []

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -229,6 +229,7 @@ grpc_cc_binary(
     ],
     deps = [
         "//:grpc++",
+        "//:grpcpp_channelz",
         "//src/proto/grpc/testing:empty_proto",
         "//src/proto/grpc/testing:messages_proto",
         "//src/proto/grpc/testing:test_proto",
@@ -248,6 +249,7 @@ grpc_cc_binary(
     ],
     deps = [
         "//:grpc++",
+        "//:grpcpp_channelz",
         "//src/proto/grpc/testing:empty_proto",
         "//src/proto/grpc/testing:messages_proto",
         "//src/proto/grpc/testing:test_proto",

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -16,6 +16,7 @@
  *
  */
 
+#include <grpcpp/ext/channelz_service_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
@@ -574,6 +575,7 @@ void BuildRpcConfigsFromFlags(RpcConfigurationsQueue* rpc_configs_queue) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
+  grpc::channelz::experimental::InitChannelzService();
   // Validate the expect_status flag.
   grpc_status_code code;
   GPR_ASSERT(grpc_status_code_from_string(

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -19,6 +19,7 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include <grpcpp/ext/channelz_service_plugin.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
@@ -155,7 +156,7 @@ void RunServer(bool secure_mode, const int port, const int maintenance_port,
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
-
+  grpc::channelz::experimental::InitChannelzService();
   char* hostname = grpc_gethostname();
   if (hostname == nullptr) {
     std::cout << "Failed to get hostname, terminating" << std::endl;


### PR DESCRIPTION
Channelz is needed for the PSM security interop tests to work.