### PR TITLE
Return port number from EventEngine::Listener::Bind

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -160,11 +160,10 @@ class EventEngine {
     virtual ~Listener() = 0;
 
     // TODO(hork): define return status codes
-    // TODO(hork): requires output port argument, return value, or callback
     /// Bind an address/port to this Listener. It is expected that multiple
     /// addresses/ports can be bound to this Listener before Listener::Start has
     /// been called.
-    virtual absl::Status Bind(const ResolvedAddress& addr) = 0;
+    virtual absl::StatusOr<int> Bind(const ResolvedAddress& addr) = 0;
     virtual absl::Status Start() = 0;
   };
 

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -162,7 +162,7 @@ class EventEngine {
     // TODO(hork): define return status codes
     /// Bind an address/port to this Listener. It is expected that multiple
     /// addresses/ports can be bound to this Listener before Listener::Start has
-    /// been called.
+    /// been called. Returns the bound port or an error status.
     virtual absl::StatusOr<int> Bind(const ResolvedAddress& addr) = 0;
     virtual absl::Status Start() = 0;
   };


### PR DESCRIPTION
This is an integer, unlike the DNSResolver, since the underlying bind syscall deals in integers.