### PR TITLE
fix xds resolver to add XdsClient to channel args even on errors

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -824,7 +824,8 @@ void XdsResolver::OnError(grpc_error_handle error) {
   gpr_log(GPR_ERROR, "[xds_resolver %p] received error from XdsClient: %s",
           this, grpc_error_std_string(error).c_str());
   Result result;
-  result.args = grpc_channel_args_copy(args_);
+  grpc_arg new_arg = xds_client_->MakeChannelArg();
+  result.args = grpc_channel_args_copy_and_add(args_, &new_arg, 1);
   result.service_config_error = error;
   result_handler_->ReturnResult(std::move(result));
 }


### PR DESCRIPTION
This was accidentally broken in #25936, but there was no test to exercise the edge case in which this problem occurred (the xDS call failing and then getting an update that changes the CDS resource immediately upon creating the new xDS call), so it wasn't noticed at the time.  This PR adds such a test, and I've verified that the test fails without the fix.

This test also uncovered another unrelated bug, which I've added a TODO about.  I believe this other bug is not new and is much less severe, so I'll work on fixing that separately.