### PR TITLE
fix: use == instead of is when comparing with a certain types of literals

### DIFF
--- a/examples/python/async_streaming/client.py
+++ b/examples/python/async_streaming/client.py
@@ -66,9 +66,9 @@ class CallMaker:
         logging.info("Call toward [%s] enters [%s] state", self._phone_number,
                      phone_pb2.CallState.State.Name(call_state))
         self._call_state = call_state
-        if call_state is phone_pb2.CallState.State.ACTIVE:
+        if call_state == phone_pb2.CallState.State.ACTIVE:
             self._peer_responded.set()
-        if call_state is phone_pb2.CallState.State.ENDED:
+        if call_state == phone_pb2.CallState.State.ENDED:
             self._peer_responded.set()
             self._call_finished.set()
 
@@ -80,13 +80,13 @@ class CallMaker:
         self._consumer_future = self._executor.submit(self._response_watcher,
                                                       response_iterator)
 
-    def wait_peer(self) -> None:
+    def wait_peer(self) -> bool:
         logging.info("Waiting for peer to connect [%s]...", self._phone_number)
         self._peer_responded.wait(timeout=None)
         if self._consumer_future.done():
             # If the future raises, forwards the exception here
             self._consumer_future.result()
-        return self._call_state is phone_pb2.CallState.State.ACTIVE
+        return self._call_state == phone_pb2.CallState.State.ACTIVE
 
     def audio_session(self) -> None:
         assert self._audio_session_link is not None


### PR DESCRIPTION
The old code can not work on the environment below：
```
OS: Windows 10 20H2(19042.867)
Python: 3.8.10

protobuf          3.17.3
grpcio            1.38.0
grpcio-tools      1.38.0
```
The client will be suspended indefinitely because `call_state` and `phone_pb2.CallState.State.ENDED` have different ids even if they have the same value which between -5 and 256. （I don't know why. Orz）
![image](https://user-images.githubusercontent.com/19882756/122745401-8a8ac680-d2bb-11eb-9312-ac7179209020.png)

after changed `is` to `==`, problem solved
![image](https://user-images.githubusercontent.com/19882756/122745669-d0478f00-d2bb-11eb-9bcf-39f9af5bfba7.png)


@lidizheng 
