### PR TITLE
[Aio] Add a correct graceful shutdown example

### DIFF
--- a/examples/python/helloworld/async_greeter_server_with_graceful_shutdown.py
+++ b/examples/python/helloworld/async_greeter_server_with_graceful_shutdown.py
@@ -1,4 +1,4 @@
-# Copyright 2020 gRPC authors.
+# Copyright 2021 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The Python AsyncIO implementation of the GRPC helloworld.Greeter server."""
+"""The graceful shutdown example for the asyncio Greeter server."""
 
 import logging
 import asyncio
@@ -20,12 +20,18 @@ import grpc
 import helloworld_pb2
 import helloworld_pb2_grpc
 
+# Coroutines to be invoked when the event loop is shutting down.
+_cleanup_coroutines = []
+
 
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
     async def SayHello(
             self, request: helloworld_pb2.HelloRequest,
             context: grpc.aio.ServicerContext) -> helloworld_pb2.HelloReply:
+        logging.info('Received request, sleeping for 4 seconds...')
+        await asyncio.sleep(4)
+        logging.info('Sleep completed, responding')
         return helloworld_pb2.HelloReply(message='Hello, %s!' % request.name)
 
 
@@ -36,9 +42,23 @@ async def serve() -> None:
     server.add_insecure_port(listen_addr)
     logging.info("Starting server on %s", listen_addr)
     await server.start()
+
+    async def server_graceful_shutdown():
+        logging.info("Starting graceful shutdown...")
+        # Shuts down the server with 0 seconds of grace period. During the
+        # grace period, the server won't accept new connections and allow
+        # existing RPCs to continue within the grace period.
+        await server.stop(5)
+
+    _cleanup_coroutines.append(server_graceful_shutdown())
     await server.wait_for_termination()
 
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    asyncio.run(serve())
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(serve())
+    finally:
+        loop.run_until_complete(*_cleanup_coroutines)
+        loop.close()


### PR DESCRIPTION
`KeyboardInterrupt` exception will not be propagated into individual coroutines, instead it will be raised in the `asyncio.run` or `loop.run_until_complete` lines. This means my previous graceful shutdown example won't work, as reported in https://github.com/grpc/grpc/issues/26123.

There are 2 ways to clear-up for `KeyboardInterrupt` in asyncio:

1. Signal handlers;
2. Try/catch the event loop executing lines.

I found signal handlers too invasive for applications, so this PR adds a graceful shutdown example with try/catch.

To run the example:

``` 
# Terminal 1
$ python3 async_greeter_server_with_graceful_shutdown.py
```

```
# Terminal 2
$ python3 async_greeter_client.py
```

```
# Terminal 1: CTRL+C
INFO:root:Starting server on [::]:50051
INFO:root:Received request, sleeping for 4 seconds...
^CINFO:root:Starting graceful shutdown...
INFO:root:Sleep completed, responding
Traceback (most recent call last):
  File "async_greeter_server_with_graceful_shutdown.py", line 61, in <module>
    loop.run_until_complete(serve())
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 574, in run_until_complete
    self.run_forever()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 541, in run_forever
    self._run_once()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 1750, in _run_once
    event_list = self._selector.select(timeout)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/selectors.py", line 558, in select
    kev_list = self._selector.control(None, max_ev, timeout)
KeyboardInterrupt
```

```
# Termnial 2
Greeter client received: Hello, you!
```

Fixes https://github.com/grpc/grpc/issues/26123