### PR TITLE
Added python deps installation to bazel/dockerfile

### DIFF
--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -43,10 +43,18 @@
   # Python dependencies
 
   # Install dependencies
+
   RUN apt-get update && apt-get install -y ${'\\'}
       python-all-dev ${'\\'}
       python3-all-dev ${'\\'}
       python-setuptools
+
+  # Install Python packages from PyPI
+  RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+  RUN pip install --upgrade pip==19.3.1
+  RUN pip install virtualenv==16.7.9
+  RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+
 
   <%include file="../../compile_python_36.include"/>
 

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -52,8 +52,8 @@
   # Install Python packages from PyPI
   RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
   RUN pip install --upgrade pip==19.3.1
-  RUN pip install virtualenv==16.7.9
-  RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+  RUN pip install virtualenv==20.7.1
+  RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 
   <%include file="../../compile_python_36.include"/>

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -41,10 +41,18 @@ RUN apt-get update && apt-get -y install \
 # Python dependencies
 
 # Install dependencies
+
 RUN apt-get update && apt-get install -y \
     python-all-dev \
     python3-all-dev \
     python-setuptools
+
+# Install Python packages from PyPI
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+RUN pip install --upgrade pip==19.3.1
+RUN pip install virtualenv==20.7.1
+RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.17.3 six==1.16.0 twisted==19.10.0
+
 
 #=================
 # Compile CPython 3.6.9 from source

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==20.7.1
-RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.17.3 six==1.16.0 twisted==19.10.0
+RUN pip install futures==3.3.0 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 
 #=================


### PR DESCRIPTION
Revived the python2 package installation because the grpc_xds_python test needs them. Previously those were stripped because bazel can deal with the package installation by itself and it's not good for the maintenance to list unused packages with versions but it appears that some of them are still in use so let's revive them. But I should update the versions because old versions are not feasible to install anymore.