### PR TITLE
Make Workload Identity optional

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_url_map.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map.sh
@@ -18,8 +18,8 @@ set -ex -o igncr || set -ex
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc"
 # GKE Cluster
-readonly GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
-readonly GKE_CLUSTER_ZONE="us-central1-a"
+readonly GKE_CLUSTER_NAME="interop-test-psm-basic"
+readonly GKE_CLUSTER_ZONE="us-central1-c"
 ## xDS test client Docker images
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.sh
@@ -18,8 +18,8 @@ set -eo pipefail
 # Constants
 readonly GITHUB_REPOSITORY_NAME="grpc"
 # GKE Cluster
-readonly GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
-readonly GKE_CLUSTER_ZONE="us-central1-a"
+readonly GKE_CLUSTER_NAME="interop-test-psm-basic"
+readonly GKE_CLUSTER_ZONE="us-central1-c"
 ## xDS test client Docker images
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"

--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -9,4 +9,4 @@
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None
 --private_api_key_secret_name=None
---disable_workload_identity
+--noenable_workload_identity

--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -6,3 +6,7 @@
 # 2. All UrlMap tests today are testing client-side logic.
 # grpc-java master: 438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa TODO: use v1.40.0
 --server_image=gcr.io/grpc-testing/xds-interop/java-server:438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa
+# Disables the GCP Workload Identity feature to simplify permission control
+--gcp_service_account=None
+--private_api_key_secret_name=None
+--disable_workload_identity

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -244,7 +244,8 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
                  service_account_template='service-account.yaml',
                  reuse_namespace=False,
                  namespace_template=None,
-                 debug_use_port_forwarding=False):
+                 debug_use_port_forwarding=False,
+                 disable_workload_identity=False):
         super().__init__(k8s_namespace, namespace_template, reuse_namespace)
 
         # Settings
@@ -257,10 +258,15 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
         self.network = network
         self.deployment_template = deployment_template
         self.debug_use_port_forwarding = debug_use_port_forwarding
+        self.disable_workload_identity = disable_workload_identity
         # Service account settings:
         # Kubernetes service account
-        self.service_account_name = service_account_name or deployment_name
-        self.service_account_template = service_account_template
+        if self.disable_workload_identity:
+            self.service_account_name = None
+            self.service_account_template = None
+        else:
+            self.service_account_name = service_account_name or deployment_name
+            self.service_account_template = service_account_template
         # GCP.
         self.gcp_project = gcp_project
         self.gcp_ui_url = gcp_api_manager.gcp_ui_url
@@ -296,19 +302,20 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
 
         super().run()
 
-        # Allow Kubernetes service account to use the GCP service account
-        # identity.
-        self._grant_workload_identity_user(
-            gcp_iam=self.gcp_iam,
-            gcp_service_account=self.gcp_service_account,
-            service_account_name=self.service_account_name)
+        if not self.disable_workload_identity:
+            # Allow Kubernetes service account to use the GCP service account
+            # identity.
+            self._grant_workload_identity_user(
+                gcp_iam=self.gcp_iam,
+                gcp_service_account=self.gcp_service_account,
+                service_account_name=self.service_account_name)
 
-        # Create service account
-        self.service_account = self._create_service_account(
-            self.service_account_template,
-            service_account_name=self.service_account_name,
-            namespace_name=self.k8s_namespace.name,
-            gcp_service_account=self.gcp_service_account)
+            # Create service account
+            self.service_account = self._create_service_account(
+                self.service_account_template,
+                service_account_name=self.service_account_name,
+                namespace_name=self.k8s_namespace.name,
+                gcp_service_account=self.gcp_service_account)
 
         # Always create a new deployment
         self.deployment = self._create_deployment(
@@ -356,7 +363,8 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
         if self.deployment or force:
             self._delete_deployment(self.deployment_name)
             self.deployment = None
-        if self.service_account or force:
+        if not self.disable_workload_identity and (self.service_account or
+                                                   force):
             self._revoke_workload_identity_user(
                 gcp_iam=self.gcp_iam,
                 gcp_service_account=self.gcp_service_account,

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -298,7 +298,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
             deployment_name=self.deployment_name,
             image_name=self.image_name,
             namespace_name=self.k8s_namespace.name,
-            # service_account_name=self.service_account_name,
+            service_account_name=self.service_account_name,
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -181,7 +181,8 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
                  reuse_service=False,
                  reuse_namespace=False,
                  namespace_template=None,
-                 debug_use_port_forwarding=False):
+                 debug_use_port_forwarding=False,
+                 disable_workload_identity=False):
         super().__init__(k8s_namespace, namespace_template, reuse_namespace)
 
         # Settings
