### PR TITLE
Ruby: Fix xds fault_injection test

### DIFF
--- a/src/ruby/pb/test/xds_client.rb
+++ b/src/ruby/pb/test/xds_client.rb
@@ -283,9 +283,7 @@ def run_test_loop(stub, target_seconds_between_rpcs, fail_on_failed_rpcs)
         raise "Unsupported rpc #{rpc}"
       end
       rpc_stats_key = rpc.to_s
-      if metadata.key?('rpc-behavior') and
-        ((metadata['rpc-behavior'] == 'keep-open') or
-         (metadata['rpc-behavior'].start_with?('sleep')))
+      if not metadata.empty?
         keep_open_threads << execute_rpc_in_thread(op, rpc_stats_key)
       else
         results[rpc] = execute_rpc(op, fail_on_failed_rpcs, rpc_stats_key)


### PR DESCRIPTION
This will fix the `fault_injection` xds test case for Ruby.

Previously I left in a condition where if the metadata the client is supposed to send contains `rpc-behavior`, then we execute those RPCs in a separate Ruby thread. But now the `fault_injection` test case's metadata has the key `fi_testcase`. So we should just generalize this - as long as the metadata we are supposed to send is non-empty, execute those RPCs in a thread.