### PR TITLE
Fix the not removing IAM binding issue

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -366,7 +366,8 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.skip_reason is None:
-            cls.test_client_runner.delete_namespace()
+            # Clean up related resources for the client
+            cls.test_client_runner.cleanup(force=True, force_namespace=True)
         cls.finished_test_cases.add(cls.__name__)
         if cls.finished_test_cases == cls.test_case_names:
             # Tear down the GCP resource after all tests finished


### PR DESCRIPTION
Fixes b/197016740.

I overlooked that removing the namespace only cleans the Kubernetes resources. However, the IAM policy binding was leftover on GCP. This causes the policy size to increase dramatically and ends up failing the tests.

This PR uses proper clean-up methods.