### PR TITLE
Install pkgconfig files into gRPC_INSTALL_LIBDIR (#24512)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17359,7 +17359,7 @@ function(generate_pkgconfig name description version requires
     "${output_filepath}"
     @ONLY)
   install(FILES "${output_filepath}"
-    DESTINATION "lib/pkgconfig/")
+    DESTINATION "${gRPC_INSTALL_LIBDIR}/pkgconfig/")
 endfunction()
 
 # gpr .pc file

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -760,7 +760,7 @@
       "<%text>${output_filepath}</%text>"
       @ONLY)
     install(FILES "<%text>${output_filepath}</%text>"
-      DESTINATION "lib/pkgconfig/")
+      DESTINATION "${gRPC_INSTALL_LIBDIR}/pkgconfig/")
   endfunction()
 
   # gpr .pc file


### PR DESCRIPTION
Fixes #24512

Instead of installing pkgconfig files into hard coded `lib/pkgconfig` path, use `gRPC_INSTALL_LIBDIR` instead.
Useful for distributions using e.g. `lib64` instead of `lib`.
This patch was taken from the openSUSE project where it is already used.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
