### PR TITLE
Remove last ref to grpc_experimental_completion_queue_functor

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -770,9 +770,6 @@ typedef struct grpc_completion_queue_functor {
   struct grpc_completion_queue_functor* internal_next;
 } grpc_completion_queue_functor;
 
-typedef grpc_completion_queue_functor
-    grpc_experimental_completion_queue_functor;
-
 #define GRPC_CQ_CURRENT_VERSION 2
 #define GRPC_CQ_VERSION_MINIMUM_FOR_CALLBACKABLE 2
 typedef struct grpc_completion_queue_attributes {


### PR DESCRIPTION
There are now officially no more supported references to grpc_experimental_completion_queue_functor. All uses are now non-experimental so this typedef can be removed. Note that this doesn't break core API because experimental is never considered API.
