### PR TITLE
Fix #25897 to avoid crashes when certificates are not yet updated (#25899)

### DIFF
--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -300,6 +300,13 @@ static grpc_error* server_auth_init_channel_elem(
   GPR_ASSERT(!args->is_last);
   grpc_auth_context* auth_context =
       grpc_find_auth_context_in_args(args->channel_args);
+  if (auth_context == nullptr) {
+    grpc_error* error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "No authorization context found. This might be a TRANSIENT failure due "
+        "to certificates not having been loaded yet.");
+    gpr_log(GPR_DEBUG, "%s", grpc_error_string(error));
+    return error;
+  }
   GPR_ASSERT(auth_context != nullptr);
   grpc_server_credentials* creds =
       grpc_find_server_credentials_in_args(args->channel_args);


### PR DESCRIPTION
Backport #25899