### PR TITLE
Changed the gpg keyserver on Mac

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -47,11 +47,11 @@ fi
 if [ "${PREPARE_BUILD_INSTALL_DEPS_RUBY}" == "true" ]
 then
   # Fetch keys per https://rvm.io/rvm/install
-  # Force use of an IPv4 key server to avoid running into https://github.com/rvm/rvm/issues/4215
   gpg_recv_keys_success=0
   for ((i=0;i<5;i++)); do
-    KEYSERVER_IPV4_ADDRESS="$(host pool.sks-keyservers.net | grep 'has address' | head -n1 | awk '{print $4}')"
-    gpg --keyserver "hkp://${KEYSERVER_IPV4_ADDRESS}" --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+    # Use the Ubuntu keyserver instead of pool.sks-keyservers.net because sks-keyservers is now deprecated.
+    GPG_KEYSERVER_ADDRESS="keyserver.ubuntu.com"
+    gpg --keyserver "hkp://${GPG_KEYSERVER_ADDRESS}" --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
       && gpg_recv_keys_success=1
     [[ "$gpg_recv_keys_success" == 1 ]] && break
     sleep 3


### PR DESCRIPTION
grpc_build_artifacts started to fail from Jun 21 with the following error ([log](https://source.cloud.google.com/results/invocations/7c155d51-2113-410a-ac2e-9edb4be80f11/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_build_artifacts/log))

> gpg --keyserver hkp:// --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
gpg: could not parse keyserver URL

This is because the script tries to connect to pool.sks-keyservers.net ([src](https://github.com/grpc/grpc/blob/master/tools/internal_ci/helper_scripts/prepare_build_macos_rc#L53)) but sks-keyservers.net is now deprecated. From `sks-keyservers.net`,

> This service is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. Service reliability should not be expected.
> Update 2021-06-21: Due to even more GDPR takedown requests, the DNS records for the pool will no longer be provided at all.

So let's use the alternative, `keyserver.ubuntu.com` which serves for IPv4 addresses only so we don't need the workaround to disable IPv6 anymore.