### PR TITLE
Added GRPC_ERROR_IS_ABSEIL_STATUS

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -34,6 +34,11 @@
 #define GPR_ABSEIL_SYNC 1
 #endif  // GPR_ABSEIL_SYNC
 
+/*
+ * Defines GRPC_ERROR_IS_ABSEIL_STATUS to use absl::Status for grpc_error_handle
+ */
+// #define GRPC_ERROR_IS_ABSEIL_STATUS 1
+
 /* Get windows.h included everywhere (we need it) */
 #if defined(_WIN64) || defined(WIN64) || defined(_WIN32) || defined(WIN32)
 #ifndef WIN32_LEAN_AND_MEAN

--- a/src/core/lib/gprpp/status_helper.cc
+++ b/src/core/lib/gprpp/status_helper.cc
@@ -43,35 +43,35 @@ const absl::string_view kChildrenPropertyUrl = TYPE_URL("children");
 
 const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
   switch (key) {
-    case StatusIntProperty::ERRNO:
+    case StatusIntProperty::kErrorNo:
       return TYPE_URL("errno");
-    case StatusIntProperty::FILE_LINE:
+    case StatusIntProperty::kFileLine:
       return TYPE_URL("file_line");
-    case StatusIntProperty::STREAM_ID:
+    case StatusIntProperty::kStreamId:
       return TYPE_URL("stream_id");
-    case StatusIntProperty::GRPC_STATUS:
+    case StatusIntProperty::kRpcStatus:
       return TYPE_URL("grpc_status");
-    case StatusIntProperty::OFFSET:
+    case StatusIntProperty::kOffset:
       return TYPE_URL("offset");
-    case StatusIntProperty::INDEX:
+    case StatusIntProperty::kIndex:
       return TYPE_URL("index");
-    case StatusIntProperty::SIZE:
+    case StatusIntProperty::kSize:
       return TYPE_URL("size");
-    case StatusIntProperty::HTTP2_ERROR:
+    case StatusIntProperty::kHttp2Error:
       return TYPE_URL("http2_error");
-    case StatusIntProperty::TSI_CODE:
+    case StatusIntProperty::kTsiCode:
       return TYPE_URL("tsi_code");
-    case StatusIntProperty::FD:
-      return TYPE_URL("fd");
-    case StatusIntProperty::WSA_ERROR:
+    case StatusIntProperty::kWsaError:
       return TYPE_URL("wsa_error");
-    case StatusIntProperty::HTTP_STATUS:
+    case StatusIntProperty::kFd:
+      return TYPE_URL("fd");
+    case StatusIntProperty::kHttpStatus:
       return TYPE_URL("http_status");
-    case StatusIntProperty::OCCURRED_DURING_WRITE:
+    case StatusIntProperty::kOccurredDuringWrite:
       return TYPE_URL("occurred_during_write");
-    case StatusIntProperty::CHANNEL_CONNECTIVITY_STATE:
+    case StatusIntProperty::ChannelConnectivityState:
       return TYPE_URL("channel_connectivity_state");
-    case StatusIntProperty::LB_POLICY_DROP:
+    case StatusIntProperty::kLbPolicyDrop:
       return TYPE_URL("lb_policy_drop");
   }
   GPR_UNREACHABLE_CODE(return "unknown");
