### PR TITLE
Add internal method to set a default EventEngine instance

### DIFF
--- a/src/core/lib/iomgr/event_engine/iomgr.cc
+++ b/src/core/lib/iomgr/event_engine/iomgr.cc
@@ -44,19 +44,15 @@ using ::grpc_event_engine::experimental::DefaultEventEngineFactory;
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::Promise;
 
-// Note: This is a pointer to a shared_ptr, so it's trivially destructible.
-std::shared_ptr<EventEngine>* g_event_engine;
+EventEngine* g_event_engine = nullptr;
 
-void iomgr_platform_init(void) {
-  g_event_engine =
-      new std::shared_ptr<EventEngine>(DefaultEventEngineFactory());
-}
+void iomgr_platform_init(void) { GPR_ASSERT(g_event_engine != nullptr); }
 
 void iomgr_platform_flush(void) {}
 
 void iomgr_platform_shutdown(void) {
   Promise<absl::Status> shutdown_status_promise;
-  (*g_event_engine)->Shutdown([&shutdown_status_promise](absl::Status status) {
+  g_event_engine->Shutdown([&shutdown_status_promise](absl::Status status) {
     shutdown_status_promise.Set(std::move(status));
   });
   auto shutdown_status = shutdown_status_promise.Get();
@@ -68,7 +64,7 @@ void iomgr_platform_shutdown(void) {
 void iomgr_platform_shutdown_background_closure(void) {}
 
 bool iomgr_platform_is_any_background_poller_thread(void) {
-  return (*g_event_engine)->IsWorkerThread();
+  return g_event_engine->IsWorkerThread();
 }
 
 bool iomgr_platform_add_closure_to_background_poller(
@@ -99,7 +95,18 @@ void grpc_set_default_iomgr_platform() {
 bool grpc_iomgr_run_in_background() { return false; }
 
 grpc_event_engine::experimental::EventEngine* grpc_iomgr_event_engine() {
-  return g_event_engine->get();
+  return g_event_engine;
 }
+
+namespace grpc_core {
+
+void SetDefaultEventEngine(
+    std::unique_ptr<grpc_event_engine::experimental::EventEngine>
+        event_engine) {
+  GPR_ASSERT(g_event_engine == nullptr);
+  g_event_engine = event_engine.release();
+}
+
+}  // namespace grpc_core
 
 #endif  // GRPC_USE_EVENT_ENGINE

--- a/src/core/lib/iomgr/event_engine/iomgr.cc
+++ b/src/core/lib/iomgr/event_engine/iomgr.cc
@@ -46,6 +46,7 @@ using ::grpc_event_engine::experimental::Promise;
 
 EventEngine* g_event_engine = nullptr;
 
+// TODO(nnoble): Instantiate the default EventEngine if none have been provided.
 void iomgr_platform_init(void) { GPR_ASSERT(g_event_engine != nullptr); }
 
 void iomgr_platform_flush(void) {}

--- a/src/core/lib/iomgr/event_engine/iomgr.h
+++ b/src/core/lib/iomgr/event_engine/iomgr.h
@@ -17,8 +17,16 @@
 
 #include <grpc/event_engine/event_engine.h>
 
-// This can be called anywhere in the EE-based iomgr impl where we need to
-// access the global EE instance.
+/// This can be called anywhere in the EE-based iomgr impl where we need to
+/// access the global EE instance.
 grpc_event_engine::experimental::EventEngine* grpc_iomgr_event_engine();
+
+namespace grpc_core {
+
+/// Set the default EventEngine. This engine is shut down along with iomgr.
+void SetDefaultEventEngine(
+    std::unique_ptr<grpc_event_engine::experimental::EventEngine> event_engine);
+
+}  // namespace grpc_core
 
 #endif  // GRPC_CORE_LIB_IOMGR_EVENT_ENGINE_IOMGR_H

--- a/src/core/lib/iomgr/event_engine/iomgr.h
+++ b/src/core/lib/iomgr/event_engine/iomgr.h
@@ -23,7 +23,17 @@ grpc_event_engine::experimental::EventEngine* grpc_iomgr_event_engine();
 
 namespace grpc_core {
 
-/// Set the default EventEngine. This engine is shut down along with iomgr.
+/// Set the default \a EventEngine.
+///
+/// The iomgr interfaces conceptually expose a global singleton iomgr instance
+/// that is shared throughout gRPC. To accomodate an EventEngine-based iomgr
+/// implementation, this method sets the default EventEngine that will be used.
+/// The default EventEngine can only be set once during the lifetime of gRPC.
+/// This method must be called before \a grpc_init() (truly, before
+/// \a grpc_iomgr_init()). This engine is shut down along with iomgr.
+///
+/// This is an internal method, not intended for public use. Public APIs are
+/// being planned.
 void SetDefaultEventEngine(
     std::unique_ptr<grpc_event_engine::experimental::EventEngine> event_engine);
 

--- a/src/core/lib/iomgr/event_engine/iomgr.h
+++ b/src/core/lib/iomgr/event_engine/iomgr.h
@@ -17,8 +17,8 @@
 
 #include <grpc/event_engine/event_engine.h>
 
-/// This can be called anywhere in the EE-based iomgr impl where we need to
-/// access the global EE instance.
+/// This can be called anywhere in the EventEngine-based iomgr impl where we
+/// need to access the global EventEngine instance.
 grpc_event_engine::experimental::EventEngine* grpc_iomgr_event_engine();
 
 namespace grpc_core {


### PR DESCRIPTION
With the current iomgr-based implementation, shared ownership of
an EventEngine is not easy to achieve, so I've simplified things a bit. 

Note: the `SetDefaultEventEngine` takes a unique_ptr to make the
ownership transfer explicit. However, the global storage needs to be
trivially destructible, so it's immediately released and stored raw.