### PR TITLE
Grpc.Tools: Use x64 protoc on macOS arm64

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
@@ -73,7 +73,16 @@ namespace Grpc.Tools.Tests
             if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
             {
                 _cpuMatched++;
-                Assert.AreEqual("arm64", _task.Cpu);
+
+                // On macosx arm64, x64 is used until a native protoc is shipped
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Assert.AreEqual("x64", _task.Cpu);
+                }
+                else
+                {
+                    Assert.AreEqual("arm64", _task.Cpu);
+                }
             }
         }
 

--- a/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
+++ b/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
@@ -59,6 +59,13 @@ namespace Grpc.Tools
                 case CommonPlatformDetection.CpuArchitecture.Arm64: Cpu = "arm64"; break;
                 default: Cpu = ""; break;
             }
+
+            // Use x64 on macosx arm64 until a native protoc is shipped
+            if (Os == "macosx" && Cpu == "arm64")
+            {
+                Cpu = "x64";
+            }
+
             return true;
         }
     };


### PR DESCRIPTION
As a workaround until #25755 is resolved.

@markdroth
