### PR TITLE
Don't link with obsolete WinSock 1.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ elseif(UNIX)
 endif()
 
 if(WIN32)
-  set(_gRPC_BASELIB_LIBRARIES wsock32 ws2_32 crypt32)
+  set(_gRPC_BASELIB_LIBRARIES ws2_32 crypt32)
 endif()
 
 # Create directory for generated .proto files

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -344,7 +344,7 @@
   endif()
 
   if(WIN32)
-    set(_gRPC_BASELIB_LIBRARIES wsock32 ws2_32 crypt32)
+    set(_gRPC_BASELIB_LIBRARIES ws2_32 crypt32)
   endif()
 
   # Create directory for generated .proto files


### PR DESCRIPTION
gRPC uses WinSock 2.0, released in 1996. Linking against a mix of WinSock 1 (wsock32.lib) and WinSock 2 (ws2_32.lib) is not supported.

It happens to work on desktop Windows, but wsock32.dll is not available on UWP. Applications using gRPC fail to load on UWP devices unless wsock32.lib is removed from the linker inputs.

@veblush for triage
