### PR TITLE
And use Python 3 explicitly in C++ interop as well

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -22,8 +22,9 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 
+python3 -m pip install virtualenv
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV" -p python3
+python3 -m virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio grpcio-tools google-api-python-client google-auth-httplib2 oauth2client xds-protos


### PR DESCRIPTION
Straightforward adaptation of https://github.com/grpc/grpc/pull/26953 to the C++ test runner script.