### PR TITLE
xds-k8s kokoro buildscripts: exclude from tests suites

### DIFF
--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -87,6 +87,7 @@ _ALLOWLIST_DICT = {
     '^test/distrib/python/': [_PYTHON_TEST_SUITE],
     '^test/distrib/ruby/': [_RUBY_TEST_SUITE],
     '^tools/run_tests/xds_k8s_test_driver/': [],
+    '^tools/internal_ci/linux/grpc_xds_k8s.*': [],
     '^vsprojects/': [_WINDOWS_TEST_SUITE],
     'composer\.json$': [_PHP_TEST_SUITE],
     'config\.m4$': [_PHP_TEST_SUITE],


### PR DESCRIPTION
Do not run expensive and time-consuming Portability Tests when changing xds-k8s kokoro buildscripts themselves. There's no benefit from running them.

Ideally, we should execute xds-k8s themselves when this is changes. We can implement this once xds-k8s driver supports multiple concurrent runs per project.

Similar to [xds-k8s test driver](https://github.com/grpc/grpc/pull/25206).