### PR TITLE
Add xds retry interop test case

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -99,6 +99,7 @@ _ADDITIONAL_TEST_CASES = [
     'timeout',
     'fault_injection',
     'csds',
+    'retry',
 ]
 
 # Test cases that require the V3 API.  Skipped in older runs.
@@ -2238,6 +2239,198 @@ def test_fault_injection(gcp, original_backend_service, instance_group):
             set_validate_for_proxyless(gcp, True)
 
 
+def test_retry(gcp, original_backend_service, instance_group):
+    '''
+    Since backend service circuit_breakers configuration cannot be unset,
+    which causes trouble for restoring validate_for_proxy flag in target
+    proxy/global forwarding rule. This test uses dedicated backend sevices.
+    The url_map and backend services undergoes the following state changes:
+
+    Before test:
+       original_backend_service -> [instance_group]
+       extra_backend_service -> []
+       more_extra_backend_service -> []
+
+       url_map -> [original_backend_service]
+
+    In test:
+       extra_backend_service (with circuit_breakers) -> [instance_group]
+       more_extra_backend_service (with circuit_breakers) -> [same_zone_instance_group]
+
+       url_map -> [extra_backend_service, more_extra_backend_service]
+
+    After test:
+       original_backend_service -> [instance_group]
+       extra_backend_service (with circuit_breakers) -> []
+       more_extra_backend_service (with circuit_breakers) -> []
+
+       url_map -> [original_backend_service]
+    '''
+    logger.info('Running test_retry')
+    passed = True
+    try:
+        # TODO(chengyuanzhang): Dedicated backend services created for circuit
+        # breaking test. Once the issue for unsetting backend service circuit
+        # breakers is resolved or configuring backend service circuit breakers is
+        # enabled for config validation, these dedicated backend services can be
+        # eliminated.
+        additional_backend_services = []
+        extra_backend_service_name = _BASE_BACKEND_SERVICE_NAME + '-extra-for-retry' + gcp_suffix
+        more_extra_backend_service_name = _BASE_BACKEND_SERVICE_NAME + '-more-extra-for-retry' + gcp_suffix
+        extra_backend_service = add_backend_service(gcp,
+                                                    extra_backend_service_name)
+        additional_backend_services.append(extra_backend_service)
+        more_extra_backend_service = add_backend_service(
+            gcp, more_extra_backend_service_name)
+        additional_backend_services.append(more_extra_backend_service)
+        # The config validation for proxyless doesn't allow setting
+        # circuit_breakers. Disable validate validate_for_proxyless
+        # for this test. This can be removed when validation
+        # accepts circuit_breakers.
+        logger.info('disabling validate_for_proxyless in target proxy')
+        set_validate_for_proxyless(gcp, False)
+        extra_backend_service_max_retries = 1000
+        more_extra_backend_service_max_retries = 1
+        patch_backend_service(
+            gcp,
+            extra_backend_service, [instance_group],
+            circuit_breakers={'maxRetries': extra_backend_service_max_retries})
+        logger.info('Waiting for extra backends to become healthy')
+        wait_for_healthy_backends(gcp, extra_backend_service, instance_group)
+        patch_backend_service(gcp,
+                              more_extra_backend_service,
+                              [same_zone_instance_group],
+                              circuit_breakers={
+                                  'maxRetries':
+                                      more_extra_backend_service_max_retries
+                              })
+        logger.info('Waiting for more extra backend to become healthy')
+        wait_for_healthy_backends(gcp, more_extra_backend_service,
+                                  same_zone_instance_group)
+        extra_backend_instances = get_instance_names(gcp, instance_group)
+        more_extra_backend_instances = get_instance_names(
+            gcp, same_zone_instance_group)
+
+        testcase_header = 'retry_testcase'
+
+        # A list of tuples (testcase_name, retry_policy, backend_service, rpc_behavior, num_rpcs, expected_succeeded_rpcs).
+        # Each test case will set the testcase_header with the testcase_name for routing
+        # to the appropriate config for the case, defined above.
+        test_cases = [
+            (
+                'retry-up-to-3-attempts',
+                (3, "unavailable"),
+                extra_backend_service,
+                'error-code-14,succeed-on-retry-attempt-4',
+                1000,
+                (0, 0),  # all fail
+            ),
+            (
+                'retry-up-to-4-attempts',
+                (4, "unavailable"),
+                extra_backend_service,
+                'error-code-14,succeed-on-retry-attempt-4',
+                1000,
+                (1000, 1000),  # all succeed
+            ),
+            ('retry-circuit-breaker', (1, "unavailable"),
+             more_extra_backend_service, 'error-code-14', 10000, (1000, 7000)),
+        ]
+
+        def _route(name, retry_policy, backend_service):
+            (num_retries, retry_on) = retry_policy
+            return {
+                'priority': 0,
+                'matchRules': [{
+                    'prefixMatch':
+                        '/',
+                    'headerMatches': [{
+                        'headerName': testcase_header,
+                        'exactMatch': name,
+                    }],
+                }],
+                'service': backend_service.url,
+                'routeAction': {
+                    'retryPolicy': {
+                        'retryConditions': [retry_on],
+                        'numRetries': num_retries,
+                    },
+                },
+            }
+
+        route_rules = []
+        for (testcase_name, retry_policy, backend_service, rpc_behavior,
+             num_rpcs, expected_succeeded_rpcs) in test_cases:
+            route_rules.append(_route(testcase_name, retry_policy))
+
+        logger.info('Patching url map with %s', route_rules)
+        patch_url_map_backend_service(gcp,
+                                      extra_backend_service,
+                                      route_rules=route_rules)
+
+        first_case = True
+        for (testcase_name, retry_policy, backend_service, rpc_behavior,
+             num_rpcs, expected_succeeded_rpcs) in test_cases:
+            logger.info('starting case %s', testcase_name)
+
+            client_config['metadata'] = [
+                (messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL,
+                 testcase_header, testcase_name, 'rpc-behavior', rpc_behavior)
+            ]
+            client_config['rpc_types'] = [
+                messages_pb2.ClientConfigureRequest.RpcType.UNARY_CALL,
+            ]
+            configure_client(**client_config)
+            # wait a second to help ensure the client stops sending RPCs with
+            # the old config.  We will make multiple attempts if it is failing,
+            # but this improves confidence that the test is valid if the
+            # previous client_config would lead to the same results.
+            time.sleep(1)
+            # Each attempt takes 10 seconds; 20 attempts is equivalent to 200
+            # second timeout.
+            attempt_count = 20
+            if first_case:
+                attempt_count = 120
+                first_case = False
+            for i in range(attempt_count):
+                logger.info('%s: attempt %d', testcase_name, i)
+
+                test_runtime_secs = 10
+                num_rpcs = test_runtime_secs * args.qps
+                stats = get_client_stats(num_rpcs, test_runtime_secs + 5)
+                succeeded_rpcs = sum(
+                    stats.rpcs_by_peer.values()) - stats.num_failures
+                success = True
+                for status, pct in expected_results.items():
+                    (expected_range_from,
+                     expected_range_to) = expected_succeeded_rpcs
+                    if succeeded_rpcs < expected_range_from or succeeded_rpcs > expected_range_to:
+                        logger.info(
+                            '%s: failed due to unexpected number of succeeded rpcs: got %d want %d ~ %d',
+                            testcase_name, succeeded_rpcs, expected_range_from,
+                            expected_range_to)
+                        success = False
+                if success:
+                    logger.info('success')
+                    break
+                logger.info('%s attempt %d failed', testcase_name, i)
+            else:
+                raise Exception(
+                    '%s: timeout waiting for expected results: %s; got %s' %
+                    (testcase_name, expected_succeeded_rpcs, succeeded_rpcs))
+    except Exception:
+        passed = False
+        raise
+    finally:
+        if passed or not args.halt_after_fail:
+            patch_url_map_backend_service(gcp, original_backend_service)
+            patch_backend_service(gcp, original_backend_service,
+                                  [instance_group])
+            for backend_service in additional_backend_services:
+                delete_backend_service(gcp, backend_service)
+            set_validate_for_proxyless(gcp, True)
+
+
 def test_csds(gcp, original_backend_service, instance_group, server_uri):
     test_csds_timeout_s = datetime.timedelta(minutes=5).total_seconds()
     sleep_interval_between_attempts_s = datetime.timedelta(
@@ -3222,6 +3415,7 @@ try:
         client_env['GRPC_XDS_EXPERIMENTAL_CIRCUIT_BREAKING'] = 'true'
         client_env['GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT'] = 'true'
         client_env['GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION'] = 'true'
+        client_env['GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY'] = 'true'
         for test_case in args.test_case:
             if test_case in _V3_TEST_CASES and not args.xds_v3_support:
                 logger.info('skipping test %s due to missing v3 support',
@@ -3350,6 +3544,8 @@ try:
                     test_timeout(gcp, backend_service, instance_group)
                 elif test_case == 'fault_injection':
                     test_fault_injection(gcp, backend_service, instance_group)
+                elif test_case == 'retry':
+                    test_retry(gcp, backend_service, instance_group)
                 elif test_case == 'api_listener':
                     server_uri = test_api_listener(gcp, backend_service,
                                                    instance_group,


### PR DESCRIPTION
Adding test case #3 in go/grpc-xds-retry-interop-test . Case #2 is not added because we are not supporting per_try_timeout for now.  Case #4 is not added because we are not supporting circuit break. Case #1 is not added now because it requires QPS =1 and additional change is needed to allow modifying QPS for the client, and it is not adding any more coverage in TD integration or xDS protocol than Case #3.

See grpc/grpc-java#8341 for server side change in java
TODO: server side changes in other languages

@ericgribkoff 