### PR TITLE
[xDS UrlMap] Move client_runner's ownership to test classes

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_url_map.cfg
+++ b/tools/internal_ci/linux/grpc_xds_url_map.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_url_map.sh"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.cfg
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_url_map_python.sh"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -145,14 +145,11 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         # Pick a client_namespace_suffix if not set
         if self.resource_suffix is None:
             self.resource_suffix = ""
-            self.client_namespace_suffix = framework.helpers.rand.random_resource_suffix(
-            )
         else:
-            self.client_namespace_suffix = self.resource_suffix
-        logging.info(
-            'GcpResourceManager: resource prefix=%s, suffix=%s, client_namespace_suffix=%s',
-            self.resource_prefix, self.resource_suffix,
-            self.client_namespace_suffix)
+            raise NotImplementedError(
+                'Predefined resource_suffix is not supported for UrlMap tests')
+        logging.info('GcpResourceManager: resource prefix=%s, suffix=%s',
+                     self.resource_prefix, self.resource_suffix)
         # API managers
         self.k8s_api_manager = k8s.KubernetesApiManager(self.kube_context)
         self.gcp_api_manager = gcp.api.GcpApiManager()
@@ -166,27 +163,6 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         # Kubernetes namespace
         self.k8s_namespace = k8s.KubernetesNamespace(self.k8s_api_manager,
                                                      self.resource_prefix)
-        if self.client_namespace_suffix != self.resource_suffix:
-            self.k8s_client_namespace = k8s.KubernetesNamespace(
-                self.k8s_api_manager,
-                client_app.KubernetesClientRunner.make_namespace_name(
-                    self.resource_prefix, self.client_namespace_suffix))
-        else:
-            self.k8s_client_namespace = self.k8s_namespace
-        # Kubernetes Test Client
-        self.test_client_runner = client_app.KubernetesClientRunner(
-            self.k8s_client_namespace,
-            deployment_name=self.client_name,
-            image_name=self.client_image,
-            gcp_project=self.project,
-            gcp_api_manager=self.gcp_api_manager,
-            gcp_service_account=self.gcp_service_account,
-            td_bootstrap_image=self.td_bootstrap_image,
-            xds_server_uri=self.xds_server_uri,
-            network=self.network,
-            debug_use_port_forwarding=self.debug_use_port_forwarding,
-            stats_port=self.client_port,
-            reuse_namespace=True)
         # Kubernetes Test Servers
         self.test_server_runner = server_app.KubernetesServerRunner(
             self.k8s_namespace,
@@ -222,14 +198,38 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             reuse_namespace=True)
         logging.info('Strategy of GCP resources management: %s', self.strategy)
 
+    def create_test_client_runner(self):
+        if self.resource_suffix:
+            client_namespace_suffix = self.resource_suffix
+        else:
+            client_namespace_suffix = framework.helpers.rand.random_resource_suffix(
+            )
+        logging.info('GcpResourceManager: client_namespace_suffix=%s',
+                     client_namespace_suffix)
+        # Kubernetes Test Client
+        return client_app.KubernetesClientRunner(
+            k8s.KubernetesNamespace(
+                self.k8s_api_manager,
+                client_app.KubernetesClientRunner.make_namespace_name(
+                    self.resource_prefix, client_namespace_suffix)),
+            deployment_name=self.client_name,
+            image_name=self.client_image,
+            gcp_project=self.project,
+            gcp_api_manager=self.gcp_api_manager,
+            gcp_service_account=self.gcp_service_account,
+            td_bootstrap_image=self.td_bootstrap_image,
+            xds_server_uri=self.xds_server_uri,
+            network=self.network,
+            debug_use_port_forwarding=self.debug_use_port_forwarding,
+            stats_port=self.client_port)
+
     def _pre_cleanup(self):
         # Cleanup existing debris
         logging.info('GcpResourceManager: pre clean-up')
         self.td.cleanup(force=True)
-        self.test_client_runner.delete_namespace()
         self.test_server_runner.delete_namespace()
 
-    def setup(self, test_case_classes: 'Iterable[XdsUrlMapTestCase]') -> None:
+    def setup(self, test_case_classes: Iterable['XdsUrlMapTestCase']) -> None:
         if self.strategy not in ['create', 'keep']:
             logging.info('GcpResourceManager: skipping setup for strategy [%s]',
                          self.strategy)
@@ -294,11 +294,6 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         self.td.wait_for_affinity_backends_healthy_status()
 
     def cleanup(self) -> None:
-        if hasattr(self, 'test_client_runner'):
-            self.test_client_runner.cleanup(
-                force=True,
-                # Clean-up ephemeral client namespace
-                force_namespace=self.k8s_client_namespace != self.k8s_namespace)
         if self.strategy not in ['create']:
             logging.info(
                 'GcpResourceManager: skipping tear down for strategy [%s]',


### PR DESCRIPTION
In the existing code, the xDS UrlMap can run concurrently at job-level. However, each job run takes 20-30 minutes, and the execution time will increase as more and more test cases joining to the xDS UrlMap test framework. The solution was less ideal.

This PR enables test-case-level concurrency. Each test case now owns a technically unique Kubernetes namespace and client_runner, so it can start and delete pods without interfering other pods.

Besides, this PR also attempt to fix several usability issues:

- Reduced log intensity from "test_client_config". With per-test-case workload identity change, the xDS config might take several minutes to arrive.
- Don't print stack trace for non-fatal exception. This was meant for framework development, but distracts people's attentions from the real failure.

Kokoro runs:
- cpp: https://fusion2.corp.google.com/invocations/a907bb76-561a-47d9-85a4-fe5a9a5763dc/targets
- python: https://fusion2.corp.google.com/invocations/6159062f-5979-481b-9def-c1175b1a4a79/targets
- go: https://fusion2.corp.google.com/invocations/d65b8508-adb4-4ae6-be2d-4f24e4e56530/targets
- java: https://fusion2.corp.google.com/invocations/36a3bbd1-5034-4262-b3ca-fac66cfe1adf/targets