### PR TITLE
Remove useless grpc_alarm type define.

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -96,7 +96,6 @@ some configuration as environment variables that can be set.
 
   The following tracers will only run in binaries built in DEBUG mode. This is
   accomplished by invoking `CONFIG=dbg make <target>`
-  - alarm_refcount - refcounting traces for grpc_alarm structure
   - metadata - tracks creation and mutation of metadata
   - combiner - traces combiner lock state
   - call_combiner - traces call combiner state

--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -55,9 +55,6 @@ typedef struct grpc_byte_buffer {
  * asynchronous actions. */
 typedef struct grpc_completion_queue grpc_completion_queue;
 
-/** An alarm associated with a completion queue. */
-typedef struct grpc_alarm grpc_alarm;
-
 /** The Channel interface allows creation of Call objects. */
 typedef struct grpc_channel grpc_channel;
 


### PR DESCRIPTION
- Remove useless grpc_alarm declaration in grpc_types.h

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
