### PR TITLE
Disable test that generates zombie pods from continuous runs.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -73,6 +73,7 @@ go build -o bin/delete_prebuilt_workers tools/delete_prebuilt_workers/delete_pre
 popd
 
 # Build test configurations.
+# TODO: Remove regex filter when test no longer generates zombie pods.
 buildConfigs() {
     local pool="$1"
     local table="$2"
@@ -87,6 +88,7 @@ buildConfigs() {
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
+        -r '^(?!cpp_protobuf_async_streaming_from_server_qps_unconstrained_secure).' \
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -74,6 +74,7 @@ go build -o bin/delete_prebuilt_workers tools/delete_prebuilt_workers/delete_pre
 popd
 
 # Build test configurations.
+# TODO: Remove regex filter when test no longer generates zombie pods.
 buildConfigs() {
     local pool="$1"
     local table="$2"
@@ -88,6 +89,7 @@ buildConfigs() {
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
+        -r '^(?!cpp_protobuf_async_streaming_from_server_qps_unconstrained_secure).' \
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 


### PR DESCRIPTION
This is a workaround for the fact that the server in the test running scenario `cpp_protobuf_async_streaming_from_server_qps_unconstrained_secure` becomes unresponsive and causes pods for this test to keep running after test timeout. The pods are deleted once the test reaches the TTL of 24h, but the number of tests with zombie pods that can accumulate in that time (at least 16) far exceeds the number of tests normally running at a time (at most 4). In order to keep the test running, with no other changes, we would need to increase the capacity of our node pools to accomodate ~20 tests, rather than the current 8.

The test can be reinstated once the zombie pod issue is addressed.