### PR TITLE
Build visibility macro system

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -313,6 +313,7 @@ grpc_cc_library(
     language = "c++",
     public_hdrs = GRPC_PUBLIC_HDRS,
     standalone = True,
+    visibility = ["@grpc:public"],
     deps = [
         "grpc_common",
         "grpc_lb_policy_grpclb",
@@ -344,6 +345,10 @@ grpc_cc_library(
         ],
     },
     standalone = True,
+    visibility = [
+        "@grpc:alt_grpc_legacy",
+        "@grpc:public",
+    ],
     deps = [
         "grpc_common",
         "grpc_lb_policy_grpclb_secure",
@@ -360,6 +365,7 @@ grpc_cc_library(
         "absl/synchronization",
         "protobuf_headers",
     ],
+    visibility = ["@grpc:public"],
 )
 
 grpc_cc_library(
@@ -381,6 +387,10 @@ grpc_cc_library(
         ],
     },
     standalone = True,
+    visibility = [
+        "@grpc:alt_grpc++_legacy",
+        "@grpc:public",
+    ],
     deps = [
         "grpc++_internals",
     ],
@@ -464,6 +474,7 @@ grpc_cc_library(
     ],
     language = "c++",
     standalone = True,
+    visibility = ["@grpc:public"],
     deps = [
         "gpr",
         "grpc++_base_unsecure",
@@ -1876,7 +1887,10 @@ grpc_cc_library(
     srcs = ["src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc"],
     hdrs = ["src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"],
     language = "c++",
-    visibility = ["//test:__subpackages__"],
+    visibility = [
+        "//test:__subpackages__",
+        "@grpc:grpc_resolver_fake",
+    ],
     deps = [
         "grpc_base",
         "grpc_client_channel",
@@ -2017,6 +2031,7 @@ grpc_cc_library(
     ],
     language = "c++",
     public_hdrs = GRPC_SECURE_PUBLIC_HDRS,
+    visibility = ["@grpc:public"],
     deps = [
         "alts_util",
         "grpc_base",
@@ -2761,6 +2776,7 @@ grpc_cc_library(
         "opencensus-context",
     ],
     language = "c++",
+    visibility = ["@grpc:grpc_opencensus_plugin"],
     deps = [
         ":census",
         ":grpc++",

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -64,6 +64,29 @@ def _get_external_deps(external_deps):
             ret += ["//external:" + dep]
     return ret
 
+def _update_visibility(visibility):
+    if visibility == None:
+        return None
+
+    # Visibility rules prefixed with '@grpc_' are used to flag different visibility rule
+    # classes upstream.
+    VISIBILITY_TARGETS = {
+        "alt_grpc_legacy": [],
+        "alt_grpc++_legacy": [],
+        "endpoint_tests": [],
+        "grpc_opencensus_plugin": ["//visibility:public"],
+        "grpc_resolver_fake": [],
+        "public": ["//visibility:public"],
+    }
+    final_visibility = []
+    for rule in visibility:
+        if rule.startswith("@grpc:"):
+            for replacement in VISIBILITY_TARGETS[rule[6:]]:
+                final_visibility.append(replacement)
+        else:
+            final_visibility.append(rule)
+    return [x for x in final_visibility]
+
 def grpc_cc_library(
         name,
         srcs = [],
@@ -82,6 +105,7 @@ def grpc_cc_library(
         use_cfstream = False,
         tags = [],
         linkstatic = False):
+    visibility = _update_visibility(visibility)
     copts = []
     if use_cfstream:
         copts = if_mac(["-DGRPC_CFSTREAM"])

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -29,7 +29,10 @@ grpc_cc_library(
     srcs = ["endpoint_tests.cc"],
     hdrs = ["endpoint_tests.h"],
     language = "C++",
-    visibility = ["//test:__subpackages__"],
+    visibility = [
+        "//test:__subpackages__",
+        "@grpc:endpoint_tests",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",


### PR DESCRIPTION
A corresponding update to the build system will need to occur before this is submitted.

Add a way of labelling in build configuration meta-visibility-rules, so that these can be leveraged to restrict visibility in Google's build system upstream.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
