### PR TITLE
Tighten the error tolerance requirement by 100x

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1615,7 +1615,7 @@ grpc_millis NowFromCycleCounter() {
   return grpc_cycle_counter_to_millis_round_up(now);
 }
 
-// Returns the number of RPCs needed to pass error_tolerance at 99.9995% chance.
+// Returns the number of RPCs needed to pass error_tolerance at 99.99994% chance.
 // Rolling dices in drop/fault-injection generates a binomial distribution (if
 // our code is not horribly wrong). Let's make "n" the number of samples, "p"
 // the probabilty. If we have np>5 & n(1-p)>5, we can approximately treat the
@@ -1623,18 +1623,18 @@ grpc_millis NowFromCycleCounter() {
 //
 // For normal distribution, we can easily look up how many standard deviation we
 // need to reach 99.995%. Based on Wiki's table
-// https://en.wikipedia.org/wiki/Standard_normal_table, we need 4.50 sigma
-// (standard deviation) to cover the probability area of 99.9995%. In another
+// https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule, we need 5.00 sigma
+// (standard deviation) to cover the probability area of 99.99994%. In another
 // word, for a sample with size "n" probability "p" error-tolerance "k", we want
-// the error always land within 4.50 sigma. The sigma of binominal distribution
+// the error always land within 5.00 sigma. The sigma of binominal distribution
 // and be computed as sqrt(np(1-p)). Hence, we have the equation:
 //
-//   kn <= 4.50 * sqrt(np(1-p))
+//   kn <= 5.00 * sqrt(np(1-p))
 //
 size_t ComputeIdealNumRpcs(double p, double error_tolerance) {
   GPR_ASSERT(p >= 0 && p <= 1);
   size_t num_rpcs =
-      ceil(p * (1 - p) * 4.50 * 4.50 / error_tolerance / error_tolerance);
+      ceil(p * (1 - p) * 5.00 * 5.00 / error_tolerance / error_tolerance);
   gpr_log(GPR_INFO,
           "Sending %" PRIuPTR " RPCs for percentage=%.3f error_tolerance=%.3f",
           num_rpcs, p, error_tolerance);

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1615,7 +1615,7 @@ grpc_millis NowFromCycleCounter() {
   return grpc_cycle_counter_to_millis_round_up(now);
 }
 
-// Returns the number of RPCs needed to pass error_tolerance at 99.995% chance.
+// Returns the number of RPCs needed to pass error_tolerance at 99.9995% chance.
 // Rolling dices in drop/fault-injection generates a binomial distribution (if
 // our code is not horribly wrong). Let's make "n" the number of samples, "p"
 // the probabilty. If we have np>5 & n(1-p)>5, we can approximately treat the
@@ -1623,20 +1623,18 @@ grpc_millis NowFromCycleCounter() {
 //
 // For normal distribution, we can easily look up how many standard deviation we
 // need to reach 99.995%. Based on Wiki's table
-// https://en.wikipedia.org/wiki/Standard_normal_table, we need 4.00 sigma
-// (standard deviation) to cover the probability area of 99.995%. In another
+// https://en.wikipedia.org/wiki/Standard_normal_table, we need 4.50 sigma
+// (standard deviation) to cover the probability area of 99.9995%. In another
 // word, for a sample with size "n" probability "p" error-tolerance "k", we want
-// the error always land within 4.00 sigma. The sigma of binominal distribution
+// the error always land within 4.50 sigma. The sigma of binominal distribution
 // and be computed as sqrt(np(1-p)). Hence, we have the equation:
 //
-//   kn <= 4.00 * sqrt(np(1-p))
+//   kn <= 4.50 * sqrt(np(1-p))
 //
-// E.g., with p=0.5 k=0.1, n >= 400; with p=0.5 k=0.05, n >= 1600; with p=0.5
-// k=0.01, n >= 40000.
 size_t ComputeIdealNumRpcs(double p, double error_tolerance) {
   GPR_ASSERT(p >= 0 && p <= 1);
   size_t num_rpcs =
-      ceil(p * (1 - p) * 4.00 * 4.00 / error_tolerance / error_tolerance);
+      ceil(p * (1 - p) * 4.50 * 4.50 / error_tolerance / error_tolerance);
   gpr_log(GPR_INFO,
           "Sending %" PRIuPTR " RPCs for percentage=%.3f error_tolerance=%.3f",
           num_rpcs, p, error_tolerance);

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1615,22 +1615,21 @@ grpc_millis NowFromCycleCounter() {
   return grpc_cycle_counter_to_millis_round_up(now);
 }
 
-// Returns the number of RPCs needed to pass error_tolerance at 99.99994% chance.
-// Rolling dices in drop/fault-injection generates a binomial distribution (if
-// our code is not horribly wrong). Let's make "n" the number of samples, "p"
-// the probabilty. If we have np>5 & n(1-p)>5, we can approximately treat the
-// binomial distribution as a normal distribution.
+// Returns the number of RPCs needed to pass error_tolerance at 99.99994%
+// chance. Rolling dices in drop/fault-injection generates a binomial
+// distribution (if our code is not horribly wrong). Let's make "n" the number
+// of samples, "p" the probabilty. If we have np>5 & n(1-p)>5, we can
+// approximately treat the binomial distribution as a normal distribution.
 //
 // For normal distribution, we can easily look up how many standard deviation we
 // need to reach 99.995%. Based on Wiki's table
-// https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule, we need 5.00 sigma
-// (standard deviation) to cover the probability area of 99.99994%. In another
-// word, for a sample with size "n" probability "p" error-tolerance "k", we want
-// the error always land within 5.00 sigma. The sigma of binominal distribution
-// and be computed as sqrt(np(1-p)). Hence, we have the equation:
+// https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule, we need 5.00
+// sigma (standard deviation) to cover the probability area of 99.99994%. In
+// another word, for a sample with size "n" probability "p" error-tolerance "k",
+// we want the error always land within 5.00 sigma. The sigma of binominal
+// distribution and be computed as sqrt(np(1-p)). Hence, we have the equation:
 //
 //   kn <= 5.00 * sqrt(np(1-p))
-//
 size_t ComputeIdealNumRpcs(double p, double error_tolerance) {
   GPR_ASSERT(p >= 0 && p <= 1);
   size_t num_rpcs =


### PR DESCRIPTION
b/191678970
Related https://github.com/grpc/grpc/pull/26408 (last error tolerance change, 29 days ago)

I had made wrong estimation about our test volume. We have done 22057848 core-related test cases in the past 29 days, that is 0.8 million per day. I thought with <50 active developers, we are looking at thousands of test cases per day. For the test case in question `XdsRoutingWeightedClusterUpdateWeights`, it has failed 6 times among 23669 runs in the past 29 days (this test case uses `ComputeIdealNumRpcs` twice so it's more flaky). BigQuery query:

```
select count(*) from jenkins_test_results.rbe_test_results where
  job_name like '%grpc/core/master/linux%'  # you can filter job name here
  and test_case like '%test/core%'  # choose a test name you are interested in
  and timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 29 DAY)
```

According to [the empirical rule Wiki](https://en.wikipedia.org/wiki/68%E2%80%9395%E2%80%9399.7_rule), this PR updated  the expected success rate from 0.99994 to 0.9999994. That's from 1 failure in 16k runs to 1 failure in 1.7M runs.

The average daily runs for `XdsRoutingWeightedClusterUpdateWeights` is 816 runs/day. There are 26 call sites in `xds_end2end_test.cc`, so statistically the mean-time-between-flake should be around `80 days=1.7M/816/26`.

TBH, we can push the expected success rate to an extreme number like 1 failure in 0.5 billion runs. The downside is that means we will run more RPC than I introduced this method. I'm interested to see how this change will impact our flake rate.