### PR TITLE
Key-Cert Pair Validation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2243,7 +2243,6 @@ grpc_cc_library(
         "absl/strings:str_format",
         "absl/time",
         "libcrypto",
-        "libssl",
     ],
     language = "c++",
     public_hdrs = GRPC_SECURE_PUBLIC_HDRS,

--- a/BUILD
+++ b/BUILD
@@ -2243,6 +2243,7 @@ grpc_cc_library(
         "absl/strings:str_format",
         "absl/time",
         "libcrypto",
+        "libssl",
     ],
     language = "c++",
     public_hdrs = GRPC_SECURE_PUBLIC_HDRS,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2064,7 +2064,7 @@ add_library(grpc
   src/core/tsi/ssl_transport_security.cc
   src/core/tsi/transport_security.cc
   src/core/tsi/transport_security_grpc.cc
-        )
+)
 
 set_target_properties(grpc PROPERTIES
   VERSION ${gRPC_CORE_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2064,7 +2064,7 @@ add_library(grpc
   src/core/tsi/ssl_transport_security.cc
   src/core/tsi/transport_security.cc
   src/core/tsi/transport_security_grpc.cc
-)
+        )
 
 set_target_properties(grpc PROPERTIES
   VERSION ${gRPC_CORE_VERSION}

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -407,8 +407,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed.");
   }
-  bool result =
-      EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
+  bool result = EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
   EVP_PKEY_free(private_evp_pkey);
   EVP_PKEY_free(public_evp_pkey);
   return result;

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -365,8 +365,8 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
   return absl::nullopt;
 }
 
