### PR TITLE
Fix pytype missing bz2 lib error

### DIFF
--- a/templates/tools/dockerfile/python_debian11.include
+++ b/templates/tools/dockerfile/python_debian11.include
@@ -1,5 +1,5 @@
 FROM debian:bullseye
-  
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y ${'\\'}
   autoconf ${'\\'}
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y time && apt-get clean
 # Install Python 3.7 from source (and installed as a default python3)
 # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
 RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev ${'\\'}
-                                 libnss3-dev libssl-dev libreadline-dev libffi-dev
+                                 libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev
 RUN curl -O https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz && ${'\\'}
     tar -xf Python-3.7.9.tar.xz && ${'\\'}
     cd Python-3.7.9 && ${'\\'}

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -13,7 +13,7 @@
   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   # See the License for the specific language governing permissions and
   # limitations under the License.
-  
+
   <%include file="../../python_debian11.include"/>
   <%include file="../../cxx_deps.include"/>
 

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM debian:bullseye
-  
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y time && apt-get clean
 # Install Python 3.7 from source (and installed as a default python3)
 # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
 RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
-                                 libnss3-dev libssl-dev libreadline-dev libffi-dev
+                                 libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev
 RUN curl -O https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz && \
     tar -xf Python-3.7.9.tar.xz && \
     cd Python-3.7.9 && \


### PR DESCRIPTION
Current Sanity Docker image doesn't contain the bz2 library in its Python3 interpretor. I thought this was a broken release from upstream, but actually we compiled Python 3.7.9 ourself. It's likely that one of the essential dependency (`libbz2-dev`) was installed implicitly before, and got removed in recent updates.

This PR explicitly installs the missing library before Python compilation, so the Python interpretor can use `bz2` library normally.

```
+ python3 -m pytype --keep-going -j 16 --strict-import --config setup.cfg
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/site-packages/pytype/__main__.py", line 6, in <module>
    from pytype.tools.analyze_project.main import main
  File "/usr/local/lib/python3.7/site-packages/pytype/tools/analyze_project/main.py", line 27, in <module>
    import importlab.graph
  File "/usr/local/lib/python3.7/site-packages/importlab/graph.py", line 4, in <module>
    import networkx as nx
  File "/usr/local/lib/python3.7/site-packages/networkx/__init__.py", line 57, in <module>
    from networkx import utils
  File "/usr/local/lib/python3.7/site-packages/networkx/utils/__init__.py", line 2, in <module>
    from networkx.utils.decorators import *
  File "/usr/local/lib/python3.7/site-packages/networkx/utils/decorators.py", line 12, in <module>
    import re, gzip, bz2
  File "/usr/local/lib/python3.7/bz2.py", line 19, in <module>
    from _bz2 import BZ2Compressor, BZ2Decompressor
ModuleNotFoundError: No module named '_bz2'
```

https://source.cloud.google.com/results/invocations/7a63c201-f098-433a-a4f3-44990dcab1c5/targets/github%2Fgrpc%2Frun_tests%2Fsanity_linux_dbg_native%2Ftools%2Fdistrib%2Fcheck_pytype.sh/tests