### PR TITLE
Sync transport implementation

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_stream.h
+++ b/src/core/ext/transport/binder/transport/binder_stream.h
@@ -24,20 +24,8 @@ struct grpc_binder_stream {
   // server_data will be null for client, and for server it will be whatever
   // passed in to the accept_stream_fn callback by client.
   grpc_binder_stream(grpc_binder_transport* t, grpc_core::Arena* arena,
-                     const void* server_data, int tx_code, bool is_client)
-      : t(t), arena(arena), seq(0), tx_code(tx_code), is_client(is_client) {
-    if (!server_data) {
-      // The stream is a client-side stream. If we indeed know what the other
-      // end is (for example, in the testing envorinment), call the
-      // accept_stream_fn callback with server_data being "this" (currently we
-      // don't need the actual value of "this"; a non-null value should work).
-      grpc_binder_transport* server = t->other_end;
-      if (server && server->accept_stream_fn) {
-        (*server->accept_stream_fn)(server->accept_stream_user_data,
-                                    &server->base, this);
-      }
-    }
-  }
+                     const void* /*server_data*/, int tx_code, bool is_client)
+      : t(t), arena(arena), seq(0), tx_code(tx_code), is_client(is_client) {}
   ~grpc_binder_stream() = default;
   int GetTxCode() { return tx_code; }
   int GetThenIncSeq() { return seq++; }