-absl::Status privateKeyPublicKeyMatch(const std::string& privateKeyString,
-                                      const std::string& certString) {
+absl::Status PrivateKeyPublicKeyMatches(const std::string& privateKeyString,
+                                        const std::string& certString) {
   if (certString.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty!");
   }

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -21,7 +21,7 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
-#include <openssl/ssl.h>
+
 
 #include "src/core/lib/gprpp/stat.h"
 #include "src/core/lib/slice/slice_internal.h"

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -22,7 +22,6 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
-
 #include "src/core/lib/gprpp/stat.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/api_trace.h"

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -373,14 +373,13 @@ absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
   if (cert_string.empty()) {  // test - done
     return absl::InvalidArgumentError("Certificate string is empty.");
   }
-  BIO* cert_string_bio =
-      BIO_new_mem_buf(cert_string.c_str(), cert_string.size());
-  if (cert_string_bio == nullptr) {
+  BIO* cert_bio = BIO_new_mem_buf(cert_string.c_str(), cert_string.size());
+  if (cert_bio == nullptr) {
     return absl::InvalidArgumentError(  // test - no idea how to
         "Conversion from certificate string to BIO failed.");
   }
-  X509* x509 = PEM_read_bio_X509(cert_string_bio, nullptr, nullptr, nullptr);
-  BIO_free(cert_string_bio);
+  X509* x509 = PEM_read_bio_X509(cert_bio, nullptr, nullptr, nullptr);
+  BIO_free(cert_bio);
   if (x509 == nullptr) {
     return absl::InvalidArgumentError(  // test - done
         "Conversion from PEM string to X509 failed.");

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -384,33 +384,33 @@ absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key_,
     return absl::InvalidArgumentError(
         "Conversion from PEM string to X509 failed.");
   }
-  EVP_PKEY* public_key = X509_get_pubkey(x509);
+  EVP_PKEY* public_evp_pkey = X509_get_pubkey(x509);
   X509_free(x509);
-  if (public_key == nullptr) {
+  if (public_evp_pkey == nullptr) {
     return absl::InvalidArgumentError(
         "Extraction of public key from x.509 certificate failed.");
   }
   BIO* private_key_bio =
       BIO_new_mem_buf(private_key_.c_str(), private_key_.size());
   if (private_key_bio == nullptr) {
-    EVP_PKEY_free(public_key);
+    EVP_PKEY_free(public_evp_pkey);
     return absl::InvalidArgumentError(
         "Conversion from private key string to BIO failed.");
   }
-  EVP_PKEY* private_key =
+  EVP_PKEY* private_evp_pkey =
       PEM_read_bio_PrivateKey(private_key_bio, nullptr, nullptr, nullptr);
   BIO_free(private_key_bio);
-  if (private_key == nullptr) {
-    EVP_PKEY_free(public_key);
+  if (private_evp_pkey == nullptr) {
+    EVP_PKEY_free(public_evp_pkey);
     return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed.");
   }
   absl::Status result =
-      EVP_PKEY_cmp(private_key, public_key) == 1
+      EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1
           ? absl::OkStatus()
           : absl::InvalidArgumentError("Invalid credentials pair.");
-  EVP_PKEY_free(private_key);
-  EVP_PKEY_free(public_key);
+  EVP_PKEY_free(private_evp_pkey);
+  EVP_PKEY_free(public_evp_pkey);
   return result;
 }
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -367,34 +367,34 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
 
 absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
                                         const std::string& cert_string) {
-  if (private_key_string.empty()) {  // test - done
+  if (private_key_string.empty()) {
     return absl::InvalidArgumentError("Private key string is empty.");
   }
-  if (cert_string.empty()) {  // test - done
+  if (cert_string.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty.");
   }
   BIO* cert_bio = BIO_new_mem_buf(cert_string.c_str(), cert_string.size());
   if (cert_bio == nullptr) {
-    return absl::InvalidArgumentError(  // test - no idea how to
+    return absl::InvalidArgumentError(
         "Conversion from certificate string to BIO failed.");
   }
   X509* x509 = PEM_read_bio_X509(cert_bio, nullptr, nullptr, nullptr);
   BIO_free(cert_bio);
   if (x509 == nullptr) {
-    return absl::InvalidArgumentError(  // test - done
+    return absl::InvalidArgumentError(
         "Conversion from PEM string to X509 failed.");
   }
   EVP_PKEY* public_key = X509_get_pubkey(x509);
   X509_free(x509);
   if (public_key == nullptr) {
-    return absl::InvalidArgumentError(  // test - no idea how to
+    return absl::InvalidArgumentError(
         "Extraction of public key from x.509 certificate failed.");
   }
   BIO* private_key_bio =
       BIO_new_mem_buf(private_key_string.c_str(), private_key_string.size());
   if (private_key_bio == nullptr) {
     EVP_PKEY_free(public_key);
-    return absl::InvalidArgumentError(  // test - no idea how to
+    return absl::InvalidArgumentError(
         "Conversion from private key string to BIO failed.");
   }
   EVP_PKEY* private_key =
@@ -402,15 +402,14 @@ absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
   BIO_free(private_key_bio);
   if (private_key == nullptr) {
     EVP_PKEY_free(public_key);
-    return absl::InvalidArgumentError(  // test - done
+    return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed.");
   }
   bool result = EVP_PKEY_cmp(private_key, public_key) == 1;
   EVP_PKEY_free(private_key);
   EVP_PKEY_free(public_key);
-  return result ? absl::OkStatus()  // test - done
-                : absl::InvalidArgumentError(
-                      "Invalid credentials pair.");  // test - done
+  return result ? absl::OkStatus()
+                : absl::InvalidArgumentError("Invalid credentials pair.");
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -365,9 +365,9 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
   return absl::nullopt;
 }
 
-absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key_,
+absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key,
                                            const std::string& cert) {
-  if (private_key_.empty()) {
+  if (private_key.empty()) {
     return absl::InvalidArgumentError("Private key string is empty.");
   }
   if (cert.empty()) {
@@ -391,7 +391,7 @@ absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key_,
         "Extraction of public key from x.509 certificate failed.");
   }
   BIO* private_key_bio =
-      BIO_new_mem_buf(private_key_.c_str(), private_key_.size());
+      BIO_new_mem_buf(private_key.c_str(), private_key.size());
   if (private_key_bio == nullptr) {
     EVP_PKEY_free(public_evp_pkey);
     return absl::InvalidArgumentError(

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -365,47 +365,47 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
   return absl::nullopt;
 }
 
-absl::Status PrivateKeyPublicKeyMatches(const std::string& privateKeyString,
-                                        const std::string& certString) {
-  if (certString.empty()) {
+absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
+                                        const std::string& cert_string) {
+  if (cert_string.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty!");
   }
   // -1 indicates a null-terminated string
-  BIO* privateStringBio(BIO_new_mem_buf(certString.c_str(), -1));
-  if (privateStringBio == nullptr) {
+  BIO* private_string_bio(BIO_new_mem_buf(cert_string.c_str(), -1));
+  if (private_string_bio == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from certificate string to BIO failed!");
   }
-  X509* x509(PEM_read_bio_X509(privateStringBio, nullptr, nullptr, nullptr));
-  BIO_free(privateStringBio);
+  X509* x509(PEM_read_bio_X509(private_string_bio, nullptr, nullptr, nullptr));
+  BIO_free(private_string_bio);
   if (x509 == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from PEM string to X509 failed!");
   }
-  EVP_PKEY* publicKey(X509_get_pubkey(x509));
-  if (publicKey == nullptr) {
+  EVP_PKEY* public_key(X509_get_pubkey(x509));
+  if (public_key == nullptr) {
     return absl::InvalidArgumentError(
         "Extraction of public key from x.509 certificate failed!");
   }
-  if (privateKeyString.empty()) {
+  if (private_key_string.empty()) {
     return absl::InvalidArgumentError("Private key string is empty!");
   }
-  BIO* certStringBio(BIO_new_mem_buf(privateKeyString.c_str(), -1));
-  if (certStringBio == nullptr) {
+  BIO* cert_string_bio(BIO_new_mem_buf(private_key_string.c_str(), -1));
+  if (cert_string_bio == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from private key string to BIO failed!");
   }
-  EVP_PKEY* privateKey(
-      PEM_read_bio_PrivateKey(certStringBio, nullptr, nullptr, nullptr));
-  BIO_free(certStringBio);
-  if (privateKey == nullptr) {
+  EVP_PKEY* private_key(
+      PEM_read_bio_PrivateKey(cert_string_bio, nullptr, nullptr, nullptr));
+  BIO_free(cert_string_bio);
+  if (private_key == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed!");
   }
-  bool result(EVP_PKEY_cmp(privateKey, publicKey) == 1);
+  bool result(EVP_PKEY_cmp(private_key, public_key) == 1);
   X509_free(x509);
-  EVP_PKEY_free(privateKey);
-  EVP_PKEY_free(publicKey);
+  EVP_PKEY_free(private_key);
+  EVP_PKEY_free(public_key);
   return result ? absl::OkStatus()
                 : absl::InvalidArgumentError("Invalid credentials pair!");
 }

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -407,6 +407,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed.");
   }
+  // `result` is true if the key-cert pair matches and false otherwise
   bool result =
       EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
   EVP_PKEY_free(private_evp_pkey);

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -407,7 +407,6 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed.");
   }
-  // `result` is true if the key-cert pair matches and false otherwise
   bool result =
       EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
   EVP_PKEY_free(private_evp_pkey);

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -21,6 +21,7 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+#include <openssl/ssl.h>
 
 #include "src/core/lib/gprpp/stat.h"
 #include "src/core/lib/slice/slice_internal.h"

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -366,19 +366,21 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
 }
 
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
-    absl::string_view private_key, absl::string_view cert) {
+    absl::string_view private_key, absl::string_view cert_chain) {
   if (private_key.empty()) {
     return absl::InvalidArgumentError("Private key string is empty.");
   }
-  if (cert.empty()) {
+  if (cert_chain.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty.");
   }
-  std::string temp = std::string(cert);
+  std::string temp = std::string(cert_chain);
   BIO* cert_bio = BIO_new_mem_buf(temp.c_str(), temp.size());
   if (cert_bio == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from certificate string to BIO failed.");
   }
+  // Reads the first cert from the cert_chain which is expected to be the leaf
+  // cert
   X509* x509 = PEM_read_bio_X509(cert_bio, nullptr, nullptr, nullptr);
   BIO_free(cert_bio);
   if (x509 == nullptr) {

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -368,51 +368,50 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
 absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
                                         const std::string& cert_string) {
   if (private_key_string.empty()) {  // test - done
-    return absl::InvalidArgumentError("Private key string is empty!");
+    return absl::InvalidArgumentError("Private key string is empty.");
   }
   if (cert_string.empty()) {  // test - done
-    return absl::InvalidArgumentError("Certificate string is empty!");
+    return absl::InvalidArgumentError("Certificate string is empty.");
   }
-  const char* cert_buffer = cert_string.c_str();
-  BIO* cert_string_bio = BIO_new_mem_buf(cert_buffer, strlen(cert_buffer));
+  BIO* cert_string_bio =
+      BIO_new_mem_buf(cert_string.c_str(), cert_string.size());
   if (cert_string_bio == nullptr) {
     return absl::InvalidArgumentError(  // test - no idea how to
-        "Conversion from certificate string to BIO failed!");
+        "Conversion from certificate string to BIO failed.");
   }
   X509* x509 = PEM_read_bio_X509(cert_string_bio, nullptr, nullptr, nullptr);
   BIO_free(cert_string_bio);
   if (x509 == nullptr) {
     return absl::InvalidArgumentError(  // test - done
-        "Conversion from PEM string to X509 failed!");
+        "Conversion from PEM string to X509 failed.");
   }
   EVP_PKEY* public_key = X509_get_pubkey(x509);
   X509_free(x509);
   if (public_key == nullptr) {
     return absl::InvalidArgumentError(  // test - no idea how to
-        "Extraction of public key from x.509 certificate failed!");
+        "Extraction of public key from x.509 certificate failed.");
   }
-  const char* private_key_buffer = private_key_string.c_str();
-  BIO* private_string_bio =
-      BIO_new_mem_buf(private_key_buffer, strlen(private_key_buffer));
-  if (private_string_bio == nullptr) {
+  BIO* private_key_bio =
+      BIO_new_mem_buf(private_key_string.c_str(), private_key_string.size());
+  if (private_key_bio == nullptr) {
     EVP_PKEY_free(public_key);
     return absl::InvalidArgumentError(  // test - no idea how to
-        "Conversion from private key string to BIO failed!");
+        "Conversion from private key string to BIO failed.");
   }
   EVP_PKEY* private_key =
-      PEM_read_bio_PrivateKey(private_string_bio, nullptr, nullptr, nullptr);
-  BIO_free(private_string_bio);
+      PEM_read_bio_PrivateKey(private_key_bio, nullptr, nullptr, nullptr);
+  BIO_free(private_key_bio);
   if (private_key == nullptr) {
     EVP_PKEY_free(public_key);
     return absl::InvalidArgumentError(  // test - done
-        "Conversion from PEM string to EVP_PKEY failed!");
+        "Conversion from PEM string to EVP_PKEY failed.");
   }
   bool result = EVP_PKEY_cmp(private_key, public_key) == 1;
   EVP_PKEY_free(private_key);
   EVP_PKEY_free(public_key);
   return result ? absl::OkStatus()  // test - done
                 : absl::InvalidArgumentError(
-                      "Invalid credentials pair!");  // test - done
+                      "Invalid credentials pair.");  // test - done
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -373,8 +373,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
   if (cert_chain.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty.");
   }
-  std::string temp = std::string(cert_chain);
-  BIO* cert_bio = BIO_new_mem_buf(temp.c_str(), temp.size());
+  BIO* cert_bio = BIO_new_mem_buf(cert_chain.data(), cert_chain.size());
   if (cert_bio == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from certificate string to BIO failed.");
@@ -393,8 +392,8 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     return absl::InvalidArgumentError(
         "Extraction of public key from x.509 certificate failed.");
   }
-  temp = std::string(private_key);
-  BIO* private_key_bio = BIO_new_mem_buf(temp.c_str(), temp.size());
+  BIO* private_key_bio =
+      BIO_new_mem_buf(private_key.data(), private_key.size());
   if (private_key_bio == nullptr) {
     EVP_PKEY_free(public_evp_pkey);
     return absl::InvalidArgumentError(
@@ -408,7 +407,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     return absl::InvalidArgumentError(
         "Conversion from PEM string to EVP_PKEY failed.");
   }
-  absl::StatusOr<bool> result =
+  bool result =
       EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
   EVP_PKEY_free(private_evp_pkey);
   EVP_PKEY_free(public_evp_pkey);

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -132,10 +132,12 @@ class FileWatcherCertificateProvider final
   // information.
   std::map<std::string, WatcherInfo> watcher_info_;
 };
+
 //  Checks if the private key matches certificate's public key. Returns error
 //  status on failure.
 absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key,
                                            const std::string& cert);
+
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -133,21 +133,11 @@ class FileWatcherCertificateProvider final
   std::map<std::string, WatcherInfo> watcher_info_;
 };
 
-// A function for converting EVP_PKEY to C style string
-char* convertPkeyToString(EVP_PKEY* pkey);
-
 // A function for converting PEM-encoded C style string to EVP_PKEY
-EVP_PKEY* convertPemStringToPkey(const char* pkeyString);
-
-// A function for converting X509 to C style string
-char* convertX509ToString(X509* x509);
+EVP_PKEY* convertPemStringToPkey(const std::string& pkeyString);
 
 // A function for converting PEM-encoded C style string to X509
-X509* convertPemStringToX509(const char* x509String);
-
-// A function for freeing the the buffers allocated in functions for
-// converting OpenSSL structures to c strings
-void freePEMString(const char* pkeyString);
+X509* convertPemStringToX509(const std::string& x509String);
 
 // A function for comparing EVP_PKEY keys that takes into consideration that
 // EVP_PKEY_cmp() returns 1 if the keys match, 0 if they don't match, -1 if the
@@ -156,10 +146,8 @@ bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
 
 // A function for checking for a match between a private key and a certificate's
 // public key
-bool privateKeyPublicKeyMatch(const char* private_key, const char* cert,
-                              grpc_error_handle error_handle);
-
-const char* boolToString(bool b);
+absl::Status privateKeyPublicKeyMatch(const std::string& private_key,
+                              const std::string& cert);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -147,7 +147,7 @@ bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
 // A function for checking for a match between a private key and a certificate's
 // public key
 absl::Status privateKeyPublicKeyMatch(const std::string& private_key,
-                              const std::string& cert);
+                                      const std::string& cert);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,8 +134,8 @@ class FileWatcherCertificateProvider final
 };
 //  Checks if the private key matches certificate's public key. Returns error
 //  status on failure.
-absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
-                                        const std::string& cert_string);
+absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key_,
+                                           const std::string& cert);
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,8 +134,9 @@ class FileWatcherCertificateProvider final
   std::map<std::string, WatcherInfo> watcher_info_;
 };
 
-//  Checks if the private key matches certificate's public key. Returns error
-//  status on failure.
+//  Checks if the private key matches certificate's public key. Returns an error
+//  absl::Status on failure or a bool for `private_key`-`cert_chain` match.
+//  The bool is true if the key-cert pair matches and false otherwise
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     absl::string_view private_key, absl::string_view cert_chain);
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -136,14 +136,14 @@ class FileWatcherCertificateProvider final
 // A function for converting EVP_PKEY to C style string
 char* convertPkeyToString(EVP_PKEY* pkey);
 
-// A function for converting C style PEM-encoded string to EVP_PKEY
+// A function for converting PEM-encoded C style string to EVP_PKEY
 EVP_PKEY* convertPemStringToPkey(const char* pkeyString);
 
 // A function for converting X509 to C style string
 char* convertX509ToString(X509* x509);
 
-// A function for converting C style PEM-encoded string to X509
-X509 *convertPemStringToX509(const char *x509String);
+// A function for converting PEM-encoded C style string to X509
+X509* convertPemStringToX509(const char* x509String);
 
 // A function for freeing the the buffers allocated in functions for
 // converting OpenSSL structures to c strings
@@ -154,7 +154,13 @@ void freePEMString(const char* pkeyString);
 // key types are different and -2 if the operation is not supported.
 bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
 
+// A function for checking for a match between a private key and a certificate's
+// public key
+bool privateKeyPublicKeyMatch(const char* private_key, const char* cert,
+                              grpc_error_handle error_handle);
+
 const char* boolToString(bool b);
+
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,9 +134,8 @@ class FileWatcherCertificateProvider final
   std::map<std::string, WatcherInfo> watcher_info_;
 };
 
-//  Checks if the private key matches certificate's public key. Returns an error
-//  absl::Status on failure or a bool for `private_key`-`cert_chain` match.
-//  The bool is true if the key-cert pair matches and false otherwise.
+//  Returns a not-OK status on failure, or a bool indicating
+//  whether the key/cert pair matches.
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     absl::string_view private_key, absl::string_view cert_chain);
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,7 +134,7 @@ class FileWatcherCertificateProvider final
 };
 //  Checks if the private key matches certificate's public key. Returns error
 //  status on failure.
-absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key_,
+absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key,
                                            const std::string& cert);
 }  // namespace grpc_core
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/status/statusor.h"
 
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
@@ -135,8 +136,8 @@ class FileWatcherCertificateProvider final
 
 //  Checks if the private key matches certificate's public key. Returns error
 //  status on failure.
-absl::Status PrivateKeyAndCertificateMatch(const std::string& private_key,
-                                           const std::string& cert);
+absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
+    absl::string_view private_key, absl::string_view cert);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -133,6 +133,21 @@ class FileWatcherCertificateProvider final
   std::map<std::string, WatcherInfo> watcher_info_;
 };
 
+// A function for converting EVP_PKEY to C style string
+char* convertPkeyToString(EVP_PKEY* pkey);
+
+// A function for freeing the the buffer allocated in convertPkeyToString()
+void freeKeyString(const char* pkeyString);
+
+// A function for converting C style string to EVP_PKEY
+EVP_PKEY* convertPemStringToPkey(const char* pkeyString);
+
+// A function for comparing EVP_PKEY keys which takes into consideration that
+// EVP_PKEY_cmp() returns 1 if the keys match, 0 if they don't match, -1 if the
+// key types are different and -2 if the operation is not supported.
+bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
+
+const char* boolToString(bool b);
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,8 +134,8 @@ class FileWatcherCertificateProvider final
 };
 //  Checks if the private key matches certificate's public key. Returns error
 //  status on failure.
