### PR TITLE
Fixes #26322

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -58,7 +58,10 @@ cdef int _get_metadata(void *state,
         cb(user_data, NULL, 0, status, c_error_details)
   args = context.service_url, context.method_name, callback,
   plugin = <object>state
-  plugin._stored_ctx.run(_spawn_callback_async, plugin, args)
+  if plugin._stored_ctx is not None:
+    plugin._stored_ctx.run(_spawn_callback_async, plugin, args)
+  else:
+    _spawn_callback_async(<object>state, args)
   return 0  # Asynchronous return
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -57,7 +57,8 @@ cdef int _get_metadata(void *state,
       with nogil:
         cb(user_data, NULL, 0, status, c_error_details)
   args = context.service_url, context.method_name, callback,
-  _spawn_callback_async(<object>state, args)
+  plugin = <object>state
+  plugin._stored_ctx.run(_spawn_callback_async, plugin, args)
   return 0  # Asynchronous return
 
 

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -68,6 +68,7 @@ class _Plugin(object):
 
     def __init__(self, metadata_plugin):
         self._metadata_plugin = metadata_plugin
+        self._stored_ctx = None
 
         try:
             import contextvars  # pylint: disable=wrong-import-position
@@ -77,7 +78,7 @@ class _Plugin(object):
             self._stored_ctx = contextvars.copy_context()
         except ImportError:
             # Support versions predating contextvars.
-            self._stored_ctx = None
+            pass
 
     def __call__(self, service_url, method_name, callback):
         context = _AuthMetadataContext(_common.decode(service_url),

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import collections
-import contextvars
 import logging
 import threading
 
@@ -70,10 +69,15 @@ class _Plugin(object):
     def __init__(self, metadata_plugin):
         self._metadata_plugin = metadata_plugin
 
-        # The plugin may be invoked on a thread created by Core, which will not
-        # have the context propagated. This context is stored and installed in
-        # the thread invoking the plugin.
-        self._stored_ctx = contextvars.copy_context()
+        try:
+            import contextvars  # pylint: disable=wrong-import-position
+            # The plugin may be invoked on a thread created by Core, which will not
+            # have the context propagated. This context is stored and installed in
+            # the thread invoking the plugin.
+            self._stored_ctx = contextvars.copy_context()
+        except ImportError:
+            # Support versions predating contextvars.
+            self._stored_ctx = None
 
     def __call__(self, service_url, method_name, callback):
         context = _AuthMetadataContext(_common.decode(service_url),

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import contextvars
 import logging
 import threading
 
@@ -68,6 +69,11 @@ class _Plugin(object):
 
     def __init__(self, metadata_plugin):
         self._metadata_plugin = metadata_plugin
+
+        # The plugin may be invoked on a thread created by Core, which will not
+        # have the context propagated. This context is stored and installed in
+        # the thread invoking the plugin.
+        self._stored_ctx = contextvars.copy_context()
 
     def __call__(self, service_url, method_name, callback):
         context = _AuthMetadataContext(_common.decode(service_url),


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/26258 changed thread scheduling in such a way that it was no longer guaranteed that metadata plugins would be run on donated threads (i.e. those created by `ForkManagedThread`) and instead, plugins would sometimes be invoked on Core-created threads. The original contextvars propagation method didn't work in this case, breaking this test.

This PR manually propagates context from between the thread creating a metadata plugin and the thread on which that plugin is invoked.

CC @drfloob since he was interested.