### PR TITLE
PHP: deleted require paths, updated grpc to v1.39.0

### DIFF
--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -2,7 +2,7 @@
   "name": "grpc/grpc-demo",
   "description": "gRPC example for PHP",
   "require": {
-    "grpc/grpc": "^v1.30.0",
+    "grpc/grpc": "^v1.39.0",
     "google/protobuf": "^v3.12.2"
   },
   "autoload": {

--- a/examples/php/greeter_and_routeguide_multi_server.php
+++ b/examples/php/greeter_and_routeguide_multi_server.php
@@ -17,12 +17,6 @@
  *
  */
 
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/MethodDescriptor.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/Status.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/ServerCallReader.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/ServerCallWriter.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/ServerContext.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/RpcServer.php';
 require dirname(__FILE__) . '/vendor/autoload.php';
 require dirname(__FILE__) . '/route_guide/RouteGuideService.php';
 

--- a/examples/php/greeter_server.php
+++ b/examples/php/greeter_server.php
@@ -17,12 +17,6 @@
  *
  */
 
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/MethodDescriptor.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/Status.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/ServerCallReader.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/ServerCallWriter.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/ServerContext.php';
-require dirname(__FILE__) . '/../../src/php/lib/Grpc/RpcServer.php';
 require dirname(__FILE__) . '/vendor/autoload.php';
 
 class Greeter extends Helloworld\GreeterStub

--- a/examples/php/route_guide/route_guide_server.php
+++ b/examples/php/route_guide/route_guide_server.php
@@ -17,12 +17,6 @@
  *
  */
 
-require dirname(__FILE__) . '/../../../src/php/lib/Grpc/MethodDescriptor.php';
-require dirname(__FILE__) . '/../../../src/php/lib/Grpc/Status.php';
-require dirname(__FILE__) . '/../../../src/php/lib/Grpc/ServerCallReader.php';
-require dirname(__FILE__) . '/../../../src/php/lib/Grpc/ServerCallWriter.php';
-require dirname(__FILE__) . '/../../../src/php/lib/Grpc/ServerContext.php';
-require dirname(__FILE__) . '/../../../src/php/lib/Grpc/RpcServer.php';
 require dirname(__FILE__) . '/../vendor/autoload.php';
 require dirname(__FILE__) . '/RouteGuideService.php';
 

--- a/src/php/tests/generated_code/math_server.php
+++ b/src/php/tests/generated_code/math_server.php
@@ -17,12 +17,6 @@
  *
  */
 
-require dirname(__FILE__) . '/../../lib/Grpc/MethodDescriptor.php';
-require dirname(__FILE__) . '/../../lib/Grpc/Status.php';
-require dirname(__FILE__) . '/../../lib/Grpc/ServerCallReader.php';
-require dirname(__FILE__) . '/../../lib/Grpc/ServerCallWriter.php';
-require dirname(__FILE__) . '/../../lib/Grpc/ServerContext.php';
-require dirname(__FILE__) . '/../../lib/Grpc/RpcServer.php';
 include 'vendor/autoload.php';
 
 class MathService extends Math\MathStub

--- a/src/php/tests/generated_code/package.json
+++ b/src/php/tests/generated_code/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "@grpc/proto-loader": "^0.1.0",
-    "grpc": "^1.11.0"
+    "grpc": "^1.39.0"
   }
 }


### PR DESCRIPTION
last step to complete php server.
deleted unnecessary paths from require, updated grpc to v1.39.0 for examples and tests.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
@stanley-cheung 
