### PR TITLE
[Backport] Extend url-map tests timeout to 90

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_url_map.cfg
+++ b/tools/internal_ci/linux/grpc_xds_url_map.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_url_map.sh"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.cfg
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_url_map_python.sh"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
As title.

This is part of https://github.com/grpc/grpc/pull/27031.

UrlMap tests on v1.40.x still fail due to timeout.