### PR TITLE
Update docker images

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -3,7 +3,7 @@ coverage==4.5.4
 cython==0.29.21
 enum34==1.1.10
 protobuf>=3.5.0.post1, < 4.0dev
-six==1.15.0
+six==1.16.0
 wheel==0.36.2
 futures==3.1.1
 google-auth==1.24.0

--- a/templates/tools/dockerfile/debian_8_header.include
+++ b/templates/tools/dockerfile/debian_8_header.include
@@ -1,0 +1,1 @@
+FROM debian:8

--- a/templates/tools/dockerfile/debian_9_header.include
+++ b/templates/tools/dockerfile/debian_9_header.include
@@ -1,0 +1,1 @@
+FROM debian:9

--- a/templates/tools/dockerfile/debian_jessie_header.include
+++ b/templates/tools/dockerfile/debian_jessie_header.include
@@ -1,1 +1,0 @@
-FROM debian:jessie

--- a/templates/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile.include
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile.include
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%include file="../../debian_jessie_header.include"/>
+<%include file="../../debian_8_header.include"/>
 
 RUN echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list && ${'\\'}
     echo 'Acquire::Check-Valid-Until no;' > /etc/apt/apt.conf.d/99no-check-valid-until && ${'\\'}

--- a/templates/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
 
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../node_deps.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
   
   <%include file="../../php7_deps.include"/>
   <%include file="../../run_tests_addons.include"/>

--- a/templates/tools/dockerfile/python_deps.include
+++ b/templates/tools/dockerfile/python_deps.include
@@ -12,4 +12,4 @@ RUN apt-get update && apt-get install -y ${'\\'}
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0

--- a/templates/tools/dockerfile/ruby_deps.include
+++ b/templates/tools/dockerfile/ruby_deps.include
@@ -3,7 +3,7 @@
 
 # Install rvm
 RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5

--- a/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
@@ -41,7 +41,7 @@
   # Install Python packages from PyPI
   RUN pip install --upgrade pip==19.3.1
   RUN pip install virtualenv
-  RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+  RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
   RUN pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
 
   # Google Cloud platform API libraries

--- a/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
 
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>

--- a/templates/tools/dockerfile/test/node_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/node_jessie_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
 
   <%include file="../../apt_get_basic.include"/>
 

--- a/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../debian_jessie_header.include"/>
+  <%include file="../../debian_8_header.include"/>
   
   <%include file="../../php7_deps.include"/>
   <%include file="../../python_deps.include"/>

--- a/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x64/Dockerfile
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 # Docker file for building gRPC artifacts.
-# Updated: 2020-10-08
+# Updated: 2021-08-23
 
 ##################
 # Base
 
-FROM dockcross/manylinux2010-x64
+FROM dockcross/manylinux2010-x64:20210210-84c47e5
 
 # Install essential packages.
 RUN yum -y install golang strace
@@ -28,7 +28,8 @@ RUN yum -y install golang strace
 # Ruby dependencies
 
 # Install rvm
-RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+RUN curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.6

--- a/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_centos6_x86/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Docker file for building gRPC artifacts.
-# Updated: 2020-10-08
+# Updated: 2021-08-23
 
 ##################
 # Base
@@ -28,7 +28,8 @@ RUN yum -y install golang strace
 # Ruby dependencies
 
 # Install rvm
-RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+RUN curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.6

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_x64/Dockerfile
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 # Docker file for building gRPC manylinux Python artifacts.
-# Updated: 2020-10-08
+# Updated: 2021-08-23
 
-FROM quay.io/pypa/manylinux2014_x86_64
+# Use a tagged version to use Python 3.5
+FROM quay.io/pypa/manylinux2014_x86_64:2021-05-01-28d233a
 
 # TODO(jtattermusch): revisit which of the deps are really required
 RUN yum update -y && yum install -y curl-devel expat-devel gettext-devel openssl-devel zlib-devel

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_x86/Dockerfile
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 # Docker file for building gRPC manylinux Python artifacts.
-# Updated: 2020-10-08
+# Updated: 2021-08-23
 
-FROM quay.io/pypa/manylinux2014_i686
+# Use a tagged version to use Python 3.5
+FROM quay.io/pypa/manylinux2014_i686:2021-05-01-28d233a
 
 # TODO(jtattermusch): revisit which of the deps are really required
 RUN yum update -y && yum install -y curl-devel expat-devel gettext-devel openssl-devel zlib-devel

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 #================
 # C# dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 #================
 # C# dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 # Install Git and basic packages.
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_go1.11/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.11/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_go1.16/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.16/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_go1.8/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.8/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 RUN pip install twisted h2==2.6.1 hyper
 

--- a/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 RUN echo "deb http://archive.debian.org/debian/ jessie-backports main contrib non-free" > /etc/apt/sources.list.d/jessie-backports.list && \

--- a/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 # Install Git and basic packages.
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 #==================
 # Node dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 # Install Git and basic packages.

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 #=================

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
@@ -63,14 +63,14 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 #==================
 # Ruby dependencies
 
 # Install rvm
 RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5

--- a/tools/dockerfile/interoptest/lb_interop_fake_servers/Dockerfile
+++ b/tools/dockerfile/interoptest/lb_interop_fake_servers/Dockerfile
@@ -28,7 +28,7 @@ RUN ln -s /usr/local/go/bin/go /usr/local/bin
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/csharp_buster_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_buster_x64/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 RUN pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
 
 # Google Cloud platform API libraries

--- a/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_buster_openssl102_x64/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/cxx_buster_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_buster_x64/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 # Install Git and basic packages.
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/cxx_ubuntu1804_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1804_x64/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/node_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/node_jessie_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 # Install Git and basic packages.
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/php73_zts_stretch_x64/Dockerfile
+++ b/tools/dockerfile/test/php73_zts_stretch_x64/Dockerfile
@@ -31,10 +31,10 @@ RUN cd pthreads && \
   make && \
   make install
 
-RUN curl https://bootstrap.pypa.io/get-pip.py | python2.7
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:8
 
 
 #=================
@@ -75,7 +75,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/python_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/python_alpine_x64/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update && apk add \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0

--- a/tools/dockerfile/test/ruby_buster_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_buster_x64/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
 RUN pip install --upgrade pip==19.3.1
 RUN pip install virtualenv==16.7.9
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.15.0 twisted==17.5.0
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0
@@ -73,7 +73,7 @@ RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 o
 
 # Install rvm
 RUN apt-get update && apt-get install -y gnupg2 && apt-get clean
-RUN gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+RUN gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 
 # Install Ruby 2.5

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -35,7 +35,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 brew config
 
 # Add GCP credentials for BQ access
-pip install --user google-api-python-client oauth2client six==1.15.0
+pip install --user google-api-python-client oauth2client six==1.16.0
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 


### PR DESCRIPTION
Update docker scripts to build images successfully
- Upgraded Python packages to avoid a new transitive dependency error (`futures==3.1.1 enum34==1.1.10 six==1.16.0 twisted==19.10.0`)
- Used Debian 8 and 9 instead of `jessie` and `stretch` for consistency
- Updated Ruby RVM key
- Fixed the version of `manylinux2010` without the yum issue. (`manylinux2010` is now deprecated)
- Fixed the version of `manylinux2014` which still has python 3.5 support. (the latest version dropped it already)