### PR TITLE
Enable Traffic Director time tracer

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -289,7 +289,8 @@ _BOOTSTRAP_TEMPLATE = """
   "node": {{
     "id": "{node_id}",
     "metadata": {{
-      "TRAFFICDIRECTOR_NETWORK_NAME": "%s"
+      "TRAFFICDIRECTOR_NETWORK_NAME": "%s",
+      "com.googleapis.trafficdirector.config_time_trace": "TRUE"
     }},
     "locality": {{
       "zone": "%s"


### PR DESCRIPTION
This PR enables TD's time trace which will yield useful information in CDS and LDS's metadata, WHEN a slow push arrived. The problem is, we might not be able to see that slow push, because if we waited the full amount of the 600s we fail the test case.

Do you think this will be a value-add to our xDS interop test? @ericgribkoff @menghanl 

Here is the time trace proto:

https://source.corp.google.com/piper///depot/google3/loadbalancer/deputy/rcth/proto/envoyconfig-metadata.proto;rcl=370374111;l=225

Here is what we received:

```
            "metadata": {
                "filter_metadata": {
                  "TRAFFICDIRECTOR_LAST_CONFIG_UPDATE": {
                    "time": "2021-04-28T18:10:47.201825662+00:00"
                  },
                  "com.google.trafficdirector": {
                    "backend_service_name": "test-backend-service-0-lidiz"
                  }
                }
              },
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26111)
<!-- Reviewable:end -->
