### PR TITLE
Switch to using protobuf's helper for the file's prefix.

### DIFF
--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -37,7 +37,7 @@ inline string MessageHeaderName(const FileDescriptor* file) {
 
 inline string ServiceClassName(const ServiceDescriptor* service) {
   const FileDescriptor* file = service->file();
-  string prefix = file->options().objc_class_prefix();
+  string prefix = google::protobuf::compiler::objectivec::FileClassPrefix(file);
   return prefix + service->name();
 }
 


### PR DESCRIPTION
This adds support for protobuf ObjC support for using the proto package to
define the prefix for the file (https://github.com/protocolbuffers/protobuf/pull/8760).

Once protobuf cuts a release, it likely makes sense to support the same
generator options that the objc generator does, but for now the environment
variable support can used to enable this when building from recent sources.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
