### PR TITLE
Name driver when generating load test configs.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -52,12 +52,6 @@ else
 fi
 GRPC_GO_GITREF="$(git ls-remote https://github.com/grpc/grpc-go.git master | cut -f1)"
 GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master | cut -f1)"
-# Prebuilt driver comes from the latest test-infra release.
-LATEST_TEST_INFRA_RELEASE="$(curl -s https://api.github.com/repos/grpc/test-infra/releases | jq '.[0].tag_name' | tr -d '"')"
-if [[ -z "${LATEST_TEST_INFRA_RELEASE}" ]]; then
-    exit 1
-fi
-DRIVER_IMAGE="gcr.io/grpc-testing/e2etest/runtime/driver:${LATEST_TEST_INFRA_RELEASE}"
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-8core-ci
@@ -77,7 +71,7 @@ buildConfigs() {
     shift 2
     tools/run_tests/performance/loadtest_config.py "$@" \
         -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
-        -s driver_pool="${DRIVER_POOL}" -s driver_image="${DRIVER_IMAGE}" \
+        -s driver_pool="${DRIVER_POOL}" -s driver_image= \
         -s client_pool="${pool}" -s server_pool="${pool}" \
         -s big_query_table="${table}" -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -53,12 +53,6 @@ else
 fi
 GRPC_GO_GITREF="$(git ls-remote https://github.com/grpc/grpc-go.git master | cut -f1)"
 GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master | cut -f1)"
-# Prebuilt driver comes from the latest test-infra release.
-LATEST_TEST_INFRA_RELEASE="$(curl -s https://api.github.com/repos/grpc/test-infra/releases | jq '.[0].tag_name' | tr -d '"')"
-if [[ -z "${LATEST_TEST_INFRA_RELEASE}" ]]; then
-    exit 1
-fi
-DRIVER_IMAGE="gcr.io/grpc-testing/e2etest/runtime/driver:${LATEST_TEST_INFRA_RELEASE}"
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-8core-ci
@@ -78,7 +72,7 @@ buildConfigs() {
     shift 2
     tools/run_tests/performance/loadtest_config.py "$@" \
         -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
-        -s driver_pool="${DRIVER_POOL}" -s driver_image="${DRIVER_IMAGE}" \
+        -s driver_pool="${DRIVER_POOL}" -s driver_image= \
         -s client_pool="${pool}" -s server_pool="${pool}" \
         -s big_query_table="${table}" -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -219,14 +219,21 @@ def gen_loadtest_configs(
             # Set servers to named instances.
             spec['servers'] = servers
 
+            # Add driver, if needed.
+            if 'driver' not in spec:
+                spec['driver'] = dict()
+
+            # Ensure driver has language and run fields.
+            driver = spec['driver']
+            if 'language' not in driver:
+                driver['language'] = safe_name('c++')
+            if 'run' not in driver:
+                driver['run'] = dict()
+
             # Name the driver with an index for consistency with workers.
             # There is only one driver, so the index is zero.
-            if 'driver' in spec and 'run' in spec['driver']:
-                driver = spec['driver']
-                if 'language' not in driver:
-                    driver['language'] = safe_name('c++')
-                if 'name' not in driver or not driver['name']:
-                    driver['name'] = '0'
+            if 'name' not in driver or not driver['name']:
+                driver['name'] = '0'
 
             spec['scenariosJSON'] = scenario_str
 
@@ -261,12 +268,9 @@ def clear_empty_fields(config: Dict[str, Any]) -> None:
         driver = spec['driver']
         if 'pool' in driver and not driver['pool']:
             del driver['pool']
-        if 'run' in driver and 'image' not in driver['run']:
-            del driver['run']
-        if not set(driver).difference({'language'}):
-            del spec['driver']
-        else:
-            spec['driver'] = driver
+        if ('run' in driver and 'image' in driver['run'] and
+                not driver['run']['image']):
+            del driver['run']['image']
     if 'results' in spec and not ('bigQueryTable' in spec['results'] and
                                   spec['results']['bigQueryTable']):
         del spec['results']


### PR DESCRIPTION
This change ensures that a valid driver configuration is always included in generated load test configurations, and that the driver pod is named with an index (`0`, since there is only one driver), in the same way as client and server pods.

Generated examples can be found in grpc/test-infra#189.

With this change, it is no longer necessary to specify a driver image in order to specify a driver name and pool, so that is removed from the kokoro jobs.