### PR TITLE
IpAuthorizationMatcher implementation.

### DIFF
--- a/src/core/lib/security/authorization/cel_authorization_engine.cc
+++ b/src/core/lib/security/authorization/cel_authorization_engine.cc
@@ -16,6 +16,7 @@
 
 #include "absl/memory/memory.h"
 
+#include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/security/authorization/cel_authorization_engine.h"
 
 namespace grpc_core {
@@ -132,7 +133,7 @@ std::unique_ptr<mock_cel::Activation> CelAuthorizationEngine::CreateActivation(
       activation->InsertValue(kHeaders,
                               mock_cel::CelValue::CreateMap(headers_.get()));
     } else if (elem == kSourceAddress) {
-      absl::string_view source_address(args.GetPeerAddress());
+      absl::string_view source_address(args.GetPeerAddressString());
       if (!source_address.empty()) {
         activation->InsertValue(
             kSourceAddress,
@@ -142,7 +143,7 @@ std::unique_ptr<mock_cel::Activation> CelAuthorizationEngine::CreateActivation(
       activation->InsertValue(
           kSourcePort, mock_cel::CelValue::CreateInt64(args.GetPeerPort()));
     } else if (elem == kDestinationAddress) {
-      absl::string_view destination_address(args.GetLocalAddress());
+      absl::string_view destination_address(args.GetLocalAddressString());
       if (!destination_address.empty()) {
         activation->InsertValue(
             kDestinationAddress,

--- a/src/core/lib/security/authorization/evaluate_args.cc
+++ b/src/core/lib/security/authorization/evaluate_args.cc
@@ -17,48 +17,43 @@
 #include "src/core/lib/security/authorization/evaluate_args.h"
 
 #include "src/core/lib/address_utils/parse_address.h"
+#include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/security/credentials/tls/tls_utils.h"
 #include "src/core/lib/slice/slice_utils.h"
 
 namespace grpc_core {
 
 namespace {
 
-absl::string_view GetAuthPropertyValue(grpc_auth_context* context,
-                                       const char* property_name) {
-  grpc_auth_property_iterator it =
-      grpc_auth_context_find_properties_by_name(context, property_name);
-  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
-  if (prop == nullptr) {
-    gpr_log(GPR_DEBUG, "No value found for %s property.", property_name);
-    return "";
-  }
-  if (grpc_auth_property_iterator_next(&it) != nullptr) {
-    gpr_log(GPR_DEBUG, "Multiple values found for %s property.", property_name);
-    return "";
-  }
-  return absl::string_view(prop->value, prop->value_length);
-}
-
-void ParseEndpointUri(absl::string_view uri_text, std::string* address,
-                      int* port) {
+EvaluateArgs::PerChannelArgs::Address ParseEndpointUri(
+    absl::string_view uri_text) {
+  EvaluateArgs::PerChannelArgs::Address address;
   absl::StatusOr<URI> uri = URI::Parse(uri_text);
   if (!uri.ok()) {
     gpr_log(GPR_DEBUG, "Failed to parse uri.");
-    return;
+    return address;
   }
   absl::string_view host_view;
   absl::string_view port_view;
   if (!SplitHostPort(uri->path(), &host_view, &port_view)) {
     gpr_log(GPR_DEBUG, "Failed to split %s into host and port.",
             uri->path().c_str());
-    return;
+    return address;
   }
-  *address = std::string(host_view);
-  if (!absl::SimpleAtoi(port_view, port)) {
+  if (!absl::SimpleAtoi(port_view, &address.port)) {
     gpr_log(GPR_DEBUG, "Port %s is out of range or null.",
             std::string(port_view).c_str());
   }
+  address.address_str = std::string(host_view);
+  grpc_error_handle error = grpc_string_to_sockaddr(
+      &address.address, address.address_str.c_str(), address.port);
+  if (error != GRPC_ERROR_NONE) {
+    gpr_log(GPR_DEBUG, "Address %s is not IPv4/IPv6. Error: %s",
+            address.address_str.c_str(), grpc_error_std_string(error).c_str());
+  }
+  GRPC_ERROR_UNREF(error);
+  return address;
 }
 
 }  // namespace
@@ -70,14 +65,13 @@ EvaluateArgs::PerChannelArgs::PerChannelArgs(grpc_auth_context* auth_context,
         auth_context, GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME);
     spiffe_id =
         GetAuthPropertyValue(auth_context, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME);
+    dns_sans = GetAuthPropertyArray(auth_context, GRPC_PEER_DNS_PROPERTY_NAME);
     common_name =
         GetAuthPropertyValue(auth_context, GRPC_X509_CN_PROPERTY_NAME);
   }
   if (endpoint != nullptr) {
-    ParseEndpointUri(grpc_endpoint_get_local_address(endpoint), &local_address,
-                     &local_port);
-    ParseEndpointUri(grpc_endpoint_get_peer(endpoint), &peer_address,
-                     &peer_port);
+    local_address = ParseEndpointUri(grpc_endpoint_get_local_address(endpoint));
+    peer_address = ParseEndpointUri(grpc_endpoint_get_peer(endpoint));
   }
 }
 
@@ -134,32 +128,46 @@ absl::optional<absl::string_view> EvaluateArgs::GetHeaderValue(
   return grpc_metadata_batch_get_value(metadata_, key, concatenated_value);
 }
 
-absl::string_view EvaluateArgs::GetLocalAddress() const {
+grpc_resolved_address EvaluateArgs::GetLocalAddress() const {
+  if (channel_args_ == nullptr) {
+    return {};
+  }
+  return channel_args_->local_address.address;
+}
+
+absl::string_view EvaluateArgs::GetLocalAddressString() const {
   if (channel_args_ == nullptr) {
     return "";
   }
-  return channel_args_->local_address;
+  return channel_args_->local_address.address_str;
 }
 
 int EvaluateArgs::GetLocalPort() const {
   if (channel_args_ == nullptr) {
     return 0;
   }
-  return channel_args_->local_port;
+  return channel_args_->local_address.port;
 }
 
-absl::string_view EvaluateArgs::GetPeerAddress() const {
+grpc_resolved_address EvaluateArgs::GetPeerAddress() const {
+  if (channel_args_ == nullptr) {
+    return {};
+  }
+  return channel_args_->peer_address.address;
+}
+
+absl::string_view EvaluateArgs::GetPeerAddressString() const {
   if (channel_args_ == nullptr) {
     return "";
   }
-  return channel_args_->peer_address;
+  return channel_args_->peer_address.address_str;
 }
 
 int EvaluateArgs::GetPeerPort() const {
   if (channel_args_ == nullptr) {
     return 0;
   }
-  return channel_args_->peer_port;
+  return channel_args_->peer_address.port;
 }
 
 absl::string_view EvaluateArgs::GetTransportSecurityType() const {
@@ -174,6 +182,13 @@ absl::string_view EvaluateArgs::GetSpiffeId() const {
     return "";
   }
   return channel_args_->spiffe_id;
+}
+
+std::vector<absl::string_view> EvaluateArgs::GetDnsSans() const {
+  if (channel_args_ == nullptr) {
+    return {};
+  }
+  return channel_args_->dns_sans;
 }
 
 absl::string_view EvaluateArgs::GetCommonName() const {

--- a/src/core/lib/security/authorization/matchers.h
+++ b/src/core/lib/security/authorization/matchers.h
@@ -107,18 +107,25 @@ class HeaderAuthorizationMatcher : public AuthorizationMatcher {
 };
 
 // Perform a match against IP Cidr Range.
-// TODO(ashithasantosh): Handle type of Ip or use seperate matchers for each
-// type. Implement Match functionality, this would require updating EvaluateArgs
-// getters, to return format of IP as well.
 class IpAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit IpAuthorizationMatcher(Rbac::CidrRange range, bool not_rule = false)
-      : range_(std::move(range)), not_rule_(not_rule) {}
+  enum class Type {
+    kDestIp,
+    kSourceIp,
+    kDirectRemoteIp,
+    kRemoteIp,
+  };
 
-  bool Matches(const EvaluateArgs&) const override;
+  IpAuthorizationMatcher(Type type, Rbac::CidrRange range,
+                         bool not_rule = false);
+
+  bool Matches(const EvaluateArgs& args) const override;
 
  private:
-  const Rbac::CidrRange range_;
+  const Type type_;
+  // Subnet masked address.
+  grpc_resolved_address subnet_address_;
+  const uint32_t prefix_len_;
   // Negates matching the provided permission/principal.
   const bool not_rule_;
 };

--- a/src/core/lib/security/authorization/rbac_policy.h
+++ b/src/core/lib/security/authorization/rbac_policy.h
@@ -58,21 +58,21 @@ struct Rbac {
     };
 
     Permission() = default;
-    // For AND/OR RuleType.
+    // For kAnd/kOr RuleType.
     Permission(Permission::RuleType type,
                std::vector<std::unique_ptr<Permission>> permissions,
                bool not_rule = false);
-    // For ANY RuleType.
+    // For kAny RuleType.
     explicit Permission(Permission::RuleType type, bool not_rule = false);
-    // For HEADER RuleType.
+    // For kHeader RuleType.
     Permission(Permission::RuleType type, HeaderMatcher header_matcher,
                bool not_rule = false);
-    // For PATH/REQ_SERVER_NAME RuleType.
+    // For kPath/kReqServerName RuleType.
     Permission(Permission::RuleType type, StringMatcher string_matcher,
                bool not_rule = false);
-    // For DEST_IP RuleType.
+    // For kDestIp RuleType.
     Permission(Permission::RuleType type, CidrRange ip, bool not_rule = false);
-    // For DEST_PORT RuleType.
+    // For kDestPort RuleType.
     Permission(Permission::RuleType type, int port, bool not_rule = false);
 
     Permission(Permission&& other) noexcept;
@@ -85,7 +85,7 @@ struct Rbac {
     StringMatcher string_matcher;
     CidrRange ip;
     int port;
-    // For type AND/OR.
+    // For type kAnd/kOr.
     std::vector<std::unique_ptr<Permission>> permissions;
     bool not_rule = false;
   };
@@ -104,18 +104,18 @@ struct Rbac {
     };
 
     Principal() = default;
-    // For AND/OR RuleType.
+    // For kAnd/kOr RuleType.
     Principal(Principal::RuleType type,
               std::vector<std::unique_ptr<Principal>> principals,
               bool not_rule = false);
-    // For ANY RuleType.
+    // For kAny RuleType.
     explicit Principal(Principal::RuleType type, bool not_rule = false);
-    // For PRINCIPAL_NAME/PATH RuleType.
+    // For kPrincipalName/kPath RuleType.
     Principal(Principal::RuleType type, StringMatcher string_matcher,
               bool not_rule = false);
-    // For SOURCE_IP/DIRECT_REMOTE_IP/REMOTE_IP RuleType.
+    // For kSourceIp/kDirectRemoteIp/kRemoteIp RuleType.
     Principal(Principal::RuleType type, CidrRange ip, bool not_rule = false);
-    // For HEADER RuleType.
+    // For kHeader RuleType.
     Principal(Principal::RuleType type, HeaderMatcher header_matcher,
               bool not_rule = false);
 
@@ -128,7 +128,7 @@ struct Rbac {
     HeaderMatcher header_matcher;
     StringMatcher string_matcher;
     CidrRange ip;
-    // For type AND/OR.
+    // For type kAnd/kOr.
     std::vector<std::unique_ptr<Principal>> principals;
     bool not_rule = false;
   };

--- a/src/core/lib/security/credentials/tls/tls_utils.cc
+++ b/src/core/lib/security/credentials/tls/tls_utils.cc
@@ -88,4 +88,36 @@ bool VerifySubjectAlternativeName(absl::string_view subject_alternative_name,
              std::string::npos;
 }
 
+absl::string_view GetAuthPropertyValue(grpc_auth_context* context,
+                                       const char* property_name) {
+  grpc_auth_property_iterator it =
+      grpc_auth_context_find_properties_by_name(context, property_name);
+  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
+  if (prop == nullptr) {
+    gpr_log(GPR_DEBUG, "No value found for %s property.", property_name);
+    return "";
+  }
+  if (grpc_auth_property_iterator_next(&it) != nullptr) {
+    gpr_log(GPR_DEBUG, "Multiple values found for %s property.", property_name);
+    return "";
+  }
+  return absl::string_view(prop->value, prop->value_length);
+}
+
+std::vector<absl::string_view> GetAuthPropertyArray(grpc_auth_context* context,
+                                                    const char* property_name) {
+  std::vector<absl::string_view> values;
+  grpc_auth_property_iterator it =
+      grpc_auth_context_find_properties_by_name(context, property_name);
+  const grpc_auth_property* prop = grpc_auth_property_iterator_next(&it);
+  while (prop != nullptr) {
+    values.emplace_back(prop->value, prop->value_length);
+    prop = grpc_auth_property_iterator_next(&it);
+  }
+  if (values.empty()) {
+    gpr_log(GPR_DEBUG, "No value found for %s property.", property_name);
+  }
+  return values;
+}
+
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/tls_utils.h
+++ b/src/core/lib/security/credentials/tls/tls_utils.h
@@ -26,12 +26,25 @@
 
 #include "absl/strings/string_view.h"
 
+#include "src/core/lib/security/context/security_context.h"
+
 namespace grpc_core {
 
 // Matches \a subject_alternative_name with \a matcher. Returns true if there
 // is a match, false otherwise.
 bool VerifySubjectAlternativeName(absl::string_view subject_alternative_name,
                                   const std::string& matcher);
+
+// Returns value for the specified property_name from auth context. Here the
+// property is expected to have a single value. Returns empty if multiple values
+// are found.
+absl::string_view GetAuthPropertyValue(grpc_auth_context* context,
+                                       const char* property_name);
+
+// Returns values for the specified property_name from auth context. Here the
+// property can have any number of values.
+std::vector<absl::string_view> GetAuthPropertyArray(grpc_auth_context* context,
+                                                    const char* property_name);
 
 }  // namespace grpc_core
 

--- a/test/core/security/authorization_matchers_test.cc
+++ b/test/core/security/authorization_matchers_test.cc
@@ -78,14 +78,13 @@ TEST_F(AuthorizationMatchersTest, AndAuthorizationMatcherFailedMatch) {
 TEST_F(AuthorizationMatchersTest, NotAndAuthorizationMatcher) {
   args_.AddPairToMetadata(":path", "/expected/foo");
   EvaluateArgs args = args_.MakeEvaluateArgs();
-  StringMatcher string_matcher =
+  std::vector<std::unique_ptr<Rbac::Permission>> ids;
+  ids.push_back(absl::make_unique<Rbac::Permission>(
+      Rbac::Permission::RuleType::kPath,
       StringMatcher::Create(StringMatcher::Type::kExact,
                             /*matcher=*/"/expected/foo",
                             /*case_sensitive=*/false)
-          .value();
-  std::vector<std::unique_ptr<Rbac::Permission>> ids;
-  ids.push_back(absl::make_unique<Rbac::Permission>(
-      Rbac::Permission::RuleType::kPath, std::move(string_matcher)));
+          .value()));
   AndAuthorizationMatcher matcher(std::move(ids), /*not_rule=*/true);
   EXPECT_FALSE(matcher.Matches(args));
 }
@@ -94,13 +93,12 @@ TEST_F(AuthorizationMatchersTest, OrAuthorizationMatcherSuccessfulMatch) {
   args_.AddPairToMetadata("foo", "bar");
   args_.SetLocalEndpoint("ipv4:255.255.255.255:123");
   EvaluateArgs args = args_.MakeEvaluateArgs();
-  HeaderMatcher header_matcher =
-      HeaderMatcher::Create(/*name=*/"foo", HeaderMatcher::Type::kExact,
-                            /*matcher=*/"bar")
-          .value();
   std::vector<std::unique_ptr<Rbac::Permission>> rules;
   rules.push_back(absl::make_unique<Rbac::Permission>(
-      Rbac::Permission::RuleType::kHeader, header_matcher));
+      Rbac::Permission::RuleType::kHeader,
+      HeaderMatcher::Create(/*name=*/"foo", HeaderMatcher::Type::kExact,
+                            /*matcher=*/"bar")
+          .value()));
   rules.push_back(absl::make_unique<Rbac::Permission>(
       Rbac::Permission::RuleType::kDestPort, /*port=*/456));
   OrAuthorizationMatcher matcher(std::move(rules));
@@ -211,7 +209,9 @@ TEST_F(AuthorizationMatchersTest, NotPathAuthorizationMatcher) {
   args_.AddPairToMetadata(":path", "expected/path");
   EvaluateArgs args = args_.MakeEvaluateArgs();
   PathAuthorizationMatcher matcher(
-      StringMatcher::Create(StringMatcher::Type::kExact, "expected/path", false)
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"expected/path",
+                            /*case_sensitive=*/false)
           .value(),
       /*not_rule=*/true);
   EXPECT_FALSE(matcher.Matches(args));
@@ -279,6 +279,60 @@ TEST_F(AuthorizationMatchersTest, NotHeaderAuthorizationMatcher) {
           .value(),
       /*not_rule=*/true);
   EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest,
+       IpAuthorizationMatcherLocalIpSuccessfulMatch) {
+  args_.SetLocalEndpoint("ipv4:1.2.3.4:123");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  IpAuthorizationMatcher matcher(
+      IpAuthorizationMatcher::Type::kDestIp,
+      Rbac::CidrRange(/*address_prefix=*/"1.7.8.9", /*prefix_len=*/8));
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest, IpAuthorizationMatcherLocalIpFailedMatch) {
+  args_.SetLocalEndpoint("ipv4:1.2.3.4:123");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  IpAuthorizationMatcher matcher(
+      IpAuthorizationMatcher::Type::kDestIp,
+      Rbac::CidrRange(/*address_prefix=*/"1.2.3.9", /*prefix_len=*/32));
+  EXPECT_FALSE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest, IpAuthorizationMatcherPeerIpSuccessfulMatch) {
+  args_.SetPeerEndpoint("ipv6:[1:2:3::]:456");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  IpAuthorizationMatcher matcher(
+      IpAuthorizationMatcher::Type::kSourceIp,
+      Rbac::CidrRange(/*address_prefix=*/"1:2:4::", /*prefix_len=*/32));
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest, IpAuthorizationMatcherPeerIpFailedMatch) {
+  args_.SetPeerEndpoint("ipv6:[1:2::]:456");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  IpAuthorizationMatcher matcher(
+      IpAuthorizationMatcher::Type::kSourceIp,
+      Rbac::CidrRange(/*address_prefix=*/"1:3::", /*prefix_len=*/32));
+  EXPECT_FALSE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest,
+       IpAuthorizationMatcherUnsupportedIpFailedMatch) {
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  IpAuthorizationMatcher matcher(IpAuthorizationMatcher::Type::kRemoteIp, {});
+  EXPECT_FALSE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest, NotIpAuthorizationMatcherSuccessfulMatch) {
+  args_.SetLocalEndpoint("ipv4:1.2.3.4:123");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  IpAuthorizationMatcher matcher(
+      IpAuthorizationMatcher::Type::kDestIp,
+      Rbac::CidrRange(/*address_prefix=*/"1.7.8.9", /*prefix_len=*/8),
+      /*not_rule=*/true);
+  EXPECT_FALSE(matcher.Matches(args));
 }
 
 TEST_F(AuthorizationMatchersTest, PortAuthorizationMatcherSuccessfulMatch) {
@@ -350,6 +404,36 @@ TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherFailedSpiffeIdMatches) {
   AuthenticatedAuthorizationMatcher matcher(
       StringMatcher::Create(StringMatcher::Type::kExact,
                             /*matcher=*/"spiffe://foo.abc",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_FALSE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherSuccessfulDnsSanMatches) {
+  args_.AddPropertyToAuthContext(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
+                                 GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  args_.AddPropertyToAuthContext(GRPC_PEER_DNS_PROPERTY_NAME,
+                                 "foo.test.domain.com");
+  args_.AddPropertyToAuthContext(GRPC_PEER_DNS_PROPERTY_NAME,
+                                 "bar.test.domain.com");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  AuthenticatedAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"bar.test.domain.com",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherFailedDnsSanMatches) {
+  args_.AddPropertyToAuthContext(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
+                                 GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  args_.AddPropertyToAuthContext(GRPC_PEER_DNS_PROPERTY_NAME,
+                                 "foo.test.domain.com");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  AuthenticatedAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"bar.test.domain.com",
                             /*case_sensitive=*/false)
           .value());
   EXPECT_FALSE(matcher.Matches(args));


### PR DESCRIPTION
This PR does the following
1. Implements IpAuthorizationMatcher
2. Adds getter for dns sans in EvaluateArgs, and updates AuthenticatedAuthorizationMatcher to use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26132)
<!-- Reviewable:end -->
