### PR TITLE
Fix the injected delay cancellation issue with non-unary calls

### DIFF
--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -299,10 +299,12 @@ void CallData::StartTransportStreamOpBatch(
       grpc_transport_stream_op_batch_finish_with_failure(
           batch, GRPC_ERROR_REF(calld->abort_error_), calld->call_combiner_);
       return;
-    } if (calld->delay_cancelled_error_ != GRPC_ERROR_NONE) {
+    }
+    if (calld->delay_cancelled_error_ != GRPC_ERROR_NONE) {
       // If the delay is cancelled, populate the error to any batch afterward.
       grpc_transport_stream_op_batch_finish_with_failure(
-          batch, GRPC_ERROR_REF(calld->delay_cancelled_error_), calld->call_combiner_);
+          batch, GRPC_ERROR_REF(calld->delay_cancelled_error_),
+          calld->call_combiner_);
       return;
     }
   }

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -12239,13 +12239,14 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionBidiStreamDelayOk) {
   // Config fault injection via different setup
   SetFilterConfig(http_fault);
   ClientContext context;
-  context.set_deadline(grpc_timeout_milliseconds_to_deadline(kRpcTimeoutMilliseconds));
+  context.set_deadline(
+      grpc_timeout_milliseconds_to_deadline(kRpcTimeoutMilliseconds));
   auto stream = stub_->BidiStream(&context);
   stream->WritesDone();
   auto status = stream->Finish();
-  EXPECT_TRUE(status.ok())
-      << status.error_message() << ", " << status.error_details() << ", "
-      << context.debug_error_string();
+  EXPECT_TRUE(status.ok()) << status.error_message() << ", "
+                           << status.error_details() << ", "
+                           << context.debug_error_string();
 }
 
 TEST_P(FaultInjectionTest, XdsFaultInjectionBidiStreamDelayError) {
@@ -12270,7 +12271,8 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionBidiStreamDelayError) {
   // Config fault injection via different setup
   SetFilterConfig(http_fault);
   ClientContext context;
-  context.set_deadline(grpc_timeout_milliseconds_to_deadline(kRpcTimeoutMilliseconds));
+  context.set_deadline(
+      grpc_timeout_milliseconds_to_deadline(kRpcTimeoutMilliseconds));
   auto stream = stub_->BidiStream(&context);
   stream->WritesDone();
   auto status = stream->Finish();

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -12216,6 +12216,49 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionMaxFault) {
   EXPECT_EQ(kMaxFault, num_delayed);
 }
 
+TEST_P(FaultInjectionTest, XdsFaultInjectionAlwaysDelayBidiStream) {
+  const uint32_t kRpcTimeoutMilliseconds = grpc_test_slowdown_factor() * 3000;
+  const uint32_t kFixedDelaySeconds = 100;
+  const uint32_t kDelayPercentagePerHundred = 100;
+  SetNextResolution({});
+  SetNextResolutionForLbChannelAllBalancers();
+  // Create an EDS resource
+  AdsServiceImpl::EdsResourceArgs args({
+      {"locality0", CreateEndpointsForBackends()},
+  });
+  balancers_[0]->ads_service()->SetEdsResource(
+      BuildEdsResource(args, DefaultEdsServiceName()));
+  // Construct the fault injection filter config
+  HTTPFault http_fault;
+  auto* delay_percentage = http_fault.mutable_delay()->mutable_percentage();
+  delay_percentage->set_numerator(kDelayPercentagePerHundred);
+  delay_percentage->set_denominator(FractionalPercent::HUNDRED);
+  auto* fixed_delay = http_fault.mutable_delay()->mutable_fixed_delay();
+  fixed_delay->set_seconds(kFixedDelaySeconds);
+  // Config fault injection via different setup
+  SetFilterConfig(http_fault);
+  // RouteConfiguration route_config = default_route_config_;
+  // auto* route1 = route_config.mutable_virtual_hosts(0)->mutable_routes(0);
+  // route1->mutable_match()->set_prefix("/grpc.testing.EchoTest1Service/");
+  // auto* header_matcher1 = route1->mutable_match()->add_headers();
+  // header_matcher1->set_name("header1");
+  // header_matcher1->set_exact_match("POST,PUT,GET");
+  // Send kNumRpcs RPCs and count the delays.
+  ClientContext context;
+  EchoRequest request;
+  EchoResponse response;
+  request.set_message("Hello");
+  context->set_deadline(grpc_timeout_milliseconds_to_deadline(kRpcTimeoutMilliseconds));
+  stream = stub_->BidiStream(&context);
+  EXPECT_TRUE(stream->Write(request));
+  stream->Read(&response);
+  EXPECT_EQ(request.message(), response.message());
+  auto status = streaming_rpcs[i].stream->Finish();
+    EXPECT_TRUE(status.ok())
+        << status.error_message() << ", " << status.error_details() << ", "
+        << streaming_rpcs[i].context.debug_error_string();
+}
+
 class BootstrapSourceTest : public XdsEnd2endTest {
  public:
   BootstrapSourceTest() : XdsEnd2endTest(4, 1) {}


### PR DESCRIPTION
Fixes b/195439751.

Thanks for help from @stanley-cheung, who has given me valuable info about gRPC PHP internals, saved me hours of digging around.

This bug has existed since the fault injection filter is implemented. The bug was exposed by PR https://github.com/grpc/grpc/pull/26766 (enable retry) and PHP's two-batch unary call design.

The wrong behavior is that if we cancel an injected delay, the following batch operations won't be cancelled. This was because the fixed delay is injected to a RPC's first batch of operations. So, if a call cancellation occur (e.g., RPC timeout), only the first batch will get the notice. I thought if the operations were cancelled, the upstream filter would handle it (e.g., upper layer won't pass down any ops once a call is in error state). But, that wasn't true.

This PR adds an error caching mechanism in fault injection filter, so it will populate the delay cancellation error to later batches. This PR also adds 2 more test cases for streaming calls.

1000x runs: [ASAN](https://source.cloud.google.com/results/invocations/7aa4e8c4-1c4f-4a49-aacb-008a8f7f00be), [UBSAN](https://source.cloud.google.com/results/invocations/ceac40df-7e83-4a8d-a0e4-50b5388471c9), [TSAN](https://source.cloud.google.com/results/invocations/8ef7d8bc-d939-49a7-8390-f00ec1434ac6), [MSAN](https://source.cloud.google.com/results/invocations/7db2fd2e-6865-4d1f-ab2c-7bc7d529f7d0).

Kokoro run: https://fusion2.corp.google.com/invocations/009cdc78-b809-4088-8ef6-4f2a2b8aae8f/targets