### PR TITLE
Disable XDS on Android/iOS platforms by default.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,7 @@ load(
     "grpc_upb_proto_library",
     "python_config_settings",
 )
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
 config_setting(
     name = "grpc_no_ares",
@@ -43,8 +44,31 @@ config_setting(
 )
 
 config_setting(
-    name = "grpc_no_xds",
+    name = "grpc_no_xds_define",
     values = {"define": "grpc_no_xds=true"},
+)
+
+config_setting(
+    name = "android",
+    values = {"crosstool_top": "//external:android/crosstool"},
+)
+
+config_setting(
+    name = "ios",
+    values = {"apple_platform_type": "ios"},
+)
+
+selects.config_setting_group(
+    name = "grpc_no_xds",
+    match_any = [
+        ":grpc_no_xds_define",
+        # In addition to disabling XDS support when --define=grpc_no_xds=true is
+        # specified, we also disable it on mobile platforms where it is not
+        # likely to be needed and where reducing the binary size is more
+        # important.
+        ":android",
+        ":ios",
+    ],
 )
 
 config_setting(


### PR DESCRIPTION
The XDS code incurs a significant binary size increase, and isn't
generally relevant/useful to builds of gRPC for mobile platforms.

Note that this makes it impossible to build the XDS for mobile platforms
(as opposed to turning XDS off by default but still allowing it to be
force-enabled via a config flag). We're going this route, because any
approach that turns the feature off by default on some platforms but
that still allows force-enabling it on those platforms ends up hitting
either bazel's limits (bazel doesn't support a select() statement where
multiple branches match), or ends up having to rely on the linker to
strip out unused code (by still including the srcs and deps
unconditionally, and using a preprocessor directive to remove symbol
references, which the linker can then remove), which we don't want to do
because relying on the linker makes it too easy to accidentally
re-introduce symbol references.

@markdroth
