### PR TITLE
v1.36.x backport: Fix resource leaks in xds test (#26967)

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1746,7 +1746,8 @@ def create_instance_template(gcp, name, network, source_image, machine_type,
                 'boot': True,
                 'initializeParams': {
                     'sourceImage': source_image
-                }
+                },
+                'autoDelete': True
             }],
             'metadata': {
                 'items': [{


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc/pull/26967