### PR TITLE
xds-k8s: add run and cleanup helpers, document bin/ scripts

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -35,7 +35,7 @@ For more details, and for the setup for security tests, see
  user guide.
  
 Update gloud sdk:
-```
+```shell
 gcloud -q components update
 ```
 
@@ -69,7 +69,6 @@ gcloud beta container clusters create "${CLUSTER_NAME}" \
 Allow [health checking mechanisms](https://cloud.google.com/traffic-director/docs/set-up-proxyless-gke#creating_the_health_check_firewall_rule_and_backend_service)
 to query the workloads health.  
 This step can be skipped, if the driver is executed with `--ensure_firewall`.
-
 ```shell
 gcloud compute firewall-rules create "${K8S_NAMESPACE}-allow-health-checks" \
   --network=default --action=allow --direction=INGRESS \
@@ -90,7 +89,6 @@ gcloud iam service-accounts add-iam-policy-binding "${PROJECT_NUMBER}-compute@de
 ``` 
 
 ##### Configure GKE cluster access
-
 ```shell
 # Configuring GKE cluster access for kubectl
 gcloud container clusters get-credentials "your_gke_cluster_name" --zone "your_gke_cluster_zone"
@@ -319,9 +317,14 @@ grpcurl --plaintext -d '{"num_rpcs": 10, "timeout_sec": 30}' 127.0.0.1:8079 \
 ```
 
 ### Cleanup
-First, make sure to stop port forwarding, if any.
+* First, make sure to stop port forwarding, if any
+* Run `./bin/cleanup.sh`
 
-#### Regular cleanup
+##### Partial cleanup
+You can run commands below to stop/start, create/delete resources however you want.  
+Generally, it's better to remove resources in the opposite order of their creation.
+
+Cleanup regular resources:
 ```shell
 # Cleanup TD resources
 ./run.sh bin/run_td_setup.py --cmd=cleanup
@@ -329,12 +332,9 @@ First, make sure to stop port forwarding, if any.
 ./run.sh bin/run_test_client.py --cmd=cleanup
 # Stop test server, and remove the namespace
 ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace
-
-# Full cleanup (run all commands above)
-./bin/cleanup.sh
 ```
 
-#### Security cleanup
+Cleanup regular and security-specific resources:
 ```shell
 # Cleanup TD resources, with security
 ./run.sh bin/run_td_setup.py --cmd=cleanup --security=mtls
@@ -342,17 +342,9 @@ First, make sure to stop port forwarding, if any.
 ./run.sh bin/run_test_client.py --cmd=cleanup --secure
 # Stop test server (secure), and remove the namespace
 ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace --secure
