### PR TITLE
[binder] Fix server-side recv_trailing_metadata

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_stream.h
+++ b/src/core/ext/transport/binder/transport/binder_stream.h
@@ -108,6 +108,9 @@ struct grpc_binder_stream {
   bool* call_failed_before_recv_message = nullptr;
   grpc_metadata_batch* recv_trailing_metadata;
   grpc_closure* recv_trailing_metadata_finished = nullptr;
+
+  bool trailing_metadata_sent = false;
+  bool need_to_call_trailing_metadata_callback = false;
 };
 
 #endif  // GRPC_CORE_EXT_TRANSPORT_BINDER_TRANSPORT_BINDER_STREAM_H

--- a/src/core/ext/transport/binder/utils/transport_stream_receiver.h
+++ b/src/core/ext/transport/binder/utils/transport_stream_receiver.h
@@ -60,15 +60,6 @@ class TransportStreamReceiver {
   virtual void NotifyRecvTrailingMetadata(
       StreamIdentifier id, absl::StatusOr<Metadata> trailing_metadata,
       int status) = 0;
-
-  // Trailing metadata marks the end of one-side of the stream. Thus, after
-  // receiving trailing metadata from the other-end, we know that there will
-  // never be in-coming message data anymore, and all recv_message callbacks
-  // registered will never be satisfied. This function cancels all such
-  // callbacks gracefully (with GRPC_ERROR_NONE) to avoid being blocked waiting
-  // for them.
-  virtual void CancelRecvMessageCallbacksDueToTrailingMetadata(
-      StreamIdentifier id) = 0;
   // Remove all entries associated with stream number `id`.
   virtual void CancelStream(StreamIdentifier id) = 0;
 

--- a/test/core/transport/binder/mock_objects.h
+++ b/test/core/transport/binder/mock_objects.h
@@ -105,8 +105,6 @@ class MockTransportStreamReceiver : public TransportStreamReceiver {
               (StreamIdentifier, absl::StatusOr<std::string>), (override));
   MOCK_METHOD(void, NotifyRecvTrailingMetadata,
               (StreamIdentifier, absl::StatusOr<Metadata>, int), (override));
-  MOCK_METHOD(void, CancelRecvMessageCallbacksDueToTrailingMetadata,
-              (StreamIdentifier), (override));
   MOCK_METHOD(void, CancelStream, (StreamIdentifier), (override));
 };
 


### PR DESCRIPTION
According to the [transport explainer](https://grpc.github.io/grpc/core/md_doc_core_transport_explainer.html), the server-side `recv_trailing_metadata` should not be completed before sending trailing metadata to the client.

Depends on #27182.