### PR TITLE
Allow url-map tests to run concurrently

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_url_map_python.cfg
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.cfg
@@ -15,7 +15,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_xds_url_map.sh"
+build_file: "grpc/tools/internal_ci/linux/grpc_xds_url_map_python.sh"
 timeout_mins: 60
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex -o igncr || set -ex
+
+# Constants
+readonly GITHUB_REPOSITORY_NAME="grpc"
+# GKE Cluster
+readonly GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
+readonly GKE_CLUSTER_ZONE="us-central1-a"
+## xDS test client Docker images
+readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
+readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
+readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
+readonly LANGUAGE_NAME="Python"
+
+#######################################
+# Builds test app Docker images and pushes them to GCR
+# Globals:
+#   BUILD_APP_PATH
+#   CLIENT_IMAGE_NAME: Test client Docker image name
+#   GIT_COMMIT: SHA-1 of git commit being built
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output of `gcloud builds submit` to stdout, stderr
+#######################################
+build_test_app_docker_images() {
+  echo "Building ${LANGUAGE_NAME} xDS interop test app Docker images"
+
+  pushd "${SRC_DIR}"
+  docker build \
+    -f src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client \
+    -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
+    .
+
+  popd
+
+  gcloud -q auth configure-docker
+
+  docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
+}
+
+#######################################
+# Builds test app and its docker images unless they already exist
+# Globals:
+#   CLIENT_IMAGE_NAME: Test client Docker image name
+#   GIT_COMMIT: SHA-1 of git commit being built
+#   FORCE_IMAGE_BUILD
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output to stdout, stderr
+#######################################
+build_docker_images_if_needed() {
+  # Check if images already exist
+  client_tags="$(gcloud_gcr_list_image_tags "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}")"
+  printf "Client image: %s:%s\n" "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}"
+  echo "${client_tags:-Client image not found}"
+
+  # Build if any of the images are missing, or FORCE_IMAGE_BUILD=1
+  if [[ "${FORCE_IMAGE_BUILD}" == "1" || -z "${client_tags}" ]]; then
+    build_test_app_docker_images
+  else
+    echo "Skipping ${LANGUAGE_NAME} test app build"
+  fi
+}
+
+#######################################
+# Executes the test case
+# Globals:
+#   TEST_DRIVER_FLAGFILE: Relative path to test driver flagfile
+#   KUBE_CONTEXT: The name of kubectl context with GKE cluster access
+#   TEST_XML_OUTPUT_DIR: Output directory for the test xUnit XML report
+#   CLIENT_IMAGE_NAME: Test client Docker image name
+#   GIT_COMMIT: SHA-1 of git commit being built
+# Arguments:
+#   Test case name
+# Outputs:
+#   Writes the output of test execution to stdout, stderr
+#   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
+#######################################
+run_test() {
+  # Test driver usage:
+  # https://github.com/grpc/grpc/tree/master/tools/run_tests/xds_k8s_test_driver#basic-usage
+  local test_name="${1:?Usage: run_test test_name}"
+  set -x
+  python -m "tests.${test_name}" \
+    --flagfile="${TEST_DRIVER_FLAGFILE}" \
+    --kube_context="${KUBE_CONTEXT}" \
+    --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
+    --xml_output_file="${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml" \
+    --flagfile="config/url-map.cfg"
+  set +x
+}
+
+#######################################
+# Main function: provision software necessary to execute tests, and run them
+# Globals:
+#   KOKORO_ARTIFACTS_DIR
+#   GITHUB_REPOSITORY_NAME
+#   SRC_DIR: Populated with absolute path to the source repo
+#   TEST_DRIVER_REPO_DIR: Populated with the path to the repo containing
+#                         the test driver
+#   TEST_DRIVER_FULL_DIR: Populated with the path to the test driver source code
+#   TEST_DRIVER_FLAGFILE: Populated with relative path to test driver flagfile
+#   TEST_XML_OUTPUT_DIR: Populated with the path to test xUnit XML report
+#   GIT_ORIGIN_URL: Populated with the origin URL of git repo used for the build
+#   GIT_COMMIT: Populated with the SHA-1 of git commit being built
+#   GIT_COMMIT_SHORT: Populated with the short SHA-1 of git commit being built
+#   KUBE_CONTEXT: Populated with name of kubectl context with GKE cluster access
+# Arguments:
+#   None
+# Outputs:
+#   Writes the output of test execution to stdout, stderr
+#######################################
+main() {
+  local script_dir
+  script_dir="$(dirname "$0")"
+  # shellcheck source=tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+  source "${script_dir}/grpc_xds_k8s_install_test_driver.sh"
+  set -x
+  if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
+    kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"
+  else
+    local_setup_test_driver "${script_dir}"
+  fi
+  build_docker_images_if_needed
+  # Run tests
+  cd "${TEST_DRIVER_FULL_DIR}"
+  run_test url_map
+}
+
+main "$@"

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex -o igncr || set -ex
+set -eo pipefail
 
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc"

