### PR TITLE
Add v1.38.0 release of grpc-ruby to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -388,6 +388,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.35.0', ReleaseInfo()),
             ('v1.36.3', ReleaseInfo()),
             ('v1.37.0', ReleaseInfo()),
+            ('v1.38.0', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([


### PR DESCRIPTION
#26316 for Go, #26291 for Java etc.

@veblush
