### PR TITLE
xds-k8s: Fix error: serviceAccountName Invalid value: None

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -182,7 +182,7 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
                  reuse_namespace=False,
                  namespace_template=None,
                  debug_use_port_forwarding=False,
-                 enable_workload_identity=False):
+                 enable_workload_identity=True):
         super().__init__(k8s_namespace, namespace_template, reuse_namespace)
 
         # Settings
@@ -250,6 +250,9 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
         if not (isinstance(test_port, int) and
                 isinstance(maintenance_port, int)):
             raise TypeError('Port numbers must be integer')
+
+        if secure_mode and not self.enable_workload_identity:
+            raise ValueError('Secure mode requires Workload Identity enabled.')
 
         logger.info(
             'Deploying xDS test server "%s" to k8s namespace %s: test_port=%s '


### PR DESCRIPTION
- Flip the default value of `KubernetesServerRunner.enable_workload_identity`. We missed this in the server runner, when inverting disable_workload_identity to enable_workload_identity in https://github.com/grpc/grpc/pull/27189. Client runner's flag [was updated correctly](https://github.com/grpc/grpc/pull/27189/commits/f2d46138439eff0de06c0a821198a23d2031d46a#diff-76d4ae650edf6a5a17e3e32601ec0dd824285c2f902b34716afa85465577f64bL248).
- Add a check to require workload identity for secure runs so to indicate the error better (and fail fast).