### PR TITLE
Add api listener test for k8s

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
@@ -134,7 +134,7 @@ main() {
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
-  test_suites=("change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
+  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
   for test in "${test_suites[@]}"; do
     run_test $test || (( failed_tests++ ))
   done

--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
@@ -144,7 +144,7 @@ main() {
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
-  test_suites=("change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
+  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
   for test in "${test_suites[@]}"; do
     run_test $test || (( failed_tests++ ))
   done

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -210,11 +210,12 @@ class ComputeV1(gcp.api.GcpProjectApiResource):
         self,
         name: str,
         url_map: GcpResource,
+        validate_for_proxyless = True,
     ) -> GcpResource:
         return self._insert_resource(self.api.targetGrpcProxies(), {
             'name': name,
             'url_map': url_map.url,
-            'validate_for_proxyless': True,
+            'validate_for_proxyless': validate_for_proxyless,
         })
 
     def delete_target_grpc_proxy(self, name):
@@ -241,6 +242,7 @@ class ComputeV1(gcp.api.GcpProjectApiResource):
         src_port: int,
         target_proxy: GcpResource,
         network_url: str,
+        ip_address = '0.0.0.0',
     ) -> GcpResource:
         return self._insert_resource(
             self.api.globalForwardingRules(),
@@ -249,7 +251,7 @@ class ComputeV1(gcp.api.GcpProjectApiResource):
                 'loadBalancingScheme':
                     'INTERNAL_SELF_MANAGED',  # Traffic Director
                 'portRange': src_port,
-                'IPAddress': '0.0.0.0',
+                'IPAddress': ip_address,
                 'network': network_url,
                 'target': target_proxy.url,
             })

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -54,9 +54,12 @@ class TrafficDirectorManager:
     AFFINITY_BACKEND_SERVICE_NAME = "backend-service-affinity"
     HEALTH_CHECK_NAME = "health-check"
     URL_MAP_NAME = "url-map"
+    ALTERNATIVE_URL_MAP_NAME = "url-map-alt"
     URL_MAP_PATH_MATCHER_NAME = "path-matcher"
     TARGET_PROXY_NAME = "target-proxy"
+    ALTERNATIVE_TARGET_PROXY_NAME = "target-proxy-alt"
     FORWARDING_RULE_NAME = "forwarding-rule"
+    ALTERNATIVE_FORWARDING_RULE_NAME = "forwarding-rule-alt"
     FIREWALL_RULE_NAME = "allow-health-checks"
 
     def __init__(
@@ -83,11 +86,14 @@ class TrafficDirectorManager:
         # TODO(sergiitk): remove this flag once backend service resource loaded
         self.backend_service_protocol: Optional[BackendServiceProtocol] = None
         self.url_map: Optional[GcpResource] = None
+        self.alternative_url_map: Optional[GcpResource] = None
         self.firewall_rule: Optional[GcpResource] = None
         self.target_proxy: Optional[GcpResource] = None
         # TODO(sergiitk): remove this flag once target proxy resource loaded
         self.target_proxy_is_http: bool = False
+        self.alternative_target_proxy: Optional[GcpResource] = None
         self.forwarding_rule: Optional[GcpResource] = None
+        self.alternative_forwarding_rule: Optional[GcpResource] = None
         self.backends: Set[ZonalGcpResource] = set()
         self.alternative_backend_service: Optional[GcpResource] = None
         # TODO(sergiitk): remove this flag once backend service resource loaded
@@ -131,9 +137,12 @@ class TrafficDirectorManager:
     def cleanup(self, *, force=False):
         # Cleanup in the reverse order of creation
         self.delete_forwarding_rule(force=force)
+        self.delete_alternative_forwarding_rule(force=force)
         self.delete_target_http_proxy(force=force)
         self.delete_target_grpc_proxy(force=force)
+        self.delete_alternative_target_grpc_proxy(force=force)
         self.delete_url_map(force=force)
+        self.delete_alternative_url_map(force=force)
         self.delete_backend_service(force=force)
         self.delete_alternative_backend_service(force=force)
         self.delete_affinity_backend_service(force=force)
@@ -390,10 +399,10 @@ class TrafficDirectorManager:
     def create_url_map(
         self,
         src_host: str,
-        src_port: int,
+        src_port: int
     ) -> GcpResource:
-        src_address = f'{src_host}:{src_port}'
         name = self.make_resource_name(self.URL_MAP_NAME)
+        src_address = f'{src_host}:{src_port}'
         matcher_name = self.make_resource_name(self.URL_MAP_PATH_MATCHER_NAME)
         logger.info('Creating URL map "%s": %s -> %s', name, src_address,
                     self.backend_service.name)
@@ -426,6 +435,33 @@ class TrafficDirectorManager:
             name = self.make_resource_name(self.URL_MAP_NAME)
         elif self.url_map:
             name = self.url_map.name
+        else:
+            return
+        logger.info('Deleting URL Map "%s"', name)
+        self.compute.delete_url_map(name)
+        self.url_map = None
+
+    def create_alternative_url_map(
+        self,
+        src_host: str,
+        src_port: int
+    ) -> GcpResource:
+        name = self.make_resource_name(self.ALTERNATIVE_URL_MAP_NAME)
+        src_address = f'{src_host}:{src_port}'
+        matcher_name = self.make_resource_name(self.URL_MAP_PATH_MATCHER_NAME)
+        logger.info('Creating URL map "%s": %s -> %s', name, src_address,
+                    self.backend_service.name)
+        resource = self.compute.create_url_map_with_content(
+            self._generate_url_map_body(name, matcher_name, [src_address],
+                                        self.backend_service))
+        self.alternative_url_map = resource
+        return resource
+
+    def delete_alternative_url_map(self, force=False):
+        if force:
+            name = self.make_resource_name(self.ALTERNATIVE_URL_MAP_NAME)
+        elif self.alternative_url_map:
+            name = self.alternative_url_map.name
         else:
             return
         logger.info('Deleting URL Map "%s"', name)
@@ -473,6 +509,27 @@ class TrafficDirectorManager:
         self.target_proxy = None
         self.target_proxy_is_http = False
 
+    def create_alternative_target_proxy(self):
+        name = self.make_resource_name(self.ALTERNATIVE_TARGET_PROXY_NAME)
+        if self.backend_service_protocol is BackendServiceProtocol.GRPC:
+            logger.info('Creating target GRPC proxy "%s" to URL map %s', name,
+                     self.alternative_url_map.name)
+            self.alternative_target_proxy = self.compute.create_target_grpc_proxy(name, self.alternative_url_map, validate_for_proxyless=False)
+        else:
+            raise TypeError('Unexpected backend service protocol')
+
+
+    def delete_alternative_target_grpc_proxy(self, force=False):
+        if force:
+            name = self.make_resource_name(self.ALTERNATIVE_TARGET_PROXY_NAME)
+        elif self.alternative_target_proxy:
+            name = self.alternative_target_proxy.name
+        else:
+            return
+        logger.info('Deleting Target GRPC proxy "%s"', name)
+        self.compute.delete_target_grpc_proxy(name)
+        self.alternative_target_proxy = None
+
     def find_unused_forwarding_rule_port(
             self,
             *,
@@ -508,6 +565,30 @@ class TrafficDirectorManager:
         logger.info('Deleting Forwarding rule "%s"', name)
         self.compute.delete_forwarding_rule(name)
         self.forwarding_rule = None
+
+    def create_alternative_forwarding_rule(self, src_port: int, ip_address='0.0.0.0'):
+        name = self.make_resource_name(self.ALTERNATIVE_FORWARDING_RULE_NAME)
+        src_port = int(src_port)
+        logging.info(
+            'Creating forwarding rule "%s" in network "%s": %s:%s -> %s',
+            name, self.network, ip_address, src_port, self.alternative_target_proxy.url)
+        resource = self.compute.create_forwarding_rule(name, src_port,
+                                                       self.alternative_target_proxy,
+                                                       self.network_url,
+                                                       ip_address)
+        self.alternative_forwarding_rule = resource
+        return resource
+
+    def delete_alternative_forwarding_rule(self, force=False):
+        if force:
+            name = self.make_resource_name(self.ALTERNATIVE_FORWARDING_RULE_NAME)
+        elif self.forwarding_rule:
+            name = self.alternative_forwarding_rule.name
+        else:
+            return
+        logger.info('Deleting Forwarding rule "%s"', name)
+        self.compute.delete_forwarding_rule(name)
+        self.alternative_forwarding_rule = None
 
     def create_firewall_rule(self, allowed_ports: List[str]):
         name = self.make_resource_name(self.FIREWALL_RULE_NAME)

--- a/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
@@ -1,0 +1,86 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import List, Optional
+
+from absl import flags
+from absl.testing import absltest
+
+from framework import xds_k8s_testcase
+from framework.infrastructure import k8s
+from framework.test_app import server_app
+
+logger = logging.getLogger(__name__)
+flags.adopt_module_key_flags(xds_k8s_testcase)
+
+# Type aliases
+_XdsTestServer = xds_k8s_testcase.XdsTestServer
+_XdsTestClient = xds_k8s_testcase.XdsTestClient
+
+
+class ApiListenerTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
+    ALTERNATE_RESOURCE_SUFFIX = '2'
+
+    def test_api_listener(self) -> None:
+        with self.subTest('00_create_health_check'):
+            self.td.create_health_check()
+
+        with self.subTest('01_create_backend_services'):
+            self.td.create_backend_service()
+
+        with self.subTest('02_create_url_maps'):
+            self.td.create_url_map(self.server_xds_host, self.server_xds_port)
+            self.td.create_alternative_url_map(self.server_xds_host, self.server_xds_port)
+
+        with self.subTest('03_create_target_proxies'):
+            self.td.create_target_proxy()
+            self.td.create_alternative_target_proxy()
+
+        with self.subTest('04_create_forwarding_rule'):
+            self.td.create_forwarding_rule(self.server_xds_port)
+            self.td.create_alternative_forwarding_rule(self.server_xds_port, ip_address='10.10.10.10')
+
+        with self.subTest('05_start_test_servers'):
+            self.test_servers: List[_XdsTestServer] = self.startTestServers()
+
+        with self.subTest('06_add_server_backends_to_backend_services'):
+            self.setupServerBackends()
+
+        with self.subTest('07_start_test_client'):
+            self.test_client: _XdsTestClient = self.startTestClient(
+                self.test_servers[0])
+
+        with self.subTest('08_test_client_xds_config_exists'):
+            self.assertXdsConfigExists(self.test_client)
+
+        with self.subTest('09_test_server_received_rpcs_from_test_client'):
+            self.assertSuccessfulRpcs(self.test_client)
+
+        with self.subTest('10_delete_one_url_map_target_proxy_forwarding_rule'):
+            self.td.delete_forwarding_rule()
+            self.td.delete_target_grpc_proxy()
+            self.td.delete_url_map()
+
+        with self.subTest('11_test_server_continues_to_receive_rpcs'):
+            # TODO: Use CSDS to check that deletions of the original forwarding
+            # rule, target proxy, and URL map have propagated from TD to the
+            # client instead of an unconditional wait.
+            ATTEMPTS_TILL_PROPAGATION = 10
+            for i in range(ATTEMPTS_TILL_PROPAGATION):
+                self.assertSuccessfulRpcs(self.test_client)
+
+
+
+if __name__ == '__main__':
+    absltest.main(failfast=True)


### PR DESCRIPTION
This ports the api listener test case to k8s. I noticed that the current implementation of this test case in `run_xds_tests.py` seems to have what amounts to an unconditional 10 minute wait [here](https://github.com/grpc/grpc/blob/master/tools/run_tests/run_xds_tests.py#L1209) - I'm not quite sure what's going on with the ` verify_attempts` calculation in Python, as it seems to come out to equal 60, which I can only reproduce in a repl with int(_WAIT_FOR_URL_MAP_PATCH_SEC / (10.0 * qps) * qps), e.g., with a floating point value for `_NUM_TEST_RPCS`. Regardless, from the [logs](https://fusion2.corp.google.com/invocations/9fd48558-83ed-4b0a-8f9a-7136ebe1de13/targets/grpc%2Fgo%2Fmaster%2Fbranch%2Fxds/log) it's clearly executing the loop 60 times at 10 seconds per call, resulting in the overall test case typically running 18-20 minutes. Since this isn't actually doing anything but (attempting) to wait for TD propagation - and we can't tell the difference between not-having-propagated and the test passing - I just shortened this loop considerably here. We _should_ be able to properly verify that the propagation has occurred via the CSDS service, which is left as a TODO.

I did not have time to finish the forwarding-rule* or metadata-filter test cases, so just sending what I have here.