### PR TITLE
Add 1.39.0 to wrapped lang interop matrix builds

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -114,6 +114,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.36.3', ReleaseInfo()),
             ('v1.37.0', ReleaseInfo()),
             ('v1.38.0', ReleaseInfo()),
+            ('v1.39.0', ReleaseInfo()),
         ]),
     'go':
         OrderedDict([
@@ -329,6 +330,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.36.3', ReleaseInfo(runtimes=['python'])),
             ('v1.37.0', ReleaseInfo(runtimes=['python'])),
             ('v1.38.0', ReleaseInfo(runtimes=['python'])),
+            ('v1.39.0', ReleaseInfo(runtimes=['python'])),
         ]),
     'node':
         OrderedDict([
@@ -396,6 +398,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.36.3', ReleaseInfo()),
             ('v1.37.0', ReleaseInfo()),
             ('v1.38.0', ReleaseInfo()),
+            ('v1.39.0', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([
@@ -436,6 +439,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.36.3', ReleaseInfo()),
             ('v1.37.0', ReleaseInfo()),
             ('v1.38.0', ReleaseInfo()),
+            ('v1.39.0', ReleaseInfo()),
         ]),
     'csharp':
         OrderedDict([


### PR DESCRIPTION
Following the 1.39 release

The new docker images have been uploaded.