### PR TITLE
Upgrade gcr.io/oss-fuzz-base/base-builder to the latest

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -21,7 +21,7 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Werror",
     # Ignore unknown warning flags
     "-Wno-unknown-warning-option",
-    # A list of flags coming from internal build system
+    # A list of enabled flags coming from internal build system
     "-Wc++20-extensions",
     "-Wctad-maybe-unsupported",
     "-Wdeprecated-increment-bool",
@@ -41,6 +41,8 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wthread-safety-beta",
     "-Wunused-comparison",
     "-Wvla",
+    # A list of disabled flags coming from internal build system
+    "-Wno-string-concatenation",
     # Exceptions but will be removed
     "-Wno-deprecated-declarations",
     "-Wno-unused-function",

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -48,12 +48,6 @@
       python3-all-dev ${'\\'}
       python-setuptools
 
-  # Install Python packages from PyPI
-  RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
-  RUN pip install --upgrade pip==19.3.1
-  RUN pip install virtualenv==20.7.0
-  RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.17.3 six==1.16.0 twisted==19.10.0
-
   <%include file="../../compile_python_36.include"/>
 
   <%include file="../../bazel.include"/>

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -17,10 +17,8 @@
   # Pinned version of the base image is used to avoid regressions caused
   # by rebuilding of this docker image. To see available versions, you can run
   # "gcloud container images list-tags gcr.io/oss-fuzz-base/base-builder"
-  # TODO(jtattermusch): with the latest version we'd get clang12+
-  # which makes our build fail due to new warnings being treated
-  # as errors.
-  FROM gcr.io/oss-fuzz-base/base-builder@sha256:de220fd2433cd53bd06b215770dcd14a5e74632e0215acea7401fee8cafb18da
+  # Image(c7f1523ebd92) is built on Jul 29, 2021
+  FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c06569143373be019c92f1e6df18a1e048f37
   
   # -------------------------- WARNING --------------------------------------
   # If you are making changes to this file, consider changing
@@ -41,9 +39,16 @@
     openjdk-8-jdk ${'\\'}
     vim
   
-  <%include file="../../python_deps.include"/>
+  # Install dependencies
+  RUN apt-get update && apt-get install -y ${'\\'}
+      python-all-dev ${'\\'}
+      python3-all-dev ${'\\'}
+      python-setuptools
 
-  <%include file="../../compile_python_36.include"/>
+  # Install Python packages from PyPI
+  RUN curl https://bootstrap.pypa.io/get-pip.py | python3
+  RUN pip install virtualenv
+  RUN pip install futures enum34 protobuf six twisted
 
   <%include file="../../bazel.include"/>
   

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -39,6 +39,9 @@
     openjdk-8-jdk ${'\\'}
     vim
   
+  #====================
+  # Python dependencies
+
   # Install dependencies
   RUN apt-get update && apt-get install -y ${'\\'}
       python-all-dev ${'\\'}
@@ -48,7 +51,27 @@
   # Install Python packages from PyPI
   RUN curl https://bootstrap.pypa.io/get-pip.py | python3
   RUN pip install virtualenv
-  RUN pip install futures enum34 protobuf six twisted
+  RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.17.3 six==1.15.0 twisted
+
+  #=================
+  # Compile CPython 3.6.9 from source
+
+  RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+  RUN apt-get update && apt-get install -y jq build-essential libffi-dev
+
+  RUN cd /tmp && ${'\\'}
+      wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
+      tar xzvf Python-3.6.9.tgz && ${'\\'}
+      cd Python-3.6.9 && ${'\\'}
+      ./configure && ${'\\'}
+      make install
+
+  RUN cd /tmp && ${'\\'}
+      echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && ${'\\'}
+      md5sum -c checksum.md5
+
+  RUN python3.6 -m ensurepip && ${'\\'}
+      python3.6 -m pip install coverage
 
   <%include file="../../bazel.include"/>
   

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -49,29 +49,12 @@
       python-setuptools
 
   # Install Python packages from PyPI
-  RUN curl https://bootstrap.pypa.io/get-pip.py | python3
-  RUN pip install virtualenv
-  RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.17.3 six==1.15.0 twisted
+  RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+  RUN pip install --upgrade pip==19.3.1
+  RUN pip install virtualenv==20.7.0
+  RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.17.3 six==1.16.0 twisted==19.10.0
 
