### PR TITLE
Respect CC variable in grpcio python build

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -228,7 +228,8 @@ class BuildExt(build_ext.build_ext):
             """
             try:
                 # TODO(lidiz) Remove the generated a.out for success tests.
-                cc_test = subprocess.Popen(['cc', '-x', 'c', '-std=c++14', '-'],
+                cc = os.environ.get('CC', 'cc')
+                cc_test = subprocess.Popen([cc, '-x', 'c', '-std=c++14', '-'],
                                            stdin=subprocess.PIPE,
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE)


### PR DESCRIPTION
if CC variable is set, this ends up testing cc binary, which may point
to gcc, but use $CC for compilation and still fail if CC=clang

Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
