### PR TITLE
Use T drive for windows bazel RBE build

### DIFF
--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %BAZEL_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat //test/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc --output_user_root=T:\_bazel_output test --invocation_id="%BAZEL_INVOCATION_ID%" %BAZEL_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
 if not "%UPLOAD_TEST_RESULTS%"=="" (


### PR DESCRIPTION
Currently Kokoro Win2016 image has two discs; the main one (220GB, ~15% free) and the additional one (100GB, ~99% free). Recently Bazel RBE started failing with `Not enough space` because Bazel uses the main drive which doesn't have much free space for output. From the previous trial, ~30GB is needed for the bazel output when running all tests under `//tests/.`.  So let's change the Bazel output directory to use the additional one (mounted to T:\) which has more free space.

##### Space usage (for the reference)

```
kbuilder@kokoro-winserver2016 /tmpfs/_bazel_output/execroot/com_github_grpc_grpc/bazel-out/x64_windows-fastbuild
$ du --max-depth 2 -h | sort -h
301K	./bin/third_party
73M	./testlogs
73M	./testlogs/test
343M	./bin/src
734M	./bin/_objs
1.3G	./bin/external
24G	./bin/test
27G	.
27G	./bin
```