@@ -79,29 +79,29 @@ const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
 
 const char* GetStatusStrPropertyUrl(StatusStrProperty key) {
   switch (key) {
-    case StatusStrProperty::KEY:
-      return TYPE_URL("key");
-    case StatusStrProperty::VALUE:
-      return TYPE_URL("value");
-    case StatusStrProperty::DESCRIPTION:
+    case StatusStrProperty::kDescription:
       return TYPE_URL("description");
-    case StatusStrProperty::OS_ERROR:
-      return TYPE_URL("os_error");
-    case StatusStrProperty::TARGET_ADDRESS:
-      return TYPE_URL("target_address");
-    case StatusStrProperty::SYSCALL:
-      return TYPE_URL("syscall");
-    case StatusStrProperty::FILE:
+    case StatusStrProperty::kFile:
       return TYPE_URL("file");
-    case StatusStrProperty::GRPC_MESSAGE:
+    case StatusStrProperty::kOsError:
+      return TYPE_URL("os_error");
+    case StatusStrProperty::kSyscall:
+      return TYPE_URL("syscall");
+    case StatusStrProperty::kTargetAddress:
+      return TYPE_URL("target_address");
+    case StatusStrProperty::kGrpcMessage:
       return TYPE_URL("grpc_message");
-    case StatusStrProperty::RAW_BYTES:
+    case StatusStrProperty::kRawBytes:
       return TYPE_URL("raw_bytes");
-    case StatusStrProperty::TSI_ERROR:
+    case StatusStrProperty::kTsiError:
       return TYPE_URL("tsi_error");
-    case StatusStrProperty::FILENAME:
+    case StatusStrProperty::kFilename:
       return TYPE_URL("filename");
-    case StatusStrProperty::CREATED_TIME:
+    case StatusStrProperty::kKey:
+      return TYPE_URL("key");
+    case StatusStrProperty::kValue:
+      return TYPE_URL("value");
+    case StatusStrProperty::kCreatedTime:
       return TYPE_URL("created_time");
   }
   GPR_UNREACHABLE_CODE(return "unknown");
@@ -145,13 +145,13 @@ absl::Status StatusCreate(absl::StatusCode code, absl::string_view msg,
                           std::initializer_list<absl::Status> children) {
   absl::Status s(code, msg);
   if (location.file() != nullptr) {
-    StatusSetStr(&s, StatusStrProperty::FILE, location.file());
+    StatusSetStr(&s, StatusStrProperty::kFile, location.file());
   }
   if (location.line() != -1) {
-    StatusSetInt(&s, StatusIntProperty::FILE_LINE, location.line());
+    StatusSetInt(&s, StatusIntProperty::kFileLine, location.line());
   }
   absl::Time now = grpc_core::ToAbslTime(gpr_now(GPR_CLOCK_REALTIME));
-  StatusSetStr(&s, StatusStrProperty::CREATED_TIME, absl::FormatTime(now));
+  StatusSetStr(&s, StatusStrProperty::kCreatedTime, absl::FormatTime(now));
   for (const absl::Status& child : children) {
     if (!child.ok()) {
       StatusAddChild(&s, child);
@@ -313,6 +313,30 @@ absl::Status StatusFromProto(google_rpc_Status* msg) {
                       absl::Cord(absl::string_view(value.data, value.size)));
   }
   return status;
+}
+
+uintptr_t StatusAllocPtr(absl::Status s) {
+  // This relies the fact that absl::Status has only one member, StatusRep*
+  // so the sizeof(absl::Status) has the same size of intptr_t and StatusRep*
+  // can be stolen using placement allocation.
+  static_assert(sizeof(intptr_t) == sizeof(absl::Status),
+                "absl::Status should be as big as intptr_t");
+  // This does two things;
+  // 1. Copies StatusRep* of absl::Status to ptr
+  // 2. Increases the counter of StatusRep if it's not inlined
+  uintptr_t ptr;
+  new (&ptr) absl::Status(s);
+  return ptr;
+}
+
+void StatusFreePtr(uintptr_t ptr) {
+  // Decreases the counter of StatusRep if it's not inlined.
+  reinterpret_cast<absl::Status*>(&ptr)->~Status();
+}
+
+absl::Status StatusGetFromPtr(uintptr_t ptr) {
+  // Constructs Status from ptr having the address of StatusRep.
+  return *reinterpret_cast<absl::Status*>(&ptr);
 }
 
 }  // namespace internal

--- a/src/core/lib/gprpp/status_helper.h
+++ b/src/core/lib/gprpp/status_helper.h
@@ -141,7 +141,7 @@ google_rpc_Status* StatusToProto(absl::Status status,
 absl::Status StatusFromProto(google_rpc_Status* msg) GRPC_MUST_USE_RESULT;
 
 /// The same value of grpc_core::internal::StatusAllocPtr(absl::OkStatus())
-static constexpr uintptr_t OK_STATUS_PTR = 0;
+static constexpr uintptr_t kOkStatusPtr = 0;
 
 /// Returns ptr where the given status is copied into.
 /// This ptr can be used to get Status later and should be freed by

--- a/src/core/lib/gprpp/status_helper.h
+++ b/src/core/lib/gprpp/status_helper.h
@@ -32,67 +32,67 @@ namespace grpc_core {
 // TODO(veblush): Use camel-case names once migration to absl::Status is done.
 enum class StatusIntProperty {
   /// 'errno' from the operating system
-  ERRNO,
+  kErrorNo,
   /// __LINE__ from the call site creating the error
-  FILE_LINE,
+  kFileLine,
   /// stream identifier: for errors that are associated with an individual
   /// wire stream
-  STREAM_ID,
+  kStreamId,
   /// grpc status code representing this error
   // TODO(veblush): Remove this after grpc_error is replaced with absl::Status
-  GRPC_STATUS,
+  kRpcStatus,
   /// offset into some binary blob (usually represented by
   /// RAW_BYTES) where the error occurred
-  OFFSET,
+  kOffset,
   /// context sensitive index associated with the error
-  INDEX,
+  kIndex,
   /// context sensitive size associated with the error
-  SIZE,
+  kSize,
   /// http2 error code associated with the error (see the HTTP2 RFC)
-  HTTP2_ERROR,
+  kHttp2Error,
   /// TSI status code associated with the error
-  TSI_CODE,
+  kTsiCode,
   /// WSAGetLastError() reported when this error occurred
-  WSA_ERROR,
+  kWsaError,
   /// File descriptor associated with this error
-  FD,
+  kFd,
   /// HTTP status (i.e. 404)
-  HTTP_STATUS,
+  kHttpStatus,
   /// chttp2: did the error occur while a write was in progress
-  OCCURRED_DURING_WRITE,
+  kOccurredDuringWrite,
   /// channel connectivity state associated with the error
-  CHANNEL_CONNECTIVITY_STATE,
+  ChannelConnectivityState,
   /// LB policy drop
-  LB_POLICY_DROP,
+  kLbPolicyDrop,
 };
 
 /// This enum should have the same value of grpc_error_strs
 // TODO(veblush): Use camel-case names once migration to absl::Status is done.
 enum class StatusStrProperty {
   /// top-level textual description of this error
-  DESCRIPTION,
+  kDescription,
   /// source file in which this error occurred
-  FILE,
+  kFile,
   /// operating system description of this error
-  OS_ERROR,
+  kOsError,
   /// syscall that generated this error
-  SYSCALL,
+  kSyscall,
   /// peer that we were trying to communicate when this error occurred
-  TARGET_ADDRESS,
+  kTargetAddress,
   /// grpc status message associated with this error
-  GRPC_MESSAGE,
+  kGrpcMessage,
   /// hex dump (or similar) with the data that generated this error
-  RAW_BYTES,
+  kRawBytes,
   /// tsi error string associated with this error
-  TSI_ERROR,
+  kTsiError,
   /// filename that we were trying to read/write when this error occurred
-  FILENAME,
+  kFilename,
   /// key associated with the error
-  KEY,
+  kKey,
   /// value associated with the error
-  VALUE,
+  kValue,
   /// time string to create the error
-  CREATED_TIME,
+  kCreatedTime,
 };
 
 /// Creates a status with given additional information
@@ -136,9 +136,25 @@ namespace internal {
 google_rpc_Status* StatusToProto(absl::Status status,
                                  upb_arena* arena) GRPC_MUST_USE_RESULT;
 
-/// Build a status from a upb message, google_rpc_Status
+/// Builds a status from a upb message, google_rpc_Status
 /// This is for internal implementation & test only
 absl::Status StatusFromProto(google_rpc_Status* msg) GRPC_MUST_USE_RESULT;
+
+/// The same value of grpc_core::internal::StatusAllocPtr(absl::OkStatus())
+static constexpr uintptr_t OK_STATUS_PTR = 0;
+
+/// Returns ptr where the given status is copied into.
+/// This ptr can be used to get Status later and should be freed by
+/// StatusFreePtr. This shouldn't be used except migration purpose.
+uintptr_t StatusAllocPtr(absl::Status s);
+
+/// Frees the allocated status at ptr.
+/// This shouldn't be used except migration purpose.
+void StatusFreePtr(uintptr_t ptr);
+
+/// Get the status from ptr.
+/// This shouldn't be used except migration purpose.
+absl::Status StatusGetFromPtr(uintptr_t ptr);
 
 }  // namespace internal
 

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -51,37 +51,49 @@ typedef grpc_error* grpc_error_handle;
 
 typedef enum {
   /// 'errno' from the operating system
-  GRPC_ERROR_INT_ERRNO,
+  GRPC_ERROR_INT_ERRNO =
+      static_cast<int>(grpc_core::StatusIntProperty::kErrorNo),
   /// __LINE__ from the call site creating the error
-  GRPC_ERROR_INT_FILE_LINE,
+  GRPC_ERROR_INT_FILE_LINE =
+      static_cast<int>(grpc_core::StatusIntProperty::kFileLine),
   /// stream identifier: for errors that are associated with an individual
   /// wire stream
-  GRPC_ERROR_INT_STREAM_ID,
+  GRPC_ERROR_INT_STREAM_ID =
+      static_cast<int>(grpc_core::StatusIntProperty::kStreamId),
   /// grpc status code representing this error
-  GRPC_ERROR_INT_GRPC_STATUS,
+  GRPC_ERROR_INT_GRPC_STATUS =
+      static_cast<int>(grpc_core::StatusIntProperty::kRpcStatus),
   /// offset into some binary blob (usually represented by
   /// GRPC_ERROR_STR_RAW_BYTES) where the error occurred
-  GRPC_ERROR_INT_OFFSET,
+  GRPC_ERROR_INT_OFFSET =
+      static_cast<int>(grpc_core::StatusIntProperty::kOffset),
   /// context sensitive index associated with the error
-  GRPC_ERROR_INT_INDEX,
+  GRPC_ERROR_INT_INDEX = static_cast<int>(grpc_core::StatusIntProperty::kIndex),
   /// context sensitive size associated with the error
-  GRPC_ERROR_INT_SIZE,
+  GRPC_ERROR_INT_SIZE = static_cast<int>(grpc_core::StatusIntProperty::kSize),
   /// http2 error code associated with the error (see the HTTP2 RFC)
-  GRPC_ERROR_INT_HTTP2_ERROR,
+  GRPC_ERROR_INT_HTTP2_ERROR =
+      static_cast<int>(grpc_core::StatusIntProperty::kHttp2Error),
   /// TSI status code associated with the error
-  GRPC_ERROR_INT_TSI_CODE,
+  GRPC_ERROR_INT_TSI_CODE =
+      static_cast<int>(grpc_core::StatusIntProperty::kTsiCode),
   /// WSAGetLastError() reported when this error occurred
-  GRPC_ERROR_INT_WSA_ERROR,
+  GRPC_ERROR_INT_WSA_ERROR =
+      static_cast<int>(grpc_core::StatusIntProperty::kWsaError),
   /// File descriptor associated with this error
-  GRPC_ERROR_INT_FD,
+  GRPC_ERROR_INT_FD = static_cast<int>(grpc_core::StatusIntProperty::kFd),
   /// HTTP status (i.e. 404)
-  GRPC_ERROR_INT_HTTP_STATUS,
+  GRPC_ERROR_INT_HTTP_STATUS =
+      static_cast<int>(grpc_core::StatusIntProperty::kHttpStatus),
   /// chttp2: did the error occur while a write was in progress
-  GRPC_ERROR_INT_OCCURRED_DURING_WRITE,
+  GRPC_ERROR_INT_OCCURRED_DURING_WRITE =
+      static_cast<int>(grpc_core::StatusIntProperty::kOccurredDuringWrite),
   /// channel connectivity state associated with the error
-  GRPC_ERROR_INT_CHANNEL_CONNECTIVITY_STATE,
+  GRPC_ERROR_INT_CHANNEL_CONNECTIVITY_STATE =
+      static_cast<int>(grpc_core::StatusIntProperty::ChannelConnectivityState),
   /// LB policy drop
-  GRPC_ERROR_INT_LB_POLICY_DROP,
+  GRPC_ERROR_INT_LB_POLICY_DROP =
+      static_cast<int>(grpc_core::StatusIntProperty::kLbPolicyDrop),
 
   /// Must always be last
   GRPC_ERROR_INT_MAX,
@@ -89,27 +101,35 @@ typedef enum {
 
 typedef enum {
   /// top-level textual description of this error
-  GRPC_ERROR_STR_DESCRIPTION,
+  GRPC_ERROR_STR_DESCRIPTION =
+      static_cast<int>(grpc_core::StatusStrProperty::kDescription),
   /// source file in which this error occurred
-  GRPC_ERROR_STR_FILE,
+  GRPC_ERROR_STR_FILE = static_cast<int>(grpc_core::StatusStrProperty::kFile),
   /// operating system description of this error
-  GRPC_ERROR_STR_OS_ERROR,
+  GRPC_ERROR_STR_OS_ERROR =
+      static_cast<int>(grpc_core::StatusStrProperty::kOsError),
   /// syscall that generated this error
-  GRPC_ERROR_STR_SYSCALL,
+  GRPC_ERROR_STR_SYSCALL =
+      static_cast<int>(grpc_core::StatusStrProperty::kSyscall),
   /// peer that we were trying to communicate when this error occurred
-  GRPC_ERROR_STR_TARGET_ADDRESS,
+  GRPC_ERROR_STR_TARGET_ADDRESS =
+      static_cast<int>(grpc_core::StatusStrProperty::kTargetAddress),
   /// grpc status message associated with this error
-  GRPC_ERROR_STR_GRPC_MESSAGE,
+  GRPC_ERROR_STR_GRPC_MESSAGE =
+      static_cast<int>(grpc_core::StatusStrProperty::kGrpcMessage),
   /// hex dump (or similar) with the data that generated this error
-  GRPC_ERROR_STR_RAW_BYTES,
+  GRPC_ERROR_STR_RAW_BYTES =
+      static_cast<int>(grpc_core::StatusStrProperty::kRawBytes),
   /// tsi error string associated with this error
-  GRPC_ERROR_STR_TSI_ERROR,
+  GRPC_ERROR_STR_TSI_ERROR =
+      static_cast<int>(grpc_core::StatusStrProperty::kTsiError),
   /// filename that we were trying to read/write when this error occurred
-  GRPC_ERROR_STR_FILENAME,
+  GRPC_ERROR_STR_FILENAME =
+      static_cast<int>(grpc_core::StatusStrProperty::kFilename),
   /// key associated with the error
-  GRPC_ERROR_STR_KEY,
+  GRPC_ERROR_STR_KEY = static_cast<int>(grpc_core::StatusStrProperty::kKey),
   /// value associated with the error
-  GRPC_ERROR_STR_VALUE,
+  GRPC_ERROR_STR_VALUE = static_cast<int>(grpc_core::StatusStrProperty::kValue),
 
   /// Must always be last
   GRPC_ERROR_STR_MAX,

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -30,15 +30,24 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/debug/trace.h"
+#include "src/core/lib/gprpp/status_helper.h"
+
+#include "absl/status/status.h"
 
 /// Opaque representation of an error.
 /// See https://github.com/grpc/grpc/blob/master/doc/core/grpc-error.md for a
 /// full write up of this object.
 
+#ifdef GRPC_ERROR_IS_ABSEIL_STATUS
+
+typedef absl::Status grpc_error_handle;
+
+#else  // GRPC_ERROR_IS_ABSEIL_STATUS
+
 typedef struct grpc_error grpc_error;
 typedef grpc_error* grpc_error_handle;
 
-extern grpc_core::DebugOnlyTraceFlag grpc_trace_error_refcount;
+#endif  // GRPC_ERROR_IS_ABSEIL_STATUS
 
 typedef enum {
   /// 'errno' from the operating system
@@ -114,6 +123,84 @@ typedef enum {
   GRPC_ERROR_TIME_MAX,
 } grpc_error_times;
 
+// DEPRECATED: Use grpc_error_std_string instead
+const char* grpc_error_string(grpc_error_handle error);
+std::string grpc_error_std_string(grpc_error_handle error);
+
+// debug only toggles that allow for a sanity to check that ensures we will
+// never create any errors in the per-RPC hotpath.
+void grpc_disable_error_creation();
+void grpc_enable_error_creation();
+
+#ifdef GRPC_ERROR_IS_ABSEIL_STATUS
+
+#define GRPC_ERROR_NONE absl::OkStatus()
+#define GRPC_ERROR_OOM absl::Status(absl::ResourceExhaustedError)
+#define GRPC_ERROR_CANCELLED absl::CancelledError()
+
+#define GRPC_ERROR_REF(err) (err)
+#define GRPC_ERROR_UNREF(err)
+
+#define GRPC_ERROR_CREATE_FROM_STATIC_STRING(desc) \
+  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
+#define GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc) \
+  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
+#define GRPC_ERROR_CREATE_FROM_STRING_VIEW(desc) \
+  StatusCreate(ababsl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
+
+absl::Status grpc_status_create(absl::StatusCode code, absl::string_view msg,
+                                const grpc_core::DebugLocation& location,
+                                size_t children_count,
+                                absl::Status* children) GRPC_MUST_USE_RESULT;
+
+// Create an error that references some other errors. This function adds a
+// reference to each error in errs - it does not consume an existing reference
+#define GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(desc, errs, count)   \
+  grpc_status_create(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, count, \
+                     errs)
+#define GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(desc, errs, count)   \
+  grpc_status_create(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, count, \
+                     errs)
+
+// Consumes all the errors in the vector and forms a referencing error from
+// them. If the vector is empty, return GRPC_ERROR_NONE.
+template <typename VectorType>
+static absl::Status grpc_status_create_from_vector(
+    const grpc_core::DebugLocation& location, const char* desc,
+    VectorType* error_list) {
+  absl::Status error = GRPC_ERROR_NONE;
+  if (error_list->size() != 0) {
+    error = grpc_status_create(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION,
+                               error_list->size(), error_list->data());
+    error_list->clear();
+  }
+  return error;
+}
+
+#define GRPC_ERROR_CREATE_FROM_VECTOR(desc, error_list) \
+  grpc_status_create_from_vector(DEBUG_LOCATION, desc, error_list)
+
+absl::Status grpc_os_error(const grpc_core::DebugLocation& location, int err,
+                           const char* call_name) GRPC_MUST_USE_RESULT;
+
+inline absl::Status grpc_assert_never_ok(absl::Status error) {
+  GPR_ASSERT(error != GRPC_ERROR_NONE);
+  return error;
+}
+
+/// create an error associated with errno!=0 (an 'operating system' error)
+#define GRPC_OS_ERROR(err, call_name) \
+  grpc_assert_never_ok(grpc_os_error(DEBUG_LOCATION, err, call_name))
+
+absl::Status grpc_wsa_error(const grpc_core::DebugLocation& location, int err,
+                            const char* call_name) GRPC_MUST_USE_RESULT;
+
+/// windows only: create an error associated with WSAGetLastError()!=0
+#define GRPC_WSA_ERROR(err, call_name) \
+  grpc_wsa_error(DEBUG_LOCATION, err, call_name)
+
+#else  // GRPC_ERROR_IS_ABSEIL_STATUS
+
 /// The following "special" errors can be propagated without allocating memory.
 /// They are always even so that other code (particularly combiner locks,
 /// polling engines) can safely use the lower bit for themselves.
@@ -129,14 +216,36 @@ inline bool grpc_error_is_special(grpc_error_handle err) {
   return err <= GRPC_ERROR_SPECIAL_MAX;
 }
 
-// debug only toggles that allow for a sanity to check that ensures we will
-// never create any errors in the per-RPC hotpath.
-void grpc_disable_error_creation();
-void grpc_enable_error_creation();
-
-// DEPRECATED: Use grpc_error_std_string instead
-const char* grpc_error_string(grpc_error_handle error);
-std::string grpc_error_std_string(grpc_error_handle error);
+#ifndef NDEBUG
+grpc_error_handle grpc_error_do_ref(grpc_error_handle err, const char* file,
+                                    int line);
+void grpc_error_do_unref(grpc_error_handle err, const char* file, int line);
+inline grpc_error_handle grpc_error_ref(grpc_error_handle err, const char* file,
+                                        int line) {
+  if (grpc_error_is_special(err)) return err;
+  return grpc_error_do_ref(err, file, line);
+}
+inline void grpc_error_unref(grpc_error_handle err, const char* file,
+                             int line) {
+  if (grpc_error_is_special(err)) return;
+  grpc_error_do_unref(err, file, line);
+}
+#define GRPC_ERROR_REF(err) grpc_error_ref(err, __FILE__, __LINE__)
+#define GRPC_ERROR_UNREF(err) grpc_error_unref(err, __FILE__, __LINE__)
+#else
+grpc_error_handle grpc_error_do_ref(grpc_error_handle err);
+void grpc_error_do_unref(grpc_error_handle err);
+inline grpc_error_handle grpc_error_ref(grpc_error_handle err) {
+  if (grpc_error_is_special(err)) return err;
+  return grpc_error_do_ref(err);
+}
+inline void grpc_error_unref(grpc_error_handle err) {
+  if (grpc_error_is_special(err)) return;
+  grpc_error_do_unref(err);
+}
+#define GRPC_ERROR_REF(err) grpc_error_ref(err)
+#define GRPC_ERROR_UNREF(err) grpc_error_unref(err)
+#endif
 
 /// Create an error - but use GRPC_ERROR_CREATE instead
 grpc_error_handle grpc_error_create(const char* file, int line,
@@ -174,37 +283,6 @@ grpc_error_handle grpc_error_create(const char* file, int line,
 #define GRPC_ERROR_CREATE_FROM_VECTOR(desc, error_list) \
   grpc_error_create_from_vector(__FILE__, __LINE__, desc, error_list)
 
-#ifndef NDEBUG
-grpc_error_handle grpc_error_do_ref(grpc_error_handle err, const char* file,
-                                    int line);
-void grpc_error_do_unref(grpc_error_handle err, const char* file, int line);
-inline grpc_error_handle grpc_error_ref(grpc_error_handle err, const char* file,
-                                        int line) {
-  if (grpc_error_is_special(err)) return err;
-  return grpc_error_do_ref(err, file, line);
-}
-inline void grpc_error_unref(grpc_error_handle err, const char* file,
-                             int line) {
-  if (grpc_error_is_special(err)) return;
-  grpc_error_do_unref(err, file, line);
-}
-#define GRPC_ERROR_REF(err) grpc_error_ref(err, __FILE__, __LINE__)
-#define GRPC_ERROR_UNREF(err) grpc_error_unref(err, __FILE__, __LINE__)
-#else
-grpc_error_handle grpc_error_do_ref(grpc_error_handle err);
-void grpc_error_do_unref(grpc_error_handle err);
-inline grpc_error_handle grpc_error_ref(grpc_error_handle err) {
-  if (grpc_error_is_special(err)) return err;
-  return grpc_error_do_ref(err);
-}
-inline void grpc_error_unref(grpc_error_handle err) {
-  if (grpc_error_is_special(err)) return;
-  grpc_error_do_unref(err);
-}
-#define GRPC_ERROR_REF(err) grpc_error_ref(err)
-#define GRPC_ERROR_UNREF(err) grpc_error_unref(err)
-#endif
-
 // Consumes all the errors in the vector and forms a referencing error from
 // them. If the vector is empty, return GRPC_ERROR_NONE.
 template <typename VectorType>
@@ -224,6 +302,25 @@ static grpc_error_handle grpc_error_create_from_vector(const char* file,
   }
   return error;
 }
+
+grpc_error_handle grpc_os_error(const char* file, int line, int err,
+                                const char* call_name) GRPC_MUST_USE_RESULT;
+
+inline grpc_error_handle grpc_assert_never_ok(grpc_error_handle error) {
+  GPR_ASSERT(error != GRPC_ERROR_NONE);
+  return error;
+}
+
+/// create an error associated with errno!=0 (an 'operating system' error)
+#define GRPC_OS_ERROR(err, call_name) \
+  grpc_assert_never_ok(grpc_os_error(__FILE__, __LINE__, err, call_name))
+grpc_error_handle grpc_wsa_error(const char* file, int line, int err,
+                                 const char* call_name) GRPC_MUST_USE_RESULT;
+/// windows only: create an error associated with WSAGetLastError()!=0
+#define GRPC_WSA_ERROR(err, call_name) \
+  grpc_wsa_error(__FILE__, __LINE__, err, call_name)
+
+#endif  // GRPC_ERROR_IS_ABSEIL_STATUS
 
 grpc_error_handle grpc_error_set_int(grpc_error_handle src,
                                      grpc_error_ints which,
@@ -255,23 +352,6 @@ bool grpc_error_get_str(grpc_error_handle error, grpc_error_strs which,
 /// received to the error in this case.)
 grpc_error_handle grpc_error_add_child(
     grpc_error_handle src, grpc_error_handle child) GRPC_MUST_USE_RESULT;
-
-grpc_error_handle grpc_os_error(const char* file, int line, int err,
-                                const char* call_name) GRPC_MUST_USE_RESULT;
-
-inline grpc_error_handle grpc_assert_never_ok(grpc_error_handle error) {
-  GPR_ASSERT(error != GRPC_ERROR_NONE);
-  return error;
-}
-
-/// create an error associated with errno!=0 (an 'operating system' error)
-#define GRPC_OS_ERROR(err, call_name) \
-  grpc_assert_never_ok(grpc_os_error(__FILE__, __LINE__, err, call_name))
-grpc_error_handle grpc_wsa_error(const char* file, int line, int err,
-                                 const char* call_name) GRPC_MUST_USE_RESULT;
-/// windows only: create an error associated with WSAGetLastError()!=0
-#define GRPC_WSA_ERROR(err, call_name) \
-  grpc_wsa_error(__FILE__, __LINE__, err, call_name)
 
 bool grpc_log_error(const char* what, grpc_error_handle error, const char* file,
                     int line);

--- a/src/core/lib/iomgr/error_internal.h
+++ b/src/core/lib/iomgr/error_internal.h
@@ -27,6 +27,8 @@
 #include <grpc/support/sync.h>
 #include "src/core/lib/iomgr/error.h"
 
+#ifndef GRPC_ERROR_IS_ABSEIL_STATUS
+
 typedef struct grpc_linked_error grpc_linked_error;
 
 struct grpc_linked_error {
@@ -57,5 +59,7 @@ struct grpc_error {
   uint8_t arena_capacity;
   intptr_t arena[0];
 };
+
+#endif  // GRPC_ERROR_IS_ABSEIL_STATUS
 
 #endif /* GRPC_CORE_LIB_IOMGR_ERROR_INTERNAL_H */


### PR DESCRIPTION
Main changes
- Added `GRPC_ERROR_IS_ABSEIL_STATUS` flag to set `grpc_error_handle` as the alias of `absl::Status`
- Added `grpc_error` compatible functions such as `grpc_error_set_int` for `absl::Status` to error.h so that the existing code can work with both `grpc_error` and `absl::Status`.

Extra changes
- Used C++ standard style for the field names of `StatusIntProperty` and `StatusStrProperty`
- Added low-level status functions such as `StatusAllocPtr` only for migration purpose.

Although all required functions are implemented in this PR, gRPC isn't able to build with `GRPC_ERROR_IS_ABSEIL_STATUS` enabled since there are a couple of cases where grpc_error_handle should be `grpc_error*` so those are addressed by separate PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26078)
<!-- Reviewable:end -->
