### PR TITLE
Introduce new Python package "xds_protos"

### DIFF
--- a/third_party/README.md
+++ b/third_party/README.md
@@ -105,3 +105,10 @@ Rule 'boringssl' indicated that a canonical reproducible form can be obtained by
 ### Updating third_party/protobuf
 
 See http://go/grpc-third-party-protobuf-update-instructions (internal only)
+
+### Updating third_party/envoy-api
+
+Apart from the above steps, please perform the following two steps to generate the Python `xds-protos` package:
+
+1. Bump the version in the `tools/distrib/python/xds_protos/setup.py`;
+2. Run `tools/distrib/python/xds_protos/build_validate_upload.sh` to upload the built wheel.

--- a/tools/distrib/python/.gitignore
+++ b/tools/distrib/python/.gitignore
@@ -1,1 +1,9 @@
 distrib_virtualenv/
+__init__.py
+generated_file_import_test.py
+envoy/
+udpa/
+validate/
+google/
+opencensus/
+xds/

--- a/tools/distrib/python/xds_protos/build_validate_upload.sh
+++ b/tools/distrib/python/xds_protos/build_validate_upload.sh
@@ -1,0 +1,27 @@
+#! /bin/bash -ex
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WORK_DIR="$(dirname "$0")"
+cd ${WORK_DIR}
+
+# Build the source wheel
+python3 setup.py sdist
+
+# Run the tests to ensure all protos are importable
+python3 -m pip install .
+python3 generated_file_import_test.py
+
+# Upload the package
+python3 -m twine upload dist/*

--- a/tools/distrib/python/xds_protos/build_validate_upload.sh
+++ b/tools/distrib/python/xds_protos/build_validate_upload.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -ex
+#! /bin/bash
 # Copyright 2021 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
+
 WORK_DIR="$(dirname "$0")"
 cd ${WORK_DIR}
 
@@ -24,4 +26,5 @@ python3 -m pip install .
 python3 generated_file_import_test.py
 
 # Upload the package
+python3 -m twine check dist/*
 python3 -m twine upload dist/*

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -72,6 +72,10 @@ COMPILE_BOTH = COMPILE_PROTO_ONLY + ['--grpc_python_out={}'.format(OUTPUT_PATH)]
 
 
 # Compile xDS protos
+def has_grpc_service(proto_package_path: str) -> bool:
+    return proto_package_path.startswith('envoy/service')
+
+
 def compile_protos(proto_root: str, sub_dir: str = '.') -> None:
     for root, _, files in os.walk(os.path.join(proto_root, sub_dir)):
         proto_package_path = os.path.relpath(root, proto_root)
@@ -81,7 +85,7 @@ def compile_protos(proto_root: str, sub_dir: str = '.') -> None:
         for file_name in files:
             if file_name.endswith('.proto'):
                 # Compile proto
-                if proto_package_path.startswith('envoy/service'):
+                if has_grpc_service(proto_package_path):
                     return_code = protoc.main(COMPILE_BOTH +
                                               [os.path.join(root, file_name)])
                     add_test_import(proto_package_path, file_name, service=True)
@@ -131,7 +135,7 @@ CLASSIFIERS = [
 ]
 setuptools.setup(
     name='xds-protos',
-    version='v0.0.1',
+    version='0.0.1',
     packages=setuptools.find_packages(where=".", exclude=[TEST_FILE_NAME]),
     description='Generated Python code from envoyproxy/data-plane-api',
     author='The gRPC Authors',

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -133,6 +133,10 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'License :: OSI Approved :: Apache Software License',
 ]
+INSTALL_REQUIRES = [
+    'protobuf',
+    'grpcio',
+]
 setuptools.setup(
     name='xds-protos',
     version='0.0.1',
@@ -142,4 +146,5 @@ setuptools.setup(
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',
     license='Apache License 2.0',
+    install_requires=INSTALL_REQUIRES,
     classifiers=CLASSIFIERS)

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -137,6 +137,7 @@ INSTALL_REQUIRES = [
     'protobuf',
     'grpcio',
 ]
+SETUP_REQUIRES = INSTALL_REQUIRES + ["grpcio-tools"]
 setuptools.setup(
     name='xds-protos',
     version='0.0.1',
@@ -147,4 +148,5 @@ setuptools.setup(
     url='https://grpc.io',
     license='Apache License 2.0',
     install_requires=INSTALL_REQUIRES,
+    setup_requires=SETUP_REQUIRES,
     classifiers=CLASSIFIERS)

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -1,0 +1,141 @@
+#! /usr/bin/env python3
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A PyPI package for xDS protos generated Python code."""
+
+import sys
+import os
+import setuptools
+import pkg_resources
+
+from grpc_tools import protoc
+
+# We might not want to compile all the protos
+EXCLUDE_PROTO_PACKAGES_LIST = [
+    # Requires extra dependency to Prometheus protos
+    'envoy/service/metrics/v2',
+    'envoy/service/metrics/v3',
+    'envoy/service/metrics/v4alpha',
+]
+
+# Compute the pathes
+WORK_DIR = os.path.dirname(os.path.abspath(__file__))
+GRPC_ROOT = os.path.abspath(os.path.join(WORK_DIR, '..', '..', '..', '..'))
+XDS_PROTO_ROOT = os.path.join(GRPC_ROOT, 'third_party', 'envoy-api')
+UDPA_PROTO_ROOT = os.path.join(GRPC_ROOT, 'third_party', 'udpa')
+GOOGLEAPIS_ROOT = os.path.join(GRPC_ROOT, 'third_party', 'googleapis')
+VALIDATE_ROOT = os.path.join(GRPC_ROOT, 'third_party', 'protoc-gen-validate')
+OPENCENSUS_PROTO_ROOT = os.path.join(GRPC_ROOT, 'third_party',
+                                     'opencensus-proto', 'src')
+WELL_KNOWN_PROTOS_INCLUDE = pkg_resources.resource_filename(
+    'grpc_tools', '_proto')
+OUTPUT_PATH = WORK_DIR
+
+# Prepare the test file generation
+TEST_FILE_NAME = 'generated_file_import_test.py'
+TEST_IMPORTS = []
+
+
+def add_test_import(proto_package_path: str,
+                    file_name: str,
+                    service: bool = False):
+    TEST_IMPORTS.append("from %s import %s\n" % (proto_package_path.replace(
+        '/', '.'), file_name.replace('.proto', '_pb2')))
+    if service:
+        TEST_IMPORTS.append("from %s import %s\n" % (proto_package_path.replace(
+            '/', '.'), file_name.replace('.proto', '_pb2_grpc')))
+
+
+# Prepare Protoc command
+COMPILE_PROTO_ONLY = [
+    'grpc_tools.protoc',
+    '--proto_path={}'.format(XDS_PROTO_ROOT),
+    '--proto_path={}'.format(UDPA_PROTO_ROOT),
+    '--proto_path={}'.format(GOOGLEAPIS_ROOT),
+    '--proto_path={}'.format(VALIDATE_ROOT),
+    '--proto_path={}'.format(WELL_KNOWN_PROTOS_INCLUDE),
+    '--proto_path={}'.format(OPENCENSUS_PROTO_ROOT),
+    '--python_out={}'.format(OUTPUT_PATH),
+]
+COMPILE_BOTH = COMPILE_PROTO_ONLY + ['--grpc_python_out={}'.format(OUTPUT_PATH)]
+
+
+# Compile xDS protos
+def compile_protos(proto_root: str, sub_dir: str = '.') -> None:
+    for root, _, files in os.walk(os.path.join(proto_root, sub_dir)):
+        proto_package_path = os.path.relpath(root, proto_root)
+        if proto_package_path in EXCLUDE_PROTO_PACKAGES_LIST:
+            print(f'Skipping package {proto_package_path}')
+            continue
+        for file_name in files:
+            if file_name.endswith('.proto'):
+                # Compile proto
+                if proto_package_path.startswith('envoy/service'):
+                    return_code = protoc.main(COMPILE_BOTH +
+                                              [os.path.join(root, file_name)])
+                    add_test_import(proto_package_path, file_name, service=True)
+                else:
+                    return_code = protoc.main(COMPILE_PROTO_ONLY +
+                                              [os.path.join(root, file_name)])
+                    add_test_import(proto_package_path,
+                                    file_name,
+                                    service=False)
+                if return_code != 0:
+                    raise Exception('error: {} failed'.format(COMPILE_BOTH))
+
+
+compile_protos(XDS_PROTO_ROOT)
+compile_protos(UDPA_PROTO_ROOT)
+# We don't want to compile the entire GCP surface API, just the essential ones
+compile_protos(GOOGLEAPIS_ROOT, os.path.join('google', 'api'))
+compile_protos(GOOGLEAPIS_ROOT, os.path.join('google', 'rpc'))
+compile_protos(GOOGLEAPIS_ROOT, os.path.join('google', 'longrunning'))
+compile_protos(GOOGLEAPIS_ROOT, os.path.join('google', 'logging'))
+compile_protos(GOOGLEAPIS_ROOT, os.path.join('google', 'type'))
+compile_protos(VALIDATE_ROOT, 'validate')
+compile_protos(OPENCENSUS_PROTO_ROOT)
+
+
+# Generate __init__.py files for
+def create_init_file(path: str) -> None:
+    f = open(os.path.join(path, "__init__.py"), 'w')
+    f.close()
+
+
+create_init_file(WORK_DIR)
+for root, _, _ in os.walk(os.path.join(WORK_DIR, 'envoy')):
+    create_init_file(root)
+
+# Generate test file
+with open(os.path.join(WORK_DIR, TEST_FILE_NAME), 'w') as f:
+    f.writelines(TEST_IMPORTS)
+
+# Use setuptools to build Python package
+CLASSIFIERS = [
+    'Development Status :: 3 - Alpha',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 3',
+    'License :: OSI Approved :: Apache Software License',
+]
+setuptools.setup(
+    name='xds-protos',
+    version='v0.0.1',
+    packages=setuptools.find_packages(where=".", exclude=[TEST_FILE_NAME]),
+    description='Generated Python code from envoyproxy/data-plane-api',
+    author='The gRPC Authors',
+    author_email='grpc-io@googlegroups.com',
+    url='https://grpc.io',
+    license='Apache License 2.0',
+    classifiers=CLASSIFIERS)


### PR DESCRIPTION
This PR introduces a new Python package `xds_protos` which packages all Envoy ProtoBuf generated Python files into one Python package. The tricky bit is that Envoy protos depends on several other packages, so they also needs to be partially included in this package. All generation logic can be found in `setup.py`.

To regenerate this package, there will be 2 steps:
1. Bump the version in the `setup.py` (currently it's `0.0.1`);
2. Run `tools/distrib/python/xds_protos/build_validate_upload.sh`.

To build the source wheel, we will need Python 3.6+ for f-strings. But the generated package can be used by Python 2 and Python 3.

The test of the generated package is generated along with the source wheel. It's a Python file tries to import every single generated Python files in the `xds_protos` package. Here is the first 10 lines (total 671):

```python
from envoy.data.dns.v2alpha import dns_table_pb2
from envoy.data.dns.v3 import dns_table_pb2
from envoy.data.dns.v4alpha import dns_table_pb2
from envoy.data.tap.v2alpha import wrapper_pb2
from envoy.data.tap.v2alpha import common_pb2
from envoy.data.tap.v2alpha import transport_pb2
from envoy.data.tap.v2alpha import http_pb2
from envoy.data.tap.v3 import wrapper_pb2
from envoy.data.tap.v3 import common_pb2
from envoy.data.tap.v3 import transport_pb2
...
```

About versioning: This PR chooses to use a separate version number to show changes in this package is independent of gRPC or `envoy-api`. Alternatively, we can use gRPC's version, or the update date of the `envoy-api` module, or the commit SHA. Among the options, I found a simple version number to be elegant and less controversial.