--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -1,6 +1,5 @@
---resource_suffix=interop-psm-url-map
+--resource_prefix=interop-psm-url-map
 --strategy=reuse
-# TODO(lidiz): Remove the next line when xds port randomization supported.
 --server_xds_port=8848
 # NOTE(lidiz) we pin the server image to java-server because:
 # 1. Only Java server understands the rpc-behavior metadata.

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/rand.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/rand.py
@@ -15,6 +15,8 @@
 import random
 import string
 
+import framework.helpers.datetime
+
 # Alphanumeric characters, similar to regex [:alnum:] class, [a-zA-Z0-9]
 ALPHANUM = string.ascii_letters + string.digits
 # Lowercase alphanumeric characters: [a-z0-9]
@@ -25,9 +27,23 @@ ALPHANUM_LOWERCASE = string.ascii_lowercase + string.digits
 def rand_string(length: int = 8, *, lowercase: bool = False) -> str:
     """Return random alphanumeric string of given length.
 
-    Space for default arguments: alphabet^length
-       lowercase and uppercase = (26*2 + 10)^8 = 2.18e14 = 218 trillion.
-       lowercase only = (26 + 10)^8 = 2.8e12 = 2.8 trillion.
-    """
+   Space for default arguments: alphabet^length
+      lowercase and uppercase = (26*2 + 10)^8 = 2.18e14 = 218 trillion.
+      lowercase only = (26 + 10)^8 = 2.8e12 = 2.8 trillion.
+   """
     alphabet = ALPHANUM_LOWERCASE if lowercase else ALPHANUM
     return ''.join(random.choices(population=alphabet, k=length))
+
+
+def random_resource_suffix() -> str:
+    """Return a ready-to-use resource suffix with datetime and nonce."""
+    # Date and time suffix for debugging. Seconds skipped, not as relevant
+    # Format example: 20210626-1859
+    datetime_suffix: str = framework.helpers.datetime.datetime_suffix()
+    # Use lowercase chars because some resource names won't allow uppercase.
+    # For len 5, total (26 + 10)^5 = 60,466,176 combinations.
+    # Approx. number of test runs needed to start at the same minute to
+    # produce a collision: math.sqrt(math.pi/2 * (26+10)**5) ≈ 9745.
+    # https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
+    unique_hash: str = rand_string(5, lowercase=True)
+    return f'{datetime_suffix}-{unique_hash}'

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -26,7 +26,6 @@ from google.protobuf import json_format
 from framework import xds_flags
 from framework import xds_k8s_flags
 from framework.helpers import retryers
-import framework.helpers.datetime
 import framework.helpers.rand
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
@@ -130,7 +129,8 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         super().setUp()
 
         if self._resource_suffix_randomize:
-            self.resource_suffix = self.random_resource_suffix()
+            self.resource_suffix = framework.helpers.rand.random_resource_suffix(
+            )
         logger.info('Test run resource prefix: %s, suffix: %s',
                     self.resource_prefix, self.resource_suffix)
 
@@ -194,19 +194,6 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         self.client_runner.cleanup(force=self.force_cleanup)
         self.server_runner.cleanup(force=self.force_cleanup,
                                    force_namespace=self.force_cleanup)
-
-    @staticmethod
-    def random_resource_suffix() -> str:
-        # Date and time suffix for debugging. Seconds skipped, not as relevant
-        # Format example: 20210626-1859
-        datetime_suffix: str = framework.helpers.datetime.datetime_suffix()
-        # Use lowercase chars because some resource names won't allow uppercase.
-        # For len 5, total (26 + 10)^5 = 60,466,176 combinations.
-        # Approx. number of test runs needed to start at the same minute to
-        # produce a collision: math.sqrt(math.pi/2 * (26+10)**5) ≈ 9745.
-        # https://en.wikipedia.org/wiki/Birthday_attack#Mathematics
-        unique_hash: str = framework.helpers.rand.rand_string(5, lowercase=True)
-        return f'{datetime_suffix}-{unique_hash}'
 
     def setupTrafficDirectorGrpc(self):
         self.td.setup_for_grpc(self.server_xds_host,

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -130,7 +130,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         super().setUp()
 
         if self._resource_suffix_randomize:
-            self.resource_suffix = self._random_resource_suffix()
+            self.resource_suffix = self.random_resource_suffix()
         logger.info('Test run resource prefix: %s, suffix: %s',
                     self.resource_prefix, self.resource_suffix)
 
@@ -196,7 +196,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
                                    force_namespace=self.force_cleanup)
 
     @staticmethod
-    def _random_resource_suffix() -> str:
+    def random_resource_suffix() -> str:
         # Date and time suffix for debugging. Seconds skipped, not as relevant
         # Format example: 20210626-1859
         datetime_suffix: str = framework.helpers.datetime.datetime_suffix()

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -24,6 +24,7 @@ from absl import logging
 from framework import xds_flags
 from framework import xds_k8s_flags
 from framework import xds_k8s_testcase
+import framework.helpers.rand
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
 from framework.infrastructure import traffic_director
@@ -144,7 +145,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         # Pick a client_namespace_suffix if not set
         if self.resource_suffix is None:
             self.resource_suffix = ""
-            self.client_namespace_suffix = xds_k8s_testcase.XdsKubernetesTestCase.random_resource_suffix(
+            self.client_namespace_suffix = framework.helpers.rand.random_resource_suffix(
             )
         else:
             self.client_namespace_suffix = self.resource_suffix

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """A test framework built for urlMap related xDS test cases."""
 
-import time
 import functools
 import inspect
+import time
 from typing import Any, Iterable, List, Mapping, Tuple
 
 from absl import flags

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -23,7 +23,6 @@ from absl import logging
 
 from framework import xds_flags
 from framework import xds_k8s_flags
-from framework import xds_k8s_testcase
 import framework.helpers.rand
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -23,6 +23,7 @@ from absl import logging
 
 from framework import xds_flags
 from framework import xds_k8s_flags
+from framework import xds_k8s_testcase
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
 from framework.infrastructure import traffic_director
@@ -143,9 +144,14 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         # Pick a client_namespace_suffix if not set
         if self.resource_suffix is None:
             self.resource_suffix = ""
-            self.client_namespace_suffix = str(int(time.time()))
+            self.client_namespace_suffix = xds_k8s_testcase.XdsKubernetesTestCase.random_resource_suffix(
+            )
         else:
             self.client_namespace_suffix = self.resource_suffix
+        logging.info(
+            'GcpResourceManager: resource prefix=%s, suffix=%s, client_namespace_suffix=%s',
+            self.resource_prefix, self.resource_suffix,
+            self.client_namespace_suffix)
         # API managers
         self.k8s_api_manager = k8s.KubernetesApiManager(self.kube_context)
         self.gcp_api_manager = gcp.api.GcpApiManager()


### PR DESCRIPTION
This PR utilizes the multi-run feature introduced in https://github.com/grpc/grpc/pull/26542. The TD resources and backends will be shared, and each run will have a unique client namespace.

Internal changes: cl/386366746

---

https://fusion2.corp.google.com/invocations/31591d4c-8f1d-403f-814e-b1d76bc4a676/targets