### PR TITLE
[Ruby] fix issue#26013, add ref in c-core

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -827,9 +827,11 @@ void ClientChannel::ExternalConnectivityWatcher::Notify(
   // automatically remove all watchers in that case.
   if (state != GRPC_CHANNEL_SHUTDOWN) {
     chand_->work_serializer_->Run(
-        [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(chand_->work_serializer_) {
-          RemoveWatcherLocked();
-        },
+        [pThis = Ref()]()
+            ABSL_EXCLUSIVE_LOCKS_REQUIRED(chand_->work_serializer_) {
+              static_cast<ExternalConnectivityWatcher*>(pThis.get())
+                  ->RemoveWatcherLocked();
+            },
         DEBUG_LOCATION);
   }
 }


### PR DESCRIPTION
This happens when `ExternalConnectivityWatcher` was destructed but there was a notify closure queued for processing.


not reproduce with 1000 runs with the above fix, used to be reproducible in < 50.
$ for i in {1..1000}; do ruby forking_client_test.rb || break; done

```
I0613 20:40:09.930794000   19566 connectivity_state.cc:161]  ConnectivityStateTracker client_channel[0x55baedae7df8]: READY -> IDLE (helper, OK)
I0613 20:40:09.930806800   19566 connectivity_state.cc:169]  ConnectivityStateTracker client_channel[0x55baedae7df8]: notifying watcher 0x7f528c0050e0: READY -> IDLE
I0613 20:40:09.930820800   19566 client_channel.cc:829]      ExternalConnectivityWatcher::Notify: this: 0x7f528c0050e0, state: IDLE, tracker: 0x55baedae7df8
I0613 20:40:09.930904000   19566 client_channel.cc:1656]     chand=0x55baedae7d38: updating subchannel wrapper 0x55baedb6dd70 data plane connected_subchannel to (nil)
I0613 20:40:09.930831600   19550 completion_queue.cc:1421]   grpc_completion_queue_shutdown(cq=0x55baedde75c0)
I0613 20:40:09.931016300   19566 connectivity_state.cc:161]  ConnectivityStateTracker client_channel[0x55baedae7df8]: IDLE -> SHUTDOWN (shutdown from API, OK)
I0613 20:40:09.931057500   19566 connectivity_state.cc:169]  ConnectivityStateTracker client_channel[0x55baedae7df8]: notifying watcher 0x7f528c0050e0: IDLE -> SHUTDOWN
I0613 20:40:09.931074300   19566 client_channel.cc:788]      ~ExternalConnectivityWatcher: this: 0x7f528c0050e0
I0613 20:40:09.931133200   19566 client_channel.cc:834]      ExternalConnectivityWatcher::Notify - lambda: this: 0x7f528c0050e0, state: IDLE, tracker: 0x7f529fc1e250
I0613 20:40:09.931147900   19566 client_channel.cc:867]      ExternalConnectivityWatcher::RemoveWatcherLocked: this: 0x7f528c0050e0, tracker: 0x7f529fc1e250
I0613 20:40:09.931168300   19566 connectivity_state.cc:147]  ConnectivityStateTracker1 0x6174730000666552[0x7f529fc1e250]: remove watcher

[BUG] Segmentation fault at 0x0000000000000000

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