@@ -200,10 +201,15 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         self.service_template = service_template
         self.reuse_service = reuse_service
         self.debug_use_port_forwarding = debug_use_port_forwarding
+        self.disable_workload_identity = disable_workload_identity
         # Service account settings:
         # Kubernetes service account
-        self.service_account_name = service_account_name or deployment_name
-        self.service_account_template = service_account_template
+        if self.disable_workload_identity:
+            self.service_account_name = None
+            self.service_account_template = None
+        else:
+            self.service_account_name = service_account_name or deployment_name
+            self.service_account_template = service_account_template
         # GCP.
         self.gcp_project = gcp_project
         self.gcp_ui_url = gcp_api_manager.gcp_ui_url
@@ -271,19 +277,20 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
                 test_port=test_port)
         self._wait_service_neg(self.service_name, test_port)
 
-        # Allow Kubernetes service account to use the GCP service account
-        # identity.
-        self._grant_workload_identity_user(
-            gcp_iam=self.gcp_iam,
-            gcp_service_account=self.gcp_service_account,
-            service_account_name=self.service_account_name)
+        if not self.disable_workload_identity:
+            # Allow Kubernetes service account to use the GCP service account
+            # identity.
+            self._grant_workload_identity_user(
+                gcp_iam=self.gcp_iam,
+                gcp_service_account=self.gcp_service_account,
+                service_account_name=self.service_account_name)
 
-        # Create service account
-        self.service_account = self._create_service_account(
-            self.service_account_template,
-            service_account_name=self.service_account_name,
-            namespace_name=self.k8s_namespace.name,
-            gcp_service_account=self.gcp_service_account)
+            # Create service account
+            self.service_account = self._create_service_account(
+                self.service_account_template,
+                service_account_name=self.service_account_name,
+                namespace_name=self.k8s_namespace.name,
+                gcp_service_account=self.gcp_service_account)
 
         # Always create a new deployment
         self.deployment = self._create_deployment(
@@ -291,7 +298,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
             deployment_name=self.deployment_name,
             image_name=self.image_name,
             namespace_name=self.k8s_namespace.name,
-            service_account_name=self.service_account_name,
+            # service_account_name=self.service_account_name,
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
@@ -351,7 +358,8 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         if (self.service and not self.reuse_service) or force:
             self._delete_service(self.service_name)
             self.service = None
-        if self.service_account or force:
+        if not self.disable_workload_identity and (self.service_account or
+                                                   force):
             self._revoke_workload_identity_user(
                 gcp_iam=self.gcp_iam,
                 gcp_service_account=self.gcp_service_account,

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -182,7 +182,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
                  reuse_namespace=False,
                  namespace_template=None,
                  debug_use_port_forwarding=False,
-                 disable_workload_identity=False):
+                 enable_workload_identity=False):
         super().__init__(k8s_namespace, namespace_template, reuse_namespace)
 
         # Settings
@@ -201,15 +201,16 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         self.service_template = service_template
         self.reuse_service = reuse_service
         self.debug_use_port_forwarding = debug_use_port_forwarding
-        self.disable_workload_identity = disable_workload_identity
+        self.enable_workload_identity = enable_workload_identity
         # Service account settings:
         # Kubernetes service account
-        if self.disable_workload_identity:
-            self.service_account_name = None
-            self.service_account_template = None
-        else:
+        if self.enable_workload_identity:
             self.service_account_name = service_account_name or deployment_name
             self.service_account_template = service_account_template
+        else:
+            self.service_account_name = None
+            self.service_account_template = None
+
         # GCP.
         self.gcp_project = gcp_project
         self.gcp_ui_url = gcp_api_manager.gcp_ui_url
@@ -277,7 +278,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
                 test_port=test_port)
         self._wait_service_neg(self.service_name, test_port)
 
