### PR TITLE
Provide custom sponge configs to exclude manual runs from testgrid

### DIFF
--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -58,7 +58,9 @@ docker run \
   -e "KOKORO_BUILD_NUMBER=$KOKORO_BUILD_NUMBER" \
   -e "KOKORO_BUILD_URL=$KOKORO_BUILD_URL" \
   -e "KOKORO_JOB_NAME=$KOKORO_JOB_NAME" \
+  -e "KOKORO_ARTIFACTS_DIR=$KOKORO_ARTIFACTS_DIR" \
   -v "$git_root:/var/local/jenkins/grpc:ro" \
+  -v "$KOKORO_ARTIFACTS_DIR:$KOKORO_ARTIFACTS_DIR" \
   -w /var/local/git/grpc \
   --name="$CONTAINER_NAME" \
   $EXTRA_DOCKER_ARGS \

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -59,6 +59,7 @@ docker run \
   -e "KOKORO_BUILD_URL=$KOKORO_BUILD_URL" \
   -e "KOKORO_JOB_NAME=$KOKORO_JOB_NAME" \
   -e "KOKORO_ARTIFACTS_DIR=$KOKORO_ARTIFACTS_DIR" \
+  -e "KOKORO_GITHUB_COMMIT_URL=$KOKORO_GITHUB_COMMIT_URL" \
   -v "$git_root:/var/local/jenkins/grpc:ro" \
   -v "$KOKORO_ARTIFACTS_DIR:$KOKORO_ARTIFACTS_DIR" \
   -w /var/local/git/grpc \

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -60,8 +60,7 @@ docker run \
   -e "KOKORO_JOB_NAME=$KOKORO_JOB_NAME" \
   -e "KOKORO_ARTIFACTS_DIR=$KOKORO_ARTIFACTS_DIR" \
   -e "GIT_ORIGIN_URL=$(git -C $git_root remote get-url origin)" \
-  # This environment variable is used by run_xds_tests and PSM Sec to prevent
-  # certain run from appearing on the Testgrid.
+  -e "GIT_COMMIT_SHORT=$(git -C $git_root rev-parse --short HEAD)" \
   -e "TESTGRID_EXCLUDE=$TESTGRID_EXCLUDE" \
   -v "$git_root:/var/local/jenkins/grpc:ro" \
   -v "$KOKORO_ARTIFACTS_DIR:$KOKORO_ARTIFACTS_DIR" \

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -59,7 +59,10 @@ docker run \
   -e "KOKORO_BUILD_URL=$KOKORO_BUILD_URL" \
   -e "KOKORO_JOB_NAME=$KOKORO_JOB_NAME" \
   -e "KOKORO_ARTIFACTS_DIR=$KOKORO_ARTIFACTS_DIR" \
-  -e "KOKORO_GITHUB_COMMIT_URL=$KOKORO_GITHUB_COMMIT_URL" \
+  -e "GIT_ORIGIN_URL=$(git -C $git_root remote get-url origin)" \
+  # This environment variable is used by run_xds_tests and PSM Sec to prevent
+  # certain run from appearing on the Testgrid.
+  -e "TESTGRID_EXCLUDE=$TESTGRID_EXCLUDE" \
   -v "$git_root:/var/local/jenkins/grpc:ro" \
   -v "$KOKORO_ARTIFACTS_DIR:$KOKORO_ARTIFACTS_DIR" \
   -w /var/local/git/grpc \

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2242,14 +2242,13 @@ def maybe_write_sponge_properties():
     """Writing test infos to enable more advanced testgrid searches."""
     if 'KOKORO_ARTIFACTS_DIR' not in os.environ:
         return
