### PR TITLE
Drop -msse4 compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ ifeq ($(SYSTEM),MINGW64)
 SYSTEM = MINGW32
 endif
 
+# Basic machine detection
+HOST_MACHINE = $(shell uname -m)
+ifeq ($(HOST_MACHINE),x86_64)
+HOST_IS_X86_64 = true
+else
+HOST_IS_X86_64 = false
+endif
+
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 ifndef BUILDDIR
 BUILDDIR_ABSOLUTE = $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
@@ -570,6 +578,11 @@ CPPFLAGS := -Ithird_party/address_sorting/include $(CPPFLAGS)
 
 GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
 GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
+ifeq ($(HOST_IS_X86_64),true)
+ABSL_RANDOM_HWAES_FLAGS = -maes -msse4
+else
+ABSL_RANDOM_HWAES_FLAGS =
+endif
 
 # Setup re2 dependency
 
@@ -2667,7 +2680,7 @@ LIBGRPC_ABSEIL_SRC = \
 
 LIBGRPC_ABSEIL_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC_ABSEIL_SRC))))
 
-$(LIBGRPC_ABSEIL_OBJS): CPPFLAGS += -Ithird_party/abseil-cpp
+$(LIBGRPC_ABSEIL_OBJS): CPPFLAGS += -g $(ABSL_RANDOM_HWAES_FLAGS) -Ithird_party/abseil-cpp
 
 $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a:  $(LIBGRPC_ABSEIL_OBJS) 
 	$(E) "[AR]      Creating $@"

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,6 @@ ifeq ($(SYSTEM),MINGW64)
 SYSTEM = MINGW32
 endif
 
-# Basic machine detection
-HOST_MACHINE = $(shell uname -m)
-ifeq ($(HOST_MACHINE),x86_64)
-HOST_IS_X86_64 = true
-else
-HOST_IS_X86_64 = false
-endif
-
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 ifndef BUILDDIR
 BUILDDIR_ABSOLUTE = $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
@@ -578,11 +570,6 @@ CPPFLAGS := -Ithird_party/address_sorting/include $(CPPFLAGS)
 
 GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
 GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
-ifeq ($(HOST_IS_X86_64),true)
-ABSL_RANDOM_HWAES_FLAGS = -maes -msse4
-else
-ABSL_RANDOM_HWAES_FLAGS =
-endif
 
 # Setup re2 dependency
 
@@ -2680,7 +2667,7 @@ LIBGRPC_ABSEIL_SRC = \
 
 LIBGRPC_ABSEIL_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPC_ABSEIL_SRC))))
 
-$(LIBGRPC_ABSEIL_OBJS): CPPFLAGS += -g $(ABSL_RANDOM_HWAES_FLAGS) -Ithird_party/abseil-cpp
+$(LIBGRPC_ABSEIL_OBJS): CPPFLAGS += -Ithird_party/abseil-cpp
 
 $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a:  $(LIBGRPC_ABSEIL_OBJS) 
 	$(E) "[AR]      Creating $@"

--- a/Makefile
+++ b/Makefile
@@ -579,7 +579,7 @@ CPPFLAGS := -Ithird_party/address_sorting/include $(CPPFLAGS)
 GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
 GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
 ifeq ($(HOST_IS_X86_64),true)
-ABSL_RANDOM_HWAES_FLAGS = -maes -msse4
+ABSL_RANDOM_HWAES_FLAGS = -maes
 else
 ABSL_RANDOM_HWAES_FLAGS =
 endif

--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -165,7 +165,7 @@ configs:
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:suppressions=test/core/util/ubsan_suppressions.txt
 defaults:
   abseil:
-    CPPFLAGS: -g $(ABSL_RANDOM_HWAES_FLAGS) -Ithird_party/abseil-cpp
+    CPPFLAGS: -Ithird_party/abseil-cpp
   ares:
     CFLAGS: -g
     CPPFLAGS: -Ithird_party/cares -Ithird_party/cares/cares -fvisibility=hidden -D_GNU_SOURCE

--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -165,7 +165,7 @@ configs:
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:suppressions=test/core/util/ubsan_suppressions.txt
 defaults:
   abseil:
-    CPPFLAGS: -Ithird_party/abseil-cpp
+    CPPFLAGS: -g $(ABSL_RANDOM_HWAES_FLAGS) -Ithird_party/abseil-cpp
   ares:
     CFLAGS: -g
     CPPFLAGS: -Ithird_party/cares -Ithird_party/cares/cares -fvisibility=hidden -D_GNU_SOURCE

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -442,7 +442,7 @@
   GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
   GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
   ifeq ($(HOST_IS_X86_64),true)
-  ABSL_RANDOM_HWAES_FLAGS = -maes -msse4
+  ABSL_RANDOM_HWAES_FLAGS = -maes
   else
   ABSL_RANDOM_HWAES_FLAGS =
   endif

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -74,6 +74,14 @@
   SYSTEM = MINGW32
   endif
 
+  # Basic machine detection
+  HOST_MACHINE = $(shell uname -m)
+  ifeq ($(HOST_MACHINE),x86_64)
+  HOST_IS_X86_64 = true
+  else
+  HOST_IS_X86_64 = false
+  endif
+
   MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
   ifndef BUILDDIR
   BUILDDIR_ABSOLUTE = $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
@@ -433,6 +441,11 @@
 
   GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
   GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
+  ifeq ($(HOST_IS_X86_64),true)
+  ABSL_RANDOM_HWAES_FLAGS = -maes -msse4
+  else
+  ABSL_RANDOM_HWAES_FLAGS =
+  endif
 
   # Setup re2 dependency
 

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -74,14 +74,6 @@
   SYSTEM = MINGW32
   endif
 
-  # Basic machine detection
-  HOST_MACHINE = $(shell uname -m)
-  ifeq ($(HOST_MACHINE),x86_64)
-  HOST_IS_X86_64 = true
-  else
-  HOST_IS_X86_64 = false
-  endif
-
   MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
   ifndef BUILDDIR
   BUILDDIR_ABSOLUTE = $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
@@ -441,11 +433,6 @@
 
   GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
   GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
-  ifeq ($(HOST_IS_X86_64),true)
-  ABSL_RANDOM_HWAES_FLAGS = -maes -msse4
-  else
-  ABSL_RANDOM_HWAES_FLAGS =
-  endif
 
   # Setup re2 dependency
 


### PR DESCRIPTION
Older CPUs that do not have SSE4.1 would crash with the Ruby native gem due to an illegal instruction exception.

The Abseil random library isn't being used at the moment (https://github.com/grpc/grpc/pull/26476), and there's no reason gRPC needs to force SSE4.1 instructions on all platforms at the moment. There are other hardware-specific issues that need to be ironed out for this to work: https://github.com/grpc/grpc/pull/26479

When the `-msse4` compiler flag was enabled, the Abseil code started using the `pinsrb` instruction:

```
$ elfx86exts abseil-cpp/absl/time/internal/cctz/src/time_zone_libc.o
MODE64 (ret)
CMOV (cmovne)
SSE2 (movdqa)
SSE41 (pinsrb)
SSE1 (movaps)
CPU Generation: Penryn
```

This was previously needed because gcc 4.8 wouldn't compile without the `-msse4` and `-maes` flags.

However, per https://github.com/gcc-mirror/gcc/commit/97db2bf7fb10e7eb2e8224e0471b56976f133843 gcc 5.0+ automatically detects whether these options are enabled.

clang still needs `-maes` since including `wmmintrin.h` expects the AES option to be enabled.

Closes https://github.com/grpc/grpc/issues/27095




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth @veblush 
