### PR TITLE
Clean up GCP resources created by tests older than 24 hrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ coverage
 .run_tests_cache
 .preprocessed_build
 
+# generated Python files for run_xds_tests.py
+tools/run_tests/src
+
 # emacs temp files
 *~
 

--- a/tools/internal_ci/linux/grpc_gcp_resources_clean.cfg
+++ b/tools/internal_ci/linux/grpc_gcp_resources_clean.cfg
@@ -1,0 +1,25 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_gcp_resources_clean.sh"
+timeout_mins: 30
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "**/perf_reports/**"
+  }
+}

--- a/tools/internal_ci/linux/grpc_gcp_resources_clean.sh
+++ b/tools/internal_ci/linux/grpc_gcp_resources_clean.sh
@@ -17,4 +17,7 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../../..
 
+# Prepares the environment to run the clean script
+tools/run_tests/helper_scripts/prep_xds.sh
+
 python3 tools/run_tests/helper_scripts/clean_xds_interop_resources.py

--- a/tools/internal_ci/linux/grpc_gcp_resources_clean.sh
+++ b/tools/internal_ci/linux/grpc_gcp_resources_clean.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+
+# Enter the gRPC repo root
+cd $(dirname $0)/../../..
+
+python3 tools/run_tests/helper_scripts/clean_xds_interop_resources.py

