### PR TITLE
Add EventEngine's port.h to the podspec

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -117,6 +117,7 @@ Pod::Spec.new do |s|
                       'include/grpc/byte_buffer_reader.h',
                       'include/grpc/census.h',
                       'include/grpc/compression.h',
+                      'include/grpc/event_engine/port.h',
                       'include/grpc/fork.h',
                       'include/grpc/grpc.h',
                       'include/grpc/grpc_posix.h',

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -59,11 +59,13 @@
         files.update(lib.get(field, []))
     return list(sorted(files))
 
-  # Wrapped languages don't need to access EventEngine APIs.
+  # Wrapped languages don't need to access EventEngine APIs. `port.h` is a
+  # special case - it's needed in some security code.
   event_engine_files = [
       file
       for file in list_lib_files("grpc", ("public_headers", "headers", "src"))
       if '/event_engine/' in file
+      and not file.endswith('/port.h')
   ]
 
   # ObjectiveC doesn't use c-ares so we don't need address_sorting files at all


### PR DESCRIPTION
This file is needed for the Objective-C cocoapod build. This may be a temporary solution, we have not fully addressed wrapped language concerns, and the gsec code that redefines iovec may be handled differently.