### PR TITLE
Use constexpr to simplify HPACK parser

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -626,9 +626,13 @@ static const int16_t emit_sub_tbl[249 * 16] = {
 };
 
 namespace {
+// The alphabet used for base64 encoding binary metadata.
 static const char kBase64Alphabet[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
+// An inverted table: for each value in kBase64Alphabet, table contains the
+// index with which it's stored, so we can quickly invert the encoding without
+// any complicated runtime logic.
 struct Base64InverseTable {
   uint8_t table[256]{};
   GRPC_HPACK_CONSTEXPR_FN Base64InverseTable() {

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -627,7 +627,7 @@ static const int16_t emit_sub_tbl[249 * 16] = {
 
 namespace {
 // The alphabet used for base64 encoding binary metadata.
-static const char kBase64Alphabet[] =
+static constexpr char kBase64Alphabet[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
 // An inverted table: for each value in kBase64Alphabet, table contains the
@@ -639,8 +639,10 @@ struct Base64InverseTable {
     for (int i = 0; i < 256; i++) {
       table[i] = 255;
     }
-    for (uint8_t i = 0; i < sizeof(Base64InverseTable) - 1; i++) {
-      table[(uint8_t)kBase64Alphabet[i]] = i;
+    for (const char* p = kBase64Alphabet; *p; p++) {
+      uint8_t idx = *p;
+      uint8_t ofs = p - kBase64Alphabet;
+      table[idx] = ofs;
     }
   }
 };

--- a/tools/codegen/core/gen_hpack_tables.cc
+++ b/tools/codegen/core/gen_hpack_tables.cc
@@ -325,29 +325,10 @@ static void generate_base64_huff_encoder_table(void) {
   printf("};\n");
 }
 
-static void generate_base64_inverse_table(void) {
-  static const char alphabet[] =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-  unsigned char inverse[256];
-  unsigned i;
-
-  memset(inverse, 255, sizeof(inverse));
-  for (i = 0; i < strlen(alphabet); i++) {
-    inverse[(unsigned char)alphabet[i]] = (unsigned char)i;
-  }
-
-  printf("static const gpr_uint8 inverse_base64[256] = {");
-  for (i = 0; i < 256; i++) {
-    printf("%d,", inverse[i]);
-  }
-  printf("};\n");
-}
-
 int main(void) {
   generate_huff_tables();
   generate_first_byte_lut();
   generate_base64_huff_encoder_table();
-  generate_base64_inverse_table();
 
   return 0;
 }


### PR DESCRIPTION
This is a bit of a trial balloon: in C++11, generate at load time a
table that used to be hard coded. In C++14, generate that same table at
compile time, but eliminate the code generator.

Should this work out, I'd like to expand the technique so that we can
eliminate some of the confusing tables in this file by keeping the code
that generates them *in the same place* as the code that consumes them.
