### PR TITLE
Pointing the protobuf submodule to the new URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	ignore = dirty
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
-	url = https://github.com/google/protobuf.git
+	url = https://github.com/protocolbuffers/protobuf.git
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -269,7 +269,7 @@ $ make
 
 ### A note on `protoc`
 
-By default gRPC uses [protocol buffers](https://github.com/google/protobuf),
+By default gRPC uses [protocol buffers](https://github.com/protocolbuffers/protobuf),
 you will need the `protoc` compiler to generate stub server and client code.
 
 If you compile gRPC from source, as described below, the Makefile will

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -14,7 +14,7 @@ of methods). From this description, gRPC will generate client and server side in
 in any of the supported languages. The server implements
 the service interface, which can be remotely invoked by the client interface.
 
-By default, gRPC uses [Protocol Buffers](https://github.com/google/protobuf) as the
+By default, gRPC uses [Protocol Buffers](https://github.com/protocolbuffers/protobuf) as the
 Interface Definition Language (IDL) for describing both the service interface
 and the structure of the payload messages. It is possible to use other
 alternatives if desired.

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -215,8 +215,8 @@ def grpc_deps():
             sha256 = "cf63d46ef743f4c30b0e36a562caf83cabed3f10e6ca49eb476913c4655394d5",
             strip_prefix = "protobuf-436bd7880e458532901c58f4d9d1ea23fa7edd52",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/protobuf/archive/436bd7880e458532901c58f4d9d1ea23fa7edd52.tar.gz",
-                "https://github.com/google/protobuf/archive/436bd7880e458532901c58f4d9d1ea23fa7edd52.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/protocolbuffers/protobuf/archive/436bd7880e458532901c58f4d9d1ea23fa7edd52.tar.gz",
+                "https://github.com/protocolbuffers/protobuf/archive/436bd7880e458532901c58f4d9d1ea23fa7edd52.tar.gz",
             ],
             patches = ["@com_github_grpc_grpc//third_party:protobuf.patch"],
             patch_args = ["-p1"],

--- a/examples/android/helloworld/README.md
+++ b/examples/android/helloworld/README.md
@@ -2,7 +2,7 @@ gRPC on Android
 ==============
 
 Note: Building the protobuf dependency for Android requires
-https://github.com/google/protobuf/pull/3878. This fix will be in the next
+https://github.com/protocolbuffers/protobuf/pull/3878. This fix will be in the next
 protobuf release, but until then must be manually patched in to
 `third_party/protobuf` to build gRPC for Android.
 

--- a/examples/cpp/compression/Makefile
+++ b/examples/cpp/compression/Makefile
@@ -83,7 +83,7 @@ ifneq ($(HAS_VALID_PROTOC),true)
 	@echo "Please install Google protocol buffers 3.0.0 and its compiler."
 	@echo "You can find it here:"
 	@echo
-	@echo "   https://github.com/google/protobuf/releases/tag/v3.0.0"
+	@echo "   https://github.com/protocolbuffers/protobuf/releases/tag/v3.0.0"
 	@echo
 	@echo "Here is what I get when trying to evaluate your version of protoc:"
 	@echo

--- a/examples/cpp/helloworld/Makefile
+++ b/examples/cpp/helloworld/Makefile
@@ -100,7 +100,7 @@ ifneq ($(HAS_VALID_PROTOC),true)
 	@echo "Please install Google protocol buffers 3.0.0 and its compiler."
 	@echo "You can find it here:"
 	@echo
-	@echo "   https://github.com/google/protobuf/releases/tag/v3.0.0"
+	@echo "   https://github.com/protocolbuffers/protobuf/releases/tag/v3.0.0"
 	@echo
 	@echo "Here is what I get when trying to evaluate your version of protoc:"
 	@echo

--- a/examples/cpp/load_balancing/Makefile
+++ b/examples/cpp/load_balancing/Makefile
@@ -83,7 +83,7 @@ ifneq ($(HAS_VALID_PROTOC),true)
 	@echo "Please install Google protocol buffers 3.0.0 and its compiler."
 	@echo "You can find it here:"
 	@echo
-	@echo "   https://github.com/google/protobuf/releases/tag/v3.0.0"
+	@echo "   https://github.com/protocolbuffers/protobuf/releases/tag/v3.0.0"
 	@echo
 	@echo "Here is what I get when trying to evaluate your version of protoc:"
 	@echo

--- a/examples/cpp/metadata/Makefile
+++ b/examples/cpp/metadata/Makefile
@@ -69,7 +69,7 @@ ifneq ($(HAS_VALID_PROTOC),true)
 	@echo "Please install Google protocol buffers 3.0.0 and its compiler."
 	@echo "You can find it here:"
 	@echo
-	@echo "   https://github.com/google/protobuf/releases/tag/v3.0.0"
+	@echo "   https://github.com/protocolbuffers/protobuf/releases/tag/v3.0.0"
 	@echo
 	@echo "Here is what I get when trying to evaluate your version of protoc:"
 	@echo

--- a/examples/cpp/route_guide/Makefile
+++ b/examples/cpp/route_guide/Makefile
@@ -83,7 +83,7 @@ ifneq ($(HAS_VALID_PROTOC),true)
 	@echo "Please install Google protocol buffers 3.0.0 and its compiler."
 	@echo "You can find it here:"
 	@echo
-	@echo "   https://github.com/google/protobuf/releases/tag/v3.0.0"
+	@echo "   https://github.com/protocolbuffers/protobuf/releases/tag/v3.0.0"
 	@echo
 	@echo "Here is what I get when trying to evaluate your version of protoc:"
 	@echo

--- a/src/android/test/interop/README.md
+++ b/src/android/test/interop/README.md
@@ -2,7 +2,7 @@ gRPC on Android
 ==============
 
 Note: Building the protobuf dependency for Android requires
-https://github.com/google/protobuf/pull/3878. This fix will be in the next
+https://github.com/protocolbuffers/protobuf/pull/3878. This fix will be in the next
 protobuf release, but until then must be manually patched in to
 `third_party/protobuf` to build gRPC for Android.
 

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -38,7 +38,7 @@ namespace grpc_csharp_generator {
 namespace {
 
 // This function is a massaged version of
-// https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
+// https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/csharp/csharp_doc_comment.cc
 // Currently, we cannot easily reuse the functionality as
 // google/protobuf/compiler/csharp/csharp_doc_comment.h is not a public header.
 // TODO(jtattermusch): reuse the functionality from google/protobuf.

--- a/src/compiler/python_generator.h
+++ b/src/compiler/python_generator.h
@@ -34,7 +34,7 @@ struct GeneratorConfiguration {
   std::string grpc_package_root;
   // TODO(https://github.com/grpc/grpc/issues/8622): Drop this.
   std::string beta_package_root;
-  // TODO(https://github.com/google/protobuf/issues/888): Drop this.
+  // TODO(https://github.com/protocolbuffers/protobuf/issues/888): Drop this.
   std::string import_prefix;
   std::vector<std::string> prefixes_to_filter;
 };

--- a/src/compiler/python_generator_helpers.h
+++ b/src/compiler/python_generator_helpers.h
@@ -61,7 +61,7 @@ static std::string StripModulePrefixes(
   return raw_module_name;
 }
 
-// TODO(https://github.com/google/protobuf/issues/888):
+// TODO(https://github.com/protocolbuffers/protobuf/issues/888):
 // Export `ModuleName` from protobuf's
 // `src/google/protobuf/compiler/python/python_generator.cc` file.
 std::string ModuleName(const std::string& filename,
@@ -74,7 +74,7 @@ std::string ModuleName(const std::string& filename,
                              prefixes_to_filter);
 }
 
-// TODO(https://github.com/google/protobuf/issues/888):
+// TODO(https://github.com/protocolbuffers/protobuf/issues/888):
 // Export `ModuleAlias` from protobuf's
 // `src/google/protobuf/compiler/python/python_generator.cc` file.
 std::string ModuleAlias(const std::string& filename,

--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -109,7 +109,7 @@ void PrintService(const ServiceDescriptor* service, Printer* out) {
 // ruby generator
 // to ensure compatibility (with the exception of int and string type changes).
 // See
-// https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/ruby/ruby_generator.cc#L250
+// https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/ruby/ruby_generator.cc#L250
 // TODO: keep up to date with protoc code generation, though this behavior isn't
 // expected to change
 bool IsLower(char ch) { return ch >= 'a' && ch <= 'z'; }

--- a/src/cpp/Protobuf-C++.podspec
+++ b/src/cpp/Protobuf-C++.podspec
@@ -2,12 +2,12 @@ Pod::Spec.new do |s|
   s.name     = 'Protobuf-C++'
   s.version  = '3.15.8'
   s.summary  = 'Protocol Buffers v3 runtime library for C++.'
-  s.homepage = 'https://github.com/google/protobuf'
+  s.homepage = 'https://github.com/protocolbuffers/protobuf'
   s.license  = '3-Clause BSD License'
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
   s.cocoapods_version = '>= 1.0'
 
-  s.source = { :git => 'https://github.com/google/protobuf.git',
+  s.source = { :git => 'https://github.com/protocolbuffers/protobuf.git',
                :tag => "v#{s.version}" }
 
   s.source_files = 'src/google/protobuf/*.{h,cc,inc}',

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -354,7 +354,7 @@ namespace Grpc.Tools
             {
                 Log.LogError("Proto compiler currently allows only one input when " +
                              "--dependency_out is specified (via ProtoDepDir or DependencyOut). " +
-                             "Tracking issue: https://github.com/google/protobuf/pull/3959");
+                             "Tracking issue: https://github.com/protocolbuffers/protobuf/pull/3959");
             }
 
             // Use ProtoDepDir to autogenerate DependencyOut

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
     The generated code will have a dependency on the Protobuf Objective-C runtime of the same
     version. The runtime can be obtained as the "Protobuf" pod.
   DESC
-  s.homepage = 'https://github.com/google/protobuf'
+  s.homepage = 'https://github.com/protocolbuffers/protobuf'
   s.license  = {
     :type => 'New BSD',
     :text => <<-LICENSE

--- a/src/objective-c/README.md
+++ b/src/objective-c/README.md
@@ -176,8 +176,8 @@ This will download and run the [gRPC install script][].
 ### Install _protoc_ and the gRPC plugin without using Homebrew
 
 First install v3 of the Protocol Buffers compiler (_protoc_), by cloning
-[its Git repository](https://github.com/google/protobuf) and following these
-[installation instructions](https://github.com/google/protobuf#c-installation---unix)
+[its Git repository](https://github.com/protocolbuffers/protobuf) and following these
+[installation instructions](https://github.com/protocolbuffers/protobuf#c-installation---unix)
 (the ones titled C++; don't miss the note for Mac users).
 
 Then clone this repository and execute the following commands from the root directory where it was
@@ -212,7 +212,7 @@ files:
 
 * [Podspec](https://github.com/grpc/grpc/blob/master/gRPC.podspec) for the Objective-C gRPC runtime
 library. This can be tedious to configure manually.
-* [Podspec](https://github.com/google/protobuf/blob/master/Protobuf.podspec) for the
+* [Podspec](https://github.com/protocolbuffers/protobuf/blob/master/Protobuf.podspec) for the
 Objective-C Protobuf runtime library.
 
 [Protocol Buffers]:https://developers.google.com/protocol-buffers/

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -872,7 +872,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
                            // - If you're developing the server, consider using response streaming,
                            // or let clients filter
                            //   responses by setting a google.protobuf.FieldMask in the request:
-                           //   https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto
+                           //   https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto
                            XCTAssertEqualObjects(
                                error.localizedDescription,
                                @"Received message larger than max (4194305 vs. 4194304)");

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -141,7 +141,7 @@ v1.8.0 | 3.5.0 | v1.21.3 | 3.7.0
 
 If `protoc` hasn't been installed, you can download the `protoc` binary from
 the protocol buffers
-[Github repository](https://github.com/google/protobuf/releases).
+[Github repository](https://github.com/protocolbuffers/protobuf/releases).
 Then unzip this file and update the environment variable `PATH` to include the
 path to the protoc binary file.
 

--- a/src/proto/grpc/testing/xds/v3/ads.proto
+++ b/src/proto/grpc/testing/xds/v3/ads.proto
@@ -40,6 +40,6 @@ service AggregatedDiscoveryService {
 }
 
 // [#not-implemented-hide:] Not configuration. Workaround c++ protobuf issue with importing
-// services: https://github.com/google/protobuf/issues/4221
+// services: https://github.com/protocolbuffers/protobuf/issues/4221
 message AdsPhony {
 }

--- a/src/python/grpcio_tests/tests/testing/_application_testing_common.py
+++ b/src/python/grpcio_tests/tests/testing/_application_testing_common.py
@@ -18,7 +18,7 @@ from tests.testing.proto import requests_pb2
 from tests.testing.proto import services_pb2
 
 # TODO(https://github.com/grpc/grpc/issues/11657): Eliminate this entirely.
-# TODO(https://github.com/google/protobuf/issues/3452): Eliminate this if/else.
+# TODO(https://github.com/protocolbuffers/protobuf/issues/3452): Eliminate this if/else.
 if services_pb2.DESCRIPTOR.services_by_name.get('FirstService') is None:
     FIRST_SERVICE = 'Fix protobuf issue 3452!'
     FIRST_SERVICE_UNUN = 'Fix protobuf issue 3452!'

--- a/src/python/grpcio_tests/tests/testing/_client_test.py
+++ b/src/python/grpcio_tests/tests/testing/_client_test.py
@@ -28,7 +28,7 @@ from tests.testing.proto import services_pb2
 from tests.unit.framework.common import test_constants
 
 
-# TODO(https://github.com/google/protobuf/issues/3452): Drop this skip.
+# TODO(https://github.com/protocolbuffers/protobuf/issues/3452): Drop this skip.
 @unittest.skipIf(
     services_pb2.DESCRIPTOR.services_by_name.get('FirstService') is None,
     'Fix protobuf issue 3452!')

--- a/templates/src/objective-c/!ProtoCompiler.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler.podspec.template
@@ -47,7 +47,7 @@
       The generated code will have a dependency on the Protobuf Objective-C runtime of the same
       version. The runtime can be obtained as the "Protobuf" pod.
     DESC
-    s.homepage = 'https://github.com/google/protobuf'
+    s.homepage = 'https://github.com/protocolbuffers/protobuf'
     s.license  = {
       :type => 'New BSD',
       :text => <<-LICENSE

--- a/test/core/util/tsan_suppressions.txt
+++ b/test/core/util/tsan_suppressions.txt
@@ -7,7 +7,7 @@ race:ssleay_rand_add
 race:ssleay_rand_bytes
 race:__sleep_for
 # protobuf has an idempotent write race in ByteSize/GetCachedSize
-# https://github.com/google/protobuf/issues/2169
+# https://github.com/protocolbuffers/protobuf/issues/2169
 race:ByteSize
 race:ByteSizeLong
 race:GetCachedSize

--- a/test/distrib/ruby/run_distrib_test.sh
+++ b/test/distrib/ruby/run_distrib_test.sh
@@ -51,7 +51,7 @@ bundle install
 bundle exec ./distribtest.rb
 
 [[ "$PACKAGE_TYPE" == "source" ]] && exit 0
-# Attempt to repro https://github.com/google/protobuf/issues/4210.
+# Attempt to repro https://github.com/protocolbuffers/protobuf/issues/4210.
 # This sanity check only works for linux-based distrib tests and for
 # binary gRPC packages.
 INSTALLATION_DIR="$(gem env | grep '\- INSTALLATION DIRECTORY' | awk '{ print $4 }')"

--- a/tools/dockerfile/grpc_dist_proto/Dockerfile
+++ b/tools/dockerfile/grpc_dist_proto/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get -y install libgtest-dev
 
 # Get the protobuf source from GitHub.
 RUN mkdir -p /var/local/git
-RUN git clone https://github.com/google/protobuf.git /var/local/git/protobuf
+RUN git clone https://github.com/protocolbuffers/protobuf.git /var/local/git/protobuf
 
 # Build the protobuf library statically and install to /tmp/protoc_static.
 WORKDIR /var/local/git/protobuf


### PR DESCRIPTION
Looks like google/protobuf's redirect got nuked, and now things break without pointing our protobuf submodule to the proper URL.