--- a/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
+++ b/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
@@ -1,0 +1,168 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import json
+import sys
+import re
+import os
+import functools
+import subprocess
+import datetime
+from dataclasses import dataclass
+from typing import List, Any
+
+# Parses commandline arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('--dry_run', action='store_true')
+args = parser.parse_args()
+
+# Type alias
+Json = Any
+
+# Configures this script
+KEEP_PERIOD = datetime.timedelta(hours=24)
+GCLOUD = os.environ.get('GCLOUD', 'gcloud')
+GCLOUD_CMD_TIMEOUT_S = datetime.timedelta(seconds=120).total_seconds()
+ZONE = 'us-central1-a'
+SECONDARY_ZONE = 'us-west1-b'
+PROJECT = 'grpc-testing'
+
+
+@functools.lru_cache()
+def get_expire_timestamp():
+    return (datetime.datetime.now() - KEEP_PERIOD).isoformat()
+
+
+def exec_gcloud(*cmds: List[str]) -> Json:
+    cmds = [GCLOUD, '--project', PROJECT] + list(cmds)
+    if 'list' in cmds:
+        # Add arguments to shape the list output
+        cmds.extend([
+            '--format', 'json', '--filter',
+            f'creationTimestamp<={get_expire_timestamp()}'
+        ])
+    if args.dry_run and 'delete' in cmds:
+        # Skip deletion for dry-runs
+        logging.debug('> Skipped: %s', " ".join(cmds))
+        return None
+    # Executing the gcloud command
+    logging.debug('Executing: %s', " ".join(cmds))
+    proc = subprocess.Popen(cmds,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True)
+    returncode = proc.wait(timeout=GCLOUD_CMD_TIMEOUT_S)
+    if returncode:
+        logging.error('> Failed to execute cmd [%s], returned %d, stderr: %s',
+                      " ".join(cmds), returncode, proc.stderr.read())
+        return None
+    return json.loads(proc.stdout.read())
+
+
+def remove_relative_resources_run_xds_tests(suffix: str):
+    """Removing GCP resources created by run_xds_tests.py."""
+    logging.info('Removing run_xds_tests.py resources with suffix [%s]', suffix)
+    exec_gcloud('compute', 'forwarding-rules', 'delete',
+                f'test-forwarding-rule{suffix}', '--global')
+    exec_gcloud('compute', 'target-http-proxies', 'delete',
+                f'test-target-proxy{suffix}')
+    exec_gcloud('alpha', 'compute', 'target-grpc-proxies', 'delete',
+                f'test-target-proxy{suffix}')
+    exec_gcloud('compute', 'url-maps', 'delete', f'test-map{suffix}')
+    exec_gcloud('compute', 'backend-services', 'delete',
+                f'test-backend-service{suffix}', '--global')
+    exec_gcloud('compute', 'backend-services', 'delete',
+                f'test-backend-service-alternate{suffix}', '--global')
+    exec_gcloud('compute', 'backend-services', 'delete',
+                f'test-backend-service-extra{suffix}', '--global')
+    exec_gcloud('compute', 'backend-services', 'delete',
+                f'test-backend-service-more-extra{suffix}', '--global')
+    exec_gcloud('compute', 'firewall-rules', 'delete', f'test-fw-rule{suffix}')
+    exec_gcloud('compute', 'health-checks', 'delete', f'test-hc{suffix}')
+    exec_gcloud('compute', 'instance-groups', 'managed', 'delete',
+                f'test-ig{suffix}', '--zone', ZONE)
+    exec_gcloud('compute', 'instance-groups', 'managed', 'delete',
+                f'test-ig-same-zone{suffix}', '--zone', ZONE)
+    exec_gcloud('compute', 'instance-groups', 'managed', 'delete',
+                f'test-ig-secondary-zone{suffix}', '--zone', SECONDARY_ZONE)
+    exec_gcloud('compute', 'instance-templates', 'delete',
+                f'test-template{suffix}')
+
+
+def remove_relative_resources_psm_sec(prefix: str):
+    """Removing GCP resources created by PSM Sec framework."""
+    logging.info('Removing PSM Security resources with prefix [%s]', prefix)
+    exec_gcloud('compute', 'forwarding-rules', 'delete',
+                f'{prefix}-forwarding-rule', '--global')
+    exec_gcloud('alpha', 'compute', 'target-grpc-proxies', 'delete',
+                f'{prefix}-target-proxy')
+    exec_gcloud('compute', 'url-maps', 'delete', f'{prefix}-url-map')
+    exec_gcloud('compute', 'backend-services', 'delete',
+                f'{prefix}-backend-service', '--global')
+    exec_gcloud('compute', 'health-checks', 'delete', f'{prefix}-health-check')
+    exec_gcloud('compute', 'firewall-rules', 'delete',
+                f'{prefix}-allow-health-checks')
+    exec_gcloud('alpha', 'network-security', 'server-tls-policies', 'delete',
+                f'{prefix}-server-tls-policy')
+    exec_gcloud('alpha', 'network-security', 'client-tls-policies', 'delete',
+                f'{prefix}-client-tls-policy')
+
+
+def check_one_type_of_gcp_resources(list_cmd: List[str],
+                                    suffix_search: str = '',
+                                    prefix_search: str = ''):
+    logging.info('Checking GCP resources with %s or %s', suffix_search,
+                 prefix_search)
+    for resource in exec_gcloud(*list_cmd):
+        if suffix_search:
+            result = re.search(suffix_search, resource['name'])
+            if result is not None:
+                remove_relative_resources_run_xds_tests(result.group(1))
+                continue
+
+        if prefix_search:
+            result = re.search(prefix_search, resource['name'])
+            if result is not None:
+                remove_relative_resources_psm_sec(result.group(1))
+                continue
+
+
+def check_costly_gcp_resources() -> None:
+    check_one_type_of_gcp_resources(['compute', 'forwarding-rules', 'list'],
+                                    suffix_search=r'test-forwarding-rule(.*)',
+                                    prefix_search=r'(.+?)-forwarding-rule')
+    check_one_type_of_gcp_resources(['compute', 'target-http-proxies', 'list'],
+                                    suffix_search=r'test-target-proxy(.*)')
+    check_one_type_of_gcp_resources(['compute', 'target-grpc-proxies', 'list'],
+                                    suffix_search=r'test-target-proxy(.*)',
+                                    prefix_search=r'(.+?)-target-proxy')
+    check_one_type_of_gcp_resources(['compute', 'url-maps', 'list'],
+                                    suffix_search=r'test-map(.*)',
+                                    prefix_search=r'(.+?)-url-map')
+    check_one_type_of_gcp_resources(['compute', 'backend-services', 'list'],
+                                    suffix_search=r'test-backend-service(.*)',
+                                    prefix_search=r'(.+?)-backend-service')
+
+
+def main():
+    logging.info('Cleaning up costly resources created before %s',
+                 get_expire_timestamp())
+    check_costly_gcp_resources()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    main()

