### PR TITLE
Workaround quota issue with target-grpc-proxies

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -84,7 +84,6 @@ _TEST_CASES = [
     'traffic_splitting',
     'path_matching',
     'header_matching',
-    'api_listener',
     'forwarding_rule_port_match',
     'forwarding_rule_default_port',
     'metadata_filter',
@@ -99,6 +98,7 @@ _ADDITIONAL_TEST_CASES = [
     'timeout',
     'fault_injection',
     'csds',
+    'api_listener',  # TODO(b/187352987) Relieve quota pressure
 ]
 
 # Test cases that require the V3 API.  Skipped in older runs.


### PR DESCRIPTION
The `api_listener` test adds an extra target-grpc-proxy and we're running into quota issues for all of the CI runs right now. Temporarily remove this test from the default `all` list until b/187352987 is resolved.