### PR TITLE
Fix a typo in CSDS interop test

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1886,7 +1886,7 @@ def test_csds(gcp, original_backend_service, instance_group, server_uri):
                         else:
                             seen.add('eds')
                 want = {'lds', 'rds', 'cds', 'eds'}
-                if seen == want:
+                if seen != want:
                     logger.info('Incomplete xDS config dump, seen=%s', seen)
                     ok = False
             except:
@@ -1902,7 +1902,8 @@ def test_csds(gcp, original_backend_service, instance_group, server_uri):
         time.sleep(sleep_interval_between_attempts_s)
         cnt += 1
 
-    raise RuntimeError('failed to receive valid xDS config')
+    raise RuntimeError('failed to receive a valid xDS config in %s seconds' %
+                       test_csds_timeout_s)
 
 
 def set_validate_for_proxyless(gcp, validate_for_proxyless):


### PR DESCRIPTION
b/185859741

I made a typo while improving Python readability in https://github.com/grpc/grpc/pull/26007. This PR fixes the typo.

The manual testing is passed for commit `d9fc7f98a43f84fed893efad2a3cadd46531fbc6` on C++/Java/Go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26021)
<!-- Reviewable:end -->
