### PR TITLE
Update tools in preparation for load test timeouts.

### DIFF
--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -257,6 +257,11 @@ The script `loadtest_config.py` takes the following options:
 - `-t`, `--template`<br> Template file. A template is a configuration file that
   may contain multiple client and server configuration, and may also include
   substitution keys.
+- `-s`, `--substitution` Substitution keys, in the format `key=value`. These
+  keys are substituted while processing the template. Environment variables that
+  are set by the load test controller at runtime are ignored by default
+  (`DRIVER_PORT`, `KILL_AFTER`, `POD_TIMEOUT`). The user can override this
+  behavior by specifying these variables as keys.
 - `-p`, `--prefix`<br> Test names consist of a prefix_joined with a uuid with a
   dash. Test names are stored in `metadata.name`. The prefix is also added as
   the `prefix` label in `metadata.labels`. The prefix defaults to the user name

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -383,7 +383,17 @@ def main() -> None:
     if args.runs_per_test < 1:
         argp.error('runs_per_test must be greater than zero.')
 
-    substitutions = parse_key_value_args(args.substitutions)
+    # Config generation ignores environment variables that are passed by the
+    # controller at runtime.
+    substitutions = {
+        'DRIVER_PORT': '${DRIVER_PORT}',
+        'KILL_AFTER': '${KILL_AFTER}',
+        'POD_TIMEOUT': '${POD_TIMEOUT}',
+    }
+
+    # The user can override the ignored variables above by passing them in as
+    # substitution keys.
+    substitutions.update(parse_key_value_args(args.substitutions))
 
     uniquifier_elements = args.uniquifier_elements
     if args.d:

--- a/tools/run_tests/performance/loadtest_template.py
+++ b/tools/run_tests/performance/loadtest_template.py
@@ -177,6 +177,15 @@ def template_dumper(header_comment: str) -> Type[yaml.SafeDumper]:
                 self.write_indent()
                 self.write_indicator(header_comment, need_whitespace=False)
 
+    def str_presenter(dumper, data):
+        if '\n' in data:
+            return dumper.represent_scalar('tag:yaml.org,2002:str',
+                                           data,
+                                           style='|')
+        return dumper.represent_scalar('tag:yaml.org,2002:str', data)
+
+    TemplateDumper.add_representer(str, str_presenter)
+
     return TemplateDumper
 
 


### PR DESCRIPTION
- Support multiline strings in template generation (as already supported in config generation, supporting roundtrip).
- Ignore substitution of variables that are set by the controller at runtime (`DRIVER_PORT`, `KILL_AFTER`, `POD_TIMEOUT`).

See also https://github.com/grpc/grpc/pull/26516.
