### PR TITLE
[check-copyright] Avoid trailing whitespaces

### DIFF
--- a/tools/distrib/check_copyright.py
+++ b/tools/distrib/check_copyright.py
@@ -149,9 +149,15 @@ LICENSE_YEAR = f'Copyright {YEAR} gRPC authors.'
 
 def join_license_text(header, prefix, footer, notice):
     text = (header + '\n') if header else ""
-    text += '\n'.join(prefix + ' ' +
-                      (LICENSE_YEAR if re.search(RE_YEAR, line) else line)
-                      for line in LICENSE_NOTICE)
+
+    def add_prefix(prefix, line):
+        # Don't put whitespace between prefix and empty line to avoid having
+        # trailing whitespaces.
+        return prefix + ('' if len(line) == 0 else ' ') + line
+
+    text += '\n'.join(
+        add_prefix(prefix, (LICENSE_YEAR if re.search(RE_YEAR, line) else line))
+        for line in LICENSE_NOTICE)
     text += '\n'
     if footer:
         text += footer + '\n'


### PR DESCRIPTION
There was a bug in #26722 where we added a whitespace between comment
prefix and each line of the license notice, regardless it's empty or not.
This creates trailing whitespaces if the license note contains blank
lines, which makes most of the formatters and linters unhappy.

This PR resolves this issue.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
@lidizheng 
