### PR TITLE
xds-k8s: Adapt URL Map tests to use resource prefix/suffix

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_url_map.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map.sh
@@ -87,18 +87,12 @@ run_test() {
   # https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver#basic-usage
   local test_name="${1:?Usage: run_test test_name}"
   set -x
-  # NOTE(lidiz) we pin the server image to java-server because: 1. only Java
-  # server understands the rpc-behavior metadata; 2. all UrlMap tests today are
-  # testing client-side logic.
   python -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --kube_context="${KUBE_CONTEXT}" \
-    --namespace="interop-psm-url-map" \
-    --server_xds_port=8848 \
-    --server_image="gcr.io/grpc-testing/xds-interop/java-server:d22f93e1ade22a1e026b57210f6fc21f7a3ca0cf" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
     --xml_output_file="${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml" \
-    --strategy="reuse"
+    --flagfile="config/url-map.cfg"
   set +x
 }
 

--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -1,0 +1,9 @@
+--resource_suffix=interop-psm-url-map
+--strategy=reuse
+# TODO(lidiz): Remove the next line when xds port randomization supported.
+--server_xds_port=8848
+# NOTE(lidiz) we pin the server image to java-server because:
+# 1. Only Java server understands the rpc-behavior metadata.
+# 2. All UrlMap tests today are testing client-side logic.
+# grpc-java v1.38.1: 389076d3733ed1d8e70234fe772307fa4809f610
+--server_image=gcr.io/grpc-testing/xds-interop/java-server:389076d3733ed1d8e70234fe772307fa4809f610

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -132,7 +132,7 @@ class TrafficDirectorManager:
         self.delete_health_check(force=force)
 
     @functools.lru_cache(None)
-    def _make_resource_name(self, name: str) -> str:
+    def make_resource_name(self, name: str) -> str:
         """Make dash-separated resource name with resource prefix and suffix."""
         parts = [self.resource_prefix, name]
         # Avoid trailing dash when the suffix is empty.
@@ -151,14 +151,14 @@ class TrafficDirectorManager:
         if protocol is None:
             protocol = _HealthCheckGRPC
 
-        name = self._make_resource_name(self.HEALTH_CHECK_NAME)
+        name = self.make_resource_name(self.HEALTH_CHECK_NAME)
         logger.info('Creating %s Health Check "%s"', protocol.name, name)
         resource = self.compute.create_health_check(name, protocol, port=port)
         self.health_check = resource
 
     def delete_health_check(self, force=False):
         if force:
-            name = self._make_resource_name(self.HEALTH_CHECK_NAME)
+            name = self.make_resource_name(self.HEALTH_CHECK_NAME)
         elif self.health_check:
             name = self.health_check.name
         else:
@@ -172,7 +172,7 @@ class TrafficDirectorManager:
         if protocol is None:
             protocol = _BackendGRPC
 
-        name = self._make_resource_name(self.BACKEND_SERVICE_NAME)
+        name = self.make_resource_name(self.BACKEND_SERVICE_NAME)
         logger.info('Creating %s Backend Service "%s"', protocol.name, name)
         resource = self.compute.create_backend_service_traffic_director(
             name, health_check=self.health_check, protocol=protocol)
@@ -180,13 +180,13 @@ class TrafficDirectorManager:
         self.backend_service_protocol = protocol
 
     def load_backend_service(self):
-        name = self._make_resource_name(self.BACKEND_SERVICE_NAME)
+        name = self.make_resource_name(self.BACKEND_SERVICE_NAME)
         resource = self.compute.get_backend_service_traffic_director(name)
         self.backend_service = resource
 
     def delete_backend_service(self, force=False):
         if force:
-            name = self._make_resource_name(self.BACKEND_SERVICE_NAME)
+            name = self.make_resource_name(self.BACKEND_SERVICE_NAME)
         elif self.backend_service:
             name = self.backend_service.name
         else:
@@ -226,7 +226,7 @@ class TrafficDirectorManager:
             self, protocol: Optional[BackendServiceProtocol] = _BackendGRPC):
         if protocol is None:
             protocol = _BackendGRPC
