### PR TITLE
Allowing for no XXHASH inlining

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -21,7 +21,9 @@
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
+#ifndef GRPC_NO_XXH_INLINE_ALL
 #define XXH_INLINE_ALL
+#endif
 #include "xxhash.h"
 
 #include <grpc/support/alloc.h>


### PR DESCRIPTION
Internally, we can toggle this new `#define` and prevent build failures.