### PR TITLE
Provide correct len to getsockopt(TCP_INFO).

### DIFF
--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -190,7 +190,7 @@ void extract_opt_stats_from_cmsg(ConnectionMetrics* metrics,
 
 static int get_socket_tcp_info(grpc_core::tcp_info* info, int fd) {
   memset(info, 0, sizeof(*info));
-  info->length = sizeof(*info) - sizeof(socklen_t);
+  info->length = offsetof(grpc_core::tcp_info, length);
   return getsockopt(fd, IPPROTO_TCP, TCP_INFO, info, &(info->length));
 }
 } /* namespace */


### PR DESCRIPTION
The alignment of `grpc_core::tcp_info` is 8-bytes and `socketlen_t` is
4-bytes. So, there is one 4-byte padding at the end of `tcp_info`:

```
grpc_core::tcp_info {
  ...
  uint64_t tcpi_pacing_rate;
  ...
  socklen_t len;
  // There is a 4-byte hole here.
}
```

So, the length we calculate here is actually including len (we are
giving kernel 4 bytes more than we should):

  info->length = sizeof(*info) - sizeof(socklen_t);

Kernel copies the length first, then copies the content. Hence it
overwrites the field by `tcpi_rcv_ooopack`. In cases, where the
`tcpi_rcv_ooopack` is less than the size of `grpc_core::tcp_info` we
won't get an asan error but otherwise we will correctly get an
asan complaint.

AFAICT, there is no real bufferoverflow though.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