-
-# Full security-specific cleanup (run all commands above)
-./bin/cleanup.sh --secure
 ```
 
-#### Partial cleanup
-You can run commands above to stop/start, create/delete resources however you want.
-Generally, it's better to remove resources in the opposite order of their creation.
-
 In addition, here's some other helpful partial cleanup commands:
-
 ```shell
 # Remove all backends from the backend services
 ./run.sh bin/run_td_setup.py --cmd=backends-cleanup

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup.sh
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup.sh
@@ -19,8 +19,8 @@ display_usage() {
   cat <<EOF >/dev/stderr
 Performs full TD and K8S resource cleanup
 
-USAGE: $0 [--secure] [arguments]
-   --secure: Perform TD resource cleanup specific for PSM Security setup
+USAGE: $0 [--nosecure] [arguments]
+   --nosecure: Skip cleanup for the resources specific for PSM Security
    arguments ...: additional arguments passed to ./run.sh
 
 ENVIRONMENT:
@@ -46,13 +46,13 @@ readonly XDS_K8S_DRIVER_DIR="${SCRIPT_DIR}/.."
 
 cd "${XDS_K8S_DRIVER_DIR}"
 
-if [[ "$1" == "--secure" ]]; then
+if [[ "$1" == "--nosecure" ]]; then
   shift
-  ./run.sh bin/run_td_setup.py --cmd=cleanup --security=mtls "$@" && \
-  ./run.sh bin/run_test_client.py --cmd=cleanup --secure "$@" && \
-  ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace --secure "$@"
-else
   ./run.sh bin/run_td_setup.py --cmd=cleanup "$@" && \
   ./run.sh bin/run_test_client.py --cmd=cleanup "$@" && \
   ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace "$@"
+else
+  ./run.sh bin/run_td_setup.py --cmd=cleanup --security=mtls "$@" && \
+  ./run.sh bin/run_test_client.py --cmd=cleanup --secure "$@" && \
+  ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace --secure "$@"
 fi

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup.sh
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eo pipefail
 
 display_usage() {

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup.sh
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+display_usage() {
+  cat <<EOF >/dev/stderr
+Performs full TD and K8S resource cleanup
+
+USAGE: $0 [--secure] [arguments]
+   --secure: Perform TD resource cleanup specific for PSM Security setup
+   arguments ...: additional arguments passed to ./run.sh
+
+ENVIRONMENT:
+   XDS_K8S_CONFIG: file path to the config flagfile, relative to
+                   driver root folder. Default: config/local-dev.cfg
+                   Will be appended as --flagfile="config_absolute_path" argument
+   XDS_K8S_DRIVER_VENV_DIR: the path to python virtual environment directory
+                            Default: $XDS_K8S_DRIVER_DIR/venv
+EXAMPLES:
+$0
+$0 --secure
+XDS_K8S_CONFIG=./path-to-flagfile.cfg $0 --namespace=override-namespace
+EOF
+  exit 1
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  display_usage
+fi
+
+readonly SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+readonly XDS_K8S_DRIVER_DIR="${SCRIPT_DIR}/.."
+
+cd "${XDS_K8S_DRIVER_DIR}"
+
+if [[ "$1" == "--secure" ]]; then
+  shift
+  ./run.sh bin/run_td_setup.py --cmd=cleanup --security=mtls "$@" && \
+  ./run.sh bin/run_test_client.py --cmd=cleanup --secure "$@" && \
+  ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace --secure "$@"
+else
+  ./run.sh bin/run_td_setup.py --cmd=cleanup "$@" && \
+  ./run.sh bin/run_test_client.py --cmd=cleanup "$@" && \
+  ./run.sh bin/run_test_server.py --cmd=cleanup --cleanup_namespace "$@"
+fi

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
@@ -26,7 +26,7 @@ Typical usage examples:
     python -m bin.run_channelz --flagfile=config/local-dev.cfg --security=mtls_error
 
     # More information and usage options
-    python -m bin.run_channelz --helpful
+    python -m bin.run_channelz --helpfull
 """
 import hashlib
 import logging

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_td_setup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_td_setup.py
@@ -28,7 +28,7 @@ Typical usage examples:
     python -m bin.run_td_setup --flagfile=config/local-dev.cfg --security=mtls
 
     # More information and usage options
-    python -m bin.run_td_setup --helpful
+    python -m bin.run_td_setup --helpfull
 """
 import logging
 import uuid

--- a/tools/run_tests/xds_k8s_test_driver/run.sh
+++ b/tools/run_tests/xds_k8s_test_driver/run.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -eo pipefail
 
 readonly XDS_K8S_DRIVER_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

--- a/tools/run_tests/xds_k8s_test_driver/run.sh
+++ b/tools/run_tests/xds_k8s_test_driver/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+readonly XDS_K8S_DRIVER_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+readonly XDS_K8S_DRIVER_VENV_DIR="${XDS_K8S_DRIVER_VENV_DIR:-$XDS_K8S_DRIVER_DIR/venv}"
+readonly XDS_K8S_CONFIG="${XDS_K8S_CONFIG:-$XDS_K8S_DRIVER_DIR/config/local-dev.cfg}"
+
+display_usage() {
+  cat <<EOF >/dev/stderr
+Convenience script to execute tests/ and helper bin/ scripts.
+
+USAGE: $0 script_path [arguments]
+   script_path: path to python script to execute, relative to driver root folder
+   arguments ...: arguments passed to program in sys.argv
+
+ENVIRONMENT:
+   XDS_K8S_CONFIG: file path to the config flagfile, relative to
+                   driver root folder. Default: config/local-dev.cfg
+                   Will be appended as --flagfile="config_absolute_path" argument
+   XDS_K8S_DRIVER_VENV_DIR: the path to python virtual environment directory
+                            Default: $XDS_K8S_DRIVER_DIR/venv
+DESCRIPTION:
+This tool performs the following:
+1) Ensures python virtual env installed and activated
+2) Exports test driver root in PYTHONPATH
+3) Automatically appends --flagfile="\$XDS_K8S_CONFIG" argument
+
+EXAMPLES:
+$0 bin/run_td_setup.py --help      # list script-specific options
+$0 bin/run_td_setup.py --helpfull  # list all available options
+XDS_K8S_CONFIG=./path-to-flagfile.cfg $0 bin/run_td_setup.py --namespace=override-namespace
+$0 tests/baseline_test.py
+$0 tests/security_test.py --verbosity=1 --logger_levels=__main__:DEBUG,framework:DEBUG
+$0 tests/security_test.py SecurityTest.test_mtls --nocheck_local_certs
+EOF
+  exit 1
+}
+
+if [[ "$#" -eq 0 || "$1" = "-h" || "$1" = "--help" ]]; then
+  display_usage
+fi
+
+if [[ -z "${VIRTUAL_ENV}" ]]; then
+  if [[ -d "${XDS_K8S_DRIVER_VENV_DIR}" ]]; then
+    # Intentional: No need to check python venv activate script.
+    # shellcheck source=/dev/null
+    source "${XDS_K8S_DRIVER_VENV_DIR}/bin/activate"
+  else
+    echo "Missing python virtual environment directory: ${XDS_K8S_DRIVER_VENV_DIR}" >&2
+    echo "Follow README.md installation steps first." >&2
+    exit 1
+  fi
+fi
+
+cd "${XDS_K8S_DRIVER_DIR}"
+export PYTHONPATH="${XDS_K8S_DRIVER_DIR}"
+exec python "$@" --flagfile="${XDS_K8S_CONFIG}"


### PR DESCRIPTION
1. Create `./run.sh` to avoid repetitive `-flagfile=config/local-dev.cfg`
2. Create `./bin/cleanup.sh` to simplify cleanup ops
3. Document `./bin` helper scripts
4. Fix `--helpful` -> `--helpfull` (reverts #25173)