### PR TITLE
Remove use of C++20 initializers

### DIFF
--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -150,11 +150,8 @@ int TcpUserTimeoutCompare(grpc_socket_mutator* /*a*/,
 void TcpUserTimeoutDestroy(grpc_socket_mutator* mutator) { gpr_free(mutator); }
 
 const grpc_socket_mutator_vtable kTcpUserTimeoutMutatorVtable =
-    grpc_socket_mutator_vtable{
-        .mutate_fd = TcpUserTimeoutMutateFd,
-        .compare = TcpUserTimeoutCompare,
-        .destroy = TcpUserTimeoutDestroy,
-    };
+    grpc_socket_mutator_vtable{TcpUserTimeoutMutateFd, TcpUserTimeoutCompare,
+                               TcpUserTimeoutDestroy};
 
 std::unique_ptr<TestService::Stub> CreateFallbackTestStub() {
   grpc::ChannelArguments channel_args;


### PR DESCRIPTION
Since this codebase only supports C++11 at this point, doing a build
with strict warnings will fail using C++20 initializers.

```
$ bazel build --define=use_strict_warning=true :all //src/core/... //src/compiler/... //test/...

test/cpp/interop/grpclb_fallback_test.cc:154:9: error: designated
initializers are a C++20 extension [-Werror,-Wc++20-designator]
        .mutate_fd = TcpUserTimeoutMutateFd,
```

See
https://source.cloud.google.com/results/invocations/f9710ed0-994f-488f-adb8-a7e987f1620d/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_bazel_build/log
