### PR TITLE
TlsCredentials: fix a typo in comments

### DIFF
--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -108,7 +108,8 @@ class FileWatcherCertificateProvider final
   // Read the root certificates from files and update the distributor.
   absl::optional<std::string> ReadRootCertificatesFromFile(
       const std::string& root_cert_full_path);
-  // Read the root certificates from files and update the distributor.
+  // Read the private key and the certificate chain from files and update the
+  // distributor.
   absl::optional<PemKeyCertPairList> ReadIdentityKeyCertPairFromFiles(
       const std::string& private_key_path,
       const std::string& identity_certificate_path);


### PR DESCRIPTION
Fix an obvious issue in the comments.
(I nearly forgot about this; Luckily it just came to me while I was checking my previous emails)
