### PR TITLE
Fix C# protoc plugin argument parsing on 1.40.x

### DIFF
--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -53,8 +53,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
         generate_server = false;
       } else if (options[i].first == "internal_access") {
         internal_access = true;
-      }
-      if (options[i].first == "file_suffix") {
+      } else if (options[i].first == "file_suffix") {
         file_suffix = options[i].second;
       } else {
         *error = "Unknown generator option: " + options[i].first;


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/26896 to 1.40.x
