### PR TITLE
xds-k8s buildscript should use the latest version of the driver

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s.sh
@@ -26,7 +26,6 @@ readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
-readonly TEST_DRIVER_REPO_DIR_USE_EXISTING=1
 
 #######################################
 # Builds test app Docker images and pushes them to GCR

--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -308,7 +308,8 @@ kokoro_setup_test_driver() {
   # Kokoro clones repo to ${KOKORO_ARTIFACTS_DIR}/github/${GITHUB_REPOSITORY}
   local github_root="${KOKORO_ARTIFACTS_DIR}/github"
   readonly SRC_DIR="${github_root}/${src_repository_name}"
-  local test_driver_repo_dir="${github_root}/${TEST_DRIVER_REPO_NAME}"
+  local test_driver_repo_dir
+  test_driver_repo_dir="${TEST_DRIVER_REPO_DIR:-$(mktemp -d)/${TEST_DRIVER_REPO_NAME}}"
   parse_src_repo_git_info SRC_DIR
   kokoro_write_sponge_properties
   kokoro_setup_python_virtual_environment

--- a/tools/internal_ci/linux/grpc_xds_k8s_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_python.sh
@@ -26,7 +26,6 @@ readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
-readonly TEST_DRIVER_REPO_DIR_USE_EXISTING=1
 readonly LANGUAGE_NAME="Python"
 
 #######################################


### PR DESCRIPTION
Due to `TEST_DRIVER_REPO_DIR_USE_EXISTING=1` setting introduced in https://github.com/grpc/grpc/pull/26041, the script used the driver from /tmpfs/src/github/grpc folder, which is on branch 1.37.x.

This change removes `TEST_DRIVER_REPO_DIR_USE_EXISTING=1` and solves an issue with test driver folder conflicting with the source folder.

Internal ref b/186236229