### PR TITLE
Compile source wheels for xds-protos

### DIFF
--- a/tools/distrib/python/xds_protos/build.py
+++ b/tools/distrib/python/xds_protos/build.py
@@ -131,5 +131,5 @@ def main():
         f.writelines(TEST_IMPORTS)
 
 
-if __file__ == "__main__":
+if __name__ == "__main__":
     main()

--- a/tools/distrib/python/xds_protos/build_validate_upload.sh
+++ b/tools/distrib/python/xds_protos/build_validate_upload.sh
@@ -21,6 +21,7 @@ cd ${WORK_DIR}
 # Generate the package content then build the source wheel
 python3 build.py
 python3 setup.py sdist
+python3 setup.py bdist_wheel
 
 # Run the tests to ensure all protos are importable, also avoid confusing normal
 # imports with relative imports

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = [
 SETUP_REQUIRES = INSTALL_REQUIRES + ['grpcio-tools']
 setuptools.setup(
     name='xds-protos',
-    version='0.0.4',
+    version='0.0.5',
     packages=PACKAGES,
     description='Generated Python code from envoyproxy/data-plane-api',
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
TIL `setuptools` doesn't produce a source wheel with `sdist` command, but needs to use `bdist_wheel`. This generates wheel like `xds_protos-0.0.5-py3-none-any.whl`, it installs with all architecture and Python 3 interpreters.

Python 2 users still have access to `*.tar.gz`.

Sorry for the spammy changes, this PR fixes yet another typo I made in the `xds-protos` generation process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26034)
<!-- Reviewable:end -->
