### PR TITLE
Fix header_matching for PHP and Ruby

### DIFF
--- a/src/php/tests/interop/xds_client.php
+++ b/src/php/tests/interop/xds_client.php
@@ -386,10 +386,14 @@ class ClientThread extends Thread {
                 // $this->metadata_to_send[$rpc] somehow becomes a
                 // Volatile object, instead of an associative array.
                 $metadata_array = [];
+                $execute_in_child_process = false;
                 foreach ($metadata as $key => $value) {
                     $metadata_array[$key] = [$value];
+                    if ($key == 'rpc-behavior' || $key == 'fi_testcase') {
+                        $execute_in_child_process = true;
+                    }
                 }
-                if ($metadata_array && $this->rpc_config->tmp_file1) {
+                if ($execute_in_child_process && $this->rpc_config->tmp_file1) {
                     // if 'rpc-behavior' is set, we need to pawn off
                     // the execution to some other child PHP processes
                     $this->execute_rpc_in_child_process(

--- a/src/ruby/pb/test/xds_client.rb
+++ b/src/ruby/pb/test/xds_client.rb
@@ -283,7 +283,7 @@ def run_test_loop(stub, target_seconds_between_rpcs, fail_on_failed_rpcs)
         raise "Unsupported rpc #{rpc}"
       end
       rpc_stats_key = rpc.to_s
-      if not metadata.empty?
+      if metadata.key?('rpc-behavior') or metadata.key?('fi_testcase')
         keep_open_threads << execute_rpc_in_thread(op, rpc_stats_key)
       else
         results[rpc] = execute_rpc(op, fail_on_failed_rpcs, rpc_stats_key)


### PR DESCRIPTION
Some newer xds test cases, like `circuit_breaking`, `timeout` and `fault_injection`, need the client to send metadata that will alter the RPC behavior (e.g, `rpc-behavior: keep-open`, `rpc-behavior: sleep-4`, `fi_testcase: xxx`). These RPCs need to be executed in a parallel / async way. In Ruby this is achieved by executing RPCs in threads. In PHP this is achieved by executing RPCs in a different process.

These test cases, only need to know the RPCs' return statuses, and don't need to know the exact remote hostname.

However, in an older test case, `header_matching`, we do need to send some metadata for the actual header matching (e.g. `xds_md:unary_yranu`), and we _do_ need the exact remote hostname being connected to, for stats collecting purposes.

So we cannot blindly say - if we are sending metadata, do it in a thread. We kind of _do_ need to know which test case needs to be executed in threads, which doesn't.