### PR TITLE
Update the Python dependency for xDS interop test

### DIFF
--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")/../../.."
 
 sudo apt-get install -y python3-pip
 sudo python3 -m pip install --upgrade pip
-sudo python3 -m pip install grpcio==1.31.0 grpcio-tools==1.31.0 google-api-python-client google-auth-httplib2 oauth2client
+sudo python3 -m pip install grpcio==1.31.0 grpcio-tools==1.31.0 google-api-python-client google-auth-httplib2 oauth2client xds-protos
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests


### PR DESCRIPTION
`xds-protos` includes all the generated Python files for Envoy protos, which is required by Envoy.

I updated 5 scripts in grpc/grpc, and it worked for C++. But I failed to notice that Java/Go are using `grpc/tools/run_tests/helper_scripts/prep_xds.sh` to bootstrap their xDS interop test environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26024)
<!-- Reviewable:end -->
