### PR TITLE
Fix binder transport BUILD dependencies

### DIFF
--- a/src/core/ext/transport/binder/transport/BUILD
+++ b/src/core/ext/transport/binder/transport/BUILD
@@ -37,13 +37,10 @@ grpc_cc_library(
         "absl/memory",
     ],
     deps = [
-        "//:gpr",
         "//:gpr_base",
         "//:gpr_platform",
-        "//:grpc",
         "//:grpc_base",
         "//:grpc_base_c",
-        "//:grpc_codegen",
         "//src/core/ext/transport/binder/utils:transport_stream_receiver",
         "//src/core/ext/transport/binder/wire_format:binder",
         "//src/core/ext/transport/binder/wire_format:wire_reader",

--- a/src/core/ext/transport/binder/transport/BUILD
+++ b/src/core/ext/transport/binder/transport/BUILD
@@ -39,7 +39,6 @@ grpc_cc_library(
     deps = [
         "//:gpr_base",
         "//:gpr_platform",
-        "//:grpc_base",
         "//:grpc_base_c",
         "//src/core/ext/transport/binder/utils:transport_stream_receiver",
         "//src/core/ext/transport/binder/wire_format:binder",


### PR DESCRIPTION
AddressSanitizer detects ODR violation because of this.

@veblush
