### PR TITLE
C-core API: remove grpc_metadata::flags, improve GRPC_INITIAL_METADATA_* comments

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -495,6 +495,7 @@ typedef enum grpc_call_error {
   (GRPC_WRITE_BUFFER_HINT | GRPC_WRITE_NO_COMPRESS | GRPC_WRITE_THROUGH)
 
 /** Initial metadata flags */
+/** These flags are to be passed to the `grpc_op::flags` field */
 /** Signal that the call is idempotent */
 #define GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST (0x00000010u)
 /** Signal that the call should not return UNAVAILABLE before it has started */
@@ -521,8 +522,6 @@ typedef struct grpc_metadata {
      changing them, update metadata.h at the same time. */
   grpc_slice key;
   grpc_slice value;
-
-  uint32_t flags;
 
   /** The following fields are reserved for grpc internal use.
       There is no need to initialize them, and they will be set to garbage

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -1625,7 +1625,6 @@ static grpc_call_error call_start_batch(grpc_call* call, const grpc_op* ops,
         grpc_metadata& compression_md = call->compression_md;
         compression_md.key = grpc_empty_slice();
         compression_md.value = grpc_empty_slice();
-        compression_md.flags = 0;
         size_t additional_metadata_count = 0;
         grpc_compression_level effective_compression_level =
             GRPC_COMPRESS_LEVEL_NONE;

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -499,7 +499,6 @@ void MetadataCredentialsPluginWrapper::InvokePlugin(
     grpc_metadata md_entry;
     md_entry.key = SliceFromCopiedString(metadatum.first);
     md_entry.value = SliceFromCopiedString(metadatum.second);
-    md_entry.flags = 0;
     md.push_back(md_entry);
   }
   if (creds_md != nullptr) {
@@ -514,7 +513,6 @@ void MetadataCredentialsPluginWrapper::InvokePlugin(
       for (const auto& elem : md) {
         creds_md[*num_creds_md].key = elem.key;
         creds_md[*num_creds_md].value = elem.value;
-        creds_md[*num_creds_md].flags = elem.flags;
         ++(*num_creds_md);
       }
       *status_code = static_cast<grpc_status_code>(status.error_code());

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -74,7 +74,6 @@ void AuthMetadataProcessorAyncWrapper::InvokeProcessor(
     grpc_metadata md_entry;
     md_entry.key = SliceReferencingString(consumed.first);
     md_entry.value = SliceReferencingString(consumed.second);
-    md_entry.flags = 0;
     consumed_md.push_back(md_entry);
   }
   std::vector<grpc_metadata> response_md;
@@ -82,7 +81,6 @@ void AuthMetadataProcessorAyncWrapper::InvokeProcessor(
     grpc_metadata md_entry;
     md_entry.key = SliceReferencingString(response.first);
     md_entry.value = SliceReferencingString(response.second);
-    md_entry.flags = 0;
     response_md.push_back(md_entry);
   }
   auto consumed_md_data = consumed_md.empty() ? nullptr : &consumed_md[0];

--- a/test/core/end2end/tests/authority_not_supported.cc
+++ b/test/core/end2end/tests/authority_not_supported.cc
@@ -92,11 +92,9 @@ static void test_with_authority_header(grpc_end2end_test_config config) {
       grpc_raw_byte_buffer_create(&request_payload_slice, 1);
   grpc_metadata meta_c[2] = {{grpc_slice_from_static_string("key1"),
                               grpc_slice_from_static_string("val1"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key2"),
                               grpc_slice_from_static_string("val2"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_end2end_test_fixture f =
       begin_test(config, "test_with_authority_header", nullptr, nullptr);

--- a/test/core/end2end/tests/binary_metadata.cc
+++ b/test/core/end2end/tests/binary_metadata.cc
@@ -100,23 +100,19 @@ static void test_request_response_with_metadata_and_payload(
       {grpc_slice_from_static_string("key1-bin"),
        grpc_slice_from_static_string(
            "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc"),
-       0,
        {{nullptr, nullptr, nullptr, nullptr}}},
       {grpc_slice_from_static_string("key2-bin"),
        grpc_slice_from_static_string(
            "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d"),
-       0,
        {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_metadata meta_s[2] = {
       {grpc_slice_from_static_string("key3-bin"),
        grpc_slice_from_static_string(
            "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee"),
-       0,
        {{nullptr, nullptr, nullptr, nullptr}}},
       {grpc_slice_from_static_string("key4-bin"),
        grpc_slice_from_static_string(
            "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff"),
-       0,
        {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_end2end_test_fixture f =
       begin_test(config, "test_request_response_with_metadata_and_payload",

--- a/test/core/end2end/tests/simple_cacheable_request.cc
+++ b/test/core/end2end/tests/simple_cacheable_request.cc
@@ -100,19 +100,15 @@ static void test_cacheable_request_response_with_metadata_and_payload(
       grpc_raw_byte_buffer_create(&response_payload_slice, 1);
   grpc_metadata meta_c[2] = {{grpc_slice_from_static_string("key1"),
                               grpc_slice_from_static_string("val1"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key2"),
                               grpc_slice_from_static_string("val2"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_metadata meta_s[2] = {{grpc_slice_from_static_string("key3"),
                               grpc_slice_from_static_string("val3"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key4"),
                               grpc_slice_from_static_string("val4"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_end2end_test_fixture f = begin_test(
       config, "test_cacheable_request_response_with_metadata_and_payload",

--- a/test/core/end2end/tests/simple_metadata.cc
+++ b/test/core/end2end/tests/simple_metadata.cc
@@ -98,19 +98,15 @@ static void test_request_response_with_metadata_and_payload(
       grpc_raw_byte_buffer_create(&response_payload_slice, 1);
   grpc_metadata meta_c[2] = {{grpc_slice_from_static_string("key1"),
                               grpc_slice_from_static_string("val1"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key2"),
                               grpc_slice_from_static_string("val2"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_metadata meta_s[2] = {{grpc_slice_from_static_string("key3"),
                               grpc_slice_from_static_string("val3"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key4"),
                               grpc_slice_from_static_string("val4"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_end2end_test_fixture f =
       begin_test(config, "test_request_response_with_metadata_and_payload",

--- a/test/core/end2end/tests/trailing_metadata.cc
+++ b/test/core/end2end/tests/trailing_metadata.cc
@@ -98,27 +98,21 @@ static void test_request_response_with_metadata_and_payload(
       grpc_raw_byte_buffer_create(&response_payload_slice, 1);
   grpc_metadata meta_c[2] = {{grpc_slice_from_static_string("key1"),
                               grpc_slice_from_static_string("val1"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key2"),
                               grpc_slice_from_static_string("val2"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_metadata meta_s[2] = {{grpc_slice_from_static_string("key3"),
                               grpc_slice_from_static_string("val3"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key4"),
                               grpc_slice_from_static_string("val4"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_metadata meta_t[2] = {{grpc_slice_from_static_string("key5"),
                               grpc_slice_from_static_string("val5"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}},
                              {grpc_slice_from_static_string("key6"),
                               grpc_slice_from_static_string("val6"),
-                              0,
                               {{nullptr, nullptr, nullptr, nullptr}}}};
   grpc_end2end_test_fixture f =
       begin_test(config, "test_request_response_with_metadata_and_payload",


### PR DESCRIPTION
Fixes #18160.

Removed the `grpc_metadata::flags` field and improved the `GRPC_INITIAL_METADATA_*` flags comments to inform users to pass said flags to the `grpc_op::flags` field.