### PR TITLE
[gRPC-ObjC] Fix potential over-releasing crash for grpc channel

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannel.m
@@ -291,8 +291,11 @@
 }
 
 - (void)dealloc {
-  if (_unmanagedChannel) {
-    grpc_channel_destroy(_unmanagedChannel);
+  @synchronized(self) {
+    if (_unmanagedChannel) {
+      grpc_channel_destroy(_unmanagedChannel);
+      _unmanagedChannel = NULL;
+    }
   }
 }
 


### PR DESCRIPTION
Existing crash dump call stack shows that the unmanaged cpp grpc_channel object is being dereferenced after already destroyed via grpc_channel_destroy (EXC_BAD_ACCESS / KERN_INVALID_ADDRESS).   Currently the only possible route for this to happen is for its objc wrapper GRPCChannel to be over-released (dealloc called twice).  Though this is usually unlikely, there are two potential racing condition leading to this given the fact that the channel object is nullified on the[ background serial queue _timerQueue](https://github.com/grpc/grpc/blob/master/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannelPool.m#L153)

* [Reentrant](https://github.com/grpc/grpc/blob/master/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannelPool.m#L159) with two block request submitted very close to each other 
*  [channel is nil-ed via self-> arrow operator](https://github.com/grpc/grpc/blob/master/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannelPool.m#L160) which might have some quirky effect for observing the nullified value

In either case, i think first step is to add the missing dealloc guard and make sure the cpp grpc_channel is destroyed exactly once.  After that, we can further verify which condition triggers the over-deallocation calls. 