### PR TITLE
Update default XDS server name in C2P resolver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -321,7 +321,7 @@ void GoogleCloud2ProdResolver::StartXdsResolver() {
   const char* server_uri =
       override_server != nullptr && strlen(override_server.get()) > 0
           ? override_server.get()
-          : "directpath-trafficdirector.googleapis.com";
+          : "directpath-pa.googleapis.com";
   Json bootstrap = Json::Object{
       {"xds_servers",
        Json::Array{


### PR DESCRIPTION
`directpath-trafficdirector.googleapis.com` has been superseded by `directpath-pa.googleapis.com`

b/184569084