### PR TITLE
Add steps to run xDS in a non-exclusive project

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -112,5 +112,5 @@ python3 -m tests.baseline_test \
   --server_image="gcr.io/grpc-testing/xds-k8s-test-server-java:latest" \
   --client_image="gcr.io/grpc-testing/xds-k8s-test-client-java:latest" \
   --namespace="box-$(date +"%F-%R")" \
-  --server_xds_port="$($(($RANDOM%1000 + 34567)))"
+  --server_xds_port="$(($RANDOM%1000 + 34567))"
 ```

--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -25,6 +25,8 @@ changes to this codebase at the moment.
 #### Requirements
 1. Python v3.6+
 2. [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+3. A GKE cluster (must enable "Enable VPC-native traffic routing" to use it with the Traffic Director)
+    * Otherwise, you will see error logs when you inspect Kubernetes virtual service
 
 #### Configure GKE cluster access
 
@@ -78,7 +80,7 @@ python -m tests.baseline_test \
   --flagfile="config/grpc-testing.cfg" \
   --kube_context="${KUBE_CONTEXT}" \
   --server_image="gcr.io/grpc-testing/xds-k8s-test-server-java:latest" \
-  --client_image="gcr.io/grpc-testing/xds-k8s-test-client-java:latest" \
+  --client_image="gcr.io/grpc-testing/xds-k8s-test-client-java:latest"
 ```
 
 ### xDS Security Tests
@@ -92,5 +94,23 @@ python -m tests.security_test \
   --flagfile="config/grpc-testing.cfg" \
   --kube_context="${KUBE_CONTEXT}" \
   --server_image="gcr.io/grpc-testing/xds-k8s-test-server-java:latest" \
+  --client_image="gcr.io/grpc-testing/xds-k8s-test-client-java:latest"
+```
+
+### Workload namespace
+
+It's possible to run multiple xDS interop test workloads in the same project.
+But we need to ensure the name of the global resources won't conflict. This can
+be solved by supplying `--namespace` and `--server_xds_port`. The xDS port needs
+to be unique across the entire project (default port range is [8080, 8280],
+avoid if possible). Here is an example:
+
+```shell
+python3 -m tests.baseline_test \
+  --flagfile="config/grpc-testing.cfg" \
+  --kube_context="${KUBE_CONTEXT}" \
+  --server_image="gcr.io/grpc-testing/xds-k8s-test-server-java:latest" \
   --client_image="gcr.io/grpc-testing/xds-k8s-test-client-java:latest" \
+  --namespace="box-$(date +"%F-%R")" \
+  --server_xds_port="$($(($RANDOM%1000 + 34567)))"
 ```

--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -93,8 +93,8 @@ python -m tests.security_test --helpful
 python -m tests.security_test \
   --flagfile="config/grpc-testing.cfg" \
   --kube_context="${KUBE_CONTEXT}" \
-  --server_image="gcr.io/grpc-testing/xds-k8s-test-server-java:latest" \
-  --client_image="gcr.io/grpc-testing/xds-k8s-test-client-java:latest"
+  --server_image="gcr.io/grpc-testing/xds-interop/java-server:git_commit_hash" \
+  --client_image="gcr.io/grpc-testing/xds-interop/java-client:git_commit_hash"
 ```
 
 ### Workload namespace

--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -77,8 +77,8 @@ disturbances.
 
 The client and server images are created based on Git commit hashes, but not
 every single one of them. It is triggered nightly and per-release. For example,
-the commit we are using below (`d12ac30cde0c4d7f03ade13de177ad96c501ff79`) comes
-from `v1.37.x` in `grpc-java` repo.
+the commit we are using below (`d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf`) comes
+from branch `v1.37.x` in `grpc-java` repo.
 
 ```sh
 # Help
@@ -89,8 +89,8 @@ python -m tests.baseline_test --helpful
 python -m tests.baseline_test \
   --flagfile="config/grpc-testing.cfg" \
   --kube_context="${KUBE_CONTEXT}" \
-  --server_image="gcr.io/grpc-testing/xds-interop/java-server:d12ac30cde0c4d7f03ade13de177ad96c501ff79" \
-  --client_image="gcr.io/grpc-testing/xds-interop/java-client:d12ac30cde0c4d7f03ade13de177ad96c501ff79"
+  --server_image="gcr.io/grpc-testing/xds-interop/java-server:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf" \
+  --client_image="gcr.io/grpc-testing/xds-interop/java-client:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf"
 ```
 
 ### xDS Security Tests
@@ -103,8 +103,8 @@ python -m tests.security_test --helpful
 python -m tests.security_test \
   --flagfile="config/grpc-testing.cfg" \
   --kube_context="${KUBE_CONTEXT}" \
-  --server_image="gcr.io/grpc-testing/xds-interop/java-server:d12ac30cde0c4d7f03ade13de177ad96c501ff79" \
-  --client_image="gcr.io/grpc-testing/xds-interop/java-client:d12ac30cde0c4d7f03ade13de177ad96c501ff79"
+  --server_image="gcr.io/grpc-testing/xds-interop/java-server:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf" \
+  --client_image="gcr.io/grpc-testing/xds-interop/java-client:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf"
 ```
 
 ### Test namespace
@@ -119,8 +119,8 @@ avoid if possible). Here is an example:
 python3 -m tests.baseline_test \
   --flagfile="config/grpc-testing.cfg" \
   --kube_context="${KUBE_CONTEXT}" \
-  --server_image="gcr.io/grpc-testing/xds-interop/java-server:d12ac30cde0c4d7f03ade13de177ad96c501ff79" \
-  --client_image="gcr.io/grpc-testing/xds-interop/java-client:d12ac30cde0c4d7f03ade13de177ad96c501ff79" \
+  --server_image="gcr.io/grpc-testing/xds-interop/java-server:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf" \
+  --client_image="gcr.io/grpc-testing/xds-interop/java-client:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf" \
   --namespace="box-$(date +"%F-%R")" \
   --server_xds_port="$(($RANDOM%1000 + 34567))"
 ```


### PR DESCRIPTION
As title.

~~Though, I did encounter a problem with my manual run. Still investigating why the backend status didn't turn green.~~

```
======================================================================
ERROR: test_traffic_director_grpc_setup (__main__.BaselineTest) [6_add_server_backends_to_backend_service]
BaselineTest.test_traffic_director_grpc_setup
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/lidiz/grpc/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py", line 51, in test_traffic_director_grpc_setup
    self.setupServerBackends()
  File "/home/lidiz/grpc/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py", line 145, in setupServerBackends
    self.td.wait_for_backends_healthy_status()
  File "/home/lidiz/grpc/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py", line 200, in wait_for_backends_healthy_status
    self.backends)
  File "/home/lidiz/grpc/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py", line 284, in wait_for_backends_healthy_status
    _retry_backends_health()
  File "/home/lidiz/grpc/py37_native/lib/python3.7/site-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/home/lidiz/grpc/py37_native/lib/python3.7/site-packages/retrying.py", line 214, in call
    raise RetryError(attempt)
retrying.RetryError: RetryError[Attempts: 145, Value: False]

----------------------------------------------------------------------
Ran 1 test in 956.225s
```

---

The UHC failed to reach K8s pod because of firewall rules, it requires a special metadata tag that I wasn't aware of.