### PR TITLE
Open census call attempt span name and attribute changes

### DIFF
--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -238,8 +238,6 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
     }
     ++num_active_rpcs_;
   }
-  // Per-attempt spans use the overall-call span as the parent.
-  GPR_DEBUG_ASSERT(context_.Context().IsValid());
   if (is_first_attempt) {
     return arena_->New<OpenCensusCallAttemptTracer>(
         this, attempt_num, is_transparent_retry, true /* arena_allocated */);

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -56,11 +56,25 @@ grpc_error_handle CensusClientCallData::Init(
 // OpenCensusCallTracer::OpenCensusCallAttemptTracer
 //
 
+OpenCensusCallTracer::OpenCensusCallAttemptTracer::OpenCensusCallAttemptTracer(
+    OpenCensusCallTracer* parent, uint64_t attempt_num,
+    bool is_transparent_retry, bool arena_allocated)
+    : parent_(parent),
+      arena_allocated_(arena_allocated),
+      context_(CensusContext(absl::StrCat("Attempt.", parent_->method_),
+                             &parent_->context_.Span(),
+                             parent_->context_.tags())),
+      start_time_(absl::Now()) {
+  GPR_DEBUG_ASSERT(parent_->context_.Context().IsValid());
+  context_.AddSpanAttribute("previous-rpc-attempts", attempt_num);
+  context_.AddSpanAttribute("transparent-retry", is_transparent_retry);
+  memset(&stats_bin_, 0, sizeof(grpc_linked_mdelem));
+  memset(&tracing_bin_, 0, sizeof(grpc_linked_mdelem));
+}
+
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
     RecordSendInitialMetadata(grpc_metadata_batch* send_initial_metadata,
                               uint32_t /* flags */) {
-  GenerateClientContextFromParentWithTags(parent_->qualified_method_, &context_,
-                                          parent_->context_);
   size_t tracing_len = TraceContextSerialize(context_.Context(), tracing_buf_,
                                              kMaxTraceContextLen);
   if (tracing_len > 0) {
@@ -173,11 +187,10 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordEnd(
 OpenCensusCallTracer::OpenCensusCallTracer(const grpc_call_element_args* args)
     : path_(grpc_slice_ref_internal(args->path)),
       method_(GetMethod(&path_)),
-      qualified_method_(absl::StrCat("Sent.", method_)),
       arena_(args->arena) {
   auto* parent_context = reinterpret_cast<CensusContext*>(
       args->context[GRPC_CONTEXT_TRACING].value);
-  GenerateClientContext(qualified_method_, &context_,
+  GenerateClientContext(absl::StrCat("Sent.", method_), &context_,
                         (parent_context == nullptr) ? nullptr : parent_context);
 }
 
@@ -199,6 +212,7 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
   // the heap, so that in the common case we don't require a heap allocation,
   // nor do we unnecessarily grow the arena.
   bool is_first_attempt = true;
+  uint64_t attempt_num;
   {
     grpc_core::MutexLock lock(&mu_);
     if (transparent_retries_ != 0 || retries_ != 0) {
@@ -207,6 +221,7 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
         retry_delay_ += absl::Now() - time_at_last_attempt_end_;
       }
     }
+    attempt_num = retries_;
     if (is_transparent_retry) {
       ++transparent_retries_;
     } else {
@@ -215,10 +230,11 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
     ++num_active_rpcs_;
   }
   if (is_first_attempt) {
-    return arena_->New<OpenCensusCallAttemptTracer>(this,
-                                                    true /* arena_allocated */);
+    return arena_->New<OpenCensusCallAttemptTracer>(
+        this, attempt_num, is_transparent_retry, true /* arena_allocated */);
   }
-  return new OpenCensusCallAttemptTracer(this, false /* arena_allocated */);
+  return new OpenCensusCallAttemptTracer(
+      this, attempt_num, is_transparent_retry, false /* arena_allocated */);
 }
 
 }  // namespace grpc

--- a/src/cpp/ext/filters/census/context.cc
+++ b/src/cpp/ext/filters/census/context.cc
@@ -67,16 +67,6 @@ void GenerateClientContext(absl::string_view method, CensusContext* ctxt,
   new (ctxt) CensusContext(method, tags);
 }
 
-void GenerateClientContextFromParentWithTags(absl::string_view method,
-                                             CensusContext* ctxt,
-                                             const CensusContext& parent_ctxt) {
-  // Destruct the current CensusContext to free the Span memory before
-  // overwriting it below.
-  ctxt->~CensusContext();
-  GPR_DEBUG_ASSERT(parent_ctxt.Context().IsValid());
-  new (ctxt) CensusContext(method, &parent_ctxt.Span(), parent_ctxt.tags());
-}
-
 size_t TraceContextSerialize(const ::opencensus::trace::SpanContext& context,
                              char* tracing_buf, size_t tracing_buf_size) {
   if (tracing_buf_size <

--- a/src/cpp/ext/filters/census/context.h
+++ b/src/cpp/ext/filters/census/context.h
@@ -64,6 +64,11 @@ class CensusContext {
             name, parent_ctxt)),
         tags_({}) {}
 
+  void AddSpanAttribute(absl::string_view key,
+                        opencensus::trace::AttributeValueRef attribute) {
+    span_.AddAttribute(key, attribute);
+  }
+
   const ::opencensus::trace::Span& Span() const { return span_; }
   const ::opencensus::tags::TagMap& tags() const { return tags_; }
 
@@ -105,12 +110,6 @@ void GenerateServerContext(absl::string_view tracing, absl::string_view method,
 // blank CensusContext as it overwrites it.
 void GenerateClientContext(absl::string_view method, CensusContext* ctxt,
                            CensusContext* parent_ctx);
-
-// Creates a new client context with \a parent_ctxt as the parent and propagates
-// the tags as well.
-void GenerateClientContextFromParentWithTags(absl::string_view method,
-                                             CensusContext* ctxt,
-                                             const CensusContext& parent_ctxt);
 
 // Returns the incoming data size from the grpc call final info.
 uint64_t GetIncomingDataSize(const grpc_call_final_info* final_info);

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -30,14 +30,9 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
  public:
   class OpenCensusCallAttemptTracer : public CallAttemptTracer {
    public:
-    explicit OpenCensusCallAttemptTracer(OpenCensusCallTracer* parent,
-                                         bool arena_allocated)
-        : parent_(parent),
-          arena_allocated_(arena_allocated),
-          start_time_(absl::Now()) {
-      memset(&stats_bin_, 0, sizeof(grpc_linked_mdelem));
-      memset(&tracing_bin_, 0, sizeof(grpc_linked_mdelem));
-    }
+    OpenCensusCallAttemptTracer(OpenCensusCallTracer* parent,
+                                uint64_t attempt_num, bool is_transparent_retry,
+                                bool arena_allocated);
     void RecordSendInitialMetadata(
         grpc_metadata_batch* /* send_initial_metadata */,
         uint32_t /* flags */) override;
@@ -95,7 +90,6 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
   // Client method.
   grpc_slice path_;
   absl::string_view method_;
-  std::string qualified_method_;
   CensusContext context_;
   grpc_core::Arena* arena_;
   grpc_core::Mutex mu_;
@@ -106,7 +100,7 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
   // Retry delay
   absl::Duration retry_delay_ ABSL_GUARDED_BY(&mu_);
   absl::Time time_at_last_attempt_end_ ABSL_GUARDED_BY(&mu_);
-  uint32_t num_active_rpcs_ ABSL_GUARDED_BY(&mu_) = 0;
+  uint64_t num_active_rpcs_ ABSL_GUARDED_BY(&mu_) = 0;
 };
 
 };  // namespace grpc


### PR DESCRIPTION
Updates based on https://github.com/grpc/proposal/pull/254/files

1. Per-attempt span name - "Attempt.<service_name>.<method_name>"
2. Add two attributes to the per-attempt span -
   i) `previous-rpc-attempts` - an integer value, number of preceding attempts, transparent retry not included.
   ii) `is-transparent-retry` - a boolean value, whether the attempt is a transparent retry.

