### PR TITLE
[Ruby] deflake-ruby-e2e-tests

### DIFF
--- a/src/ruby/end2end/channel_closing_test.rb
+++ b/src/ruby/end2end/channel_closing_test.rb
@@ -24,13 +24,13 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    'channel_closing_client.rb', server_port)
-  # sleep to allow time for the client to get into
-  # the middle of a "watch connectivity state" call
-  sleep 3
 
   begin
+    client_controller = ClientController.new(
+      'channel_closing_client.rb', server_port)
+    # sleep to allow time for the client to get into
+    # the middle of a "watch connectivity state" call
+    sleep 3
     Timeout.timeout(20) do
       loop do
         begin
@@ -51,6 +51,9 @@ def main
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. It likely freezes when a ' \
       'channel is closed while connectivity is watched'
+  rescue => e
+    server_runner.stop
+    raise "ClientController creation failed, error: #{e}"
   end
 
   client_exit_code = $CHILD_STATUS

--- a/src/ruby/end2end/channel_state_test.rb
+++ b/src/ruby/end2end/channel_state_test.rb
@@ -23,14 +23,14 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    'channel_state_client.rb', server_port)
-  # sleep to allow time for the client to get into
-  # the middle of a "watch connectivity state" call
-  sleep 3
-  Process.kill('SIGTERM', client_controller.client_pid)
 
   begin
+    client_controller = ClientController.new(
+      'channel_state_client.rb', server_port)
+    # sleep to allow time for the client to get into
+    # the middle of a "watch connectivity state" call
+    sleep 3
+    Process.kill('SIGTERM', client_controller.client_pid)
     Timeout.timeout(10) { Process.wait(client_controller.client_pid) }
   rescue Timeout::Error
     STDERR.puts "timeout wait for client pid #{client_controller.client_pid}"
@@ -38,7 +38,10 @@ def main
     Process.wait(client_controller.client_pid)
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. ' \
-           'It likely freezes when ended abruptly'
+    'It likely freezes when ended abruptly'
+  rescue => e
+    server_runner.stop
+    raise "ClientController creation failed, error: #{e}"
   end
 
   # The interrupt in the child process should cause it to

--- a/src/ruby/end2end/client_memory_usage_test.rb
+++ b/src/ruby/end2end/client_memory_usage_test.rb
@@ -21,10 +21,14 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    'client_memory_usage_client.rb', server_port)
-
-  Process.wait(client_controller.client_pid)
+  begin
+    client_controller = ClientController.new(
+      'client_memory_usage_client.rb', server_port)
+    Process.wait(client_controller.client_pid)
+  rescue => e
+    @server_runner.stop
+    fail "timeout waiting for child process to report port. error: #{e}"
+  end
 
   client_exit_code = $CHILD_STATUS
   if client_exit_code != 0

--- a/src/ruby/end2end/end2end_common.rb
+++ b/src/ruby/end2end/end2end_common.rb
@@ -102,7 +102,7 @@ class ClientController < ClientControl::ParentController::Service
                                 "--parent_controller_port=#{port}",
                                 "--server_port=#{server_port}")
     begin
-      Timeout.timeout(10) do
+      Timeout.timeout(20) do
         @client_controller_port_mu.synchronize do
           while @client_controller_port.nil?
             @client_controller_port_cv.wait(@client_controller_port_mu)
@@ -110,6 +110,8 @@ class ClientController < ClientControl::ParentController::Service
         end
       end
     rescue => e
+      @server.stop
+      server_thread.join
       fail "timeout waiting for child process to report port. error: #{e}"
     end
     @server.stop

--- a/src/ruby/end2end/forking_client_test.rb
+++ b/src/ruby/end2end/forking_client_test.rb
@@ -21,10 +21,10 @@ def main
   server_runner = ServerRunner.new(EchoServerImpl)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    'forking_client_client.rb', server_port)
 
   begin
+    client_controller = ClientController.new(
+      'forking_client_client.rb', server_port)
     Timeout.timeout(10) do
       Process.wait(client_controller.client_pid)
     end
@@ -35,6 +35,9 @@ def main
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. ' \
       'It likely freezes when requiring grpc, then forking, then using grpc '
+  rescue => e
+    server_runner.stop
+    raise "ClientController creation failed, error: #{e}"
   end
 
   client_exit_code = $CHILD_STATUS

