### PR TITLE
xds/testing: fix usage of datetime astimezone

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3093,7 +3093,7 @@ class GcpState(object):
 
 logging.debug(
     "script start time: %s",
-    datetime.datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
+    datetime.datetime.now(datetime.timezone.utc).astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
 logging.debug("logging local timezone: %s",
               datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
 alpha_compute = None

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -3093,7 +3093,8 @@ class GcpState(object):
 
 logging.debug(
     "script start time: %s",
-    datetime.datetime.now(datetime.timezone.utc).astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
+    datetime.datetime.now(
+        datetime.timezone.utc).astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
 logging.debug("logging local timezone: %s",
               datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo)
 alpha_compute = None


### PR DESCRIPTION
It caused failure:

```
Traceback (most recent call last):
  File "tools/run_tests/run_xds_tests.py", line 3096, in <module>
    datetime.datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S %Z"))
ValueError: astimezone() cannot be applied to a naive datetime
```