### PR TITLE
Fix C# protoc plugin argument parsing

### DIFF
--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -53,8 +53,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
         generate_server = false;
       } else if (options[i].first == "internal_access") {
         internal_access = true;
-      }
-      if (options[i].first == "file_suffix") {
+      } else if (options[i].first == "file_suffix") {
         file_suffix = options[i].second;
       } else {
         *error = "Unknown generator option: " + options[i].first;


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/26819

https://github.com/grpc/grpc/pull/26162 caused a regression by adding the check for "file_suffix" in an if rather than `else if`, causing the `else` block to always be hit in the case that a non-"file_suffix" option is passed in.
