### PR TITLE
De-experimentalize default_reactor_test_peer.h and last uses of CallbackServerContext (plus namespace cleanup)

### DIFF
--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -101,15 +101,6 @@ class GenericServerContext;
 class Server;
 class ServerInterface;
 class ContextAllocator;
-
-// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
-namespace experimental {
-
-typedef ::grpc::ServerContextBase ServerContextBase;
-typedef ::grpc::CallbackServerContext CallbackServerContext;
-
-}  // namespace experimental
-
 class GenericCallbackServerContext;
 
 namespace internal {
@@ -122,7 +113,7 @@ class ServerContextTestSpouse;
 class DefaultReactorTestPeer;
 }  // namespace testing
 
-/// Base class of ServerContext. Experimental until callback API is final.
+/// Base class of ServerContext.
 class ServerContextBase {
  public:
   virtual ~ServerContextBase();
@@ -310,8 +301,6 @@ class ServerContextBase {
   ///
   /// This method should not be called more than once or called after return
   /// from the method handler.
-  ///
-  /// WARNING: This is experimental API and could be changed or removed.
   ::grpc::ServerUnaryReactor* DefaultReactor() {
     // Short-circuit the case where a default reactor was already set up by
     // the TestPeer.

--- a/include/grpcpp/test/default_reactor_test_peer.h
+++ b/include/grpcpp/test/default_reactor_test_peer.h
@@ -34,22 +34,21 @@ namespace testing {
 /// test mode rather than letting it follow the normal paths.
 class DefaultReactorTestPeer {
  public:
-  explicit DefaultReactorTestPeer(experimental::CallbackServerContext* ctx)
-      : DefaultReactorTestPeer(ctx, [](::grpc::Status) {}) {}
-  DefaultReactorTestPeer(experimental::CallbackServerContext* ctx,
-                         std::function<void(::grpc::Status)> finish_func)
+  explicit DefaultReactorTestPeer(CallbackServerContext* ctx)
+      : DefaultReactorTestPeer(ctx, [](Status) {}) {}
+  DefaultReactorTestPeer(CallbackServerContext* ctx,
+                         std::function<void(Status)> finish_func)
       : ctx_(ctx) {
     ctx->SetupTestDefaultReactor(std::move(finish_func));
   }
-  ::grpc::experimental::ServerUnaryReactor* reactor() const {
-    return reinterpret_cast<experimental::ServerUnaryReactor*>(
-        &ctx_->default_reactor_);
+  ServerUnaryReactor* reactor() const {
+    return reinterpret_cast<ServerUnaryReactor*>(&ctx_->default_reactor_);
   }
   bool test_status_set() const { return ctx_->test_status_set(); }
   Status test_status() const { return ctx_->test_status(); }
 
  private:
-  experimental::CallbackServerContext* const ctx_;  // not owned
+  CallbackServerContext* const ctx_;  // not owned
 };
 
 }  // namespace testing


### PR DESCRIPTION
Some de-experimentalization previously missed in include/grpcpp/test, which in turn allows complete removal of experimental from the ServerContext header.