### PR TITLE
Fix an unused parameter warning in grpcpp/impl/codegen/service_type.h

### DIFF
--- a/include/grpcpp/impl/codegen/server_interface.h
+++ b/include/grpcpp/impl/codegen/server_interface.h
@@ -147,7 +147,8 @@ class ServerInterface : public internal::CallHook {
     /// May not be abstract since this is a post-1.0 API addition
     virtual void RegisterCallbackGenericService(
         experimental::CallbackGenericService* /*service*/) {}
-    virtual void RegisterContextAllocator(std::unique_ptr<ContextAllocator>) {}
+    virtual void RegisterContextAllocator(
+        std::unique_ptr<ContextAllocator> /*context_allocator*/) {}
   };
 
   /// NOTE: The function experimental_registration() is not stable public API.

--- a/include/grpcpp/impl/codegen/server_interface.h
+++ b/include/grpcpp/impl/codegen/server_interface.h
@@ -147,8 +147,7 @@ class ServerInterface : public internal::CallHook {
     /// May not be abstract since this is a post-1.0 API addition
     virtual void RegisterCallbackGenericService(
         experimental::CallbackGenericService* /*service*/) {}
-    virtual void RegisterContextAllocator(
-        std::unique_ptr<ContextAllocator> context_allocator) {}
+    virtual void RegisterContextAllocator(std::unique_ptr<ContextAllocator>) {}
   };
 
   /// NOTE: The function experimental_registration() is not stable public API.


### PR DESCRIPTION
This is a trivial fix that remove `context_allocator` argument to avoid the unused-parameter warnings. 

Below is the sample warning without this fix

```
In file included from /home/hungptit/working/grpc-build/client/greeter-client.cpp:19:
In file included from /home/hungptit/working/grpc-build/client/client.h:6:
In file included from /home/hungptit/working/grpc-build/protos/codegen/helloworld.grpc.pb.h:26:
In file included from /home/hungptit/working/grpc-build/_deps/grpc-src/include/grpcpp/impl/codegen/async_generic_service.h:24:
In file included from /home/hungptit/working/grpc-build/_deps/grpc-src/include/grpcpp/impl/codegen/async_stream.h:25:
In file included from /home/hungptit/working/grpc-build/_deps/grpc-src/include/grpcpp/impl/codegen/service_type.h:26:
/home/hungptit/working/grpc-build/_deps/grpc-src/include/grpcpp/impl/codegen/server_interface.h:151:43: warning: unused parameter 'context_allocator' [-Wunused-parameter]
        std::unique_ptr<ContextAllocator> context_allocator) {}
``` 

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
