### PR TITLE
WriteOptions::clear_write_through method

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -165,6 +165,12 @@ class WriteOptions {
     return *this;
   }
 
+  /// Get value for the flag indicating that this is the last message, and
+  /// should be coalesced with trailing metadata.
+  ///
+  /// \sa GRPC_WRITE_LAST_MESSAGE
+  bool is_last_message() const { return last_message_; }
+
   /// Guarantee that all bytes have been written to the socket before completing
   /// this write (usually writes are completed when they pass flow control).
   inline WriteOptions& set_write_through() {
@@ -178,12 +184,6 @@ class WriteOptions {
   }
 
   inline bool is_write_through() const { return GetBit(GRPC_WRITE_THROUGH); }
-
-  /// Get value for the flag indicating that this is the last message, and
-  /// should be coalesced with trailing metadata.
-  ///
-  /// \sa GRPC_WRITE_LAST_MESSAGE
-  bool is_last_message() const { return last_message_; }
 
  private:
   void SetBit(const uint32_t mask) { flags_ |= mask; }

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -172,6 +172,11 @@ class WriteOptions {
     return *this;
   }
 
+  inline WriteOptions& clear_write_through() {
+    ClearBit(GRPC_WRITE_THROUGH);
+    return *this;
+  }
+
   inline bool is_write_through() const { return GetBit(GRPC_WRITE_THROUGH); }
 
   /// Get value for the flag indicating that this is the last message, and


### PR DESCRIPTION
Adds `WriteOptions::clear_write_through` method and groups `*_last_message` methods of `WriteOptions` for the sake of consistency.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