--- a/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
+++ b/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 import argparse
-import logging
-import json
-import sys
-import re
-import os
-import functools
-import subprocess
 import datetime
+import functools
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
 from dataclasses import dataclass
-from typing import List, Any
+from typing import Any, List, Optional
 
 # Parses commandline arguments
 parser = argparse.ArgumentParser()
@@ -34,16 +34,40 @@ Json = Any
 
 # Configures this script
 KEEP_PERIOD = datetime.timedelta(hours=24)
+COMMAND_TIMEOUT_S = datetime.timedelta(seconds=180).total_seconds()
 GCLOUD = os.environ.get('GCLOUD', 'gcloud')
-GCLOUD_CMD_TIMEOUT_S = datetime.timedelta(seconds=120).total_seconds()
 ZONE = 'us-central1-a'
 SECONDARY_ZONE = 'us-west1-b'
 PROJECT = 'grpc-testing'
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../../..'))
+RUN_XDS_TESTS = os.path.join(ROOT, 'tools', 'run_tests', 'run_xds_tests.py')
 
 
 @functools.lru_cache()
 def get_expire_timestamp():
     return (datetime.datetime.now() - KEEP_PERIOD).isoformat()
+
+
+def exec_command(*cmds: List[str], cwd: Optional[str] = None) -> Optional[str]:
+    logging.debug('Executing: %s', " ".join(cmds))
+    proc = subprocess.Popen(cmds,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            cwd=cwd)
+    # Overcome the potential buffer deadlocking
+    # https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate
+    try:
+        outs, errs = proc.communicate(timeout=COMMAND_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        outs, errs = proc.communicate()
+    if proc.returncode:
+        logging.error('> Failed to execute cmd [%s], returned %d, stderr: %s',
+                      " ".join(cmds), proc.returncode, errs)
+        return None
+    return outs
 
 
 def exec_gcloud(*cmds: List[str]) -> Json:
@@ -54,107 +78,90 @@ def exec_gcloud(*cmds: List[str]) -> Json:
             '--format', 'json', '--filter',
             f'creationTimestamp<={get_expire_timestamp()}'
         ])
-    if args.dry_run and 'delete' in cmds:
-        # Skip deletion for dry-runs
-        logging.debug('> Skipped: %s', " ".join(cmds))
-        return None
     # Executing the gcloud command
-    logging.debug('Executing: %s', " ".join(cmds))
-    proc = subprocess.Popen(cmds,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True)
-    returncode = proc.wait(timeout=GCLOUD_CMD_TIMEOUT_S)
-    if returncode:
-        logging.error('> Failed to execute cmd [%s], returned %d, stderr: %s',
-                      " ".join(cmds), returncode, proc.stderr.read())
-        return None
-    return json.loads(proc.stdout.read())
+    return json.loads(exec_command(*cmds))
 
 
 def remove_relative_resources_run_xds_tests(suffix: str):
     """Removing GCP resources created by run_xds_tests.py."""
     logging.info('Removing run_xds_tests.py resources with suffix [%s]', suffix)
