### PR TITLE
Fix bug in CQNext

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -175,9 +175,14 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// \return true if got an event, false if the queue is fully drained and
   ///         shut down.
   bool Next(void** tag, bool* ok) {
+    // Check return type == GOT_EVENT... cases:
+    // SHUTDOWN  - queue has been shutdown, return false.
+    // TIMEOUT   - we passed infinity time => queue has been shutdown, return
+    //             false.
+    // GOT_EVENT - we actually got an event, return true.
     return (AsyncNextInternal(tag, ok,
                               ::grpc::g_core_codegen_interface->gpr_inf_future(
-                                  GPR_CLOCK_REALTIME)) != SHUTDOWN);
+                                  GPR_CLOCK_REALTIME)) == GOT_EVENT);
   }
 
   /// Read from the queue, blocking up to \a deadline (or the queue's shutdown).


### PR DESCRIPTION
Internal bug b/170934515

In some cases, calling CQ::Next will return true without passing up a
new tag value, which is very much illegal. My expectation is that this
is due to messing up between SHUTDOWN and TIMEOUT in lower layer code
that doesn't particularly matter much to most callers, but was being
erroneously checked here.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
