### PR TITLE
Experimental: add a roll-up semi-optional status action

### DIFF
--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,5 +1,22 @@
 name: Happy Pancakes
-on: status
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
 jobs:
   check_status:
     name: Check Status

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -26,7 +26,11 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            let pull = await github.pulls.get("grpc", "grpc", ${{ github.event.number }});
+            let pull = await github.pulls.get({
+              owner: "grpc",
+              repo: "grpc",
+              pull_number: ${{ github.event.number }}
+            });
             for (let label in pull.labels) {
               if (label.name == "force-merge") {
                 console.log("Saw force-merge label");

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -2,20 +2,26 @@ name: Ignore - Experimental
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize, ready_for_review, auto_merge_enabled, auto_merge_disabled]
-  status: {}
-  check_run:
-    types: [created, completed]
-  check_suite: 
-    types: [created, completed]
 jobs:
   check_status:
     name: Check Status
     runs-on: ubuntu-latest
     steps:
+      # Cancel current runs if they're still running
+      # (saves processing on fast pushes)
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+      # Wait until our required statuses are ready or failed
+      # Unless force-merge is present, and then just be good.
       - name: Check Status
         uses: actions/github-script@v4
         with:
           script: |
+            function sleep(ms) {
+              return new Promise(resolve => setTimeout(resolve, ms));
+            }
             let pull = await github.pulls.get({
               owner: "grpc",
               repo: "grpc",
@@ -28,24 +34,34 @@ jobs:
                 return;
               }
             }
-            let statuses = await github.repos.listCommitStatusesForRef({
-              owner: "grpc",
-              repo: "grpc",
-              ref: "${{ github.event.pull_request.head.sha }}"
-            });
-            need = new Set();
+            var need = new Set();
             need.add("Bazel Basic build for C/C++");
             need.add("Portability Tests Linux [Build Only] (internal CI)");
-            console.log(statuses);
-            for (var i = 0; i < statuses.data.length; i++) {
-              let status = statuses.data[i];
-              if (status.state == "success") {
-                need.delete(status.context);
+            while (true) {
+              let statuses = await github.repos.listCommitStatusesForRef({
+                owner: "grpc",
+                repo: "grpc",
+                ref: "${{ github.event.pull_request.head.sha }}"
+              });
+              console.log(statuses);
+              var have = 0;
+              for (var i = 0; i < statuses.data.length; i++) {
+                let status = statuses.data[i];
+                if (need.has(status.context)) {
+                  if (status.state == "success") {
+                    have++;
+                  } else if (status.state == "pending") {
+                    // do nothing
+                  } else {
+                    core.setFailed("Required status failed: " + status.context);
+                    return;
+                  }
+                }
               }
+              if (have == need.size) {
+                return;
+              }
+              // Sleep 5 minutes between polls
+              await sleep(5 * 60 * 1000);
             }
-            if (need.size == 0) {
-              return;
-            }
-            console.log(need);
-            core.setFailed("Waiting for: " + [...need].join(', '));
 

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -43,11 +43,10 @@ jobs:
                 repo: "grpc",
                 ref: "${{ github.event.pull_request.head.sha }}"
               });
-              console.log(statuses);
               for (var i = 0; i < statuses.data.length; i++) {
                 let status = statuses.data[i];
+                console.log(status.context, status.state, need);
                 if (need.has(status.context)) {
-                  console.log(status.context, status.state);
                   if (status.state == "success") {
                     need.delete(status.context);
                   } else if (status.state == "pending") {

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -48,6 +48,7 @@ jobs:
               for (var i = 0; i < statuses.data.length; i++) {
                 let status = statuses.data[i];
                 if (need.has(status.context)) {
+                  console.log(status.context, status.state);
                   if (status.state == "success") {
                     have++;
                   } else if (status.state == "pending") {
@@ -58,10 +59,11 @@ jobs:
                   }
                 }
               }
+              console.log(have, need.size);
               if (have == need.size) {
                 return;
               }
-              // Sleep 5 minutes between polls
-              await sleep(5 * 60 * 1000);
+              // Sleep 15 minutes between polls
+              await sleep(15 * 60 * 1000);
             }
 

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,10 +1,10 @@
-name: Ignore - Experimental
+name: Happy Pancakes
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize, ready_for_review, auto_merge_enabled, auto_merge_disabled]
 jobs:
   check_status:
-    name: Check Status
+    name: Check Required Status or force-merge label
     runs-on: ubuntu-latest
     steps:
       # Cancel current runs if they're still running

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -34,23 +34,22 @@ jobs:
                 return;
               }
             }
