### PR TITLE
Update conditional matcher ctors and include NotMatcher.

### DIFF
--- a/src/core/lib/security/authorization/matchers.h
+++ b/src/core/lib/security/authorization/matchers.h
@@ -47,46 +47,46 @@ class AuthorizationMatcher {
 
 class AlwaysAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit AlwaysAuthorizationMatcher(bool not_rule = false)
-      : not_rule_(not_rule) {}
+  explicit AlwaysAuthorizationMatcher() = default;
 
-  bool Matches(const EvaluateArgs&) const override { return !not_rule_; }
-
- private:
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
+  bool Matches(const EvaluateArgs&) const override { return true; }
 };
 
 class AndAuthorizationMatcher : public AuthorizationMatcher {
  public:
   explicit AndAuthorizationMatcher(
-      std::vector<std::unique_ptr<Rbac::Permission>> rules,
-      bool not_rule = false);
-  explicit AndAuthorizationMatcher(
-      std::vector<std::unique_ptr<Rbac::Principal>> ids, bool not_rule = false);
+      std::vector<std::unique_ptr<AuthorizationMatcher>> matchers)
+      : matchers_(std::move(matchers)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
   std::vector<std::unique_ptr<AuthorizationMatcher>> matchers_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 class OrAuthorizationMatcher : public AuthorizationMatcher {
  public:
   explicit OrAuthorizationMatcher(
-      std::vector<std::unique_ptr<Rbac::Permission>> rules,
-      bool not_rule = false);
-  explicit OrAuthorizationMatcher(
-      std::vector<std::unique_ptr<Rbac::Principal>> ids, bool not_rule = false);
+      std::vector<std::unique_ptr<AuthorizationMatcher>> matchers)
+      : matchers_(std::move(matchers)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
   std::vector<std::unique_ptr<AuthorizationMatcher>> matchers_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
+};
+
+// Negates matching the provided permission/principal.
+class NotAuthorizationMatcher : public AuthorizationMatcher {
+ public:
+  explicit NotAuthorizationMatcher(
+      std::unique_ptr<AuthorizationMatcher> matcher)
+      : matcher_(std::move(matcher)) {}
+
+  bool Matches(const EvaluateArgs& args) const override;
+
+ private:
+  std::unique_ptr<AuthorizationMatcher> matcher_;
 };
 
 // TODO(ashithasantosh): Add matcher implementation for metadata field.
@@ -94,16 +94,13 @@ class OrAuthorizationMatcher : public AuthorizationMatcher {
 // Perform a match against HTTP headers.
 class HeaderAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit HeaderAuthorizationMatcher(HeaderMatcher matcher,
-                                      bool not_rule = false)
-      : matcher_(std::move(matcher)), not_rule_(not_rule) {}
+  explicit HeaderAuthorizationMatcher(HeaderMatcher matcher)
+      : matcher_(std::move(matcher)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
   const HeaderMatcher matcher_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 // Perform a match against IP Cidr Range.
@@ -116,8 +113,7 @@ class IpAuthorizationMatcher : public AuthorizationMatcher {
     kRemoteIp,
   };
 
-  IpAuthorizationMatcher(Type type, Rbac::CidrRange range,
-                         bool not_rule = false);
+  IpAuthorizationMatcher(Type type, Rbac::CidrRange range);
 
   bool Matches(const EvaluateArgs& args) const override;
 
@@ -126,38 +122,30 @@ class IpAuthorizationMatcher : public AuthorizationMatcher {
   // Subnet masked address.
   grpc_resolved_address subnet_address_;
   const uint32_t prefix_len_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 // Perform a match against port number of the destination (local) address.
 class PortAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit PortAuthorizationMatcher(int port, bool not_rule = false)
-      : port_(port), not_rule_(not_rule) {}
+  explicit PortAuthorizationMatcher(int port) : port_(port) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
   const int port_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 // Matches the principal name as described in the peer certificate. Uses URI SAN
 // or DNS SAN in that order, otherwise uses subject field.
 class AuthenticatedAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit AuthenticatedAuthorizationMatcher(StringMatcher auth,
-                                             bool not_rule = false)
-      : matcher_(std::move(auth)), not_rule_(not_rule) {}
+  explicit AuthenticatedAuthorizationMatcher(StringMatcher auth)
+      : matcher_(std::move(auth)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
   const StringMatcher matcher_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 // Perform a match against the request server from the client's connection
@@ -165,29 +153,25 @@ class AuthenticatedAuthorizationMatcher : public AuthorizationMatcher {
 class ReqServerNameAuthorizationMatcher : public AuthorizationMatcher {
  public:
   explicit ReqServerNameAuthorizationMatcher(
-      StringMatcher requested_server_name, bool not_rule = false)
-      : matcher_(std::move(requested_server_name)), not_rule_(not_rule) {}
+      StringMatcher requested_server_name)
+      : matcher_(std::move(requested_server_name)) {}
 
   bool Matches(const EvaluateArgs&) const override;
 
  private:
   const StringMatcher matcher_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 // Perform a match against the path header of HTTP request.
 class PathAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit PathAuthorizationMatcher(StringMatcher path, bool not_rule = false)
-      : matcher_(std::move(path)), not_rule_(not_rule) {}
+  explicit PathAuthorizationMatcher(StringMatcher path)
+      : matcher_(std::move(path)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
   const StringMatcher matcher_;
-  // Negates matching the provided permission/principal.
-  const bool not_rule_;
 };
 
 // Performs a match for policy field in RBAC, which is a collection of

--- a/src/core/lib/security/authorization/rbac_policy.h
+++ b/src/core/lib/security/authorization/rbac_policy.h
@@ -49,6 +49,7 @@ struct Rbac {
     enum class RuleType {
       kAnd,
       kOr,
+      kNot,
       kAny,
       kHeader,
       kPath,
@@ -60,20 +61,19 @@ struct Rbac {
     Permission() = default;
     // For kAnd/kOr RuleType.
     Permission(Permission::RuleType type,
-               std::vector<std::unique_ptr<Permission>> permissions,
-               bool not_rule = false);
+               std::vector<std::unique_ptr<Permission>> permissions);
+    // For kNot RuleType.
+    Permission(Permission::RuleType type, Permission permission);
     // For kAny RuleType.
-    explicit Permission(Permission::RuleType type, bool not_rule = false);
+    explicit Permission(Permission::RuleType type);
     // For kHeader RuleType.
-    Permission(Permission::RuleType type, HeaderMatcher header_matcher,
-               bool not_rule = false);
+    Permission(Permission::RuleType type, HeaderMatcher header_matcher);
     // For kPath/kReqServerName RuleType.
-    Permission(Permission::RuleType type, StringMatcher string_matcher,
-               bool not_rule = false);
+    Permission(Permission::RuleType type, StringMatcher string_matcher);
     // For kDestIp RuleType.
-    Permission(Permission::RuleType type, CidrRange ip, bool not_rule = false);
+    Permission(Permission::RuleType type, CidrRange ip);
     // For kDestPort RuleType.
-    Permission(Permission::RuleType type, int port, bool not_rule = false);
+    Permission(Permission::RuleType type, int port);
 
     Permission(Permission&& other) noexcept;
     Permission& operator=(Permission&& other) noexcept;
@@ -85,15 +85,16 @@ struct Rbac {
     StringMatcher string_matcher;
     CidrRange ip;
     int port;
-    // For type kAnd/kOr.
+    // For type kAnd/kOr/kNot. For kNot type, the vector will have only one
+    // element.
     std::vector<std::unique_ptr<Permission>> permissions;
-    bool not_rule = false;
   };
 
   struct Principal {
     enum class RuleType {
       kAnd,
       kOr,
+      kNot,
       kAny,
       kPrincipalName,
       kSourceIp,
@@ -106,18 +107,17 @@ struct Rbac {
     Principal() = default;
     // For kAnd/kOr RuleType.
     Principal(Principal::RuleType type,
-              std::vector<std::unique_ptr<Principal>> principals,
-              bool not_rule = false);
+              std::vector<std::unique_ptr<Principal>> principals);
+    // For kNot RuleType.
+    Principal(Principal::RuleType type, Principal principal);
     // For kAny RuleType.
-    explicit Principal(Principal::RuleType type, bool not_rule = false);
+    explicit Principal(Principal::RuleType type);
     // For kPrincipalName/kPath RuleType.
-    Principal(Principal::RuleType type, StringMatcher string_matcher,
-              bool not_rule = false);
+    Principal(Principal::RuleType type, StringMatcher string_matcher);
     // For kSourceIp/kDirectRemoteIp/kRemoteIp RuleType.
-    Principal(Principal::RuleType type, CidrRange ip, bool not_rule = false);
+    Principal(Principal::RuleType type, CidrRange ip);
     // For kHeader RuleType.
-    Principal(Principal::RuleType type, HeaderMatcher header_matcher,
-              bool not_rule = false);
+    Principal(Principal::RuleType type, HeaderMatcher header_matcher);
 
     Principal(Principal&& other) noexcept;
     Principal& operator=(Principal&& other) noexcept;
@@ -128,9 +128,9 @@ struct Rbac {
     HeaderMatcher header_matcher;
     StringMatcher string_matcher;
     CidrRange ip;
-    // For type kAnd/kOr.
+    // For type kAnd/kOr/kNot. For kNot type, the vector will have only one
+    // element.
     std::vector<std::unique_ptr<Principal>> principals;
-    bool not_rule = false;
   };
 
   struct Policy {

--- a/test/core/security/grpc_authorization_engine_test.cc
+++ b/test/core/security/grpc_authorization_engine_test.cc
@@ -23,8 +23,10 @@ namespace grpc_core {
 
 TEST(GrpcAuthorizationEngineTest, AllowEngineWithMatchingPolicy) {
   Rbac::Policy policy1(
-      Rbac::Permission(Rbac::Permission::RuleType::kAny, /*not_rule=*/true),
-      Rbac::Principal(Rbac::Principal::RuleType::kAny, /*not_rule=*/true));
+      Rbac::Permission(Rbac::Permission::RuleType::kNot,
+                       Rbac::Permission(Rbac::Permission::RuleType::kAny)),
+      Rbac::Principal(Rbac::Principal::RuleType::kNot,
+                      Rbac::Principal(Rbac::Principal::RuleType::kAny)));
   Rbac::Policy policy2((Rbac::Permission(Rbac::Permission::RuleType::kAny)),
                        (Rbac::Principal(Rbac::Principal::RuleType::kAny)));
   std::map<std::string, Rbac::Policy> policies;
@@ -40,8 +42,10 @@ TEST(GrpcAuthorizationEngineTest, AllowEngineWithMatchingPolicy) {
 
 TEST(GrpcAuthorizationEngineTest, AllowEngineWithNoMatchingPolicy) {
   Rbac::Policy policy1(
-      Rbac::Permission(Rbac::Permission::RuleType::kAny, /*not_rule=*/true),
-      Rbac::Principal(Rbac::Principal::RuleType::kAny, /*not_rule=*/true));
+      Rbac::Permission(Rbac::Permission::RuleType::kNot,
+                       Rbac::Permission(Rbac::Permission::RuleType::kAny)),
+      Rbac::Principal(Rbac::Principal::RuleType::kNot,
+                      Rbac::Principal(Rbac::Principal::RuleType::kAny)));
   std::map<std::string, Rbac::Policy> policies;
   policies["policy1"] = std::move(policy1);
   Rbac rbac(Rbac::Action::kAllow, std::move(policies));
@@ -62,8 +66,10 @@ TEST(GrpcAuthorizationEngineTest, AllowEngineWithEmptyPolicies) {
 
 TEST(GrpcAuthorizationEngineTest, DenyEngineWithMatchingPolicy) {
   Rbac::Policy policy1(
-      Rbac::Permission(Rbac::Permission::RuleType::kAny, /*not_rule=*/true),
-      Rbac::Principal(Rbac::Principal::RuleType::kAny, /*not_rule=*/true));
+      Rbac::Permission(Rbac::Permission::RuleType::kNot,
+                       Rbac::Permission(Rbac::Permission::RuleType::kAny)),
+      Rbac::Principal(Rbac::Principal::RuleType::kNot,
+                      Rbac::Principal(Rbac::Principal::RuleType::kAny)));
   Rbac::Policy policy2((Rbac::Permission(Rbac::Permission::RuleType::kAny)),
                        (Rbac::Principal(Rbac::Principal::RuleType::kAny)));
   std::map<std::string, Rbac::Policy> policies;
@@ -79,8 +85,10 @@ TEST(GrpcAuthorizationEngineTest, DenyEngineWithMatchingPolicy) {
 
 TEST(GrpcAuthorizationEngineTest, DenyEngineWithNoMatchingPolicy) {
   Rbac::Policy policy1(
-      Rbac::Permission(Rbac::Permission::RuleType::kAny, /*not_rule=*/true),
-      Rbac::Principal(Rbac::Principal::RuleType::kAny, /*not_rule=*/true));
+      Rbac::Permission(Rbac::Permission::RuleType::kNot,
+                       Rbac::Permission(Rbac::Permission::RuleType::kAny)),
+      Rbac::Principal(Rbac::Principal::RuleType::kNot,
+                      Rbac::Principal(Rbac::Principal::RuleType::kAny)));
   std::map<std::string, Rbac::Policy> policies;
   policies["policy1"] = std::move(policy1);
   Rbac rbac(Rbac::Action::kDeny, std::move(policies));


### PR DESCRIPTION
1. Updates conditional matchers to expose single ctor instead of separate ctors for permission and principal config.
2. Adds NotAuthorizationMatcher

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26256)
<!-- Reviewable:end -->
