### PR TITLE
async_unary_call: add a Destroy method to ClientAsyncResponseReaderInterface

### DIFF
--- a/include/grpcpp/impl/codegen/async_unary_call.h
+++ b/include/grpcpp/impl/codegen/async_unary_call.h
@@ -69,6 +69,22 @@ class ClientAsyncResponseReaderInterface {
   /// \param[out] status To be updated with the operation status.
   /// \param[out] msg To be filled in with the server's response message.
   virtual void Finish(R* msg, ::grpc::Status* status, void* tag) = 0;
+
+  /// Destroy the reader, in whatever manner is appropriate for this
+  /// implementation.
+  ///
+  /// Most users shouldn't need to touch this method; it is called automatically
+  /// by std::unique_ptr due to the specializations of std::default_delete
+  /// defined below.
+  virtual void Destroy() {
+    // HACK(jacobsa): don't do anything by default, preserving the behavior that
+    // existed before the commit that added this note. This is a bad default,
+    // and should be fixed in a follow-up commit.
+    //
+    // TODO(jacobsa): change this to instead run `delete this`. There will still
+    // be no effect on ClientAsyncResponseReader, since it overrides this
+    // method.
+  }
 };
 
 namespace internal {
@@ -261,6 +277,19 @@ class ClientAsyncResponseReader final
             static_cast<void*>(msg), status, tag);
   }
 
+  void Destroy() override {
+    // Don't free our backing memory. ClientAsyncResponseReaderHelper::Create
+    // allocated us on an arena, and it's up to the arena owner to free our
+    // backing memory.
+    //
+    // NOTE(jacobsa): we also don't run the destructor (which we could do
+    // explicitly using `this->~ClientAsyncResponseReader()`) only for
+    // historical reasons, preserving exactly the behavior of the code as it
+    // existed before the commit that added this note. This winds up being okay
+    // only because our destructor doesn't currently have important side
+    // effects.
+  }
+
  private:
   friend class internal::ClientAsyncResponseReaderHelper;
   ::grpc::ClientContext* const context_;
@@ -396,16 +425,38 @@ class ServerAsyncResponseWriter final
 }  // namespace grpc
 
 namespace std {
-template <class R>
-class default_delete<::grpc::ClientAsyncResponseReader<R>> {
- public:
-  void operator()(void* /*p*/) {}
-};
+
+// Tell std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<R>> not to use
+// `operator delete` to destroy the reader, instead letting the object's Destroy
+// method do so. This allows subclasses like ClientAsyncResponseReader to avoid
+// freeing their backing storage, since they expect to be allocated only on
+// arenas.
+//
+// NOTE(jacobsa): this API is not ideal. For example, it doesn't cover the case
+// of the object being deleted some other way: if the user has a unique_ptr `p`,
+// then it seems reasonable that they should be able to do `delete p.release()`
+// and get the same effect. Instead it would be better to use some API with
+// actual type erasure for the deleter, like std::shared_ptr, to hide this
+// detail. But the assumption that readers are returned from stubs using
+// std::unique_ptr is probably impractical to change at this point.
 template <class R>
 class default_delete<::grpc::ClientAsyncResponseReaderInterface<R>> {
  public:
-  void operator()(void* /*p*/) {}
+  void operator()(::grpc::ClientAsyncResponseReaderInterface<R>* const reader) {
+    reader->Destroy();
+  }
 };
+
+// As above, but for the case where the user has a unique_ptr to the important
+// subclass in hand, rather than the interface.
+template <class R>
+class default_delete<::grpc::ClientAsyncResponseReader<R>> {
+ public:
+  void operator()(::grpc::ClientAsyncResponseReader<R>* const reader) {
+    reader->Destroy();
+  }
+};
+
 }  // namespace std
 
 #endif  // GRPCPP_IMPL_CODEGEN_ASYNC_UNARY_CALL_H


### PR DESCRIPTION
Before this commit, we specialized `std::default_delete` for
`ClientAsyncResponseReaderInterface` to do nothing. This means that, despite the
fact that async stub methods return
`std::unique_ptr<ClientAsyncResponseReaderInterface>`, it's impossible to have a
subclass of that interface that is allocated on the heap or whose destructor has
side effects without a hack that manages ownership _outside of_ the `unique_ptr`
returned by the stub.

This was introduced by dd36b153, which introduced the specialization for
`grpc::ClientAsyncResponseReader` itself, and e8a61d63b, which did so
for the interface. Neither of them left any explanation. :-/

I think the intent is a combination of the following facts:

*   In production uses, `ClientAsyncResponseReaderHelper::Create` allocates the
    `ClientAsyncResponseReader` on an arena.

*   Although it's technically non-trivial, the `ClientAsyncResponseReader`
    destructor doesn't actually have any important side effects.

*   Therefore it's not necessary to run the destructor, and it's not correct to
    use `delete` to free the backing memory.

From this point of view, the original commit (`dd36b153`) is technically
correct: `std::unique_ptr<ClientAsyncResponseReader>` doesn't actually need to
do anything. But:

*   Of course the objects may be deleted other ways. If I have a
    `std::unique_ptr<ClientAsyncResponseReaderInterface>` (i.e. without a
    specific deleter type), it would be natural for me to assume that I can do
    `delete p.release()` to get the same effect as destroying the unique
    pointer. But that is not true, and doing so will be undefined behavior.

    So from this point of view `dd36b153` is not correct, or at least makes for
    a surprising API.

*   `ClientAsyncResponseReader` is not the only subclass of the interface. The
    interface's destructor is virtual, so other subclasses may have destructors
    with side effects. However they are never actually run! This is a huge
    surprise: it took me hours yesterday to figure out that I wasn't actually
    crazy: `delete p.release()` really was working differently than just letting
    a `std::unique_ptr p` go out of scope.

    So from this point of view `e8a61d63` is also not correct.

This is not a theoretical concern: I've found multiple hacks in user
code working around this with a grumbling tone. For example, see in the
cloud bigtable library that uses the phrase "terrible, horrible, no
good, very bad hack":

    https://github.com/googleapis/google-cloud-cpp/blob/74de20227371119ea8b8c788d37ae4e24be8ed5d/google/cloud/bigtable/testing/mock_response_reader.h#L77-L106

This commit makes it possible for subclasses to opt into reasonable behavior by
defining an override for `Destroy` that calls `delete this`. We change the
specialization to call `Destroy` in order to make this possible. There is no
behavior change in existing code. I will follow up separately with a change to
the base implementation of `Destroy`, making the reasonable behavior opt-out
instead`, which will be a behavior change for any subclass that depends on the
surprising default.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@soheilhy @vjpai 