-absl::Status PrivateKeyPublicKeyMatches(const std::string& privateKeyString,
-                                        const std::string& certString);
+absl::Status PrivateKeyPublicKeyMatches(const std::string& private_key_string,
+                                        const std::string& cert_string);
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -24,7 +24,6 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/status/statusor.h"
-#include "openssl/ssl.h"
 
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -136,7 +136,7 @@ class FileWatcherCertificateProvider final
 
 //  Checks if the private key matches certificate's public key. Returns an error
 //  absl::Status on failure or a bool for `private_key`-`cert_chain` match.
-//  The bool is true if the key-cert pair matches and false otherwise
+//  The bool is true if the key-cert pair matches and false otherwise.
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
     absl::string_view private_key, absl::string_view cert_chain);
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,7 +134,7 @@ class FileWatcherCertificateProvider final
   std::map<std::string, WatcherInfo> watcher_info_;
 };
 
-//  Checks if the private key and leaf cert for all pairs in the list match.
+//  Checks if the private key matches the certificate's public key.
 //  Returns a not-OK status on failure, or a bool indicating
 //  whether the key/cert pair matches.
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -137,7 +137,7 @@ class FileWatcherCertificateProvider final
 //  Checks if the private key matches certificate's public key. Returns error
 //  status on failure.
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
-    absl::string_view private_key, absl::string_view cert);
+    absl::string_view private_key, absl::string_view cert_chain);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -145,19 +145,14 @@ char* convertX509ToString(X509* x509);
 // A function for converting C style PEM-encoded string to X509
 X509 *convertPemStringToX509(const char *x509String);
 
