### PR TITLE
Run ./tools/distrib/check_include_guards.py --fix

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -479,4 +479,4 @@ extern TestOnlyTransportTargetWindowEstimatesMocker*
 }  // namespace chttp2
 }  // namespace grpc_core
 
-#endif
+#endif  // GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FLOW_CONTROL_H

--- a/src/core/lib/compression/stream_compression.h
+++ b/src/core/lib/compression/stream_compression.h
@@ -113,4 +113,4 @@ void grpc_stream_compression_context_destroy(
 int grpc_stream_compression_method_parse(
     grpc_slice value, bool is_compress, grpc_stream_compression_method* method);
 
-#endif
+#endif  // GRPC_CORE_LIB_COMPRESSION_STREAM_COMPRESSION_H

--- a/src/core/lib/compression/stream_compression_gzip.h
+++ b/src/core/lib/compression/stream_compression_gzip.h
@@ -25,4 +25,4 @@
 
 extern const grpc_stream_compression_vtable grpc_stream_compression_gzip_vtable;
 
-#endif
+#endif  // GRPC_CORE_LIB_COMPRESSION_STREAM_COMPRESSION_GZIP_H

--- a/src/core/lib/compression/stream_compression_identity.h
+++ b/src/core/lib/compression/stream_compression_identity.h
@@ -26,4 +26,4 @@
 extern const grpc_stream_compression_vtable
     grpc_stream_compression_identity_vtable;
 
-#endif
+#endif  // GRPC_CORE_LIB_COMPRESSION_STREAM_COMPRESSION_IDENTITY_H

--- a/src/core/lib/debug/stats.h
+++ b/src/core/lib/debug/stats.h
@@ -67,4 +67,4 @@ double grpc_stats_histo_percentile(const grpc_stats_data* stats,
 size_t grpc_stats_histo_count(const grpc_stats_data* stats,
                               grpc_stats_histograms histogram);
 
-#endif
+#endif  // GRPC_CORE_LIB_DEBUG_STATS_H

--- a/src/core/lib/gprpp/manual_constructor.h
+++ b/src/core/lib/gprpp/manual_constructor.h
@@ -210,4 +210,4 @@ class ManualConstructor {
 
 }  // namespace grpc_core
 
-#endif
+#endif  // GRPC_CORE_LIB_GPRPP_MANUAL_CONSTRUCTOR_H

--- a/src/core/lib/iomgr/ev_apple.h
+++ b/src/core/lib/iomgr/ev_apple.h
@@ -40,4 +40,4 @@ extern grpc_pollset_set_vtable grpc_apple_pollset_set_vtable;
 
 #endif
 
-#endif
+#endif  // GRPC_CORE_LIB_IOMGR_EV_APPLE_H

--- a/src/core/lib/iomgr/python_util.h
+++ b/src/core/lib/iomgr/python_util.h
@@ -43,4 +43,4 @@ inline int grpc_slice_buffer_length(grpc_slice_buffer* buffer, int i) {
   return GRPC_SLICE_LENGTH(buffer->slices[i]);
 }
 
-#endif
+#endif  // GRPC_CORE_LIB_IOMGR_PYTHON_UTIL_H


### PR DESCRIPTION
When I run this script to fix my BinderTransport code import, I found these files are also not formatted correctly

@drfloob
