### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,8 +11,8 @@
 # [3] https://github.com/grpc/grpc/pull/20784
 ---
 # TODO(yannic): Ideally, we should also enable buildifier and all platforms should test `//...`.
-platforms:
-  ubuntu1604:
+tasks:
+  ubuntu1804:
     build_targets:
       - //:all
       - //src/proto/...


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
