### PR TITLE
Workaround #26279 by publishing manylinux_2_24 wheels instead of manylinux2014 on aarch64

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux_2_24_aarch64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_2_24_aarch64/Dockerfile
@@ -15,9 +15,15 @@
 # The aarch64 wheels are being crosscompiled to allow running the build
 # on x64 machine. The dockcross/manylinux2014-aarch64 image is a x86_64
 # image with crosscompilation toolchain installed.
-# Use an older version of dockcross image that has gcc4.9.4 because it was built
+# We use an older version of dockcross image that has gcc4.9.4 because it was built
 # before https://github.com/dockcross/dockcross/pull/449
+# Thanks to that, wheel build with this image aren't actually
+# compliant with manylinux2014, but only with manylinux_2_24
 FROM dockcross/manylinux2014-aarch64:20200929-608e6ac
+
+# Make the grpc wheels correctly tagged with manylinux_2_24
+# instead of the incorrect manylinux2014 (see the note above).
+ENV AUDITWHEEL_PLAT manylinux_2_24_$AUDITWHEEL_ARCH
 
 ###################################
 # Install Python build requirements

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -270,7 +270,7 @@ class CSharpExtArtifact:
                 if self.arch == 'aarch64':
                     # for aarch64, use a dockcross manylinux image that will
                     # give us both ready to use crosscompiler and sufficient backward compatibility
-                    dockerfile_dir = 'tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64'
+                    dockerfile_dir = 'tools/dockerfile/grpc_artifact_python_manylinux_2_24_aarch64'
                 return create_docker_jobspec(
                     self.name, dockerfile_dir,
                     'tools/run_tests/artifacts/build_artifact_csharp.sh')
@@ -395,10 +395,10 @@ def targets():
         PythonArtifact('manylinux2010', 'x86', 'cp37-cp37m'),
         PythonArtifact('manylinux2010', 'x86', 'cp38-cp38'),
         PythonArtifact('manylinux2010', 'x86', 'cp39-cp39'),
-        PythonArtifact('manylinux2014', 'aarch64', 'cp36-cp36m'),
-        PythonArtifact('manylinux2014', 'aarch64', 'cp37-cp37m'),
-        PythonArtifact('manylinux2014', 'aarch64', 'cp38-cp38'),
-        PythonArtifact('manylinux2014', 'aarch64', 'cp39-cp39'),
+        PythonArtifact('manylinux_2_24', 'aarch64', 'cp36-cp36m'),
+        PythonArtifact('manylinux_2_24', 'aarch64', 'cp37-cp37m'),
+        PythonArtifact('manylinux_2_24', 'aarch64', 'cp38-cp38'),
+        PythonArtifact('manylinux_2_24', 'aarch64', 'cp39-cp39'),
         PythonArtifact('linux_extra', 'armv7', 'cp36-cp36m'),
         PythonArtifact('linux_extra', 'armv7', 'cp37-cp37m'),
         PythonArtifact('linux_extra', 'armv7', 'cp38-cp38'),

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -126,7 +126,11 @@ class PythonArtifact:
             # This is needed because C core won't build with GCC 4.8 that's
             # included in the default dockcross toolchain and we needed
             # to opt into using a slighly newer version of GCC.
-            environ['GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX'] = 'TRUE'
+            # TODO(jtattermusch): Due to https://github.com/grpc/grpc/issues/26279
+            # we can't enable static linking libstdc++. Because of that,
+            # the resulting wheel will be compatible with fewer platforms
+            # but at least it will work.
+            # environ['GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX'] = 'TRUE'
 
             return create_docker_jobspec(
                 self.name,
@@ -152,8 +156,11 @@ class PythonArtifact:
                 # This is needed because C core won't build with GCC 4.8 that's
                 # included in the default dockcross toolchain and we needed
                 # to opt into using a slighly newer version of GCC.
-                environ['GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX'] = 'TRUE'
-
+                # TODO(jtattermusch): Due to https://github.com/grpc/grpc/issues/26279
+                # we can't enable static linking libstdc++. Because of that,
+                # the resulting wheel will be compatible with fewer platforms
+                # but at least it will work.
+                # environ['GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX'] = 'TRUE'
             else:
                 # only run auditwheel if we're not crosscompiling
                 environ['GRPC_RUN_AUDITWHEEL_REPAIR'] = 'TRUE'


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/26279.

Context:
- the dockcross/manylinux2014-aarch64 image provides a broken version of libstdc++ that (if statically linked), causes #26279 
- we need to use a version of dockcross/manylinux2014-aarch64 that has gcc newer than 4.8 (because otherwise we won't be able to build gRPC C core, since the compiler would be too old).
- When a version of dockcross/manylinux2014-aarch64 that has gcc 4.9.4, the resulting wheel won't be manylinux2014 compliant since the libstdc++ is too new (but at the same time we can't statically link libstdc++ since we know that's broken for some reason).
- the only reasonable solution in short term seems to be to compromise on the level of binary compatibility and publish  manylinux_2_24 compliant wheels instead of manylinux2014 (see https://www.python.org/dev/peps/pep-0600/). Then we can stop statically linking libstdc++ and that in turn fixes #26279.


(the armv7l wheels were suffering from the same problem as reported in #26279, so I'm removing static linking of libstdc++ for armv7 as well).
