### PR TITLE
Add cpp macros to append wrapped language info to xDS user agent

### DIFF
--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -830,12 +830,20 @@ bool IsEds(absl::string_view type_url) {
 
 }  // namespace
 
-// If gRPC is built with -DGRPC_XDS_USER_AGENT_SUFFIX="...", that string
-// will be appended to the user agent reported to the xDS server.
-#ifdef GRPC_XDS_USER_AGENT_SUFFIX
-#define GRPC_XDS_USER_AGENT_SUFFIX " " GRPC_XDS_USER_AGENT_SUFFIX
+// If gRPC is built with -DGRPC_XDS_USER_AGENT_NAME_SUFFIX="...", that string
+// will be appended to the user agent name reported to the xDS server.
+#ifdef GRPC_XDS_USER_AGENT_NAME_SUFFIX
+#define _GRPC_XDS_USER_AGENT_NAME_SUFFIX " " GRPC_XDS_USER_AGENT_NAME_SUFFIX
 #else
-#define GRPC_XDS_USER_AGENT_SUFFIX ""
+#define _GRPC_XDS_USER_AGENT_NAME_SUFFIX ""
+#endif
+
+// If gRPC is built with -DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="...", that string
+// will be appended to the user agent version reported to the xDS server.
+#ifdef GRPC_XDS_USER_AGENT_VERSION_SUFFIX
+#define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX " " GRPC_XDS_USER_AGENT_VERSION_SUFFIX
+#else
+#define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX ""
 #endif
 
 XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
@@ -844,9 +852,14 @@ XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
       tracer_(tracer),
       node_(node),
       build_version_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING, " ",
-                                  grpc_version_string())),
+                                  grpc_version_string(),
+                                  _GRPC_XDS_USER_AGENT_NAME_SUFFIX,
+                                  _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)),
       user_agent_name_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING,
