### PR TITLE
Use plane clang instead of clang-5.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ If you plan to build using CMake
 If you are a contributor and plan to build and run tests, install the following as well:
 ```sh
  $ # clang and LLVM C++ lib is only required for sanitizer builds
- $ [sudo] apt-get install clang-5.0 libc++-dev
+ $ [sudo] apt-get install clang libc++-dev
 ```
 
 ## MacOS


### PR DESCRIPTION
From https://github.com/grpc/grpc/pull/25620, installing clang 5 in the building doc is now outdated. Rather, installing clang which is expected to be higher than 5 these days would be more correct.