### PR TITLE
Faster pancakes: cache bazel steps between builds

### DIFF
--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -4,6 +4,14 @@ jobs:
   PRAutoFix:
     runs-on: ubuntu-latest
     steps:
+      # Cache bazel build
+      - name: Cache bazel
+        uses: actions/cache@v2
+        env:
+          cache-name: bazel-cache
+        with:
+          path: ~/.cache/bazel
+          key: ${{ runner.os }}-${{ env.cache-name }}
       # Cancel current runs if they're still running
       # (saves processing on fast pushes)
       - name: Cancel Previous Runs

--- a/src/core/lib/gprpp/table.h
+++ b/src/core/lib/gprpp/table.h
@@ -183,7 +183,7 @@ class Table {
   }
 
   // Move from another table
-  Table(Table&& rhs) noexcept {
+  Table(Table&& rhs)  {
     // Since we know all fields are clear initially, pass false for or_clear.
     Move<false>(absl::make_index_sequence<sizeof...(Ts)>(),
                 std::forward<Table>(rhs));


### PR DESCRIPTION
If we could figure out how to cache the docker image builds too I think we'd be down to a minute or two.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