-    exec_gcloud('compute', 'forwarding-rules', 'delete',
-                f'test-forwarding-rule{suffix}', '--global')
-    exec_gcloud('compute', 'target-http-proxies', 'delete',
-                f'test-target-proxy{suffix}')
-    exec_gcloud('alpha', 'compute', 'target-grpc-proxies', 'delete',
-                f'test-target-proxy{suffix}')
-    exec_gcloud('compute', 'url-maps', 'delete', f'test-map{suffix}')
-    exec_gcloud('compute', 'backend-services', 'delete',
-                f'test-backend-service{suffix}', '--global')
-    exec_gcloud('compute', 'backend-services', 'delete',
-                f'test-backend-service-alternate{suffix}', '--global')
-    exec_gcloud('compute', 'backend-services', 'delete',
-                f'test-backend-service-extra{suffix}', '--global')
-    exec_gcloud('compute', 'backend-services', 'delete',
-                f'test-backend-service-more-extra{suffix}', '--global')
-    exec_gcloud('compute', 'firewall-rules', 'delete', f'test-fw-rule{suffix}')
-    exec_gcloud('compute', 'health-checks', 'delete', f'test-hc{suffix}')
-    exec_gcloud('compute', 'instance-groups', 'managed', 'delete',
-                f'test-ig{suffix}', '--zone', ZONE)
-    exec_gcloud('compute', 'instance-groups', 'managed', 'delete',
-                f'test-ig-same-zone{suffix}', '--zone', ZONE)
-    exec_gcloud('compute', 'instance-groups', 'managed', 'delete',
-                f'test-ig-secondary-zone{suffix}', '--zone', SECONDARY_ZONE)
-    exec_gcloud('compute', 'instance-templates', 'delete',
-                f'test-template{suffix}')
+    cmds = [
+        sys.executable, RUN_XDS_TESTS, '--clean_only', '--gcp_suffix', suffix
+    ]
+    if args.dry_run:
+        logging.debug('> Skipped: %s', " ".join(cmds))
+        return
+    exec_command(cmds, cwd=ROOT)
 
 
 def remove_relative_resources_psm_sec(prefix: str):
     """Removing GCP resources created by PSM Sec framework."""
     logging.info('Removing PSM Security resources with prefix [%s]', prefix)
-    exec_gcloud('compute', 'forwarding-rules', 'delete',
-                f'{prefix}-forwarding-rule', '--global')
-    exec_gcloud('alpha', 'compute', 'target-grpc-proxies', 'delete',
-                f'{prefix}-target-proxy')
-    exec_gcloud('compute', 'url-maps', 'delete', f'{prefix}-url-map')
-    exec_gcloud('compute', 'backend-services', 'delete',
-                f'{prefix}-backend-service', '--global')
-    exec_gcloud('compute', 'health-checks', 'delete', f'{prefix}-health-check')
-    exec_gcloud('compute', 'firewall-rules', 'delete',
-                f'{prefix}-allow-health-checks')
-    exec_gcloud('alpha', 'network-security', 'server-tls-policies', 'delete',
-                f'{prefix}-server-tls-policy')
-    exec_gcloud('alpha', 'network-security', 'client-tls-policies', 'delete',
-                f'{prefix}-client-tls-policy')
+    cmds = [
+        sys.executable,
+        '-m',
+        'bin.run_td_setup',
+        '--cmd',
+        'cleanup',
+        '--flagfile',
+        'config/grpc-testing.cfg',
+        '--namespace',
+        prefix,
+        # Following arguments doesn't matter
+        '--kube_context',
+        'DUMMY_DOES_MATTER',
+        '--server_image',
+        'DUMMY_DOES_MATTER',
+        '--client_image',
+        'DUMMY_DOES_MATTER'
+    ]
+    if args.dry_run:
+        logging.debug('> Skipped: %s', " ".join(cmds))
+        return
+    exec_command(cmds,
+                 cwd=os.path.join(ROOT, 'tools', 'run_tests',
+                                  'xds_k8s_test_driver'))
 
 
 def check_one_type_of_gcp_resources(list_cmd: List[str],
-                                    suffix_search: str = '',
-                                    prefix_search: str = ''):
-    logging.info('Checking GCP resources with %s or %s', suffix_search,
-                 prefix_search)
+                                    old_framework_residual_search: str = '',
+                                    new_framework_residual_search: str = ''):
+    logging.info('Checking GCP resources with %s or %s',
+                 old_framework_residual_search, new_framework_residual_search)
     for resource in exec_gcloud(*list_cmd):
-        if suffix_search:
-            result = re.search(suffix_search, resource['name'])
+        if old_framework_residual_search:
+            result = re.search(old_framework_residual_search, resource['name'])
             if result is not None:
                 remove_relative_resources_run_xds_tests(result.group(1))
                 continue
 
