### PR TITLE
Don't reference symbol memcpy@GLIBC_2.2.5 on Android

### DIFF
--- a/src/core/lib/gpr/wrap_memcpy.cc
+++ b/src/core/lib/gpr/wrap_memcpy.cc
@@ -27,7 +27,7 @@
  */
 
 extern "C" {
-#ifndef OS_ANDROID
+#ifndef __ANDROID__
 #ifdef __linux__
 #if defined(__x86_64__) && !defined(GPR_MUSL_LIBC_COMPAT)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");

--- a/src/core/lib/gpr/wrap_memcpy.cc
+++ b/src/core/lib/gpr/wrap_memcpy.cc
@@ -27,9 +27,9 @@
  */
 
 extern "C" {
-#ifndef __ANDROID__
 #ifdef __linux__
-#if defined(__x86_64__) && !defined(GPR_MUSL_LIBC_COMPAT)
+#if defined(__x86_64__) && !defined(GPR_MUSL_LIBC_COMPAT) && \
+    !defined(__ANDROID__)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 void* __wrap_memcpy(void* destination, const void* source, size_t num) {
   return memcpy(destination, source, num);
@@ -38,7 +38,6 @@ void* __wrap_memcpy(void* destination, const void* source, size_t num) {
 void* __wrap_memcpy(void* destination, const void* source, size_t num) {
   return memmove(destination, source, num);
 }
-#endif
 #endif
 #endif
 }

--- a/src/core/lib/gpr/wrap_memcpy.cc
+++ b/src/core/lib/gpr/wrap_memcpy.cc
@@ -27,6 +27,7 @@
  */
 
 extern "C" {
+#ifndef OS_ANDROID
 #ifdef __linux__
 #if defined(__x86_64__) && !defined(GPR_MUSL_LIBC_COMPAT)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
@@ -37,6 +38,7 @@ void* __wrap_memcpy(void* destination, const void* source, size_t num) {
 void* __wrap_memcpy(void* destination, const void* source, size_t num) {
   return memmove(destination, source, num);
 }
+#endif
 #endif
 #endif
 }


### PR DESCRIPTION
Don't reference symbol memcpy@GLIBC_2.2.5 on Android, which can lead to issues with the link option "-Wl,--no-undefined"




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
