### PR TITLE
Bazelize some of the python testing helpers

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/BUILD.bazel
+++ b/src/python/grpcio_testing/grpc_testing/BUILD.bazel
@@ -20,6 +20,6 @@ py_library(
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_testing/grpc_testing/_channel",
         "//src/python/grpcio_testing/grpc_testing/_server",
-        "@six//:six",
+        "@six",
     ],
 )

--- a/src/python/grpcio_testing/grpc_testing/BUILD.bazel
+++ b/src/python/grpcio_testing/grpc_testing/BUILD.bazel
@@ -1,0 +1,25 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "common",
+    srcs = ["_common.py"],
+)
+
+py_library(
+    name = "time",
+    srcs = ["_time.py"],
+)
+
+py_library(
+    name = "grpcio_testing",
+    srcs = ["__init__.py"],
+    imports = ["../"],
+    deps = [
+        ":common",
+        ":time",
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_testing/grpc_testing/_channel",
+        "//src/python/grpcio_testing/grpc_testing/_server",
+        "@six//:six",
+    ],
+)

--- a/src/python/grpcio_testing/grpc_testing/_channel/BUILD.bazel
+++ b/src/python/grpcio_testing/grpc_testing/_channel/BUILD.bazel
@@ -9,8 +9,8 @@ py_library(
     name = "channel_state",
     srcs = ["_channel_state.py"],
     deps = [
-        ":channel"
-    ]
+        ":channel",
+    ],
 )
 
 py_library(
@@ -19,7 +19,7 @@ py_library(
     deps = [
         ":channel_rpc",
         ":multi_callable",
-    ]
+    ],
 )
 
 py_library(
@@ -32,7 +32,7 @@ py_library(
     srcs = ["_multi_callable.py"],
     deps = [
         ":invocation",
-    ]
+    ],
 )
 
 py_library(
@@ -45,9 +45,9 @@ py_library(
     srcs = ["__init__.py"],
     imports = ["../"],
     deps = [
+        ":channel",
         ":channel_rpc",
         ":channel_state",
-        ":channel",
         ":invocation",
         ":multi_callable",
         ":rpc_state",

--- a/src/python/grpcio_testing/grpc_testing/_channel/BUILD.bazel
+++ b/src/python/grpcio_testing/grpc_testing/_channel/BUILD.bazel
@@ -1,0 +1,57 @@
+package(default_visibility = ["//src/python/grpcio_testing/grpc_testing:__subpackages__"])
+
+py_library(
+    name = "channel_rpc",
+    srcs = ["_channel_rpc.py"],
+)
+
+py_library(
+    name = "channel_state",
+    srcs = ["_channel_state.py"],
+    deps = [
+        ":channel"
+    ]
+)
+
+py_library(
+    name = "channel",
+    srcs = ["_channel.py"],
+    deps = [
+        ":channel_rpc",
+        ":multi_callable",
+    ]
+)
+
+py_library(
+    name = "invocation",
+    srcs = ["_invocation.py"],
+)
+
+py_library(
+    name = "multi_callable",
+    srcs = ["_multi_callable.py"],
+    deps = [
+        ":invocation",
+    ]
+)
+
+py_library(
+    name = "rpc_state",
+    srcs = ["_rpc_state.py"],
+)
+
+py_library(
+    name = "_channel",
+    srcs = ["__init__.py"],
+    imports = ["../"],
+    deps = [
+        ":channel_rpc",
+        ":channel_state",
+        ":channel",
+        ":invocation",
+        ":multi_callable",
+        ":rpc_state",
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_testing/grpc_testing:common",
+    ],
+)

--- a/src/python/grpcio_testing/grpc_testing/_server/BUILD.bazel
+++ b/src/python/grpcio_testing/grpc_testing/_server/BUILD.bazel
@@ -1,0 +1,53 @@
+package(default_visibility = ["//src/python/grpcio_testing/grpc_testing:__subpackages__"])
+
+py_library(
+    name = "handler",
+    srcs = ["_handler.py"],
+)
+
+py_library(
+    name = "rpc",
+    srcs = ["_rpc.py"],
+)
+
+py_library(
+    name = "server_rpc",
+    srcs = ["_server_rpc.py"],
+)
+
+py_library(
+    name = "server",
+    srcs = ["_server.py"],
+    deps = [
+        ":rpc",
+        ":server_rpc",
+        ":service",
+        ":servicer_context",
+    ],
+)
+
+py_library(
+    name = "service",
+    srcs = ["_service.py"],
+)
+
+py_library(
+    name = "servicer_context",
+    srcs = ["_servicer_context.py"],
+)
+
+py_library(
+    name = "_server",
+    srcs = ["__init__.py"],
+    imports = ["../"],
+    deps = [
+        ":handler",
+        ":rpc",
+        ":server_rpc",
+        ":server",
+        ":service",
+        ":servicer_context",
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_testing/grpc_testing:common",
+    ],
+)

--- a/src/python/grpcio_testing/grpc_testing/_server/BUILD.bazel
+++ b/src/python/grpcio_testing/grpc_testing/_server/BUILD.bazel
@@ -43,8 +43,8 @@ py_library(
     deps = [
         ":handler",
         ":rpc",
-        ":server_rpc",
         ":server",
+        ":server_rpc",
         ":service",
         ":servicer_context",
         "//src/python/grpcio/grpc:grpcio",


### PR DESCRIPTION
To improve testing of python grpc implementations when bring in this workspace as an external repostiory add some py_library rules.

@gnossen 
