### PR TITLE
Only enable binder transport code when API level is high enough

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -117,6 +117,11 @@
 #elif defined(ANDROID) || defined(__ANDROID__)
 #define GPR_PLATFORM_STRING "android"
 #define GPR_ANDROID 1
+#ifdef __ANDROID_API__
+#if (__ANDROID_API__) >= 29
+#define GPR_SUPPORT_BINDER_TRANSPORT 1
+#endif
+#endif
 // TODO(apolcyn): re-evaluate support for c-ares
 // on android after upgrading our c-ares dependency.
 // See https://github.com/grpc/grpc/issues/18038.

--- a/src/core/ext/transport/binder/client/channel_create.cc
+++ b/src/core/ext/transport/binder/client/channel_create.cc
@@ -16,14 +16,23 @@
 
 #include "src/core/ext/transport/binder/client/channel_create.h"
 
-#if defined(ANDROID) || defined(__ANDROID__)
+// The interface is only defined if GPR_ANDROID is defined, because some
+// arguments requires JNI.
+// Furthermore, the interface is non-phony only when
+// GPR_SUPPORT_BINDER_TRANSPORT is true because actual implementation of binder
+// transport requires newer version of NDK API
+
+#ifdef GPR_ANDROID
+
+#include <grpc/grpc.h>
+#include <grpc/grpc_posix.h>
+
+#ifdef GPR_SUPPORT_BINDER_TRANSPORT
 
 #include <android/binder_auto_utils.h>
 #include <android/binder_ibinder.h>
 #include <android/binder_ibinder_jni.h>
 #include <android/binder_interface_utils.h>
-#include <grpc/grpc.h>
-#include <grpc/grpc_posix.h>
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 #include <grpcpp/impl/grpc_library.h>
@@ -94,4 +103,20 @@ std::shared_ptr<grpc::Channel> CreateBinderChannel(
 }  // namespace experimental
 }  // namespace grpc
 
-#endif  // ANDROID
+#else  // !GPR_SUPPORT_BINDER_TRANSPORT
+
+std::shared_ptr<grpc::Channel> CreateBinderChannel(void*, jobject,
+                                                   absl::string_view,
+                                                   absl::string_view) {
+  GPR_ASSERT(0);
+  return {};
+}
+
+void BindToOnDeviceServerService(void*, jobject, absl::string_view,
+                                 absl::string_view) {
+  GPR_ASSERT(0);
+}
+
+#endif  // GPR_SUPPORT_BINDER_TRANSPORT
+
+#endif  // GPR_ANDROID

--- a/src/core/ext/transport/binder/client/channel_create.h
+++ b/src/core/ext/transport/binder/client/channel_create.h
@@ -15,9 +15,9 @@
 #ifndef GRPC_CORE_EXT_TRANSPORT_BINDER_CLIENT_CHANNEL_CREATE_H
 #define GRPC_CORE_EXT_TRANSPORT_BINDER_CLIENT_CHANNEL_CREATE_H
 
-#if defined(ANDROID) || defined(__ANDROID__)
-
 #include <grpc/impl/codegen/port_platform.h>
+
+#ifdef GPR_ANDROID
 
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/port_platform.h>

--- a/src/core/ext/transport/binder/wire_format/binder_android.cc
+++ b/src/core/ext/transport/binder/wire_format/binder_android.cc
@@ -14,12 +14,11 @@
 
 #include <grpc/impl/codegen/port_platform.h>
 
+#ifdef GPR_SUPPORT_BINDER_TRANSPORT
+
 #include "src/core/ext/transport/binder/wire_format/binder_android.h"
 
-#if defined(ANDROID) || defined(__ANDROID__)
-
 #include <grpc/support/log.h>
-
 #include <map>
 
 #include "absl/memory/memory.h"
@@ -250,4 +249,4 @@ absl::Status ReadableParcelAndroid::ReadString(char data[111]) const {
 
 }  // namespace grpc_binder
 
-#endif  // defined(ANDROID) || defined(__ANDROID__)
+#endif  // GPR_SUPPORT_BINDER_TRANSPORT

--- a/src/core/ext/transport/binder/wire_format/binder_android.h
+++ b/src/core/ext/transport/binder/wire_format/binder_android.h
@@ -15,9 +15,9 @@
 #ifndef GRPC_CORE_EXT_TRANSPORT_BINDER_WIRE_FORMAT_BINDER_ANDROID_H
 #define GRPC_CORE_EXT_TRANSPORT_BINDER_WIRE_FORMAT_BINDER_ANDROID_H
 
-#if defined(ANDROID) || defined(__ANDROID__)
-
 #include <grpc/impl/codegen/port_platform.h>
+
+#ifdef GPR_SUPPORT_BINDER_TRANSPORT
 
 #include <android/binder_auto_utils.h>
 #include <android/binder_ibinder.h>
@@ -30,11 +30,6 @@
 #include "absl/memory/memory.h"
 #include "src/core/ext/transport/binder/wire_format/binder.h"
 #include "src/core/ext/transport/binder/wire_format/wire_reader.h"
-
-// TODO(b/192208764): move this check to somewhere else
-#if __ANDROID_API__ < 29
-#error "We only support Android API level >= 29."
-#endif
 
 namespace grpc_binder {
 
@@ -127,6 +122,6 @@ class TransactionReceiverAndroid final : public TransactionReceiver {
 
 }  // namespace grpc_binder
 
-#endif  // defined(ANDROID) || defined(__ANDROID__)
+#endif /*GPR_SUPPORT_BINDER_TRANSPORT*/
 
 #endif  // GRPC_CORE_EXT_TRANSPORT_BINDER_WIRE_FORMAT_BINDER_ANDROID_H

--- a/src/core/ext/transport/binder/wire_format/binder_constants.cc
+++ b/src/core/ext/transport/binder/wire_format/binder_constants.cc
@@ -16,12 +16,12 @@
 
 #include "src/core/ext/transport/binder/wire_format/binder_constants.h"
 
-#if !(defined(ANDROID) || defined(__ANDROID__))
+#ifndef GPR_SUPPORT_BINDER_TRANSPORT
 
 const int FIRST_CALL_TRANSACTION = 0x00000001;
 const int LAST_CALL_TRANSACTION = 0x00FFFFFF;
 
-#endif  // !(defined(ANDROID) || defined(__ANDROID__))
+#endif  // GPR_SUPPORT_BINDER_TRANSPORT
 
 namespace grpc_binder {
 

--- a/src/core/ext/transport/binder/wire_format/binder_constants.h
+++ b/src/core/ext/transport/binder/wire_format/binder_constants.h
@@ -19,7 +19,7 @@
 
 #include "absl/base/attributes.h"
 
-#if defined(ANDROID) || defined(__ANDROID__)
+#ifdef GPR_SUPPORT_BINDER_TRANSPORT
 
 #include <android/binder_auto_utils.h>
 #include <android/binder_ibinder.h>
@@ -33,7 +33,7 @@ using transaction_code_t = uint32_t;
 ABSL_CONST_INIT extern const int FIRST_CALL_TRANSACTION;
 ABSL_CONST_INIT extern const int LAST_CALL_TRANSACTION;
 
-#endif  // defined(ANDROID) || defined(__ANDROID__)
+#endif  // GPR_SUPPORT_BINDER_TRANSPORT
 
 namespace grpc_binder {
 


### PR DESCRIPTION
This will help avoid surprising compilation failure when compiled with
old NDK or low API level



