### PR TITLE
Explicitly import importlib.abc; required on Python 3.10. Fixes #26062.

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -42,6 +42,7 @@ def main(command_arguments):
 if sys.version_info >= (3, 5, 0):
     import contextlib
     import importlib
+    import importlib.abc
     import importlib.machinery
     import threading
 


### PR DESCRIPTION


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@lidizheng

Fixes #26062.

Previously, `grpc_tools.protoc` relied on `importlib.abc` being implicitly imported as a side effect of importing `importlib`. This PR adds an explicit `importlib.abc` import, which is always correct, and is necessary for Python 3.10.