### PR TITLE
Ensure a new timestamp is obtained in FI filter

### DIFF
--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -428,6 +428,7 @@ void CallData::DelayBatch(grpc_call_element* elem,
   MutexLock lock(&delay_mu_);
   delayed_batch_ = batch;
   resume_batch_canceller_ = new ResumeBatchCanceller(elem);
+  ExecCtx::Get()->InvalidateNow();
   grpc_millis resume_time = ExecCtx::Get()->Now() + fi_policy_->delay;
   GRPC_CLOSURE_INIT(&batch->handler_private.closure, ResumeBatch, elem,
                     grpc_schedule_on_exec_ctx);

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -428,6 +428,11 @@ void CallData::DelayBatch(grpc_call_element* elem,
   MutexLock lock(&delay_mu_);
   delayed_batch_ = batch;
   resume_batch_canceller_ = new ResumeBatchCanceller(elem);
+  // By default, ExecCtx::Get()->Now() returns a cached timestamp. If there are
+  // thousands of RPCs happen on one thread, we might observe ms-level error in
+  // Now(). This could mean the construction of RPC object is microseconds
+  // earlier than the filter execution. But we still haven't found the root
+  // cause. Read more: https://github.com/grpc/grpc/pull/25738.
   ExecCtx::Get()->InvalidateNow();
   grpc_millis resume_time = ExecCtx::Get()->Now() + fi_policy_->delay;
   GRPC_CLOSURE_INIT(&batch->handler_private.closure, ResumeBatch, elem,

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -428,11 +428,11 @@ void CallData::DelayBatch(grpc_call_element* elem,
   MutexLock lock(&delay_mu_);
   delayed_batch_ = batch;
   resume_batch_canceller_ = new ResumeBatchCanceller(elem);
-  // By default, ExecCtx::Get()->Now() returns a cached timestamp. If there are
-  // thousands of RPCs happen on one thread, we might observe ms-level error in
-  // Now(). This could mean the construction of RPC object is microseconds
-  // earlier than the filter execution. But we still haven't found the root
-  // cause. Read more: https://github.com/grpc/grpc/pull/25738.
+  // Without this line, ExecCtx::Get()->Now() will return a cached timestamp. If
+  // there are thousands of RPCs happen on one thread, we might observe ms-level
+  // error in Now(). This could mean the construction of RPC object is
+  // microseconds earlier than the filter execution. But we still haven't found
+  // the root cause. Read more: https://github.com/grpc/grpc/pull/25738.
   ExecCtx::Get()->InvalidateNow();
   grpc_millis resume_time = ExecCtx::Get()->Now() + fi_policy_->delay;
   GRPC_CLOSURE_INIT(&batch->handler_private.closure, ResumeBatch, elem,


### PR DESCRIPTION
In https://github.com/grpc/grpc/pull/25738, I tried to make the tests happy by ensuring the channel is ready before scheduling any calls. However, the flake still exists. I think the best options now is getting a new timestamp in fault injection filter, so we have minimum impact to performance and other components.

1000x of opt: https://source.cloud.google.com/results/invocations/b94a28de-2c10-4662-95da-7fb61849a783

https://source.cloud.google.com/results/invocations/7bd45434-a2eb-46d7-9f23-b2d64b8e9de8
bug: b/185138304