### PR TITLE
[python] Define RpcError interface

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -306,6 +306,7 @@ class RpcError(Exception):
         Returns:
           The trailing :term:`metadata`.
         """
+        raise NotImplementedError()
 
     def code(self):
         """Accesses the status code sent by the server.
@@ -315,6 +316,7 @@ class RpcError(Exception):
         Returns:
           The StatusCode value for the RPC.
         """
+        raise NotImplementedError()
 
     def details(self):
         """Accesses the details sent by the server.
@@ -324,6 +326,7 @@ class RpcError(Exception):
         Returns:
           The details string of the RPC.
         """
+        raise NotImplementedError()
 
 
 ##############################  Shared Context  ################################

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -298,6 +298,33 @@ class Status(six.with_metaclass(abc.ABCMeta)):
 class RpcError(Exception):
     """Raised by the gRPC library to indicate non-OK-status RPC termination."""
 
+    def trailing_metadata(self):
+        """Accesses the trailing metadata sent by the server.
+
+        This method blocks until the value is available.
+
+        Returns:
+          The trailing :term:`metadata`.
+        """
+
+    def code(self):
+        """Accesses the status code sent by the server.
+
+        This method blocks until the value is available.
+
+        Returns:
+          The StatusCode value for the RPC.
+        """
+
+    def details(self):
+        """Accesses the details sent by the server.
+
+        This method blocks until the value is available.
+
+        Returns:
+          The details string of the RPC.
+        """
+
 
 ##############################  Shared Context  ################################
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -292,43 +292,6 @@ class Status(six.with_metaclass(abc.ABCMeta)):
     """
 
 
-#############################  gRPC Exceptions  ################################
-
-
-class RpcError(Exception):
-    """Raised by the gRPC library to indicate non-OK-status RPC termination."""
-
-    def trailing_metadata(self):
-        """Accesses the trailing metadata sent by the server.
-
-        This method blocks until the value is available.
-
-        Returns:
-          The trailing :term:`metadata`.
-        """
-        raise NotImplementedError()
-
-    def code(self):
-        """Accesses the status code sent by the server.
-
-        This method blocks until the value is available.
-
-        Returns:
-          The StatusCode value for the RPC.
-        """
-        raise NotImplementedError()
-
-    def details(self):
-        """Accesses the details sent by the server.
-
-        This method blocks until the value is available.
-
-        Returns:
-          The details string of the RPC.
-        """
-        raise NotImplementedError()
-
-
 ##############################  Shared Context  ################################
 
 
@@ -428,6 +391,13 @@ class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
           The details string of the RPC.
         """
         raise NotImplementedError()
+
+
+#############################  gRPC Exceptions  ################################
+
+
+class RpcError(Exception, Call):
+    """Raised by the gRPC library to indicate non-OK-status RPC termination."""
 
 
 ##############  Invocation-Side Interceptor Interfaces & Classes  ##############


### PR DESCRIPTION
Without this each call of `RpcError.code()` needs to be annotated with `# pylint: disable=no-member` if `pylint` is used in the project. Should be good for IDE completion as well.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
