### PR TITLE
Upgrade setuptools and ProtoBuf Python in prep_xds.sh

### DIFF
--- a/tools/internal_ci/linux/grpc_python_bazel_test.cfg
+++ b/tools/internal_ci/linux/grpc_python_bazel_test.cfg
@@ -1,4 +1,4 @@
-# Copyright 2018 gRPC authors.
+# Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,15 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_bazel.sh"
-timeout_mins: 240
+build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
+timeout_mins: 180
 env_vars {
   key: "BAZEL_SCRIPT"
-  value: "tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh"
+  value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
 }

--- a/tools/internal_ci/linux/grpc_python_bazel_test.cfg
+++ b/tools/internal_ci/linux/grpc_python_bazel_test.cfg
@@ -1,4 +1,4 @@
-# Copyright 2020 gRPC authors.
+# Copyright 2018 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,15 +15,9 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_xds.sh"
-timeout_mins: 180
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel.sh"
+timeout_mins: 240
 env_vars {
   key: "BAZEL_SCRIPT"
-  value: "tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh"
-}
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.*"
-    regex: "github/grpc/reports/**"
-  }
+  value: "tools/internal_ci/linux/grpc_python_bazel_test_in_docker.sh"
 }

--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -21,7 +21,7 @@ cd "$(dirname "$0")/../../.."
 sudo apt-get install -y python3-pip
 sudo python3 -m pip install --upgrade pip
 sudo python3 -m pip install --upgrade setuptools
-sudo python3 -m pip install grpcio==1.31.0 grpcio-tools==1.31.0 google-api-python-client google-auth-httplib2 oauth2client xds-protos
+sudo python3 -m pip install --upgrade grpcio==1.31.0 grpcio-tools==1.31.0 protobuf google-api-python-client google-auth-httplib2 oauth2client xds-protos
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests

--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -20,6 +20,7 @@ cd "$(dirname "$0")/../../.."
 
 sudo apt-get install -y python3-pip
 sudo python3 -m pip install --upgrade pip
+sudo python3 -m pip install --upgrade setuptools
 sudo python3 -m pip install grpcio==1.31.0 grpcio-tools==1.31.0 google-api-python-client google-auth-httplib2 oauth2client xds-protos
 
 # Prepare generated Python code.

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -44,12 +44,17 @@ from src.proto.grpc.testing import test_pb2_grpc
 
 # Envoy protos provided by PyPI package xds-protos
 # Needs to import the generated Python file to load descriptors
-from envoy.service.status.v3 import csds_pb2
-from envoy.service.status.v3 import csds_pb2_grpc
-from envoy.extensions.filters.network.http_connection_manager.v3 import http_connection_manager_pb2
-from envoy.extensions.filters.common.fault.v3 import fault_pb2
-from envoy.extensions.filters.http.fault.v3 import fault_pb2
-from envoy.extensions.filters.http.router.v3 import router_pb2
+try:
+    from envoy.service.status.v3 import csds_pb2
+    from envoy.service.status.v3 import csds_pb2_grpc
+    from envoy.extensions.filters.network.http_connection_manager.v3 import http_connection_manager_pb2
+    from envoy.extensions.filters.common.fault.v3 import fault_pb2
+    from envoy.extensions.filters.http.fault.v3 import fault_pb2
+    from envoy.extensions.filters.http.router.v3 import router_pb2
+except ImportError:
+    # These protos are required by CSDS test. We should not fail the entire
+    # script for one test case.
+    pass
 
 logger = logging.getLogger()
 console_handler = logging.StreamHandler()


### PR DESCRIPTION
The `find_namespace_packages` is introduced in setuptools `v40`: https://setuptools.readthedocs.io/en/latest/history.html#v40-1-0. The latest setuptools available in 3.4 is `v43`. This upgrade should fix the `AttributeError: 'module' object has no attribute 'find_namespace_packages'` issue.

Also, there is a ProtoBuf mismatching issue:

```
Traceback (most recent call last):
  File "grpc/tools/run_tests/run_xds_tests.py", line 39, in <module>
    from src.proto.grpc.health.v1 import health_pb2
  File "/tmpfs/src/github/grpc/tools/run_tests/src/proto/grpc/health/v1/health_pb2.py", line 21, in <module>
    create_key=_descriptor._internal_create_key,
AttributeError: module 'google.protobuf.descriptor' has no attribute '_internal_create_key'
```

Our Ubuntu 1604 image pre-installs an old version of ProtoBuf Python (3.6.1)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26029)
<!-- Reviewable:end -->
