### PR TITLE
Normalize grpc_error_handle usage

### DIFF
--- a/src/core/ext/filters/client_idle/client_idle_filter.cc
+++ b/src/core/ext/filters/client_idle/client_idle_filter.cc
@@ -187,7 +187,7 @@ void ChannelData::StartTransportOp(grpc_channel_element* elem,
                                    grpc_transport_op* op) {
   ChannelData* chand = static_cast<ChannelData*>(elem->channel_data);
   // Catch the disconnect_with_error transport op.
-  if (op->disconnect_with_error != nullptr) {
+  if (op->disconnect_with_error != GRPC_ERROR_NONE) {
     // IncreaseCallCount() introduces a phony call and prevent the timer from
     // being reset by other threads.
     chand->IncreaseCallCount();

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -564,7 +564,7 @@ static void close_transport_locked(grpc_chttp2_transport* t,
                                  GRPC_STATUS_UNAVAILABLE);
     }
     if (t->write_state != GRPC_CHTTP2_WRITE_STATE_IDLE) {
-      if (t->close_transport_on_writes_finished == nullptr) {
+      if (t->close_transport_on_writes_finished == GRPC_ERROR_NONE) {
         t->close_transport_on_writes_finished =
             GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                 "Delayed close due to in-progress write");
@@ -821,9 +821,9 @@ static void set_write_state(grpc_chttp2_transport* t,
   // from peer while we had some pending writes)
   if (st == GRPC_CHTTP2_WRITE_STATE_IDLE) {
     grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &t->run_after_write);
-    if (t->close_transport_on_writes_finished != nullptr) {
+    if (t->close_transport_on_writes_finished != GRPC_ERROR_NONE) {
       grpc_error_handle err = t->close_transport_on_writes_finished;
-      t->close_transport_on_writes_finished = nullptr;
+      t->close_transport_on_writes_finished = GRPC_ERROR_NONE;
       close_transport_locked(t, err);
     }
   }
@@ -1795,7 +1795,7 @@ static void perform_transport_op_locked(void* stream_op,
   grpc_chttp2_transport* t =
       static_cast<grpc_chttp2_transport*>(op->handler_private.extra_arg);
 
-  if (op->goaway_error) {
+  if (op->goaway_error != GRPC_ERROR_NONE) {
     send_goaway(t, op->goaway_error);
   }
 

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -246,10 +246,10 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         t->incoming_frame_size -= static_cast<uint32_t>(end - cur);
         return GRPC_ERROR_NONE;
       }
-      GPR_UNREACHABLE_CODE(return nullptr);
+      GPR_UNREACHABLE_CODE(return GRPC_ERROR_NONE);
   }
 
-  GPR_UNREACHABLE_CODE(return nullptr);
+  GPR_UNREACHABLE_CODE(return GRPC_ERROR_NONE);
 }
 
 static grpc_error_handle init_frame_parser(grpc_chttp2_transport* t) {

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -59,7 +59,7 @@ absl::Status grpc_status_create(absl::StatusCode code, absl::string_view msg,
   absl::Status s = StatusCreate(code, msg, location, {});
   for (size_t i = 0; i < children_count; ++i) {
     if (!children[i].ok()) {
-      StatusAddChild(&s, children[i]);
+      grpc_core::StatusAddChild(&s, children[i]);
     }
   }
   return s;
@@ -73,10 +73,11 @@ absl::Status grpc_os_error(const grpc_core::DebugLocation& location, int err,
                            const char* call_name) {
   absl::Status s =
       StatusCreate(absl::StatusCode::kUnknown, "OS Error", location, {});
-  grpc_core::StatusSetInt(&s, grpc_core::StatusIntProperty::ERRNO, err);
-  grpc_core::StatusSetStr(&s, grpc_core::StatusStrProperty::OS_ERROR,
+  grpc_core::StatusSetInt(&s, grpc_core::StatusIntProperty::kErrorNo, err);
+  grpc_core::StatusSetStr(&s, grpc_core::StatusStrProperty::kOsError,
                           strerror(err));
-  grpc_core::StatusSetStr(&s, grpc_core::StatusStrProperty::SYSCALL, call_name);
+  grpc_core::StatusSetStr(&s, grpc_core::StatusStrProperty::kSyscall,
+                          call_name);
   return s;
 }
 

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -166,7 +166,7 @@ void grpc_enable_error_creation();
 #define GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc) \
   StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
 #define GRPC_ERROR_CREATE_FROM_STRING_VIEW(desc) \
-  StatusCreate(ababsl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
+  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
 
 absl::Status grpc_status_create(absl::StatusCode code, absl::string_view msg,
                                 const grpc_core::DebugLocation& location,

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -362,10 +362,9 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
     for (sp = s->head; sp; sp = sp->next) {
       socket = sp->socket;
       sockname_temp.len = GRPC_MAX_SOCKADDR_SIZE;
-      if (nullptr == grpc_custom_socket_vtable->getsockname(
-                         socket,
-                         reinterpret_cast<grpc_sockaddr*>(&sockname_temp.addr),
-                         reinterpret_cast<int*>(&sockname_temp.len))) {
+      if (grpc_custom_socket_vtable->getsockname(
+              socket, reinterpret_cast<grpc_sockaddr*>(&sockname_temp.addr),
+              reinterpret_cast<int*>(&sockname_temp.len)) == GRPC_ERROR_NONE) {
         *port = grpc_sockaddr_get_port(&sockname_temp);
         if (*port > 0) {
           allocated_addr = static_cast<grpc_resolved_address*>(

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -74,7 +74,7 @@ void grpc_error_get_status(grpc_error_handle error, grpc_millis deadline,
   // until we find the first one that has a status code.
   grpc_error_handle found_error =
       recursively_find_error_with_field(error, GRPC_ERROR_INT_GRPC_STATUS);
-  if (found_error == nullptr) {
+  if (found_error == GRPC_ERROR_NONE) {
     /// If no grpc-status exists, retry through the tree to find a http2 error
     /// code
     found_error =
@@ -83,7 +83,7 @@ void grpc_error_get_status(grpc_error_handle error, grpc_millis deadline,
 
   // If we found an error with a status code above, use that; otherwise,
   // fall back to using the parent error.
-  if (found_error == nullptr) found_error = error;
+  if (found_error == GRPC_ERROR_NONE) found_error = error;
 
   grpc_status_code status = GRPC_STATUS_UNKNOWN;
   intptr_t integer;

--- a/src/core/lib/transport/transport_op_string.cc
+++ b/src/core/lib/transport/transport_op_string.cc
@@ -135,7 +135,7 @@ std::string grpc_transport_op_string(grpc_transport_op* op) {
         " DISCONNECT:", grpc_error_std_string(op->disconnect_with_error)));
   }
 
-  if (op->goaway_error) {
+  if (op->goaway_error != GRPC_ERROR_NONE) {
     out.push_back(absl::StrCat(" SEND_GOAWAY:%s",
                                grpc_error_std_string(op->goaway_error)));
   }


### PR DESCRIPTION
In order for `absl::Status` to be used as a drop-in replacemant for `grpc_error*`, gRPC code are updated to be more normalized like;
 - Use `GRPC_ERROR_NONE` instead of `nullptr`
 - `absl::Status` cannot be formatted with `%p` so all error are converted to a string in `INPROC_LOG`.

In addition to this, some build error in error.cc are fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26240)
<!-- Reviewable:end -->