-        if not self.disable_workload_identity:
+        if self.enable_workload_identity:
             # Allow Kubernetes service account to use the GCP service account
             # identity.
             self._grant_workload_identity_user(
@@ -358,8 +359,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         if (self.service and not self.reuse_service) or force:
             self._delete_service(self.service_name)
             self.service = None
-        if not self.disable_workload_identity and (self.service_account or
-                                                   force):
+        if self.enable_workload_identity and (self.service_account or force):
             self._revoke_workload_identity_user(
                 gcp_iam=self.gcp_iam,
                 gcp_service_account=self.gcp_service_account,

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
@@ -44,7 +44,7 @@ DEBUG_USE_PORT_FORWARDING = flags.DEFINE_bool(
 ENABLE_WORKLOAD_IDENTITY = flags.DEFINE_bool(
     "enable_workload_identity",
     default=True,
-    help="Disable the WorkloadIdentity feature simplify permission control")
+    help="Enable the WorkloadIdentity feature")
 
 flags.mark_flags_as_required([
     "kube_context",

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
@@ -41,9 +41,12 @@ DEBUG_USE_PORT_FORWARDING = flags.DEFINE_bool(
     "debug_use_port_forwarding",
     default=False,
     help="Development only: use kubectl port-forward to connect to test app")
+DISABLE_WORKLOAD_IDENTITY = flags.DEFINE_bool(
+    "disable_workload_identity",
+    default=False,
+    help="Disable the WorkloadIdentity feature simplify permission control")
 
 flags.mark_flags_as_required([
-    "gcp_service_account",
     "kube_context",
     "td_bootstrap_image",
     "server_image",

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
@@ -41,9 +41,9 @@ DEBUG_USE_PORT_FORWARDING = flags.DEFINE_bool(
     "debug_use_port_forwarding",
     default=False,
     help="Development only: use kubectl port-forward to connect to test app")
-DISABLE_WORKLOAD_IDENTITY = flags.DEFINE_bool(
-    "disable_workload_identity",
-    default=False,
+ENABLE_WORKLOAD_IDENTITY = flags.DEFINE_bool(
+    "enable_workload_identity",
+    default=True,
     help="Disable the WorkloadIdentity feature simplify permission control")
 
 flags.mark_flags_as_required([

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -114,6 +114,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         cls.force_cleanup = _FORCE_CLEANUP.value
         cls.debug_use_port_forwarding = \
             xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
+        cls.disable_workload_identity = xds_k8s_flags.DISABLE_WORKLOAD_IDENTITY.value
         cls.check_local_certs = _CHECK_LOCAL_CERTS.value
 
         # Resource managers
@@ -346,7 +347,8 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             gcp_service_account=self.gcp_service_account,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
-            debug_use_port_forwarding=self.debug_use_port_forwarding)
+            debug_use_port_forwarding=self.debug_use_port_forwarding,
+            disable_workload_identity=self.disable_workload_identity)
 
     def initKubernetesClientRunner(self) -> KubernetesClientRunner:
         return KubernetesClientRunner(
@@ -361,6 +363,7 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             xds_server_uri=self.xds_server_uri,
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
+            disable_workload_identity=self.disable_workload_identity,
             stats_port=self.client_port,
             reuse_namespace=self.server_namespace == self.client_namespace)
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -114,7 +114,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         cls.force_cleanup = _FORCE_CLEANUP.value
         cls.debug_use_port_forwarding = \
             xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
-        cls.disable_workload_identity = xds_k8s_flags.DISABLE_WORKLOAD_IDENTITY.value
+        cls.enable_workload_identity = xds_k8s_flags.enable_workload_identity.value
         cls.check_local_certs = _CHECK_LOCAL_CERTS.value
 
         # Resource managers
@@ -348,7 +348,7 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             xds_server_uri=self.xds_server_uri,
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
-            disable_workload_identity=self.disable_workload_identity)
+            enable_workload_identity=self.enable_workload_identity)
 
     def initKubernetesClientRunner(self) -> KubernetesClientRunner:
         return KubernetesClientRunner(
@@ -363,7 +363,7 @@ class RegularXdsKubernetesTestCase(XdsKubernetesTestCase):
             xds_server_uri=self.xds_server_uri,
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
-            disable_workload_identity=self.disable_workload_identity,
+            enable_workload_identity=self.enable_workload_identity,
             stats_port=self.client_port,
             reuse_namespace=self.server_namespace == self.client_namespace)
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -174,7 +174,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
-            disable_workload_identity=self.disable_workload_identity)
+            enable_workload_identity=self.enable_workload_identity)
         self.test_server_alternative_runner = server_app.KubernetesServerRunner(
             self.k8s_namespace,
             deployment_name=self.server_name + '-alternative',
@@ -185,7 +185,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
-            disable_workload_identity=self.disable_workload_identity,
+            enable_workload_identity=self.enable_workload_identity,
             reuse_namespace=True)
         self.test_server_affinity_runner = server_app.KubernetesServerRunner(
             self.k8s_namespace,
@@ -197,7 +197,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
-            disable_workload_identity=self.disable_workload_identity,
+            enable_workload_identity=self.enable_workload_identity,
             reuse_namespace=True)
         logging.info('Strategy of GCP resources management: %s', self.strategy)
 
@@ -224,7 +224,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             xds_server_uri=self.xds_server_uri,
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
-            disable_workload_identity=self.disable_workload_identity,
+            enable_workload_identity=self.enable_workload_identity,
             stats_port=self.client_port)
 
     def _pre_cleanup(self):

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -173,7 +173,8 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             gcp_service_account=self.gcp_service_account,
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
-            network=self.network)
+            network=self.network,
+            disable_workload_identity=self.disable_workload_identity)
         self.test_server_alternative_runner = server_app.KubernetesServerRunner(
             self.k8s_namespace,
             deployment_name=self.server_name + '-alternative',
@@ -184,6 +185,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
+            disable_workload_identity=self.disable_workload_identity,
             reuse_namespace=True)
         self.test_server_affinity_runner = server_app.KubernetesServerRunner(
             self.k8s_namespace,
@@ -195,6 +197,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             td_bootstrap_image=self.td_bootstrap_image,
             xds_server_uri=self.xds_server_uri,
             network=self.network,
+            disable_workload_identity=self.disable_workload_identity,
             reuse_namespace=True)
         logging.info('Strategy of GCP resources management: %s', self.strategy)
 
