### PR TITLE
release v1.40.0: build gcr images for release, fix python2.7

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -264,6 +264,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.37.1', ReleaseInfo()),
             ('v1.38.1', ReleaseInfo()),
             ('v1.39.0', ReleaseInfo()),
+            ('v1.40.0', ReleaseInfo()),
         ]),
     'python':
         OrderedDict([

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 # Copyright 2017 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -339,7 +339,7 @@ def checkout_grpc_stack(lang, release):
                    do_newline=True)
 
     # Write git log to commit_log so it can be packaged with the docker image.
-    with open(os.path.join(stack_base, 'commit_log'), 'w') as f:
+    with open(os.path.join(stack_base, 'commit_log'), 'wb') as f:
         f.write(commit_log)
     return stack_base
 

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -136,7 +136,7 @@ def message(tag, msg, explanatory_text=None, do_newline=False):
                 sys.stdout.write(
                     '%s%s%s\x1b[%d;%dm%s\x1b[0m: %s%s' %
                     (_BEGINNING_OF_LINE, _CLEAR_LINE, '\n%s' %
-                     explanatory_text.decode('utf8') if explanatory_text
+                     explanatory_text if explanatory_text
                      is not None else '', _COLORS[_TAG_COLOR[tag]][1],
                      _COLORS[_TAG_COLOR[tag]][0], tag, msg, '\n'
                      if do_newline or explanatory_text is not None else ''))

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -136,9 +136,9 @@ def message(tag, msg, explanatory_text=None, do_newline=False):
                 sys.stdout.write(
                     '%s%s%s\x1b[%d;%dm%s\x1b[0m: %s%s' %
                     (_BEGINNING_OF_LINE, _CLEAR_LINE, '\n%s' %
-                     explanatory_text if explanatory_text
-                     is not None else '', _COLORS[_TAG_COLOR[tag]][1],
-                     _COLORS[_TAG_COLOR[tag]][0], tag, msg, '\n'
+                     explanatory_text if explanatory_text is not None else '',
+                     _COLORS[_TAG_COLOR[tag]][1], _COLORS[_TAG_COLOR[tag]][0],
+                     tag, msg, '\n'
                      if do_newline or explanatory_text is not None else ''))
             sys.stdout.flush()
             return


### PR DESCRIPTION
I ran these commands in GCP VM:
https://github.com/grpc/grpc/blob/master/tools/interop_matrix/README.md#step-by-step-instructions-for-adding-a-gcr-image-for-a-new-release-for-compatibility-test
And it was successful for Java. I had to use python3 because python2.7 is gone in the environment, then there were a few syntax changes in the code for python3.

I had problem running them in dev desktop.


cc @ejona86 