### PR TITLE
Fix an instance of -Wunreachable-code-aggressive.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1286,7 +1286,6 @@ static void continue_fetching_send_locked(grpc_chttp2_transport* t,
     if (s->fetching_send_message == nullptr) {
       // Stream was cancelled before message fetch completed
       abort(); /* TODO(ctiller): what cleanup here? */
-      return;  /* early out */
     }
     if (s->fetched_send_message_length == s->fetching_send_message->length()) {
       int64_t notify_offset = s->next_message_end_offset;


### PR DESCRIPTION
abort() never returns, so any code after it is unreachable.  This
triggers a warning.

Bug: chromium:1066980




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
