### PR TITLE
Revert "Revert "Revert "Revert "Expose trailers-only response status through C++ callback API""""

### DIFF
--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -120,6 +120,11 @@ size_t grpc_call_get_initial_size_estimate();
 grpc_compression_algorithm grpc_call_compression_for_level(
     grpc_call* call, grpc_compression_level level);
 
+/* Did this client call receive a trailers-only response */
+/* TODO(markdroth): This is currently available only to the C++ API.
+                    Move to surface API if requested by other languages. */
+bool grpc_call_is_trailers_only(const grpc_call* call);
+
 /* Returns whether or not the call's receive message operation failed because of
  * an error (as opposed to a graceful end-of-stream) */
 /* TODO(markdroth): This is currently available only to the C++ API.

--- a/src/cpp/client/client_callback.cc
+++ b/src/cpp/client/client_callback.cc
@@ -20,6 +20,7 @@
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/executor.h"
+#include "src/core/lib/surface/call.h"
 
 namespace grpc {
 namespace internal {
@@ -46,6 +47,10 @@ void ClientReactor::InternalScheduleOnDone(grpc::Status s) {
   };
   ClosureWithArg* arg = new ClosureWithArg(this, std::move(s));
   grpc_core::Executor::Run(&arg->closure, GRPC_ERROR_NONE);
+}
+
+bool ClientReactor::InternalTrailersOnly(const grpc_call* call) const {
+  return grpc_call_is_trailers_only(call);
 }
 
 }  // namespace internal

--- a/src/proto/grpc/testing/echo.proto
+++ b/src/proto/grpc/testing/echo.proto
@@ -33,6 +33,7 @@ service EchoTestService {
   rpc ResponseStream(EchoRequest) returns (stream EchoResponse);
   rpc BidiStream(stream EchoRequest) returns (stream EchoResponse);
   rpc Unimplemented(EchoRequest) returns (EchoResponse);
+  rpc UnimplementedBidi(stream EchoRequest) returns (stream EchoResponse);
 }
 
 service EchoTest1Service {

--- a/test/cpp/util/grpc_tool_test.cc
+++ b/test/cpp/util/grpc_tool_test.cc
@@ -62,7 +62,8 @@ using grpc::testing::EchoResponse;
   "RequestStream\n"               \
   "ResponseStream\n"              \
   "BidiStream\n"                  \
-  "Unimplemented\n"
+  "Unimplemented\n"               \
+  "UnimplementedBidi\n"
 
 #define ECHO_TEST_SERVICE_DESCRIPTION                                          \
   "filename: src/proto/grpc/testing/echo.proto\n"                              \
@@ -88,6 +89,8 @@ using grpc::testing::EchoResponse;
   "grpc.testing.EchoResponse) {}\n"                                            \
   "  rpc Unimplemented(grpc.testing.EchoRequest) returns "                     \
   "(grpc.testing.EchoResponse) {}\n"                                           \
+  "  rpc UnimplementedBidi(stream grpc.testing.EchoRequest) returns (stream "  \
+  "grpc.testing.EchoResponse) {}\n"                                            \
   "}\n"                                                                        \
   "\n"
 


### PR DESCRIPTION
Reverts grpc/grpc#26375

This is a pure revert. The internal import breakage was because of trailing_metadata_available not being supported in an internal transport. Working on that now.