### PR TITLE
Modernized host name resolution to avoid memory leak.

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -258,9 +258,9 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
         error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
             "field:clientHostname error:should be of type array"));
       } else {
-        char* hostname = grpc_gethostname();
-        if (hostname == nullptr ||
-            !ValueInJsonArray(it->second.array_value(), hostname)) {
+        absl::StatusOr<std::string> hostname = grpc_core::GetHostName();
+        if (hostname.ok() &&
+            !ValueInJsonArray(it->second.array_value(), hostname->c_str())) {
           continue;
         }
       }

--- a/src/core/lib/iomgr/gethostname.h
+++ b/src/core/lib/iomgr/gethostname.h
@@ -19,8 +19,11 @@
 #ifndef GRPC_CORE_LIB_IOMGR_GETHOSTNAME_H
 #define GRPC_CORE_LIB_IOMGR_GETHOSTNAME_H
 
+#include "absl/status/statusor.h"
+
+namespace grpc_core {
 // Returns the hostname of the local machine.
-// Caller takes ownership of result.
-char* grpc_gethostname();
+absl::StatusOr<std::string> GetHostName();
+}  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_IOMGR_GETHOSTNAME_H */

--- a/src/core/lib/iomgr/gethostname_fallback.cc
+++ b/src/core/lib/iomgr/gethostname_fallback.cc
@@ -23,8 +23,9 @@
 
 #ifdef GRPC_GETHOSTNAME_FALLBACK
 
-#include <stddef.h>
-
-char* grpc_gethostname() { return NULL; }
+absl::StatusOr<std::string> grpc_core::GetHostName() {
+  return absl::UnimplementedError(
+      "Hostname resolution fallback not implemented");
+}
 
 #endif  // GRPC_GETHOSTNAME_FALLBACK

--- a/src/core/lib/iomgr/gethostname_host_name_max.cc
+++ b/src/core/lib/iomgr/gethostname_host_name_max.cc
@@ -26,13 +26,12 @@
 #include <limits.h>
 #include <unistd.h>
 
-#include <grpc/support/alloc.h>
-
-char* grpc_gethostname() {
-  char* hostname = static_cast<char*>(gpr_malloc(HOST_NAME_MAX));
+absl::StatusOr<std::string> grpc_core::GetHostName() {
+  char hostname[HOST_NAME_MAX];
   if (gethostname(hostname, HOST_NAME_MAX) != 0) {
-    gpr_free(hostname);
-    return nullptr;
+    // TODO: Supply more diagnostically valuable information, possibly using
+    // perror.
+    return absl::UnknownError("Cannot get hostname");
   }
   return hostname;
 }

--- a/src/core/lib/iomgr/gethostname_sysconf.cc
+++ b/src/core/lib/iomgr/gethostname_sysconf.cc
@@ -27,12 +27,12 @@
 
 #include <grpc/support/alloc.h>
 
-char* grpc_gethostname() {
+absl::StatusOr<std::string> grpc_core::GetHostName() {
   size_t host_name_max = (size_t)sysconf(_SC_HOST_NAME_MAX);
-  char* hostname = (char*)gpr_malloc(host_name_max);
-  if (gethostname(hostname, host_name_max) != 0) {
-    gpr_free(hostname);
-    return nullptr;
+  std::string hostname;
+  hostname.resize(host_name_max);
+  if (gethostname(hostname.data(), host_name_max) != 0) {
+    return absl::UnknownError("Cannot get host name");
   }
   return hostname;
 }

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -160,8 +160,8 @@ void RunServer(bool secure_mode, const int port, const int maintenance_port,
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc::testing::InitTest(&argc, &argv, true);
-  char* hostname = grpc_gethostname();
-  if (hostname == nullptr) {
+  absl::StatusOr<std::string> hostname = grpc_core::GetHostName();
+  if (!hostname.ok()) {
     std::cout << "Failed to get hostname, terminating" << std::endl;
     return 1;
   }
@@ -176,7 +176,8 @@ int main(int argc, char** argv) {
     return 1;
   }
   grpc::EnableDefaultHealthCheckService(false);
-  RunServer(absl::GetFlag(FLAGS_secure_mode), port, maintenance_port, hostname);
+  RunServer(absl::GetFlag(FLAGS_secure_mode), port, maintenance_port,
+            *hostname);
 
   return 0;
 }


### PR DESCRIPTION
### The issue

The function `grpc_gethostname` returns a `gpr_malloc`'d `char*` and transfers ownership to the caller. I picked up a case where the caller does not free the returned string, nor stores it - a memory leak, albeit minor.

### The remedy and motivation
There is a unique pointer class called `grpc_core::UniquePtr<T>` which uses the correct deallocator for `gpr_malloc`'d memory. This lets us transfer ownership and freeing (no pun intended :laughing: ) the caller from the responsibility of managing the memory. 

Looking forward to feedback!

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