--- a/src/ruby/end2end/graceful_sig_stop_test.rb
+++ b/src/ruby/end2end/graceful_sig_stop_test.rb
@@ -25,10 +25,15 @@ def main
   server_runner = ServerRunner.new(echo_service)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    './graceful_sig_stop_client.rb', server_port)
-  client_controller.stub.shutdown(ClientControl::Void.new)
-  Process.wait(client_controller.client_pid)
+  begin
+    client_controller = ClientController.new(
+      './graceful_sig_stop_client.rb', server_port)
+    client_controller.stub.shutdown(ClientControl::Void.new)
+    Process.wait(client_controller.client_pid)
+  rescue => e
+    server_runner.stop
+    raise "ClientController creation failed, error: #{e}"
+  end
   fail "client exit code: #{$CHILD_STATUS}" unless $CHILD_STATUS.to_i.zero?
   server_runner.stop
 end

--- a/src/ruby/end2end/killed_client_thread_test.rb
+++ b/src/ruby/end2end/killed_client_thread_test.rb
@@ -52,8 +52,14 @@ def main
   server_runner = ServerRunner.new(service_impl, rpc_server_args: rpc_server_args)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    'killed_client_thread_client.rb', server_port)
+  client_controller = nil
+  begin
+    client_controller = ClientController.new(
+      'killed_client_thread_client.rb', server_port)
+  rescue => e
+    server_runner.stop
+    raise "ClientController creation failed, error: #{e}"
+  end
 
   received_rpc_mu.synchronize do
     received_rpc_cv.wait(received_rpc_mu) until received_rpc

--- a/src/ruby/end2end/sig_int_during_channel_watch_test.rb
+++ b/src/ruby/end2end/sig_int_during_channel_watch_test.rb
@@ -25,13 +25,13 @@ def main
   server_runner = ServerRunner.new(echo_service)
   server_port = server_runner.run
   STDERR.puts 'start client'
-  client_controller = ClientController.new(
-    'sig_int_during_channel_watch_client.rb', server_port)
-  # give time for the client to get into the middle
-  # of a channel state watch call
-  sleep 1
-  Process.kill('SIGINT', client_controller.client_pid)
   begin
+    client_controller = ClientController.new(
+      'sig_int_during_channel_watch_client.rb', server_port)
+    # give time for the client to get into the middle
+    # of a channel state watch call
+    sleep 1
+    Process.kill('SIGINT', client_controller.client_pid)
     Timeout.timeout(10) do
       Process.wait(client_controller.client_pid)
     end
@@ -42,6 +42,9 @@ def main
     STDERR.puts 'killed client child'
     raise 'Timed out waiting for client process. It likely freezes when a ' \
       'SIGINT is sent while there is an active connectivity_state call'
+  rescue => e
+    server_runner.stop
+    raise "ClientController creation failed, error: #{e}"
   end
   client_exit_code = $CHILD_STATUS
   if client_exit_code != 0


### PR DESCRIPTION
fix #25662 and #25423 

This happens when RpcServer is garbage collected before stopping, in the free function in the extension, it shuts down grpc without waiting for the thread pools that are processing the server calls to finish.

When stress running e2e tests, ClientController.new may throw exception, as a result, neither the servers started in [ClientController.initialize](https://github.com/grpc/grpc/blob/master/src/ruby/end2end/end2end_common.rb#L94) or in [ServerRunner](https://github.com/grpc/grpc/blob/master/src/ruby/end2end/end2end_common.rb#L69) were properly stopped, for such cases, grpc server and completion queue were shut down by ruby GC while there was an ongoing [server call](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/generic/rpc_server.rb#L452), this caused the assertion in [completion_queue.cc](https://github.com/grpc/grpc/blob/master/src/core/lib/surface/completion_queue.cc#L277) as the per-call completion queue was not drained.

This PR added proper server shutdown when ClientController.new throws so the assertion will not be triggered.
It also bumped the ClientController timeout so it's less likely ClientController.new will throw so the test will less likely to fail due to timeout.


PS: I tried to fix these issues by adding finalizer to rpc_server.rb to stop the server and wait the running thread to finish. However it didn't work, because when GC happens, the thread for server.run is already terminated and events left in the server call CQ cannot be processed.


@stanley-cheung @apolcyn 


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
