### PR TITLE
Install abseil along with gRPC

### DIFF
--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -17,15 +17,12 @@ if(gRPC_ABSL_PROVIDER STREQUAL "module")
     set(ABSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/abseil-cpp)
   endif()
   if(EXISTS "${ABSL_ROOT_DIR}/CMakeLists.txt")
-    add_subdirectory(${ABSL_ROOT_DIR} third_party/abseil-cpp)
-    if(TARGET absl_base)
-      if(gRPC_INSTALL AND _gRPC_INSTALL_SUPPORTED_FROM_MODULE)
-        install(TARGETS ${gRPC_ABSL_USED_TARGETS} EXPORT gRPCTargets
-          RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
-          LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
-          ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR})
-      endif()
+    if(gRPC_INSTALL)
+      # When gRPC_INSTALL is enabled and Abseil will be built as a module,
+      # Abseil will be installed along with gRPC for convenience.
+      set(ABSL_ENABLE_INSTALL ON)
     endif()
+    add_subdirectory(${ABSL_ROOT_DIR} third_party/abseil-cpp)
   else()
     message(WARNING "gRPC_ABSL_PROVIDER is \"module\" but ABSL_ROOT_DIR is wrong")
   endif()
@@ -36,5 +33,5 @@ if(gRPC_ABSL_PROVIDER STREQUAL "module")
 elseif(gRPC_ABSL_PROVIDER STREQUAL "package")
   # Use "CONFIG" as there is no built-in cmake module for absl.
   find_package(absl REQUIRED CONFIG)
-  set(_gRPC_FIND_ABSL "if(NOT absl_FOUND)\n  find_package(absl CONFIG)\nendif()")
 endif()
+set(_gRPC_FIND_ABSL "if(NOT TARGET absl::strings)\n  find_package(absl CONFIG)\nendif()")

--- a/test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh
@@ -53,17 +53,6 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 EOT
 
-# Build and install absl (absl won't be installed down below)
-mkdir -p "third_party/abseil-cpp/cmake/build_arm"
-pushd "third_party/abseil-cpp/cmake/build_arm"
-cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/toolchain.cmake \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=/tmp/install \
-      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
-      ../..
-make -j4 install
-popd
-
 # Build and install gRPC for ARM.
 # This build will use the host architecture copies of protoc and
 # grpc_cpp_plugin that we built earlier because we installed them
@@ -84,6 +73,7 @@ mkdir -p "examples/cpp/helloworld/cmake/build_arm"
 pushd "examples/cpp/helloworld/cmake/build_arm"
 cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/toolchain.cmake \
       -DCMAKE_BUILD_TYPE=Release \
+      -Dabsl_DIR=/tmp/stage/lib/cmake/absl \
       -DProtobuf_DIR=/tmp/stage/lib/cmake/protobuf \
       -DgRPC_DIR=/tmp/stage/lib/cmake/grpc \
       ../..

--- a/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
@@ -26,13 +26,6 @@ wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.
 sh cmake-linux.sh -- --skip-license --prefix=/usr
 rm cmake-linux.sh
 
-# Install absl (absl won't be installed down below)
-mkdir -p "third_party/abseil-cpp/cmake/build"
-pushd "third_party/abseil-cpp/cmake/build"
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ../..
-make -j4 install
-popd
-
 # Install gRPC and its dependencies
 mkdir -p "cmake/build"
 pushd "cmake/build"
@@ -40,7 +33,6 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DgRPC_INSTALL=ON \
   -DgRPC_BUILD_TESTS=OFF \
-  -DgRPC_ABSL_PROVIDER=package \
   -DgRPC_SSL_PROVIDER=package \
   ../..
 make -j4 install

--- a/test/distrib/cpp/run_distrib_test_cmake_module_install_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install_pkgconfig.sh
@@ -26,13 +26,6 @@ wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.
 sh cmake-linux.sh -- --skip-license --prefix=/usr
 rm cmake-linux.sh
 
-# Install absl (absl won't be installed down below)
-mkdir -p "third_party/abseil-cpp/cmake/build"
-pushd "third_party/abseil-cpp/cmake/build"
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ../..
-make -j4 install
-popd
-
 # Install gRPC and its dependencies
 mkdir -p "cmake/build"
 pushd "cmake/build"
@@ -40,7 +33,6 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DgRPC_INSTALL=ON \
   -DgRPC_BUILD_TESTS=OFF \
-  -DgRPC_ABSL_PROVIDER=package \
   -DgRPC_SSL_PROVIDER=package \
   ../..
 make -j4 install


### PR DESCRIPTION
Previously Abseil always needed to be installed separately since it prevents itself from being installed when it's used as a submodule. This became a bit annoying for those who used to install gRPC by simply running gRPC cmake installation and realized that abseil was missing. Therefore, abseil should be installed independently before gRPC installation, which was decided by the Abseil team because it was considered dangerous to install Abseil implicitly because it could override the existing abseil installed already.

But this would be acceptable for the most cases especially when abseil is used as a submodule for gRPC which needs abseil picked by gRPC anyway. Abseil appeared to change this a bit to allow to override this behavior ([commit](https://github.com/abseil/abseil-cpp/commit/f624790b7f76ab92fed5ae966abb99a0d455c96f)) so let's lift this limitation by installing abseil along with gRPC only when abseil is used as a submodule of gRPC.

Context: https://github.com/grpc/grpc/issues/26122