### PR TITLE
Fix docstring gramma in Python module

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -206,7 +206,7 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
 
     @abc.abstractmethod
     def invocation_metadata(self) -> Optional[Metadata]:
-        """Accesses the metadata from the sent by the client.
+        """Accesses the metadata sent by the client.
 
         Returns:
           The invocation :term:`metadata`.


### PR DESCRIPTION
Might be my lack of English language skills but I think this docstring should be fixed.

Instead of:
* Accesses the metadata from the sent by the client.

Either one of:
* Accesses the metadata from the client.
* Accesses the metadata sent by the client.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
