### PR TITLE
Fix invalid grpc_resolved_address length in test server

### DIFF
--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -405,6 +405,7 @@ static grpc_error_handle clone_port(grpc_tcp_listener* listener,
 static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
                                              const grpc_resolved_address* addr,
                                              int* out_port) {
+  GPR_ASSERT(addr->len <= GRPC_MAX_SOCKADDR_SIZE);
   grpc_tcp_listener* sp;
   grpc_resolved_address sockname_temp;
   grpc_resolved_address addr6_v4mapped;

--- a/test/core/util/test_tcp_server.cc
+++ b/test/core/util/test_tcp_server.cc
@@ -63,6 +63,7 @@ void test_tcp_server_start(test_tcp_server* server, int port) {
   addr->sin_family = GRPC_AF_INET;
   addr->sin_port = grpc_htons(static_cast<uint16_t>(port));
   memset(&addr->sin_addr, 0, sizeof(addr->sin_addr));
+  resolved_addr.len = static_cast<socklen_t>(sizeof(grpc_sockaddr_in));
 
   grpc_error_handle error = grpc_tcp_server_create(
       &server->shutdown_complete, nullptr, &server->tcp_server);


### PR DESCRIPTION
The length of the address was invalid (uninitialized data). It just so
happens that the posix iomgr implementation wasn't affected by this, but
the EventEngine iomgr asserts the validity of addresses and would crash.

I've added an assert for valid address length in the posix iomgr impl as
well.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
