### PR TITLE
[C#] Add CallOptions ctor with waitForReady parameter

### DIFF
--- a/src/csharp/Grpc.Core.Api/CallOptions.cs
+++ b/src/csharp/Grpc.Core.Api/CallOptions.cs
@@ -47,6 +47,26 @@ namespace Grpc.Core
         /// <param name="credentials">Credentials to use for this call.</param>
         public CallOptions(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken),
                            WriteOptions writeOptions = null, ContextPropagationToken propagationToken = null, CallCredentials credentials = null)
+            : this(waitForReady: false, headers, deadline, cancellationToken, writeOptions, propagationToken, credentials)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <c>CallOptions</c> struct.
+        /// </summary>
+        /// <param name="headers">Headers to be sent with the call.</param>
+        /// <param name="deadline">Deadline for the call to finish. null means no deadline.</param>
+        /// <param name="cancellationToken">Can be used to request cancellation of the call.</param>
+        /// <param name="writeOptions">Write options that will be used for this call.</param>
+        /// <param name="propagationToken">Context propagation token obtained from <see cref="ServerCallContext"/>.</param>
+        /// <param name="credentials">Credentials to use for this call.</param>
+        /// <param name="waitForReady">
+        /// If <c>true</c> and channel is in <c>ChannelState.TransientFailure</c>, the call will attempt waiting for the channel to recover
+        /// instead of failing immediately (which is the default "FailFast" semantics).
+        /// Note: experimental API that can change or be removed without any prior notice.
+        /// </param>
+        public CallOptions(bool waitForReady, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken),
+                           WriteOptions writeOptions = null, ContextPropagationToken propagationToken = null, CallCredentials credentials = null)
         {
             this.headers = headers;
             this.deadline = deadline;
@@ -54,7 +74,7 @@ namespace Grpc.Core
             this.writeOptions = writeOptions;
             this.propagationToken = propagationToken;
             this.credentials = credentials;
-            this.flags = default(CallFlags);
+            this.flags = waitForReady ? CallFlags.WaitForReady : default(CallFlags);
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core.Tests/CallOptionsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CallOptionsTest.cs
@@ -93,6 +93,9 @@ namespace Grpc.Core.Tests
             Assert.AreEqual(CallFlags.WaitForReady, callOptions.WithWaitForReady().Flags);
             Assert.IsTrue(callOptions.WithWaitForReady().IsWaitForReady);
             Assert.IsFalse(callOptions.WithWaitForReady(true).WithWaitForReady(false).IsWaitForReady);
+
+            callOptions = new CallOptions(waitForReady: true);
+            Assert.IsTrue(callOptions.IsWaitForReady);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/26185

@jtattermusch 

Add CallOptions ctor with waitForReady parameter. A new ctor is created because adding an optional parameter to the existing ctor would be a binary breaking change.

In the new ctor, the `waitForReady` parameter needs to be non-optional and first. This is to avoid an ambiguous method error from the compiler. If `waitForReady` is added as an optional parameter then the compiler doesn't know which ctor to call.