### PR TITLE
Add v1.39.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -188,7 +188,8 @@ LANG_RELEASE_MATRIX = {
             ('v1.36.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.37.0', ReleaseInfo(runtimes=['go1.11'])),
             # NOTE: starting from release v1.38.0, use runtimes=['go1.16']
-            ('v1.38.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.38.1', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.39.0', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush

The tests seem to have passed with patch release + new release: https://fusion2.corp.google.com/invocations/006cdbd1-dd15-4bdd-8834-30606b7a4ef4/targets/grpc%2Fcore%2Fexperimental%2Flinux%2Fgrpc_interop_matrix_adhoc;config=default/log.
