### PR TITLE
Adjust concurrency levels for performance tests.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -62,7 +62,7 @@ buildConfigs() {
         -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
         -s prebuilt_image_tag="${UNIQUE_IDENTIFIER}" \
-        --prefix=$KOKORO_BUILD_INITIATOR -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
+        --prefix="${KOKORO_BUILD_INITIATOR}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
@@ -97,4 +97,4 @@ trap deleteImages EXIT
 ../test-infra/bin/runner \
     -i ../grpc/loadtest_with_prebuilt_workers_workers-8core.yaml \
     -i ../grpc/loadtest_with_prebuilt_workers_workers-32core.yaml \
-    -c workers-8core:5 -c workers-32core:5
+    -c workers-8core:2 -c workers-32core:2


### PR DESCRIPTION
Experiments show that 4 tests running concurrrently (two on 8-core nodes and two on 32-core nodes) is enough to run all tests within two hours with time to spare.