### PR TITLE
Allow Python xDS interop client to be configured for EmptyCall

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -327,7 +327,7 @@ class _XdsUpdateClientConfigureServicer(
             context: grpc.ServicerContext
     ) -> messages_pb2.ClientConfigureResponse:
         logger.info("Received Configure RPC: %s", request)
-        method_strs = (_METHOD_ENUM_TO_STR[t] for t in request.types)
+        method_strs = [_METHOD_ENUM_TO_STR[t] for t in request.types]
         for method in _SUPPORTED_METHODS:
             method_enum = _METHOD_STR_TO_ENUM[method]
             channel_config = self._per_method_configs[method]


### PR DESCRIPTION
This is an interesting bug. Python's generator can only be looked once for `A in B` syntax.

```py
foo = iter((1, 2, 3))
assert 1 in foo  # ok
assert 1 in foo  # fail
```

In code, because EmptyCall is always the second item in `_SUPPORTED_METHODS`, so it's check will never be true. This bug didn't show in the existing xDS tests, because all existing test cases are setting client to send UnaryCall...