### PR TITLE
Remove _xds suffix Bazel rules completely

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -32,7 +32,6 @@ package(
 load(
     "//bazel:grpc_build_system.bzl",
     "grpc_cc_library",
-    "grpc_cc_library_xds",
     "grpc_generate_one_off_targets",
     "grpc_upb_proto_library",
     "python_config_settings",

--- a/BUILD
+++ b/BUILD
@@ -2626,7 +2626,7 @@ grpc_cc_library(
     alwayslink = 1,
 )
 
-grpc_cc_library_xds(
+grpc_cc_library(
     name = "grpcpp_csds",
     srcs = [
         "src/cpp/server/csds/csds.cc",

--- a/BUILD
+++ b/BUILD
@@ -2642,7 +2642,7 @@ grpc_cc_library_xds(
     alwayslink = 1,
 )
 
-grpc_cc_library_xds(
+grpc_cc_library(
     name = "grpcpp_admin",
     srcs = [
         "src/cpp/server/admin/admin_services.cc",

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -128,12 +128,6 @@ def grpc_cc_library(
         linkstatic = linkstatic,
     )
 
-# TODO(lidiz) remove this rule once we can depend on the xDS protos internally
-def grpc_cc_library_xds(
-        *args,
-        **kwargs):
-    grpc_cc_library(*args, **kwargs)
-
 def grpc_proto_plugin(name, srcs = [], deps = []):
     native.cc_binary(
         name = name,
@@ -247,10 +241,6 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         tags = tags,
         **args
     )
-
-# TODO(lidiz) remove this rule once we can depend on the xDS protos internally
-def grpc_cc_test_xds(*args, **kwargs):
-    grpc_cc_test(*args, **kwargs)
 
 def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], data = [], language = "C++", testonly = False, linkshared = False, linkopts = [], tags = [], features = []):
     copts = []

--- a/src/cpp/server/admin/admin_services.cc
+++ b/src/cpp/server/admin/admin_services.cc
@@ -28,25 +28,25 @@
 // TODO(lidiz) build a real registration system that can pull in services
 // automatically with minimum amount of code.
 #include "src/cpp/server/channelz/channelz_service.h"
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
 #include "src/cpp/server/csds/csds.h"
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 namespace grpc {
 
 namespace {
 
 static auto* g_channelz_service = new ChannelzService();
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
 static auto* g_csds = new xds::experimental::ClientStatusDiscoveryService();
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 
 }  // namespace
 
 void AddAdminServices(ServerBuilder* builder) {
   builder->RegisterService(g_channelz_service);
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
   builder->RegisterService(g_csds);
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 }
 
 }  // namespace grpc

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -874,7 +874,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_test_xds(
     name = "admin_services_end2end_test",
     srcs = ["admin_services_end2end_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -874,7 +874,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test_xds(
+grpc_cc_test(
     name = "admin_services_end2end_test",
     srcs = ["admin_services_end2end_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -510,7 +510,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test_xds(
+grpc_cc_test(
     name = "xds_end2end_test",
     size = "large",
     srcs = ["xds_end2end_test.cc"],
@@ -874,7 +874,7 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test_xds(
+grpc_cc_test(
     name = "admin_services_end2end_test",
     srcs = ["admin_services_end2end_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_cc_test_xds", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(
     name = "test/cpp/end2end",

--- a/test/cpp/end2end/admin_services_end2end_test.cc
+++ b/test/cpp/end2end/admin_services_end2end_test.cc
@@ -28,7 +28,6 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-#ifndef DISABLED_XDS_PROTO_IN_CC
 #include <grpcpp/ext/admin_services.h>
 
 namespace grpc {
@@ -73,7 +72,7 @@ class AdminServicesTest : public ::testing::Test {
       stream_;
 };
 
-#ifndef GRPC_NO_XDS
+#if !defined(GRPC_NO_XDS) && !defined(DISABLED_XDS_PROTO_IN_CC)
 // The ifndef conflicts with TEST_F and EXPECT_THAT macros, so we better isolate
 // the condition at test case level.
 TEST_F(AdminServicesTest, XdsEnabled) {
@@ -83,21 +82,19 @@ TEST_F(AdminServicesTest, XdsEnabled) {
                   "grpc.channelz.v1.Channelz",
                   "grpc.reflection.v1alpha.ServerReflection"));
 }
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 
-#ifdef GRPC_NO_XDS
+#if defined(GRPC_NO_XDS) || defined(DISABLED_XDS_PROTO_IN_CC)
 TEST_F(AdminServicesTest, XdsDisabled) {
   EXPECT_THAT(GetServiceList(),
               ::testing::UnorderedElementsAre(
                   "grpc.channelz.v1.Channelz",
                   "grpc.reflection.v1alpha.ServerReflection"));
 }
-#endif  // GRPC_NO_XDS
+#endif  // GRPC_NO_XDS or DISABLED_XDS_PROTO_IN_CC
 
 }  // namespace testing
 }  // namespace grpc
-
-#endif  // DISABLED_XDS_PROTO_IN_CC
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);


### PR DESCRIPTION
As title. Most logic will be in google3, see [cl/368529309](http://cl/368529309).

We added "_xds" suffix Bazel rules, because we hope to have a clean separation between specially treated targets and normal targets. However, `grpcpp_csds` is going to be depended by many tests and binaries, existing solution requires people to remember changing the normal rule to "_xds" ones, WHENEVER the target transitively depends on `grpcpp_csds`. This is very error-prone.

Besides, Bazel rules `grpc_cc_library`/`grpc_cc_test` are exempted from strict headers check: https://source.corp.google.com/piper///depot/google3/java/com/google/devtools/build/lib/view/cpp/LayeringCheckAllowlists.java?q=grpc_cc_library. The new "_xds" Bazel rules ain't, and will trigger following error:

> ERROR: /google/src/cloud/lidiz/github-sync-20210414144431/google3/third_party/grpc/BUILD:2647:20: in cc_library rule //third_party/grpc:grpcpp_admin: C++ rules should use 'strict' hdrs_check (not 'loose' or 'warn').The hdrs_check='strict' ensures that all #included files must be explicitly declared somewhere in the hdrs or srcs of the rules providing the libraries or the rules containing the including source. Please remove 'hdrs_check' attribute from this rule, as well as the 'default_hdrs_check' attribute from the package, or set them to 'strict'. If you think your use case qualifies for an exception, please see go/blaze-strict-layering-exception

So, this PR:

- Treat `DISABLED_XDS_PROTO_IN_CC` as `GRPC_NO_XDS` in admin services
- Simplified the preprocessing logic in `admin_services_end2end_test`
- Remove all `_xds` Bazel rules (internally, existing logics are merged into normal Bazel rules)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/25980)
<!-- Reviewable:end -->
