### PR TITLE
Avoid unsetting target_proxy when it is actually a gRPC target proxy

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -412,7 +412,7 @@ class TrafficDirectorManager:
     def delete_target_http_proxy(self, force=False):
         if force:
             name = self.make_resource_name(self.TARGET_PROXY_NAME)
-        elif self.target_proxy:
+        elif self.target_proxy and self.target_proxy_is_http:
             name = self.target_proxy.name
         else:
             return


### PR DESCRIPTION
Otherwise, unless force_cleanup is set to true, the HTTP target proxy
deletion fails but still unsets the target_proxy field, resulting in the
gRPC target proxy deletion being skipped (and preventing all subsequent
cleanup operations)
