### PR TITLE
Increase timeout for building mac ruby artifact

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -201,7 +201,7 @@ class RubyArtifact:
         return create_jobspec(
             self.name, ['tools/run_tests/artifacts/build_artifact_ruby.sh'],
             use_workspace=True,
-            timeout_seconds=60 * 60)
+            timeout_seconds=90 * 60)
 
 
 class CSharpExtArtifact:


### PR DESCRIPTION
Recently I saw a few occurrences of ruby artifact build timing out.

e.g. here https://source.cloud.google.com/results/invocations/f7dcd41b-1265-465f-b59f-e5ceb7e02289/log
`2021-09-01 06:33:48,949 TIMEOUT: build_artifact.ruby_native_gem_macos_x64 [pid=17109, time=3607.0sec]`

I looked at a few successful runs and usually ruby finished within 5 mins of the current timeout value.