### PR TITLE
[gRPC/ObjC] Fix flaky test InteropTests::testHijackingInterceptor

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1603,6 +1603,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
   XCTAssertNotNil([[self class] host]);
   __weak XCTestExpectation *expectUserCallComplete =
       [self expectationWithDescription:@"User call completed."];
+  __weak XCTestExpectation *expectResponseCallbackComplete =
+      [self expectationWithDescription:@"Hook interceptor response callback completed"];
 
   NSArray *responses = @[ @1, @2, @3, @4 ];
   __block int index = 0;
@@ -1659,6 +1661,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
         XCTAssertNil(trailingMetadata);
         XCTAssertNotNil(error);
         XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
+        [expectResponseCallbackComplete fulfill];
       }
       didWriteDataHook:nil];
 


### PR DESCRIPTION
Fixing flaky InteropTest case for testHijackingInterceptor

- turns out [reponseCloseHook callback](https://github.com/grpc/grpc/blob/master/src/objective-c/tests/InteropTests/InteropTests.m#L1655)  are happening on background queue, and may / may not be reached prior to finish hook to [hijack](https://github.com/grpc/grpc/blob/master/src/objective-c/tests/InteropTests/InteropTests.m#L1642) and close the main call's expectation.   Thus the flakyness 

added expectation to wait for the hook interceptor's responseCloseHook to finish, before we assert final conditions. 