### PR TITLE
Update test runner invocation in performance tests.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -90,4 +90,4 @@ go run ../test-infra/tools/prepare_prebuilt_workers/prepare_prebuilt_workers.go 
 ../test-infra/bin/runner \
     -i ../grpc/loadtest_with_prebuilt_workers_workers-8core.yaml \
     -i ../grpc/loadtest_with_prebuilt_workers_workers-32core.yaml \
-    -a pool -c workers-8core:8 -c workers-32core:8
+    -c workers-8core:5 -c workers-32core:5


### PR DESCRIPTION
* Removes optional flag -a, allowing it to be changed to a long-form flag in https://github.com/grpc/test-infra/pull/155
* Updates concurrency levels to one more than what each worker node pool can support (each test requires two workers, and there are nine nodes in each pool, so each node can support four tests).