### PR TITLE
Reduce the usage of _xds Bazel rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2642,7 +2642,7 @@ grpc_cc_library_xds(
     alwayslink = 1,
 )
 
-grpc_cc_library_xds(
+grpc_cc_library(
     name = "grpcpp_admin",
     srcs = [
         "src/cpp/server/admin/admin_services.cc",

--- a/src/cpp/server/admin/admin_services.cc
+++ b/src/cpp/server/admin/admin_services.cc
@@ -28,25 +28,25 @@
 // TODO(lidiz) build a real registration system that can pull in services
 // automatically with minimum amount of code.
 #include "src/cpp/server/channelz/channelz_service.h"
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
 #include "src/cpp/server/csds/csds.h"
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 namespace grpc {
 
 namespace {
 
 static auto* g_channelz_service = new ChannelzService();
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
 static auto* g_csds = new xds::experimental::ClientStatusDiscoveryService();
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 
 }  // namespace
 
 void AddAdminServices(ServerBuilder* builder) {
   builder->RegisterService(g_channelz_service);
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
   builder->RegisterService(g_csds);
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 }
 
 }  // namespace grpc

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -874,7 +874,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_test_xds(
     name = "admin_services_end2end_test",
     srcs = ["admin_services_end2end_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -874,7 +874,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test_xds(
+grpc_cc_test(
     name = "admin_services_end2end_test",
     srcs = ["admin_services_end2end_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/admin_services_end2end_test.cc
+++ b/test/cpp/end2end/admin_services_end2end_test.cc
@@ -28,7 +28,6 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-#ifndef DISABLED_XDS_PROTO_IN_CC
 #include <grpcpp/ext/admin_services.h>
 
 namespace grpc {
@@ -73,7 +72,7 @@ class AdminServicesTest : public ::testing::Test {
       stream_;
 };
 
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
 // The ifndef conflicts with TEST_F and EXPECT_THAT macros, so we better isolate
 // the condition at test case level.
 TEST_F(AdminServicesTest, XdsEnabled) {
@@ -83,21 +82,19 @@ TEST_F(AdminServicesTest, XdsEnabled) {
                   "grpc.channelz.v1.Channelz",
                   "grpc.reflection.v1alpha.ServerReflection"));
 }
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 
-#ifdef GRPC_NO_XDS
+#if defined(GRPC_NO_XDS) || defined(DISABLED_XDS_PROTO_IN_CC)
 TEST_F(AdminServicesTest, XdsDisabled) {
   EXPECT_THAT(GetServiceList(),
               ::testing::UnorderedElementsAre(
                   "grpc.channelz.v1.Channelz",
                   "grpc.reflection.v1alpha.ServerReflection"));
 }
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 
 }  // namespace testing
 }  // namespace grpc
-
-#endif  // DISABLED_XDS_PROTO_IN_CC
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);


### PR DESCRIPTION
This PR removes the unnecessary "_xds" hack from "grpcpp_admin".

In google3, "grpc_cc_library_xds" translates to a dummy target; "grpc_cc_test_xds" means injecting a `DISABLED_XDS_PROTO_IN_CC` C flag.

But there was an issue, "grpcpp_admin" will pick CSDS if none of `GRPC_NO_XDS` and `DISABLED_XDS_PROTO_IN_CC` is defined. There wasn't a mechanism to inject a `DISABLED_XDS_PROTO_IN_CC` flag to an intermediate library (":grpcpp_admin" in this case).

So, this updated approach reduces the usage of the hacks, but will cause 4 more targets to failed to build internally. We have many targets that are only buildable in OSS. Alternatively, we can add one more Bazel rule, but that makes the hack slightly more complex. WDYT?

```
# Targets that won't build internally
//third_party/grpc:alternative/grpcpp_admin
//third_party/grpc:grpcpp_admin_internal
//third_party/grpc:alternative/grpcpp_admin_internal
//third_party/grpc:grpcpp_admin
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25978)
<!-- Reviewable:end -->
