### PR TITLE
Custom binder channel

### DIFF
--- a/src/core/ext/transport/binder/client/channel_create.cc
+++ b/src/core/ext/transport/binder/client/channel_create.cc
@@ -78,8 +78,20 @@ void BindToOnDeviceServerService(void* jni_env_void, jobject application,
 // https://stackoverflow.com/a/3055749)
 // TODO(mingcl): Support multiple endpoint binder objects
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
+    void* jni_env_void, jobject application, absl::string_view package_name,
+    absl::string_view class_name) {
+  return CreateCustomBinderChannel(jni_env_void, application, package_name,
+                                   class_name, ChannelArguments());
+}
+
+// BindToOndeviceServerService need to be called before this, in a different
+// task (due to Android API design). (Reference:
+// https://stackoverflow.com/a/3055749)
+// TODO(mingcl): Support multiple endpoint binder objects
+std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
     void* jni_env_void, jobject /*application*/,
-    absl::string_view /*package_name*/, absl::string_view /*class_name*/) {
+    absl::string_view /*package_name*/, absl::string_view /*class_name*/,
+    const ChannelArguments& args) {
   JNIEnv* jni_env = static_cast<JNIEnv*>(jni_env_void);
 
   // clang-format off
@@ -90,12 +102,14 @@ std::shared_ptr<grpc::Channel> CreateBinderChannel(
       "()Landroid/os/IBinder;");
   // clang-format on
 
+  grpc_channel_args channel_args;
+  args.SetChannelArgs(&channel_args);
   return CreateChannelInternal(
       "",
       ::grpc::internal::CreateChannelFromBinderImpl(
           absl::make_unique<grpc_binder::BinderAndroid>(
               grpc_binder::FromJavaBinder(jni_env, object)),
-          nullptr),
+          &channel_args),
       std::vector<
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>());
 }
@@ -116,6 +130,13 @@ void BindToOnDeviceServerService(void*, jobject, absl::string_view,
 std::shared_ptr<grpc::Channel> CreateBinderChannel(void*, jobject,
                                                    absl::string_view,
                                                    absl::string_view) {
+  GPR_ASSERT(0);
+  return {};
+}
+
+std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
+    void*, jobject, absl::string_view, absl::string_view,
+    const ChannelArguments&) {
   GPR_ASSERT(0);
   return {};
 }

--- a/src/core/ext/transport/binder/client/channel_create.h
+++ b/src/core/ext/transport/binder/client/channel_create.h
@@ -22,6 +22,7 @@
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/port_platform.h>
 #include <grpcpp/channel.h>
+#include <grpcpp/support/channel_arguments.h>
 #include <jni.h>
 
 #include "absl/strings/string_view.h"
@@ -41,6 +42,13 @@ void BindToOnDeviceServerService(void* jni_env_void, jobject application,
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
     void* jni_env_void, jobject application, absl::string_view package_name,
     absl::string_view class_name);
+
+// Need to be invoked after BindToOnDeviceServerService
+// Create a new Channel from server package name and service class name and with
+// custom channel arguments.
+std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
+    void* jni_env_void, jobject application, absl::string_view package_name,
+    absl::string_view class_name, const ChannelArguments& args);
 
 }  // namespace experimental
 }  // namespace grpc


### PR DESCRIPTION
Add `CreateCustomBinderChannel()` API to allow users pass in custom channel arguments when creating binder channels.