### PR TITLE
Fix unused variable error

### DIFF
--- a/src/core/lib/iomgr/tcp_server_utils_posix_noifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_noifaddrs.cc
@@ -24,10 +24,10 @@
 
 #include "src/core/lib/iomgr/tcp_server_utils_posix.h"
 
-grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
-                                                      unsigned port_index,
-                                                      int requested_port,
-                                                      int* out_port) {
+grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* /*s*/,
+                                                      unsigned /*port_index*/,
+                                                      int /*requested_port*/,
+                                                      int* /*out_port*/) {
   return GRPC_ERROR_CREATE_FROM_STATIC_STRING("no ifaddrs available");
 }
 


### PR DESCRIPTION
This does not build on Android when warning-as-error compiler option is
enabled.

@veblush