-        name = self._make_resource_name(self.ALTERNATIVE_BACKEND_SERVICE_NAME)
+        name = self.make_resource_name(self.ALTERNATIVE_BACKEND_SERVICE_NAME)
         logger.info('Creating %s Alternative Backend Service "%s"',
                     protocol.name, name)
         resource = self.compute.create_backend_service_traffic_director(
@@ -235,13 +235,13 @@ class TrafficDirectorManager:
         self.alternative_backend_service_protocol = protocol
 
     def load_alternative_backend_service(self):
-        name = self._make_resource_name(self.ALTERNATIVE_BACKEND_SERVICE_NAME)
+        name = self.make_resource_name(self.ALTERNATIVE_BACKEND_SERVICE_NAME)
         resource = self.compute.get_backend_service_traffic_director(name)
         self.alternative_backend_service = resource
 
     def delete_alternative_backend_service(self, force=False):
         if force:
-            name = self._make_resource_name(
+            name = self.make_resource_name(
                 self.ALTERNATIVE_BACKEND_SERVICE_NAME)
         elif self.alternative_backend_service:
             name = self.alternative_backend_service.name
@@ -286,8 +286,8 @@ class TrafficDirectorManager:
         src_port: int,
     ) -> GcpResource:
         src_address = f'{src_host}:{src_port}'
-        name = self._make_resource_name(self.URL_MAP_NAME)
-        matcher_name = self._make_resource_name(self.URL_MAP_PATH_MATCHER_NAME)
+        name = self.make_resource_name(self.URL_MAP_NAME)
+        matcher_name = self.make_resource_name(self.URL_MAP_PATH_MATCHER_NAME)
         logger.info('Creating URL map "%s": %s -> %s', name, src_address,
                     self.backend_service.name)
         resource = self.compute.create_url_map(name, matcher_name,
@@ -304,7 +304,7 @@ class TrafficDirectorManager:
 
     def delete_url_map(self, force=False):
         if force:
-            name = self._make_resource_name(self.URL_MAP_NAME)
+            name = self.make_resource_name(self.URL_MAP_NAME)
         elif self.url_map:
             name = self.url_map.name
         else:
@@ -314,7 +314,7 @@ class TrafficDirectorManager:
         self.url_map = None
 
     def create_target_proxy(self):
-        name = self._make_resource_name(self.TARGET_PROXY_NAME)
+        name = self.make_resource_name(self.TARGET_PROXY_NAME)
         if self.backend_service_protocol is BackendServiceProtocol.GRPC:
             target_proxy_type = 'GRPC'
             create_proxy_fn = self.compute.create_target_grpc_proxy
@@ -332,7 +332,7 @@ class TrafficDirectorManager:
 
     def delete_target_grpc_proxy(self, force=False):
         if force:
-            name = self._make_resource_name(self.TARGET_PROXY_NAME)
+            name = self.make_resource_name(self.TARGET_PROXY_NAME)
         elif self.target_proxy:
             name = self.target_proxy.name
         else:
@@ -344,7 +344,7 @@ class TrafficDirectorManager:
 
     def delete_target_http_proxy(self, force=False):
         if force:
-            name = self._make_resource_name(self.TARGET_PROXY_NAME)
+            name = self.make_resource_name(self.TARGET_PROXY_NAME)
         elif self.target_proxy:
             name = self.target_proxy.name
         else:
@@ -368,7 +368,7 @@ class TrafficDirectorManager:
         raise RuntimeError("Couldn't find unused forwarding rule port")
 
     def create_forwarding_rule(self, src_port: int):
-        name = self._make_resource_name(self.FORWARDING_RULE_NAME)
+        name = self.make_resource_name(self.FORWARDING_RULE_NAME)
         src_port = int(src_port)
         logging.info(
             'Creating forwarding rule "%s" in network "%s": 0.0.0.0:%s -> %s',
@@ -381,7 +381,7 @@ class TrafficDirectorManager:
 
     def delete_forwarding_rule(self, force=False):
         if force:
-            name = self._make_resource_name(self.FORWARDING_RULE_NAME)
+            name = self.make_resource_name(self.FORWARDING_RULE_NAME)
         elif self.forwarding_rule:
             name = self.forwarding_rule.name
         else:
@@ -391,7 +391,7 @@ class TrafficDirectorManager:
         self.forwarding_rule = None
 
     def create_firewall_rule(self, allowed_ports: List[str]):
-        name = self._make_resource_name(self.FIREWALL_RULE_NAME)
+        name = self.make_resource_name(self.FIREWALL_RULE_NAME)
         logging.info(
             'Creating firewall rule "%s" in network "%s" with allowed ports %s',
             name, self.network, allowed_ports)
@@ -403,7 +403,7 @@ class TrafficDirectorManager:
     def delete_firewall_rule(self, force=False):
         """The firewall rule won't be automatically removed."""
         if force:
-            name = self._make_resource_name(self.FIREWALL_RULE_NAME)
+            name = self.make_resource_name(self.FIREWALL_RULE_NAME)
         elif self.firewall_rule:
             name = self.firewall_rule.name
         else:
@@ -475,7 +475,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
         self.delete_client_tls_policy(force=force)
 
     def create_server_tls_policy(self, *, tls, mtls):
-        name = self._make_resource_name(self.SERVER_TLS_POLICY_NAME)
+        name = self.make_resource_name(self.SERVER_TLS_POLICY_NAME)
         logger.info('Creating Server TLS Policy %s', name)
         if not tls and not mtls:
             logger.warning(
@@ -498,7 +498,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
 
     def delete_server_tls_policy(self, force=False):
         if force:
-            name = self._make_resource_name(self.SERVER_TLS_POLICY_NAME)
+            name = self.make_resource_name(self.SERVER_TLS_POLICY_NAME)
         elif self.server_tls_policy:
             name = self.server_tls_policy.name
         else:
@@ -509,7 +509,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
 
     def create_endpoint_config_selector(self, server_namespace, server_name,
                                         server_port):
-        name = self._make_resource_name(self.ENDPOINT_CONFIG_SELECTOR_NAME)
+        name = self.make_resource_name(self.ENDPOINT_CONFIG_SELECTOR_NAME)
         logger.info('Creating Endpoint Config Selector %s', name)
         endpoint_matcher_labels = [{
             "labelName": "app",
@@ -541,7 +541,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
 
     def delete_endpoint_config_selector(self, force=False):
         if force:
-            name = self._make_resource_name(self.ENDPOINT_CONFIG_SELECTOR_NAME)
+            name = self.make_resource_name(self.ENDPOINT_CONFIG_SELECTOR_NAME)
         elif self.ecs:
             name = self.ecs.name
         else:
@@ -551,7 +551,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
         self.ecs = None
 
     def create_client_tls_policy(self, *, tls, mtls):
-        name = self._make_resource_name(self.CLIENT_TLS_POLICY_NAME)
+        name = self.make_resource_name(self.CLIENT_TLS_POLICY_NAME)
         logger.info('Creating Client TLS Policy %s', name)
         if not tls and not mtls:
             logger.warning(
@@ -572,7 +572,7 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
 
     def delete_client_tls_policy(self, force=False):
         if force:
-            name = self._make_resource_name(self.CLIENT_TLS_POLICY_NAME)
+            name = self.make_resource_name(self.CLIENT_TLS_POLICY_NAME)
         elif self.client_tls_policy:
             name = self.client_tls_policy.name
         else:

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """A test framework built for urlMap related xDS test cases."""
 
-import inspect
 import functools
+import inspect
 from typing import Any, Iterable, List, Mapping, Tuple
 
 from absl import flags
@@ -132,16 +132,22 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
     (except the client K8s deployment).
     """
 
-    def __init__(self, absl_flags: Mapping[str, Any]):
-        for key in absl_flags:
-            setattr(self, key, absl_flags[key])
+    # This class dynamically set, so disable "no-member" check.
+    # pylint: disable=no-member
+
+    def __init__(self, absl_flags: Mapping[str, Any] = None):
+        if absl_flags is not None:
+            for key in absl_flags:
+                setattr(self, key, absl_flags[key])
         # API managers
         self.k8s_api_manager = k8s.KubernetesApiManager(self.kube_context)
         self.gcp_api_manager = gcp.api.GcpApiManager()
         self.td = traffic_director.TrafficDirectorManager(
             self.gcp_api_manager,
             self.project,
+            # TODO(lidiz): replace namespace with resource prefix/suffix.
             resource_prefix=self.namespace,
+            resource_suffix="",
             network=self.network,
         )
         # Kubernetes namespace

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -145,14 +145,13 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         self.td = traffic_director.TrafficDirectorManager(
             self.gcp_api_manager,
             self.project,
-            # TODO(lidiz): replace namespace with resource prefix/suffix.
-            resource_prefix=self.namespace,
-            resource_suffix="",
+            resource_prefix=self.resource_prefix,
+            resource_suffix=(self.resource_suffix or ""),
             network=self.network,
         )
         # Kubernetes namespace
         self.k8s_namespace = k8s.KubernetesNamespace(self.k8s_api_manager,
-                                                     self.namespace)
+                                                     self.resource_prefix)
         # Kubernetes Test Client
         self.test_client_runner = client_app.KubernetesClientRunner(
             self.k8s_namespace,
@@ -203,7 +202,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         # This is the step that mostly likely to go wrong. Lifting it to be the
         # first task ensures fail fast.
         aggregator = _UrlMapChangeAggregator(
-            url_map_name="%s-%s" % (self.namespace, self.td.URL_MAP_NAME))
+            url_map_name=self.td.make_resource_name(self.td.URL_MAP_NAME))
         for test_case_class in test_case_classes:
             aggregator.apply_change(test_case_class)
         final_url_map = aggregator.get_map()

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -18,10 +18,10 @@ from dataclasses import dataclass
 import datetime
 import json
 import os
-import unittest
 import sys
 import time
 from typing import Any, Iterable, Mapping, Optional, Tuple, Union
+import unittest
 
 from absl import flags
 from absl import logging


### PR DESCRIPTION
1. fixes `TypeError: __init__() missing 1 required keyword-only argument: 'resource_suffix'` caused by https://github.com/grpc/grpc/pull/26542
2. isort
3. minor pylint fixes/suggestions


Test run: https://source.cloud.google.com/results/invocations/dd413577-cc68-4e6e-843b-27e1eb598ffe