-        if prefix_search:
-            result = re.search(prefix_search, resource['name'])
+        if new_framework_residual_search:
+            result = re.search(new_framework_residual_search, resource['name'])
             if result is not None:
                 remove_relative_resources_psm_sec(result.group(1))
                 continue
 
 
 def check_costly_gcp_resources() -> None:
-    check_one_type_of_gcp_resources(['compute', 'forwarding-rules', 'list'],
-                                    suffix_search=r'test-forwarding-rule(.*)',
-                                    prefix_search=r'(.+?)-forwarding-rule')
-    check_one_type_of_gcp_resources(['compute', 'target-http-proxies', 'list'],
-                                    suffix_search=r'test-target-proxy(.*)')
-    check_one_type_of_gcp_resources(['compute', 'target-grpc-proxies', 'list'],
-                                    suffix_search=r'test-target-proxy(.*)',
-                                    prefix_search=r'(.+?)-target-proxy')
-    check_one_type_of_gcp_resources(['compute', 'url-maps', 'list'],
-                                    suffix_search=r'test-map(.*)',
-                                    prefix_search=r'(.+?)-url-map')
-    check_one_type_of_gcp_resources(['compute', 'backend-services', 'list'],
-                                    suffix_search=r'test-backend-service(.*)',
-                                    prefix_search=r'(.+?)-backend-service')
+    check_one_type_of_gcp_resources(
+        ['compute', 'forwarding-rules', 'list'],
+        old_framework_residual_search=r'^test-forwarding-rule(.*)$',
+        new_framework_residual_search=r'^(.+?)-forwarding-rule$')
+    check_one_type_of_gcp_resources(
+        ['compute', 'target-http-proxies', 'list'],
+        old_framework_residual_search=r'^test-target-proxy(.*)$')
+    check_one_type_of_gcp_resources(
+        ['compute', 'target-grpc-proxies', 'list'],
+        old_framework_residual_search=r'^test-target-proxy(.*)$',
+        new_framework_residual_search=r'^(.+?)-target-proxy$')
+    check_one_type_of_gcp_resources(
+        ['compute', 'url-maps', 'list'],
+        old_framework_residual_search=r'^test-map(.*)$',
+        new_framework_residual_search=r'^(.+?)-url-map$')
+    check_one_type_of_gcp_resources(
+        ['compute', 'backend-services', 'list'],
+        old_framework_residual_search=r'^test-backend-service(.*)$',
+        new_framework_residual_search=r'^(.+?)-backend-service$')
 
 
 def main():

--- a/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
+++ b/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
@@ -119,19 +119,19 @@ def remove_relative_resources_psm_sec(prefix: str):
 
 
 def check_one_type_of_gcp_resources(list_cmd: List[str],
-                                    old_framework_residual_search: str = '',
-                                    new_framework_residual_search: str = ''):
+                                    run_xds_tests_residual_search: str = '',
+                                    psm_sec_tests_residual_search: str = ''):
     logging.info('Checking GCP resources with %s or %s',
-                 old_framework_residual_search, new_framework_residual_search)
+                 run_xds_tests_residual_search, psm_sec_tests_residual_search)
     for resource in exec_gcloud(*list_cmd):
-        if old_framework_residual_search:
-            result = re.search(old_framework_residual_search, resource['name'])
+        if run_xds_tests_residual_search:
+            result = re.search(run_xds_tests_residual_search, resource['name'])
             if result is not None:
                 remove_relative_resources_run_xds_tests(result.group(1))
                 continue
 
-        if new_framework_residual_search:
-            result = re.search(new_framework_residual_search, resource['name'])
+        if psm_sec_tests_residual_search:
+            result = re.search(psm_sec_tests_residual_search, resource['name'])
             if result is not None:
                 remove_relative_resources_psm_sec(result.group(1))
                 continue
