### PR TITLE
[csharp] Fix error loading library grpc_csharp_ext.*.dll on windows with non-ASCII encoding

### DIFF
--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -134,19 +134,18 @@ namespace Grpc.Core.Internal
         {
             if (PlatformApis.IsWindows)
             {
-                // TODO(jtattermusch): populate the error on Windows
                 errorMsg = null;
                 var handle = Windows.LoadLibrary(libraryPath);
-
                 if (handle == IntPtr.Zero)
                 {
                     int win32Error = Marshal.GetLastWin32Error();
-                    errorMsg = $"Error {win32Error}: ";
-
+                    errorMsg = $"LoadLibrary failed with error {win32Error}";
+                    // add extra info for the most common error ERROR_MOD_NOT_FOUND
                     if (win32Error == 126)
-                        errorMsg += "The specified module could not be found";
+                    {
+                        errorMsg += ": The specified module could not be found.";
+                    }
                 }
-
                 return handle;
             }
             if (PlatformApis.IsLinux)

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -195,7 +195,7 @@ namespace Grpc.Core.Internal
 
         private static class Windows
         {
-            [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             internal static extern IntPtr LoadLibrary(string filename);
 
             [DllImport("kernel32.dll")]


### PR DESCRIPTION
Fix error loading library grpc_csharp_ext.x64.dll on desktop Windows application with charset on non ANSI encoding. Example library path: C:\тест\grpc_csharp_ext.x64.dll
+ Added handle of the win error code that occurred

lang/csharp
.NET Framework 4.7.2


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
