### PR TITLE
Add xds retry interop test to GKE test framework

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -4,5 +4,5 @@
 # NOTE(lidiz) we pin the server image to java-server because:
 # 1. Only Java server understands the rpc-behavior metadata.
 # 2. All UrlMap tests today are testing client-side logic.
-# grpc-java v1.38.1: 389076d3733ed1d8e70234fe772307fa4809f610
---server_image=gcr.io/grpc-testing/xds-interop/java-server:389076d3733ed1d8e70234fe772307fa4809f610
+# grpc-java master: 438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa TODO: use v1.40.0
+--server_image=gcr.io/grpc-testing/xds-interop/java-server:438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -37,6 +37,8 @@ spec:
             value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
           - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH
             value: "true"
+          - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY
+            value: "true"
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -63,7 +63,7 @@ def _build_retry_route_rule(retryConditions, num_retries):
 
 
 @absltest.skipUnless('java-client' in xds_k8s_flags.CLIENT_IMAGE.value,
-                     'Affinity is currently only implemented in Java.')
+                     'Retry is currently only implemented in Java.')
 class TestRetryUpTo3Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
@@ -99,7 +99,8 @@ class TestRetryUpTo3Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
                                  tolerance=_NON_RANDOM_ERROR_TOLERANCE)
 
 
-
+@absltest.skipUnless('java-client' in xds_k8s_flags.CLIENT_IMAGE.value,
+                     'Retry is currently only implemented in Java.')
 class TestRetryUpTo4Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -19,6 +19,7 @@ from absl import flags
 from absl.testing import absltest
 import grpc
 
+from framework import xds_k8s_flags
 from framework import xds_url_map_testcase
 from framework.test_app import client_app
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -1,0 +1,139 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import time
+from typing import Tuple
+
+from absl import flags
+from absl.testing import absltest
+import grpc
+
+from framework import xds_url_map_testcase
+from framework.test_app import client_app
+
+# Type aliases
+HostRule = xds_url_map_testcase.HostRule
+PathMatcher = xds_url_map_testcase.PathMatcher
+GcpResourceManager = xds_url_map_testcase.GcpResourceManager
+DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
+RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
+XdsTestClient = client_app.XdsTestClient
+ExpectedResult = xds_url_map_testcase.ExpectedResult
+
+logger = logging.getLogger(__name__)
+flags.adopt_module_key_flags(xds_url_map_testcase)
+
+# The first batch of RPCs don't count towards the result of test case. They are
+# meant to prove the communication between driver and client is fine.
+_NUM_RPCS = 10
+_LENGTH_OF_RPC_SENDING_SEC = 16
+# We are using sleep to synchronize test driver and the client... Even though
+# the client is sending at QPS rate, we can't assert that exactly QPS *
+# SLEEP_DURATION number of RPC is finished. The final completed RPC might be
+# slightly more or less.
+_NON_RANDOM_ERROR_TOLERANCE = 0.01
+_RPC_BEHAVIOR_HEADER_NAME = 'rpc-behavior'
+
+
+def _build_retry_route_rule(retryConditions, num_retries):
+    return {
+        'priority': 0,
+        'matchRules': [{
+            'fullPathMatch': '/grpc.testing.TestService/UnaryCall'
+        }],
+        'service': GcpResourceManager().default_backend_service(),
+        'routeAction': {
+            'retryPolicy': {
+                'retryConditions': retryConditions,
+                'numRetries': num_retries,
+            }
+        },
+    }
+
+
+@absltest.skipUnless('java-client' in xds_k8s_flags.CLIENT_IMAGE.value,
+                     'Affinity is currently only implemented in Java.')
+class TestRetryUpTo3Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def url_map_change(
+            host_rule: HostRule,
+            path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
+        path_matcher["routeRules"] = [
+            _build_retry_route_rule(retryConditions=["unavailable"],
+                                    num_retries=3)
+        ]
+        return host_rule, path_matcher
+
+    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+        self.assertNumEndpoints(xds_config, 1)
+        retry_config = xds_config.rds['virtualHosts'][0]['routes'][0]['route'][
+            'retryPolicy']
+        self.assertEqual(3, retry_config['numRetries'])
+        self.assertEqual('unavailable', retry_config['retryOn'])
+
+    def rpc_distribution_validate(self, test_client: XdsTestClient):
+        rpc_distribution = self.configure_and_send(
+            test_client,
+            rpc_types=[RpcTypeUnaryCall],
+            metadata=[(RpcTypeUnaryCall, _RPC_BEHAVIOR_HEADER_NAME,
+                       'error-code-14,succeed-on-retry-attempt-4')],
+            num_rpcs=_NUM_RPCS)
+        self.assertRpcStatusCode(test_client,
+                                 expected=(ExpectedResult(
+                                     rpc_type=RpcTypeUnaryCall,
+                                     status_code=grpc.StatusCode.UNAVAILABLE,
+                                     ratio=1),),
+                                 length=_LENGTH_OF_RPC_SENDING_SEC,
+                                 tolerance=_NON_RANDOM_ERROR_TOLERANCE)
+
+
+
+class TestRetryUpTo4Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def url_map_change(
+            host_rule: HostRule,
+            path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
+        path_matcher["routeRules"] = [
+            _build_retry_route_rule(retryConditions=["unavailable"],
+                                    num_retries=4)
+        ]
+        return host_rule, path_matcher
+
+    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+        self.assertNumEndpoints(xds_config, 1)
+        retry_config = xds_config.rds['virtualHosts'][0]['routes'][0]['route'][
+            'retryPolicy']
+        self.assertEqual(4, retry_config['numRetries'])
+        self.assertEqual('unavailable', retry_config['retryOn'])
+
+    def rpc_distribution_validate(self, test_client: XdsTestClient):
+        rpc_distribution = self.configure_and_send(
+            test_client,
+            rpc_types=[RpcTypeUnaryCall],
+            metadata=[(RpcTypeUnaryCall, _RPC_BEHAVIOR_HEADER_NAME,
+                       'error-code-14,succeed-on-retry-attempt-4')],
+            num_rpcs=_NUM_RPCS)
+        self.assertRpcStatusCode(test_client,
+                                 expected=(ExpectedResult(
+                                     rpc_type=RpcTypeUnaryCall,
+                                     status_code=grpc.StatusCode.OK,
+                                     ratio=1),),
+                                 length=_LENGTH_OF_RPC_SENDING_SEC,
+                                 tolerance=_NON_RANDOM_ERROR_TOLERANCE)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -64,7 +64,7 @@ def _build_retry_route_rule(retryConditions, num_retries):
 
 @absltest.skipUnless('java-client' in xds_k8s_flags.CLIENT_IMAGE.value,
                      'Retry is currently only implemented in Java.')
-class TestRetryUpTo3Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
+class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def url_map_change(
@@ -101,7 +101,7 @@ class TestRetryUpTo3Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
 
 @absltest.skipUnless('java-client' in xds_k8s_flags.CLIENT_IMAGE.value,
                      'Retry is currently only implemented in Java.')
-class TestRetryUpTo4Attempts(xds_url_map_testcase.XdsUrlMapTestCase):
+class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def url_map_change(


### PR DESCRIPTION
Migrate #26746 to GKE, using https://github.com/grpc/grpc/blob/master/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py as a template.

@lidizheng, @ericgribkoff 