@@ -140,23 +140,16 @@ def check_one_type_of_gcp_resources(list_cmd: List[str],
 def check_costly_gcp_resources() -> None:
     check_one_type_of_gcp_resources(
         ['compute', 'forwarding-rules', 'list'],
-        old_framework_residual_search=r'^test-forwarding-rule(.*)$',
-        new_framework_residual_search=r'^(.+?)-forwarding-rule$')
-    check_one_type_of_gcp_resources(
-        ['compute', 'target-http-proxies', 'list'],
-        old_framework_residual_search=r'^test-target-proxy(.*)$')
-    check_one_type_of_gcp_resources(
-        ['compute', 'target-grpc-proxies', 'list'],
-        old_framework_residual_search=r'^test-target-proxy(.*)$',
-        new_framework_residual_search=r'^(.+?)-target-proxy$')
+        run_xds_tests_residual_search=r'^test-forwarding-rule(.*)$',
+        psm_sec_tests_residual_search=r'^(.+?)-forwarding-rule$')
     check_one_type_of_gcp_resources(
         ['compute', 'url-maps', 'list'],
-        old_framework_residual_search=r'^test-map(.*)$',
-        new_framework_residual_search=r'^(.+?)-url-map$')
+        run_xds_tests_residual_search=r'^test-map(.*)$',
+        psm_sec_tests_residual_search=r'^(.+?)-url-map$')
     check_one_type_of_gcp_resources(
         ['compute', 'backend-services', 'list'],
-        old_framework_residual_search=r'^test-backend-service(.*)$',
-        new_framework_residual_search=r'^(.+?)-backend-service$')
+        run_xds_tests_residual_search=r'^test-backend-service(.*)$',
+        psm_sec_tests_residual_search=r'^(.+?)-backend-service$')
 
 
 def main():

--- a/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
+++ b/tools/run_tests/helper_scripts/clean_xds_interop_resources.py
@@ -86,7 +86,8 @@ def remove_relative_resources_run_xds_tests(suffix: str):
     """Removing GCP resources created by run_xds_tests.py."""
     logging.info('Removing run_xds_tests.py resources with suffix [%s]', suffix)
     cmds = [
-        sys.executable, RUN_XDS_TESTS, '--clean_only', '--gcp_suffix', suffix
+        sys.executable, RUN_XDS_TESTS, '--clean_only',
+        f'--gcp_suffix="{suffix}"', '--verbose'
     ]
     if args.dry_run:
         logging.debug('> Skipped: %s', " ".join(cmds))
@@ -101,19 +102,13 @@ def remove_relative_resources_psm_sec(prefix: str):
         sys.executable,
         '-m',
         'bin.run_td_setup',
-        '--cmd',
-        'cleanup',
-        '--flagfile',
-        'config/grpc-testing.cfg',
-        '--namespace',
-        prefix,
+        '--cmd=cleanup',
+        '--flagfile=config/grpc-testing.cfg',
+        f'--namespace={prefix}',
         # Following arguments doesn't matter
-        '--kube_context',
-        'DUMMY_DOES_MATTER',
-        '--server_image',
-        'DUMMY_DOES_MATTER',
-        '--client_image',
-        'DUMMY_DOES_MATTER'
+        '--kube_context=DUMMY_DOES_MATTER',
+        '--server_image=DUMMY_DOES_MATTER',
+        '--client_image=DUMMY_DOES_MATTER'
     ]
     if args.dry_run:
         logging.debug('> Skipped: %s', " ".join(cmds))


### PR DESCRIPTION
This script needs a google3 counterpart to run as a cron job. This PR itself is sufficient to be invoked manually (`--dry_run` to skip the actual deletion):

```sh
python3 tools/run_tests/helper_scripts/clean_xds_interop_resources.py --dry_run
```

The target resources are found through searching forwarding-rule, target-proxy, url-map, and backend-services. It's possible that there are still some forgotten resources. But this could be a good start.

Next step, if we actively clean up resources created by test, we can potentially keep resources created by failed test runs for debugging purposes. We can limit the number of total kept set of resources, and how maximum lifespan.

---

Also, credit to a gpaste snippet wrote by @ericgribkoff that cleans up the GCP resources. Otherwise, I won't know the right order of deletion or if I really get all of them.