### PR TITLE
Remove EventEngine::Shutdown

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -308,16 +308,6 @@ class EventEngine {
   /// callback will be run exactly once from either cancellation or from its
   /// activation.
   virtual void TryCancel(TaskHandle handle) = 0;
-  /// Immediately run all callbacks with status indicating the shutdown. Every
-  /// EventEngine is expected to shut down exactly once. No new callbacks/tasks
-  /// should be scheduled after shutdown has begun, no new connections should be
-  /// created.
-  ///
-  /// If the \a on_shutdown_complete callback is given a non-OK status, errors
-  /// are expected to be unrecoverable. For example, an implementation could
-  /// warn callers about leaks if memory cannot be freed within a certain
-  /// timeframe.
-  virtual void Shutdown(Callback on_shutdown_complete) = 0;
 };
 
 // TODO(hork): finalize the API and document it. We need to firm up the story

--- a/src/core/lib/iomgr/event_engine/iomgr.cc
+++ b/src/core/lib/iomgr/event_engine/iomgr.cc
@@ -20,7 +20,6 @@
 
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/event_engine/promise.h"
 #include "src/core/lib/iomgr/iomgr_internal.h"
 #include "src/core/lib/iomgr/tcp_client.h"
 #include "src/core/lib/iomgr/tcp_server.h"

--- a/src/core/lib/iomgr/event_engine/iomgr.cc
+++ b/src/core/lib/iomgr/event_engine/iomgr.cc
@@ -52,12 +52,6 @@ void iomgr_platform_init(void) { GPR_ASSERT(g_event_engine != nullptr); }
 void iomgr_platform_flush(void) {}
 
 void iomgr_platform_shutdown(void) {
-  Promise<absl::Status> shutdown_status_promise;
-  g_event_engine->Shutdown([&shutdown_status_promise](absl::Status status) {
-    shutdown_status_promise.Set(std::move(status));
-  });
-  auto shutdown_status = shutdown_status_promise.Get();
-  GPR_ASSERT(shutdown_status.ok());
   delete g_event_engine;
   g_event_engine = nullptr;
 }


### PR DESCRIPTION
@nicolasnoble @markdroth 

It was determined that an explicit Shutdown method is not necessary, and further, it can be challenging to implement efficiently in some cases. Instead, EventEngines are expected to clean themselves up upon destruction. Anything that relies on an EventEngine's existence must coordinate itself to ensure the engine remains alive for as long as it's needed.

I've updated https://github.com/grpc/proposal/pull/245 accordingly.