### PR TITLE
Re-experimentalize XdsServerBuilder

### DIFF
--- a/include/grpcpp/xds_server_builder.h
+++ b/include/grpcpp/xds_server_builder.h
@@ -24,6 +24,7 @@
 #include <grpcpp/server_builder.h>
 
 namespace grpc {
+namespace experimental {
 
 class XdsServerServingStatusNotifierInterface {
  public:
@@ -73,17 +74,6 @@ class XdsServerBuilder : public ::grpc::ServerBuilder {
   XdsServerServingStatusNotifierInterface* notifier_ = nullptr;
 };
 
-namespace experimental {
-// TODO(yashykt): Delete this after the 1.41 release.
-GRPC_DEPRECATED(
-    "Use grpc::XdsServerServingStatusNotifierInterface instead. The "
-    "experimental version will be deleted after the 1.41 release.")
-typedef grpc::XdsServerServingStatusNotifierInterface
-    XdsServerServingStatusNotifierInterface;
-GRPC_DEPRECATED(
-    "Use grpc::XdsServerBuilder instead. The experimental version will be "
-    "deleted after the 1.41 release.")
-typedef grpc::XdsServerBuilder XdsServerBuilder;
 }  // namespace experimental
 }  // namespace grpc
 

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -2505,7 +2505,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
       std::ostringstream server_address;
       server_address << "localhost:" << port_;
       if (use_xds_enabled_server_) {
-        XdsServerBuilder builder;
+        experimental::XdsServerBuilder builder;
         if (GetParam().bootstrap_source() ==
             TestType::kBootstrapFromChannelArg) {
           builder.SetOption(

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -55,7 +55,7 @@ using grpc::Server;
 using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::Status;
-using grpc::XdsServerBuilder;
+using grpc::experimental::XdsServerBuilder;
 using grpc::testing::Empty;
 using grpc::testing::HealthCheckServiceImpl;
 using grpc::testing::SimpleRequest;
@@ -128,7 +128,7 @@ void RunServer(bool secure_mode, const int port, const int maintenance_port,
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   if (secure_mode) {
-    grpc::XdsServerBuilder xds_builder;
+    XdsServerBuilder xds_builder;
     xds_builder.RegisterService(&service);
     xds_builder.AddListeningPort(absl::StrCat("0.0.0.0:", port),
                                  grpc::experimental::XdsServerCredentials(


### PR DESCRIPTION
Reason for re-experimentalizing - PR https://github.com/grpc/grpc/pull/26543 to de-experimentalize XdsServerBuilder has not yet made it to a release and there might be some modifications needed here.