### PR TITLE
Add bootstrap_generator to non-secure server deployments as well

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: ${deployment_name}
+        owner: xds-k8s-interop-test
     spec:
       serviceAccountName: ${service_account_name}
       containers:
@@ -26,6 +27,15 @@ spec:
           - "--port=${test_port}"
         ports:
           - containerPort: ${test_port}
+        env:
+          - name: GRPC_XDS_BOOTSTRAP
+            value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
+          - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
+            value: "true"
+        volumeMounts:
+          - mountPath: /tmp/grpc-xds/
+            name: grpc-td-conf
+            readOnly: true
         resources:
           limits:
             cpu: 800m
@@ -33,4 +43,30 @@ spec:
           requests:
             cpu: 100m
             memory: 512Mi
+      initContainers:
+        - name: grpc-td-init
+          image: ${td_bootstrap_image}
+          imagePullPolicy: Always
+          args:
+            - "--output=/tmp/bootstrap/td-grpc-bootstrap.json"
+            - "--vpc-network-name=${network}"
+            % if xds_server_uri:
+            - "--xds-server-uri=${xds_server_uri}"
+            % endif
+            - "--include-v3-features-experimental"
+            - "--node-metadata-experimental=app=${namespace_name}-${deployment_name}"
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 100Mi
+          volumeMounts:
+            - mountPath: /tmp/bootstrap/
+              name: grpc-td-conf
+      volumes:
+        - name: grpc-td-conf
+          emptyDir:
+            medium: Memory
 ...


### PR DESCRIPTION
In gRPC-Go repo, as part of the PSM security interop tests, we changed
the xDS interop server to register admin services (in both secure and
non-secure modes).  Attempting to register CSDS without an xds bootstrap
file causes the server binary to exit.

While we work to find a graceful solution to the problem of registering
CSDS without an xds bootstrap file, adding the bootstrap generator to
the non-secure server deployment fixes the issue.

Also, it looks like we would need an xds bootstrap file for non-secure
servers in the near future to test other server features.

@sergiitk 
@lidizheng 