### PR TITLE
Python AIO: Match continuation typing on Interceptors

### DIFF
--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -169,7 +169,7 @@ class StreamUnaryClientInterceptor(ClientInterceptor, metaclass=ABCMeta):
     async def intercept_stream_unary(
         self,
         continuation: Callable[[ClientCallDetails, RequestType],
-                               UnaryStreamCall],
+                               StreamUnaryCall],
         client_call_details: ClientCallDetails,
         request_iterator: RequestIterableType,
     ) -> StreamUnaryCall:
@@ -210,7 +210,7 @@ class StreamStreamClientInterceptor(ClientInterceptor, metaclass=ABCMeta):
     async def intercept_stream_stream(
         self,
         continuation: Callable[[ClientCallDetails, RequestType],
-                               UnaryStreamCall],
+                               StreamStreamCall],
         client_call_details: ClientCallDetails,
         request_iterator: RequestIterableType,
     ) -> Union[ResponseIterableType, StreamStreamCall]:


### PR DESCRIPTION
This seems to be a minor mistake in the typing of continuations for 2/4 call types. 

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
