### PR TITLE
Break after WriteLast()

### DIFF
--- a/test/cpp/end2end/test_service_impl.h
+++ b/test/cpp/end2end/test_service_impl.h
@@ -403,6 +403,7 @@ class TestMultipleServiceImpl : public RpcService {
       response.set_message(request.message());
       if (read_counts == server_write_last) {
         stream->WriteLast(response, WriteOptions());
+        break;
       } else {
         stream->Write(response);
       }


### PR DESCRIPTION
If we continue to call `Write()` after `WriteLast()` (because client is still sending us data and thus `Read()` returns `true`), the buffer might become invalid and results in assertion failures.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
