### PR TITLE
Support GTMSessionFetcher transport retry configuration.

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCallOptions.h
+++ b/src/objective-c/GRPCClient/GRPCCallOptions.h
@@ -301,6 +301,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(readwrite) BOOL retryEnabled;
 
+// Parameters for GTMSessionFetcher transport retry policy. This is only for internal users.
+@property(atomic, assign) NSTimeInterval maxRetryInterval;
+@property(atomic, assign) NSTimeInterval minRetryInterval;
+@property(atomic, assign) NSUInteger retryCount;
+@property(atomic, assign) double retryFactor;
+
 // HTTP/2 keep-alive feature. The parameter \a keepaliveInterval specifies the interval between two
 // PING frames. The parameter \a keepaliveTimeout specifies the length of the period for which the
 // call should wait for PING ACK. If PING ACK is not received after this period, the call fails.


### PR DESCRIPTION
Support passing retry parameters via gRPC callOptions to GTMSessionFetcher transport.

Implementation will be in google3.