### PR TITLE
Revert grpc_xds_k8s_python timeout to 120mins

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_python.cfg
+++ b/tools/internal_ci/linux/grpc_xds_k8s_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s_python.sh"
-timeout_mins: 360
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
Seems to have been inadvertently increased in https://github.com/grpc/grpc/pull/26187