### PR TITLE
xds-k8s: Fix regression with returning multiple test servers

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -20,7 +20,7 @@ modules.
 import functools
 import logging
 import threading
-from typing import Iterator, Optional
+from typing import Iterator, List, Optional
 
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
@@ -198,7 +198,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
             maintenance_port=None,
             secure_mode=False,
             server_id=None,
-            replica_count=1) -> Iterator[XdsTestServer]:
+            replica_count=1) -> List[XdsTestServer]:
         # Implementation detail: in secure mode, maintenance ("backchannel")
         # port must be different from the test port so communication with
         # maintenance services can be reached independently from the security

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -317,7 +317,7 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             replica_count=replica_count,
             test_port=self.server_port,
             maintenance_port=self.server_maintenance_port,
-            **kwargs)
+            **kwargs)[0]
         test_server.set_xds_address(self.server_xds_host, self.server_xds_port)
         return test_server
 
@@ -397,7 +397,7 @@ class SecurityXdsKubernetesTestCase(XdsKubernetesTestCase):
             test_port=self.server_port,
             maintenance_port=self.server_maintenance_port,
             secure_mode=True,
-            **kwargs)
+            **kwargs)[0]
         test_server.set_xds_address(self.server_xds_host, self.server_xds_port)
         return test_server
 


### PR DESCRIPTION
Regression introduced in #26759 broke PSM Security tests:

```
Traceback (most recent call last):
  File "/tmpfs/src/github/grpc/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py", line 48, in test_traffic_director_grpc_setup
    test_server: _XdsTestServer = self.startTestServer()
  File "/tmpfs/src/github/grpc/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py", line 321, in startTestServer
    test_server.set_xds_address(self.server_xds_host, self.server_xds_port)
AttributeError: 'list' object has no attribute 'set_xds_address'
```

https://source.cloud.google.com/results/invocations/5e777a0a-8786-4b49-b316-4dccf278f20a

