### PR TITLE
Fix python header resolution on Windows

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -256,7 +256,7 @@ def _get_python_include(repository_ctx, python_bin):
             python_bin,
             "-c",
             "import os;" +
-            "main_header = os.path.join('{}', 'Python.h');".format(include_path) +
+            "main_header = os.path.join(r'{}', 'Python.h');".format(include_path) +
             "assert os.path.exists(main_header), main_header + ' does not exist.'",
         ],
         error_msg = "Unable to find Python headers for {}".format(python_bin),


### PR DESCRIPTION
The substring "\U" in the path to the Python binary was confused for a unicode escape sequence. This should be a raw string.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
