### PR TITLE
Fix incorrect loop variable type

### DIFF
--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -83,7 +83,7 @@ class ForwardingLoadBalancingPolicy : public LoadBalancingPolicy {
 MetadataVector CopyMetadataToVector(
     LoadBalancingPolicy::MetadataInterface* metadata) {
   MetadataVector result;
-  for (const auto& p : *metadata) {
+  for (auto p : *metadata) {
     result.push_back({std::string(p.first), std::string(p.second)});
   }
   return result;


### PR DESCRIPTION
The iterator returns a newly-constructed `std::pair<absl::string_view, absl::string_view>`.
Compiled with `-Wrange-loop-bind-reference` on iOS due to new dependencies for
iOS tests.

See https://source.cloud.google.com/results/invocations/17a9bfe4-2352-43a2-b6d1-c8c1e4f5c21a/targets/github%2Fgrpc%2Frun_tests%2Fobjc_macos_opt_native%2Fios-test-cfstream-tests/tests.

Snippet:
```
/Volumes/BuildData/tmpfs/src/github/grpc/workspace_objc_macos_opt_native/test/core/util/test_lb_policies.cc:86:20: error: loop variable 'p' is always a copy because the range of type 'LoadBalancingPolicy::MetadataInterface' does not return a reference [-Werror,-Wrange-loop-analysis]
  for (const auto& p : *metadata) {
                   ^
/Volumes/BuildData/tmpfs/src/github/grpc/workspace_objc_macos_opt_native/test/core/util/test_lb_policies.cc:86:8: note: use non-reference type 'std::__1::pair<absl::lts_20210324::string_view, absl::lts_20210324::string_view>'
  for (const auto& p : *metadata) {
       ^~~~~~~~~~~~~~~
1 error generated.
Test session results, code coverage, and logs:
	/Users/kbuilder/Library/Developer/Xcode/DerivedData/CFStreamTests-eysagtowlpfcwyfevvouytnaykfx/Logs/Test/Test-CFStreamTests-2021.08.18_11-28-18--0700.xcresult
```