### PR TITLE
xds/testing: print timestamp of commands in xds tests cripts to help debug timeout failures

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'date' DEBUG
 set -ex -o igncr || set -ex
 
 mkdir -p /var/local/git

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'date' DEBUG
 set -ex -o igncr || set -ex
 
 mkdir -p /var/local/git

--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'date' DEBUG
 set -ex -o igncr || set -ex
 
 mkdir -p /var/local/git

--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'date' DEBUG
 set -ex -o igncr || set -ex
 
 mkdir -p /var/local/git

--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+trap 'date' DEBUG
 set -ex
 
 # change to grpc repo root

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3094,9 +3094,8 @@ class GcpState(object):
 logging.debug(
     "script start time: %s",
     datetime.datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
-logging.debug(
-    "logging local timezone: %s",
-    datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
+logging.debug("logging local timezone: %s",
+              datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
 alpha_compute = None
 if args.compute_discovery_document:
     with open(args.compute_discovery_document, 'r') as discovery_doc:

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3091,6 +3091,12 @@ class GcpState(object):
         self.errors = []
 
 
+logging.debug(
+    "script start time: %s",
+    datetime.datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
+logging.debug(
+    "logging local timezone: %s",
+    datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
 alpha_compute = None
 if args.compute_discovery_document:
     with open(args.compute_discovery_document, 'r') as discovery_doc:


### PR DESCRIPTION
There were recently many kokoro timeout, after job running for 6 hours.
In those, the run_xds_tests.py only ran less then 2 hours.

There was no enough timestamp to find what was taking so long (either
run_xds_tests.py is stuck, or something before it took too long). This
should add more timestamps to help debug.