### PR TITLE
Fix typo in python aarch64 testing script.

### DIFF
--- a/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
@@ -30,7 +30,7 @@ git submodule update --init
 
 # build and test python (currently we only test with python3.6, but that's ok since our aarch64 testing resources are limited)
 tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform native -t -x run_tests/python_linux_opt_native/sponge_log.xml --report_suite_name python_linux_opt_native --report_multi_target || FAILED=true
-tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform asyncio -t -x run_tests/python_linux_opt_gevent/sponge_log.xml --report_suite_name python_linux_opt_asyncio --report_multi_target || FAILED=true
+tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform asyncio -t -x run_tests/python_linux_opt_asyncio/sponge_log.xml --report_suite_name python_linux_opt_asyncio --report_multi_target || FAILED=true
 tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform gevent -t -x run_tests/python_linux_opt_gevent/sponge_log.xml --report_suite_name python_linux_opt_gevent --report_multi_target || FAILED=true
 
 if [ "$FAILED" != "" ]


### PR DESCRIPTION
Currently the reports generated by the aarch64 tests are a bit confusing because of this (but at least they still contain all the necessary info if you look carefully).