-// A function for freeing the the buffer allocated in convertPkeyToString()
-// TODO: Change to freePEMString for both cert and key strings
-void freeKeyString(const char* pkeyString);
+// A function for freeing the the buffers allocated in functions for
+// converting OpenSSL structures to c strings
+void freePEMString(const char* pkeyString);
 
 // A function for comparing EVP_PKEY keys that takes into consideration that
 // EVP_PKEY_cmp() returns 1 if the keys match, 0 if they don't match, -1 if the
 // key types are different and -2 if the operation is not supported.
 bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
-
-// A function for comparing X509 certificates that takes into consideration
-// that X509_cmp() returns -1, 0, or 1 if object a is found to be less than,
-// to match, or be greater than object b, respectively
-bool compareCerts(const X509* a, const X509* b);
 
 const char* boolToString(bool b);
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -132,10 +132,10 @@ class FileWatcherCertificateProvider final
   // information.
   std::map<std::string, WatcherInfo> watcher_info_;
 };
-// A function for checking for a match between a private key and a certificate's
-// public key
-absl::Status privateKeyPublicKeyMatch(const std::string& privateKeyString,
-                                      const std::string& certString);
+//  Checks if the private key matches certificate's public key. Returns error
+//  status on failure.
+absl::Status PrivateKeyPublicKeyMatches(const std::string& privateKeyString,
+                                        const std::string& certString);
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -134,6 +134,7 @@ class FileWatcherCertificateProvider final
   std::map<std::string, WatcherInfo> watcher_info_;
 };
 
+//  Checks if the private key and leaf cert for all pairs in the list match.
 //  Returns a not-OK status on failure, or a bool indicating
 //  whether the key/cert pair matches.
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -132,23 +132,10 @@ class FileWatcherCertificateProvider final
   // information.
   std::map<std::string, WatcherInfo> watcher_info_;
 };
-
-// A function for converting PEM-encoded C style string to EVP_PKEY
-EVP_PKEY* convertPemStringToPkey(const std::string& pkeyString);
-
-// A function for converting PEM-encoded C style string to X509
-X509* convertPemStringToX509(const std::string& x509String);
-
-// A function for comparing EVP_PKEY keys that takes into consideration that
-// EVP_PKEY_cmp() returns 1 if the keys match, 0 if they don't match, -1 if the
-// key types are different and -2 if the operation is not supported.
-bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
-
 // A function for checking for a match between a private key and a certificate's
 // public key
-absl::Status privateKeyPublicKeyMatch(const std::string& private_key,
-                                      const std::string& cert);
-
+absl::Status privateKeyPublicKeyMatch(const std::string& privateKeyString,
+                                      const std::string& certString);
 }  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_SECURITY_CREDENTIALS_TLS_GRPC_TLS_CERTIFICATE_PROVIDER_H

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -136,16 +136,28 @@ class FileWatcherCertificateProvider final
 // A function for converting EVP_PKEY to C style string
 char* convertPkeyToString(EVP_PKEY* pkey);
 
-// A function for freeing the the buffer allocated in convertPkeyToString()
-void freeKeyString(const char* pkeyString);
-
-// A function for converting C style string to EVP_PKEY
+// A function for converting C style PEM-encoded string to EVP_PKEY
 EVP_PKEY* convertPemStringToPkey(const char* pkeyString);
 
-// A function for comparing EVP_PKEY keys which takes into consideration that
+// A function for converting X509 to C style string
+char* convertX509ToString(X509* x509);
+
+// A function for converting C style PEM-encoded string to X509
+X509 *convertPemStringToX509(const char *x509String);
+
+// A function for freeing the the buffer allocated in convertPkeyToString()
+// TODO: Change to freePEMString for both cert and key strings
+void freeKeyString(const char* pkeyString);
+
+// A function for comparing EVP_PKEY keys that takes into consideration that
 // EVP_PKEY_cmp() returns 1 if the keys match, 0 if they don't match, -1 if the
 // key types are different and -2 if the operation is not supported.
 bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b);
