### PR TITLE
List leftover tests that have running pods and are in Errored state.

### DIFF
--- a/tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
+++ b/tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
@@ -28,6 +28,7 @@ kubectl get pods --no-headers -o jsonpath='{range .items[*]}{.metadata.ownerRefe
     | cut -f1 -d' ' \
     | xargs -r kubectl delete loadtest
 
+# Show collected information about deleted tests.
 cat leftovertests.txt
 
 echo "END Listing and deleting leftover tests."

--- a/tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
+++ b/tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# BEGIN ignore errors.
+set +e
+
+# Find tests that have running pods and are in Errored state.
+kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
+    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.ownerReferences[0].name}'); done) \
+    | (while read f; do state=$(kubectl get loadtest "$f" --no-headers -o  jsonpath='{.status.state}'); if [[ "${state}" == Errored ]]; then echo "$f"; fi; done) \
+    | sort > leftovertests.txt
+
+# List annotations of tests that have running pods and are in Errored state.
+# Expression is intended to work across versions of kubectl.
+cat leftovertests.txt \
+    | xargs -r kubectl get loadtest --no-headers \
+    | (while read -a words; do annotations=(
+        $(kubectl get loadtest "${words[0]}" --no-headers -o jsonpath='{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.metadata.annotations.uniquifier}')
+        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":\"${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
+    | sort
+
+# END ignore errors.
+set -e
+
+# Delete tests that have running pods and are in Errored state.
+# This is a workaround for the accumulation of leftover tests.
+uniq leftovertests.txt | xargs -r kubectl delete loadtest

--- a/tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
+++ b/tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
@@ -15,20 +15,14 @@
 
 set -ex
 
-echo "BEGIN Listing and deleting leftover tests."
+echo "BEGIN Listing leftover tests."
 
-# Find tests that have running pods and are in Errored state, and delete them.
+# Find tests that have running pods and are in Errored state.
 kubectl get pods --no-headers -o jsonpath='{range .items[*]}{.metadata.ownerReferences[0].name}{" "}{.status.phase}{"\n"}{end}' \
     | grep Running \
     | cut -f1 -d' ' \
     | sort -u \
     | xargs -r kubectl get loadtest --no-headers -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.state}{" "}{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{"\n"}{end}' \
-    | grep Errored \
-    | tee leftovertests.txt \
-    | cut -f1 -d' ' \
-    | xargs -r kubectl delete loadtest
+    | grep Errored
 
-# Show collected information about deleted tests.
-cat leftovertests.txt
-
-echo "END Listing and deleting leftover tests."
+echo "END Listing leftover tests."

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -40,7 +40,7 @@ kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
     | xargs -r kubectl get loadtest --no-headers \
     | (while read -a words; do annotations=(
         $(kubectl get loadtest "${words[0]}" --no-headers -o jsonpath='{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.metadata.annotations.uniquifier}')
-        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
+        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":\"${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
     | sort
 
 # Set up environment variables.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -35,7 +35,7 @@ kubectl get pods | grep -v Completed
 # List annotations of tests that have running pods and are in Errored state.
 # Expression is intended to work across versions of kubectl.
 kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
-    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.labels.loadtest}'); done) \
+    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.ownerReferences[0].name}'); done) \
     | (while read f; do state=$(kubectl get loadtest "$f" --no-headers -o  jsonpath='{.status.state}'); if [[ "${state}" == Errored ]]; then echo "$f"; fi; done) \
     | xargs -r kubectl get loadtest --no-headers \
     | (while read -a words; do annotations=(

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -29,9 +29,6 @@ gcloud config set project grpc-testing
 gcloud container clusters get-credentials benchmarks-prod \
     --zone us-central1-b --project grpc-testing
 
-# List pods that may be left over from a previous run.
-kubectl get pods | grep -v Completed
-
 # List and delete tests that have running pods and are in errored state.
 source tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -29,8 +29,9 @@ gcloud config set project grpc-testing
 gcloud container clusters get-credentials benchmarks-prod \
     --zone us-central1-b --project grpc-testing
 
-# List and delete tests that have running pods and are in errored state.
-source tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
+# List tests that have running pods and are in errored state.
+# This is an unexpected condition, and it is logged here for monitoring.
+source tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -32,16 +32,8 @@ gcloud container clusters get-credentials benchmarks-prod \
 # List pods that may be left over from a previous run.
 kubectl get pods | grep -v Completed
 
-# List annotations of tests that have running pods and are in Errored state.
-# Expression is intended to work across versions of kubectl.
-kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
-    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.ownerReferences[0].name}'); done) \
-    | (while read f; do state=$(kubectl get loadtest "$f" --no-headers -o  jsonpath='{.status.state}'); if [[ "${state}" == Errored ]]; then echo "$f"; fi; done) \
-    | xargs -r kubectl get loadtest --no-headers \
-    | (while read -a words; do annotations=(
-        $(kubectl get loadtest "${words[0]}" --no-headers -o jsonpath='{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.metadata.annotations.uniquifier}')
-        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":\"${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
-    | sort
+# List and delete tests that have running pods and are in errored state.
+source tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -40,7 +40,7 @@ kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
     | xargs -r kubectl get loadtest --no-headers \
     | (while read -a words; do annotations=(
         $(kubectl get loadtest "${words[0]}" --no-headers -o jsonpath='{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.metadata.annotations.uniquifier}')
-        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
+        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":\"${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
     | sort
 
 # Set up environment variables.

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -35,7 +35,7 @@ kubectl get pods | grep -v Completed
 # List annotations of tests that have running pods and are in Errored state.
 # Expression is intended to work across versions of kubectl.
 kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
-    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.labels.loadtest}'); done) \
+    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.ownerReferences[0].name}'); done) \
     | (while read f; do state=$(kubectl get loadtest "$f" --no-headers -o  jsonpath='{.status.state}'); if [[ "${state}" == Errored ]]; then echo "$f"; fi; done) \
     | xargs -r kubectl get loadtest --no-headers \
     | (while read -a words; do annotations=(

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -29,9 +29,6 @@ gcloud config set project grpc-testing
 gcloud container clusters get-credentials benchmarks-prod \
     --zone us-central1-b --project grpc-testing
 
-# List pods that may be left over from a previous run.
-kubectl get pods | grep -v Completed
-
 # List and delete tests that have running pods and are in errored state.
 source tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -29,8 +29,9 @@ gcloud config set project grpc-testing
 gcloud container clusters get-credentials benchmarks-prod \
     --zone us-central1-b --project grpc-testing
 
-# List and delete tests that have running pods and are in errored state.
-source tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
+# List tests that have running pods and are in errored state.
+# This is an unexpected condition, and it is logged here for monitoring.
+source tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -32,16 +32,8 @@ gcloud container clusters get-credentials benchmarks-prod \
 # List pods that may be left over from a previous run.
 kubectl get pods | grep -v Completed
 
-# List annotations of tests that have running pods and are in Errored state.
-# Expression is intended to work across versions of kubectl.
-kubectl get pods --no-headers | grep -v Completed | cut -f1 -d' ' \
-    | (while read f;  do echo $(kubectl get pod "$f" --no-headers -o jsonpath='{.metadata.ownerReferences[0].name}'); done) \
-    | (while read f; do state=$(kubectl get loadtest "$f" --no-headers -o  jsonpath='{.status.state}'); if [[ "${state}" == Errored ]]; then echo "$f"; fi; done) \
-    | xargs -r kubectl get loadtest --no-headers \
-    | (while read -a words; do annotations=(
-        $(kubectl get loadtest "${words[0]}" --no-headers -o jsonpath='{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.metadata.annotations.uniquifier}')
-        ); echo "${words[1]} {\"pool\":\"${annotations[0]}\",\"scenario\":\"${annotations[1]}\",\"uniquifier\":\"${annotations[2]}\"}"; done) \
-    | sort
+# List and delete tests that have running pods and are in errored state.
+source tools/internal_ci/helper_scripts/delete_leftover_loadtests.sh
 
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"


### PR DESCRIPTION
This change monitors for an unexpected condition where pods may become unresponsive and continue to run after a test terminates. The pods are deleted once the test reaches its TTL of 24 hours, but these zombie pods can accumulate in the meantime, reducing the capacity of the cluster. See also https://github.com/grpc/grpc/pull/26339. 