### PR TITLE
Do not use flow style when dumping LoadTest configurations.

### DIFF
--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -209,7 +209,7 @@ def parse_key_value_args(args: Optional[Iterable[str]]) -> Dict[str, str]:
 def config_dumper(header_comment: str) -> Type[yaml.Dumper]:
     """Returns a custom dumper to dump configurations in the expected format."""
 
-    class ConfigDumper(yaml.Dumper):
+    class ConfigDumper(yaml.SafeDumper):
 
         def expect_stream_start(self):
             super().expect_stream_start()
@@ -351,7 +351,8 @@ def main() -> None:
         yaml.dump_all(configs,
                       stream=f,
                       Dumper=config_dumper(
-                          CONFIGURATION_FILE_HEADER_COMMENT.strip()))
+                          CONFIGURATION_FILE_HEADER_COMMENT.strip()),
+                      default_flow_style=False)
 
 
 if __name__ == '__main__':

--- a/tools/run_tests/performance/loadtest_template.py
+++ b/tools/run_tests/performance/loadtest_template.py
@@ -125,7 +125,7 @@ def loadtest_template(
 def template_dumper(header_comment: str) -> Type[yaml.Dumper]:
     """Returns a custom dumper to dump templates in the expected format."""
 
-    class TemplateDumper(yaml.Dumper):
+    class TemplateDumper(yaml.SafeDumper):
 
         def expect_stream_start(self):
             super().expect_stream_start()
@@ -199,7 +199,8 @@ def main() -> None:
     with open(args.output, 'w') if args.output else sys.stdout as f:
         yaml.dump(template,
                   stream=f,
-                  Dumper=template_dumper(TEMPLATE_FILE_HEADER_COMMENT.strip()))
+                  Dumper=template_dumper(TEMPLATE_FILE_HEADER_COMMENT.strip()),
+                  default_flow_style=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change makes the format for dumping load test YAML configurations to a file consistent between kokoro and the desktop.