### PR TITLE
Add  release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -189,7 +189,8 @@ LANG_RELEASE_MATRIX = {
             ('v1.37.0', ReleaseInfo(runtimes=['go1.11'])),
             # NOTE: starting from release v1.38.0, use runtimes=['go1.16']
             ('v1.38.1', ReleaseInfo(runtimes=['go1.16'])),
-            ('v1.39.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.39.1', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.40.0', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

```
> gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.16
DIGEST        TAGS     TIMESTAMP            VULNERABILITIES
12e59c6bc7ab  v1.40.0  2021-08-11T17:26:17
0fe88cc2e3a5  v1.39.1  2021-08-05T13:39:49  CRITICAL=1,HIGH=7,LOW=198,MEDIUM=30
0fd707d7b388  v1.38.1  2021-07-20T10:25:48  CRITICAL=1,HIGH=7,LOW=199,MEDIUM=30
882f5d476c85  v1.39.0  2021-06-30T10:49:15  CRITICAL=1,HIGH=7,LOW=199,MEDIUM=30
334c21d8db64  v1.38.0  2021-05-19T16:42:53  CRITICAL=1,HIGH=14,LOW=246,MEDIUM=54
79d2758fd03d  v1.37.x  2021-04-29T06:21:16  CRITICAL=1,HIGH=7,LOW=226,MEDIUM=40```
```