### PR TITLE
fix retry code to fail batches instead of creating attempt if previously cancelled from surface

### DIFF
--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -2175,6 +2175,7 @@ void RetryFilter::CallData::StartTransportStreamOpBatch(
       return;
     }
     // Save cancel_error in case subsequent batches are started.
+    GRPC_ERROR_UNREF(cancelled_from_surface_);
     cancelled_from_surface_ = GRPC_ERROR_REF(cancel_error);
     // Cancel retry timer.
     if (retry_timer_pending_) {

--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -88,9 +88,7 @@
 
 // TODO(roth): In subsequent PRs:
 // - add support for transparent retries (including initial metadata)
-// - figure out how to record stats in census for retries
-//   (census filter is on top of this one)
-// - add census stats for retries
+// - implement hedging
 
 // By default, we buffer 256 KiB per RPC for retries.
 // TODO(roth): Do we have any data to suggest a better value?
@@ -538,6 +536,8 @@ class RetryFilter::CallData {
   grpc_call_stack* owning_call_;
   CallCombiner* call_combiner_;
   grpc_call_context_element* call_context_;
+
+  grpc_error_handle cancelled_from_surface_ = GRPC_ERROR_NONE;
 
   RefCountedPtr<CallStackDestructionBarrier> call_stack_destruction_barrier_;
 
@@ -2141,6 +2141,7 @@ RetryFilter::CallData::~CallData() {
   for (size_t i = 0; i < GPR_ARRAY_SIZE(pending_batches_); ++i) {
     GPR_ASSERT(pending_batches_[i].batch == nullptr);
   }
+  GRPC_ERROR_UNREF(cancelled_from_surface_);
 }
 
 void RetryFilter::CallData::StartTransportStreamOpBatch(
@@ -2173,6 +2174,8 @@ void RetryFilter::CallData::StartTransportStreamOpBatch(
       call_attempt_->CancelFromSurface(batch);
       return;
     }
+    // Save cancel_error in case subsequent batches are started.
+    cancelled_from_surface_ = GRPC_ERROR_REF(cancel_error);
     // Cancel retry timer.
     if (retry_timer_pending_) {
       if (GRPC_TRACE_FLAG_ENABLED(grpc_retry_trace)) {
@@ -2201,6 +2204,15 @@ void RetryFilter::CallData::StartTransportStreamOpBatch(
   }
   // If we do not yet have a call attempt, create one.
   if (call_attempt_ == nullptr) {
+    // If we were previously cancelled from the surface, cancel this
+    // batch instead of creating a call attempt.
+    if (cancelled_from_surface_ != GRPC_ERROR_NONE) {
+      PendingBatchClear(pending);
+      // Note: This will release the call combiner.
+      grpc_transport_stream_op_batch_finish_with_failure(
+          batch, GRPC_ERROR_REF(cancelled_from_surface_), call_combiner_);
+      return;
+    }
     // If there is no retry policy, then commit retries immediately.
     // This ensures that the code below will always jump to the fast path.
     // TODO(roth): Remove this special case when we implement


### PR DESCRIPTION
This problem was triggered in an xDS interop test in the following sequence of events:

1. The client started a batch containing a send_initial_metadata op, and the fault injection filter delayed the batch.
2. The FI delay was longer than the call's deadline, so the call was cancelled by the deadline timer.  This caused the FI filter to fail the batch containing send_initial_metadata before it ever got to the retry filter.
3. The retry filter saw the cancel_stream op, but it had no pending batches to fail, so it was a no-op.
4. The client started a batch containing other ops.  This batch made it down to the retry filter, which should have failed it immediately due to the earlier cancellation, but it instead created an LB call for it.  That LB call was not aware of the cancellation and would never see a send_initial_metadata op, so it was impossible for it to make progress.

To fix this, I've changed the retry filter to save the cancellation error when it is cancelled from the surface, so that it can immediately fail any subsequent batches it sees if it does not already have a call attempt.

Unfortunately, it's not trivial to create a core end2end test for this case, because the core end2end tests don't use the fake resolver and therefore have no way to inject a ConfigSelector that will configure a filter that could fail the send_initial_metadata op *after* the client channel filter starts resolving but *before* it gets to the retry filter.  Instead, we use the xDS end2end tests written by @lidizheng for #27209.