### PR TITLE
Make brew update

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -135,12 +135,18 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PHP}" == "true" ]
 then
-  # Install PHP 7.2 explictly to address missing php header files and
+  # It's required to update the brew because it won't work with the default version Kokoro has.
+  # This can be fragile, though because the future version of brew can break. In that case,
+  # please consider to fix the certain version like https://github.com/grpc/grpc/pull/24837.
+  brew update || true
+  brew config
+
+  # Install PHP 7.3 explictly to address missing php header files and
   # to work well with the pre-installed phpunit 8.4
-  brew install php@7.2
-  export LDFLAGS="-L/usr/local/opt/php@7.2/lib $(LDFLAGS)"
-  export CPPFLAGS="-I/usr/local/opt/php@7.2/include $(CPPFLAGS)"
-  export PATH="/usr/local/opt/php@7.2/bin:/usr/local/opt/php@7.2/sbin:$PATH"
+  brew install php@7.3 || true
+  export LDFLAGS="-L/usr/local/opt/php@7.3/lib $(LDFLAGS)"
+  export CPPFLAGS="-I/usr/local/opt/php@7.3/include $(CPPFLAGS)"
+  export PATH="/usr/local/opt/php@7.3/bin:/usr/local/opt/php@7.3/sbin:$PATH"
 
   # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081
   mkdir -p /usr/local/lib/php/pecl


### PR DESCRIPTION
Currently mac builds with php installation are failing with the [log](https://source.cloud.google.com/results/invocations/f77d540f-cd0f-4377-9179-0933deb3c4f4/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_build_artifacts/log)

```
==> Installing php@7.2 dependency: apr
==> Downloading https://homebrew.bintray.com/bottles/apr-1.7.0.mojave.bottle.tar.gz
curl: (22) The requested URL returned error: 403 Forbidden
Error: Failed to download resource "apr"
```

as a reference, the output is `brea config` is

```
++ brew config
HOMEBREW_VERSION: 2.2.6
ORIGIN: https://github.com/Homebrew/brew
HEAD: 27fa87c94a6cf7be40fc8f8fc96bc7c387b7781e
Last commit: 1 year, 5 months ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 2517c6edb81b18a3768a640ab60c101ef60fbaa8
Core tap last commit: 1 year, 4 months ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_NO_AUTO_UPDATE: 1
CPU: quad-core 64-bit haswell
Homebrew Ruby: 2.6.3 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/bin/ruby
Clang: 11.0 build 1100
Git: 2.25.0 => /usr/local/bin/git
Curl: 7.54.0 => /usr/bin/curl
Java: 11.0.3, 10.0.2, 9.0.4, 1.8.0_212
macOS: 10.14.6-x86_64
CLT: 11.3.0.0.1.1574140115
Xcode: 11.3 => /Applications/Xcode_11.3.app/Contents/Developer
```

This is because bintray no longer provides the storage for homebrew. ([link](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)) To work around this issue, `brew update` will be done only for PHP build because it will interfere with ruby. Also brew update and install are forcefully done by ignoring errors.