### PR TITLE
Remove experimental tag from uses of the C++ callback API

### DIFF
--- a/include/grpcpp/alarm.h
+++ b/include/grpcpp/alarm.h
@@ -81,7 +81,6 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   /// has already fired has no effect.
   void Cancel();
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   /// Set an alarm to invoke callback \a f. The argument to the callback
   /// states whether the alarm expired at \a deadline (true) or was cancelled
   /// (false)
@@ -89,32 +88,6 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   void Set(const T& deadline, std::function<void(bool)> f) {
     SetInternal(::grpc::TimePoint<T>(deadline).raw_time(), std::move(f));
   }
-#endif
-
-  /// NOTE: class experimental_type is not part of the public API of this class
-  /// TODO(vjpai): Move these contents to the public API of Alarm when
-  ///              they are no longer experimental
-  class experimental_type {
-   public:
-    explicit experimental_type(Alarm* alarm) : alarm_(alarm) {}
-
-    /// Set an alarm to invoke callback \a f. The argument to the callback
-    /// states whether the alarm expired at \a deadline (true) or was cancelled
-    /// (false)
-    template <typename T>
-    void Set(const T& deadline, std::function<void(bool)> f) {
-      alarm_->SetInternal(::grpc::TimePoint<T>(deadline).raw_time(),
-                          std::move(f));
-    }
-
-   private:
-    Alarm* alarm_;
-  };
-
-  /// NOTE: The function experimental() is not stable public API. It is a view
-  /// to the experimental components of this class. It may be changed or removed
-  /// at any time.
-  experimental_type experimental() { return experimental_type(this); }
 
  private:
   void SetInternal(::grpc::CompletionQueue* cq, gpr_timespec deadline,

--- a/include/grpcpp/impl/codegen/async_generic_service.h
+++ b/include/grpcpp/impl/codegen/async_generic_service.h
@@ -79,10 +79,6 @@ class AsyncGenericService final {
   grpc::Server* server_;
 };
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-namespace experimental {
-#endif
-
 /// \a ServerGenericBidiReactor is the reactor class for bidi streaming RPCs
 /// invoked on a CallbackGenericService. It is just a ServerBidi reactor with
 /// ByteBuffer arguments.
@@ -134,9 +130,6 @@ class CallbackGenericService {
   grpc::Server* server_{nullptr};
 };
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-}  // namespace experimental
-#endif
 }  // namespace grpc
 
 #endif  // GRPCPP_IMPL_CODEGEN_ASYNC_GENERIC_SERVICE_H

--- a/include/grpcpp/impl/codegen/message_allocator.h
+++ b/include/grpcpp/impl/codegen/message_allocator.h
@@ -20,9 +20,6 @@
 #define GRPCPP_IMPL_CODEGEN_MESSAGE_ALLOCATOR_H
 
 namespace grpc {
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-namespace experimental {
-#endif
 
 // NOTE: This is an API for advanced users who need custom allocators.
 // Per rpc struct for the allocator. This is the interface to return to user.
@@ -68,25 +65,6 @@ class MessageAllocator {
   virtual ~MessageAllocator() = default;
   virtual MessageHolder<RequestT, ResponseT>* AllocateMessages() = 0;
 };
-
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-}  // namespace experimental
-#endif
-
-// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-namespace experimental {
-
-using ::grpc::RpcAllocatorState;
-
-template <typename RequestT, typename ResponseT>
-using MessageHolder = ::grpc::MessageHolder<RequestT, ResponseT>;
-
-template <typename RequestT, typename ResponseT>
-using MessageAllocator = ::grpc::MessageAllocator<RequestT, ResponseT>;
-
-}  // namespace experimental
-#endif
 
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -158,8 +158,7 @@ class ServerCallbackCall {
 };
 
 template <class Request, class Response>
