### PR TITLE
Add uri sans

### DIFF
--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -45,6 +45,7 @@ extern "C" {
 #define GRPC_TRANSPORT_SECURITY_LEVEL_PROPERTY_NAME "security_level"
 #define GRPC_PEER_DNS_PROPERTY_NAME "peer_dns"
 #define GRPC_PEER_SPIFFE_ID_PROPERTY_NAME "peer_spiffe_id"
+#define GRPC_PEER_URI_PROPERTY_NAME "peer_uri"
 #define GRPC_PEER_EMAIL_PROPERTY_NAME "peer_email"
 #define GRPC_PEER_IP_PROPERTY_NAME "peer_ip"
 

--- a/src/core/lib/security/authorization/evaluate_args.cc
+++ b/src/core/lib/security/authorization/evaluate_args.cc
@@ -65,6 +65,7 @@ EvaluateArgs::PerChannelArgs::PerChannelArgs(grpc_auth_context* auth_context,
         auth_context, GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME);
     spiffe_id =
         GetAuthPropertyValue(auth_context, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME);
+    uri_sans = GetAuthPropertyArray(auth_context, GRPC_PEER_URI_PROPERTY_NAME);
     dns_sans = GetAuthPropertyArray(auth_context, GRPC_PEER_DNS_PROPERTY_NAME);
     common_name =
         GetAuthPropertyValue(auth_context, GRPC_X509_CN_PROPERTY_NAME);
@@ -182,6 +183,13 @@ absl::string_view EvaluateArgs::GetSpiffeId() const {
     return "";
   }
   return channel_args_->spiffe_id;
+}
+
+std::vector<absl::string_view> EvaluateArgs::GetUriSans() const {
+  if (channel_args_ == nullptr) {
+    return {};
+  }
+  return channel_args_->uri_sans;
 }
 
 std::vector<absl::string_view> EvaluateArgs::GetDnsSans() const {

--- a/src/core/lib/security/authorization/evaluate_args.h
+++ b/src/core/lib/security/authorization/evaluate_args.h
@@ -45,6 +45,7 @@ class EvaluateArgs {
 
     absl::string_view transport_security_type;
     absl::string_view spiffe_id;
+    std::vector<absl::string_view> uri_sans;
     std::vector<absl::string_view> dns_sans;
     absl::string_view common_name;
     Address local_address;
@@ -76,6 +77,7 @@ class EvaluateArgs {
   int GetPeerPort() const;
   absl::string_view GetTransportSecurityType() const;
   absl::string_view GetSpiffeId() const;
+  std::vector<absl::string_view> GetUriSans() const;
   std::vector<absl::string_view> GetDnsSans() const;
   absl::string_view GetCommonName() const;
 

--- a/src/core/lib/security/authorization/matchers.cc
+++ b/src/core/lib/security/authorization/matchers.cc
@@ -180,9 +180,13 @@ bool AuthenticatedAuthorizationMatcher::Matches(
     // Allows any authenticated user.
     return true;
   }
-  absl::string_view spiffe_id = args.GetSpiffeId();
-  if (!spiffe_id.empty()) {
-    return matcher_.Match(spiffe_id);
+  std::vector<absl::string_view> uri_sans = args.GetUriSans();
+  if (!uri_sans.empty()) {
+    for (const auto& uri : uri_sans) {
+      if (matcher_.Match(uri)) {
+        return true;
+      }
+    }
   }
   std::vector<absl::string_view> dns_sans = args.GetDnsSans();
   if (!dns_sans.empty()) {

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -309,6 +309,8 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
       grpc_auth_context_add_property(ctx.get(), GRPC_PEER_DNS_PROPERTY_NAME,
                                      prop->value.data, prop->value.length);
     } else if (strcmp(prop->name, TSI_X509_URI_PEER_PROPERTY) == 0) {
+      grpc_auth_context_add_property(ctx.get(), GRPC_PEER_URI_PROPERTY_NAME,
+                                     prop->value.data, prop->value.length);
       uri_count++;
       absl::string_view spiffe_id(prop->value.data, prop->value.length);
       if (IsSpiffeId(spiffe_id)) {
@@ -388,6 +390,9 @@ tsi_peer grpc_shallow_peer_from_ssl_auth_context(
       } else if (strcmp(prop->name, GRPC_PEER_DNS_PROPERTY_NAME) == 0) {
         add_shallow_auth_property_to_peer(&peer, prop,
                                           TSI_X509_DNS_PEER_PROPERTY);
+      } else if (strcmp(prop->name, GRPC_PEER_URI_PROPERTY_NAME) == 0) {
+        add_shallow_auth_property_to_peer(&peer, prop,
+                                          TSI_X509_URI_PEER_PROPERTY);
       } else if (strcmp(prop->name, GRPC_PEER_SPIFFE_ID_PROPERTY_NAME) == 0) {
         add_shallow_auth_property_to_peer(&peer, prop,
                                           TSI_X509_URI_PEER_PROPERTY);

--- a/test/core/security/authorization_matchers_test.cc
+++ b/test/core/security/authorization_matchers_test.cc
@@ -339,12 +339,13 @@ TEST_F(AuthorizationMatchersTest,
   EXPECT_TRUE(matcher.Matches(args));
 }
 
-TEST_F(AuthorizationMatchersTest,
-       AuthenticatedMatcherSuccessfulSpiffeIdMatches) {
+TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherSuccessfulUriSanMatches) {
   args_.AddPropertyToAuthContext(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
                                  GRPC_SSL_TRANSPORT_SECURITY_TYPE);
-  args_.AddPropertyToAuthContext(GRPC_PEER_SPIFFE_ID_PROPERTY_NAME,
+  args_.AddPropertyToAuthContext(GRPC_PEER_URI_PROPERTY_NAME,
                                  "spiffe://foo.abc");
+  args_.AddPropertyToAuthContext(GRPC_PEER_URI_PROPERTY_NAME,
+                                 "https://foo.domain.com");
   EvaluateArgs args = args_.MakeEvaluateArgs();
   AuthenticatedAuthorizationMatcher matcher(
       StringMatcher::Create(StringMatcher::Type::kExact,
@@ -354,10 +355,10 @@ TEST_F(AuthorizationMatchersTest,
   EXPECT_TRUE(matcher.Matches(args));
 }
 
-TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherFailedSpiffeIdMatches) {
+TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherFailedUriSanMatches) {
   args_.AddPropertyToAuthContext(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
                                  GRPC_SSL_TRANSPORT_SECURITY_TYPE);
-  args_.AddPropertyToAuthContext(GRPC_PEER_SPIFFE_ID_PROPERTY_NAME,
+  args_.AddPropertyToAuthContext(GRPC_PEER_URI_PROPERTY_NAME,
                                  "spiffe://bar.abc");
   EvaluateArgs args = args_.MakeEvaluateArgs();
   AuthenticatedAuthorizationMatcher matcher(

--- a/test/core/security/authorization_matchers_test.cc
+++ b/test/core/security/authorization_matchers_test.cc
@@ -372,11 +372,14 @@ TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherFailedUriSanMatches) {
 TEST_F(AuthorizationMatchersTest, AuthenticatedMatcherSuccessfulDnsSanMatches) {
   args_.AddPropertyToAuthContext(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
                                  GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  args_.AddPropertyToAuthContext(GRPC_PEER_URI_PROPERTY_NAME,
+                                 "spiffe://bar.abc");
   args_.AddPropertyToAuthContext(GRPC_PEER_DNS_PROPERTY_NAME,
                                  "foo.test.domain.com");
   args_.AddPropertyToAuthContext(GRPC_PEER_DNS_PROPERTY_NAME,
                                  "bar.test.domain.com");
   EvaluateArgs args = args_.MakeEvaluateArgs();
+  // No match found in URI SANs, finds match in DNS SANs.
   AuthenticatedAuthorizationMatcher matcher(
       StringMatcher::Create(StringMatcher::Type::kExact,
                             /*matcher=*/"bar.test.domain.com",

--- a/test/core/security/evaluate_args_test.cc
+++ b/test/core/security/evaluate_args_test.cc
@@ -100,6 +100,7 @@ TEST_F(EvaluateArgsTest, EmptyAuthContext) {
   EvaluateArgs args = util_.MakeEvaluateArgs();
   EXPECT_TRUE(args.GetTransportSecurityType().empty());
   EXPECT_TRUE(args.GetSpiffeId().empty());
+  EXPECT_TRUE(args.GetUriSans().empty());
   EXPECT_TRUE(args.GetDnsSans().empty());
   EXPECT_TRUE(args.GetCommonName().empty());
 }
@@ -131,6 +132,13 @@ TEST_F(EvaluateArgsTest, GetSpiffeIdFailDuplicateProperty) {
   util_.AddPropertyToAuthContext(GRPC_PEER_SPIFFE_ID_PROPERTY_NAME, "id456");
   EvaluateArgs args = util_.MakeEvaluateArgs();
   EXPECT_TRUE(args.GetSpiffeId().empty());
+}
+
+TEST_F(EvaluateArgsTest, GetUriSanSuccessMultipleProperties) {
+  util_.AddPropertyToAuthContext(GRPC_PEER_URI_PROPERTY_NAME, "foo");
+  util_.AddPropertyToAuthContext(GRPC_PEER_URI_PROPERTY_NAME, "bar");
+  EvaluateArgs args = util_.MakeEvaluateArgs();
+  EXPECT_THAT(args.GetUriSans(), ::testing::ElementsAre("foo", "bar"));
 }
 
 TEST_F(EvaluateArgsTest, GetDnsSanSuccessMultipleProperties) {

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -487,6 +487,23 @@ static void test_dns_peer_to_auth_context(void) {
   ctx.reset(DEBUG_LOCATION, "test");
 }
 
+static void test_uri_peer_to_auth_context(void) {
+  tsi_peer peer;
+  const std::vector<std::string> expected_uri = {"uri1", "uri2", "uri3"};
+  GPR_ASSERT(tsi_construct_peer(expected_uri.size(), &peer) == TSI_OK);
+  for (size_t i = 0; i < expected_uri.size(); ++i) {
+    GPR_ASSERT(tsi_construct_string_peer_property_from_cstring(
+                   TSI_X509_URI_PEER_PROPERTY, expected_uri[i].c_str(),
+                   &peer.properties[i]) == TSI_OK);
+  }
+  grpc_core::RefCountedPtr<grpc_auth_context> ctx =
+      grpc_ssl_peer_to_auth_context(&peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+  GPR_ASSERT(ctx != nullptr);
+  GPR_ASSERT(check_sans(ctx.get(), GRPC_PEER_URI_PROPERTY_NAME, expected_uri));
+  tsi_peer_destruct(&peer);
+  ctx.reset(DEBUG_LOCATION, "test");
+}
+
 static void test_email_peer_to_auth_context(void) {
   tsi_peer peer;
   const std::vector<std::string> expected_emails = {"email1", "email2"};
@@ -753,6 +770,7 @@ int main(int argc, char** argv) {
   test_cn_and_multiple_sans_ssl_peer_to_auth_context();
   test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context();
   test_dns_peer_to_auth_context();
+  test_uri_peer_to_auth_context();
   test_email_peer_to_auth_context();
   test_ip_peer_to_auth_context();
   test_spiffe_id_peer_to_auth_context();


### PR DESCRIPTION
1. Adds URI SANs to grpc_auth_context.
2. Update RBAC matcher to use URI SANs in AuthenticatedMatcher