### PR TITLE
Fix OOM issues in qps async tests

### DIFF
--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -90,7 +90,7 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
 
     int num_threads = config.async_server_threads();
     if (num_threads <= 0) {  // dynamic sizing
-      num_threads = cores();
+      num_threads = std::min(64, cores());
       gpr_log(GPR_INFO, "Sizing async server to %d threads", num_threads);
     }
 

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -91,7 +91,11 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     int num_threads = config.async_server_threads();
     if (num_threads <= 0) {  // dynamic sizing
       num_threads = std::min(64, cores());
-      gpr_log(GPR_INFO, "Sizing async server to %d threads. Defaults to number of cores in machine or 64 threads if machine has more than 64 cores to avoid OOMs.", num_threads);
+      gpr_log(GPR_INFO,
+              "Sizing async server to %d threads. Defaults to number of cores "
+              "in machine or 64 threads if machine has more than 64 cores to "
+              "avoid OOMs.",
+              num_threads);
     }
 
     int tpc = std::max(1, config.threads_per_cq());  // 1 if unspecified

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -91,7 +91,7 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     int num_threads = config.async_server_threads();
     if (num_threads <= 0) {  // dynamic sizing
       num_threads = std::min(64, cores());
-      gpr_log(GPR_INFO, "Sizing async server to %d threads", num_threads);
+      gpr_log(GPR_INFO, "Sizing async server to %d threads. Defaults to number of cores in machine or 64 threads if machine has more than 64 cores to avoid OOMs.", num_threads);
     }
 
     int tpc = std::max(1, config.threads_per_cq());  // 1 if unspecified


### PR DESCRIPTION
In the QPS async tests, we used num_cores as the default number of cqs used. The issue is that the number of cores in machines nowadays can be something like 256 cores vs. roughly 64 when the tests were written, which causes these tests to OOM. 

This change caps the number of cqs at 64.