### PR TITLE
Backport fixes from #26465 to v1.38.x

### DIFF
--- a/src/csharp/global.json
+++ b/src/csharp/global.json
@@ -1,6 +1,0 @@
-﻿{
-  "sdk": {
-    "version": "3.0.100",
-    "rollForward": "latestMinor"
-  }
-}

--- a/src/csharp/install_dotnet_sdk.ps1
+++ b/src/csharp/install_dotnet_sdk.ps1
@@ -22,5 +22,4 @@ Invoke-WebRequest -Uri $InstallScriptUrl -OutFile $InstallScriptPath
 
 # Installed versions should be kept in sync with
 # templates/tools/dockerfile/csharp_dotnetcli_deps.include
-&$InstallScriptPath -Version 2.1.802
-&$InstallScriptPath -Version 3.1.301
+&$InstallScriptPath -Version 2.1.816

--- a/templates/tools/dockerfile/csharp_dotnetcli_deps.include
+++ b/templates/tools/dockerfile/csharp_dotnetcli_deps.include
@@ -1,17 +1,10 @@
 # Install dotnet SDK
-ENV DOTNET_SDK_VERSION 3.1.301
+ENV DOTNET_SDK_VERSION 2.1.816
 RUN curl -sSL -o dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz ${'\\'}
     && mkdir -p /usr/share/dotnet ${'\\'}
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet ${'\\'}
     && rm dotnet.tar.gz ${'\\'}
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
-# dotnet SDK 2.1 required to run netcoreapp2.1 targets
-ENV DOTNET_SDK_OLD_VERSION 2.1.802
-RUN curl -sSL -o dotnet_old.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_OLD_VERSION/dotnet-sdk-$DOTNET_SDK_OLD_VERSION-linux-x64.tar.gz ${'\\'}
-    && mkdir -p /usr/share/dotnet ${'\\'}
-    && tar -zxf dotnet_old.tar.gz -C /usr/share/dotnet ${'\\'}
-    && rm dotnet_old.tar.gz
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -82,19 +82,12 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean
 
 # Install dotnet SDK
-ENV DOTNET_SDK_VERSION 3.1.301
+ENV DOTNET_SDK_VERSION 2.1.816
 RUN curl -sSL -o dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
-# dotnet SDK 2.1 required to run netcoreapp2.1 targets
-ENV DOTNET_SDK_OLD_VERSION 2.1.802
-RUN curl -sSL -o dotnet_old.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_OLD_VERSION/dotnet-sdk-$DOTNET_SDK_OLD_VERSION-linux-x64.tar.gz \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet_old.tar.gz -C /usr/share/dotnet \
-    && rm dotnet_old.tar.gz
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -82,19 +82,12 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean
 
 # Install dotnet SDK
-ENV DOTNET_SDK_VERSION 3.1.301
+ENV DOTNET_SDK_VERSION 2.1.816
 RUN curl -sSL -o dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
-# dotnet SDK 2.1 required to run netcoreapp2.1 targets
-ENV DOTNET_SDK_OLD_VERSION 2.1.802
-RUN curl -sSL -o dotnet_old.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_OLD_VERSION/dotnet-sdk-$DOTNET_SDK_OLD_VERSION-linux-x64.tar.gz \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet_old.tar.gz -C /usr/share/dotnet \
-    && rm dotnet_old.tar.gz
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/tools/dockerfile/test/csharp_buster_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_buster_x64/Dockerfile
@@ -85,19 +85,12 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean
 
 # Install dotnet SDK
-ENV DOTNET_SDK_VERSION 3.1.301
+ENV DOTNET_SDK_VERSION 2.1.816
 RUN curl -sSL -o dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
     && mkdir -p /usr/share/dotnet \
     && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
     && rm dotnet.tar.gz \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
-
-# dotnet SDK 2.1 required to run netcoreapp2.1 targets
-ENV DOTNET_SDK_OLD_VERSION 2.1.802
-RUN curl -sSL -o dotnet_old.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_OLD_VERSION/dotnet-sdk-$DOTNET_SDK_OLD_VERSION-linux-x64.tar.gz \
-    && mkdir -p /usr/share/dotnet \
-    && tar -zxf dotnet_old.tar.gz -C /usr/share/dotnet \
-    && rm dotnet_old.tar.gz
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -127,11 +127,6 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_CSHARP}" == "true" ]
 then
-  # install dotnet SDK 3.x
-  # no need to install dotnet SDK 2.x since it's already installed on Kokoro MacOS workers.
-  time curl -sSL -O https://download.visualstudio.microsoft.com/download/pr/964ae449-a8b8-46d1-b944-c54f6e1bf8fc/f0cbcb2df3409d865b62f0c02a9ebbb9/dotnet-sdk-3.1.409-osx-x64.pkg
-  time sudo installer -pkg ./dotnet-sdk-3.1.409-osx-x64.pkg -target /
-
   # Disable some unwanted dotnet options
   export NUGET_XMLDOC_MODE=skip
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true

--- a/tools/internal_ci/linux/grpc_xds_csharp.sh
+++ b/tools/internal_ci/linux/grpc_xds_csharp.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/csharp_stretch_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/csharp_buster_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_csharp_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_xds_v3_csharp.sh
+++ b/tools/internal_ci/linux/grpc_xds_v3_csharp.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/csharp_stretch_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/csharp_buster_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_v3_csharp_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -90,11 +90,11 @@ class CSharpPackage:
     def build_jobspec(self):
         if self.unity:
             return create_docker_jobspec(
-                self.name, 'tools/dockerfile/test/csharp_stretch_x64',
+                self.name, 'tools/dockerfile/test/csharp_buster_x64',
                 'src/csharp/build_unitypackage.sh')
         else:
             return create_docker_jobspec(
-                self.name, 'tools/dockerfile/test/csharp_stretch_x64',
+                self.name, 'tools/dockerfile/test/csharp_buster_x64',
                 'src/csharp/build_nuget.sh')
 
     def __str__(self):


### PR DESCRIPTION
Bring fixes from #26465 into release branch as well.

Since the original PR was only reverted on the master branch, we don't need to re-introduce it into v1.38.x, but the followup fixes still need to make it into v1.38.x (e.g. to unbreak building packages on v1.38.x)
