### PR TITLE
Remove most uses of grpc::experimental for callback API

### DIFF
--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -1226,32 +1226,5 @@ class ClientCallbackUnaryFactory {
 };
 
 }  // namespace internal
-
-// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
-namespace experimental {
-
-template <class Response>
-using ClientCallbackReader = ::grpc::ClientCallbackReader<Response>;
-
-template <class Request>
-using ClientCallbackWriter = ::grpc::ClientCallbackWriter<Request>;
-
-template <class Request, class Response>
-using ClientCallbackReaderWriter =
-    ::grpc::ClientCallbackReaderWriter<Request, Response>;
-
-template <class Response>
-using ClientReadReactor = ::grpc::ClientReadReactor<Response>;
-
-template <class Request>
-using ClientWriteReactor = ::grpc::ClientWriteReactor<Request>;
-
-template <class Request, class Response>
-using ClientBidiReactor = ::grpc::ClientBidiReactor<Request, Response>;
-
-typedef ::grpc::ClientUnaryReactor ClientUnaryReactor;
-
-}  // namespace experimental
-
 }  // namespace grpc
 #endif  // GRPCPP_IMPL_CODEGEN_CLIENT_CALLBACK_H

--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -783,19 +783,12 @@ using UnimplementedBidiReactor =
 
 }  // namespace internal
 
-// TODO(vjpai): Remove namespace experimental when de-experimentalized fully.
+// TODO(vjpai): Remove namespace experimental when last known users are migrated
+// off.
 namespace experimental {
-
-template <class Request>
-using ServerReadReactor = ::grpc::ServerReadReactor<Request>;
-
-template <class Response>
-using ServerWriteReactor = ::grpc::ServerWriteReactor<Response>;
 
 template <class Request, class Response>
 using ServerBidiReactor = ::grpc::ServerBidiReactor<Request, Response>;
-
-using ServerUnaryReactor = ::grpc::ServerUnaryReactor;
 
 }  // namespace experimental
 


### PR DESCRIPTION
I couldn't remove grpc::experimental::ServerBidiReactor because of 1 dependent downstream user that can't be migrated at the current time. Otherwise all reactors are no longer available through grpc::experimental

Tested internally with TGP

