### PR TITLE
Changed grpc_closure to support absl::Status

### DIFF
--- a/src/core/lib/iomgr/closure.h
+++ b/src/core/lib/iomgr/closure.h
@@ -72,7 +72,7 @@ struct grpc_closure {
 
   /** Once queued, the result of the closure. Before then: scratch space */
   union {
-    grpc_error_handle error;
+    uintptr_t ptr;
     uintptr_t scratch;
   } error_data;
 
@@ -98,7 +98,7 @@ inline grpc_closure* grpc_closure_init(grpc_closure* closure,
 #endif
   closure->cb = cb;
   closure->cb_arg = cb_arg;
-  closure->error_data.error = GRPC_ERROR_NONE;
+  closure->error_data.ptr = 0;
 #ifndef NDEBUG
   closure->scheduled = false;
   closure->file_initiated = nullptr;
@@ -181,7 +181,8 @@ inline bool grpc_closure_list_append(grpc_closure_list* closure_list,
     GRPC_ERROR_UNREF(error);
     return false;
   }
-  closure->error_data.error = error;
+  closure->error_data.ptr = GRPC_ERROR_ALLOC_PTR(error);
+  GRPC_ERROR_UNREF(error);
   closure->next_data.next = nullptr;
   bool was_empty = (closure_list->head == nullptr);
   if (was_empty) {
@@ -197,8 +198,8 @@ inline bool grpc_closure_list_append(grpc_closure_list* closure_list,
 inline void grpc_closure_list_fail_all(grpc_closure_list* list,
                                        grpc_error_handle forced_failure) {
   for (grpc_closure* c = list->head; c != nullptr; c = c->next_data.next) {
-    if (c->error_data.error == GRPC_ERROR_NONE) {
-      c->error_data.error = GRPC_ERROR_REF(forced_failure);
+    if (c->error_data.ptr == 0) {
+      c->error_data.ptr = GRPC_ERROR_ALLOC_PTR(forced_failure);
     }
   }
   GRPC_ERROR_UNREF(forced_failure);

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -154,7 +154,8 @@ static void combiner_exec(grpc_core::Combiner* lock, grpc_closure* cl,
   }
   GPR_ASSERT(last & STATE_UNORPHANED);  // ensure lock has not been destroyed
   assert(cl->cb);
-  cl->error_data.error = error;
+  cl->error_data.ptr = GRPC_ERROR_ALLOC_PTR(error);
+  GRPC_ERROR_UNREF(error);
   lock->queue.Push(cl->next_data.mpscq_node.get());
 }
 
@@ -231,7 +232,8 @@ bool grpc_combiner_continue_exec_ctx() {
     }
     GPR_TIMER_SCOPE("combiner.exec1", 0);
     grpc_closure* cl = reinterpret_cast<grpc_closure*>(n);
-    grpc_error_handle cl_err = cl->error_data.error;
+    grpc_error_handle cl_err = GRPC_ERROR_GET_FROM_PTR(cl->error_data.ptr);
+    GRPC_ERROR_FREE_PTR(cl->error_data.ptr);
 #ifndef NDEBUG
     cl->scheduled = false;
 #endif
@@ -247,7 +249,8 @@ bool grpc_combiner_continue_exec_ctx() {
       GRPC_COMBINER_TRACE(
           gpr_log(GPR_INFO, "C:%p execute_final[%d] c=%p", lock, loops, c));
       grpc_closure* next = c->next_data.next;
-      grpc_error_handle error = c->error_data.error;
+      grpc_error_handle error = GRPC_ERROR_GET_FROM_PTR(c->error_data.ptr);
+      GRPC_ERROR_FREE_PTR(c->error_data.ptr);
 #ifndef NDEBUG
       c->scheduled = false;
 #endif

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -219,6 +219,14 @@ absl::Status grpc_wsa_error(const grpc_core::DebugLocation& location, int err,
 #define GRPC_WSA_ERROR(err, call_name) \
   grpc_wsa_error(DEBUG_LOCATION, err, call_name)
 
+#define GRPC_ERROR_ALLOC_PTR(e) grpc_core::internal::StatusAllocPtr(e)
+#define GRPC_ERROR_GET_FROM_PTR(p) grpc_core::internal::StatusGetFromPtr(p)
+#define GRPC_ERROR_FREE_PTR(p)             \
+  do {                                     \
+    grpc_core::internal::StatusFreePtr(p); \
+    (p) = 0;                               \
+  } while (false)
+
 #else  // GRPC_ERROR_IS_ABSEIL_STATUS
 
 /// The following "special" errors can be propagated without allocating memory.
@@ -339,6 +347,15 @@ grpc_error_handle grpc_wsa_error(const char* file, int line, int err,
 /// windows only: create an error associated with WSAGetLastError()!=0
 #define GRPC_WSA_ERROR(err, call_name) \
   grpc_wsa_error(__FILE__, __LINE__, err, call_name)
+
+#define GRPC_ERROR_ALLOC_PTR(e) reinterpret_cast<uintptr_t>(GRPC_ERROR_REF(e))
+#define GRPC_ERROR_GET_FROM_PTR(p) \
+  GRPC_ERROR_REF(reinterpret_cast<grpc_error_handle>(p))
+#define GRPC_ERROR_FREE_PTR(p)                                \
+  do {                                                        \
+    GRPC_ERROR_UNREF(reinterpret_cast<grpc_error_handle>(p)); \
+    (p) = 0;                                                  \
+  } while (false)
 
 #endif  // GRPC_ERROR_IS_ABSEIL_STATUS
 

--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -152,7 +152,8 @@ bool ExecCtx::Flush() {
       closure_list_.head = closure_list_.tail = nullptr;
       while (c != nullptr) {
         grpc_closure* next = c->next_data.next;
-        grpc_error_handle error = c->error_data.error;
+        grpc_error_handle error = GRPC_ERROR_GET_FROM_PTR(c->error_data.ptr);
+        GRPC_ERROR_FREE_PTR(c->error_data.ptr);
         did_something = true;
         exec_ctx_run(c, error);
         c = next;
@@ -219,7 +220,9 @@ void ExecCtx::RunList(const DebugLocation& location, grpc_closure_list* list) {
     c->run = false;
     GPR_ASSERT(c->cb != nullptr);
 #endif
-    exec_ctx_sched(c, c->error_data.error);
+    grpc_error_handle error = GRPC_ERROR_GET_FROM_PTR(c->error_data.ptr);
+    GRPC_ERROR_FREE_PTR(c->error_data.ptr);
+    exec_ctx_sched(c, error);
     c = next;
   }
   list->head = list->tail = nullptr;

--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -115,7 +115,8 @@ size_t Executor::RunClosures(const char* executor_name,
   grpc_closure* c = list.head;
   while (c != nullptr) {
     grpc_closure* next = c->next_data.next;
-    grpc_error_handle error = c->error_data.error;
+    grpc_error_handle error = GRPC_ERROR_GET_FROM_PTR(c->error_data.ptr);
+    GRPC_ERROR_FREE_PTR(c->error_data.ptr);
 #ifndef NDEBUG
     EXECUTOR_TRACE("(%s) run %p [created by %s:%d]", executor_name, c,
                    c->file_created, c->line_created);


### PR DESCRIPTION
Changed `grpc_closure` to support absl::Status by changing the type of it member `error_data.error` from `grpc_error_handle` to `uintptr_t`. Because this memeber is in the union, absl::Status which is a C++ class cannot be used there. This can be addressed by not using union but `grpc_closure` is instantiated a lot throughout core so a bit hacky way is used in this PR to keep the same memory footprint.

Both `grpc_error*` and `absl::Status` have the same size, `sizeof(void*)` so both can be stored in `uintptr_t`. Whenever `grpc_error_handle` is stored into or fetched from `error_data.error`, it can be successfully done with `uintptr_t` with conversion functions.

To accommodate `grpc_error*` and `absl::Status` here, the following macros are introduced as conversion functions;

- GRPC_ERROR_ALLOC_PTR(error_handle): Stores the given `grpc_error_handle` into the ptr and returns it.
- GRPC_ERROR_GET_FROM_PTR(ptr): Gets the `grpc_error_handle` from ptr.
- GRPC_ERROR_FREE_PTR(ptr): Deallocate the ptr which stores the `grpc_error_handle`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26239)
<!-- Reviewable:end -->
