### PR TITLE
Add an annotation to allow tooling to make better choices

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -323,6 +323,7 @@ grpc_cc_library(
     language = "c++",
     public_hdrs = GPR_PUBLIC_HDRS,
     standalone = True,
+    tags = ["avoid_dep"],
     visibility = ["@grpc:public"],
     deps = [
         "gpr_base",
@@ -347,6 +348,7 @@ grpc_cc_library(
     language = "c++",
     public_hdrs = GRPC_PUBLIC_HDRS,
     standalone = True,
+    tags = ["avoid_dep"],
     visibility = ["@grpc:public"],
     deps = [
         "config",
@@ -522,6 +524,7 @@ grpc_cc_library(
     ],
     language = "c++",
     standalone = True,
+    tags = ["avoid_dep"],
     visibility = ["@grpc:public"],
     deps = [
         "gpr",
@@ -3149,6 +3152,7 @@ grpc_cc_library(
     ],
     language = "c++",
     public_hdrs = GRPCXX_PUBLIC_HDRS,
+    tags = ["avoid_dep"],
     visibility = ["@grpc:alt_grpc++_base_unsecure_legacy"],
     deps = [
         "gpr_base",


### PR DESCRIPTION
Some tooling we have can use this annotation to avoid adding dependencies to build targets that probably don't do what users intend.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