-
-    project_root = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                '../..')
-    git_origin_url = subprocess.getoutput('git -C "%s" remote get-url origin' %
-                                          project_root)
-    git_commit_short = subprocess.getoutput(
-        'git -C "%s" rev-parse --short HEAD' % project_root)
-
+    if 'KOKORO_GITHUB_COMMIT_URL' not in os.environ:
+        return
+    # Commit url example:
+    # KOKORO_GITHUB_COMMIT_URL="https://github.com/lidizheng/grpc/commit/e38cbb245a69b3112bb65b164ce2ca6b2dff0d7b"
+    tokens = os.environ['KOKORO_GITHUB_COMMIT_URL'].split('/commit/')
+    git_origin_url = tokens[0] + '.git'
+    git_commit_short = tokens[1][:10]
     properties = [
         # Technically, 'TESTS_FORMAT_VERSION' is not required for run_xds_tests.
         # We keep it here so one day we may merge the process of writing sponge

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2242,20 +2242,19 @@ def maybe_write_sponge_properties():
     """Writing test infos to enable more advanced testgrid searches."""
     if 'KOKORO_ARTIFACTS_DIR' not in os.environ:
         return
-    if 'KOKORO_GITHUB_COMMIT_URL' not in os.environ:
+    if 'GIT_ORIGIN_URL' not in os.environ:
         return
-    # Commit url example:
-    # KOKORO_GITHUB_COMMIT_URL="https://github.com/lidizheng/grpc/commit/e38cbb245a69b3112bb65b164ce2ca6b2dff0d7b"
-    tokens = os.environ['KOKORO_GITHUB_COMMIT_URL'].split('/commit/')
-    git_origin_url = tokens[0] + '.git'
-    git_commit_short = tokens[1][:10]
+    project_root = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '../..')
+    git_commit_short = subprocess.getoutput(
+        'git -C "%s" rev-parse --short HEAD' % project_root)
     properties = [
         # Technically, 'TESTS_FORMAT_VERSION' is not required for run_xds_tests.
         # We keep it here so one day we may merge the process of writing sponge
         # properties.
         'TESTS_FORMAT_VERSION,2',
         'TESTGRID_EXCLUDE,%s' % os.environ.get('TESTGRID_EXCLUDE', 0),
-        'GIT_ORIGIN_URL,%s' % git_origin_url,
+        'GIT_ORIGIN_URL,%s' % os.environ['GIT_ORIGIN_URL'],
         'GIT_COMMIT_SHORT,%s' % git_commit_short,
     ]
     logger.info('Writing Sponge configs: %s', properties)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2244,10 +2244,8 @@ def maybe_write_sponge_properties():
         return
     if 'GIT_ORIGIN_URL' not in os.environ:
         return
-    project_root = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                '../..')
-    git_commit_short = subprocess.getoutput(
-        'git -C "%s" rev-parse --short HEAD' % project_root)
+    if 'GIT_COMMIT_SHORT' not in os.environ:
+        return
     properties = [
         # Technically, 'TESTS_FORMAT_VERSION' is not required for run_xds_tests.
         # We keep it here so one day we may merge the process of writing sponge
@@ -2255,7 +2253,7 @@ def maybe_write_sponge_properties():
         'TESTS_FORMAT_VERSION,2',
         'TESTGRID_EXCLUDE,%s' % os.environ.get('TESTGRID_EXCLUDE', 0),
         'GIT_ORIGIN_URL,%s' % os.environ['GIT_ORIGIN_URL'],
-        'GIT_COMMIT_SHORT,%s' % git_commit_short,
+        'GIT_COMMIT_SHORT,%s' % os.environ['GIT_COMMIT_SHORT'],
     ]
     logger.info('Writing Sponge configs: %s', properties)
     with open(

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2262,8 +2262,9 @@ def maybe_write_sponge_properties():
     logger.info('Writing Sponge configs: %s', properties)
     with open(
             os.path.join(os.environ['KOKORO_ARTIFACTS_DIR'],
-                         "custom_sponge_config.csv")) as f:
-        f.writelines(properties)
+                         "custom_sponge_config.csv"), 'w') as f:
+        f.write("\n".join(properties))
+        f.write("\n")
 
 
 def set_validate_for_proxyless(gcp, validate_for_proxyless):


### PR DESCRIPTION
Internal counterpart [cl/374442201](http://cl/374442201)

Sponge tests allow the test script to provide additional sponge configs in CSV to search test results.

This is implemented by PSM Sec framework for a while:
https://github.com/grpc/grpc/blob/c8350cce049ad057dbe29d648970f809f363ed27/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh#L229-L241

This PR hope to bring this functionality to `run_xds_tests.py` as well.

The bash scripts are scattered for xDS interop tests that we have multiple languages times v2/v3. Backporting that many bash scripts might take forever. Hence, this PR choose to add the logic to the LCA of all build runs, `run_xds_tests.py`.