### PR TITLE
List full status of tests in Errored state that contain running pods.

### DIFF
--- a/tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
+++ b/tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
@@ -22,7 +22,7 @@ kubectl get pods --no-headers -o jsonpath='{range .items[*]}{.metadata.ownerRefe
     | grep Running \
     | cut -f1 -d' ' \
     | sort -u \
-    | xargs -r kubectl get loadtest --no-headers -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.state}{" "}{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{"\n"}{end}' \
-    | grep Errored
+    | xargs -r kubectl get loadtest --no-headers -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.status}{"\n"}{end}' \
+    | grep '"state":"Errored"'
 
 echo "END Listing leftover tests."

--- a/tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
+++ b/tools/internal_ci/helper_scripts/list_leftover_loadtests.sh
@@ -23,6 +23,6 @@ kubectl get pods --no-headers -o jsonpath='{range .items[*]}{.metadata.ownerRefe
     | cut -f1 -d' ' \
     | sort -u \
     | xargs -r kubectl get loadtest --no-headers -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.annotations.pool}{" "}{.metadata.annotations.scenario}{" "}{.status}{"\n"}{end}' \
-    | grep '"state":"Errored"'
+    | grep '"state":"Errored"' || true
 
 echo "END Listing leftover tests."


### PR DESCRIPTION
This change lists the full status, including failure reason and start and end time. This change is important to improve monitornig: if tests that are in an unexpected status, we want to know when they started and ended, to distinguished transient states (the test timed out but the pods have not completed yet) from bugs we should be concerned about (the test timed out and the pods stayed running forever). 