### PR TITLE
Avoid submitting blocks to a nil dispatch queue.

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCallLegacy.m
+++ b/src/objective-c/GRPCClient/GRPCCallLegacy.m
@@ -271,10 +271,14 @@ static NSString *const kBearerPrefix = @"Bearer ";
 }
 
 - (void)dealloc {
-  __block GRPCWrappedCall *wrappedCall = _wrappedCall;
-  dispatch_async(_callQueue, ^{
-    wrappedCall = nil;
-  });
+  if (_callQueue) {
+    __block GRPCWrappedCall *wrappedCall = _wrappedCall;
+    dispatch_async(_callQueue, ^{
+      wrappedCall = nil;
+    });
+  } else {
+    _wrappedCall = nil;
+  }
 }
 
 #pragma mark Read messages


### PR DESCRIPTION
The crash happens when GRPCCall initialization fails, that's because we submit a block to a nil dispatch queue in `dealloc` method.
