### PR TITLE
Update load test deadlines and differentiate kokoro runs.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.cfg
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_e2e_performance_gke.sh"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.cfg
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_e2e_performance_v2.sh"
-timeout_mins: 120
+timeout_mins: 720
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -33,7 +33,15 @@ gcloud container clusters get-credentials benchmarks-prod \
 kubectl get pods | grep -v Completed
 
 # Set up environment variables.
-PREBUILT_IMAGE_PREFIX="gcr.io/grpc-testing/e2etesting/pre_built_workers/${KOKORO_BUILD_INITIATOR}"
+# BEGIN differentiate experimental configuration from master configuration.
+LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
+if [[ "${KOKORO_BUILD_INITIATOR}" == kokoro ]]; then
+    LOAD_TEST_PREFIX=kokoro-test
+fi
+BIGQUERY_TABLE_8CORE=e2e_benchmarks.experimental_results
+BIGQUERY_TABLE_32CORE=e2e_benchmarks.experimental_results_32core
+# END differentiate experimental configuration from master configuration.
+PREBUILT_IMAGE_PREFIX="gcr.io/grpc-testing/e2etesting/pre_built_workers/${LOAD_TEST_PREFIX}"
 UNIQUE_IDENTIFIER="$(date +%Y%m%d%H%M%S)"
 ROOT_DIRECTORY_OF_DOCKERFILES="../test-infra/containers/pre_built_workers/"
 # Prebuilt workers for core languages are always built from grpc/grpc.
@@ -66,15 +74,15 @@ buildConfigs() {
         -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
         -s prebuilt_image_tag="${UNIQUE_IDENTIFIER}" \
-        --prefix="${KOKORO_BUILD_INITIATOR}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
+        --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
-buildConfigs workers-8core e2e_benchmarks.experimental_results -l c++ -l csharp -l go -l java -l python -l ruby
+buildConfigs workers-8core "${BIGQUERY_TABLE_8CORE}" -l c++ -l csharp -l go -l java -l python -l ruby
 
-buildConfigs workers-32core e2e_benchmarks.experimental_results_32core -l c++ -l csharp -l go -l java
+buildConfigs workers-32core "${BIGQUERY_TABLE_32CORE}" -l c++ -l csharp -l go -l java
 
 # Delete prebuilt images on exit.
 deleteImages() {


### PR DESCRIPTION
This change sets the deadline of master and experimental kokoro jobs to match their running interval (4 hours and 12 hours), and makes a change so runs initiated by kokoro are marked 'kokoro' for the master job and 'kokoro-test' for the experimental job.