### PR TITLE
AWS integration: allow copying test reports back to the kokoro instance.

### DIFF
--- a/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh
+++ b/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh
@@ -122,10 +122,19 @@ SSH_COMMAND='uname -a; rm -f /tmp/aws_build.log /tmp/aws_build.exitcode /tmp/aws
 REMOTE_SCRIPT_EXITCODE=0
 time ssh -i ~/.ssh/temp_client_key ubuntu@$IP "${SSH_COMMAND}" || REMOTE_SCRIPT_EXITCODE=$?
 
+echo "Copying artifacts from the remote instance..."
+ARTIFACT_RSYNC_PATTERN="**/*sponge_log.*"
+# NOTE: the include "*/" rule and --prune-empty-dirs are important for not
+# excluding parent directories that contain artifacts before they have
+# get a chance to be examined (see man rsync)
+time rsync -av -e "ssh -i ~/.ssh/temp_client_key" --include="${ARTIFACT_RSYNC_PATTERN}" --include="*/" --exclude="*" --prune-empty-dirs ubuntu@$IP:~/workspace/grpc github
+
 # Regardless of the remote script's result (success or failure), initiate shutdown of AWS instance a minute from now.
 # The small delay is useful to make sure the ssh session doesn't hang up on us if shutdown happens too quickly.
 echo "Shutting down instance $ID."
 ssh -i ~/.ssh/temp_client_key ubuntu@$IP "sudo shutdown +1" || echo "WARNING: Failed to initiate AWS instance shutdown."
+
+
 
 # Match exitcode
 echo "Exiting with exitcode $REMOTE_SCRIPT_EXITCODE based on remote script output."

--- a/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh
+++ b/tools/internal_ci/linux/aws/grpc_aws_run_remote_test.sh
@@ -127,14 +127,19 @@ ARTIFACT_RSYNC_PATTERN="**/*sponge_log.*"
 # NOTE: the include "*/" rule and --prune-empty-dirs are important for not
 # excluding parent directories that contain artifacts before they have
 # get a chance to be examined (see man rsync)
-time rsync -av -e "ssh -i ~/.ssh/temp_client_key" --include="${ARTIFACT_RSYNC_PATTERN}" --include="*/" --exclude="*" --prune-empty-dirs ubuntu@$IP:~/workspace/grpc github
+COPY_ARTIFACTS_EXITCODE=0
+time rsync -av -e "ssh -i ~/.ssh/temp_client_key" --include="${ARTIFACT_RSYNC_PATTERN}" --include="*/" --exclude="*" --prune-empty-dirs ubuntu@$IP:~/workspace/grpc github || COPY_ARTIFACTS_EXITCODE=$?
 
 # Regardless of the remote script's result (success or failure), initiate shutdown of AWS instance a minute from now.
 # The small delay is useful to make sure the ssh session doesn't hang up on us if shutdown happens too quickly.
 echo "Shutting down instance $ID."
 ssh -i ~/.ssh/temp_client_key ubuntu@$IP "sudo shutdown +1" || echo "WARNING: Failed to initiate AWS instance shutdown."
 
-
+if [ "$REMOTE_SCRIPT_EXITCODE" == "0" ] && [ "$COPY_ARTIFACTS_EXITCODE" != "0" ]
+then
+  echo "Exiting with exitcode $COPY_ARTIFACTS_EXITCODE since remote script has passed, but copying artifacts has failed."
+  exit $COPY_ARTIFACTS_EXITCODE
+fi
 
 # Match exitcode
 echo "Exiting with exitcode $REMOTE_SCRIPT_EXITCODE based on remote script output."


### PR DESCRIPTION
This is useful for being able to see structured test results in resultstore:
Example run result:
https://fusion2.corp.google.com/invocations/94e58622-67d7-4f25-ab77-08eb85eaea0d/targets
https://fusion2.corp.google.com/invocations/a8aa98be-9fcd-4bae-8aff-b3ecb523a430/targets

