### PR TITLE
Don't use legacy EDS-only flow for google-c2p resolver.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -1100,7 +1100,7 @@ class XdsClusterResolverLbFactory : public LoadBalancingPolicyFactory {
     GPR_ASSERT(uri.ok() && !uri->path().empty());
     absl::string_view server_name = absl::StripPrefix(uri->path(), "/");
     // Determine if it's an xds URI.
-    bool is_xds_uri = uri->scheme() == "xds";
+    bool is_xds_uri = uri->scheme() == "xds" || uri->scheme() == "google-c2p";
     // Get XdsClient.
     RefCountedPtr<XdsClient> xds_client =
         XdsClient::GetFromChannelArgs(*args.args);


### PR DESCRIPTION
The legacy EDS-only flow does not use the XdsClient instance from channel args and overrides the EDS resource name.  Neither of those behaviors are appropriate for the google-c2p resolver, which instead should be treated the same as the xds resolver.