### PR TITLE
xds-k8s: fix a bug with ordering flags in run.sh

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/run.sh
+++ b/tools/run_tests/xds_k8s_test_driver/run.sh
@@ -68,4 +68,8 @@ fi
 
 cd "${XDS_K8S_DRIVER_DIR}"
 export PYTHONPATH="${XDS_K8S_DRIVER_DIR}"
-exec python "$@" --flagfile="${XDS_K8S_CONFIG}"
+# Split path to python file from the rest of the args.
+readonly PY_FILE="$1"
+shift
+# Append args after --flagfile, so they take higher priority.
+exec python "${PY_FILE}" --flagfile="${XDS_K8S_CONFIG}" "$@"


### PR DESCRIPTION
Append run.sh arguments after the flagfile, so they it's possible to override flags set in the flagfile.

Note: this is extracted from #26542, in case we want to revert that PR
