### PR TITLE
Open census call attempt span name and attribute changes (#26889)

### DIFF
--- a/src/cpp/ext/filters/census/context.cc
+++ b/src/cpp/ext/filters/census/context.cc
@@ -67,16 +67,6 @@ void GenerateClientContext(absl::string_view method, CensusContext* ctxt,
   new (ctxt) CensusContext(method, tags);
 }
 
-void GenerateClientContextFromParentWithTags(absl::string_view method,
-                                             CensusContext* ctxt,
-                                             const CensusContext& parent_ctxt) {
-  // Destruct the current CensusContext to free the Span memory before
-  // overwriting it below.
-  ctxt->~CensusContext();
-  GPR_DEBUG_ASSERT(parent_ctxt.Context().IsValid());
-  new (ctxt) CensusContext(method, &parent_ctxt.Span(), parent_ctxt.tags());
-}
-
 size_t TraceContextSerialize(const ::opencensus::trace::SpanContext& context,
                              char* tracing_buf, size_t tracing_buf_size) {
   if (tracing_buf_size <

--- a/src/cpp/ext/filters/census/context.h
+++ b/src/cpp/ext/filters/census/context.h
@@ -64,6 +64,11 @@ class CensusContext {
             name, parent_ctxt)),
         tags_({}) {}
 
+  void AddSpanAttribute(absl::string_view key,
+                        opencensus::trace::AttributeValueRef attribute) {
+    span_.AddAttribute(key, attribute);
+  }
+
   const ::opencensus::trace::Span& Span() const { return span_; }
   const ::opencensus::tags::TagMap& tags() const { return tags_; }
 
@@ -105,12 +110,6 @@ void GenerateServerContext(absl::string_view tracing, absl::string_view method,
 // blank CensusContext as it overwrites it.
 void GenerateClientContext(absl::string_view method, CensusContext* ctxt,
                            CensusContext* parent_ctx);
-
-// Creates a new client context with \a parent_ctxt as the parent and propagates
-// the tags as well.
-void GenerateClientContextFromParentWithTags(absl::string_view method,
-                                             CensusContext* ctxt,
-                                             const CensusContext& parent_ctxt);
 
 // Returns the incoming data size from the grpc call final info.
 uint64_t GetIncomingDataSize(const grpc_call_final_info* final_info);

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -30,14 +30,9 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
  public:
   class OpenCensusCallAttemptTracer : public CallAttemptTracer {
    public:
-    explicit OpenCensusCallAttemptTracer(OpenCensusCallTracer* parent,
-                                         bool arena_allocated)
-        : parent_(parent),
-          arena_allocated_(arena_allocated),
-          start_time_(absl::Now()) {
-      memset(&stats_bin_, 0, sizeof(grpc_linked_mdelem));
-      memset(&tracing_bin_, 0, sizeof(grpc_linked_mdelem));
-    }
+    OpenCensusCallAttemptTracer(OpenCensusCallTracer* parent,
+                                uint64_t attempt_num, bool is_transparent_retry,
+                                bool arena_allocated);
     void RecordSendInitialMetadata(
         grpc_metadata_batch* /* send_initial_metadata */,
         uint32_t /* flags */) override;
@@ -95,7 +90,6 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
   // Client method.
   grpc_slice path_;
   absl::string_view method_;
-  std::string qualified_method_;
   CensusContext context_;
   grpc_core::Arena* arena_;
   grpc_core::Mutex mu_;
@@ -106,7 +100,7 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
   // Retry delay
   absl::Duration retry_delay_ ABSL_GUARDED_BY(&mu_);
   absl::Time time_at_last_attempt_end_ ABSL_GUARDED_BY(&mu_);
-  uint32_t num_active_rpcs_ ABSL_GUARDED_BY(&mu_) = 0;
+  uint64_t num_active_rpcs_ ABSL_GUARDED_BY(&mu_) = 0;
 };
 
 };  // namespace grpc


### PR DESCRIPTION
Backport #26889 to v1.40.x

* C++ OpenCensus filter: Add attributes to per-attempt span

* Reviewer comments

* Reviewer comment

* Remove extraneous assert

