### PR TITLE
Annotate copied Content native lib items with package id to enable customization

### DIFF
--- a/src/csharp/Grpc.Core/build/net45/Grpc.Core.targets
+++ b/src/csharp/Grpc.Core/build/net45/Grpc.Core.targets
@@ -14,21 +14,25 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>grpc_csharp_ext.x86.dll</Link>
       <Visible>false</Visible>
+      <NuGetPackageId>Grpc.Core</NuGetPackageId>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\grpc_csharp_ext.x64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>grpc_csharp_ext.x64.dll</Link>
       <Visible>false</Visible>
+      <NuGetPackageId>Grpc.Core</NuGetPackageId>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libgrpc_csharp_ext.x64.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libgrpc_csharp_ext.x64.so</Link>
       <Visible>false</Visible>
+      <NuGetPackageId>Grpc.Core</NuGetPackageId>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libgrpc_csharp_ext.x64.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libgrpc_csharp_ext.x64.dylib</Link>
       <Visible>false</Visible>
+      <NuGetPackageId>Grpc.Core</NuGetPackageId>
     </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add `%(NuGetPackageId)` as is standard procedure for nuget package-provided assets, 
so that other MSBuild targets can act on items contributed by Grpc.Core as needed, for 
example, in Pack scenarios.

Fixes #26724


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
