### PR TITLE
[DO NOT MERGE] Add benchmark code

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -988,7 +988,7 @@ static void write_action_begin_locked(void* gt,
       continue_read_action_locked(t);
     }
   } else {
-    GRPC_STATS_INC_HTTP2_SPURIOUS_WRITES_BEGUN();
+    // GRPC_STATS_INC_HTTP2_SPURIOUS_WRITES_BEGUN();
     set_write_state(t, GRPC_CHTTP2_WRITE_STATE_IDLE, "begin writing nothing");
     GRPC_CHTTP2_UNREF_TRANSPORT(t, "writing");
   }


### PR DESCRIPTION
Simple hack to show how many errors are thrown in the test (`http2_spurious_writes_begun ` stat) and what errors they are (e.g. `error create 'Server Shutdown' [src/core/lib/surface/server.cc:830]`) 