### PR TITLE
[gRPC ObjC] Adding strong self nullability check

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCWrappedCall.m
@@ -143,9 +143,11 @@
       __weak typeof(self) weakSelf = self;
       _handler = ^{
         __strong typeof(self) strongSelf = weakSelf;
-        NSDictionary *metadata =
-            [NSDictionary grpc_dictionaryFromMetadataArray:strongSelf->_headers];
-        handler(metadata);
+        if (strongSelf) {
+          NSDictionary *metadata =
+              [NSDictionary grpc_dictionaryFromMetadataArray:strongSelf->_headers];
+          handler(metadata);
+        }
       };
     }
   }
@@ -175,7 +177,9 @@
       __weak typeof(self) weakSelf = self;
       _handler = ^{
         __strong typeof(self) strongSelf = weakSelf;
-        handler(strongSelf->_receivedMessage);
+        if (strongSelf) {
+          handler(strongSelf->_receivedMessage);
+        }
       };
     }
   }


### PR DESCRIPTION
Add missing nullability check on strong self when handler block are executed to avoid potential crash when access ivars with arrow operators. 