### PR TITLE
Upgrade six from 1.12 to 1.16 in Bazel

### DIFF
--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -24,8 +24,8 @@ def grpc_python_deps():
         http_archive(
             name = "six",
             build_file = "@com_github_grpc_grpc//third_party:six.BUILD",
-            sha256 = "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73",
-            urls = ["https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"],
+            sha256 = "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+            urls = ["https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"],
         )
 
     if "enum34" not in native.existing_rules():

--- a/third_party/six.BUILD
+++ b/third_party/six.BUILD
@@ -1,6 +1,6 @@
 genrule(
     name = "copy_six",
-    srcs = ["six-1.12.0/six.py"],
+    srcs = ["six-1.16.0/six.py"],
     outs = ["__init__.py"],
     cmd = "cp $< $(@)",
 )


### PR DESCRIPTION
This is needed to port the K8s framework to Bazel. The newer GCP Python library `>=1.12` uses `six.moves.collections_abc`, which is only available in `six>=1.13`.