### PR TITLE
TLS Security Connector: Add an always-fail-handshaker when certificates are not ready

### DIFF
--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -193,6 +193,8 @@ void TlsChannelSecurityConnector::add_handshakers(
   // BlockOnInitialCredentialHandshaker) when certificates are not ready.
   gpr_log(GPR_ERROR, "%s not supported yet.",
           "Client BlockOnInitialCredentialHandshaker");
+  // Add a handshaker that always fails.
+  handshake_mgr->Add(SecurityHandshakerCreate(nullptr, nullptr, nullptr));
 }
 
 void TlsChannelSecurityConnector::check_peer(
@@ -567,6 +569,8 @@ void TlsServerSecurityConnector::add_handshakers(
   // BlockOnInitialCredentialHandshaker) when certificates are not ready.
   gpr_log(GPR_ERROR, "%s not supported yet.",
           "Server BlockOnInitialCredentialHandshaker");
+  // Add a handshaker that always fails.
+  handshake_mgr->Add(SecurityHandshakerCreate(nullptr, nullptr, nullptr));
 }
 
 void TlsServerSecurityConnector::check_peer(

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -172,9 +172,9 @@ void TlsChannelSecurityConnector::add_handshakers(
     const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
     HandshakeManager* handshake_mgr) {
   MutexLock lock(&mu_);
+  tsi_handshaker* tsi_hs = nullptr;
   if (client_handshaker_factory_ != nullptr) {
     // Instantiate TSI handshaker.
-    tsi_handshaker* tsi_hs = nullptr;
     tsi_result result = tsi_ssl_client_handshaker_factory_create_handshaker(
         client_handshaker_factory_,
         overridden_target_name_.empty() ? target_name_.c_str()
@@ -183,18 +183,10 @@ void TlsChannelSecurityConnector::add_handshakers(
     if (result != TSI_OK) {
       gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
               tsi_result_to_string(result));
-      return;
     }
-    // Create handshakers.
-    handshake_mgr->Add(SecurityHandshakerCreate(tsi_hs, this, args));
-    return;
   }
-  // TODO(ZhenLian): Implement the logic(delegation to
-  // BlockOnInitialCredentialHandshaker) when certificates are not ready.
-  gpr_log(GPR_ERROR, "%s not supported yet.",
-          "Client BlockOnInitialCredentialHandshaker");
-  // Add a handshaker that always fails.
-  handshake_mgr->Add(SecurityHandshakerCreate(nullptr, nullptr, nullptr));
+  // If tsi_hs is null, this will add a failing handshaker.
+  handshake_mgr->Add(SecurityHandshakerCreate(tsi_hs, this, args));
 }
 
 void TlsChannelSecurityConnector::check_peer(
@@ -551,26 +543,18 @@ void TlsServerSecurityConnector::add_handshakers(
     const grpc_channel_args* args, grpc_pollset_set* /*interested_parties*/,
     HandshakeManager* handshake_mgr) {
   MutexLock lock(&mu_);
+  tsi_handshaker* tsi_hs = nullptr;
   if (server_handshaker_factory_ != nullptr) {
     // Instantiate TSI handshaker.
-    tsi_handshaker* tsi_hs = nullptr;
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
         server_handshaker_factory_, &tsi_hs);
     if (result != TSI_OK) {
       gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
               tsi_result_to_string(result));
-      return;
     }
-    // Create handshakers.
-    handshake_mgr->Add(SecurityHandshakerCreate(tsi_hs, this, args));
-    return;
   }
-  // TODO(ZhenLian): Implement the logic(delegation to
-  // BlockOnInitialCredentialHandshaker) when certificates are not ready.
-  gpr_log(GPR_ERROR, "%s not supported yet.",
-          "Server BlockOnInitialCredentialHandshaker");
-  // Add a handshaker that always fails.
-  handshake_mgr->Add(SecurityHandshakerCreate(nullptr, nullptr, nullptr));
+  // If tsi_hs is null, this will add a failing handshaker.
+  handshake_mgr->Add(SecurityHandshakerCreate(tsi_hs, this, args));
 }
 
 void TlsServerSecurityConnector::check_peer(

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -306,13 +306,6 @@ static grpc_error_handle server_auth_init_channel_elem(
   GPR_ASSERT(!args->is_last);
   grpc_auth_context* auth_context =
       grpc_find_auth_context_in_args(args->channel_args);
-  if (auth_context == nullptr) {
-    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "No authorization context found. This might be a TRANSIENT failure due "
-        "to certificates not having been loaded yet.");
-    gpr_log(GPR_DEBUG, "%s", grpc_error_std_string(error).c_str());
-    return error;
-  }
   GPR_ASSERT(auth_context != nullptr);
   grpc_server_credentials* creds =
       grpc_find_server_credentials_in_args(args->channel_args);

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -9026,6 +9026,14 @@ TEST_P(XdsServerSecurityTest, UnknownRootCertificateProvider) {
           true /* test_expects_failure */);
 }
 
+TEST_P(XdsServerSecurityTest, CertificatesNotAvailable) {
+  FakeCertificateProvider::CertDataMap fake1_cert_map;
+  g_fake1_cert_data_map = &fake1_cert_map;
+  SetLdsUpdate("fake_plugin1", "", "fake_plugin1", "", true);
+  SendRpc([this]() { return CreateMtlsChannel(); }, {}, {},
+          true /* test_expects_failure */);
+}
+
 TEST_P(XdsServerSecurityTest, TestMtls) {
   FakeCertificateProvider::CertDataMap fake1_cert_map = {
       {"", {root_cert_, identity_pair_}}};


### PR DESCRIPTION
Also, fixes a leak in FailHandshaker.

cc @markdroth 