### PR TITLE
Fix the timeout flag name in PHP's Python xds_manager

### DIFF
--- a/src/php/bin/xds_manager.py
+++ b/src/php/bin/xds_manager.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
                         'extension=pthreads.so',
                         'src/php/tests/interop/xds_empty_call.php',
                         '--server=' + server_address, '--num=' + str(num),
-                        '--metadata=' + metadata, '--timeout=' + timeout_sec
+                        '--metadata=' + metadata, '--timeout_sec=' + timeout_sec
                     ],
                                          env=client_env)
                 else:


### PR DESCRIPTION
As title. Found while fixing b/195439751.