### PR TITLE
Prevent race causing early-destruction of grpc_winsocket object when creating a TCP connection

### DIFF
--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -206,8 +206,10 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   GRPC_CLOSURE_INIT(&ac->on_connect, on_connect, ac, grpc_schedule_on_exec_ctx);
 
   GRPC_CLOSURE_INIT(&ac->on_alarm, on_alarm, ac, grpc_schedule_on_exec_ctx);
+  gpr_mu_lock(&ac->mu);
   grpc_timer_init(&ac->alarm, deadline, &ac->on_alarm);
   grpc_socket_notify_on_write(socket, &ac->on_connect);
+  gpr_mu_unlock(&ac->mu);
   return;
 
 failure:


### PR DESCRIPTION
As noted in internal issue b/182296465, the test in `//test/cpp/client:destroy_grpclb_channel_with_active_connect_stress_test` has been flakey on Windows for some time.

We can see both of the following assertion aborts in failures:

`assertion failed: !info->has_pending_iocp`

`assertion failed: info->closure == NULL`

We can also see a fair number of "socket is null" connect failure error messages.

It looks like this can happen by the following:

1) We begin an attempt to connect, and [initialize the connection timeout alarm](https://github.com/grpc/grpc/blob/dc6f6e36fc6af0344c1525d489da41c2fd66106e/src/core/lib/iomgr/tcp_client_windows.cc#L209)

2) Connection timeout alarm runs and then destroys the grpc_winsocket object [because no readable/writable callbacks are registered on it yet](https://github.com/grpc/grpc/blob/dc6f6e36fc6af0344c1525d489da41c2fd66106e/src/core/lib/iomgr/socket_windows.cc#L101)

3) The same thread from 1) continues on and calls grpc_socket_notify_on_write on the same socket that was just destroyed on 2) - committing a use-after-free. The assertion failure triggers because the memory has been over-written.

I ran windows kokoro tests with the following patch to confirm this:

```
diff --git a/src/core/lib/iomgr/tcp_client_windows.cc b/src/core/lib/iomgr/tcp_client_windows.cc
index ef260cad75..fd708fc45c 100644
--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -70,6 +70,7 @@ static void on_alarm(void* acp, grpc_error_handle error) {
   async_connect* ac = (async_connect*)acp;
   gpr_mu_lock(&ac->mu);
   grpc_winsocket* socket = ac->socket;
+  gpr_log(GPR_INFO, "apolcyn on_alarm ac=%p socket=%p error=%s", ac, socket, grpc_error_string(error));
   ac->socket = NULL;
   if (socket != NULL) {
     grpc_winsocket_shutdown(socket);
@@ -87,6 +88,7 @@ static void on_connect(void* acp, grpc_error_handle error) {
 
   gpr_mu_lock(&ac->mu);
   grpc_winsocket* socket = ac->socket;
+  gpr_log(GPR_INFO, "apolcyn on_connect ac=%p socket=%p error=%s", ac, socket, grpc_error_string(error));
   ac->socket = NULL;
   gpr_mu_unlock(&ac->mu);
 
@@ -206,7 +208,10 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   GRPC_CLOSURE_INIT(&ac->on_connect, on_connect, ac, grpc_schedule_on_exec_ctx);
 
   GRPC_CLOSURE_INIT(&ac->on_alarm, on_alarm, ac, grpc_schedule_on_exec_ctx);
+  gpr_log(GPR_INFO, "apolcyn connecting now run grpc_timer_init ac=%p socket=%p", ac, socket);
   grpc_timer_init(&ac->alarm, deadline, &ac->on_alarm);
+  gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC), gpr_time_from_millis(100, GPR_TIMESPAN)));
+  gpr_log(GPR_INFO, "apolcyn connecting now run grpc_socket_notify_on_write ac=%p socket=%p", ac, socket);
   grpc_socket_notify_on_write(socket, &ac->on_connect);
   return;
```

^ note the 100ms sleep to exaggerate the failure

This repro'd the assertion failures and caused the following logs, confirming this sequence of events can happen:

```
I0709 03:16:14.862000000  3748 src/core/lib/iomgr/tcp_client_windows.cc:211] apolcyn connecting now run grpc_timer_init ac=0000029EB3D86BC0 socket=0000029EB38B3D30
...
I0709 03:16:14.958000000  4164 src/core/lib/iomgr/tcp_client_windows.cc:73] apolcyn on_alarm ac=0000029EB3D86BC0 socket=0000029EB38B3D30 error="No Error"
...
I0709 03:16:14.963000000  3748 src/core/lib/iomgr/tcp_client_windows.cc:214] apolcyn connecting now run grpc_socket_notify_on_write ac=0000029EB3D86BC0 socket=0000029EB38B3D30
...
E0709 03:16:14.963000000  3748 src/core/lib/iomgr/socket_windows.cc:122] assertion failed: info->closure == NULL

*** SIGABRT received at time=1625800574 ***
```