-            var need = new Set();
-            need.add("Bazel Basic build for C/C++");
-            need.add("Portability Tests Linux [Build Only] (internal CI)");
             while (true) {
+              var need = new Set();
+              need.add("Bazel Basic build for C/C++");
+              need.add("Portability Tests Linux [Build Only] (internal CI)");
               let statuses = await github.repos.listCommitStatusesForRef({
                 owner: "grpc",
                 repo: "grpc",
                 ref: "${{ github.event.pull_request.head.sha }}"
               });
               console.log(statuses);
-              var have = 0;
               for (var i = 0; i < statuses.data.length; i++) {
                 let status = statuses.data[i];
                 if (need.has(status.context)) {
                   console.log(status.context, status.state);
                   if (status.state == "success") {
-                    have++;
+                    need.delete(status.context);
                   } else if (status.state == "pending") {
                     // do nothing
                   } else {
@@ -59,8 +58,7 @@ jobs:
                   }
                 }
               }
-              console.log(have, need.size);
-              if (have == need.size) {
+              if (need.size == 0) {
                 return;
               }
               // Sleep 15 minutes between polls

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -40,7 +40,7 @@ jobs:
             let statuses = await github.repos.listCommitStatusesForRef({
               owner: "grpc",
               repo: "grpc",
-              ref: ${{ github.event.ref }}
+              ref: pull.head.ref
             });
             need = new Set();
             need.add("Bazel Basic build for C/C++");

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -38,7 +38,7 @@ jobs:
               var need = new Set();
               need.add("Bazel Basic build for C/C++");
               need.add("Portability Tests Linux [Build Only] (internal CI)");
-              for (var page=0;; page++) {
+              for (var page=1;; page++) {
                 console.log("***** page " + page);
                 let statuses = await github.repos.listCommitStatusesForRef({
                   owner: "grpc",

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,4 +1,4 @@
-name: Happy Pancakes
+name: Ignore: Experimental
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize, ready_for_review, auto_merge_enabled, auto_merge_disabled]

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,4 +1,4 @@
-name: Ignore: Experimental
+name: Ignore - Experimental
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize, ready_for_review, auto_merge_enabled, auto_merge_disabled]

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -37,8 +37,8 @@ jobs:
             need.add("Bazel Basic build for C/C++");
             need.add("Portability Tests Linux [Build Only] (internal CI)");
             console.log(statuses);
-            for (var i = 0; i < statuses.length; i++) {
-              let status = statuses[i];
+            for (var i = 0; i < statuses.data.length; i++) {
+              let status = statuses.data[i];
               if (status.state == "success") {
                 need.delete(status.context);
               }

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -40,7 +40,7 @@ jobs:
             let statuses = await github.repos.listCommitStatusesForRef({
               owner: "grpc",
               repo: "grpc",
-              ref: ${{ github.ref }}
+              ref: "${{ github.ref }}"
             });
             need = new Set();
             need.add("Bazel Basic build for C/C++");

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,5 +1,7 @@
 name: Happy Pancakes
-on: check_run
+on:
+  - check_run
+  - status
 jobs:
   check_status:
     name: Check Status

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -53,6 +53,12 @@ jobs:
             if (need.size == 0) {
               return;
             }
-            console.log("not yet mergeable... waiting for: ", need);
-            core.setFailed("Not yet mergeable, waiting for: " + need);
+            var error = "Waiting for: ";
+            var first = true;
+            for (let status in need) {
+              if (!first) error += ", ";
+              error += status;
+              first = false;
+            }
+            core.setFailed(error);
 

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -41,7 +41,8 @@ jobs:
               let statuses = await github.repos.listCommitStatusesForRef({
                 owner: "grpc",
                 repo: "grpc",
-                ref: "${{ github.event.pull_request.head.sha }}"
+                ref: "${{ github.event.pull_request.head.sha }}",
+                per_page: 100
               });
               for (var i = 0; i < statuses.data.length; i++) {
                 let status = statuses.data[i];

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -38,24 +38,31 @@ jobs:
               var need = new Set();
               need.add("Bazel Basic build for C/C++");
               need.add("Portability Tests Linux [Build Only] (internal CI)");
-              let statuses = await github.repos.listCommitStatusesForRef({
-                owner: "grpc",
-                repo: "grpc",
-                ref: "${{ github.event.pull_request.head.sha }}",
-                per_page: 100
-              });
-              for (var i = 0; i < statuses.data.length; i++) {
-                let status = statuses.data[i];
-                console.log(status.context, status.state, need);
-                if (need.has(status.context)) {
-                  if (status.state == "success") {
-                    need.delete(status.context);
-                  } else if (status.state == "pending") {
-                    // do nothing
-                  } else {
-                    core.setFailed("Required status failed: " + status.context);
-                    return;
+              for (var page=0;; page++) {
+                console.log("***** page " + page);
+                let statuses = await github.repos.listCommitStatusesForRef({
+                  owner: "grpc",
+                  repo: "grpc",
+                  ref: "${{ github.event.pull_request.head.sha }}",
+                  per_page: 100,
+                  page: page
+                });
+                for (var i = 0; i < statuses.data.length; i++) {
+                  let status = statuses.data[i];
+                  console.log(status.context, status.state, need);
+                  if (need.has(status.context)) {
+                    if (status.state == "success") {
+                      need.delete(status.context);
+                    } else if (status.state == "pending") {
+                      // do nothing
+                    } else {
+                      core.setFailed("Required status failed: " + status.context);
+                      return;
+                    }
                   }
+                }
+                if (statuses.data.length < 100) {
+                  break;
                 }
               }
               if (need.size == 0) {

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,0 +1,33 @@
+name: Happy Pancakes
+on: status
+jobs:
+  check_status:
+    name: Check Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Status
+        uses: actions/github-script@v4
+        with:
+          script: |
+            let pull = await github.pulls.get("grpc", "grpc", ${{ github.event.number }});
+            for (let label in pull.labels) {
+              if (label.name == "force-merge") {
+                console.log("Saw force-merge label");
+                return;
+              }
+            }
+            let statuses = await github.listCommitStatusesForRef("grpc", "grpc", ${{ github.event.ref }});
+            need = new Set();
+            need.add("Bazel Basic build for C/C++");
+            need.add("Portability Tests Linux [Build Only] (internal CI)");
+            for (let status in statuses) {
+              if (status.state == "success") {
+                need.delete(status.context);
+              }
+            }
+            if (need.size == 0) {
+              return;
+            }
+            console.log("not yet mergeable... waiting for: ", need);
+            core.setFailed("Not yet mergeable, waiting for: " + need);
+

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,22 +1,5 @@
 name: Happy Pancakes
-on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-  pull_request_review:
-    types:
-      - submitted
-  check_suite:
-    types:
-      - completed
-  status: {}
+on: check_run
 jobs:
   check_status:
     name: Check Status

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -40,7 +40,7 @@ jobs:
             let statuses = await github.repos.listCommitStatusesForRef({
               owner: "grpc",
               repo: "grpc",
-              ref: pull.head.ref
+              ref: ${{ github.ref }}
             });
             need = new Set();
             need.add("Bazel Basic build for C/C++");

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -31,7 +31,7 @@ jobs:
             let statuses = await github.repos.listCommitStatusesForRef({
               owner: "grpc",
               repo: "grpc",
-              ref: "${{ github.ref }}"
+              ref: "${{ github.sha }}"
             });
             need = new Set();
             need.add("Bazel Basic build for C/C++");

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -1,7 +1,12 @@
 name: Happy Pancakes
 on:
-  - check_run
-  - status
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize, ready_for_review, auto_merge_enabled, auto_merge_disabled]
+  status: {}
+  check_run:
+    types: [created, completed]
+  check_suite: 
+    types: [created, completed]
 jobs:
   check_status:
     name: Check Status
@@ -14,9 +19,10 @@ jobs:
             let pull = await github.pulls.get({
               owner: "grpc",
               repo: "grpc",
-              pull_number: ${{ github.event.number }}
+              pull_number: ${{ github.event.pull_request.number }}
             });
-            for (let label in pull.labels) {
+            for (var i = 0; i < pull.data.labels.length; i++) {
+              let label = pull.data.labels[i];
               if (label.name == "force-merge") {
                 console.log("Saw force-merge label");
                 return;
@@ -30,7 +36,9 @@ jobs:
             need = new Set();
             need.add("Bazel Basic build for C/C++");
             need.add("Portability Tests Linux [Build Only] (internal CI)");
-            for (let status in statuses) {
+            console.log(statuses);
+            for (var i = 0; i < statuses.length; i++) {
+              let status = statuses[i];
               if (status.state == "success") {
                 need.delete(status.context);
               }
@@ -38,12 +46,6 @@ jobs:
             if (need.size == 0) {
               return;
             }
-            var error = "Waiting for: ";
-            var first = true;
-            for (let status in need) {
-              if (!first) error += ", ";
-              error += status;
-              first = false;
-            }
-            core.setFailed(error);
+            console.log(need);
+            core.setFailed("Waiting for: " + [...need].join(', '));
 

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -31,7 +31,7 @@ jobs:
             let statuses = await github.repos.listCommitStatusesForRef({
               owner: "grpc",
               repo: "grpc",
-              ref: "${{ github.sha }}"
+              ref: "${{ github.event.pull_request.head.sha }}"
             });
             need = new Set();
             need.add("Bazel Basic build for C/C++");

--- a/.github/workflows/happy-pancakes.yml
+++ b/.github/workflows/happy-pancakes.yml
@@ -37,7 +37,11 @@ jobs:
                 return;
               }
             }
-            let statuses = await github.listCommitStatusesForRef("grpc", "grpc", ${{ github.event.ref }});
+            let statuses = await github.repos.listCommitStatusesForRef({
+              owner: "grpc",
+              repo: "grpc",
+              ref: ${{ github.event.ref }}
+            });
             need = new Set();
             need.add("Bazel Basic build for C/C++");
             need.add("Portability Tests Linux [Build Only] (internal CI)");


### PR DESCRIPTION
The idea here is to wait for some statuses to become ok before becoming ok ourselves... BUT allow a force-merge status to override that check.

We then make this action a required thing, and remove the required from the things it checks. Allows us to verify that required statuses are present, BUT ALSO override that requirement with a label (who's use will be logged and audit-able later).