### PR TITLE
Run test that will show on the dashboard.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -36,8 +36,9 @@ tools/run_tests/performance/loadtest_config.py -l go \
     -s client_pool=workers-8core -s server_pool=workers-8core \
     -s big_query_table=e2e_benchmarks.experimental_results \
     -s timeout_seconds=900 --prefix="kokoro-test" -u "$(date +%Y%m%d%H%M%S)" \
-    -r go_generic_sync_streaming_ping_pong_secure -o ./loadtest.yaml
-    
+    -r '(go_generic_sync_streaming_ping_pong_secure|go_protobuf_sync_unary_ping_pong_secure)' \
+    -o ./loadtest.yaml
+
 # Dump the contents of the loadtest.yaml (since loadtest_config.py doesn't
 # list the scenarios that will be run).
 cat ./loadtest.yaml


### PR DESCRIPTION
Adds scenario `go_protobuf_sync_unary_ping_pong_secure`, since this is displayed on the current dashboard.
