### PR TITLE
Python simpler distribtests

### DIFF
--- a/tools/internal_ci/linux/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/linux/grpc_distribtests_python.cfg
@@ -1,0 +1,26 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_distribtests_python.sh"
+timeout_mins: 360
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}

--- a/tools/internal_ci/linux/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/linux/grpc_distribtests_python.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017 gRPC authors.
+# Copyright 2021 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_distribtests_python.sh"
-timeout_mins: 360
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -46,6 +46,8 @@ mkdir -p input_artifacts
 cp -r artifacts/* input_artifacts/ || true
 
 # Run all python linux distribtests
+# We run the distribtests even if some of the artifacts have failed to build, since that gives
+# a better signal about which distribtest are affected by the currently broken artifact builds.
 tools/run_tests/task_runner.py -f distribtest linux python -j 6 -x distribtests/sponge_log.xml || FAILED="true"
 
 if [ "$FAILED" != "" ]

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
+
+# some distribtests use a pre-registered binfmt_misc hook
+# to automatically execute foreign binaries (such as aarch64)
+# under qemu emulator.
+source tools/internal_ci/helper_scripts/prepare_qemu_rc
+
+# Build all python linux artifacts (this step actually builds all the binary wheels and source archives)
+tools/run_tests/task_runner.py -f artifact linux python -j 6 -x build_artifacts/sponge_log.xml || FAILED="true"
+
+# the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
+rm -rf input_artifacts
+mkdir -p input_artifacts
+cp -r artifacts/* input_artifacts/ || true
+rm -rf artifacts_from_build_artifacts_step
+mv artifacts artifacts_from_build_artifacts_step || true
+
+# This step mostly just copies artifacts from input_artifacts (but it also does some wheel stripping)
+tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml || FAILED="true"
+
+# the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
+# in addition to that, preserve the contents of "artifacts" directory since we want kokoro
+# to upload its contents as job output artifacts
+rm -rf input_artifacts
+mkdir -p input_artifacts
+cp -r artifacts/* input_artifacts/ || true
+
+# Run all python linux distribtests
+tools/run_tests/task_runner.py -f distribtest linux python -j 6 -x distribtests/sponge_log.xml || FAILED="true"
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -73,6 +73,11 @@ argp.add_argument('-t',
                   default=False,
                   action='store_const',
                   const=True)
+argp.add_argument('-x',
+                  '--xml_report',
+                  default='report_taskrunner_sponge_log.xml',
+                  type=str,
+                  help='Filename for the JUnit-compatible XML report')
 
 args = argp.parse_args()
 

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -114,7 +114,7 @@ num_failures, resultset = jobset.run(build_jobs,
                                      newline_on_success=True,
                                      maxjobs=args.jobs)
 report_utils.render_junit_xml_report(resultset,
-                                     'report_taskrunner_sponge_log.xml',
+                                     args.xml_report,
                                      suite_name='tasks')
 if num_failures == 0:
     jobset.message('SUCCESS',


### PR DESCRIPTION
Currently running the artifacts - packages - distribtests flow needs to be done manually, it's a hassle to do it and it takes many hours for the flow to finish (and after that interpreting the results is involves lots of clicking on links in the test results).

Since as of now the python wheels built on linux  are only tested by distribtests on linux, it is possible to run the entire python-specific artifact - package - distribtests flow for linux in a single kokoro job.

So this new job first builds python linux wheels (and source archives) and then tests them with distribtests in a single kokoro job.
Advantages:
- the test results are easy to interpret
- the job can run on PRs
- the test script basically shows how to run the test python wheels with distribtest locally on dev's workstation.
