### PR TITLE
Allow Ruby server interceptor to access response

### DIFF
--- a/src/ruby/lib/grpc/generic/bidi_call.rb
+++ b/src/ruby/lib/grpc/generic/bidi_call.rb
@@ -102,6 +102,7 @@ module GRPC
       end
 
       write_loop(replies, is_client: false)
+      replies
     end
 
     ##

--- a/src/ruby/lib/grpc/generic/rpc_desc.rb
+++ b/src/ruby/lib/grpc/generic/rpc_desc.rb
@@ -62,6 +62,7 @@ module GRPC
           resp,
           trailing_metadata: active_call.output_metadata
         )
+        resp
       end
     end
 
@@ -78,6 +79,7 @@ module GRPC
           resp,
           trailing_metadata: active_call.output_metadata
         )
+        resp
       end
     end
 
@@ -94,6 +96,7 @@ module GRPC
         replies = mth.call(req, call)
         replies.each { |r| active_call.remote_send(r) }
         send_status(active_call, OK, 'OK', active_call.output_metadata)
+        replies
       end
     end
 
@@ -103,8 +106,9 @@ module GRPC
     # @param [Array<GRPC::InterceptionContext>] inter_ctx
     #
     def handle_bidi_streamer(active_call, mth, inter_ctx)
-      active_call.run_server_bidi(mth, inter_ctx)
+      replies = active_call.run_server_bidi(mth, inter_ctx)
       send_status(active_call, OK, 'OK', active_call.output_metadata)
+      replies
     end
 
     ##

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -42,6 +42,20 @@ describe 'Server Interceptors' do
         end
       end
 
+      it 'should return response', server: true do
+        value = nil
+        expect(interceptor).to receive(:request_response)
+          .once.and_wrap_original do |original_method, *args, &block|
+            value = original_method.call(*args, &block)
+          end
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub)
+          expect(stub.an_rpc(request)).to be_a(EchoMsg)
+          expect(value).to be_a(EchoMsg)
+        end
+      end
+
       it 'can modify trailing metadata', server: true do
         expect(interceptor).to receive(:request_response)
           .once.and_call_original
@@ -74,6 +88,20 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect(stub.a_client_streaming_rpc(requests)).to be_a(EchoMsg)
+        end
+      end
+
+      it 'should return response', server: true do
+        value = nil
+        expect(interceptor).to receive(:client_streamer)
+          .once.and_wrap_original do |original_method, *args, &block|
+            value = original_method.call(*args, &block)
+          end
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub)
+          expect(stub.a_client_streaming_rpc(requests)).to be_a(EchoMsg)
+          expect(value).to be_a(EchoMsg)
         end
       end
 
@@ -115,6 +143,25 @@ describe 'Server Interceptors' do
         end
       end
 
+      it 'should return response', server: true do
+        value = nil
+        expect(interceptor).to receive(:server_streamer)
+          .once.and_wrap_original do |original_method, *args, &block|
+            value = original_method.call(*args, &block)
+          end
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub)
+          responses = stub.a_server_streaming_rpc(request)
+          responses.each do |r|
+            expect(r).to be_a(EchoMsg)
+          end
+          value.each do |r|
+            expect(r).to be_a(EchoMsg)
+          end
+        end
+      end
+
       it 'can modify trailing metadata', server: true do
         expect(interceptor).to receive(:server_streamer)
           .once.and_call_original
@@ -143,6 +190,25 @@ describe 'Server Interceptors' do
       let(:requests) { [EchoMsg.new, EchoMsg.new] }
 
       it 'should be called', server: true do
+        value = nil
+        expect(interceptor).to receive(:bidi_streamer)
+          .once.and_wrap_original do |original_method, *args, &block|
+            value = original_method.call(*args, &block)
+          end
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub)
+          responses = stub.a_bidi_rpc(requests)
+          responses.each do |r|
+            expect(r).to be_a(EchoMsg)
+          end
+          value.each do |r|
+            expect(r).to be_a(EchoMsg)
+          end
+        end
+      end
+
+      it 'should return response', server: true do
         expect(interceptor).to receive(:bidi_streamer)
           .once.and_call_original
 


### PR DESCRIPTION
These changes allow ruby ServerInterceptor to get access to response after the request is done. Currently, the behaviour is inconsistent as ClientInterceptor can access the response, while the server one receives nil. For our scenario it will allow making logging interceptor that can log responses.

@yashykt
