### PR TITLE
Revert "Provide custom sponge configs to exclude manual runs from testgrid"

### DIFF
--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -58,12 +58,7 @@ docker run \
   -e "KOKORO_BUILD_NUMBER=$KOKORO_BUILD_NUMBER" \
   -e "KOKORO_BUILD_URL=$KOKORO_BUILD_URL" \
   -e "KOKORO_JOB_NAME=$KOKORO_JOB_NAME" \
-  -e "KOKORO_ARTIFACTS_DIR=$KOKORO_ARTIFACTS_DIR" \
-  -e "GIT_ORIGIN_URL=$(git -C $git_root remote get-url origin)" \
-  -e "GIT_COMMIT_SHORT=$(git -C $git_root rev-parse --short HEAD)" \
-  -e "TESTGRID_EXCLUDE=$TESTGRID_EXCLUDE" \
   -v "$git_root:/var/local/jenkins/grpc:ro" \
-  -v "$KOKORO_ARTIFACTS_DIR:$KOKORO_ARTIFACTS_DIR" \
   -w /var/local/git/grpc \
   --name="$CONTAINER_NAME" \
   $EXTRA_DOCKER_ARGS \

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2238,31 +2238,6 @@ def test_csds(gcp, original_backend_service, instance_group, server_uri):
                        test_csds_timeout_s)
 
 
-def maybe_write_sponge_properties():
-    """Writing test infos to enable more advanced testgrid searches."""
-    if 'KOKORO_ARTIFACTS_DIR' not in os.environ:
-        return
-    if 'GIT_ORIGIN_URL' not in os.environ:
-        return
-    if 'GIT_COMMIT_SHORT' not in os.environ:
-        return
-    properties = [
-        # Technically, 'TESTS_FORMAT_VERSION' is not required for run_xds_tests.
-        # We keep it here so one day we may merge the process of writing sponge
-        # properties.
-        'TESTS_FORMAT_VERSION,2',
-        'TESTGRID_EXCLUDE,%s' % os.environ.get('TESTGRID_EXCLUDE', 0),
-        'GIT_ORIGIN_URL,%s' % os.environ['GIT_ORIGIN_URL'],
-        'GIT_COMMIT_SHORT,%s' % os.environ['GIT_COMMIT_SHORT'],
-    ]
-    logger.info('Writing Sponge configs: %s', properties)
-    with open(
-            os.path.join(os.environ['KOKORO_ARTIFACTS_DIR'],
-                         "custom_sponge_config.csv"), 'w') as f:
-        f.write("\n".join(properties))
-        f.write("\n")
-
-
 def set_validate_for_proxyless(gcp, validate_for_proxyless):
     if not gcp.alpha_compute:
         logger.debug(
@@ -2979,7 +2954,6 @@ class GcpState(object):
         self.instance_groups = []
 
 
-maybe_write_sponge_properties()
 alpha_compute = None
 if args.compute_discovery_document:
     with open(args.compute_discovery_document, 'r') as discovery_doc:


### PR DESCRIPTION
Reverts grpc/grpc#26283

A code-change solution is found in cl/374912883. Let's reduce the amount of code that is not in use.