### PR TITLE
do best-effort cleanup even if some resources not found

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2639,7 +2639,7 @@ def delete_global_forwarding_rule(gcp, name=None):
     else:
         forwarding_rule_to_delete = gcp.global_forwarding_rule.name
     try:
-        logger.debug('Deleting forwarding rule', forwarding_rule_to_delete)
+        logger.debug('Deleting forwarding rule %s', forwarding_rule_to_delete)
         result = gcp.compute.globalForwardingRules().delete(
             project=gcp.project,
             forwardingRule=forwarding_rule_to_delete).execute(
@@ -2656,12 +2656,12 @@ def delete_target_proxy(gcp, name=None):
         proxy_to_delete = gcp.target_proxy.name
     try:
         if gcp.alpha_compute:
-            logger.debug('Deleting grpc proxy', proxy_to_delete)
+            logger.debug('Deleting grpc proxy %s', proxy_to_delete)
             result = gcp.alpha_compute.targetGrpcProxies().delete(
                 project=gcp.project, targetGrpcProxy=proxy_to_delete).execute(
                     num_retries=_GCP_API_RETRIES)
         else:
-            logger.debug('Deleting http proxy', proxy_to_delete)
+            logger.debug('Deleting http proxy %s', proxy_to_delete)
             result = gcp.compute.targetHttpProxies().delete(
                 project=gcp.project, targetHttpProxy=proxy_to_delete).execute(
                     num_retries=_GCP_API_RETRIES)
@@ -2676,7 +2676,7 @@ def delete_url_map(gcp, name=None):
     else:
         url_map_to_delete = gcp.url_map.name
     try:
-        logger.debug('Deleting url map', url_map_to_delete)
+        logger.debug('Deleting url map %s', url_map_to_delete)
         result = gcp.compute.urlMaps().delete(
             project=gcp.project,
             urlMap=url_map_to_delete).execute(num_retries=_GCP_API_RETRIES)
@@ -2687,7 +2687,7 @@ def delete_url_map(gcp, name=None):
 
 def delete_backend_service(gcp, backend_service):
     try:
-        logger.debug('Deleting backend service', backend_service.name)
+        logger.debug('Deleting backend service %s', backend_service.name)
         result = gcp.compute.backendServices().delete(
             project=gcp.project, backendService=backend_service.name).execute(
                 num_retries=_GCP_API_RETRIES)
@@ -2703,7 +2703,7 @@ def delete_backend_services(gcp):
 
 def delete_firewall(gcp):
     try:
-        logger.debug('Deleting firewall', gcp.health_check_firewall_rule.name)
+        logger.debug('Deleting firewall %s', gcp.health_check_firewall_rule.name)
         result = gcp.compute.firewalls().delete(
             project=gcp.project,
             firewall=gcp.health_check_firewall_rule.name).execute(
@@ -2715,7 +2715,7 @@ def delete_firewall(gcp):
 
 def delete_health_check(gcp):
     try:
-        logger.debug('Deleting health check', gcp.health_check.name)
+        logger.debug('Deleting health check %s', gcp.health_check.name)
         result = gcp.compute.healthChecks().delete(
             project=gcp.project, healthCheck=gcp.health_check.name).execute(
                 num_retries=_GCP_API_RETRIES)
@@ -2727,7 +2727,7 @@ def delete_health_check(gcp):
 def delete_instance_groups(gcp):
     for instance_group in gcp.instance_groups:
         try:
-            logger.debug('Deleting instance group', gcp.instance_group.name)
+            logger.debug('Deleting instance group %s %s', instance_group.name, instance_group.zone)
             result = gcp.compute.instanceGroupManagers().delete(
                 project=gcp.project,
                 zone=instance_group.zone,
@@ -2743,7 +2743,7 @@ def delete_instance_groups(gcp):
 
 def delete_instance_template(gcp):
     try:
-        logger.debug('Deleting instance template', gcp.instance_template.name)
+        logger.debug('Deleting instance template %s', gcp.instance_template.name)
         result = gcp.compute.instanceTemplates().delete(
             project=gcp.project,
             instanceTemplate=gcp.instance_template.name).execute(

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2550,7 +2550,6 @@ def get_health_check(gcp, health_check_name):
         gcp.health_check = GcpResource(health_check_name, None)
 
 
-
 def get_health_check_firewall_rule(gcp, firewall_name):
     try:
         result = gcp.compute.firewalls().get(project=gcp.project,
@@ -2583,14 +2582,17 @@ def get_url_map(gcp, url_map_name):
         gcp.errors.append(e)
         gcp.url_map = GcpResource(url_map_name, None)
 
+
 def get_target_proxy(gcp, target_proxy_name):
     try:
         if gcp.alpha_compute:
             result = gcp.alpha_compute.targetGrpcProxies().get(
-                project=gcp.project, targetGrpcProxy=target_proxy_name).execute()
+                project=gcp.project,
+                targetGrpcProxy=target_proxy_name).execute()
         else:
             result = gcp.compute.targetHttpProxies().get(
-                project=gcp.project, targetHttpProxy=target_proxy_name).execute()
+                project=gcp.project,
+                targetHttpProxy=target_proxy_name).execute()
         gcp.target_proxy = GcpResource(target_proxy_name, result['selfLink'])
     except Exception as e:
         gcp.errors.append(e)
@@ -2703,7 +2705,8 @@ def delete_backend_services(gcp):
 
 def delete_firewall(gcp):
     try:
-        logger.debug('Deleting firewall %s', gcp.health_check_firewall_rule.name)
+        logger.debug('Deleting firewall %s',
+                     gcp.health_check_firewall_rule.name)
         result = gcp.compute.firewalls().delete(
             project=gcp.project,
             firewall=gcp.health_check_firewall_rule.name).execute(
@@ -2727,7 +2730,8 @@ def delete_health_check(gcp):
 def delete_instance_groups(gcp):
     for instance_group in gcp.instance_groups:
         try:
-            logger.debug('Deleting instance group %s %s', instance_group.name, instance_group.zone)
+            logger.debug('Deleting instance group %s %s', instance_group.name,
+                         instance_group.zone)
             result = gcp.compute.instanceGroupManagers().delete(
                 project=gcp.project,
                 zone=instance_group.zone,
@@ -2743,7 +2747,8 @@ def delete_instance_groups(gcp):
 
 def delete_instance_template(gcp):
     try:
-        logger.debug('Deleting instance template %s', gcp.instance_template.name)
+        logger.debug('Deleting instance template %s',
+                     gcp.instance_template.name)
         result = gcp.compute.instanceTemplates().delete(
             project=gcp.project,
             instanceTemplate=gcp.instance_template.name).execute(

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2639,6 +2639,7 @@ def delete_global_forwarding_rule(gcp, name=None):
     else:
         forwarding_rule_to_delete = gcp.global_forwarding_rule.name
     try:
+        logger.debug('Deleting forwarding rule', forwarding_rule_to_delete)
         result = gcp.compute.globalForwardingRules().delete(
             project=gcp.project,
             forwardingRule=forwarding_rule_to_delete).execute(
@@ -2655,10 +2656,12 @@ def delete_target_proxy(gcp, name=None):
         proxy_to_delete = gcp.target_proxy.name
     try:
         if gcp.alpha_compute:
+            logger.debug('Deleting grpc proxy', proxy_to_delete)
             result = gcp.alpha_compute.targetGrpcProxies().delete(
                 project=gcp.project, targetGrpcProxy=proxy_to_delete).execute(
                     num_retries=_GCP_API_RETRIES)
         else:
+            logger.debug('Deleting http proxy', proxy_to_delete)
             result = gcp.compute.targetHttpProxies().delete(
                 project=gcp.project, targetHttpProxy=proxy_to_delete).execute(
                     num_retries=_GCP_API_RETRIES)
@@ -2673,6 +2676,7 @@ def delete_url_map(gcp, name=None):
     else:
         url_map_to_delete = gcp.url_map.name
     try:
+        logger.debug('Deleting url map', url_map_to_delete)
         result = gcp.compute.urlMaps().delete(
             project=gcp.project,
             urlMap=url_map_to_delete).execute(num_retries=_GCP_API_RETRIES)
@@ -2683,6 +2687,7 @@ def delete_url_map(gcp, name=None):
 
 def delete_backend_service(gcp, backend_service):
     try:
+        logger.debug('Deleting backend service', backend_service.name)
         result = gcp.compute.backendServices().delete(
             project=gcp.project, backendService=backend_service.name).execute(
                 num_retries=_GCP_API_RETRIES)
@@ -2698,6 +2703,7 @@ def delete_backend_services(gcp):
 
 def delete_firewall(gcp):
     try:
+        logger.debug('Deleting firewall', gcp.health_check_firewall_rule.name)
         result = gcp.compute.firewalls().delete(
             project=gcp.project,
             firewall=gcp.health_check_firewall_rule.name).execute(
@@ -2709,6 +2715,7 @@ def delete_firewall(gcp):
 
 def delete_health_check(gcp):
     try:
+        logger.debug('Deleting health check', gcp.health_check.name)
         result = gcp.compute.healthChecks().delete(
             project=gcp.project, healthCheck=gcp.health_check.name).execute(
                 num_retries=_GCP_API_RETRIES)
@@ -2720,6 +2727,7 @@ def delete_health_check(gcp):
 def delete_instance_groups(gcp):
     for instance_group in gcp.instance_groups:
         try:
+            logger.debug('Deleting instance group', gcp.instance_group.name)
             result = gcp.compute.instanceGroupManagers().delete(
                 project=gcp.project,
                 zone=instance_group.zone,
@@ -2735,6 +2743,7 @@ def delete_instance_groups(gcp):
 
 def delete_instance_template(gcp):
     try:
+        logger.debug('Deleting instance template', gcp.instance_template.name)
         result = gcp.compute.instanceTemplates().delete(
             project=gcp.project,
             instanceTemplate=gcp.instance_template.name).execute(


### PR DESCRIPTION
Currently if we run with `--use_existing_resources` and `--testcase=''` just to clean up previously created resources, and then for any reason the call to `get_health_check` fails, we won't end up deleting anything as this first failed call aborts the process of finding what resources exist.

This PR changes the codepath to still check for all known resources so whatever is still present in the project can be deleted.

See also b/186617027