-                                    GRPC_XDS_USER_AGENT_SUFFIX)) {
+                                    _GRPC_XDS_USER_AGENT_NAME_SUFFIX)),
+      user_agent_version_(absl::StrCat(
+          "C-core ", grpc_version_string(), _GRPC_XDS_USER_AGENT_NAME_SUFFIX,
+          _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)) {
   // Populate upb symtab with xDS proto messages that we want to print
   // properly in logs.
   // Note: This won't actually work properly until upb adds support for
@@ -977,6 +990,7 @@ void PopulateNode(const EncodingContext& context,
                   const XdsBootstrap::Node* node,
                   const std::string& build_version,
                   const std::string& user_agent_name,
+                  const std::string& user_agent_version,
                   envoy_config_core_v3_Node* node_msg) {
   if (node != nullptr) {
     if (!node->id.empty()) {
@@ -1016,7 +1030,7 @@ void PopulateNode(const EncodingContext& context,
   envoy_config_core_v3_Node_set_user_agent_name(
       node_msg, StdStringToUpbString(user_agent_name));
   envoy_config_core_v3_Node_set_user_agent_version(
-      node_msg, upb_strview_makez(grpc_version_string()));
+      node_msg, StdStringToUpbString(user_agent_version));
   envoy_config_core_v3_Node_add_client_features(
       node_msg, upb_strview_makez("envoy.lb.does_not_support_overprovisioning"),
       context.arena);
@@ -1122,7 +1136,8 @@ grpc_slice XdsApi::CreateAdsRequest(
     envoy_config_core_v3_Node* node_msg =
         envoy_service_discovery_v3_DiscoveryRequest_mutable_node(request,
                                                                  arena.ptr());
-    PopulateNode(context, node_, build_version_, user_agent_name_, node_msg);
+    PopulateNode(context, node_, build_version_, user_agent_name_,
+                 user_agent_version_, node_msg);
   }
   // Add resource_names.
   for (const auto& resource_name : resource_names) {
@@ -3371,7 +3386,8 @@ grpc_slice XdsApi::CreateLrsInitialRequest(
   envoy_config_core_v3_Node* node_msg =
       envoy_service_load_stats_v3_LoadStatsRequest_mutable_node(request,
                                                                 arena.ptr());
-  PopulateNode(context, node_, build_version_, user_agent_name_, node_msg);
+  PopulateNode(context, node_, build_version_, user_agent_name_,
+               user_agent_version_, node_msg);
   envoy_config_core_v3_Node_add_client_features(
       node_msg, upb_strview_makez("envoy.lrs.supports_send_all_clusters"),
       arena.ptr());
@@ -3768,7 +3784,8 @@ std::string XdsApi::AssembleClientConfig(
                                                                  arena.ptr());
   const EncodingContext context = {client_, tracer_, symtab_.ptr(), arena.ptr(),
                                    true};
-  PopulateNode(context, node_, build_version_, user_agent_name_, node);
+  PopulateNode(context, node_, build_version_, user_agent_name_,
+               user_agent_version_, node);
   // Dump each xDS-type config into PerXdsConfig
   for (auto& p : resource_type_metadata_map) {
     absl::string_view type_url = p.first;

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -841,7 +841,8 @@ bool IsEds(absl::string_view type_url) {
 // If gRPC is built with -DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="...", that string
 // will be appended to the user agent version reported to the xDS server.
 #ifdef GRPC_XDS_USER_AGENT_VERSION_SUFFIX
-#define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX " " GRPC_XDS_USER_AGENT_VERSION_SUFFIX
+#define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX \
+  " " GRPC_XDS_USER_AGENT_VERSION_SUFFIX
 #else
 #define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX ""
 #endif
@@ -857,9 +858,9 @@ XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
                                   _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)),
       user_agent_name_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING,
                                     _GRPC_XDS_USER_AGENT_NAME_SUFFIX)),
-      user_agent_version_(absl::StrCat(
-          "C-core ", grpc_version_string(), _GRPC_XDS_USER_AGENT_NAME_SUFFIX,
-          _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)) {
+      user_agent_version_(absl::StrCat("C-core ", grpc_version_string(),
+                                       _GRPC_XDS_USER_AGENT_NAME_SUFFIX,
+                                       _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)) {
   // Populate upb symtab with xDS proto messages that we want to print
   // properly in logs.
   // Note: This won't actually work properly until upb adds support for

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -833,18 +833,19 @@ bool IsEds(absl::string_view type_url) {
 // If gRPC is built with -DGRPC_XDS_USER_AGENT_NAME_SUFFIX="...", that string
 // will be appended to the user agent name reported to the xDS server.
 #ifdef GRPC_XDS_USER_AGENT_NAME_SUFFIX
-#define _GRPC_XDS_USER_AGENT_NAME_SUFFIX " " GRPC_XDS_USER_AGENT_NAME_SUFFIX
+#define GRPC_XDS_USER_AGENT_NAME_SUFFIX_STRING \
+  " " GRPC_XDS_USER_AGENT_NAME_SUFFIX
 #else
-#define _GRPC_XDS_USER_AGENT_NAME_SUFFIX ""
+#define GRPC_XDS_USER_AGENT_NAME_SUFFIX_STRING ""
 #endif
 
 // If gRPC is built with -DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="...", that string
 // will be appended to the user agent version reported to the xDS server.
 #ifdef GRPC_XDS_USER_AGENT_VERSION_SUFFIX
-#define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX \
+#define GRPC_XDS_USER_AGENT_VERSION_SUFFIX_STRING \
   " " GRPC_XDS_USER_AGENT_VERSION_SUFFIX
 #else
-#define _GRPC_XDS_USER_AGENT_VERSION_SUFFIX ""
+#define GRPC_XDS_USER_AGENT_VERSION_SUFFIX_STRING ""
 #endif
 
 XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
@@ -854,13 +855,14 @@ XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
       node_(node),
       build_version_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING, " ",
                                   grpc_version_string(),
-                                  _GRPC_XDS_USER_AGENT_NAME_SUFFIX,
-                                  _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)),
+                                  GRPC_XDS_USER_AGENT_NAME_SUFFIX_STRING,
+                                  GRPC_XDS_USER_AGENT_VERSION_SUFFIX_STRING)),
       user_agent_name_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING,
-                                    _GRPC_XDS_USER_AGENT_NAME_SUFFIX)),
-      user_agent_version_(absl::StrCat("C-core ", grpc_version_string(),
-                                       _GRPC_XDS_USER_AGENT_NAME_SUFFIX,
-                                       _GRPC_XDS_USER_AGENT_VERSION_SUFFIX)) {
+                                    GRPC_XDS_USER_AGENT_NAME_SUFFIX_STRING)),
+      user_agent_version_(
+          absl::StrCat("C-core ", grpc_version_string(),
+                       GRPC_XDS_USER_AGENT_NAME_SUFFIX_STRING,
+                       GRPC_XDS_USER_AGENT_VERSION_SUFFIX_STRING)) {
   // Populate upb symtab with xDS proto messages that we want to print
   // properly in logs.
   // Note: This won't actually work properly until upb adds support for

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -830,6 +830,14 @@ bool IsEds(absl::string_view type_url) {
 
 }  // namespace
 
+// If gRPC is built with -DGRPC_XDS_USER_AGENT_SUFFIX="...", that string
+// will be appended to the user agent reported to the xDS server.
+#ifdef GRPC_XDS_USER_AGENT_SUFFIX
+#define GRPC_XDS_USER_AGENT_SUFFIX " " GRPC_XDS_USER_AGENT_SUFFIX
+#else
+#define GRPC_XDS_USER_AGENT_SUFFIX ""
+#endif
+
 XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
                const XdsBootstrap::Node* node)
     : client_(client),
@@ -837,7 +845,8 @@ XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
       node_(node),
       build_version_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING, " ",
                                   grpc_version_string())),
-      user_agent_name_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING)) {
+      user_agent_name_(absl::StrCat("gRPC C-core ", GPR_PLATFORM_STRING,
+                                    GRPC_XDS_USER_AGENT_SUFFIX)) {
   // Populate upb symtab with xDS proto messages that we want to print
   // properly in logs.
   // Note: This won't actually work properly until upb adds support for

--- a/src/core/ext/xds/xds_api.h
+++ b/src/core/ext/xds/xds_api.h
@@ -664,6 +664,7 @@ class XdsApi {
   upb::SymbolTable symtab_;
   const std::string build_version_;
   const std::string user_agent_name_;
+  const std::string user_agent_version_;
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
@nicolasnoble, can you please advise as to the best way to set this macro in the build system for C++?  I assume that we'll need to add it for both bazel and cmake?  Thanks!

CC @srini100 @yashykt 