### PR TITLE
Update rules_apple

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -337,11 +337,11 @@ def grpc_deps():
     if "build_bazel_rules_apple" not in native.existing_rules():
         http_archive(
             name = "build_bazel_rules_apple",
-            strip_prefix = "rules_apple-b869b0d3868d78a1d4ffd866ccb304fb68aa12c3",
-            sha256 = "bdc8e66e70b8a75da23b79f1f8c6207356df07d041d96d2189add7ee0780cf4e",
+            strip_prefix = "rules_apple-709d8b12d68b571f23a1187b1cf7b10bb89fa46f",
+            sha256 = "c84962b64d9ae4472adfb01ec2cf1aa73cb2ee8308242add55fa7cc38602d882",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
-                "https://github.com/bazelbuild/rules_apple/archive/b869b0d3868d78a1d4ffd866ccb304fb68aa12c3.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
+                "https://github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
             ],
         )
 

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -338,7 +338,7 @@ def grpc_deps():
         http_archive(
             name = "build_bazel_rules_apple",
             strip_prefix = "rules_apple-709d8b12d68b571f23a1187b1cf7b10bb89fa46f",
-            sha256 = "c84962b64d9ae4472adfb01ec2cf1aa73cb2ee8308242add55fa7cc38602d882",
+            sha256 = "a0b7066d9f4193e8a800db2a66f4fe867a7806b8cdeecc3f0b9c9b3fc415338e",
             urls = [
                 "https://github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
             ],

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -340,6 +340,7 @@ def grpc_deps():
             strip_prefix = "rules_apple-709d8b12d68b571f23a1187b1cf7b10bb89fa46f",
             sha256 = "a0b7066d9f4193e8a800db2a66f4fe867a7806b8cdeecc3f0b9c9b3fc415338e",
             urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
                 "https://github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
             ],
         )

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -340,7 +340,6 @@ def grpc_deps():
             strip_prefix = "rules_apple-709d8b12d68b571f23a1187b1cf7b10bb89fa46f",
             sha256 = "c84962b64d9ae4472adfb01ec2cf1aa73cb2ee8308242add55fa7cc38602d882",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
                 "https://github.com/bazelbuild/rules_apple/archive/709d8b12d68b571f23a1187b1cf7b10bb89fa46f.tar.gz",
             ],
         )


### PR DESCRIPTION
The currently used version of rules_apple is incompatible with upcoming Bazel releases and will cause breakages.

release notes: no

@nicolasnoble
