### PR TITLE
Delete unneeded parts of generic_stub callback header

### DIFF
--- a/include/grpcpp/generic/generic_stub.h
+++ b/include/grpcpp/generic/generic_stub.h
@@ -87,7 +87,6 @@ class TemplatedGenericStub final {
                         true, tag);
   }
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   /// Setup and start a unary call to a named method \a method using
   /// \a context and specifying the \a request and \a response buffers.
   void UnaryCall(ClientContext* context, const std::string& method,
@@ -95,16 +94,6 @@ class TemplatedGenericStub final {
                  ResponseType* response,
                  std::function<void(grpc::Status)> on_completion) {
     UnaryCallInternal(context, method, options, request, response,
-                      std::move(on_completion));
-  }
-
-  /// NOTE: THE FOLLOWING VERSION IS NOT API. It is present only to
-  /// breakage of some existing codes that were de-experimentalized
-  /// before gRFC L67 completed. This will be removed soon.
-  void UnaryCall(ClientContext* context, const std::string& method,
-                 const RequestType* request, ResponseType* response,
-                 std::function<void(grpc::Status)> on_completion) {
-    UnaryCallInternal(context, method, /*options=*/{}, request, response,
                       std::move(on_completion));
   }
 
@@ -127,63 +116,6 @@ class TemplatedGenericStub final {
       ClientBidiReactor<RequestType, ResponseType>* reactor) {
     PrepareBidiStreamingCallInternal(context, method, options, reactor);
   }
-
-  /// NOTE: THE FOLLOWING VERSION IS NOT API. It is present only to
-  /// breakage of some existing codes that were de-experimentalized
-  /// before gRFC L67 completed. This will be removed soon.
-  void PrepareBidiStreamingCall(
-      ClientContext* context, const std::string& method,
-      ClientBidiReactor<RequestType, ResponseType>* reactor) {
-    PrepareBidiStreamingCallInternal(context, method, /*options=*/{}, reactor);
-  }
-#endif
-
-  /// NOTE: class experimental_type is not part of the public API of this class
-  /// TODO(vjpai): Move these contents to the public API of GenericStub when
-  ///              they are no longer experimental
-  class experimental_type {
-   public:
-    explicit experimental_type(TemplatedGenericStub* stub) : stub_(stub) {}
-
-    /// Setup and start a unary call to a named method \a method using
-    /// \a context and specifying the \a request and \a response buffers.
-    void UnaryCall(ClientContext* context, const std::string& method,
-                   StubOptions options, const RequestType* request,
-                   ResponseType* response,
-                   std::function<void(grpc::Status)> on_completion) {
-      stub_->UnaryCallInternal(context, method, options, request, response,
-                               std::move(on_completion));
-    }
-
-    /// Setup a unary call to a named method \a method using
-    /// \a context and specifying the \a request and \a response buffers.
-    /// Like any other reactor-based RPC, it will not be activated until
-    /// StartCall is invoked on its reactor.
-    void PrepareUnaryCall(ClientContext* context, const std::string& method,
-                          StubOptions options, const RequestType* request,
-                          ResponseType* response, ClientUnaryReactor* reactor) {
-      stub_->PrepareUnaryCallInternal(context, method, options, request,
-                                      response, reactor);
-    }
-
-    /// Setup a call to a named method \a method using \a context and tied to
-    /// \a reactor . Like any other bidi streaming RPC, it will not be activated
-    /// until StartCall is invoked on its reactor.
-    void PrepareBidiStreamingCall(
-        ClientContext* context, const std::string& method, StubOptions options,
-        ClientBidiReactor<RequestType, ResponseType>* reactor) {
-      stub_->PrepareBidiStreamingCallInternal(context, method, options,
-                                              reactor);
-    }
-
-   private:
-    TemplatedGenericStub* stub_;
-  };
-
-  /// NOTE: The function experimental() is not stable public API. It is a view
-  /// to the experimental components of this class. It may be changed or removed
-  /// at any time.
-  experimental_type experimental() { return experimental_type(this); }
 
  private:
   std::shared_ptr<grpc::ChannelInterface> channel_;


### PR DESCRIPTION
Remove non-API portions of generic_stub.h now that callback API is de-experimentalized. An easy cleanup since so few users of the old way of doing things. Cleanup CLs are in progress to fix those users, and this PR won't be merged until those submit.

Pure deletion CL for simplicity (no other cleanup included).
