### PR TITLE
Remove mockability of experimental_async() stub function

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -640,13 +640,11 @@ void PrintHeaderClientMethodCallbackInterfacesEnd(
   // Intentionally include the word "class" to avoid possible shadowing.
   // TODO: Remove experimental_async call when possible, replace with nullptr.
   printer->Print(
-      "virtual class async_interface* async() { "
-      "return experimental_async(); }\n");
+      "virtual class async_interface* async() { return nullptr; }\n");
 
   // TODO: Remove experimental_async call when possible.
   printer->Print(
-      "virtual class async_interface* experimental_async() { "
-      "return nullptr; }\n");
+      "class async_interface* experimental_async() { return async(); }\n");
 }
 
 void PrintHeaderClientMethodCallbackStart(
@@ -713,9 +711,6 @@ void PrintHeaderClientMethodCallbackEnd(
 
   printer->Print(
       "class async* async() override { "
-      "return experimental_async(); }\n");
-  printer->Print(
-      "class async* experimental_async() override { "
       "return &async_stub_; }\n");
 }
 

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -127,8 +127,8 @@ class ServiceA final {
       // Method A4 trailing comment 1
     };
     typedef class async_interface experimental_async_interface;
-    virtual class async_interface* async() { return experimental_async(); }
-    virtual class async_interface* experimental_async() { return nullptr; }
+    virtual class async_interface* async() { return nullptr; }
+    class async_interface* experimental_async() { return async(); }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* AsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* PrepareAsyncMethodA1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -193,8 +193,7 @@ class ServiceA final {
       Stub* stub() { return stub_; }
       Stub* stub_;
     };
-    class async* async() override { return experimental_async(); }
-    class async* experimental_async() override { return &async_stub_; }
+    class async* async() override { return &async_stub_; }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
@@ -737,8 +736,8 @@ class ServiceB final {
       // MethodB1 trailing comment 1
     };
     typedef class async_interface experimental_async_interface;
-    virtual class async_interface* async() { return experimental_async(); }
-    virtual class async_interface* experimental_async() { return nullptr; }
+    virtual class async_interface* async() { return nullptr; }
+    class async_interface* experimental_async() { return async(); }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* AsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc::testing::Response>* PrepareAsyncMethodB1Raw(::grpc::ClientContext* context, const ::grpc::testing::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -764,8 +763,7 @@ class ServiceB final {
       Stub* stub() { return stub_; }
       Stub* stub_;
     };
-    class async* async() override { return experimental_async(); }
-    class async* experimental_async() override { return &async_stub_; }
+    class async* async() override { return &async_stub_; }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;


### PR DESCRIPTION
Devirtualize experimental_async() as a stub function since all known mockers have been migrated to async(). Can't remove the function altogether yet since at least one major known OSS project is using an older version of gRPC that doesn't support its removal.

Tested internally via TGP.
