### PR TITLE
Add "sub" field to self-signed JWT token used to access google APIs

### DIFF
--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -182,7 +182,15 @@ static char* encoded_jwt_claim(const grpc_auth_json_key* json_key,
 
   if (scope != nullptr) {
     object["scope"] = scope;
-    if (!clear_audience) {
+    // This code path is for the self-signed jwt token used to access
+    // google API's, and it needs to satisfy the requirement specified
+    // in https://google.aip.dev/auth/4111. Specifically,
+    // 1) "scope" and "aud" fields can not coexist.
+    // 2) "sub" and "iss" fields should be set to the service account's email
+    //    address.
+    if (clear_audience) {
+      object["sub"] = json_key->client_email;
+    } else {
       object["aud"] = audience;
     }
   } else {

--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -176,26 +176,17 @@ static char* encoded_jwt_claim(const grpc_auth_json_key* json_key,
 
   Json::Object object = {
       {"iss", json_key->client_email},
+      {"sub", json_key->client_email},
       {"iat", now.tv_sec},
       {"exp", expiration.tv_sec},
   };
 
   if (scope != nullptr) {
     object["scope"] = scope;
-    // This code path is for the self-signed jwt token used to access
-    // google API's, and it needs to satisfy the requirement specified
-    // in https://google.aip.dev/auth/4111. Specifically,
-    // 1) "scope" and "aud" fields can not coexist.
-    // 2) "sub" and "iss" fields should be set to the service account's email
-    //    address.
-    if (clear_audience) {
-      object["sub"] = json_key->client_email;
-    } else {
+    if (!clear_audience) {
       object["aud"] = audience;
     }
   } else {
-    /* Unscoped JWTs need a sub field. */
-    object["sub"] = json_key->client_email;
     object["aud"] = audience;
   }
 

--- a/test/core/security/json_token_test.cc
+++ b/test/core/security/json_token_test.cc
@@ -79,9 +79,6 @@ static const char test_scope[] = "myperm1 myperm2";
 
 static const char test_service_url[] = "https://foo.com/foo.v1";
 
-static const char test_subject[] =
-    "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com";
-
 static char* test_json_key_str(const char* bad_part3) {
   const char* part3 =
       bad_part3 != nullptr ? bad_part3 : test_json_key_str_part3;

--- a/test/core/security/json_token_test.cc
+++ b/test/core/security/json_token_test.cc
@@ -245,14 +245,17 @@ static void check_jwt_header(const Json& header) {
 }
 
 static void check_jwt_claim(const Json& claim, const char* expected_audience,
-                            const char* expected_scope,
-                            const char* expected_subject) {
+                            const char* expected_scope) {
   Json::Object object = claim.object_value();
 
   Json value = object["iss"];
   GPR_ASSERT(value.type() == Json::Type::STRING);
   GPR_ASSERT(value.string_value() ==
              "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com");
+  value = object["sub"];
+  GPR_ASSERT(value.type() == Json::Type::STRING);
+  GPR_ASSERT(value.string_value() == object["iss"].string_value());
+
   if (expected_scope != nullptr) {
     value = object["scope"];
     GPR_ASSERT(value.type() == Json::Type::STRING);
@@ -267,14 +270,6 @@ static void check_jwt_claim(const Json& claim, const char* expected_audience,
     GPR_ASSERT(value.string_value() == expected_audience);
   } else {
     GPR_ASSERT(object.find("aud") == object.end());
-  }
-
-  if (expected_subject != nullptr) {
-    value = object["sub"];
-    GPR_ASSERT(value.type() == Json::Type::STRING);
-    GPR_ASSERT(value.string_value() == object["iss"].string_value());
-  } else {
-    GPR_ASSERT(object.find("sub") == object.end());
   }
 
   gpr_timespec expiration = gpr_time_0(GPR_CLOCK_REALTIME);
@@ -339,16 +334,16 @@ static char* jwt_creds_jwt_encode_and_sign(const grpc_auth_json_key* key) {
 }
 
 static void service_account_creds_check_jwt_claim(const Json& claim) {
-  check_jwt_claim(claim, GRPC_JWT_OAUTH2_AUDIENCE, test_scope, nullptr);
+  check_jwt_claim(claim, GRPC_JWT_OAUTH2_AUDIENCE, test_scope);
 }
 
 static void service_account_creds_no_audience_check_jwt_claim(
     const Json& claim) {
-  check_jwt_claim(claim, nullptr, test_scope, test_subject);
+  check_jwt_claim(claim, nullptr, test_scope);
 }
 
 static void jwt_creds_check_jwt_claim(const Json& claim) {
-  check_jwt_claim(claim, test_service_url, nullptr, test_subject);
+  check_jwt_claim(claim, test_service_url, nullptr);
 }
 
 static void test_jwt_encode_and_sign(

--- a/test/core/security/json_token_test.cc
+++ b/test/core/security/json_token_test.cc
@@ -79,6 +79,9 @@ static const char test_scope[] = "myperm1 myperm2";
 
 static const char test_service_url[] = "https://foo.com/foo.v1";
 
+static const char test_subject[] =
+    "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com";
+
 static char* test_json_key_str(const char* bad_part3) {
   const char* part3 =
       bad_part3 != nullptr ? bad_part3 : test_json_key_str_part3;
@@ -242,7 +245,8 @@ static void check_jwt_header(const Json& header) {
 }
 
 static void check_jwt_claim(const Json& claim, const char* expected_audience,
-                            const char* expected_scope) {
+                            const char* expected_scope,
+                            const char* expected_subject) {
   Json::Object object = claim.object_value();
 
   Json value = object["iss"];
@@ -250,16 +254,11 @@ static void check_jwt_claim(const Json& claim, const char* expected_audience,
   GPR_ASSERT(value.string_value() ==
              "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com");
   if (expected_scope != nullptr) {
-    GPR_ASSERT(object.find("sub") == object.end());
     value = object["scope"];
     GPR_ASSERT(value.type() == Json::Type::STRING);
     GPR_ASSERT(value.string_value() == expected_scope);
   } else {
-    /* Claims without scope must have a sub. */
     GPR_ASSERT(object.find("scope") == object.end());
-    value = object["sub"];
-    GPR_ASSERT(value.type() == Json::Type::STRING);
-    GPR_ASSERT(value.string_value() == object["iss"].string_value());
   }
 
   if (expected_audience != nullptr) {
@@ -268,6 +267,14 @@ static void check_jwt_claim(const Json& claim, const char* expected_audience,
     GPR_ASSERT(value.string_value() == expected_audience);
   } else {
     GPR_ASSERT(object.find("aud") == object.end());
+  }
+
+  if (expected_subject != nullptr) {
+    value = object["sub"];
+    GPR_ASSERT(value.type() == Json::Type::STRING);
+    GPR_ASSERT(value.string_value() == object["iss"].string_value());
+  } else {
+    GPR_ASSERT(object.find("sub") == object.end());
   }
 
   gpr_timespec expiration = gpr_time_0(GPR_CLOCK_REALTIME);
@@ -332,16 +339,16 @@ static char* jwt_creds_jwt_encode_and_sign(const grpc_auth_json_key* key) {
 }
 
 static void service_account_creds_check_jwt_claim(const Json& claim) {
-  check_jwt_claim(claim, GRPC_JWT_OAUTH2_AUDIENCE, test_scope);
+  check_jwt_claim(claim, GRPC_JWT_OAUTH2_AUDIENCE, test_scope, nullptr);
 }
 
 static void service_account_creds_no_audience_check_jwt_claim(
     const Json& claim) {
-  check_jwt_claim(claim, nullptr, test_scope);
+  check_jwt_claim(claim, nullptr, test_scope, test_subject);
 }
 
 static void jwt_creds_check_jwt_claim(const Json& claim) {
-  check_jwt_claim(claim, test_service_url, nullptr);
+  check_jwt_claim(claim, test_service_url, nullptr, test_subject);
 }
 
 static void test_jwt_encode_and_sign(


### PR DESCRIPTION
Per https://google.aip.dev/auth/4111, the self-signed JWT token used to access google API's should have "sub" field that is set to the service account's email address. The current implementation does not include the "sub" field, and this PR fixes it. 