### PR TITLE
Increase artifact build timeout for windows-C#

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -254,6 +254,7 @@ class CSharpExtArtifact:
                 'tools\\run_tests\\artifacts\\build_artifact_csharp.bat',
                 self.arch
             ],
+                                  timeout_seconds=45 * 60,
                                   use_workspace=True)
         else:
             if self.platform == 'linux':


### PR DESCRIPTION
The 30min timeout has caused the multiarch artifact build to fail twice
in the past week. See http://sponge2/55f7f6f8-d3c0-4b6e-91c8-c0c316f4717b