### PR TITLE
Fix exception in setup phase handling

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3102,6 +3102,8 @@ else:
     if not args.only_stable_gcp_apis:
         alpha_compute = googleapiclient.discovery.build('compute', 'alpha')
 
+test_results = {}
+failed_tests = []
 try:
     gcp = GcpState(compute, alpha_compute, args.project_id, args.project_num)
     gcp_suffix = args.gcp_suffix
@@ -3220,8 +3222,6 @@ try:
         client_env['GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING'] = 'true'
         client_env['GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT'] = 'true'
         client_env['GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION'] = 'true'
-        test_results = {}
-        failed_tests = []
         for test_case in args.test_case:
             if test_case in _V3_TEST_CASES and not args.xds_v3_support:
                 logger.info('skipping test %s due to missing v3 support',
@@ -3412,7 +3412,7 @@ try:
             sys.exit(1)
 finally:
     keep_resources = args.keep_gcp_resources
-    if args.halt_after_fail and args.test_case and failed_tests:
+    if args.halt_after_fail and failed_tests:
         logger.info(
             'Halt after fail triggered, exiting without cleaning up resources')
         keep_resources = True

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3412,7 +3412,7 @@ try:
             sys.exit(1)
 finally:
     keep_resources = args.keep_gcp_resources
-    if args.halt_after_fail and failed_tests:
+    if args.halt_after_fail and args.test_case and failed_tests:
         logger.info(
             'Halt after fail triggered, exiting without cleaning up resources')
         keep_resources = True


### PR DESCRIPTION
b/193902025

The new HaltAndSave mode has a bug that if the resource setup failed, it will try to access a variable `failed_tests` which is not initialized yet. The downside of this is the bug report unable to find the correct root cause.