--- a/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.cc
+++ b/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.cc
@@ -30,7 +30,7 @@ const absl::string_view
 
 void TransportStreamReceiverImpl::RegisterRecvInitialMetadata(
     StreamIdentifier id, InitialMetadataCallbackType cb) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   GPR_ASSERT(initial_metadata_cbs_.count(id) == 0);
   absl::StatusOr<Metadata> initial_metadata{};
   {
@@ -54,7 +54,7 @@ void TransportStreamReceiverImpl::RegisterRecvInitialMetadata(
 
 void TransportStreamReceiverImpl::RegisterRecvMessage(
     StreamIdentifier id, MessageDataCallbackType cb) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   GPR_ASSERT(message_cbs_.count(id) == 0);
   absl::StatusOr<std::string> message{};
   {
@@ -88,7 +88,7 @@ void TransportStreamReceiverImpl::RegisterRecvMessage(
 
 void TransportStreamReceiverImpl::RegisterRecvTrailingMetadata(
     StreamIdentifier id, TrailingMetadataCallbackType cb) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   GPR_ASSERT(trailing_metadata_cbs_.count(id) == 0);
   std::pair<absl::StatusOr<Metadata>, int> trailing_metadata{};
   {
@@ -112,7 +112,10 @@ void TransportStreamReceiverImpl::RegisterRecvTrailingMetadata(
 
 void TransportStreamReceiverImpl::NotifyRecvInitialMetadata(
     StreamIdentifier id, absl::StatusOr<Metadata> initial_metadata) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
+  if (!is_client_ && accept_stream_callback_) {
+    accept_stream_callback_();
+  }
   InitialMetadataCallbackType cb;
   {
     grpc_core::MutexLock l(&m_);
@@ -130,7 +133,7 @@ void TransportStreamReceiverImpl::NotifyRecvInitialMetadata(
 
 void TransportStreamReceiverImpl::NotifyRecvMessage(
     StreamIdentifier id, absl::StatusOr<std::string> message) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   MessageDataCallbackType cb;
   {
     grpc_core::MutexLock l(&m_);
@@ -153,7 +156,7 @@ void TransportStreamReceiverImpl::NotifyRecvTrailingMetadata(
   // assumes in-order commitments of transactions and that trailing metadata is
   // parsed after message data, we can safely cancel all upcoming callbacks of
   // recv_message.
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   CancelRecvMessageCallbacksDueToTrailingMetadata(id);
   TrailingMetadataCallbackType cb;
   {
@@ -173,7 +176,7 @@ void TransportStreamReceiverImpl::NotifyRecvTrailingMetadata(
 
 void TransportStreamReceiverImpl::
     CancelRecvMessageCallbacksDueToTrailingMetadata(StreamIdentifier id) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   MessageDataCallbackType cb = nullptr;
   {
     grpc_core::MutexLock l(&m_);
@@ -226,7 +229,7 @@ void TransportStreamReceiverImpl::CancelStream(StreamIdentifier id,
 }
 
 void TransportStreamReceiverImpl::Clear(StreamIdentifier id) {
-  gpr_log(GPR_ERROR, "%s id = %d is_client = %d", __func__, id, is_client_);
+  gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
   grpc_core::MutexLock l(&m_);
   initial_metadata_cbs_.erase(id);
   message_cbs_.erase(id);

--- a/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.h
+++ b/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.h
@@ -32,8 +32,10 @@ namespace grpc_binder {
 // Routes the data received from transport to corresponding streams
 class TransportStreamReceiverImpl : public TransportStreamReceiver {
  public:
-  explicit TransportStreamReceiverImpl(bool is_client)
-      : is_client_(is_client) {}
+  explicit TransportStreamReceiverImpl(
+      bool is_client, std::function<void()> accept_stream_callback = nullptr)
+      : is_client_(is_client),
+        accept_stream_callback_(accept_stream_callback) {}
   void RegisterRecvInitialMetadata(StreamIdentifier id,
                                    InitialMetadataCallbackType cb) override;
   void RegisterRecvMessage(StreamIdentifier id,
@@ -92,6 +94,9 @@ class TransportStreamReceiverImpl : public TransportStreamReceiver {
   std::set<StreamIdentifier> recv_message_cancelled_ ABSL_GUARDED_BY(m_);
 
   bool is_client_;
+  // Called when receiving initial metadata to inform the server about a new
+  // stream.
+  std::function<void()> accept_stream_callback_;
 };
 }  // namespace grpc_binder
 

--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
@@ -43,8 +43,11 @@ absl::StatusOr<Metadata> parse_metadata(const ReadableParcel* reader) {
   int num_header;
   RETURN_IF_ERROR(reader->ReadInt32(&num_header));
   gpr_log(GPR_INFO, "num_header = %d", num_header);
+  if (num_header < 0) {
+    return absl::InvalidArgumentError("num_header cannot be negative");
+  }
   std::vector<std::pair<std::string, std::string>> ret;
-  for (int i = 0; i != num_header; i++) {
+  for (int i = 0; i < num_header; i++) {
     int count;
     RETURN_IF_ERROR(reader->ReadInt32(&count));
     gpr_log(GPR_INFO, "count = %d", count);
@@ -65,18 +68,21 @@ absl::StatusOr<Metadata> parse_metadata(const ReadableParcel* reader) {
 
 WireReaderImpl::WireReaderImpl(
     std::shared_ptr<TransportStreamReceiver> transport_stream_receiver,
-    bool is_client)
+    bool is_client, std::function<void()> on_destruct_callback)
     : transport_stream_receiver_(std::move(transport_stream_receiver)),
-      is_client_(is_client) {}
+      is_client_(is_client),
+      on_destruct_callback_(on_destruct_callback) {}
 
-WireReaderImpl::~WireReaderImpl() = default;
+WireReaderImpl::~WireReaderImpl() {
+  if (on_destruct_callback_) {
+    on_destruct_callback_();
+  }
+}
 
 std::unique_ptr<WireWriter> WireReaderImpl::SetupTransport(
     std::unique_ptr<Binder> binder) {
   gpr_log(GPR_INFO, "Setting up transport");
   if (!is_client_) {
-    gpr_log(GPR_ERROR,
-            "[WARNING] Server-side setup transport is currently test-only");
     SendSetupTransport(binder.get());
     return absl::make_unique<WireWriterImpl>(std::move(binder));
   } else {
@@ -106,7 +112,7 @@ void WireReaderImpl::SendSetupTransport(Binder* binder) {
   // during callback execution. TransactionReceiver should make sure that the
   // callback owns a Ref() when it's being invoked.
   tx_receiver_ = binder->ConstructTxReceiver(
-      Ref(),
+      /*wire_reader_ref=*/Ref(),
       [this](transaction_code_t code, const ReadableParcel* readable_parcel) {
         return this->ProcessTransaction(code, readable_parcel);
       });
@@ -140,7 +146,7 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
                     BinderTransportTxCode::SETUP_TRANSPORT) &&
         code <= static_cast<transaction_code_t>(
                     BinderTransportTxCode::PING_RESPONSE))) {
-    gpr_log(GPR_ERROR,
+    gpr_log(GPR_INFO,
             "Received unknown control message. Shutdown transport gracefully.");
     // TODO(waynetu): Shutdown transport gracefully.
     return absl::OkStatus();
@@ -148,6 +154,10 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
 
   switch (BinderTransportTxCode(code)) {
     case BinderTransportTxCode::SETUP_TRANSPORT: {
+      if (connected_) {
+        return absl::InvalidArgumentError("Already connected");
+      }
+      connected_ = true;
       // int datasize;
       int version;
       // getDataSize not supported until 31
@@ -211,15 +221,15 @@ absl::Status WireReaderImpl::ProcessStreamingTransaction(
             status.ToString().c_str());
     // Something went wrong when receiving transaction. Cancel failed requests.
     if (cancellation_flags & kFlagPrefix) {
-      gpr_log(GPR_ERROR, "cancelling initial metadata");
+      gpr_log(GPR_INFO, "cancelling initial metadata");
       transport_stream_receiver_->NotifyRecvInitialMetadata(code, status);
     }
     if (cancellation_flags & kFlagMessageData) {
-      gpr_log(GPR_ERROR, "cancelling message data");
+      gpr_log(GPR_INFO, "cancelling message data");
       transport_stream_receiver_->NotifyRecvMessage(code, status);
     }
     if (cancellation_flags & kFlagSuffix) {
-      gpr_log(GPR_ERROR, "cancelling trailing metadata");
+      gpr_log(GPR_INFO, "cancelling trailing metadata");
       transport_stream_receiver_->NotifyRecvTrailingMetadata(code, status, 0);
     }
   }


### PR DESCRIPTION
Sync binder transport implementation from the internal repository to make tests work.

#26970 depends on this.

@ctiller
