### PR TITLE
[gRPC ObjC] Adding copy property attribte to response header & traile…

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCallLegacy.h
+++ b/src/objective-c/GRPCClient/GRPCCallLegacy.h
@@ -66,7 +66,7 @@
  * The value of this property is nil until all response headers are received, and will change before
  * any of -writeValue: or -writesFinishedWithError: are sent to the writeable.
  */
-@property(atomic, readonly) NSDictionary *responseHeaders;
+@property(atomic, copy, readonly) NSDictionary *responseHeaders;
 
 /**
  * Same as responseHeaders, but populated with the HTTP trailers received from the server before the
@@ -75,7 +75,7 @@
  * The value of this property is nil until all response trailers are received, and will change
  * before -writesFinishedWithError: is sent to the writeable.
  */
-@property(atomic, readonly) NSDictionary *responseTrailers;
+@property(atomic, copy, readonly) NSDictionary *responseTrailers;
 
 /**
  * The request writer has to write NSData objects into the provided Writeable. The server will

--- a/src/objective-c/GRPCClient/GRPCCallLegacy.m
+++ b/src/objective-c/GRPCClient/GRPCCallLegacy.m
@@ -48,8 +48,8 @@ static NSString *const kBearerPrefix = @"Bearer ";
 
 @interface GRPCCall () <GRXWriteable>
 // Make them read-write.
-@property(atomic, strong) NSDictionary *responseHeaders;
-@property(atomic, strong) NSDictionary *responseTrailers;
+@property(atomic, copy) NSDictionary *responseHeaders;
+@property(atomic, copy) NSDictionary *responseTrailers;
 
 - (void)receiveNextMessages:(NSUInteger)numberOfMessages;
 


### PR DESCRIPTION
Adding copy attribute to improve access safety for the response header & trailer dictionary exposed from GRPCCall's API. Internally these instances are dynamically modified from non-main queue and may cause unexpected side-effect when being observed via KVO. 