### PR TITLE
Change experimental performance test to run on a new cluster

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -26,7 +26,7 @@ gcloud auth configure-docker
 
 # Connect to benchmarks-prod cluster.
 gcloud config set project grpc-testing
-gcloud container clusters get-credentials benchmarks-prod2 \
+gcloud container clusters get-credentials benchmarks-kb3 \
     --zone us-central1-b --project grpc-testing
 
 # List tests that have running pods and are in errored state.


### PR DESCRIPTION
Change experimental continuous integration cluster to benchmarks-kb3.
