### PR TITLE
Add tooling to auto-fix sanity tests

### DIFF
--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -62,3 +62,4 @@ jobs:
 
             We noticed that our 'sanity' test was going to fail, but we think we can fix that automatically, so we put together this PR to do just that!
 
+            If you'd like to opt-out of these PR's, add yourself to NO_AUTOFIX_USERS in .github/workflows/pr-auto-fix.yaml

--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -1,0 +1,64 @@
+name: PR AutoFix
+on: [push]
+jobs:
+  PRAutoFix:
+    runs-on: ubuntu-latest
+    steps:
+      # Cancel current runs if they're still running
+      # (saves processing on fast pushes)
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+      # Allow opt-out for some users
+      - name: Should I Stay Or Should I Go
+        uses: actions/github-script@v4
+        id: check
+        with:
+          script: |
+            // If you'd like not to run this code on your commits, add your github user id here:
+            NO_AUTOFIX_USERS = []
+            const { owner, repo } = context.repo
+            if (NO_AUTOFIX_USERS.includes(context.actor)) {
+              console.log('Cancelling');
+              const run_id = "${{ github.run_id }}";
+              await github.actions.cancelWorkflowRun({ owner, repo, run_id });
+              return 'go';
+            } else {
+              return 'stay';
+            }
+      - name: Wait for cancellation
+        run: sleep 60
+        if: steps.check.outputs.result == 'go'
+      - name: Should build?
+        run: test "${{ steps.check.outputs.result }}" = "stay"
+      # Setup to run sanity suite
+      - name: Install Python Interpreter
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Python Packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml mako
+          sudo apt-get install python-dev
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          submodules: True
+          fetch-depth: 0
+      # Run the things!
+      - name: clang-tidy fixes
+        run: ${{ github.workspace }}/tools/distrib/clang_tidy_code.sh --fix --only-changed || true
+      - name: Run sanitize
+        run: ${{ github.workspace }}/tools/distrib/sanitize.sh
+      # Report back with a PR if things are broken
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "Automated change: Fix sanity tests"
+          body: |
+            PanCakes to the rescue!
+
+            We noticed that our 'sanity' test was going to fail, but we think we can fix that automatically, so we put together this PR to do just that!
+

--- a/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
@@ -17,7 +17,7 @@
   FROM debian:bullseye
   
   # Install clang-tidy 11
-  RUN apt-get update && apt-get install -y clang-tidy-11 jq
+  RUN apt-get update && apt-get install -y clang-tidy-11 jq git
   ENV CLANG_TIDY=clang-tidy-11
 
   ADD clang_tidy_all_the_things.sh /

--- a/tools/distrib/run_clang_tidy.py
+++ b/tools/distrib/run_clang_tidy.py
@@ -34,7 +34,8 @@ argp.add_argument('-j',
                   type=int,
                   default=multiprocessing.cpu_count(),
                   help='Number of CPUs to use')
-argp.set_defaults(fix=False)
+argp.add_argument('--only-changed', dest='only_changed', action='store_true')
+argp.set_defaults(fix=False, only_changed=False)
 args = argp.parse_args()
 
 # Explicitly passing the .clang-tidy config by reading it.
@@ -50,6 +51,19 @@ cmdline = [
 
 if args.fix:
     cmdline.append('--fix')
+
+if args.only_changed:
+    orig_files = set(args.files)
+    actual_files = []
+    output = subprocess.check_output(
+        ['git', 'diff', 'origin/master', 'HEAD', '--name-only'])
+    for line in output.decode('ascii').splitlines(False):
+        if line in orig_files:
+            print("check: %s" % line)
+            actual_files.append(line)
+        else:
+            print("skip: %s - not in the build" % line)
+    args.files = actual_files
 
 jobs = []
 for filename in args.files:

--- a/tools/distrib/sanitize.sh
+++ b/tools/distrib/sanitize.sh
@@ -18,8 +18,10 @@ set -ex
 cd $(dirname $0)/../..
 
 tools/buildgen/generate_projects.sh
-tools/distrib/clang_format_code.sh
 tools/distrib/check_copyright.py --fix
 tools/distrib/check_trailing_newlines.sh --fix
 tools/run_tests/sanity/check_port_platform.py --fix
+tools/distrib/clang_format_code.sh
+tools/distrib/buildifier_format_code.sh
+tools/distrib/yapf_code.sh
 

--- a/tools/distrib/sanitize.sh
+++ b/tools/distrib/sanitize.sh
@@ -23,5 +23,4 @@ tools/distrib/check_trailing_newlines.sh --fix
 tools/run_tests/sanity/check_port_platform.py --fix
 tools/distrib/clang_format_code.sh
 tools/distrib/buildifier_format_code.sh
-tools/distrib/yapf_code.sh
 

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -15,7 +15,7 @@
 FROM debian:bullseye
 
 # Install clang-tidy 11
-RUN apt-get update && apt-get install -y clang-tidy-11 jq
+RUN apt-get update && apt-get install -y clang-tidy-11 jq git
 ENV CLANG_TIDY=clang-tidy-11
 
 ADD clang_tidy_all_the_things.sh /


### PR DESCRIPTION
If sanity tests would fail and we can fix them, send a PR to do so.
If no changes are required, send no PR.

Adds a change to clang-tidy stuff to only check files that have changed.