### PR TITLE
Add OpenCensus measures and views for retries

### DIFF
--- a/src/cpp/ext/filters/census/grpc_plugin.cc
+++ b/src/cpp/ext/filters/census/grpc_plugin.cc
@@ -47,6 +47,9 @@ void RegisterOpenCensusPlugin() {
   RpcClientServerLatency();
   RpcClientSentMessagesPerRpc();
   RpcClientReceivedMessagesPerRpc();
+  RpcClientRetriesPerCall();
+  RpcClientTransparentRetriesPerCall();
+  RpcClientRetryDelayPerCall();
 
   RpcServerSentBytesPerRpc();
   RpcServerReceivedBytesPerRpc();
@@ -111,6 +114,16 @@ ABSL_CONST_INIT const absl::string_view kRpcClientRoundtripLatencyMeasureName =
 
 ABSL_CONST_INIT const absl::string_view kRpcClientServerLatencyMeasureName =
     "grpc.io/client/server_latency";
+
+ABSL_CONST_INIT const absl::string_view kRpcClientRetriesPerCallMeasureName =
+    "grpc.io/client/retries_per_call";
+
+ABSL_CONST_INIT const absl::string_view
+    kRpcClientTransparentRetriesPerCallMeasureName =
+        "grpc.io/client/transparent_retries_per_call";
+
+ABSL_CONST_INIT const absl::string_view kRpcClientRetryDelayPerCallMeasureName =
+    "grpc.io/client/retry_delay_per_call";
 
 // Server
 ABSL_CONST_INIT const absl::string_view

--- a/src/cpp/ext/filters/census/grpc_plugin.cc
+++ b/src/cpp/ext/filters/census/grpc_plugin.cc
@@ -118,16 +118,9 @@ ABSL_CONST_INIT const absl::string_view kRpcClientServerLatencyMeasureName =
 ABSL_CONST_INIT const absl::string_view kRpcClientRetriesPerCallMeasureName =
     "grpc.io/client/retries_per_call";
 
-ABSL_CONST_INIT const absl::string_view kRpcClientRetriesMeasureName =
-    "grpc.io/client/retries";
-
 ABSL_CONST_INIT const absl::string_view
     kRpcClientTransparentRetriesPerCallMeasureName =
         "grpc.io/client/transparent_retries_per_call";
-
-ABSL_CONST_INIT const absl::string_view
-    kRpcClientTransparentRetriesMeasureName =
-        "grpc.io/client/transparent_retries";
 
 ABSL_CONST_INIT const absl::string_view kRpcClientRetryDelayPerCallMeasureName =
     "grpc.io/client/retry_delay_per_call";

--- a/src/cpp/ext/filters/census/grpc_plugin.cc
+++ b/src/cpp/ext/filters/census/grpc_plugin.cc
@@ -118,9 +118,16 @@ ABSL_CONST_INIT const absl::string_view kRpcClientServerLatencyMeasureName =
 ABSL_CONST_INIT const absl::string_view kRpcClientRetriesPerCallMeasureName =
     "grpc.io/client/retries_per_call";
 
+ABSL_CONST_INIT const absl::string_view kRpcClientRetriesMeasureName =
+    "grpc.io/client/retries";
+
 ABSL_CONST_INIT const absl::string_view
     kRpcClientTransparentRetriesPerCallMeasureName =
         "grpc.io/client/transparent_retries_per_call";
+
+ABSL_CONST_INIT const absl::string_view
+    kRpcClientTransparentRetriesMeasureName =
+        "grpc.io/client/transparent_retries";
 
 ABSL_CONST_INIT const absl::string_view kRpcClientRetryDelayPerCallMeasureName =
     "grpc.io/client/retry_delay_per_call";

--- a/src/cpp/ext/filters/census/grpc_plugin.h
+++ b/src/cpp/ext/filters/census/grpc_plugin.h
@@ -63,8 +63,11 @@ const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatencyCumulative();
 const ::opencensus::stats::ViewDescriptor& ClientServerLatencyCumulative();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcsCumulative();
 const ::opencensus::stats::ViewDescriptor& ClientRetriesPerCallCumulative();
+const ::opencensus::stats::ViewDescriptor& ClientRetriesCumulative();
 const ::opencensus::stats::ViewDescriptor&
 ClientTransparentRetriesPerCallCumulative();
+const ::opencensus::stats::ViewDescriptor& ClientTransparentRetriesCumulative();
+const ::opencensus::stats::ViewDescriptor& ClientRetryDelayPerCallCumulative();
 
 const ::opencensus::stats::ViewDescriptor& ServerSentBytesPerRpcCumulative();
 const ::opencensus::stats::ViewDescriptor&
@@ -84,8 +87,10 @@ const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatencyMinute();
 const ::opencensus::stats::ViewDescriptor& ClientServerLatencyMinute();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcsMinute();
 const ::opencensus::stats::ViewDescriptor& ClientRetriesPerCallMinute();
+const ::opencensus::stats::ViewDescriptor& ClientRetriesMinute();
 const ::opencensus::stats::ViewDescriptor&
 ClientTransparentRetriesPerCallMinute();
+const ::opencensus::stats::ViewDescriptor& ClientTransparentRetriesMinute();
 const ::opencensus::stats::ViewDescriptor& ClientRetryDelayPerCallMinute();
 
 const ::opencensus::stats::ViewDescriptor& ServerSentMessagesPerRpcMinute();
@@ -103,8 +108,10 @@ const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatencyHour();
 const ::opencensus::stats::ViewDescriptor& ClientServerLatencyHour();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcsHour();
 const ::opencensus::stats::ViewDescriptor& ClientRetriesPerCallHour();
+const ::opencensus::stats::ViewDescriptor& ClientRetriesHour();
 const ::opencensus::stats::ViewDescriptor&
 ClientTransparentRetriesPerCallHour();
+const ::opencensus::stats::ViewDescriptor& ClientTransparentRetriesHour();
 const ::opencensus::stats::ViewDescriptor& ClientRetryDelayPerCallHour();
 
 const ::opencensus::stats::ViewDescriptor& ServerSentMessagesPerRpcHour();

--- a/src/cpp/ext/filters/census/grpc_plugin.h
+++ b/src/cpp/ext/filters/census/grpc_plugin.h
@@ -42,6 +42,9 @@ extern const absl::string_view kRpcClientReceivedMessagesPerRpcMeasureName;
 extern const absl::string_view kRpcClientReceivedBytesPerRpcMeasureName;
 extern const absl::string_view kRpcClientRoundtripLatencyMeasureName;
 extern const absl::string_view kRpcClientServerLatencyMeasureName;
+extern const absl::string_view kRpcClientRetriesPerCallMeasureName;
+extern const absl::string_view kRpcClientTransparentRetriesPerCallMeasureName;
+extern const absl::string_view kRpcClientRetryDelayPerCallMeasureName;
 
 extern const absl::string_view kRpcServerSentMessagesPerRpcMeasureName;
 extern const absl::string_view kRpcServerSentBytesPerRpcMeasureName;
@@ -59,6 +62,9 @@ ClientReceivedBytesPerRpcCumulative();
 const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatencyCumulative();
 const ::opencensus::stats::ViewDescriptor& ClientServerLatencyCumulative();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcsCumulative();
+const ::opencensus::stats::ViewDescriptor& ClientRetriesPerCallCumulative();
+const ::opencensus::stats::ViewDescriptor&
+ClientTransparentRetriesPerCallCumulative();
 
 const ::opencensus::stats::ViewDescriptor& ServerSentBytesPerRpcCumulative();
 const ::opencensus::stats::ViewDescriptor&
@@ -77,6 +83,10 @@ const ::opencensus::stats::ViewDescriptor& ClientReceivedBytesPerRpcMinute();
 const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatencyMinute();
 const ::opencensus::stats::ViewDescriptor& ClientServerLatencyMinute();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcsMinute();
+const ::opencensus::stats::ViewDescriptor& ClientRetriesPerCallMinute();
+const ::opencensus::stats::ViewDescriptor&
+ClientTransparentRetriesPerCallMinute();
+const ::opencensus::stats::ViewDescriptor& ClientRetryDelayPerCallMinute();
 
 const ::opencensus::stats::ViewDescriptor& ServerSentMessagesPerRpcMinute();
 const ::opencensus::stats::ViewDescriptor& ServerSentBytesPerRpcMinute();
@@ -92,6 +102,10 @@ const ::opencensus::stats::ViewDescriptor& ClientReceivedBytesPerRpcHour();
 const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatencyHour();
 const ::opencensus::stats::ViewDescriptor& ClientServerLatencyHour();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcsHour();
+const ::opencensus::stats::ViewDescriptor& ClientRetriesPerCallHour();
+const ::opencensus::stats::ViewDescriptor&
+ClientTransparentRetriesPerCallHour();
+const ::opencensus::stats::ViewDescriptor& ClientRetryDelayPerCallHour();
 
 const ::opencensus::stats::ViewDescriptor& ServerSentMessagesPerRpcHour();
 const ::opencensus::stats::ViewDescriptor& ServerSentBytesPerRpcHour();

--- a/src/cpp/ext/filters/census/measures.cc
+++ b/src/cpp/ext/filters/census/measures.cc
@@ -88,6 +88,32 @@ MeasureInt64 RpcClientReceivedMessagesPerRpc() {
   return measure;
 }
 
+// Client per-overall-client-call measures
+MeasureInt64 RpcClientRetriesPerCall() {
+  static const auto measure =
+      MeasureInt64::Register(kRpcClientRetriesPerCallMeasureName,
+                             "Number of retry or hedging attempts excluding "
+                             "transparent retries made during the client call",
+                             kCount);
+  return measure;
+}
+
+MeasureInt64 RpcClientTransparentRetriesPerCall() {
+  static const auto measure = MeasureInt64::Register(
+      kRpcClientTransparentRetriesPerCallMeasureName,
+      "Number of transparent retries made during the client call", kCount);
+  return measure;
+}
+
+MeasureDouble RpcClientRetryDelayPerCall() {
+  static const auto measure =
+      MeasureDouble::Register(kRpcClientRetryDelayPerCallMeasureName,
+                              "Total time of delay while there is no active "
+                              "attempt during the client call",
+                              kUnitMilliseconds);
+  return measure;
+}
+
 // Server
 MeasureDouble RpcServerSentBytesPerRpc() {
   static const auto measure = MeasureDouble::Register(

--- a/src/cpp/ext/filters/census/measures.h
+++ b/src/cpp/ext/filters/census/measures.h
@@ -33,6 +33,9 @@ namespace grpc {
 ::opencensus::stats::MeasureDouble RpcClientRoundtripLatency();
 ::opencensus::stats::MeasureDouble RpcClientServerLatency();
 ::opencensus::stats::MeasureInt64 RpcClientCompletedRpcs();
+::opencensus::stats::MeasureInt64 RpcClientRetriesPerCall();
+::opencensus::stats::MeasureInt64 RpcClientTransparentRetriesPerCall();
+::opencensus::stats::MeasureDouble RpcClientRetryDelayPerCall();
 
 ::opencensus::stats::MeasureInt64 RpcServerSentMessagesPerRpc();
 ::opencensus::stats::MeasureDouble RpcServerSentBytesPerRpc();

--- a/src/cpp/ext/filters/census/views.cc
+++ b/src/cpp/ext/filters/census/views.cc
@@ -172,7 +172,7 @@ const ViewDescriptor& ClientRetriesCumulative() {
   const static ViewDescriptor descriptor =
       ViewDescriptor()
           .set_name("grpc.io/client/retries/cumulative")
-          .set_measure(kRpcClientRetriesMeasureName)
+          .set_measure(kRpcClientRetriesPerCallMeasureName)
           .set_aggregation(Aggregation::Sum())
           .add_column(ClientMethodTagKey());
   return descriptor;
@@ -192,7 +192,7 @@ const ViewDescriptor& ClientTransparentRetriesCumulative() {
   const static ViewDescriptor descriptor =
       ViewDescriptor()
           .set_name("grpc.io/client/transparent_retries/cumulative")
-          .set_measure(kRpcClientTransparentRetriesMeasureName)
+          .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
           .set_aggregation(Aggregation::Sum())
           .add_column(ClientMethodTagKey());
   return descriptor;
@@ -356,7 +356,7 @@ const ViewDescriptor& ClientRetriesMinute() {
   const static ViewDescriptor descriptor =
       MinuteDescriptor()
           .set_name("grpc.io/client/retries/minute")
-          .set_measure(kRpcClientRetriesMeasureName)
+          .set_measure(kRpcClientRetriesPerCallMeasureName)
           .set_aggregation(Aggregation::Sum())
           .add_column(ClientMethodTagKey());
   return descriptor;
@@ -376,7 +376,7 @@ const ViewDescriptor& ClientTransparentRetriesMinute() {
   const static ViewDescriptor descriptor =
       MinuteDescriptor()
           .set_name("grpc.io/client/transparent_retries/minute")
-          .set_measure(kRpcClientTransparentRetriesMeasureName)
+          .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
           .set_aggregation(Aggregation::Sum())
           .add_column(ClientMethodTagKey());
   return descriptor;
@@ -540,7 +540,7 @@ const ViewDescriptor& ClientRetriesHour() {
   const static ViewDescriptor descriptor =
       HourDescriptor()
           .set_name("grpc.io/client/retries/hour")
-          .set_measure(kRpcClientRetriesMeasureName)
+          .set_measure(kRpcClientRetriesPerCallMeasureName)
           .set_aggregation(Aggregation::Sum())
           .add_column(ClientMethodTagKey());
   return descriptor;
@@ -560,7 +560,7 @@ const ViewDescriptor& ClientTransparentRetriesHour() {
   const static ViewDescriptor descriptor =
       HourDescriptor()
           .set_name("grpc.io/client/transparent_retries/hour")
-          .set_measure(kRpcClientTransparentRetriesMeasureName)
+          .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
           .set_aggregation(Aggregation::Sum())
           .add_column(ClientMethodTagKey());
   return descriptor;

--- a/src/cpp/ext/filters/census/views.cc
+++ b/src/cpp/ext/filters/census/views.cc
@@ -158,6 +158,26 @@ const ViewDescriptor& ClientReceivedMessagesPerRpcCumulative() {
   return descriptor;
 }
 
+const ViewDescriptor& ClientRetriesPerCallCumulative() {
+  const static ViewDescriptor descriptor =
+      ViewDescriptor()
+          .set_name("grpc.io/client/retries_per_call/cumulative")
+          .set_measure(kRpcClientRetriesPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientTransparentRetriesPerCallCumulative() {
+  const static ViewDescriptor descriptor =
+      ViewDescriptor()
+          .set_name("grpc.io/client/transparent_retries_per_call/cumulative")
+          .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
 // server cumulative
 const ViewDescriptor& ServerSentBytesPerRpcCumulative() {
   const static ViewDescriptor descriptor =
@@ -292,6 +312,36 @@ const ViewDescriptor& ClientReceivedMessagesPerRpcMinute() {
   return descriptor;
 }
 
+const ViewDescriptor& ClientRetriesPerCallMinute() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/retries_per_call/minute")
+          .set_measure(kRpcClientRetriesPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientTransaparentRetriesPerCallMinute() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/transparent_retries_per_call/minute")
+          .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientRetryDelayPerCallMinute() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/retry_delay_per_call/minute")
+          .set_measure(kRpcClientRetryDelayPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
 // server minute
 const ViewDescriptor& ServerSentBytesPerRpcMinute() {
   const static ViewDescriptor descriptor =
@@ -421,6 +471,36 @@ const ViewDescriptor& ClientReceivedMessagesPerRpcHour() {
       HourDescriptor()
           .set_name("grpc.io/client/received_messages_per_rpc/hour")
           .set_measure(kRpcClientReceivedMessagesPerRpcMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientRetriesPerCallHour() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/retries_per_call/hour")
+          .set_measure(kRpcClientRetriesPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientTransaparentRetriesPerCallHour() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/transparent_retries_per_call/hour")
+          .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
+          .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientRetryDelayPerCallHour() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/retry_delay_per_call/hour")
+          .set_measure(kRpcClientRetryDelayPerCallMeasureName)
           .set_aggregation(CountDistributionAggregation())
           .add_column(ClientMethodTagKey());
   return descriptor;

--- a/src/cpp/ext/filters/census/views.cc
+++ b/src/cpp/ext/filters/census/views.cc
@@ -168,12 +168,42 @@ const ViewDescriptor& ClientRetriesPerCallCumulative() {
   return descriptor;
 }
 
+const ViewDescriptor& ClientRetriesCumulative() {
+  const static ViewDescriptor descriptor =
+      ViewDescriptor()
+          .set_name("grpc.io/client/retries/cumulative")
+          .set_measure(kRpcClientRetriesMeasureName)
+          .set_aggregation(Aggregation::Sum())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
 const ViewDescriptor& ClientTransparentRetriesPerCallCumulative() {
   const static ViewDescriptor descriptor =
       ViewDescriptor()
           .set_name("grpc.io/client/transparent_retries_per_call/cumulative")
           .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
           .set_aggregation(CountDistributionAggregation())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientTransparentRetriesCumulative() {
+  const static ViewDescriptor descriptor =
+      ViewDescriptor()
+          .set_name("grpc.io/client/transparent_retries/cumulative")
+          .set_measure(kRpcClientTransparentRetriesMeasureName)
+          .set_aggregation(Aggregation::Sum())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientRetryDelayPerCallCumulative() {
+  const static ViewDescriptor descriptor =
+      ViewDescriptor()
+          .set_name("grpc.io/client/retry_delay_per_call/cumulative")
+          .set_measure(kRpcClientRetryDelayPerCallMeasureName)
+          .set_aggregation(MillisDistributionAggregation())
           .add_column(ClientMethodTagKey());
   return descriptor;
 }
@@ -322,7 +352,17 @@ const ViewDescriptor& ClientRetriesPerCallMinute() {
   return descriptor;
 }
 
-const ViewDescriptor& ClientTransaparentRetriesPerCallMinute() {
+const ViewDescriptor& ClientRetriesMinute() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/retries/minute")
+          .set_measure(kRpcClientRetriesMeasureName)
+          .set_aggregation(Aggregation::Sum())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientTransparentRetriesPerCallMinute() {
   const static ViewDescriptor descriptor =
       MinuteDescriptor()
           .set_name("grpc.io/client/transparent_retries_per_call/minute")
@@ -332,12 +372,22 @@ const ViewDescriptor& ClientTransaparentRetriesPerCallMinute() {
   return descriptor;
 }
 
+const ViewDescriptor& ClientTransparentRetriesMinute() {
+  const static ViewDescriptor descriptor =
+      MinuteDescriptor()
+          .set_name("grpc.io/client/transparent_retries/minute")
+          .set_measure(kRpcClientTransparentRetriesMeasureName)
+          .set_aggregation(Aggregation::Sum())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
 const ViewDescriptor& ClientRetryDelayPerCallMinute() {
   const static ViewDescriptor descriptor =
       MinuteDescriptor()
           .set_name("grpc.io/client/retry_delay_per_call/minute")
           .set_measure(kRpcClientRetryDelayPerCallMeasureName)
-          .set_aggregation(CountDistributionAggregation())
+          .set_aggregation(MillisDistributionAggregation())
           .add_column(ClientMethodTagKey());
   return descriptor;
 }
@@ -478,7 +528,7 @@ const ViewDescriptor& ClientReceivedMessagesPerRpcHour() {
 
 const ViewDescriptor& ClientRetriesPerCallHour() {
   const static ViewDescriptor descriptor =
-      MinuteDescriptor()
+      HourDescriptor()
           .set_name("grpc.io/client/retries_per_call/hour")
           .set_measure(kRpcClientRetriesPerCallMeasureName)
           .set_aggregation(CountDistributionAggregation())
@@ -486,9 +536,19 @@ const ViewDescriptor& ClientRetriesPerCallHour() {
   return descriptor;
 }
 
-const ViewDescriptor& ClientTransaparentRetriesPerCallHour() {
+const ViewDescriptor& ClientRetriesHour() {
   const static ViewDescriptor descriptor =
-      MinuteDescriptor()
+      HourDescriptor()
+          .set_name("grpc.io/client/retries/hour")
+          .set_measure(kRpcClientRetriesMeasureName)
+          .set_aggregation(Aggregation::Sum())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
+const ViewDescriptor& ClientTransparentRetriesPerCallHour() {
+  const static ViewDescriptor descriptor =
+      HourDescriptor()
           .set_name("grpc.io/client/transparent_retries_per_call/hour")
           .set_measure(kRpcClientTransparentRetriesPerCallMeasureName)
           .set_aggregation(CountDistributionAggregation())
@@ -496,12 +556,22 @@ const ViewDescriptor& ClientTransaparentRetriesPerCallHour() {
   return descriptor;
 }
 
+const ViewDescriptor& ClientTransparentRetriesHour() {
+  const static ViewDescriptor descriptor =
+      HourDescriptor()
+          .set_name("grpc.io/client/transparent_retries/hour")
+          .set_measure(kRpcClientTransparentRetriesMeasureName)
+          .set_aggregation(Aggregation::Sum())
+          .add_column(ClientMethodTagKey());
+  return descriptor;
+}
+
 const ViewDescriptor& ClientRetryDelayPerCallHour() {
   const static ViewDescriptor descriptor =
-      MinuteDescriptor()
+      HourDescriptor()
           .set_name("grpc.io/client/retry_delay_per_call/hour")
           .set_measure(kRpcClientRetryDelayPerCallMeasureName)
-          .set_aggregation(CountDistributionAggregation())
+          .set_aggregation(MillisDistributionAggregation())
           .add_column(ClientMethodTagKey());
   return descriptor;
 }


### PR DESCRIPTION
This is in preparation for #26739 for collecting metrics which uses the new stats API merged in #26673

Posting my understanding of the OpenCensus views as used by the gRPC C++ OpenCensus filter - 
From what I understand, for any particular view found in the spec, we implement three views. For example, if we want to implement `grpc.io/client/retries_per_call` with `distribution` as the aggregation, we actually define three views - `grpc.io/client/retries_per_call/cumulative`, `grpc.io/client/retries_per_call/minute` and `grpc.io/client/retries_per_call/hour`. These three views differ in their aggregation window. (AggregationWindow defines the time range over which recorded data is aggregated for each view.) 'Cumulative' is the default aggregation window, and based on the comment -
```
// You probably do not need this: ViewDescriptor has a Cumulative aggregation
// window by default, and that is what most exporters expect. Interval
// aggregation is mainly useful for on-task purposes, such as server status
// displays.
```
we don't really need the minute and hour aggregation windows, but that is what the already implemented views do, and so I've replicated that effort.

For each of these individual views, we also specify the `name` of the view, the `measure` to be used, the `aggregation` type (distribution, sum, count, last value) and `tags` if any (we use the client method as the tag).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/26751)
<!-- Reviewable:end -->
