### PR TITLE
short-circuit retry code when retries not configured

### DIFF
--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -2189,6 +2189,11 @@ void RetryFilter::CallData::StartTransportStreamOpBatch(
   }
   // If we do not yet have a call attempt, create one.
   if (call_attempt_ == nullptr) {
+    // If there is no retry policy, then commit retries immediately.
+    // This ensures that the code below will always jump to the fast path.
+    // TODO(roth): Remove this special case when we implement
+    // transparent retries.
+    if (retry_policy_ == nullptr) retry_committed_ = true;
     // If this is the first batch and retries are already committed
     // (e.g., if this batch put the call above the buffer size limit), then
     // immediately create an LB call and delegate the batch to it.  This


### PR DESCRIPTION
Pulling this out of #26766.

When the full retry code-path is enabled, users of the C++ API that fail to call `Finish()` before unreffing a call will see a memory leak.  This is a bug in the user's code, not a bug in gRPC, but until now the consequences of that bug have not been as severe.

To avoid immediate problems caused by this, this PR adds a short-circuit that bypasses the vast majority of the retry code if retries are not actually configured, even if the retry filter is enabled via the channel arg (which will soon be on by default).  This will limit the set of users affected by this problem: it will be a problem only for those that both (a) fail to call `Finish()` and (b) explicitly configure retries.

Note that this short-circuit will need to be removed when we implement transparent retries.  Before that happens, we will need to warn users that they need to make sure they are calling `Finish()` on every call.

CC @ctiller 