### PR TITLE
[C#] Add ChannelCredentials.SecureSsl property for better codecompletion with ChannelCredentials

### DIFF
--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -58,6 +58,7 @@ namespace Grpc.Core
         /// When used with Grpc.Core, these credentials will load from a
         /// disk file pointed to by the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable.
         /// If that fails, gets the roots certificates from a well known place on disk.
+        /// Use <see cref="SslCredentials"/> to customize the credentials.
         /// </para>
         /// </summary>
         public static ChannelCredentials Secure

--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -31,7 +31,7 @@ namespace Grpc.Core
     public abstract class ChannelCredentials
     {
         static readonly ChannelCredentials InsecureInstance = new InsecureCredentials();
-        static readonly ChannelCredentials SecureInstance = new SslCredentials();
+        static readonly ChannelCredentials SecureSslInstance = new SslCredentials();
 
         /// <summary>
         /// Creates a new instance of channel credentials
@@ -55,17 +55,16 @@ namespace Grpc.Core
         /// <summary>
         /// Returns instance of credentials that provides SSL security.
         /// <para>
-        /// When used with Grpc.Core, these credentials will load from a
-        /// disk file pointed to by the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable.
-        /// If that fails, gets the roots certificates from a well known place on disk.
-        /// Use <see cref="SslCredentials"/> to customize the credentials.
+        /// These credentials are the same as creating <see cref="SslCredentials"/> without parameters.
+        /// Apps that are using Grpc.Core can create <see cref="SslCredentials"/> directly to customize
+        /// the secure SSL credentials.
         /// </para>
         /// </summary>
-        public static ChannelCredentials Secure
+        public static ChannelCredentials SecureSsl
         {
             get
             {
-                return SecureInstance;
+                return SecureSslInstance;
             }
         }
 

--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -31,6 +31,7 @@ namespace Grpc.Core
     public abstract class ChannelCredentials
     {
         static readonly ChannelCredentials InsecureInstance = new InsecureCredentials();
+        static readonly ChannelCredentials SecureInstance = new SslCredentials();
 
         /// <summary>
         /// Creates a new instance of channel credentials
@@ -48,6 +49,22 @@ namespace Grpc.Core
             get
             {
                 return InsecureInstance;
+            }
+        }
+
+        /// <summary>
+        /// Returns instance of credentials that provides SSL security.
+        /// <para>
+        /// When used with Grpc.Core, these credentials will load from a
+        /// disk file pointed to by the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable.
+        /// If that fails, gets the roots certificates from a well known place on disk.
+        /// </para>
+        /// </summary>
+        public static ChannelCredentials Secure
+        {
+            get
+            {
+                return SecureInstance;
             }
         }
 

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -58,6 +58,9 @@ namespace Grpc.Core.Tests
             var nativeCreds1 = creds.ToNativeCredentials();
             var nativeCreds2 = creds.ToNativeCredentials();
             Assert.AreSame(nativeCreds1, nativeCreds2);
+
+            var nativeCreds3 = ChannelCredentials.Secure.ToNativeCredentials();
+            Assert.AreSame(nativeCreds1, nativeCreds3);
         }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -31,6 +31,12 @@ namespace Grpc.Core.Tests
         }
 
         [Test]
+        public void SecureCredentials_IsNonComposable()
+        {
+            Assert.IsFalse(ChannelCredentials.Secure.IsComposable);
+        }
+
+        [Test]
         public void ChannelCredentials_CreateComposite()
         {
             var composite = ChannelCredentials.Create(new FakeChannelCredentials(true), new FakeCallCredentials());

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -31,9 +31,9 @@ namespace Grpc.Core.Tests
         }
 
         [Test]
-        public void SecureCredentials_IsNonComposable()
+        public void SecureCredentials_IsComposable()
         {
-            Assert.IsFalse(ChannelCredentials.Secure.IsComposable);
+            Assert.IsTrue(ChannelCredentials.SecureSsl.IsComposable);
         }
 
         [Test]
@@ -59,8 +59,9 @@ namespace Grpc.Core.Tests
             var nativeCreds2 = creds.ToNativeCredentials();
             Assert.AreSame(nativeCreds1, nativeCreds2);
 
-            var nativeCreds3 = ChannelCredentials.Secure.ToNativeCredentials();
-            Assert.AreSame(nativeCreds1, nativeCreds3);
+            var nativeCreds3 = ChannelCredentials.SecureSsl.ToNativeCredentials();
+            var nativeCreds4 = ChannelCredentials.SecureSsl.ToNativeCredentials();
+            Assert.AreSame(nativeCreds3, nativeCreds4);
         }
     }
 }


### PR DESCRIPTION
Adds `ChannelCredentials.Secure`. The same as using `new SslCredentials()`.

I want to add this as grpc-dotnet only cares about `new SslCredentials()` and `ChannelCredentials.Secure` is much more discoverable via intellisense.

Grpc.Core users can use the new property if they wish. Doc comment mentions that `SslCredentials` should be used if they want to customize the credentials.

@jtattermusch