### PR TITLE
Added external_deps to grpc++_authorization_provider

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2133,6 +2133,10 @@ grpc_cc_library(
     srcs = [
         "src/cpp/server/authorization_policy_provider.cc",
     ],
+    external_deps = [
+        "absl/synchronization",
+        "protobuf_headers",
+    ],
     language = "c++",
     public_hdrs = GRPCXX_PUBLIC_HDRS + GRPC_SECURE_PUBLIC_HDRS,
     deps = [


### PR DESCRIPTION
Added missing dependencies to `grpc++_authorization_provider`  (which was introduced by https://github.com/grpc/grpc/pull/26134) fixing clang-tidy issue not finding `google/protobuf/message.h` ([log](https://source.cloud.google.com/results/invocations/1643da32-cd04-4ffb-9526-d56ad1a50f39/log))