### PR TITLE
Bump bazel urllib3 version to 1.26.5

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -9,7 +9,7 @@ futures==3.1.1
 google-auth==1.24.0
 oauth2client==4.1.0
 requests==2.25.1
-urllib3==1.26.3
+urllib3==1.26.5
 chardet==3.0.4
 certifi==2017.4.17
 idna==2.7


### PR DESCRIPTION
Manually created version of https://github.com/grpc/grpc/pull/25894 since dependabot PRs can't be merged in our repo currently due to CLA problems.