### PR TITLE
Add C# plugin "file_suffix" option defaulting to "Grpc.cs"

### DIFF
--- a/src/compiler/csharp_generator_helpers.h
+++ b/src/compiler/csharp_generator_helpers.h
@@ -25,10 +25,10 @@
 namespace grpc_csharp_generator {
 
 inline bool ServicesFilename(const grpc::protobuf::FileDescriptor* file,
-                             const std::string file_extension,
+                             const std::string file_suffix,
                              std::string* file_name_or_error) {
   *file_name_or_error =
-      grpc_generator::FileNameInUpperCamel(file, false) + file_extension;
+      grpc_generator::FileNameInUpperCamel(file, false) + file_suffix;
   return true;
 }
 

--- a/src/compiler/csharp_generator_helpers.h
+++ b/src/compiler/csharp_generator_helpers.h
@@ -25,9 +25,10 @@
 namespace grpc_csharp_generator {
 
 inline bool ServicesFilename(const grpc::protobuf::FileDescriptor* file,
+                             const std::string file_extension,
                              std::string* file_name_or_error) {
   *file_name_or_error =
-      grpc_generator::FileNameInUpperCamel(file, false) + "Grpc.cs";
+      grpc_generator::FileNameInUpperCamel(file, false) + file_extension;
   return true;
 }
 

--- a/src/compiler/csharp_generator_helpers.h
+++ b/src/compiler/csharp_generator_helpers.h
@@ -25,9 +25,9 @@
 namespace grpc_csharp_generator {
 
 inline bool ServicesFilename(const grpc::protobuf::FileDescriptor* file,
-                             const std::string file_suffix,
-                             std::string* file_name_or_error) {
-  *file_name_or_error =
+                             const std::string& file_suffix,
+                             std::string& out_file_name_or_error) {
+  out_file_name_or_error =
       grpc_generator::FileNameInUpperCamel(file, false) + file_suffix;
   return true;
 }

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -43,6 +43,9 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     bool generate_client = true;
     bool generate_server = true;
     bool internal_access = false;
+    // the suffix that will get appended to the name generated from the name
+    // of the original .proto file
+    std::string file_extension = "Grpc.cs";
     for (size_t i = 0; i < options.size(); i++) {
       if (options[i].first == "no_client") {
         generate_client = false;
@@ -50,6 +53,8 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
         generate_server = false;
       } else if (options[i].first == "internal_access") {
         internal_access = true;
+      } if (options[i].first == "file_extension") {
+        file_extension = options[i].second;
       } else {
         *error = "Unknown generator option: " + options[i].first;
         return false;
@@ -64,7 +69,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     // Get output file name.
     std::string file_name;
-    if (!grpc_csharp_generator::ServicesFilename(file, &file_name)) {
+    if (!grpc_csharp_generator::ServicesFilename(file, file_extension, &file_name)) {
       return false;
     }
     std::unique_ptr<grpc::protobuf::io::ZeroCopyOutputStream> output(

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -71,7 +71,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     // Get output file name.
     std::string file_name;
     if (!grpc_csharp_generator::ServicesFilename(file, file_suffix,
-                                                 &file_name)) {
+                                                 file_name)) {
       return false;
     }
     std::unique_ptr<grpc::protobuf::io::ZeroCopyOutputStream> output(

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -45,7 +45,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     bool internal_access = false;
     // the suffix that will get appended to the name generated from the name
     // of the original .proto file
-    std::string file_extension = "Grpc.cs";
+    std::string file_suffix = "Grpc.cs";
     for (size_t i = 0; i < options.size(); i++) {
       if (options[i].first == "no_client") {
         generate_client = false;
@@ -53,8 +53,9 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
         generate_server = false;
       } else if (options[i].first == "internal_access") {
         internal_access = true;
-      } if (options[i].first == "file_extension") {
-        file_extension = options[i].second;
+      }
+      if (options[i].first == "file_suffix") {
+        file_suffix = options[i].second;
       } else {
         *error = "Unknown generator option: " + options[i].first;
         return false;
@@ -69,7 +70,8 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     // Get output file name.
     std::string file_name;
-    if (!grpc_csharp_generator::ServicesFilename(file, file_extension, &file_name)) {
+    if (!grpc_csharp_generator::ServicesFilename(file, file_suffix,
+                                                 &file_name)) {
       return false;
     }
     std::unique_ptr<grpc::protobuf::io::ZeroCopyOutputStream> output(


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/26056

note that in the current version of this PR, the `file_suffix` option's default value is actually "Grpc.cs" (but I thought that configuring the "Grpc" suffix might be useful as well).

IMPORTANT: This option should only be used with "manual" invocations of protoc from a shell script. The Grpc.Tools integration won't support this option since it relies on "guessing" the exact name of the generated files produced by protoc.