### PR TITLE
[Backport][1.37.x] Backport xds-k8s driver changes

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,4 +1,4 @@
 --namespace=interop-psm-security
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:8af4336691ba23683ee3e280275894959dc47c4c
+--td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:2558ec79df06984ed0d37e9e69f34688ffe301bb
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
@@ -137,7 +137,7 @@ class GcpApiManager:
         if version == 'v1':
             return secretmanager_v1.SecretManagerServiceClient()
 
-        raise NotImplementedError(f'Secrets Manager {version} not supported')
+        raise NotImplementedError(f'Secret Manager {version} not supported')
 
     def _build_from_discovery_v1(self, api_name, version):
         api = discovery.build(api_name,

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     app: ${deployment_name}
     owner: xds-k8s-interop-test
-  annotations:
-    security.cloud.google.com/use-workload-certificates: ""
 spec:
   replicas: 1
   selector:
@@ -19,6 +17,8 @@ spec:
       labels:
         app: ${deployment_name}
         owner: xds-k8s-interop-test
+      annotations:
+        security.cloud.google.com/use-workload-certificates: ""
     spec:
       serviceAccountName: ${service_account_name}
       containers:

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app: ${deployment_name}
     owner: xds-k8s-interop-test
+  annotations:
+    security.cloud.google.com/use-workload-certificates: ""
 spec:
   replicas: 1
   selector:
@@ -43,9 +45,6 @@ spec:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf
             readOnly: true
-          - mountPath: /var/run/gke-spiffe/certs
-            name: gke-spiffe-certs-volume
-            readOnly: true
         resources:
           limits:
             cpu: 800m
@@ -79,7 +78,4 @@ spec:
         - name: grpc-td-conf
           emptyDir:
             medium: Memory
-        - name: gke-spiffe-certs-volume
-          csi:
-            driver: certs.spiffe.gke.io
 ...

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     app: ${deployment_name}
     owner: xds-k8s-interop-test
-  annotations:
-    security.cloud.google.com/use-workload-certificates: ""
 spec:
   replicas: ${replica_count}
   selector:
@@ -16,6 +14,8 @@ spec:
       app: ${deployment_name}
   template:
     metadata:
+      annotations:
+        security.cloud.google.com/use-workload-certificates: ""
       labels:
         app: ${deployment_name}
         owner: xds-k8s-interop-test

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   labels:
     app: ${deployment_name}
     owner: xds-k8s-interop-test
+  annotations:
+    security.cloud.google.com/use-workload-certificates: ""
 spec:
   replicas: ${replica_count}
   selector:
@@ -44,9 +46,6 @@ spec:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf
             readOnly: true
-          - mountPath: /var/run/gke-spiffe/certs
-            name: gke-spiffe-certs-volume
-            readOnly: true
         resources:
           limits:
             cpu: 800m
@@ -81,7 +80,4 @@ spec:
         - name: grpc-td-conf
           emptyDir:
             medium: Memory
-        - name: gke-spiffe-certs-volume
-          csi:
-            driver: certs.spiffe.gke.io
 ...


### PR DESCRIPTION
At the moment v1.37.x PSM Security job uses xds-k8s driver from the same branch. This PR backports the difference between v1.37.x and master.

```
❯ git --no-pager log upstream/v1.37.x..master -- tools/run_tests/xds_k8s_test_driver
3223b4fe98 Seth Vargo         Naming fix (secrets manager -> secret manager) (#25990) [6 days ago]
72632aebd7 Sergii Tkachenko   xds-k8s: Use latest TD bootstrap supporting new secrets dir (#25925) [2 weeks ago]
9a2c2c0afc Sergii Tkachenko   xds-k8s: Update GKE workload certificates: fix annotation (#25882) [2 weeks ago]
1e065a0918 Sergii Tkachenko   xds-k8s: Update Private CA GKE workload certificates config (#25875) [3 weeks ago]

❯ git cherry-pick 1e065a0918 9a2c2c0afc 72632aebd7 3223b4fe98
```

This is a temporary measure. The job will be switched to always use the latest xds-k8s driver.