### PR TITLE
Fix resource leaks in xds test

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2422,7 +2422,8 @@ def create_instance_template(gcp, name, network, source_image, machine_type,
                 'boot': True,
                 'initializeParams': {
                     'sourceImage': source_image
-                }
+                },
+                'autoDelete': True
             }],
             'metadata': {
                 'items': [{

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -2649,13 +2649,14 @@ def get_health_check_firewall_rule(gcp, firewall_name):
         gcp.health_check_firewall_rule = GcpResource(firewall_name, None)
 
 
-def get_backend_service(gcp, backend_service_name):
+def get_backend_service(gcp, backend_service_name, record_error=True):
     try:
         result = gcp.compute.backendServices().get(
             project=gcp.project, backendService=backend_service_name).execute()
         backend_service = GcpResource(backend_service_name, result['selfLink'])
     except Exception as e:
-        gcp.errors.append(e)
+        if record_error:
+            gcp.errors.append(e)
         backend_service = GcpResource(backend_service_name, None)
     gcp.backend_services.append(backend_service)
     return backend_service
@@ -3132,6 +3133,8 @@ try:
     firewall_name = _BASE_FIREWALL_RULE_NAME + gcp_suffix
     backend_service_name = _BASE_BACKEND_SERVICE_NAME + gcp_suffix
     alternate_backend_service_name = _BASE_BACKEND_SERVICE_NAME + '-alternate' + gcp_suffix
+    extra_backend_service_name = _BASE_BACKEND_SERVICE_NAME + '-extra' + gcp_suffix
+    more_extra_backend_service_name = _BASE_BACKEND_SERVICE_NAME + '-more-extra' + gcp_suffix
     url_map_name = _BASE_URL_MAP_NAME + gcp_suffix
     service_host_name = _BASE_SERVICE_HOST + gcp_suffix
     target_proxy_name = _BASE_TARGET_PROXY_NAME + gcp_suffix
@@ -3149,6 +3152,8 @@ try:
         backend_service = get_backend_service(gcp, backend_service_name)
         alternate_backend_service = get_backend_service(
             gcp, alternate_backend_service_name)
+        extra_backend_service = get_backend_service(gcp, extra_backend_service_name, record_error=False)
+        more_extra_backend_service = get_backend_service(gcp, more_extra_backend_service_name, record_error=False)
         get_url_map(gcp, url_map_name)
         get_target_proxy(gcp, target_proxy_name)
         get_global_forwarding_rule(gcp, forwarding_rule_name)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3153,8 +3153,11 @@ try:
         backend_service = get_backend_service(gcp, backend_service_name)
         alternate_backend_service = get_backend_service(
             gcp, alternate_backend_service_name)
-        extra_backend_service = get_backend_service(gcp, extra_backend_service_name, record_error=False)
-        more_extra_backend_service = get_backend_service(gcp, more_extra_backend_service_name, record_error=False)
+        extra_backend_service = get_backend_service(gcp,
+                                                    extra_backend_service_name,
+                                                    record_error=False)
+        more_extra_backend_service = get_backend_service(
+            gcp, more_extra_backend_service_name, record_error=False)
         get_url_map(gcp, url_map_name)
         get_target_proxy(gcp, target_proxy_name)
         get_global_forwarding_rule(gcp, forwarding_rule_name)


### PR DESCRIPTION
The circuit breaking test creates its own backend services outside of the normal flow, which can potentially be leaked, preventing other GCP resources from being deleted; this adjusts the clean-up step for a subsequent run with `--use_existing_gcp_resources` to be able to discover - and more importantly, delete - these leaked backend services. More context on b/192095168.

The second commit ensures that disk images are deleted when the instance group is terminated, which is the default when creating via gcloud (https://cloud.google.com/sdk/gcloud/reference/compute/instance-templates/create#--boot-disk-auto-delete) but not when using the rest API (a regular clean-up job has been running to delete stranded disks, but this removes the leak altogether).