### PR TITLE
Make sure C# developer build works even when on arm64 linux

### DIFF
--- a/src/csharp/Grpc.Core/NativeDeps.Linux.csproj.include
+++ b/src/csharp/Grpc.Core/NativeDeps.Linux.csproj.include
@@ -5,5 +5,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>false</Pack>
     </Content>
+    <Content Include="..\..\..\cmake\build\libgrpc_csharp_ext.so">
+      <!-- make sure the developer build works when on arm64 linux as well -->
+      <Link>libgrpc_csharp_ext.arm64.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>false</Pack>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The change has no effect on the nuget package we distribute, only on the developer build from source (e.g. when building and running tests locally).
The change is required to enable continuous testing of grpc C# on ARM64 (so that run_tests.py for C# can run on ARM64 linux machine). Basically it just takes the locally-built grpc_csharp_ext.so and exposes it as both libgrpc_csharp_ext.x64.so (which will be consumed in case we are developing on x64) and libgrpc_csharp_ext.arm64.so (which will be consumed when we're developing on arm64)
