### PR TITLE
Bugfix/issue 24422 add trace list flag can create cycles

### DIFF
--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -39,22 +39,21 @@ namespace grpc_core {
 TraceFlag* TraceFlagList::root_tracer_ = nullptr;
 
 bool TraceFlagList::Set(const char* name, bool enabled) {
-  TraceFlag* t;
   if (0 == strcmp(name, "all")) {
-    for (t = root_tracer_; t != nullptr; t = t->next_tracer_) {
+    for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
       t->set_enabled(enabled);
     }
   } else if (0 == strcmp(name, "list_tracers")) {
     LogAllTracers();
   } else if (0 == strcmp(name, "refcount")) {
-    for (t = root_tracer_; t != nullptr; t = t->next_tracer_) {
+    for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
       if (strstr(t->name_, "refcount") != nullptr) {
         t->set_enabled(enabled);
       }
     }
   } else {
     bool found = false;
-    for (t = root_tracer_; t != nullptr; t = t->next_tracer_) {
+    for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
       if (0 == strcmp(name, t->name_)) {
         t->set_enabled(enabled);
         found = true;
@@ -70,9 +69,9 @@ bool TraceFlagList::Set(const char* name, bool enabled) {
 }
 
 void TraceFlagList::Add(TraceFlag* flag) {
-  bool found = false;
+  gpr_log(GPR_DEBUG, "Add tracer:\t%s", flag->name_);
   // prevent cycles at 'Add' flag to 'root_tracer_'
-  for (t = root_tracer_; t != nullptr; t = t->next_tracer_) {
+  for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
     // check if flag is already part of 'root_tracer_'
     if (t == flag) {
       return;
@@ -84,8 +83,7 @@ void TraceFlagList::Add(TraceFlag* flag) {
 
 void TraceFlagList::LogAllTracers() {
   gpr_log(GPR_DEBUG, "available tracers:");
-  TraceFlag* t;
-  for (t = root_tracer_; t != nullptr; t = t->next_tracer_) {
+  for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
     gpr_log(GPR_DEBUG, "\t%s", t->name_);
   }
 }

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -49,21 +49,21 @@ bool TraceFlagList::Set(const char* name, bool enabled) {
     for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
       if (strstr(t->name_, "refcount") != nullptr) {
         t->set_enabled(enabled);
+        return true;
       }
     }
+  } else if (0 == strcmp(name, "")) {
+    return true;
   } else {
-    bool found = false;
-    for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
+    for (auto t = root_tracer_; t != nullptr || found; t = t->next_tracer_) {
       if (0 == strcmp(name, t->name_)) {
         t->set_enabled(enabled);
-        found = true;
+        return true;
       }
     }
     // check for unknowns, but ignore "", to allow to GRPC_TRACE=
-    if (!found && 0 != strcmp(name, "")) {
-      gpr_log(GPR_ERROR, "Unknown trace var: '%s'", name);
-      return false; /* early return */
-    }
+    gpr_log(GPR_ERROR, "Unknown trace var: '%s'", name);
+    return false; /* early return */
   }
   return true;
 }

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -39,7 +39,9 @@ namespace grpc_core {
 TraceFlag* TraceFlagList::root_tracer_ = nullptr;
 
 bool TraceFlagList::Set(const char* name, bool enabled) {
-  if (0 == strcmp(name, "all")) {
+  if (0 == strlen(name)) {
+    gpr_log(GPR_DEBUG, "No trace flags are changed");
+  } else if (0 == strcmp(name, "all")) {
     for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
       t->set_enabled(enabled);
     }
@@ -49,11 +51,9 @@ bool TraceFlagList::Set(const char* name, bool enabled) {
     for (auto t = root_tracer_; t != nullptr; t = t->next_tracer_) {
       if (strstr(t->name_, "refcount") != nullptr) {
         t->set_enabled(enabled);
-        return true;
+        break;
       }
     }
-  } else if (0 == strcmp(name, "")) {
-    return true;
   } else {
     for (auto t = root_tracer_; t != nullptr || found; t = t->next_tracer_) {
       if (0 == strcmp(name, t->name_)) {

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -75,14 +75,11 @@ void TraceFlagList::Add(TraceFlag* flag) {
   for (t = root_tracer_; t != nullptr; t = t->next_tracer_) {
     // check if flag is already part of 'root_tracer_'
     if (t == flag) {
-      found = true;
+      return;
     }
   }
-  // append ot 'root_tracer_' only if not found
-  if (! found) {
-    flag->next_tracer_ = root_tracer_;
-    root_tracer_ = flag;
-  }
+  flag->next_tracer_ = root_tracer_;
+  root_tracer_ = flag;
 }
 
 void TraceFlagList::LogAllTracers() {


### PR DESCRIPTION
This PR should solve issue https://github.com/grpc/grpc/issues/24422
The issue is caused by grpc used in different execution units (shared libs) in one process which causes the TraceFlags to be added not only once to the TraceFlagList. This lead to a cycle in the list which caused endless loops during initialization.
Since the root cause static global variable initialization cannot be fixed easily the fix just checks if a TraceFlag is already in the TraceFlagList and if so doesn't add it again to prevent from cycles.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
