### PR TITLE
doc/PROTOCOL-HTTP2.md: Document usages of RST_STREAM

### DIFF
--- a/doc/PROTOCOL-HTTP2.md
+++ b/doc/PROTOCOL-HTTP2.md
@@ -255,9 +255,8 @@ the client by a round-trip time, the client will generally not need to process
 the server's RST_STREAM. However, to deal with client-side races and minor
 clock-rate skew, when a call fails with CANCELLED status the client is
 encouraged to check whether the deadline has expired and fail the call with
-DEADLINE_EXCEEDED instead of CANCELLED. Note that the client must fully-generate
-the failure locally, without using any part of the server's failure (i.e.,
-response metadata from server must be discarded).
+DEADLINE_EXCEEDED instead of CANCELLED. Note that the client must fully generate
+the failure locally, without using any part of **Trailers**.
 
 ##### Security
 


### PR DESCRIPTION
It was revealed during the [HTTP/3 gRFC discussion][1] that servers
using RST_STREAM for deadlines and the client-side trick of
double-checking the deadline when processing CANCELLED status wasn't
documented.

I'm not all that bothered if an implementation uses Trailers instead of
RST_STREAM for deadline, but it does seem hard for an implementation to
avoid truncating a message in that situation and it may extend the
amount of time the RPC consumes memory.

[1]: https://github.com/grpc/proposal/pull/256

cc @JamesNK