### PR TITLE
Use manylinux_2_17 instead of manylinux_2_24 tag for manylinux2014 aarch64 wheels

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux_2_24_aarch64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_2_24_aarch64/Dockerfile
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The aarch64 wheels are being crosscompiled to allow running the build
-# on x64 machine. The dockcross/manylinux2014-aarch64 image is a x86_64
-# image with crosscompilation toolchain installed.
-# We use an older version of dockcross image that has gcc4.9.4 because it was built
-# before https://github.com/dockcross/dockcross/pull/449
-# Thanks to that, wheel build with this image aren't actually
-# compliant with manylinux2014, but only with manylinux_2_24
 FROM dockcross/manylinux2014-aarch64:20210826-19322ba
 
-# Make the grpc wheels correctly tagged with manylinux_2_24
-# instead of the incorrect manylinux2014 (see the note above).
-ENV AUDITWHEEL_PLAT manylinux_2_24_$AUDITWHEEL_ARCH
+# manylinux_2_17 is the preferred alias of manylinux2014
+ENV AUDITWHEEL_PLAT manylinux_2_17_$AUDITWHEEL_ARCH
 
 ###################################
 # Install Python build requirements


### PR DESCRIPTION
Follow-up of Jan's comment in https://github.com/grpc/grpc/pull/26074.