+
+// A function for comparing X509 certificates that takes into consideration
+// that X509_cmp() returns -1, 0, or 1 if object a is found to be less than,
+// to match, or be greater than object b, respectively
+bool compareCerts(const X509* a, const X509* b);
 
 const char* boolToString(bool b);
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -24,6 +24,7 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/status/statusor.h"
+#include "openssl/ssl.h"
 
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -496,27 +496,27 @@ TEST_F(GrpcTlsCertificateProviderTest,
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPairOne) {
-  absl::Status matchStatus(
+  absl::Status match_status(
       PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_2_));
-  EXPECT_TRUE(matchStatus.ok());
+  EXPECT_TRUE(match_status.ok());
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPairTwo) {
-  absl::Status matchStatus(
+  absl::Status match_status(
       PrivateKeyPublicKeyMatches(private_key_, cert_chain_));
-  EXPECT_TRUE(matchStatus.ok());
+  EXPECT_TRUE(match_status.ok());
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPairOne) {
-  absl::Status matchStatus(
+  absl::Status match_status(
       PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_));
-  EXPECT_FALSE(matchStatus.ok());
+  EXPECT_FALSE(match_status.ok());
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPairTwo) {
-  absl::Status matchStatus(
+  absl::Status match_status(
       PrivateKeyPublicKeyMatches(private_key_, cert_chain_2_));
-  EXPECT_FALSE(matchStatus.ok());
+  EXPECT_FALSE(match_status.ok());
 }
 }  // namespace testing
 }  // namespace grpc_core

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -495,31 +495,30 @@ TEST_F(GrpcTlsCertificateProviderTest,
   CancelWatch(watcher_state_1);
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, CertifyServer0CredentialsPairMatch) {
+TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPairOne) {
   absl::Status matchStatus(
-      privateKeyPublicKeyMatch(private_key_2_, cert_chain_2_));
-  EXPECT_TRUE(matchStatus.ok()) << matchStatus.ToString().c_str();
+      PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_2_));
+  EXPECT_TRUE(matchStatus.ok());
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, CertifyServer1CredentialsPairMatch) {
-  absl::Status matchStatus(privateKeyPublicKeyMatch(private_key_, cert_chain_));
-  EXPECT_TRUE(matchStatus.ok()) << matchStatus.ToString().c_str();
-}
-
-TEST_F(GrpcTlsCertificateProviderTest, CertifyServer0KeyServer1CertMismatch) {
+TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPairTwo) {
   absl::Status matchStatus(
-      privateKeyPublicKeyMatch(private_key_2_, cert_chain_));
-  EXPECT_FALSE(matchStatus.ok()) << matchStatus.ToString().c_str();
+      PrivateKeyPublicKeyMatches(private_key_, cert_chain_));
+  EXPECT_TRUE(matchStatus.ok());
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, CertifyServer1KeyServer1CertMismatch) {
+TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPairOne) {
   absl::Status matchStatus(
-      privateKeyPublicKeyMatch(private_key_, cert_chain_2_));
-  EXPECT_FALSE(matchStatus.ok()) << matchStatus.ToString().c_str();
+      PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_));
+  EXPECT_FALSE(matchStatus.ok());
 }
 
+TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPairTwo) {
+  absl::Status matchStatus(
+      PrivateKeyPublicKeyMatches(private_key_, cert_chain_2_));
+  EXPECT_FALSE(matchStatus.ok());
+}
 }  // namespace testing
-
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -504,7 +504,7 @@ TEST_F(GrpcTlsCertificateProviderTest, EmptyPrivateKeyString) {
 
 TEST_F(GrpcTlsCertificateProviderTest, EmptyCertificateString) {
   absl::Status status =
-      PrivateKeyPublicKeyMatches(private_key_2_, /*certificate_string=*/"");
+      PrivateKeyPublicKeyMatches(private_key_2_, /*cert_string=*/"");
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Certificate string is empty.");
 }

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -495,42 +495,44 @@ TEST_F(GrpcTlsCertificateProviderTest,
   CancelWatch(watcher_state_1);
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, EmptyPrivateKeyString) {
+TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {
   absl::Status status =
-      PrivateKeyPublicKeyMatches(/*private_key_string=*/"", cert_chain_);
+      PrivateKeyAndCertificateMatch(/*private_key_=*/"", cert_chain_);
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Private key string is empty.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, EmptyCertificateString) {
+TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyCertificate) {
   absl::Status status =
-      PrivateKeyPublicKeyMatches(private_key_2_, /*cert_string=*/"");
+      PrivateKeyAndCertificateMatch(private_key_2_, /*cert=*/"");
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Certificate string is empty.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, FailedStringToX509Conversion) {
+TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidCertFormat) {
   absl::Status status =
-      PrivateKeyPublicKeyMatches(private_key_2_, "invalid_certificate");
+      PrivateKeyAndCertificateMatch(private_key_2_, "invalid_certificate");
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Conversion from PEM string to X509 failed.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, FailedStringToEVP_PKEYConversion) {
+TEST_F(GrpcTlsCertificateProviderTest,
+       FailedKeyCertMatchOnInvalidPrivateKeyFormat) {
   absl::Status status =
-      PrivateKeyPublicKeyMatches("invalid_private_key", cert_chain_2_);
+      PrivateKeyAndCertificateMatch("invalid_private_key", cert_chain_2_);
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Conversion from PEM string to EVP_PKEY failed.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPair) {
+TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertPair) {
   absl::Status status =
-      PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_2_);
+      PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_2_);
   EXPECT_TRUE(status.ok());
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPair) {
-  absl::Status status = PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_);
+TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertPair) {
+  absl::Status status =
+      PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_);
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Invalid credentials pair.");
 }

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -505,7 +505,7 @@ TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyCertificate) {
   absl::StatusOr<bool> status =
-      PrivateKeyAndCertificateMatch(private_key_2_, /*cert=*/"");
+      PrivateKeyAndCertificateMatch(private_key_2_, /*cert_chain=*/"");
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.status().message(), "Certificate string is empty.");

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -524,13 +524,13 @@ TEST_F(GrpcTlsCertificateProviderTest,
   EXPECT_EQ(status.message(), "Conversion from PEM string to EVP_PKEY failed.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertPair) {
+TEST_F(GrpcTlsCertificateProviderTest, SuccessfulKeyCertMatch) {
   absl::Status status =
       PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_2_);
   EXPECT_TRUE(status.ok());
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertPair) {
+TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidPair) {
   absl::Status status =
       PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_);
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -497,7 +497,7 @@ TEST_F(GrpcTlsCertificateProviderTest,
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {
   absl::Status status =
-      PrivateKeyAndCertificateMatch(/*private_key_=*/"", cert_chain_);
+      PrivateKeyAndCertificateMatch(/*private_key=*/"", cert_chain_);
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(status.message(), "Private key string is empty.");
 }

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -495,27 +495,15 @@ TEST_F(GrpcTlsCertificateProviderTest,
   CancelWatch(watcher_state_1);
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPairOne) {
+TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPair) {
   absl::Status match_status(
       PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_2_));
   EXPECT_TRUE(match_status.ok());
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPairTwo) {
-  absl::Status match_status(
-      PrivateKeyPublicKeyMatches(private_key_, cert_chain_));
-  EXPECT_TRUE(match_status.ok());
-}
-
-TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPairOne) {
+TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPair) {
   absl::Status match_status(
       PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_));
