### PR TITLE
Add a list of banned macOS gevent tests

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -231,6 +231,9 @@ class TestGevent(setuptools.Command):
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
         'unit._server_test.ServerTest.test_failed_port_binding_exception',
     )
+    BANNED_MACOS_TESTS = (
+        # TODO(https://github.com/grpc/grpc/issues/15411) enable this test
+        'unit._dynamic_stubs_test.DynamicStubTest',)
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 
@@ -258,6 +261,8 @@ class TestGevent(setuptools.Command):
         runner = tests.Runner()
         if sys.platform == 'win32':
             runner.skip_tests(self.BANNED_TESTS + self.BANNED_WINDOWS_TESTS)
+        elif sys.platform == 'darwin':
+            runner.skip_tests(self.BANNED_TESTS + self.BANNED_MACOS_TESTS)
         else:
             runner.skip_tests(self.BANNED_TESTS)
         result = gevent.spawn(runner.run, loader.suite)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/25675
Related https://github.com/grpc/grpc/issues/15411

We currently don't have the man power to fix the gevent issue on macOS, where a skipping test case became timeout. I seen this flake twice in a day. So, this PR disabled `unit._dynamic_stubs_test.DynamicStubTest` on macOS with gevent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26027)
<!-- Reviewable:end -->
