### PR TITLE
Fix executable path for Java workers

### DIFF
--- a/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
@@ -57,7 +57,7 @@ spec:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /executable/bin/worker \
+            /execute/bin/benchmark_worker \
             --driver_port="${DRIVER_PORT}"
       command:
       - bash
@@ -168,7 +168,7 @@ spec:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /executable/bin/worker \
+            /execute/bin/benchmark_worker \
             --driver_port="${DRIVER_PORT}"
       command:
       - bash


### PR DESCRIPTION
This commit fixes executable path in the prebuilt template for Java
tests.