### PR TITLE
Fix EventEngine factory method return types

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -173,7 +173,7 @@ class EventEngine {
   // TODO(hork): define return status codes
   // TODO(hork): document status arg meanings for on_accept and on_shutdown
   /// Factory method to create a network listener.
-  virtual absl::StatusOr<Listener> CreateListener(
+  virtual absl::StatusOr<std::unique_ptr<Listener>> CreateListener(
       Listener::AcceptCallback on_accept, Callback on_shutdown,
       const ChannelArgs& args,
       SliceAllocatorFactory slice_allocator_factory) = 0;
@@ -236,7 +236,7 @@ class EventEngine {
 
   // TODO(hork): define return status codes
   /// Retrieves an instance of a DNSResolver.
-  virtual absl::StatusOr<DNSResolver> GetDNSResolver() = 0;
+  virtual absl::StatusOr<std::unique_ptr<DNSResolver>> GetDNSResolver() = 0;
 
   /// Intended for future expansion of Task run functionality.
   struct RunOptions {};

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -172,10 +172,6 @@ class EventEngine {
   // TODO(hork): define return status codes
   // TODO(hork): document status arg meanings for on_accept and on_shutdown
   /// Factory method to create a network listener.
-  ///
-  /// The EventEngine implementation is responsible for defining the lifteime of
-  /// the Listener; the caller only needs to let the unique_ptr go out of scope
-  /// for any cleanup to occur.
   virtual absl::StatusOr<std::unique_ptr<Listener>> CreateListener(
       Listener::AcceptCallback on_accept, Callback on_shutdown,
       const ChannelArgs& args,
@@ -239,10 +235,6 @@ class EventEngine {
 
   // TODO(hork): define return status codes
   /// Retrieves an instance of a DNSResolver.
-  ///
-  /// The EventEngine implementation is responsible for defining the lifteime of
-  /// the underlying DNSResolver; the caller only needs to let the unique_ptr go
-  /// out of scope for any cleanup to occur.
   virtual absl::StatusOr<std::unique_ptr<DNSResolver>> GetDNSResolver() = 0;
 
   /// Intended for future expansion of Task run functionality.

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -166,13 +166,16 @@ class EventEngine {
     /// been called.
     virtual absl::Status Bind(const ResolvedAddress& addr) = 0;
     virtual absl::Status Start() = 0;
-    virtual absl::Status Shutdown() = 0;
   };
 
   // TODO(hork): define status codes for the callback
   // TODO(hork): define return status codes
   // TODO(hork): document status arg meanings for on_accept and on_shutdown
   /// Factory method to create a network listener.
+  ///
+  /// The EventEngine implementation is responsible for defining the lifteime of
+  /// the Listener; the caller only needs to let the unique_ptr go out of scope
+  /// for any cleanup to occur.
   virtual absl::StatusOr<std::unique_ptr<Listener>> CreateListener(
       Listener::AcceptCallback on_accept, Callback on_shutdown,
       const ChannelArgs& args,
@@ -236,6 +239,10 @@ class EventEngine {
 
   // TODO(hork): define return status codes
   /// Retrieves an instance of a DNSResolver.
+  ///
+  /// The EventEngine implementation is responsible for defining the lifteime of
+  /// the underlying DNSResolver; the caller only needs to let the unique_ptr go
+  /// out of scope for any cleanup to occur.
   virtual absl::StatusOr<std::unique_ptr<DNSResolver>> GetDNSResolver() = 0;
 
   /// Intended for future expansion of Task run functionality.


### PR DESCRIPTION
Obvious issue: since Listener and DNSResolver are abstract, they cannot
be returned by value.

This change returns unique_ptr from both factory methods. Listener objects
will be stored exclusively inside a grpc_tcp_server struct, which is
itself ref counted.

The DNSResolver situation is less clear. EventEngine implementations may want to
reuse resolver instances, which could make unique_ptrs a poor fit. However, I'm
not sure it's wise to have the EventEngine API defer to implementations on
ownership of DNSResolvers, since EventEngines would then not be interchangeable.
So I propose the API return unique_ptr here as well. I considered returning a
`DNSResolver*` with documentation that indicated the caller takes ownership, but
that's effectively an unenforceable unique_ptr (of course, with the added 
uniqueness constraint).