### PR TITLE
Fix invalid argument in README example for loadtest_config.py

### DIFF
--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -241,7 +241,7 @@ twice:
 $ ./tools/run_tests/performance/loadtest_config.py -l go -l java \
     -t ./tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml \
     -s client_pool=workers-8core -s server_pool=workers-8core \
-    -s big_query_table=grpc-testing.e2e_benchmarks.experimental_results \
+    -s big_query_table=e2e_benchmarks.experimental_results \
     -s timeout_seconds=3600 --category=scalable \
     -d --allow_client_language=c++ --allow_server_language=c++ \
     --runs_per_test=2 -o ./loadtest.yaml


### PR DESCRIPTION
This example crashes the driver process, since `bq_upload_result.py` expects
the `big_query_table` argument to have the format `<dataset name>.<table name>`.
The project ID is already encoded in the script.

```
+ python3 /src/code/tools/run_tests/performance/bq_upload_result.py --bq_result_table=grpc-testing.e2e_benchmarks.experimental_results_hork_x5
Traceback (most recent call last):
  File "/src/code/tools/run_tests/performance/bq_upload_result.py", line 177, in <module>
    dataset_id, table_id = args.bq_result_table.split('.', 2)
ValueError: too many values to unpack (expected 2)
```
