### PR TITLE
Fix injected abort error not recorded after injected delay

### DIFF
--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -458,7 +458,8 @@ void CallData::ResumeBatch(void* arg, grpc_error_handle error) {
   if (error != GRPC_ERROR_NONE) {
     calld->abort_error_ = error;
     grpc_transport_stream_op_batch_finish_with_failure(
-        calld->delayed_batch_, GRPC_ERROR_REF(calld->abort_error_), calld->call_combiner_);
+        calld->delayed_batch_, GRPC_ERROR_REF(calld->abort_error_),
+        calld->call_combiner_);
     return;
   }
   // Chain to the next filter.

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -456,8 +456,9 @@ void CallData::ResumeBatch(void* arg, grpc_error_handle error) {
   // Abort if needed.
   error = calld->MaybeAbort();
   if (error != GRPC_ERROR_NONE) {
+    calld->abort_error_ = error;
     grpc_transport_stream_op_batch_finish_with_failure(
-        calld->delayed_batch_, error, calld->call_combiner_);
+        calld->delayed_batch_, GRPC_ERROR_REF(calld->abort_error_), calld->call_combiner_);
     return;
   }
   // Chain to the next filter.

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -12052,6 +12052,43 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionPercentageDelayViaHeaders) {
               ::testing::DoubleNear(kDelayRate, kErrorTolerance));
 }
 
+TEST_P(FaultInjectionTest, XdsFaultInjectionAbortAfterDelayForStreamCall) {
+  const uint32_t kFixedDelaySeconds = 1;
+  const uint32_t kRpcTimeoutMilliseconds = 100 * 1000;  // 100s should not reach
+  SetNextResolution({});
+  SetNextResolutionForLbChannelAllBalancers();
+  // Create an EDS resource
+  AdsServiceImpl::EdsResourceArgs args({
+      {"locality0", CreateEndpointsForBackends()},
+  });
+  balancers_[0]->ads_service()->SetEdsResource(
+      BuildEdsResource(args, DefaultEdsServiceName()));
+  // Construct the fault injection filter config
+  HTTPFault http_fault;
+  auto* abort_percentage = http_fault.mutable_abort()->mutable_percentage();
+  abort_percentage->set_numerator(100);  // Always inject ABORT!
+  abort_percentage->set_denominator(FractionalPercent::HUNDRED);
+  http_fault.mutable_abort()->set_grpc_status(
+      static_cast<uint32_t>(StatusCode::ABORTED));
+  auto* delay_percentage = http_fault.mutable_delay()->mutable_percentage();
+  delay_percentage->set_numerator(100);  // Always inject DELAY!
+  delay_percentage->set_denominator(FractionalPercent::HUNDRED);
+  auto* fixed_delay = http_fault.mutable_delay()->mutable_fixed_delay();
+  fixed_delay->set_seconds(kFixedDelaySeconds);
+  // Config fault injection via different setup
+  SetFilterConfig(http_fault);
+  // Send a stream RPC and check its status code
+  ClientContext context;
+  context.set_deadline(
+      grpc_timeout_milliseconds_to_deadline(kRpcTimeoutMilliseconds));
+  auto stream = stub_->BidiStream(&context);
+  stream->WritesDone();
+  auto status = stream->Finish();
+  EXPECT_EQ(StatusCode::ABORTED, status.error_code())
+      << status.error_message() << ", " << status.error_details() << ", "
+      << context.debug_error_string();
+}
+
 TEST_P(FaultInjectionTest, XdsFaultInjectionAlwaysDelayPercentageAbort) {
   const uint32_t kAbortPercentagePerHundred = 50;
   const double kAbortRate = kAbortPercentagePerHundred / 100.0;


### PR DESCRIPTION
In a streaming call, a RPC could span over several batches of ops.

The existing logic assumes that if we fail the first batch with certain error, later batches will automatically be marked as the same error. But it seems the filter itself needs to uphold the error it's yielding to current and future batches of a call.

Test case added, without this PR's change, the test case will hang like https://github.com/grpc/grpc/pull/27217.