-  EXPECT_FALSE(match_status.ok());
-}
-
-TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPairTwo) {
-  absl::Status match_status(
-      PrivateKeyPublicKeyMatches(private_key_, cert_chain_2_));
   EXPECT_FALSE(match_status.ok());
 }
 }  // namespace testing

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -496,44 +496,43 @@ TEST_F(GrpcTlsCertificateProviderTest,
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, EmptyPrivateKeyString) {
-  absl::Status match_status = PrivateKeyPublicKeyMatches("", cert_chain_);
-  EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(), "Private key string is empty.");
+  absl::Status status =
+      PrivateKeyPublicKeyMatches(/*private_key_string=*/"", cert_chain_);
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(), "Private key string is empty.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, EmptyCertificateString) {
-  absl::Status match_status = PrivateKeyPublicKeyMatches(private_key_2_, "");
-  EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(), "Certificate string is empty.");
+  absl::Status status =
+      PrivateKeyPublicKeyMatches(private_key_2_, /*certificate_string=*/"");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(), "Certificate string is empty.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedStringToX509Conversion) {
-  absl::Status match_status =
+  absl::Status status =
       PrivateKeyPublicKeyMatches(private_key_2_, "invalid_certificate");
-  EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(),
-            "Conversion from PEM string to X509 failed.");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(), "Conversion from PEM string to X509 failed.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedStringToEVP_PKEYConversion) {
-  absl::Status match_status =
+  absl::Status status =
       PrivateKeyPublicKeyMatches("invalid_private_key", cert_chain_2_);
-  EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(),
-            "Conversion from PEM string to EVP_PKEY failed.");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(), "Conversion from PEM string to EVP_PKEY failed.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPair) {
-  absl::Status match_status =
+  absl::Status status =
       PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_2_);
