### PR TITLE
Allow access to Google API regional endpoints via Google Default Credentials

### DIFF
--- a/src/core/lib/security/credentials/jwt/jwt_credentials.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_credentials.cc
@@ -31,6 +31,7 @@
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/api_trace.h"
+#include "src/core/lib/uri/uri_parser.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -63,12 +64,19 @@ bool grpc_service_account_jwt_access_credentials::get_request_metadata(
   gpr_timespec refresh_threshold = gpr_time_from_seconds(
       GRPC_SECURE_TOKEN_REFRESH_THRESHOLD_SECS, GPR_TIMESPAN);
 
+  // Remove service name from service_url to follow the audience format
+  // dictated in https://google.aip.dev/auth/4111.
+  char* url = grpc_remove_service_name_from_uri(context.service_url);
+  if (url == nullptr) {
+    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Invalid service URL.");
+    return true;
+  }
   /* See if we can return a cached jwt. */
   grpc_mdelem jwt_md = GRPC_MDNULL;
   {
     gpr_mu_lock(&cache_mu_);
     if (cached_.service_url != nullptr &&
-        strcmp(cached_.service_url, context.service_url) == 0 &&
+        strcmp(cached_.service_url, url) == 0 &&
         !GRPC_MDISNULL(cached_.jwt_md) &&
         (gpr_time_cmp(
              gpr_time_sub(cached_.jwt_expiration, gpr_now(GPR_CLOCK_REALTIME)),
@@ -83,14 +91,13 @@ bool grpc_service_account_jwt_access_credentials::get_request_metadata(
     /* Generate a new jwt. */
     gpr_mu_lock(&cache_mu_);
     reset_cache();
-    jwt = grpc_jwt_encode_and_sign(&key_, context.service_url, jwt_lifetime_,
-                                   nullptr);
+    jwt = grpc_jwt_encode_and_sign(&key_, url, jwt_lifetime_, nullptr);
     if (jwt != nullptr) {
       std::string md_value = absl::StrCat("Bearer ", jwt);
       gpr_free(jwt);
       cached_.jwt_expiration =
           gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), jwt_lifetime_);
-      cached_.service_url = gpr_strdup(context.service_url);
+      cached_.service_url = gpr_strdup(url);
       cached_.jwt_md = grpc_mdelem_from_slices(
           grpc_slice_from_static_string(GRPC_AUTHORIZATION_METADATA_KEY),
           grpc_slice_from_cpp_string(std::move(md_value)));
@@ -105,6 +112,7 @@ bool grpc_service_account_jwt_access_credentials::get_request_metadata(
   } else {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Could not generate JWT.");
   }
+  gpr_free(url);
   return true;
 }
 
@@ -172,4 +180,15 @@ grpc_call_credentials* grpc_service_account_jwt_access_credentials_create(
   return grpc_service_account_jwt_access_credentials_create_from_auth_json_key(
              grpc_auth_json_key_create_from_string(json_key), token_lifetime)
       .release();
+}
+
+char* grpc_remove_service_name_from_uri(const char* peer_uri) {
+  absl::StatusOr<grpc_core::URI> uri = grpc_core::URI::Parse(peer_uri);
+  if (!uri.ok()) {
+    return nullptr;
+  }
+  char* result = nullptr;
+  gpr_asprintf(&result, "%s://%s/", uri->scheme().c_str(),
+               uri->authority().c_str());
+  return result;
 }

--- a/src/core/lib/security/credentials/jwt/jwt_credentials.h
+++ b/src/core/lib/security/credentials/jwt/jwt_credentials.h
@@ -64,7 +64,7 @@ class grpc_service_account_jwt_access_credentials
   gpr_mu cache_mu_;
   struct {
     grpc_mdelem jwt_md = GRPC_MDNULL;
-    char* service_url = nullptr;
+    std::string service_url;
     gpr_timespec jwt_expiration;
   } cached_;
 
@@ -78,10 +78,11 @@ grpc_core::RefCountedPtr<grpc_call_credentials>
 grpc_service_account_jwt_access_credentials_create_from_auth_json_key(
     grpc_auth_json_key key, gpr_timespec token_lifetime);
 
-// Helper function that removes RPC service name from uri.
-// The caller takes ownership of the returned value.
-//
-// Exposed for testing purpose.
-char* grpc_remove_service_name_from_uri(const char* peer_uri);
+namespace grpc_core {
+
+// Exposed for testing purposes only.
+absl::StatusOr<std::string> RemoveServiceNameFromJwtUri(absl::string_view uri);
+
+}  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_SECURITY_CREDENTIALS_JWT_JWT_CREDENTIALS_H */

--- a/src/core/lib/security/credentials/jwt/jwt_credentials.h
+++ b/src/core/lib/security/credentials/jwt/jwt_credentials.h
@@ -78,4 +78,10 @@ grpc_core::RefCountedPtr<grpc_call_credentials>
 grpc_service_account_jwt_access_credentials_create_from_auth_json_key(
     grpc_auth_json_key key, gpr_timespec token_lifetime);
 
+// Helper function that removes RPC service name from uri.
+// The caller takes ownership of the returned value.
+//
+// Exposed for testing purpose.
+char* grpc_remove_service_name_from_uri(const char* peer_uri);
+
 #endif /* GRPC_CORE_LIB_SECURITY_CREDENTIALS_JWT_JWT_CREDENTIALS_H */

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -1405,14 +1405,14 @@ static void test_jwt_creds_lifetime(void) {
   gpr_free(json_key_string);
 }
 
-static void test_jwt_creds_uri_process(void) {
+static void test_remove_service_from_jwt_uri(void) {
   const char wrong_uri[] = "hello world";
-  GPR_ASSERT(grpc_remove_service_name_from_uri(wrong_uri) == nullptr);
+  GPR_ASSERT(!grpc_core::RemoveServiceNameFromJwtUri(wrong_uri).ok());
   const char valid_uri[] = "https://foo.com/get/";
   const char expected_uri[] = "https://foo.com/";
-  char* output = grpc_remove_service_name_from_uri(valid_uri);
-  GPR_ASSERT(strcmp(output, expected_uri) == 0);
-  gpr_free(output);
+  auto output = grpc_core::RemoveServiceNameFromJwtUri(valid_uri);
+  GPR_ASSERT(output.ok());
+  GPR_ASSERT(strcmp(output->c_str(), expected_uri) == 0);
 }
 
 static void test_jwt_creds_success(void) {
@@ -3509,7 +3509,7 @@ int main(int argc, char** argv) {
   test_jwt_creds_lifetime();
   test_jwt_creds_success();
   test_jwt_creds_signing_failure();
-  test_jwt_creds_uri_process();
+  test_remove_service_from_jwt_uri();
   test_google_default_creds_auth_key();
   test_google_default_creds_refresh_token();
   test_google_default_creds_external_account_credentials();


### PR DESCRIPTION
The self-signed JWT used to access Google API regional endpoints do not have a correct audience format dictated in https://google.aip.dev/auth/4111. That is, it includes a trailing RPC service name while the spec requires only the presence of hostname (or endpoint). 

This should fix https://github.com/grpc/grpc/issues/27098#event-5208869132

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/27155)
<!-- Reviewable:end -->
