### PR TITLE
Fix grpc distribtests - broken virtualenv install

### DIFF
--- a/tools/dockerfile/distribtest/python_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_ubuntu1604_x64/Dockerfile
@@ -16,4 +16,6 @@ FROM ubuntu:16.04
 
 RUN apt-get update -y && apt-get install -y python python-pip
 
-RUN pip install virtualenv
+RUN pip install --upgrade pip==19.3.1
+
+RUN /usr/local/bin/pip install virtualenv


### PR DESCRIPTION
See the breakage here: http://fusion/runanalysis/buildlogs/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_distribtests/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_distribtests/KOKORO/7d11a8e5-6930-4f30-9977-fca90bcb8312/1619778728188/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_distribtests%20build%20%2315492/Targets

Note that the command `pip` fails after the upgrade since /usr/bin/pip
is the OS default, and the (incompatible) upgrade is installed to
/usr/local/bin/pip.

Edit: This ran successfully after manually triggering `grpc_build_artifacts_multiplatform`: http://fusion/runanalysis/info/prod:grpc%2Fcore%2Fexperimental%2Fgrpc_build_artifacts_multiplatform/prod:grpc%2Fcore%2Fexperimental%2Fgrpc_build_artifacts_multiplatform/KOKORO/224005eb-2222-4777-bc9d-0e4f70e046bd/1620076143416/build%20%231392/Targets