### PR TITLE
Increase timeout for PHP and Ruby xds v3 tests

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_v3_php.cfg
+++ b/tools/internal_ci/linux/grpc_xds_v3_php.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_v3_php.sh"
-timeout_mins: 180
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_xds_v3_ruby.cfg
+++ b/tools/internal_ci/linux/grpc_xds_v3_ruby.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_v3_ruby.sh"
-timeout_mins: 180
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
I noticed that recently, after the `api_listener`, `forwarding_rule_port_match`, `forwarding_rule_default_port`, `metadata_filter` test cases got added, PHP and Ruby x3 tests are more likely to timed out with

`ERROR: Aborting VM command due to timeout of 10800 seconds`.   <-- this is 180 minutes.

Ruby v3 Dashboard: https://testgrid.corp.google.com/grpc-lb#gRPC%20Ruby%20xDS%20v3%20Master
PHP v3 Dashboard: https://testgrid.corp.google.com/grpc-lb#gRPC%20PHP%20xDS%20v3%20Master

Note how the timeout error started happening after those 4 new test cases were added on Apr 30.


Now the test suite is running up to 20 xds test cases sequentially (if all the test cases are implemented for the language. PHP is having 18. Ruby is having 19 now). There are lots of adding, deleting and waiting on GCP resources to be ready inside each of these test cases. We can't expect to be able to keep adding test cases while keeping the same timeout value in the kokoro job config.