-  #=================
-  # Compile CPython 3.6.9 from source
-
-  RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
-  RUN apt-get update && apt-get install -y jq build-essential libffi-dev
-
-  RUN cd /tmp && ${'\\'}
-      wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
-      tar xzvf Python-3.6.9.tgz && ${'\\'}
-      cd Python-3.6.9 && ${'\\'}
-      ./configure && ${'\\'}
-      make install
-
-  RUN cd /tmp && ${'\\'}
-      echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && ${'\\'}
-      md5sum -c checksum.md5
-
-  RUN python3.6 -m ensurepip && ${'\\'}
-      python3.6 -m pip install coverage
+  <%include file="../../compile_python_36.include"/>
 
   <%include file="../../bazel.include"/>
   

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -47,9 +47,10 @@ RUN apt-get update && apt-get install -y \
     python-setuptools
 
 # Install Python packages from PyPI
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3
-RUN pip install virtualenv
-RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.17.3 six==1.15.0 twisted
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+RUN pip install --upgrade pip==19.3.1
+RUN pip install virtualenv==20.7.0
+RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.17.3 six==1.16.0 twisted==19.10.0
 
 #=================
 # Compile CPython 3.6.9 from source
@@ -70,6 +71,7 @@ RUN cd /tmp && \
 
 RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage
+
 
 #========================
 # Bazel installation

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -46,12 +46,6 @@ RUN apt-get update && apt-get install -y \
     python3-all-dev \
     python-setuptools
 
-# Install Python packages from PyPI
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
-RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv==20.7.0
-RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.17.3 six==1.16.0 twisted==19.10.0
-
 #=================
 # Compile CPython 3.6.9 from source
 

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -37,6 +37,9 @@ RUN apt-get update && apt-get -y install \
   openjdk-8-jdk \
   vim
 
+#====================
+# Python dependencies
+
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     python-all-dev \
@@ -46,7 +49,27 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3
 RUN pip install virtualenv
-RUN pip install futures enum34 protobuf six twisted
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.17.3 six==1.15.0 twisted
+
+#=================
+# Compile CPython 3.6.9 from source
+
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
+
+RUN cd /tmp && \
+    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+    tar xzvf Python-3.6.9.tgz && \
+    cd Python-3.6.9 && \
+    ./configure && \
+    make install
+
+RUN cd /tmp && \
+    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
+    md5sum -c checksum.md5
+
+RUN python3.6 -m ensurepip && \
+    python3.6 -m pip install coverage
 
 #========================
 # Bazel installation

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -15,10 +15,8 @@
 # Pinned version of the base image is used to avoid regressions caused
 # by rebuilding of this docker image. To see available versions, you can run
 # "gcloud container images list-tags gcr.io/oss-fuzz-base/base-builder"
-# TODO(jtattermusch): with the latest version we'd get clang12+
-# which makes our build fail due to new warnings being treated
-# as errors.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:de220fd2433cd53bd06b215770dcd14a5e74632e0215acea7401fee8cafb18da
+# Image(c7f1523ebd92) is built on Jul 29, 2021
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c06569143373be019c92f1e6df18a1e048f37
 
 # -------------------------- WARNING --------------------------------------
 # If you are making changes to this file, consider changing
@@ -39,43 +37,16 @@ RUN apt-get update && apt-get -y install \
   openjdk-8-jdk \
   vim
 
-#====================
-# Python dependencies
-
 # Install dependencies
-
 RUN apt-get update && apt-get install -y \
     python-all-dev \
     python3-all-dev \
     python-setuptools
 
 # Install Python packages from PyPI
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
-RUN pip install --upgrade pip==19.3.1
-RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
-
-
-#=================
-# Compile CPython 3.6.9 from source
-
-RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
-RUN apt-get update && apt-get install -y jq build-essential libffi-dev
-
-RUN cd /tmp && \
-    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
-    tar xzvf Python-3.6.9.tgz && \
-    cd Python-3.6.9 && \
-    ./configure && \
-    make install
-
-RUN cd /tmp && \
-    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
-    md5sum -c checksum.md5
-
-RUN python3.6 -m ensurepip && \
-    python3.6 -m pip install coverage
-
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3
+RUN pip install virtualenv
+RUN pip install futures enum34 protobuf six twisted
 
 #========================
 # Bazel installation

--- a/tools/dockerfile/test/binder_transport_apk/Dockerfile
+++ b/tools/dockerfile/test/binder_transport_apk/Dockerfile
@@ -15,10 +15,8 @@
 # Pinned version of the base image is used to avoid regressions caused
 # by rebuilding of this docker image. To see available versions, you can run
 # "gcloud container images list-tags gcr.io/oss-fuzz-base/base-builder"
-# TODO(jtattermusch): with the latest version we'd get clang12+
-# which makes our build fail due to new warnings being treated
-# as errors.
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:de220fd2433cd53bd06b215770dcd14a5e74632e0215acea7401fee8cafb18da
+# Image(c7f1523ebd92) is built on Jul 29, 2021
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c06569143373be019c92f1e6df18a1e048f37
 
 # This Dockerfile creates the environment for compiling and e2e testing of Android binder transport implementation
 


### PR DESCRIPTION
Upgraded `gcr.io/oss-fuzz-base/base-builder` used in the bazel docker image to the latest so that it can use clang-12. This is to get the latest clang to use recent clang-tidy and clang warnings.