@@ -221,6 +224,7 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             xds_server_uri=self.xds_server_uri,
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
+            disable_workload_identity=self.disable_workload_identity,
             stats_port=self.client_port)
 
     def _pre_cleanup(self):

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -18,7 +18,9 @@ spec:
         app: ${deployment_name}
         owner: xds-k8s-interop-test
     spec:
+      % if service_account_name:
       serviceAccountName: ${service_account_name}
+      % endif
       containers:
       - name: ${deployment_name}
         image: ${image_name}

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -18,7 +18,9 @@ spec:
         app: ${deployment_name}
         owner: xds-k8s-interop-test
     spec:
+      % if service_account_name:
       serviceAccountName: ${service_account_name}
+      % endif
       containers:
       - name: ${deployment_name}
         image: ${image_name}


### PR DESCRIPTION
This PR adds a flag to opt-out of the Workload Identity feature. However, the Workload Identity is bound with GKE cluster. So, this PR also changes the GKE cluster for url-map tests.

UrlMap tests will create 27 unique namespace for each run, and I suspect there is a certain resource race happen when modifying the binding rules (after all, we are not adding the policy binding as transaction). We are running 4 languages 2 branches and 8 rounds per day, in total 64 runs, equals to 1728 potential policy binding addition per day. If there is a leak, it accumulates much faster than before, hence exposed the problem.

Workload Identity is demanded for security features, and a bonus for other basic tests. Until we have a more concrete solution to solve the policy binding issue, I think the basic tests should opt-out for now.

Runs:

- cpp: https://fusion2.corp.google.com/invocations/cc3fd374-40e1-406c-a0b2-b32e5cab15d1/targets
- python: https://fusion2.corp.google.com/invocations/f458e388-2697-4354-839f-da9313a3043e/targets

New Kokoro runs:

- cpp: https://fusion2.corp.google.com/invocations/af8e074c-82c1-40ff-ac50-89a7ce98cc28/targets
- python: https://fusion2.corp.google.com/invocations/3d0623f9-0275-4de6-910e-530efb22a0bb/targets