-class DefaultMessageHolder
-    : public ::grpc::experimental::MessageHolder<Request, Response> {
+class DefaultMessageHolder : public MessageHolder<Request, Response> {
  public:
   DefaultMessageHolder() {
     this->set_request(&request_obj_);

--- a/include/grpcpp/impl/codegen/server_callback_handlers.h
+++ b/include/grpcpp/impl/codegen/server_callback_handlers.h
@@ -37,17 +37,16 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
       : get_reactor_(std::move(get_reactor)) {}
 
   void SetMessageAllocator(
-      ::grpc::experimental::MessageAllocator<RequestType, ResponseType>*
-          allocator) {
+      MessageAllocator<RequestType, ResponseType>* allocator) {
     allocator_ = allocator;
   }
 
   void RunHandler(const HandlerParameter& param) final {
     // Arena allocate a controller structure (that includes request/response)
     ::grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
-    auto* allocator_state = static_cast<
-        ::grpc::experimental::MessageHolder<RequestType, ResponseType>*>(
-        param.internal_data);
+    auto* allocator_state =
+        static_cast<MessageHolder<RequestType, ResponseType>*>(
+            param.internal_data);
 
     auto* call = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackUnaryImpl)))
@@ -82,8 +81,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
     ::grpc::ByteBuffer buf;
     buf.set_buffer(req);
     RequestType* request = nullptr;
-    ::grpc::experimental::MessageHolder<RequestType, ResponseType>*
-        allocator_state = nullptr;
+    MessageHolder<RequestType, ResponseType>* allocator_state = nullptr;
     if (allocator_ != nullptr) {
       allocator_state = allocator_->AllocateMessages();
     } else {
@@ -109,8 +107,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
   std::function<ServerUnaryReactor*(::grpc::CallbackServerContext*,
                                     const RequestType*, ResponseType*)>
       get_reactor_;
-  ::grpc::experimental::MessageAllocator<RequestType, ResponseType>*
-      allocator_ = nullptr;
+  MessageAllocator<RequestType, ResponseType>* allocator_ = nullptr;
 
   class ServerCallbackUnaryImpl : public ServerCallbackUnary {
    public:
@@ -181,8 +178,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
 
     ServerCallbackUnaryImpl(
         ::grpc::CallbackServerContext* ctx, ::grpc::internal::Call* call,
-        ::grpc::experimental::MessageHolder<RequestType, ResponseType>*
-            allocator_state,
+        MessageHolder<RequestType, ResponseType>* allocator_state,
         std::function<void()> call_requester)
         : ctx_(ctx),
           call_(*call),
@@ -233,8 +229,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
 
     ::grpc::CallbackServerContext* const ctx_;
     ::grpc::internal::Call call_;
-    ::grpc::experimental::MessageHolder<RequestType, ResponseType>* const
-        allocator_state_;
+    MessageHolder<RequestType, ResponseType>* const allocator_state_;
     std::function<void()> call_requester_;
     // reactor_ can always be loaded/stored with relaxed memory ordering because
     // its value is only set once, independently of other data in the object,

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -110,13 +110,8 @@ typedef ::grpc::CallbackServerContext CallbackServerContext;
 
 }  // namespace experimental
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-namespace experimental {
-#endif
 class GenericCallbackServerContext;
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-}  // namespace experimental
-#endif
+
 namespace internal {
 class Call;
 }  // namespace internal
@@ -299,10 +294,7 @@ class ServerContextBase {
   /// NOTE: This is an API for advanced users who need custom allocators.
   /// Get and maybe mutate the allocator state associated with the current RPC.
   /// Currently only applicable for callback unary RPC methods.
-  /// WARNING: This is experimental API and could be changed or removed.
-  ::grpc::experimental::RpcAllocatorState* GetRpcAllocatorState() {
-    return message_allocator_state_;
-  }
+  RpcAllocatorState* GetRpcAllocatorState() { return message_allocator_state_; }
 
   /// Get a library-owned default unary reactor for use in minimal reaction
   /// cases. This supports typical unary RPC usage of providing a response and
@@ -394,11 +386,7 @@ class ServerContextBase {
   friend class ::grpc::internal::FinishOnlyReactor;
   friend class ::grpc::ClientContext;
   friend class ::grpc::GenericServerContext;
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   friend class ::grpc::GenericCallbackServerContext;
-#else
-  friend class ::grpc::experimental::GenericCallbackServerContext;
-#endif
 
   /// Prevent copying.
   ServerContextBase(const ServerContextBase&);
@@ -429,8 +417,7 @@ class ServerContextBase {
     return rpc_info_;
   }
 
-  void set_message_allocator_state(
-      ::grpc::experimental::RpcAllocatorState* allocator_state) {
+  void set_message_allocator_state(RpcAllocatorState* allocator_state) {
     message_allocator_state_ = allocator_state;
   }
 
@@ -471,7 +458,7 @@ class ServerContextBase {
   bool has_pending_ops_ = false;
 
   ::grpc::experimental::ServerRpcInfo* rpc_info_ = nullptr;
-  ::grpc::experimental::RpcAllocatorState* message_allocator_state_ = nullptr;
+  RpcAllocatorState* message_allocator_state_ = nullptr;
   ContextAllocator* context_allocator_ = nullptr;
 
   class Reactor : public ::grpc::ServerUnaryReactor {
@@ -638,24 +625,13 @@ class ContextAllocator {
 
   virtual CallbackServerContext* NewCallbackServerContext() { return nullptr; }
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  virtual experimental::GenericCallbackServerContext*
-  NewGenericCallbackServerContext() {
-    return nullptr;
-  }
-#else
   virtual GenericCallbackServerContext* NewGenericCallbackServerContext() {
     return nullptr;
   }
-#endif
 
   virtual void Release(CallbackServerContext*) {}
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  virtual void Release(experimental::GenericCallbackServerContext*) {}
-#else
   virtual void Release(GenericCallbackServerContext*) {}
-#endif
 };
 
 }  // namespace grpc

--- a/include/grpcpp/impl/codegen/server_interface.h
+++ b/include/grpcpp/impl/codegen/server_interface.h
@@ -50,13 +50,7 @@ namespace internal {
 class ServerAsyncStreamingInterface;
 }  // namespace internal
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-namespace experimental {
-#endif
 class CallbackGenericService;
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-}  // namespace experimental
-#endif
 
 namespace experimental {
 class ServerInterceptorFactoryInterface;
@@ -130,35 +124,12 @@ class ServerInterface : public internal::CallHook {
   /// service. The service must exist for the lifetime of the Server instance.
   virtual void RegisterAsyncGenericService(AsyncGenericService* service) = 0;
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   /// Register a callback generic service. This call does not take ownership of
   /// the  service. The service must exist for the lifetime of the Server
   /// instance. May not be abstract since this is a post-1.0 API addition.
 
   virtual void RegisterCallbackGenericService(CallbackGenericService*
                                               /*service*/) {}
-#else
-  /// NOTE: class experimental_registration_interface is not part of the public
-  /// API of this class
-  /// TODO(vjpai): Move these contents to public API when no longer experimental
-  class experimental_registration_interface {
-   public:
-    virtual ~experimental_registration_interface() {}
-    /// May not be abstract since this is a post-1.0 API addition
-    virtual void RegisterCallbackGenericService(
-        experimental::CallbackGenericService* /*service*/) {}
-    virtual void RegisterContextAllocator(
-        std::unique_ptr<ContextAllocator> /*context_allocator*/) {}
-  };
-
-  /// NOTE: The function experimental_registration() is not stable public API.
-  /// It is a view to the experimental components of this class. It may be
-  /// changed or removed at any time. May not be abstract since this is a
-  /// post-1.0 API addition
-  virtual experimental_registration_interface* experimental_registration() {
-    return nullptr;
-  }
-#endif
 
   /// Tries to bind \a server to the given \a addr.
   ///

--- a/include/grpcpp/impl/codegen/service_type.h
+++ b/include/grpcpp/impl/codegen/service_type.h
@@ -99,29 +99,6 @@ class Service {
   }
 
  protected:
-  // TODO(vjpai): Promote experimental contents once callback API is accepted
-  class experimental_type {
-   public:
-    explicit experimental_type(Service* service) : service_(service) {}
-
-    void MarkMethodCallback(int index, internal::MethodHandler* handler) {
-      service_->MarkMethodCallbackInternal(index, handler);
-    }
-
-    void MarkMethodRawCallback(int index, internal::MethodHandler* handler) {
-      service_->MarkMethodRawCallbackInternal(index, handler);
-    }
-
-    internal::MethodHandler* GetHandler(int index) {
-      return service_->GetHandlerInternal(index);
-    }
-
-   private:
-    Service* service_;
-  };
-
-  experimental_type experimental() { return experimental_type(this); }
-
   template <class Message>
   void RequestAsyncUnary(int index, ::grpc::ServerContext* context,
                          Message* request,
@@ -216,23 +193,7 @@ class Service {
     methods_[idx]->SetMethodType(internal::RpcMethod::BIDI_STREAMING);
   }
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   void MarkMethodCallback(int index, internal::MethodHandler* handler) {
-    MarkMethodCallbackInternal(index, handler);
-  }
-
-  void MarkMethodRawCallback(int index, internal::MethodHandler* handler) {
-    MarkMethodRawCallbackInternal(index, handler);
-  }
-
-  internal::MethodHandler* GetHandler(int index) {
-    return GetHandlerInternal(index);
-  }
-#endif
- private:
-  // TODO(vjpai): migrate the Internal functions to mainline functions once
-  //              callback API is fully de-experimental
-  void MarkMethodCallbackInternal(int index, internal::MethodHandler* handler) {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
@@ -245,8 +206,7 @@ class Service {
         internal::RpcServiceMethod::ApiType::CALL_BACK);
   }
 
-  void MarkMethodRawCallbackInternal(int index,
-                                     internal::MethodHandler* handler) {
+  void MarkMethodRawCallback(int index, internal::MethodHandler* handler) {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
@@ -259,11 +219,12 @@ class Service {
         internal::RpcServiceMethod::ApiType::RAW_CALL_BACK);
   }
 
-  internal::MethodHandler* GetHandlerInternal(int index) {
+  internal::MethodHandler* GetHandler(int index) {
     size_t idx = static_cast<size_t>(index);
     return methods_[idx]->handler();
   }
 
+ private:
   friend class Server;
   friend class ServerInterface;
   ServerInterface* server_;

--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -237,7 +237,6 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
   /// service. The service must exist for the lifetime of the Server instance.
   void RegisterAsyncGenericService(AsyncGenericService* service) override;
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   /// Register a callback-based generic service. This call does not take
   /// ownership of theservice. The service must exist for the lifetime of the
   /// Server instance.
@@ -247,41 +246,6 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
       std::unique_ptr<ContextAllocator> context_allocator) {
     context_allocator_ = std::move(context_allocator);
   }
-
-#else
-  /// NOTE: class experimental_registration_type is not part of the public API
-  /// of this class
-  /// TODO(vjpai): Move these contents to the public API of Server when
-  ///              they are no longer experimental
-  class experimental_registration_type final
-      : public experimental_registration_interface {
-   public:
-    explicit experimental_registration_type(Server* server) : server_(server) {}
-    void RegisterCallbackGenericService(
-        experimental::CallbackGenericService* service) override {
-      server_->RegisterCallbackGenericService(service);
-    }
-
-    void RegisterContextAllocator(
-        std::unique_ptr<ContextAllocator> context_allocator) override {
-      server_->context_allocator_ = std::move(context_allocator);
-    }
-
-   private:
-    Server* server_;
-  };
-
-  /// TODO(vjpai): Mark this override when experimental type above is deleted
-  void RegisterCallbackGenericService(
-      experimental::CallbackGenericService* service);
-
-  /// NOTE: The function experimental_registration() is not stable public API.
-  /// It is a view to the experimental components of this class. It may be
-  /// changed or removed at any time.
-  experimental_registration_interface* experimental_registration() override {
-    return &experimental_registration_;
-  }
-#endif
 
   void PerformOpsOnCall(internal::CallOpSetInterface* ops,
                         internal::Call* call) override;
@@ -327,12 +291,6 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
   /// the \a sync_server_cqs)
   std::vector<std::unique_ptr<SyncRequestThreadManager>> sync_req_mgrs_;
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  // For registering experimental callback generic service; remove when that
-  // method longer experimental
-  experimental_registration_type experimental_registration_{this};
-#endif
-
   // Server status
   internal::Mutex mu_;
   bool started_;
@@ -364,11 +322,7 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
 
   // When appropriate, use a default callback generic service to handle
   // unimplemented methods
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   std::unique_ptr<CallbackGenericService> unimplemented_service_;
-#else
-  std::unique_ptr<experimental::CallbackGenericService> unimplemented_service_;
-#endif
 
   // A special handler for resource exhausted in sync case
   std::unique_ptr<internal::MethodHandler> resource_exhausted_handler_;

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -55,13 +55,7 @@ namespace internal {
 class ExternalConnectionAcceptorImpl;
 }  // namespace internal
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-namespace experimental {
-#endif
 class CallbackGenericService;
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-}  // namespace experimental
-#endif
 
 namespace experimental {
 // EXPERIMENTAL API:
@@ -269,20 +263,6 @@ class ServerBuilder {
       builder_->interceptor_creators_ = std::move(interceptor_creators);
     }
 
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-    /// Set the allocator for creating and releasing callback server context.
-    /// Takes the owndership of the allocator.
-    ServerBuilder& SetContextAllocator(
-        std::unique_ptr<grpc::ContextAllocator> context_allocator);
-
-    /// Register a generic service that uses the callback API.
-    /// Matches requests with any :authority
-    /// This is mostly useful for writing generic gRPC Proxies where the exact
-    /// serialization format is unknown
-    ServerBuilder& RegisterCallbackGenericService(
-        grpc::experimental::CallbackGenericService* service);
-#endif
-
     enum class ExternalConnectionType {
       FROM_FD = 0  // in the form of a file descriptor
     };
@@ -299,7 +279,6 @@ class ServerBuilder {
     ServerBuilder* builder_;
   };
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   /// Set the allocator for creating and releasing callback server context.
   /// Takes the owndership of the allocator.
   ServerBuilder& SetContextAllocator(
@@ -311,7 +290,6 @@ class ServerBuilder {
   /// serialization format is unknown
   ServerBuilder& RegisterCallbackGenericService(
       grpc::CallbackGenericService* service);
-#endif
 
   /// NOTE: The function experimental() is not stable public API. It is a view
   /// to the experimental components of this class. It may be changed or removed
@@ -403,12 +381,7 @@ class ServerBuilder {
   grpc_resource_quota* resource_quota_;
   grpc::AsyncGenericService* generic_service_{nullptr};
   std::unique_ptr<ContextAllocator> context_allocator_;
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   grpc::CallbackGenericService* callback_generic_service_{nullptr};
-#else
-  grpc::experimental::CallbackGenericService* callback_generic_service_{
-      nullptr};
-#endif
 
   struct {
     bool is_set;

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -136,12 +136,8 @@ std::string GetHeaderIncludes(grpc_generator::File* file,
       PrintIncludes(printer.get(), params.additional_header_includes, false,
                     "");
     }
-    // TODO(vjpai): Remove port_platform.h from header list when callback API is
-    //              fully de-experimentalized since we will no longer be using
-    //              macros from it.
     static const char* headers_strs[] = {
         "functional",
-        "grpc/impl/codegen/port_platform.h",
         "grpcpp/impl/codegen/async_generic_service.h",
         "grpcpp/impl/codegen/async_stream.h",
         "grpcpp/impl/codegen/async_unary_call.h",
@@ -584,12 +580,12 @@ void PrintHeaderClientMethodCallbackInterfacesStart(
   // are pure; even though this is new (post-1.0) API, it can be pure because
   // it is an entirely new interface that happens to be scoped within
   // StubInterface, not new additions to StubInterface itself
-  printer->Print("class experimental_async_interface {\n");
+  printer->Print("class async_interface {\n");
   // All methods in this new interface are public. There is no need for private
   // "Raw" methods since the callback-based API returns unowned raw pointers
   printer->Print(" public:\n");
   printer->Indent();
-  printer->Print("virtual ~experimental_async_interface() {}\n");
+  printer->Print("virtual ~async_interface() {}\n");
 }
 
 void PrintHeaderClientMethodCallbackInterfaces(
@@ -604,55 +600,27 @@ void PrintHeaderClientMethodCallbackInterfaces(
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
                    "std::function<void(::grpc::Status)>) = 0;\n");
-    // TODO(vjpai): Remove experimental versions and macros when callback API is
-    //              fully de-experimentalized.
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
-                   "::grpc::ClientUnaryReactor* reactor) = 0;\n"
-                   "#else\n"
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "const $Request$* request, $Response$* response, "
-                   "::grpc::experimental::ClientUnaryReactor* reactor) = 0;\n"
-                   "#endif\n");
+                   "::grpc::ClientUnaryReactor* reactor) = 0;\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "$Response$* response, "
                    "::grpc::ClientWriteReactor< $Request$>* "
-                   "reactor) = 0;\n"
-                   "#else\n"
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "$Response$* response, "
-                   "::grpc::experimental::ClientWriteReactor< $Request$>* "
-                   "reactor) = 0;\n"
-                   "#endif\n");
+                   "reactor) = 0;\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, "
                    "::grpc::ClientReadReactor< $Response$>* "
-                   "reactor) = 0;\n"
-                   "#else\n"
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "const $Request$* request, "
-                   "::grpc::experimental::ClientReadReactor< $Response$>* "
-                   "reactor) = 0;\n"
-                   "#endif\n");
+                   "reactor) = 0;\n");
   } else if (method->BidiStreaming()) {
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual void $Method$(::grpc::ClientContext* context, "
                    "::grpc::ClientBidiReactor< "
-                   "$Request$,$Response$>* reactor) = 0;\n"
-                   "#else\n"
-                   "virtual void $Method$(::grpc::ClientContext* context, "
-                   "::grpc::experimental::ClientBidiReactor< "
-                   "$Request$,$Response$>* reactor) = 0;\n"
-                   "#endif\n");
+                   "$Request$,$Response$>* reactor) = 0;\n");
   }
 }
 
@@ -661,22 +629,23 @@ void PrintHeaderClientMethodCallbackInterfacesEnd(
     std::map<std::string, std::string>* /*vars*/) {
   printer->Outdent();
   printer->Print("};\n");
+  // TODO: Remove typedef when all uses of experimental_async are migrated off.
   printer->Print(
-      "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-      "typedef class experimental_async_interface async_interface;\n"
-      "#endif\n");
+      "typedef class async_interface experimental_async_interface;\n");
 
   // Declare a function to give the async stub contents. It can't be pure
   // since this is a new API in StubInterface, but it is meaningless by default
   // (since any stub that wants to use it must have its own implementation of
   // the callback functions therein), so make the default return value nullptr.
   // Intentionally include the word "class" to avoid possible shadowing.
+  // TODO: Remove experimental_async call when possible, replace with nullptr.
   printer->Print(
-      "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-      "async_interface* async() { return experimental_async(); }\n"
-      "#endif\n");
+      "virtual class async_interface* async() { "
+      "return experimental_async(); }\n");
+
+  // TODO: Remove experimental_async call when possible.
   printer->Print(
-      "virtual class experimental_async_interface* experimental_async() { "
+      "virtual class async_interface* experimental_async() { "
       "return nullptr; }\n");
 }
 
@@ -684,8 +653,8 @@ void PrintHeaderClientMethodCallbackStart(
     grpc_generator::Printer* printer,
     std::map<std::string, std::string>* /*vars*/) {
   // This declares the stub entry for the callback-based API.
-  printer->Print("class experimental_async final :\n");
-  printer->Print("  public StubInterface::experimental_async_interface {\n");
+  printer->Print("class async final :\n");
+  printer->Print("  public StubInterface::async_interface {\n");
   printer->Print(" public:\n");
   printer->Indent();
 }
@@ -702,55 +671,28 @@ void PrintHeaderClientMethodCallback(grpc_generator::Printer* printer,
                    "void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
                    "std::function<void(::grpc::Status)>) override;\n");
-    printer->Print(
-        *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "void $Method$(::grpc::ClientContext* context, "
-        "const $Request$* request, $Response$* response, "
-        "::grpc::ClientUnaryReactor* reactor) override;\n"
-        "#else\n"
-        "void $Method$(::grpc::ClientContext* context, "
-        "const $Request$* request, $Response$* response, "
-        "::grpc::experimental::ClientUnaryReactor* reactor) override;\n"
-        "#endif\n");
+    printer->Print(*vars,
+                   "void $Method$(::grpc::ClientContext* context, "
+                   "const $Request$* request, $Response$* response, "
+                   "::grpc::ClientUnaryReactor* reactor) override;\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "void $Method$(::grpc::ClientContext* context, "
                    "$Response$* response, "
                    "::grpc::ClientWriteReactor< $Request$>* "
-                   "reactor) override;\n"
-                   "#else\n"
-                   "void $Method$(::grpc::ClientContext* context, "
-                   "$Response$* response, "
-                   "::grpc::experimental::ClientWriteReactor< $Request$>* "
-                   "reactor) override;\n"
-                   "#endif\n");
+                   "reactor) override;\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "void $Method$(::grpc::ClientContext* context, "
                    "const $Request$* request, "
                    "::grpc::ClientReadReactor< $Response$>* "
-                   "reactor) override;\n"
-                   "#else\n"
-                   "void $Method$(::grpc::ClientContext* context, "
-                   "const $Request$* request, "
-                   "::grpc::experimental::ClientReadReactor< $Response$>* "
-                   "reactor) override;\n"
-                   "#endif\n");
+                   "reactor) override;\n");
 
   } else if (method->BidiStreaming()) {
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "void $Method$(::grpc::ClientContext* context, "
                    "::grpc::ClientBidiReactor< "
-                   "$Request$,$Response$>* reactor) override;\n"
-                   "#else\n"
-                   "void $Method$(::grpc::ClientContext* context, "
-                   "::grpc::experimental::ClientBidiReactor< "
-                   "$Request$,$Response$>* reactor) override;\n"
-                   "#endif\n");
+                   "$Request$,$Response$>* reactor) override;\n");
   }
 }
 
@@ -761,7 +703,7 @@ void PrintHeaderClientMethodCallbackEnd(
   printer->Print(" private:\n");
   printer->Indent();
   printer->Print("friend class Stub;\n");
-  printer->Print("explicit experimental_async(Stub* stub): stub_(stub) { }\n");
+  printer->Print("explicit async(Stub* stub): stub_(stub) { }\n");
   // include a function with a phony use of stub_ to avoid an unused
   // private member warning for service with no methods
   printer->Print("Stub* stub() { return stub_; }\n");
@@ -770,7 +712,10 @@ void PrintHeaderClientMethodCallbackEnd(
   printer->Print("};\n");
 
   printer->Print(
-      "class experimental_async_interface* experimental_async() override { "
+      "class async* async() override { "
+      "return experimental_async(); }\n");
+  printer->Print(
+      "class async* experimental_async() override { "
       "return &async_stub_; }\n");
 }
 
@@ -963,18 +908,10 @@ void PrintHeaderServerCallbackMethodsHelper(
         "  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, \"\");\n"
         "}\n");
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual ::grpc::ServerUnaryReactor* $Method$(\n"
                    "  ::grpc::CallbackServerContext* /*context*/, "
                    "const $RealRequest$* /*request*/, "
-                   "$RealResponse$* /*response*/)\n"
-                   "#else\n"
-                   "virtual ::grpc::experimental::ServerUnaryReactor* "
-                   "$Method$(\n"
-                   "  ::grpc::experimental::CallbackServerContext* "
-                   "/*context*/, const $RealRequest$* /*request*/, "
-                   "$RealResponse$* /*response*/)\n"
-                   "#endif\n"
+                   "$RealResponse$* /*response*/)"
                    "  { return nullptr; }\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(
@@ -988,17 +925,10 @@ void PrintHeaderServerCallbackMethodsHelper(
         "  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, \"\");\n"
         "}\n");
     printer->Print(*vars,
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "virtual ::grpc::ServerReadReactor< "
                    "$RealRequest$>* $Method$(\n"
                    "  ::grpc::CallbackServerContext* "
-                   "/*context*/, $RealResponse$* /*response*/)\n"
-                   "#else\n"
-                   "virtual ::grpc::experimental::ServerReadReactor< "
-                   "$RealRequest$>* $Method$(\n"
-                   "  ::grpc::experimental::CallbackServerContext* "
-                   "/*context*/, $RealResponse$* /*response*/)\n"
-                   "#endif\n"
+                   "/*context*/, $RealResponse$* /*response*/)"
                    "  { return nullptr; }\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(
@@ -1013,16 +943,9 @@ void PrintHeaderServerCallbackMethodsHelper(
         "}\n");
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
         "virtual ::grpc::ServerWriteReactor< $RealResponse$>* $Method$(\n"
         "  ::grpc::CallbackServerContext* "
-        "/*context*/, const $RealRequest$* /*request*/)\n"
-        "#else\n"
-        "virtual ::grpc::experimental::ServerWriteReactor< $RealResponse$>* "
-        "$Method$(\n"
-        "  ::grpc::experimental::CallbackServerContext* "
-        "/*context*/, const $RealRequest$* /*request*/)\n"
-        "#endif\n"
+        "/*context*/, const $RealRequest$* /*request*/)"
         "  { return nullptr; }\n");
   } else if (method->BidiStreaming()) {
     printer->Print(
@@ -1037,16 +960,9 @@ void PrintHeaderServerCallbackMethodsHelper(
         "}\n");
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
         "virtual ::grpc::ServerBidiReactor< $RealRequest$, $RealResponse$>* "
         "$Method$(\n"
         "  ::grpc::CallbackServerContext* /*context*/)\n"
-        "#else\n"
-        "virtual ::grpc::experimental::ServerBidiReactor< "
-        "$RealRequest$, $RealResponse$>* "
-        "$Method$(\n"
-        "  ::grpc::experimental::CallbackServerContext* /*context*/)\n"
-        "#endif\n"
         "  { return nullptr; }\n");
   }
 }
@@ -1062,117 +978,70 @@ void PrintHeaderServerMethodCallback(grpc_generator::Printer* printer,
   (*vars)["RealRequest"] = method->input_type_name();
   (*vars)["RealResponse"] = method->output_type_name();
   printer->Print(*vars, "template <class BaseClass>\n");
-  printer->Print(
-      *vars,
-      "class ExperimentalWithCallbackMethod_$Method$ : public BaseClass {\n");
+  printer->Print(*vars,
+                 "class WithCallbackMethod_$Method$ : public BaseClass {\n");
   printer->Print(
       " private:\n"
       "  void BaseClassMustBeDerivedFromService(const Service* /*service*/) "
       "{}\n");
   printer->Print(" public:\n");
   printer->Indent();
-  printer->Print(*vars, "ExperimentalWithCallbackMethod_$Method$() {\n");
+  printer->Print(*vars, "WithCallbackMethod_$Method$() {\n");
   if (method->NoStreaming()) {
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodCallback($Idx$,\n"
+        "  ::grpc::Service::MarkMethodCallback($Idx$,\n"
         "      new ::grpc::internal::CallbackUnaryHandler< "
         "$RealRequest$, $RealResponse$>(\n"
         "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context, "
+        "               ::grpc::CallbackServerContext* context, "
         "const $RealRequest$* "
         "request, "
         "$RealResponse$* response) { "
         "return this->$Method$(context, request, response); }));}\n");
     printer->Print(*vars,
                    "void SetMessageAllocatorFor_$Method$(\n"
-                   "    ::grpc::experimental::MessageAllocator< "
+                   "    ::grpc::MessageAllocator< "
                    "$RealRequest$, $RealResponse$>* allocator) {\n"
-                   "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
                    "  ::grpc::internal::MethodHandler* const handler = "
                    "::grpc::Service::GetHandler($Idx$);\n"
-                   "#else\n"
-                   "  ::grpc::internal::MethodHandler* const handler = "
-                   "::grpc::Service::experimental().GetHandler($Idx$);\n"
-                   "#endif\n"
                    "  static_cast<::grpc::internal::CallbackUnaryHandler< "
                    "$RealRequest$, $RealResponse$>*>(handler)\n"
                    "          ->SetMessageAllocator(allocator);\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodCallback($Idx$,\n"
+        "  ::grpc::Service::MarkMethodCallback($Idx$,\n"
         "      new ::grpc::internal::CallbackClientStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
         "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context, "
+        "               ::grpc::CallbackServerContext* context, "
         "$RealResponse$* "
         "response) { "
         "return this->$Method$(context, response); }));\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodCallback($Idx$,\n"
+        "  ::grpc::Service::MarkMethodCallback($Idx$,\n"
         "      new ::grpc::internal::CallbackServerStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
         "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context, "
+        "               ::grpc::CallbackServerContext* context, "
         "const $RealRequest$* "
         "request) { "
         "return this->$Method$(context, request); }));\n");
   } else if (method->BidiStreaming()) {
-    printer->Print(
-        *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodCallback($Idx$,\n"
-        "      new ::grpc::internal::CallbackBidiHandler< "
-        "$RealRequest$, $RealResponse$>(\n"
-        "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context) "
-        "{ return this->$Method$(context); }));\n");
+    printer->Print(*vars,
+                   "  ::grpc::Service::MarkMethodCallback($Idx$,\n"
+                   "      new ::grpc::internal::CallbackBidiHandler< "
+                   "$RealRequest$, $RealResponse$>(\n"
+                   "        [this](\n"
+                   "               ::grpc::CallbackServerContext* context) "
+                   "{ return this->$Method$(context); }));\n");
   }
   printer->Print(*vars, "}\n");
   printer->Print(*vars,
-                 "~ExperimentalWithCallbackMethod_$Method$() override {\n"
+                 "~WithCallbackMethod_$Method$() override {\n"
                  "  BaseClassMustBeDerivedFromService(this);\n"
                  "}\n");
   PrintHeaderServerCallbackMethodsHelper(printer, method, vars);
@@ -1192,7 +1061,7 @@ void PrintHeaderServerMethodRawCallback(
   (*vars)["RealResponse"] = "::grpc::ByteBuffer";
   printer->Print(*vars, "template <class BaseClass>\n");
   printer->Print(*vars,
-                 "class ExperimentalWithRawCallbackMethod_$Method$ : public "
+                 "class WithRawCallbackMethod_$Method$ : public "
                  "BaseClass {\n");
   printer->Print(
       " private:\n"
@@ -1200,93 +1069,51 @@ void PrintHeaderServerMethodRawCallback(
       "{}\n");
   printer->Print(" public:\n");
   printer->Indent();
-  printer->Print(*vars, "ExperimentalWithRawCallbackMethod_$Method$() {\n");
+  printer->Print(*vars, "WithRawCallbackMethod_$Method$() {\n");
   if (method->NoStreaming()) {
-    printer->Print(
-        *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodRawCallback($Idx$,\n"
-        "      new ::grpc::internal::CallbackUnaryHandler< "
-        "$RealRequest$, $RealResponse$>(\n"
-        "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context, "
-        "const $RealRequest$* "
-        "request, "
-        "$RealResponse$* response) { return "
-        "this->$Method$(context, request, response); }));\n");
+    printer->Print(*vars,
+                   "  ::grpc::Service::MarkMethodRawCallback($Idx$,\n"
+                   "      new ::grpc::internal::CallbackUnaryHandler< "
+                   "$RealRequest$, $RealResponse$>(\n"
+                   "        [this](\n"
+                   "               ::grpc::CallbackServerContext* context, "
+                   "const $RealRequest$* "
+                   "request, "
+                   "$RealResponse$* response) { return "
+                   "this->$Method$(context, request, response); }));\n");
   } else if (ClientOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodRawCallback($Idx$,\n"
+        "  ::grpc::Service::MarkMethodRawCallback($Idx$,\n"
         "      new ::grpc::internal::CallbackClientStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
         "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context, "
+        "               ::grpc::CallbackServerContext* context, "
         "$RealResponse$* response) "
         "{ return this->$Method$(context, response); }));\n");
   } else if (ServerOnlyStreaming(method)) {
     printer->Print(
         *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodRawCallback($Idx$,\n"
+        "  ::grpc::Service::MarkMethodRawCallback($Idx$,\n"
         "      new ::grpc::internal::CallbackServerStreamingHandler< "
         "$RealRequest$, $RealResponse$>(\n"
         "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context, "
+        "               ::grpc::CallbackServerContext* context, "
         "const"
         "$RealRequest$* request) { return "
         "this->$Method$(context, request); }));\n");
   } else if (method->BidiStreaming()) {
-    printer->Print(
-        *vars,
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "  ::grpc::Service::\n"
-        "#else\n"
-        "  ::grpc::Service::experimental().\n"
-        "#endif\n"
-        "    MarkMethodRawCallback($Idx$,\n"
-        "      new ::grpc::internal::CallbackBidiHandler< "
-        "$RealRequest$, $RealResponse$>(\n"
-        "        [this](\n"
-        "#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n"
-        "               ::grpc::CallbackServerContext*\n"
-        "#else\n"
-        "               ::grpc::experimental::CallbackServerContext*\n"
-        "#endif\n"
-        "                 context) "
-        "{ return this->$Method$(context); }));\n");
+    printer->Print(*vars,
+                   "  ::grpc::Service::MarkMethodRawCallback($Idx$,\n"
+                   "      new ::grpc::internal::CallbackBidiHandler< "
+                   "$RealRequest$, $RealResponse$>(\n"
+                   "        [this](\n"
+                   "               ::grpc::CallbackServerContext* context) "
+                   "{ return this->$Method$(context); }));\n");
   }
   printer->Print(*vars, "}\n");
   printer->Print(*vars,
-                 "~ExperimentalWithRawCallbackMethod_$Method$() override {\n"
+                 "~WithRawCallbackMethod_$Method$() override {\n"
                  "  BaseClassMustBeDerivedFromService(this);\n"
                  "}\n");
   PrintHeaderServerCallbackMethodsHelper(printer, method, vars);
@@ -1571,7 +1398,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
   printer->Print("\n private:\n");
   printer->Indent();
   printer->Print("std::shared_ptr< ::grpc::ChannelInterface> channel_;\n");
-  printer->Print("class experimental_async async_stub_{this};\n");
+  printer->Print("class async async_stub_{this};\n");
   for (int i = 0; i < service->method_count(); ++i) {
     PrintHeaderClientMethod(printer, service->method(i).get(), vars, false);
   }
@@ -1624,31 +1451,21 @@ void PrintHeaderService(grpc_generator::Printer* printer,
     PrintHeaderServerMethodCallback(printer, service->method(i).get(), vars);
   }
 
-  printer->Print("#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL\n");
   printer->Print("typedef ");
 
   for (int i = 0; i < service->method_count(); ++i) {
     (*vars)["method_name"] = service->method(i)->name();
-    printer->Print(*vars, "ExperimentalWithCallbackMethod_$method_name$<");
+    printer->Print(*vars, "WithCallbackMethod_$method_name$<");
   }
   printer->Print("Service");
   for (int i = 0; i < service->method_count(); ++i) {
     printer->Print(" >");
   }
   printer->Print(" CallbackService;\n");
-  printer->Print("#endif\n\n");
 
-  printer->Print("typedef ");
-
-  for (int i = 0; i < service->method_count(); ++i) {
-    (*vars)["method_name"] = service->method(i)->name();
-    printer->Print(*vars, "ExperimentalWithCallbackMethod_$method_name$<");
-  }
-  printer->Print("Service");
-  for (int i = 0; i < service->method_count(); ++i) {
-    printer->Print(" >");
-  }
-  printer->Print(" ExperimentalCallbackService;\n");
+  // TODO: Remove following typedef once all uses of ExperimentalCallbackService
+  //       are migrated to CallbackService
+  printer->Print("typedef CallbackService ExperimentalCallbackService;\n");
 
   // Server side - Generic
   for (int i = 0; i < service->method_count(); ++i) {
@@ -1894,7 +1711,7 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "context, request, response);\n}\n\n");
 
     printer->Print(*vars,
-                   "void $ns$$Service$::Stub::experimental_async::$Method$("
+                   "void $ns$$Service$::Stub::async::$Method$("
                    "::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
                    "std::function<void(::grpc::Status)> f) {\n");
@@ -1906,10 +1723,10 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "context, request, response, std::move(f));\n}\n\n");
 
     printer->Print(*vars,
-                   "void $ns$$Service$::Stub::experimental_async::$Method$("
+                   "void $ns$$Service$::Stub::async::$Method$("
                    "::grpc::ClientContext* context, "
                    "const $Request$* request, $Response$* response, "
-                   "::grpc::experimental::ClientUnaryReactor* reactor) {\n");
+                   "::grpc::ClientUnaryReactor* reactor) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::ClientCallbackUnaryFactory::Create"
                    "< ::grpc::protobuf::MessageLite, "
@@ -1956,12 +1773,11 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "context, response);\n"
                    "}\n\n");
 
-    printer->Print(
-        *vars,
-        "void $ns$$Service$::"
-        "Stub::experimental_async::$Method$(::grpc::ClientContext* context, "
-        "$Response$* response, "
-        "::grpc::experimental::ClientWriteReactor< $Request$>* reactor) {\n");
+    printer->Print(*vars,
+                   "void $ns$$Service$::"
+                   "Stub::async::$Method$(::grpc::ClientContext* context, "
+                   "$Response$* response, "
+                   "::grpc::ClientWriteReactor< $Request$>* reactor) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::ClientCallbackWriterFactory< "
                    "$Request$>::Create("
@@ -2002,12 +1818,11 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "context, request);\n"
                    "}\n\n");
 
-    printer->Print(
-        *vars,
-        "void $ns$$Service$::Stub::experimental_async::$Method$(::grpc::"
-        "ClientContext* context, "
-        "const $Request$* request, "
-        "::grpc::experimental::ClientReadReactor< $Response$>* reactor) {\n");
+    printer->Print(*vars,
+                   "void $ns$$Service$::Stub::async::$Method$(::grpc::"
+                   "ClientContext* context, "
+                   "const $Request$* request, "
+                   "::grpc::ClientReadReactor< $Response$>* reactor) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::ClientCallbackReaderFactory< "
                    "$Response$>::Create("
@@ -2048,12 +1863,11 @@ void PrintSourceClientMethod(grpc_generator::Printer* printer,
                    "context);\n"
                    "}\n\n");
 
-    printer->Print(
-        *vars,
-        "void $ns$$Service$::Stub::experimental_async::$Method$(::grpc::"
-        "ClientContext* context, "
-        "::grpc::experimental::ClientBidiReactor< $Request$,$Response$>* "
-        "reactor) {\n");
+    printer->Print(*vars,
+                   "void $ns$$Service$::Stub::async::$Method$(::grpc::"
+                   "ClientContext* context, "
+                   "::grpc::ClientBidiReactor< $Request$,$Response$>* "
+                   "reactor) {\n");
     printer->Print(*vars,
                    "  ::grpc::internal::ClientCallbackReaderWriterFactory< "
                    "$Request$,$Response$>::Create("

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -102,7 +102,6 @@ ServerBuilder& ServerBuilder::RegisterAsyncGenericService(
   return *this;
 }
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
 ServerBuilder& ServerBuilder::RegisterCallbackGenericService(
     CallbackGenericService* service) {
   if (generic_service_ || callback_generic_service_) {
@@ -121,26 +120,6 @@ ServerBuilder& ServerBuilder::SetContextAllocator(
   context_allocator_ = std::move(context_allocator);
   return *this;
 }
-#else
-ServerBuilder& ServerBuilder::experimental_type::RegisterCallbackGenericService(
-    experimental::CallbackGenericService* service) {
-  if (builder_->generic_service_ || builder_->callback_generic_service_) {
-    gpr_log(GPR_ERROR,
-            "Adding multiple generic services is unsupported for now. "
-            "Dropping the service %p",
-            service);
-  } else {
-    builder_->callback_generic_service_ = service;
-  }
-  return *builder_;
-}
-
-ServerBuilder& ServerBuilder::experimental_type::SetContextAllocator(
-    std::unique_ptr<grpc::ContextAllocator> context_allocator) {
-  builder_->context_allocator_ = std::move(context_allocator);
-  return *builder_;
-}
-#endif
 
 std::unique_ptr<grpc::experimental::ExternalConnectionAcceptor>
 ServerBuilder::experimental_type::AddExternalConnectionAcceptor(
@@ -388,12 +367,7 @@ std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
     return nullptr;
   }
 
-#ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
   server->RegisterContextAllocator(std::move(context_allocator_));
-#else
-  server->experimental_registration()->RegisterContextAllocator(
-      std::move(context_allocator_));
-#endif
 
   for (const auto& value : services_) {
     if (!server->RegisterService(value->host.get(), value->service)) {

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -114,15 +114,6 @@ class UnimplementedAsyncRequestContext {
   GenericServerAsyncReaderWriter generic_stream_;
 };
 
-// TODO(vjpai): Just for this file, use some contents of the experimental
-// namespace here to make the code easier to read below. Remove this when
-// de-experimentalized fully.
-#ifndef GRPC_CALLBACK_API_NONEXPERIMENTAL
-using ::grpc::experimental::CallbackGenericService;
-using ::grpc::experimental::CallbackServerContext;
-using ::grpc::experimental::GenericCallbackServerContext;
-#endif
-
 }  // namespace
 
 ServerInterface::BaseAsyncRequest::BaseAsyncRequest(

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -27,7 +27,6 @@
 #include "src/proto/grpc/testing/compiler_test.pb.h"
 
 #include <functional>
-#include <grpc/impl/codegen/port_platform.h>
 #include <grpcpp/impl/codegen/async_generic_service.h>
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
@@ -107,49 +106,29 @@ class ServiceA final {
       return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc::testing::Request, ::grpc::testing::Response>>(PrepareAsyncMethodA4Raw(context, cq));
     }
     // Method A4 trailing comment 1
-    class experimental_async_interface {
+    class async_interface {
      public:
-      virtual ~experimental_async_interface() {}
+      virtual ~async_interface() {}
       // MethodA1 leading comment 1
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      #else
-      virtual void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
-      #endif
       // MethodA1 trailing comment 1
       // MethodA2 detached leading comment 1
       //
       // Method A2 leading comment 1
       // Method A2 leading comment 2
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::ClientWriteReactor< ::grpc::testing::Request>* reactor) = 0;
-      #else
-      virtual void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::experimental::ClientWriteReactor< ::grpc::testing::Request>* reactor) = 0;
-      #endif
       // MethodA2 trailing comment 1
       // Method A3 leading comment 1
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodA3(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::ClientReadReactor< ::grpc::testing::Response>* reactor) = 0;
-      #else
-      virtual void MethodA3(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::experimental::ClientReadReactor< ::grpc::testing::Response>* reactor) = 0;
-      #endif
       // Method A3 trailing comment 1
       // Method A4 leading comment 1
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodA4(::grpc::ClientContext* context, ::grpc::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) = 0;
-      #else
-      virtual void MethodA4(::grpc::ClientContext* context, ::grpc::experimental::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) = 0;
-      #endif
       // Method A4 trailing comment 1
     };
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-    typedef class experimental_async_interface async_interface;
-    #endif
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-    async_interface* async() { return experimental_async(); }
-    #endif
-    virtual class experimental_async_interface* experimental_async() { return nullptr; }
+    typedef class async_interface experimental_async_interface;
+    virtual class async_interface* async() { return experimental_async(); }
+    virtual class async_interface* experimental_async() { return nullptr; }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* AsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* PrepareAsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -200,41 +179,26 @@ class ServiceA final {
     std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc::testing::Request, ::grpc::testing::Response>> PrepareAsyncMethodA4(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc::testing::Request, ::grpc::testing::Response>>(PrepareAsyncMethodA4Raw(context, cq));
     }
-    class experimental_async final :
-      public StubInterface::experimental_async_interface {
+    class async final :
+      public StubInterface::async_interface {
      public:
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
-      #else
-      void MethodA1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::ClientWriteReactor< ::grpc::testing::Request>* reactor) override;
-      #else
-      void MethodA2(::grpc::ClientContext* context, ::grpc::testing::Response* response, ::grpc::experimental::ClientWriteReactor< ::grpc::testing::Request>* reactor) override;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodA3(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::ClientReadReactor< ::grpc::testing::Response>* reactor) override;
-      #else
-      void MethodA3(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::experimental::ClientReadReactor< ::grpc::testing::Response>* reactor) override;
-      #endif
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodA4(::grpc::ClientContext* context, ::grpc::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) override;
-      #else
-      void MethodA4(::grpc::ClientContext* context, ::grpc::experimental::ClientBidiReactor< ::grpc::testing::Request,::grpc::testing::Response>* reactor) override;
-      #endif
      private:
       friend class Stub;
-      explicit experimental_async(Stub* stub): stub_(stub) { }
+      explicit async(Stub* stub): stub_(stub) { }
       Stub* stub() { return stub_; }
       Stub* stub_;
     };
-    class experimental_async_interface* experimental_async() override { return &async_stub_; }
+    class async* async() override { return experimental_async(); }
+    class async* experimental_async() override { return &async_stub_; }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    class experimental_async async_stub_{this};
+    class async async_stub_{this};
     ::grpc::ClientAsyncResponseReader< ::grpc::testing::Response>* AsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc::testing::Response>* PrepareAsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientWriter< ::grpc::testing::Request>* MethodA2Raw(::grpc::ClientContext* context, ::grpc::testing::Response* response) override;
@@ -355,36 +319,22 @@ class ServiceA final {
   };
   typedef WithAsyncMethod_MethodA1<WithAsyncMethod_MethodA2<WithAsyncMethod_MethodA3<WithAsyncMethod_MethodA4<Service > > > > AsyncService;
   template <class BaseClass>
-  class ExperimentalWithCallbackMethod_MethodA1 : public BaseClass {
+  class WithCallbackMethod_MethodA1 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithCallbackMethod_MethodA1() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodCallback(0,
+    WithCallbackMethod_MethodA1() {
+      ::grpc::Service::MarkMethodCallback(0,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodA1(context, request, response); }));}
+                   ::grpc::CallbackServerContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodA1(context, request, response); }));}
     void SetMessageAllocatorFor_MethodA1(
-        ::grpc::experimental::MessageAllocator< ::grpc::testing::Request, ::grpc::testing::Response>* allocator) {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+        ::grpc::MessageAllocator< ::grpc::testing::Request, ::grpc::testing::Response>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
-    #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(0);
-    #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>*>(handler)
               ->SetMessageAllocator(allocator);
     }
-    ~ExperimentalWithCallbackMethod_MethodA1() override {
+    ~WithCallbackMethod_MethodA1() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -392,37 +342,21 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerUnaryReactor* MethodA1(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
-    #else
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodA1(
-      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithCallbackMethod_MethodA2 : public BaseClass {
+  class WithCallbackMethod_MethodA2 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithCallbackMethod_MethodA2() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodCallback(1,
+    WithCallbackMethod_MethodA2() {
+      ::grpc::Service::MarkMethodCallback(1,
           new ::grpc::internal::CallbackClientStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, ::grpc::testing::Response* response) { return this->MethodA2(context, response); }));
+                   ::grpc::CallbackServerContext* context, ::grpc::testing::Response* response) { return this->MethodA2(context, response); }));
     }
-    ~ExperimentalWithCallbackMethod_MethodA2() override {
+    ~WithCallbackMethod_MethodA2() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -430,37 +364,21 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerReadReactor< ::grpc::testing::Request>* MethodA2(
-      ::grpc::CallbackServerContext* /*context*/, ::grpc::testing::Response* /*response*/)
-    #else
-    virtual ::grpc::experimental::ServerReadReactor< ::grpc::testing::Request>* MethodA2(
-      ::grpc::experimental::CallbackServerContext* /*context*/, ::grpc::testing::Response* /*response*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, ::grpc::testing::Response* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithCallbackMethod_MethodA3 : public BaseClass {
+  class WithCallbackMethod_MethodA3 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithCallbackMethod_MethodA3() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodCallback(2,
+    WithCallbackMethod_MethodA3() {
+      ::grpc::Service::MarkMethodCallback(2,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, const ::grpc::testing::Request* request) { return this->MethodA3(context, request); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::testing::Request* request) { return this->MethodA3(context, request); }));
     }
-    ~ExperimentalWithCallbackMethod_MethodA3() override {
+    ~WithCallbackMethod_MethodA3() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -468,37 +386,21 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerWriteReactor< ::grpc::testing::Response>* MethodA3(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/)
-    #else
-    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::testing::Response>* MethodA3(
-      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithCallbackMethod_MethodA4 : public BaseClass {
+  class WithCallbackMethod_MethodA4 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithCallbackMethod_MethodA4() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodCallback(3,
+    WithCallbackMethod_MethodA4() {
+      ::grpc::Service::MarkMethodCallback(3,
           new ::grpc::internal::CallbackBidiHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context) { return this->MethodA4(context); }));
+                   ::grpc::CallbackServerContext* context) { return this->MethodA4(context); }));
     }
-    ~ExperimentalWithCallbackMethod_MethodA4() override {
+    ~WithCallbackMethod_MethodA4() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -506,20 +408,12 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerBidiReactor< ::grpc::testing::Request, ::grpc::testing::Response>* MethodA4(
       ::grpc::CallbackServerContext* /*context*/)
-    #else
-    virtual ::grpc::experimental::ServerBidiReactor< ::grpc::testing::Request, ::grpc::testing::Response>* MethodA4(
-      ::grpc::experimental::CallbackServerContext* /*context*/)
-    #endif
       { return nullptr; }
   };
-  #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_MethodA1<ExperimentalWithCallbackMethod_MethodA2<ExperimentalWithCallbackMethod_MethodA3<ExperimentalWithCallbackMethod_MethodA4<Service > > > > CallbackService;
-  #endif
-
-  typedef ExperimentalWithCallbackMethod_MethodA1<ExperimentalWithCallbackMethod_MethodA2<ExperimentalWithCallbackMethod_MethodA3<ExperimentalWithCallbackMethod_MethodA4<Service > > > > ExperimentalCallbackService;
+  typedef WithCallbackMethod_MethodA1<WithCallbackMethod_MethodA2<WithCallbackMethod_MethodA3<WithCallbackMethod_MethodA4<Service > > > > CallbackService;
+  typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_MethodA1 : public BaseClass {
    private:
@@ -669,27 +563,17 @@ class ServiceA final {
     }
   };
   template <class BaseClass>
-  class ExperimentalWithRawCallbackMethod_MethodA1 : public BaseClass {
+  class WithRawCallbackMethod_MethodA1 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithRawCallbackMethod_MethodA1() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodRawCallback(0,
+    WithRawCallbackMethod_MethodA1() {
+      ::grpc::Service::MarkMethodRawCallback(0,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodA1(context, request, response); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodA1(context, request, response); }));
     }
-    ~ExperimentalWithRawCallbackMethod_MethodA1() override {
+    ~WithRawCallbackMethod_MethodA1() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -697,37 +581,21 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerUnaryReactor* MethodA1(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
-    #else
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodA1(
-      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithRawCallbackMethod_MethodA2 : public BaseClass {
+  class WithRawCallbackMethod_MethodA2 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithRawCallbackMethod_MethodA2() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodRawCallback(1,
+    WithRawCallbackMethod_MethodA2() {
+      ::grpc::Service::MarkMethodRawCallback(1,
           new ::grpc::internal::CallbackClientStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, ::grpc::ByteBuffer* response) { return this->MethodA2(context, response); }));
+                   ::grpc::CallbackServerContext* context, ::grpc::ByteBuffer* response) { return this->MethodA2(context, response); }));
     }
-    ~ExperimentalWithRawCallbackMethod_MethodA2() override {
+    ~WithRawCallbackMethod_MethodA2() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -735,37 +603,21 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerReadReactor< ::grpc::ByteBuffer>* MethodA2(
-      ::grpc::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/)
-    #else
-    virtual ::grpc::experimental::ServerReadReactor< ::grpc::ByteBuffer>* MethodA2(
-      ::grpc::experimental::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithRawCallbackMethod_MethodA3 : public BaseClass {
+  class WithRawCallbackMethod_MethodA3 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithRawCallbackMethod_MethodA3() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodRawCallback(2,
+    WithRawCallbackMethod_MethodA3() {
+      ::grpc::Service::MarkMethodRawCallback(2,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, const::grpc::ByteBuffer* request) { return this->MethodA3(context, request); }));
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->MethodA3(context, request); }));
     }
-    ~ExperimentalWithRawCallbackMethod_MethodA3() override {
+    ~WithRawCallbackMethod_MethodA3() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -773,37 +625,21 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* MethodA3(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)
-    #else
-    virtual ::grpc::experimental::ServerWriteReactor< ::grpc::ByteBuffer>* MethodA3(
-      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class ExperimentalWithRawCallbackMethod_MethodA4 : public BaseClass {
+  class WithRawCallbackMethod_MethodA4 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithRawCallbackMethod_MethodA4() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodRawCallback(3,
+    WithRawCallbackMethod_MethodA4() {
+      ::grpc::Service::MarkMethodRawCallback(3,
           new ::grpc::internal::CallbackBidiHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context) { return this->MethodA4(context); }));
+                   ::grpc::CallbackServerContext* context) { return this->MethodA4(context); }));
     }
-    ~ExperimentalWithRawCallbackMethod_MethodA4() override {
+    ~WithRawCallbackMethod_MethodA4() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -811,13 +647,8 @@ class ServiceA final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerBidiReactor< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* MethodA4(
       ::grpc::CallbackServerContext* /*context*/)
-    #else
-    virtual ::grpc::experimental::ServerBidiReactor< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* MethodA4(
-      ::grpc::experimental::CallbackServerContext* /*context*/)
-    #endif
       { return nullptr; }
   };
   template <class BaseClass>
@@ -897,25 +728,17 @@ class ServiceB final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>>(PrepareAsyncMethodB1Raw(context, request, cq));
     }
     // MethodB1 trailing comment 1
-    class experimental_async_interface {
+    class async_interface {
      public:
-      virtual ~experimental_async_interface() {}
+      virtual ~async_interface() {}
       // MethodB1 leading comment 1
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) = 0;
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      #else
-      virtual void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
-      #endif
       // MethodB1 trailing comment 1
     };
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-    typedef class experimental_async_interface async_interface;
-    #endif
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-    async_interface* async() { return experimental_async(); }
-    #endif
-    virtual class experimental_async_interface* experimental_async() { return nullptr; }
+    typedef class async_interface experimental_async_interface;
+    virtual class async_interface* async() { return experimental_async(); }
+    virtual class async_interface* experimental_async() { return nullptr; }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* AsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* PrepareAsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -930,26 +753,23 @@ class ServiceB final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc::testing::Response>> PrepareAsyncMethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc::testing::Response>>(PrepareAsyncMethodB1Raw(context, request, cq));
     }
-    class experimental_async final :
-      public StubInterface::experimental_async_interface {
+    class async final :
+      public StubInterface::async_interface {
      public:
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, std::function<void(::grpc::Status)>) override;
-      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::ClientUnaryReactor* reactor) override;
-      #else
-      void MethodB1(::grpc::ClientContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
-      #endif
      private:
       friend class Stub;
-      explicit experimental_async(Stub* stub): stub_(stub) { }
+      explicit async(Stub* stub): stub_(stub) { }
       Stub* stub() { return stub_; }
       Stub* stub_;
     };
-    class experimental_async_interface* experimental_async() override { return &async_stub_; }
+    class async* async() override { return experimental_async(); }
+    class async* experimental_async() override { return &async_stub_; }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    class experimental_async async_stub_{this};
+    class async async_stub_{this};
     ::grpc::ClientAsyncResponseReader< ::grpc::testing::Response>* AsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc::testing::Response>* PrepareAsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_MethodB1_;
@@ -986,36 +806,22 @@ class ServiceB final {
   };
   typedef WithAsyncMethod_MethodB1<Service > AsyncService;
   template <class BaseClass>
-  class ExperimentalWithCallbackMethod_MethodB1 : public BaseClass {
+  class WithCallbackMethod_MethodB1 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithCallbackMethod_MethodB1() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodCallback(0,
+    WithCallbackMethod_MethodB1() {
+      ::grpc::Service::MarkMethodCallback(0,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodB1(context, request, response); }));}
+                   ::grpc::CallbackServerContext* context, const ::grpc::testing::Request* request, ::grpc::testing::Response* response) { return this->MethodB1(context, request, response); }));}
     void SetMessageAllocatorFor_MethodB1(
-        ::grpc::experimental::MessageAllocator< ::grpc::testing::Request, ::grpc::testing::Response>* allocator) {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+        ::grpc::MessageAllocator< ::grpc::testing::Request, ::grpc::testing::Response>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(0);
-    #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(0);
-    #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc::testing::Request, ::grpc::testing::Response>*>(handler)
               ->SetMessageAllocator(allocator);
     }
-    ~ExperimentalWithCallbackMethod_MethodB1() override {
+    ~WithCallbackMethod_MethodB1() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -1023,20 +829,11 @@ class ServiceB final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerUnaryReactor* MethodB1(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
-    #else
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodB1(
-      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::testing::Request* /*request*/, ::grpc::testing::Response* /*response*/)  { return nullptr; }
   };
-  #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_MethodB1<Service > CallbackService;
-  #endif
-
-  typedef ExperimentalWithCallbackMethod_MethodB1<Service > ExperimentalCallbackService;
+  typedef WithCallbackMethod_MethodB1<Service > CallbackService;
+  typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_MethodB1 : public BaseClass {
    private:
@@ -1075,27 +872,17 @@ class ServiceB final {
     }
   };
   template <class BaseClass>
-  class ExperimentalWithRawCallbackMethod_MethodB1 : public BaseClass {
+  class WithRawCallbackMethod_MethodB1 : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    ExperimentalWithRawCallbackMethod_MethodB1() {
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::Service::
-    #else
-      ::grpc::Service::experimental().
-    #endif
-        MarkMethodRawCallback(0,
+    WithRawCallbackMethod_MethodB1() {
+      ::grpc::Service::MarkMethodRawCallback(0,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-                   ::grpc::CallbackServerContext*
-    #else
-                   ::grpc::experimental::CallbackServerContext*
-    #endif
-                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodB1(context, request, response); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->MethodB1(context, request, response); }));
     }
-    ~ExperimentalWithRawCallbackMethod_MethodB1() override {
+    ~WithRawCallbackMethod_MethodB1() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
@@ -1103,14 +890,8 @@ class ServiceB final {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
     virtual ::grpc::ServerUnaryReactor* MethodB1(
-      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
-    #else
-    virtual ::grpc::experimental::ServerUnaryReactor* MethodB1(
-      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
-    #endif
-      { return nullptr; }
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_MethodB1 : public BaseClass {

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -1406,11 +1406,10 @@ TEST_P(ClientCallbackEnd2endTest, TestTrailersOnlyOnError) {
   }
 
   ResetStub();
-  class Reactor : public grpc::experimental::ClientBidiReactor<EchoRequest,
-                                                               EchoResponse> {
+  class Reactor : public grpc::ClientBidiReactor<EchoRequest, EchoResponse> {
    public:
     explicit Reactor(grpc::testing::EchoTestService::Stub* stub) {
-      stub->experimental_async()->UnimplementedBidi(&context_, this);
+      stub->async()->UnimplementedBidi(&context_, this);
       StartCall();
     }
     void Await() {

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2680,18 +2680,17 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
       ConcurrentRpc* rpc = &rpcs[i];
       rpc_options.SetupRpc(&rpc->context, &request);
       grpc_millis t0 = NowFromCycleCounter();
-      stub->experimental_async()->Echo(
-          &rpc->context, &request, &rpc->response,
-          [rpc, &mu, &completed, &cv, num_rpcs, t0](Status s) {
-            rpc->status = s;
-            rpc->elapsed_time = NowFromCycleCounter() - t0;
-            bool done;
-            {
-              absl::MutexLock lock(&mu);
-              done = (++completed) == num_rpcs;
-            }
-            if (done) cv.Signal();
-          });
+      stub->async()->Echo(&rpc->context, &request, &rpc->response,
+                          [rpc, &mu, &completed, &cv, num_rpcs, t0](Status s) {
+                            rpc->status = s;
+                            rpc->elapsed_time = NowFromCycleCounter() - t0;
+                            bool done;
+                            {
+                              absl::MutexLock lock(&mu);
+                              done = (++completed) == num_rpcs;
+                            }
+                            if (done) cv.Signal();
+                          });
     }
     {
       absl::MutexLock lock(&mu);


### PR DESCRIPTION
This removes nearly all uses of the experimental tag from the gRPC C++ callback API. A few uses remain but will be cleaned up later...

Internally tested with TGP

~~Cannot merge until after #26493 is imported.~~

