### PR TITLE
Better way of building protoc aarch64 artifacts

### DIFF
--- a/tools/dockerfile/grpc_artifact_protoc_aarch64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_protoc_aarch64/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# On aarch64 the protoc and codegen plugins are built via crosscompilation.
+FROM dockcross/linux-arm64

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -318,7 +318,7 @@ class ProtocArtifact:
                 if self.arch == 'aarch64':
                     # for aarch64, use a dockcross manylinux image that will
                     # give us both ready to use crosscompiler and sufficient backward compatibility
-                    dockerfile_dir = 'tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64'
+                    dockerfile_dir = 'tools/dockerfile/grpc_artifact_protoc_aarch64'
                 environ['LDFLAGS'] += ' -static-libgcc -static-libstdc++ -s'
                 return create_docker_jobspec(
                     self.name,


### PR DESCRIPTION
An alternative (and cleaner) solution for https://github.com/grpc/grpc/pull/26415.

Fixes #26032.

```
$ ldd protoc 
	linux-vdso.so.1 (0x0000ffffb2294000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffffb223c000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffffb2183000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffb202a000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffffb2268000)
```


```
$ ldd grpc_csharp_plugin 
	linux-vdso.so.1 (0x0000ffff8fedb000)
	libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffff8fe9a000)
	librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000ffff8fe83000)
	libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff8fe57000)
	libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff8fd9e000)
	libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff8fc45000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffff8feaf000)
```

all libc symbols used are from GLIBC_2.17  (that could be better but it will work on most linux distros that aren't very old, so for now that seems good enough).
