### PR TITLE
Backport: Fix pytype missing bz2 lib error

### DIFF
--- a/templates/tools/dockerfile/python_debian11.include
+++ b/templates/tools/dockerfile/python_debian11.include
@@ -1,5 +1,5 @@
 FROM debian:bullseye
-  
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y ${'\\'}
   autoconf ${'\\'}
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y time && apt-get clean
 # Install Python 3.7 from source (and installed as a default python3)
 # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
 RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev ${'\\'}
-                                 libnss3-dev libssl-dev libreadline-dev libffi-dev
+                                 libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev
 RUN curl -O https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz && ${'\\'}
     tar -xf Python-3.7.9.tar.xz && ${'\\'}
     cd Python-3.7.9 && ${'\\'}

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -13,7 +13,7 @@
   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   # See the License for the specific language governing permissions and
   # limitations under the License.
-  
+
   <%include file="../../python_debian11.include"/>
   <%include file="../../cxx_deps.include"/>
 

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM debian:bullseye
-  
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y time && apt-get clean
 # Install Python 3.7 from source (and installed as a default python3)
 # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
 RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
-                                 libnss3-dev libssl-dev libreadline-dev libffi-dev
+                                 libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev
 RUN curl -O https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tar.xz && \
     tar -xf Python-3.7.9.tar.xz && \
     cd Python-3.7.9 && \


### PR DESCRIPTION
Backports #26638 to v1.39.x