### PR TITLE
Use 'python2' as default Python 2 command in Bazel build instead of 'python'

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -348,7 +348,7 @@ def _python_autoconf_impl(repository_ctx):
         repository_ctx,
         "_python2",
         _PYTHON2_BIN_PATH,
-        "python",
+        "python2",
         _PYTHON2_LIB_PATH,
         True
     )


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/21963.

This brings us up-to-date with guidance modified in PEP 394.