### PR TITLE
Revert "Enable retries by default (#26766)"

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -381,7 +381,7 @@ typedef struct {
     Defaults to "blend". In the current implementation "blend" is equivalent to
     "latency". */
 #define GRPC_ARG_OPTIMIZATION_TARGET "grpc.optimization_target"
-/** Enables retry functionality.  Defaults to true.  When enabled,
+/** Enables retry functionality.  Defaults to false.  When enabled,
     configurable retries are enabled when they are configured via the
     service config.  For details, see:
       https://github.com/grpc/proposal/blob/master/A6-client-retries.md

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1515,7 +1515,7 @@ void ClientChannel::UpdateServiceConfigInDataPlaneLocked() {
       channel_args_, args_to_add.data(), args_to_add.size());
   new_args = config_selector->ModifyChannelArgs(new_args);
   bool enable_retries =
-      grpc_channel_args_find_bool(new_args, GRPC_ARG_ENABLE_RETRIES, true);
+      grpc_channel_args_find_bool(new_args, GRPC_ARG_ENABLE_RETRIES, false);
   // Construct dynamic filter stack.
   std::vector<const grpc_channel_filter*> filters =
       config_selector->GetFilters();

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -242,6 +242,7 @@ class XdsResolver : public Resolver {
     RouteTable route_table_;
     std::map<absl::string_view, RefCountedPtr<ClusterState>> clusters_;
     std::vector<const grpc_channel_filter*> filters_;
+    bool retry_enabled_ = false;
   };
 
   void OnListenerUpdate(XdsApi::LdsUpdate listener);
@@ -470,6 +471,7 @@ grpc_error_handle XdsResolver::XdsConfigSelector::CreateMethodConfig(
   std::vector<std::string> fields;
   // Set retry policy if any.
   if (route.retry_policy.has_value()) {
+    retry_enabled_ = true;
     std::vector<std::string> retry_parts;
     retry_parts.push_back(absl::StrFormat(
         "\"retryPolicy\": {\n"
@@ -573,7 +575,18 @@ grpc_error_handle XdsResolver::XdsConfigSelector::CreateMethodConfig(
 
 grpc_channel_args* XdsResolver::XdsConfigSelector::ModifyChannelArgs(
     grpc_channel_args* args) {
-  return args;
+  // The max number of args to add is 1 so far; when more args need to be added
+  // we will increase the size of args_to_add accordingly;
+  absl::InlinedVector<grpc_arg, 1> args_to_add;
+  if (retry_enabled_) {
+    args_to_add.emplace_back(grpc_channel_arg_integer_create(
+        const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1));
+  }
+  if (args_to_add.empty()) return args;
+  grpc_channel_args* new_args = grpc_channel_args_copy_and_add(
+      args, args_to_add.data(), args_to_add.size());
+  grpc_channel_args_destroy(args);
+  return new_args;
 }
 
 void XdsResolver::XdsConfigSelector::MaybeAddCluster(const std::string& name) {

--- a/test/core/end2end/tests/retry.cc
+++ b/test/core/end2end/tests/retry.cc
@@ -121,6 +121,8 @@ static void test_retry(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_cancel_during_delay.cc
+++ b/test/core/end2end/tests/retry_cancel_during_delay.cc
@@ -120,6 +120,8 @@ static void test_retry_cancel_during_delay(grpc_end2end_test_config config,
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_cancellation.cc
+++ b/test/core/end2end/tests/retry_cancellation.cc
@@ -122,6 +122,8 @@ static void test_retry_cancellation(grpc_end2end_test_config config,
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_disabled.cc
+++ b/test/core/end2end/tests/retry_disabled.cc
@@ -93,11 +93,13 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-// Tests that we don't retry when retries are disabled via the
+// Tests that we don't retry when retries are not enabled via the
 // GRPC_ARG_ENABLE_RETRIES channel arg, even when there is retry
 // configuration in the service config.
 // - 1 retry allowed for ABORTED status
 // - first attempt returns ABORTED but does not retry
+// TODO(roth): Update this when we change the default of
+// GRPC_ARG_ENABLE_RETRIES to true.
 static void test_retry_disabled(grpc_end2end_test_config config) {
   grpc_call* c;
   grpc_call* s;
@@ -121,28 +123,24 @@ static void test_retry_disabled(grpc_end2end_test_config config) {
   int was_cancelled = 2;
   char* peer;
 
-  grpc_arg args[] = {
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 0),
-      grpc_channel_arg_string_create(
-          const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
-          const_cast<char*>(
-              "{\n"
-              "  \"methodConfig\": [ {\n"
-              "    \"name\": [\n"
-              "      { \"service\": \"service\", \"method\": \"method\" }\n"
-              "    ],\n"
-              "    \"retryPolicy\": {\n"
-              "      \"maxAttempts\": 2,\n"
-              "      \"initialBackoff\": \"1s\",\n"
-              "      \"maxBackoff\": \"120s\",\n"
-              "      \"backoffMultiplier\": 1.6,\n"
-              "      \"retryableStatusCodes\": [ \"ABORTED\" ]\n"
-              "    }\n"
-              "  } ]\n"
-              "}")),
-  };
-  grpc_channel_args client_args = {GPR_ARRAY_SIZE(args), args};
+  grpc_arg arg = grpc_channel_arg_string_create(
+      const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
+      const_cast<char*>(
+          "{\n"
+          "  \"methodConfig\": [ {\n"
+          "    \"name\": [\n"
+          "      { \"service\": \"service\", \"method\": \"method\" }\n"
+          "    ],\n"
+          "    \"retryPolicy\": {\n"
+          "      \"maxAttempts\": 2,\n"
+          "      \"initialBackoff\": \"1s\",\n"
+          "      \"maxBackoff\": \"120s\",\n"
+          "      \"backoffMultiplier\": 1.6,\n"
+          "      \"retryableStatusCodes\": [ \"ABORTED\" ]\n"
+          "    }\n"
+          "  } ]\n"
+          "}"));
+  grpc_channel_args client_args = {1, &arg};
   grpc_end2end_test_fixture f =
       begin_test(config, "retry_disabled", &client_args, nullptr);
 

--- a/test/core/end2end/tests/retry_exceeds_buffer_size_in_delay.cc
+++ b/test/core/end2end/tests/retry_exceeds_buffer_size_in_delay.cc
@@ -127,6 +127,8 @@ static void test_retry_exceeds_buffer_size_in_delay(
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_exceeds_buffer_size_in_initial_batch.cc
+++ b/test/core/end2end/tests/retry_exceeds_buffer_size_in_initial_batch.cc
@@ -124,6 +124,8 @@ static void test_retry_exceeds_buffer_size_in_initial_batch(
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_exceeds_buffer_size_in_subsequent_batch.cc
+++ b/test/core/end2end/tests/retry_exceeds_buffer_size_in_subsequent_batch.cc
@@ -129,6 +129,8 @@ static void test_retry_exceeds_buffer_size_in_subsequent_batch(
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_lb_drop.cc
+++ b/test/core/end2end/tests/retry_lb_drop.cc
@@ -180,6 +180,8 @@ static void test_retry_lb_drop(grpc_end2end_test_config config) {
   grpc_core::g_pick_args_vector = &pick_args_seen;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_non_retriable_status.cc
+++ b/test/core/end2end/tests/retry_non_retriable_status.cc
@@ -120,6 +120,8 @@ static void test_retry_non_retriable_status(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_non_retriable_status_before_recv_trailing_metadata_started.cc
+++ b/test/core/end2end/tests/retry_non_retriable_status_before_recv_trailing_metadata_started.cc
@@ -123,6 +123,8 @@ test_retry_non_retriable_status_before_recv_trailing_metadata_started(
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_per_attempt_recv_timeout.cc
+++ b/test/core/end2end/tests/retry_per_attempt_recv_timeout.cc
@@ -123,6 +123,8 @@ static void test_retry_per_attempt_recv_timeout(
 
   grpc_arg args[] = {
       grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
+      grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_EXPERIMENTAL_ENABLE_HEDGING), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),

--- a/test/core/end2end/tests/retry_per_attempt_recv_timeout_on_last_attempt.cc
+++ b/test/core/end2end/tests/retry_per_attempt_recv_timeout_on_last_attempt.cc
@@ -119,6 +119,8 @@ static void test_retry_per_attempt_recv_timeout_on_last_attempt(
 
   grpc_arg args[] = {
       grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
+      grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_EXPERIMENTAL_ENABLE_HEDGING), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),

--- a/test/core/end2end/tests/retry_recv_initial_metadata.cc
+++ b/test/core/end2end/tests/retry_recv_initial_metadata.cc
@@ -125,6 +125,8 @@ static void test_retry_recv_initial_metadata(grpc_end2end_test_config config) {
       {{nullptr, nullptr, nullptr, nullptr}}};
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_recv_message.cc
+++ b/test/core/end2end/tests/retry_recv_message.cc
@@ -121,6 +121,8 @@ static void test_retry_recv_message(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
+++ b/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
@@ -125,6 +125,8 @@ static void test_retry_recv_trailing_metadata_error(
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_send_op_fails.cc
+++ b/test/core/end2end/tests/retry_send_op_fails.cc
@@ -127,6 +127,8 @@ static void test_retry_send_op_fails(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_server_pushback_delay.cc
+++ b/test/core/end2end/tests/retry_server_pushback_delay.cc
@@ -126,6 +126,8 @@ static void test_retry_server_pushback_delay(grpc_end2end_test_config config) {
   pushback_md.value = grpc_slice_from_static_string("2000");
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_server_pushback_disabled.cc
+++ b/test/core/end2end/tests/retry_server_pushback_disabled.cc
@@ -127,6 +127,8 @@ static void test_retry_server_pushback_disabled(
   pushback_md.value = grpc_slice_from_static_string("-1");
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_streaming.cc
+++ b/test/core/end2end/tests/retry_streaming.cc
@@ -138,6 +138,8 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
 
   grpc_arg args[] = {
       grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
+      grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE),
           1024 * 8),
       grpc_channel_arg_integer_create(

--- a/test/core/end2end/tests/retry_streaming_after_commit.cc
+++ b/test/core/end2end/tests/retry_streaming_after_commit.cc
@@ -127,6 +127,8 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_streaming_succeeds_before_replay_finished.cc
+++ b/test/core/end2end/tests/retry_streaming_succeeds_before_replay_finished.cc
@@ -128,6 +128,8 @@ static void test_retry_streaming_succeeds_before_replay_finished(
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_throttled.cc
+++ b/test/core/end2end/tests/retry_throttled.cc
@@ -120,6 +120,8 @@ static void test_retry_throttled(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/test/core/end2end/tests/retry_too_many_attempts.cc
+++ b/test/core/end2end/tests/retry_too_many_attempts.cc
@@ -121,6 +121,8 @@ static void test_retry_too_many_attempts(grpc_end2end_test_config config) {
   char* peer;
 
   grpc_arg args[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_ENABLE_RETRIES), 1),
       grpc_channel_arg_string_create(
           const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
           const_cast<char*>(

--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -71,10 +71,9 @@ export CC=/usr/bin/gcc
   composer install && \
   ./bin/generate_proto_php.sh)
 
-GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
+GRPC_VERBOSITY=debug GRPC_TRACE=retry,channel,call_combiner,client_channel_routing,fault_injection_filter "$PYTHON" \
   tools/run_tests/run_xds_tests.py \
-  --halt_after_fail \
-  --test_case="timeout,fault_injection" \
+  --test_case="fault_injection" \
   --project_id=grpc-testing \
   --project_num=830293263384 \
   --source_image=projects/grpc-testing/global/images/xds-test-server-4 \
@@ -85,15 +84,3 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,c
   ${XDS_V3_OPT-} \
   --client_cmd='./src/php/bin/run_xds_client.sh --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps} {fail_on_failed_rpc} {rpcs_to_send} {metadata_to_send}'
 
-GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
-  tools/run_tests/run_xds_tests.py \
-  --halt_after_fail \
-  --test_case="all,path_matching,header_matching" \
-  --project_id=grpc-testing \
-  --project_num=830293263384 \
-  --source_image=projects/grpc-testing/global/images/xds-test-server-4 \
-  --path_to_server_binary=/java_server/grpc-java/interop-testing/build/install/grpc-interop-testing/bin/xds-test-server \
-  --gcp_suffix=$(date '+%s') \
-  --verbose \
-  ${XDS_V3_OPT-} \
-  --client_cmd='php -d extension=grpc.so -d extension=pthreads.so src/php/tests/interop/xds_client.php --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps} {fail_on_failed_rpc} {rpcs_to_send} {metadata_to_send}'


### PR DESCRIPTION
This reverts commit d140f14caf5f5a8aca21827c335a003f33a5bb99.

https://github.com/grpc/grpc/pull/26766

This is a testing branch for b/195439751.