### PR TITLE
[Cherry-Pick][gRPC-ObjC] Fix potential over releasing crash for grp channel (#27061)

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCChannel.m
@@ -291,8 +291,11 @@
 }
 
 - (void)dealloc {
-  if (_unmanagedChannel) {
-    grpc_channel_destroy(_unmanagedChannel);
+  @synchronized(self) {
+    if (_unmanagedChannel) {
+      grpc_channel_destroy(_unmanagedChannel);
+      _unmanagedChannel = NULL;
+    }
   }
 }
 


### PR DESCRIPTION
This is a cherry-pick for PR https://github.com/grpc/grpc/pull/27061  for v1.40.x release branch 