### PR TITLE
Updated instructions for vcpkg install on Windows

### DIFF
--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -159,8 +159,6 @@ cd vcpkg
 ./vcpkg install grpc
 ```
 
-For Windows installation use these commands instead
-
 The gRPC port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -147,12 +147,19 @@ gRPC is available using the [vcpkg](https://github.com/Microsoft/vcpkg) dependen
 # install vcpkg package manager on your system using the official instructions
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
+
+# Bootstrap on Linux:
 ./bootstrap-vcpkg.sh
+# Bootstrap on Windows instead:
+# ./bootstrap-vcpkg.bat
+
 ./vcpkg integrate install
 
 # install gRPC using vcpkg package manager
-vcpkg install grpc
+./vcpkg install grpc
 ```
+
+For Windows installation use these commands instead
 
 The gRPC port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 


### PR DESCRIPTION
bootstrap-vcpkg.sh script doesn't work out of the box on Windows
Rest of the commands are OS-neutral




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