-  EXPECT_TRUE(match_status.ok());
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPair) {
-  absl::Status match_status =
-      PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_);
-  EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(), "Invalid credentials pair.");
+  absl::Status status = PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_);
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(), "Invalid credentials pair.");
 }
 
 }  // namespace testing

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -496,45 +496,51 @@ TEST_F(GrpcTlsCertificateProviderTest,
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {
-  absl::Status status =
+  absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(/*private_key=*/"", cert_chain_);
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(status.message(), "Private key string is empty.");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.status().message(), "Private key string is empty.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyCertificate) {
-  absl::Status status =
+  absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, /*cert=*/"");
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(status.message(), "Certificate string is empty.");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.status().message(), "Certificate string is empty.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidCertFormat) {
-  absl::Status status =
+  absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, "invalid_certificate");
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(status.message(), "Conversion from PEM string to X509 failed.");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.status().message(),
+            "Conversion from PEM string to X509 failed.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
        FailedKeyCertMatchOnInvalidPrivateKeyFormat) {
-  absl::Status status =
+  absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch("invalid_private_key", cert_chain_2_);
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(status.message(), "Conversion from PEM string to EVP_PKEY failed.");
+  EXPECT_EQ(status.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.status().message(),
+            "Conversion from PEM string to EVP_PKEY failed.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, SuccessfulKeyCertMatch) {
-  absl::Status status =
+  absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_2_);
   EXPECT_TRUE(status.ok());
+  EXPECT_TRUE(*status);
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidPair) {
-  absl::Status status =
+  absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_);
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(status.message(), "Invalid credentials pair.");
+  EXPECT_TRUE(status.ok());
+  EXPECT_FALSE(*status);
 }
 
 }  // namespace testing

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -169,8 +169,6 @@ class GrpcTlsCertificateProviderTest : public ::testing::Test {
     root_cert_2_ = GetFileContents(CA_CERT_PATH_2);
     cert_chain_2_ = GetFileContents(SERVER_CERT_PATH_2);
     private_key_2_ = GetFileContents(SERVER_KEY_PATH_2);
-    testPkey = nullptr;
-    testX509 = nullptr;
   }
 
   WatcherState* MakeWatcher(
@@ -210,8 +208,6 @@ class GrpcTlsCertificateProviderTest : public ::testing::Test {
   std::list<WatcherState> watchers_;
   // This is to make watchers_ thread-safe.
   Mutex mu_;
-  EVP_PKEY* testPkey;
-  X509* testX509;
 };
 
 TEST_F(GrpcTlsCertificateProviderTest, StaticDataCertificateProviderCreation) {
@@ -301,9 +297,9 @@ TEST_F(GrpcTlsCertificateProviderTest,
 TEST_F(GrpcTlsCertificateProviderTest,
        FileWatcherCertificateProviderOnBothCertsRefreshed) {
   // Create temporary files and copy cert data into them.
-  TmpFile tmp_root_cert((root_cert_));
+  TmpFile tmp_root_cert(root_cert_);
   TmpFile tmp_identity_key(private_key_);
-  TmpFile tmp_identity_cert((cert_chain_));
+  TmpFile tmp_identity_cert(cert_chain_);
   // Create FileWatcherCertificateProvider.
   FileWatcherCertificateProvider provider(tmp_identity_key.name(),
                                           tmp_identity_cert.name(),
@@ -338,7 +334,7 @@ TEST_F(GrpcTlsCertificateProviderTest,
   // Create temporary files and copy cert data into them.
   TmpFile tmp_root_cert(root_cert_);
   TmpFile tmp_identity_key(private_key_);
-  TmpFile tmp_identity_cert((cert_chain_));
+  TmpFile tmp_identity_cert(cert_chain_);
   // Create FileWatcherCertificateProvider.
   FileWatcherCertificateProvider provider(tmp_identity_key.name(),
                                           tmp_identity_cert.name(),
@@ -438,8 +434,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
        FileWatcherCertificateProviderWithGoodAtFirstThenDeletedRootCerts) {
   // Create temporary files and copy cert data into it.
   auto tmp_root_cert = absl::make_unique<TmpFile>(root_cert_);
-  TmpFile tmp_identity_key((private_key_));
-  TmpFile tmp_identity_cert((cert_chain_));
+  TmpFile tmp_identity_key(private_key_);
+  TmpFile tmp_identity_cert(cert_chain_);
   // Create FileWatcherCertificateProvider.
   FileWatcherCertificateProvider provider(tmp_identity_key.name(),
                                           tmp_identity_cert.name(),
@@ -500,22 +496,25 @@ TEST_F(GrpcTlsCertificateProviderTest,
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, CertifyServer0CredentialsPairMatch) {
-  absl::Status matchStatus{privateKeyPublicKeyMatch(private_key_2_, cert_chain_2_)};
+  absl::Status matchStatus(
+      privateKeyPublicKeyMatch(private_key_2_, cert_chain_2_));
   EXPECT_TRUE(matchStatus.ok()) << matchStatus.ToString().c_str();
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, CertifyServer1CredentialsPairMatch) {
-  absl::Status matchStatus{privateKeyPublicKeyMatch(private_key_, cert_chain_)};
+  absl::Status matchStatus(privateKeyPublicKeyMatch(private_key_, cert_chain_));
   EXPECT_TRUE(matchStatus.ok()) << matchStatus.ToString().c_str();
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, CertifyServer0KeyServer1CertMismatch) {
-  absl::Status matchStatus{privateKeyPublicKeyMatch(private_key_2_, cert_chain_)};
+  absl::Status matchStatus(
+      privateKeyPublicKeyMatch(private_key_2_, cert_chain_));
   EXPECT_FALSE(matchStatus.ok()) << matchStatus.ToString().c_str();
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, CertifyServer1KeyServer1CertMismatch) {
-  absl::Status matchStatus{privateKeyPublicKeyMatch(private_key_, cert_chain_2_)};
+  absl::Status matchStatus(
+      privateKeyPublicKeyMatch(private_key_, cert_chain_2_));
   EXPECT_FALSE(matchStatus.ok()) << matchStatus.ToString().c_str();
 }
 

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -496,37 +496,31 @@ TEST_F(GrpcTlsCertificateProviderTest,
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, EmptyPrivateKeyString) {
-  std::string empty_string;
-  absl::Status match_status =
-      PrivateKeyPublicKeyMatches(empty_string, cert_chain_);
+  absl::Status match_status = PrivateKeyPublicKeyMatches("", cert_chain_);
   EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(), "Private key string is empty!");
+  EXPECT_EQ(match_status.message(), "Private key string is empty.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, EmptyCertificateString) {
-  std::string empty_string;
-  absl::Status match_status =
-      PrivateKeyPublicKeyMatches(private_key_2_, empty_string);
+  absl::Status match_status = PrivateKeyPublicKeyMatches(private_key_2_, "");
   EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(), "Certificate string is empty!");
+  EXPECT_EQ(match_status.message(), "Certificate string is empty.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedStringToX509Conversion) {
-  std::string rubbish_string = "rubbish string";
   absl::Status match_status =
-      PrivateKeyPublicKeyMatches(private_key_2_, rubbish_string);
+      PrivateKeyPublicKeyMatches(private_key_2_, "invalid_certificate");
   EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(match_status.message(),
-            "Conversion from PEM string to X509 failed!");
+            "Conversion from PEM string to X509 failed.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedStringToEVP_PKEYConversion) {
-  std::string rubbish_string = "rubbish string";
   absl::Status match_status =
-      PrivateKeyPublicKeyMatches(rubbish_string, cert_chain_2_);
+      PrivateKeyPublicKeyMatches("invalid_private_key", cert_chain_2_);
   EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(match_status.message(),
-            "Conversion from PEM string to EVP_PKEY failed!");
+            "Conversion from PEM string to EVP_PKEY failed.");
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, ValidPrivateKeyCertChainPair) {
@@ -539,7 +533,7 @@ TEST_F(GrpcTlsCertificateProviderTest, InvalidPrivateKeyCertChainPair) {
   absl::Status match_status =
       PrivateKeyPublicKeyMatches(private_key_2_, cert_chain_);
   EXPECT_EQ(match_status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(match_status.message(), "Invalid credentials pair!");
+  EXPECT_EQ(match_status.message(), "Invalid credentials pair.");
 }
 
 }  // namespace testing


### PR DESCRIPTION
**Contains functionality for converting PEM-encoded string to equivalent OpenSSL structures and accompanying functions for testing.**

The main functionality, converting PEM string to `EVP_PKEY`, is handled by `EVP_PKEY* convertPemStringToPkey(const char* pkeyString)`.

To test this function, an RSA key (`EVP_PKEY_RSA`) is generated and converted to string by the function `char* convertPkeyToString(EVP_PKEY* pkey)`. This string is then converted back to OpenSSL key form `EVP_PKEY`. The returned and generated keys are compared for equality by `bool compareKeys(const EVP_PKEY* a, const EVP_PKEY* b)` and the test finally expects its return value to be `true`.

A function `const char* boolToString(bool b)` is written for logging boolean assertions during the test `TEST_F(GrpcTlsCertificateProviderTest, ConvertPkeyToStringHandlesEVP_PKEY_RSA)`.

Also, considering the char buffer returned by `convertPkeyToString()` is allocated memory using `malloc()`, the function `void freeKeyString(const char* pkeyString)` is implemented to free the memory block and avoid memory leaks.

@ZhenLian @ashithasantosh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26471)
<!-- Reviewable:end -->
