### PR TITLE
Backport "Increase timeout of macos artifact build to 4 hours (#26732) to 1.39.x"

### DIFF
--- a/tools/internal_ci/macos/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/macos/grpc_build_artifacts.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_build_artifacts.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 150
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Backports #26732 to unblock the release
