### PR TITLE
xDS Security: Use new way to fetch certificate provider plugin instance config

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -572,11 +572,11 @@ grpc_error_handle CdsLb::UpdateXdsCertificateProvider(
   }
   // Configure root cert.
   absl::string_view root_provider_instance_name =
-      cluster_data.common_tls_context.combined_validation_context
-          .validation_context_certificate_provider_instance.instance_name;
+      cluster_data.common_tls_context.certificate_validation_context
+          .ca_certificate_provider_instance.instance_name;
   absl::string_view root_provider_cert_name =
-      cluster_data.common_tls_context.combined_validation_context
-          .validation_context_certificate_provider_instance.certificate_name;
+      cluster_data.common_tls_context.certificate_validation_context
+          .ca_certificate_provider_instance.certificate_name;
   RefCountedPtr<XdsCertificateProvider> new_root_provider;
   if (!root_provider_instance_name.empty()) {
     new_root_provider =
@@ -612,11 +612,11 @@ grpc_error_handle CdsLb::UpdateXdsCertificateProvider(
           : root_certificate_provider_->distributor());
   // Configure identity cert.
   absl::string_view identity_provider_instance_name =
-      cluster_data.common_tls_context
-          .tls_certificate_certificate_provider_instance.instance_name;
+      cluster_data.common_tls_context.tls_certificate_provider_instance
+          .instance_name;
   absl::string_view identity_provider_cert_name =
-      cluster_data.common_tls_context
-          .tls_certificate_certificate_provider_instance.certificate_name;
+      cluster_data.common_tls_context.tls_certificate_provider_instance
+          .certificate_name;
   RefCountedPtr<XdsCertificateProvider> new_identity_provider;
   if (!identity_provider_instance_name.empty()) {
     new_identity_provider =
@@ -653,8 +653,8 @@ grpc_error_handle CdsLb::UpdateXdsCertificateProvider(
           : identity_certificate_provider_->distributor());
   // Configure SAN matchers.
   const std::vector<StringMatcher>& match_subject_alt_names =
-      cluster_data.common_tls_context.combined_validation_context
-          .default_validation_context.match_subject_alt_names;
+      cluster_data.common_tls_context.certificate_validation_context
+          .match_subject_alt_names;
   xds_certificate_provider_->UpdateSubjectAlternativeNameMatchers(
       cluster_name, match_subject_alt_names);
   return GRPC_ERROR_NONE;

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -437,11 +437,11 @@ bool XdsApi::CommonTlsContext::CertificateValidationContext::Empty() const {
 }
 
 //
-// XdsApi::CommonTlsContext::CertificateValidationContext
+// XdsApi::CommonTlsContext::CertificateProviderPluginInstance
 //
 
-std::string XdsApi::CommonTlsContext::CertificateProviderInstance::ToString()
-    const {
+std::string
+XdsApi::CommonTlsContext::CertificateProviderPluginInstance::ToString() const {
   absl::InlinedVector<std::string, 2> contents;
   if (!instance_name.empty()) {
     contents.push_back(absl::StrFormat("instance_name=%s", instance_name));
@@ -453,34 +453,9 @@ std::string XdsApi::CommonTlsContext::CertificateProviderInstance::ToString()
   return absl::StrCat("{", absl::StrJoin(contents, ", "), "}");
 }
 
-bool XdsApi::CommonTlsContext::CertificateProviderInstance::Empty() const {
+bool XdsApi::CommonTlsContext::CertificateProviderPluginInstance::Empty()
+    const {
   return instance_name.empty() && certificate_name.empty();
-}
-
-//
-// XdsApi::CommonTlsContext::CombinedCertificateValidationContext
-//
-
-std::string
-XdsApi::CommonTlsContext::CombinedCertificateValidationContext::ToString()
-    const {
-  absl::InlinedVector<std::string, 2> contents;
-  if (!default_validation_context.Empty()) {
-    contents.push_back(absl::StrFormat("default_validation_context=%s",
-                                       default_validation_context.ToString()));
-  }
-  if (!validation_context_certificate_provider_instance.Empty()) {
-    contents.push_back(absl::StrFormat(
-        "validation_context_certificate_provider_instance=%s",
-        validation_context_certificate_provider_instance.ToString()));
-  }
-  return absl::StrCat("{", absl::StrJoin(contents, ", "), "}");
-}
-
-bool XdsApi::CommonTlsContext::CombinedCertificateValidationContext::Empty()
-    const {
-  return default_validation_context.Empty() &&
-         validation_context_certificate_provider_instance.Empty();
 }
 
 //
@@ -489,21 +464,22 @@ bool XdsApi::CommonTlsContext::CombinedCertificateValidationContext::Empty()
 
 std::string XdsApi::CommonTlsContext::ToString() const {
   absl::InlinedVector<std::string, 2> contents;
-  if (!tls_certificate_certificate_provider_instance.Empty()) {
-    contents.push_back(absl::StrFormat(
-        "tls_certificate_certificate_provider_instance=%s",
-        tls_certificate_certificate_provider_instance.ToString()));
+  if (!tls_certificate_provider_instance.Empty()) {
+    contents.push_back(
+        absl::StrFormat("tls_certificate_provider_instance=%s",
+                        tls_certificate_provider_instance.ToString()));
   }
-  if (!combined_validation_context.Empty()) {
-    contents.push_back(absl::StrFormat("combined_validation_context=%s",
-                                       combined_validation_context.ToString()));
+  if (!certificate_validation_context.Empty()) {
+    contents.push_back(
+        absl::StrFormat("certificate_validation_context=%s",
+                        certificate_validation_context.ToString()));
   }
   return absl::StrCat("{", absl::StrJoin(contents, ", "), "}");
 }
 
 bool XdsApi::CommonTlsContext::Empty() const {
-  return tls_certificate_certificate_provider_instance.Empty() &&
-         combined_validation_context.Empty();
+  return tls_certificate_provider_instance.Empty() &&
+         certificate_validation_context.Empty();
 }
 
 //
@@ -1933,13 +1909,16 @@ grpc_error_handle RouteConfigParse(
   return GRPC_ERROR_NONE;
 }
 
+// CertificateProviderInstance is deprecated but we are still supporting it for
+// backward compatibility reasons. Note that we still parse the data into the
+// same CertificateProviderPluginInstance struct since the fields are the same.
 grpc_error_handle CertificateProviderInstanceParse(
     const EncodingContext& context,
     const envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CertificateProviderInstance*
         certificate_provider_instance_proto,
-    XdsApi::CommonTlsContext::CertificateProviderInstance*
-        certificate_provider_instance) {
-  *certificate_provider_instance = {
+    XdsApi::CommonTlsContext::CertificateProviderPluginInstance*
+        certificate_provider_plugin_instance) {
+  *certificate_provider_plugin_instance = {
       UpbStringToStdString(
           envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CertificateProviderInstance_instance_name(
               certificate_provider_instance_proto)),
@@ -1947,14 +1926,149 @@ grpc_error_handle CertificateProviderInstanceParse(
           envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CertificateProviderInstance_certificate_name(
               certificate_provider_instance_proto))};
   if (context.certificate_provider_definition_map->find(
-          certificate_provider_instance->instance_name) ==
+          certificate_provider_plugin_instance->instance_name) ==
       context.certificate_provider_definition_map->end()) {
     return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
         absl::StrCat("Unrecognized certificate provider instance name: ",
-                     certificate_provider_instance->instance_name)
+                     certificate_provider_plugin_instance->instance_name)
             .c_str());
   }
   return GRPC_ERROR_NONE;
+}
+
+grpc_error_handle CertificateProviderPluginInstanceParse(
+    const EncodingContext& context,
+    const envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance*
+        certificate_provider_plugin_instance_proto,
+    XdsApi::CommonTlsContext::CertificateProviderPluginInstance*
+        certificate_provider_plugin_instance) {
+  *certificate_provider_plugin_instance = {
+      UpbStringToStdString(
+          envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance_instance_name(
+              certificate_provider_plugin_instance_proto)),
+      UpbStringToStdString(
+          envoy_extensions_transport_sockets_tls_v3_CertificateProviderPluginInstance_certificate_name(
+              certificate_provider_plugin_instance_proto))};
+  if (context.certificate_provider_definition_map->find(
+          certificate_provider_plugin_instance->instance_name) ==
+      context.certificate_provider_definition_map->end()) {
+    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        absl::StrCat("Unrecognized certificate provider instance name: ",
+                     certificate_provider_plugin_instance->instance_name)
+            .c_str());
+  }
+  return GRPC_ERROR_NONE;
+}
+
+grpc_error_handle CertificateValidationContextParse(
+    const EncodingContext& context,
+    const envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext*
+        certificate_validation_context_proto,
+    XdsApi::CommonTlsContext::CertificateValidationContext*
+        certificate_validation_context) {
+  std::vector<grpc_error_handle> errors;
+  size_t len = 0;
+  auto* subject_alt_names_matchers =
+      envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_match_subject_alt_names(
+          certificate_validation_context_proto, &len);
+  for (size_t i = 0; i < len; ++i) {
+    StringMatcher::Type type;
+    std::string matcher;
+    if (envoy_type_matcher_v3_StringMatcher_has_exact(
+            subject_alt_names_matchers[i])) {
+      type = StringMatcher::Type::kExact;
+      matcher = UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_exact(
+          subject_alt_names_matchers[i]));
+    } else if (envoy_type_matcher_v3_StringMatcher_has_prefix(
+                   subject_alt_names_matchers[i])) {
+      type = StringMatcher::Type::kPrefix;
+      matcher = UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_prefix(
+          subject_alt_names_matchers[i]));
+    } else if (envoy_type_matcher_v3_StringMatcher_has_suffix(
+                   subject_alt_names_matchers[i])) {
+      type = StringMatcher::Type::kSuffix;
+      matcher = UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_suffix(
+          subject_alt_names_matchers[i]));
+    } else if (envoy_type_matcher_v3_StringMatcher_has_contains(
+                   subject_alt_names_matchers[i])) {
+      type = StringMatcher::Type::kContains;
+      matcher =
+          UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_contains(
+              subject_alt_names_matchers[i]));
+    } else if (envoy_type_matcher_v3_StringMatcher_has_safe_regex(
+                   subject_alt_names_matchers[i])) {
+      type = StringMatcher::Type::kSafeRegex;
+      auto* regex_matcher = envoy_type_matcher_v3_StringMatcher_safe_regex(
+          subject_alt_names_matchers[i]);
+      matcher = UpbStringToStdString(
+          envoy_type_matcher_v3_RegexMatcher_regex(regex_matcher));
+    } else {
+      errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          "Invalid StringMatcher specified"));
+      continue;
+    }
+    bool ignore_case = envoy_type_matcher_v3_StringMatcher_ignore_case(
+        subject_alt_names_matchers[i]);
+    absl::StatusOr<StringMatcher> string_matcher =
+        StringMatcher::Create(type, matcher,
+                              /*case_sensitive=*/!ignore_case);
+    if (!string_matcher.ok()) {
+      errors.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          absl::StrCat("string matcher: ", string_matcher.status().message())
+              .c_str()));
+      continue;
+    }
+    if (type == StringMatcher::Type::kSafeRegex && ignore_case) {
+      errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          "StringMatcher: ignore_case has no effect for SAFE_REGEX."));
+      continue;
+    }
+    certificate_validation_context->match_subject_alt_names.push_back(
+        std::move(string_matcher.value()));
+  }
+  auto* ca_certificate_provider_instance =
+      envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_ca_certificate_provider_instance(
+          certificate_validation_context_proto);
+  if (ca_certificate_provider_instance != nullptr) {
+    grpc_error_handle error = CertificateProviderPluginInstanceParse(
+        context, ca_certificate_provider_instance,
+        &certificate_validation_context->ca_certificate_provider_instance);
+    if (error != GRPC_ERROR_NONE) errors.push_back(error);
+  }
+  if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_verify_certificate_spki(
+          certificate_validation_context_proto, nullptr) != nullptr) {
+    errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "CertificateValidationContext: verify_certificate_spki "
+        "unsupported"));
+  }
+  if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_verify_certificate_hash(
+          certificate_validation_context_proto, nullptr) != nullptr) {
+    errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "CertificateValidationContext: verify_certificate_hash "
+        "unsupported"));
+  }
+  auto* require_signed_certificate_timestamp =
+      envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_require_signed_certificate_timestamp(
+          certificate_validation_context_proto);
+  if (require_signed_certificate_timestamp != nullptr &&
+      google_protobuf_BoolValue_value(require_signed_certificate_timestamp)) {
+    errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "CertificateValidationContext: "
+        "require_signed_certificate_timestamp unsupported"));
+  }
+  if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_has_crl(
+          certificate_validation_context_proto)) {
+    errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "CertificateValidationContext: crl unsupported"));
+  }
+  if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_has_custom_validator_config(
+          certificate_validation_context_proto)) {
+    errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "CertificateValidationContext: custom_validator_config "
+        "unsupported"));
+  }
+  return GRPC_ERROR_CREATE_FROM_VECTOR(
+      "Error parsing CertificateValidationContext", &errors);
 }
 
 grpc_error_handle CommonTlsContextParse(
@@ -1966,128 +2080,85 @@ grpc_error_handle CommonTlsContextParse(
   auto* combined_validation_context =
       envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_combined_validation_context(
           common_tls_context_proto);
+  // The validation context is derived from the oneof in
+  // 'validation_context_type'. 'validation_context_sds_secret_config' is not
+  // supported.
   if (combined_validation_context != nullptr) {
     auto* default_validation_context =
         envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CombinedCertificateValidationContext_default_validation_context(
             combined_validation_context);
     if (default_validation_context != nullptr) {
-      size_t len = 0;
-      auto* subject_alt_names_matchers =
-          envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_match_subject_alt_names(
-              default_validation_context, &len);
-      for (size_t i = 0; i < len; ++i) {
-        StringMatcher::Type type;
-        std::string matcher;
-        if (envoy_type_matcher_v3_StringMatcher_has_exact(
-                subject_alt_names_matchers[i])) {
-          type = StringMatcher::Type::kExact;
-          matcher =
-              UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_exact(
-                  subject_alt_names_matchers[i]));
-        } else if (envoy_type_matcher_v3_StringMatcher_has_prefix(
-                       subject_alt_names_matchers[i])) {
-          type = StringMatcher::Type::kPrefix;
-          matcher =
-              UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_prefix(
-                  subject_alt_names_matchers[i]));
-        } else if (envoy_type_matcher_v3_StringMatcher_has_suffix(
-                       subject_alt_names_matchers[i])) {
-          type = StringMatcher::Type::kSuffix;
-          matcher =
-              UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_suffix(
-                  subject_alt_names_matchers[i]));
-        } else if (envoy_type_matcher_v3_StringMatcher_has_contains(
-                       subject_alt_names_matchers[i])) {
-          type = StringMatcher::Type::kContains;
-          matcher =
-              UpbStringToStdString(envoy_type_matcher_v3_StringMatcher_contains(
-                  subject_alt_names_matchers[i]));
-        } else if (envoy_type_matcher_v3_StringMatcher_has_safe_regex(
-                       subject_alt_names_matchers[i])) {
-          type = StringMatcher::Type::kSafeRegex;
-          auto* regex_matcher = envoy_type_matcher_v3_StringMatcher_safe_regex(
-              subject_alt_names_matchers[i]);
-          matcher = UpbStringToStdString(
-              envoy_type_matcher_v3_RegexMatcher_regex(regex_matcher));
-        } else {
-          errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-              "Invalid StringMatcher specified"));
-          continue;
-        }
-        bool ignore_case = envoy_type_matcher_v3_StringMatcher_ignore_case(
-            subject_alt_names_matchers[i]);
-        absl::StatusOr<StringMatcher> string_matcher =
-            StringMatcher::Create(type, matcher,
-                                  /*case_sensitive=*/!ignore_case);
-        if (!string_matcher.ok()) {
-          errors.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("string matcher: ",
-                           string_matcher.status().message())
-                  .c_str()));
-          continue;
-        }
-        if (type == StringMatcher::Type::kSafeRegex && ignore_case) {
-          errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-              "StringMatcher: ignore_case has no effect for SAFE_REGEX."));
-          continue;
-        }
-        common_tls_context->combined_validation_context
-            .default_validation_context.match_subject_alt_names.push_back(
-                std::move(string_matcher.value()));
-      }
-      if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_verify_certificate_spki(
-              default_validation_context, nullptr) != nullptr) {
-        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "CertificateValidationContext: verify_certificate_spki "
-            "unsupported"));
-      }
-      if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_verify_certificate_hash(
-              default_validation_context, nullptr) != nullptr) {
-        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "CertificateValidationContext: verify_certificate_hash "
-            "unsupported"));
-      }
-      auto* require_signed_certificate_timestamp =
-          envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_require_signed_certificate_timestamp(
-              default_validation_context);
-      if (require_signed_certificate_timestamp != nullptr &&
-          google_protobuf_BoolValue_value(
-              require_signed_certificate_timestamp)) {
-        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "CertificateValidationContext: "
-            "require_signed_certificate_timestamp unsupported"));
-      }
-      if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_has_crl(
-              default_validation_context)) {
-        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "CertificateValidationContext: crl unsupported"));
-      }
-      if (envoy_extensions_transport_sockets_tls_v3_CertificateValidationContext_has_custom_validator_config(
-              default_validation_context)) {
-        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "CertificateValidationContext: custom_validator_config "
-            "unsupported"));
-      }
+      grpc_error_handle error = CertificateValidationContextParse(
+          context, default_validation_context,
+          &common_tls_context->certificate_validation_context);
+      if (error != GRPC_ERROR_NONE) errors.push_back(error);
     }
+    // If after parsing default_validation_context,
+    // common_tls_context->certificate_validation_context.ca_certificate_provider_instance
+    // is empty, fall back onto
+    // 'validation_context_certificate_provider_instance' inside
+    // 'combined_validation_context'. Note that this way of fetching root
+    // certificates is deprecated and might be removed in the future.
     auto* validation_context_certificate_provider_instance =
         envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CombinedCertificateValidationContext_validation_context_certificate_provider_instance(
             combined_validation_context);
-    if (validation_context_certificate_provider_instance != nullptr) {
+    if (common_tls_context->certificate_validation_context
+            .ca_certificate_provider_instance.Empty() &&
+        validation_context_certificate_provider_instance != nullptr) {
       grpc_error_handle error = CertificateProviderInstanceParse(
           context, validation_context_certificate_provider_instance,
-          &common_tls_context->combined_validation_context
-               .validation_context_certificate_provider_instance);
+          &common_tls_context->certificate_validation_context
+               .ca_certificate_provider_instance);
       if (error != GRPC_ERROR_NONE) errors.push_back(error);
     }
+  } else {
+    auto* validation_context =
+        envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_validation_context(
+            common_tls_context_proto);
+    if (validation_context != nullptr) {
+      grpc_error_handle error = CertificateValidationContextParse(
+          context, validation_context,
+          &common_tls_context->certificate_validation_context);
+      if (error != GRPC_ERROR_NONE) errors.push_back(error);
+    } else if (
+        envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_validation_context_sds_secret_config(
+            common_tls_context_proto)) {
+      errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          "validation_context_sds_secret_config unsupported"));
+    }
   }
-  auto* tls_certificate_certificate_provider_instance =
-      envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_tls_certificate_certificate_provider_instance(
+  auto* tls_certificate_provider_instance =
+      envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_tls_certificate_provider_instance(
           common_tls_context_proto);
-  if (tls_certificate_certificate_provider_instance != nullptr) {
-    grpc_error_handle error = CertificateProviderInstanceParse(
-        context, tls_certificate_certificate_provider_instance,
-        &common_tls_context->tls_certificate_certificate_provider_instance);
+  if (tls_certificate_provider_instance != nullptr) {
+    grpc_error_handle error = CertificateProviderPluginInstanceParse(
+        context, tls_certificate_provider_instance,
+        &common_tls_context->tls_certificate_provider_instance);
     if (error != GRPC_ERROR_NONE) errors.push_back(error);
+  } else {
+    // Fall back onto 'tls_certificate_certificate_provider_instance'. Note that
+    // this way of fetching identity certificates is deprecated and might be
+    // removed in the future.
+    auto* tls_certificate_certificate_provider_instance =
+        envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_tls_certificate_certificate_provider_instance(
+            common_tls_context_proto);
+    if (tls_certificate_certificate_provider_instance != nullptr) {
+      grpc_error_handle error = CertificateProviderInstanceParse(
+          context, tls_certificate_certificate_provider_instance,
+          &common_tls_context->tls_certificate_provider_instance);
+      if (error != GRPC_ERROR_NONE) errors.push_back(error);
+    } else {
+      if (envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_tls_certificates(
+              common_tls_context_proto)) {
+        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+            "tls_certificates unsupported"));
+      }
+      if (envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_tls_certificate_sds_secret_configs(
+              common_tls_context_proto)) {
+        errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+            "tls_certificate_sds_secret_configs unsupported"));
+      }
+    }
   }
   return GRPC_ERROR_CREATE_FROM_VECTOR("Error parsing CommonTlsContext",
                                        &errors);
@@ -2322,16 +2393,14 @@ grpc_error_handle DownstreamTlsContextParse(
     }
   }
   if (downstream_tls_context->common_tls_context
-          .tls_certificate_certificate_provider_instance.instance_name
-          .empty()) {
+          .tls_certificate_provider_instance.instance_name.empty()) {
     errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "TLS configuration provided but no "
-        "tls_certificate_certificate_provider_instance found."));
+        "tls_certificate_provider_instance found."));
   }
   if (downstream_tls_context->require_client_certificate &&
-      downstream_tls_context->common_tls_context.combined_validation_context
-          .validation_context_certificate_provider_instance.instance_name
-          .empty()) {
+      downstream_tls_context->common_tls_context.certificate_validation_context
+          .ca_certificate_provider_instance.instance_name.empty()) {
     errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "TLS configuration requires client certificates but no certificate "
         "provider instance specified for validation."));
@@ -2962,13 +3031,11 @@ grpc_error_handle UpstreamTlsContextParse(
       }
     }
   }
-  if (common_tls_context->combined_validation_context
-          .validation_context_certificate_provider_instance.instance_name
-          .empty()) {
+  if (common_tls_context->certificate_validation_context
+          .ca_certificate_provider_instance.instance_name.empty()) {
     return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
         "UpstreamTlsContext: TLS configuration provided but no "
-        "validation_context_certificate_provider_instance "
-        "found.");
+        "ca_certificate_provider_instance found.");
   }
   return GRPC_ERROR_NONE;
 }

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -2164,6 +2164,16 @@ grpc_error_handle CommonTlsContextParse(
       }
     }
   }
+  if (envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_tls_params(
+          common_tls_context_proto)) {
+    errors.push_back(
+        GRPC_ERROR_CREATE_FROM_STATIC_STRING("tls_params unsupported"));
+  }
+  if (envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_custom_handshaker(
+          common_tls_context_proto)) {
+    errors.push_back(
+        GRPC_ERROR_CREATE_FROM_STATIC_STRING("custom_handshaker unsupported"));
+  }
   return GRPC_ERROR_CREATE_FROM_VECTOR("Error parsing CommonTlsContext",
                                        &errors);
 }

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -1912,6 +1912,8 @@ grpc_error_handle RouteConfigParse(
 // CertificateProviderInstance is deprecated but we are still supporting it for
 // backward compatibility reasons. Note that we still parse the data into the
 // same CertificateProviderPluginInstance struct since the fields are the same.
+// TODO(yashykt): Remove this once we stop supporting the old way of fetching
+// certificate provider instances.
 grpc_error_handle CertificateProviderInstanceParse(
     const EncodingContext& context,
     const envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CertificateProviderInstance*
@@ -2077,12 +2079,12 @@ grpc_error_handle CommonTlsContextParse(
         common_tls_context_proto,
     XdsApi::CommonTlsContext* common_tls_context) {
   std::vector<grpc_error_handle> errors;
-  auto* combined_validation_context =
-      envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_combined_validation_context(
-          common_tls_context_proto);
   // The validation context is derived from the oneof in
   // 'validation_context_type'. 'validation_context_sds_secret_config' is not
   // supported.
+  auto* combined_validation_context =
+      envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_combined_validation_context(
+          common_tls_context_proto);
   if (combined_validation_context != nullptr) {
     auto* default_validation_context =
         envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CombinedCertificateValidationContext_default_validation_context(
@@ -2098,7 +2100,8 @@ grpc_error_handle CommonTlsContextParse(
     // is empty, fall back onto
     // 'validation_context_certificate_provider_instance' inside
     // 'combined_validation_context'. Note that this way of fetching root
-    // certificates is deprecated and might be removed in the future.
+    // certificates is deprecated and will be removed in the future.
+    // TODO(yashykt): Remove this once it's no longer needed.
     auto* validation_context_certificate_provider_instance =
         envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_CombinedCertificateValidationContext_validation_context_certificate_provider_instance(
             combined_validation_context);
@@ -2137,8 +2140,9 @@ grpc_error_handle CommonTlsContextParse(
     if (error != GRPC_ERROR_NONE) errors.push_back(error);
   } else {
     // Fall back onto 'tls_certificate_certificate_provider_instance'. Note that
-    // this way of fetching identity certificates is deprecated and might be
+    // this way of fetching identity certificates is deprecated and will be
     // removed in the future.
+    // TODO(yashykt): Remove this once it's no longer needed.
     auto* tls_certificate_certificate_provider_instance =
         envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_tls_certificate_certificate_provider_instance(
             common_tls_context_proto);
@@ -2404,6 +2408,11 @@ grpc_error_handle DownstreamTlsContextParse(
     errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "TLS configuration requires client certificates but no certificate "
         "provider instance specified for validation."));
+  }
+  if (!downstream_tls_context->common_tls_context.certificate_validation_context
+           .match_subject_alt_names.empty()) {
+    errors.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "match_subject_alt_names not supported on servers"));
   }
   return GRPC_ERROR_CREATE_FROM_VECTOR("Error parsing DownstreamTlsContext",
                                        &errors);

--- a/src/core/ext/xds/xds_api.h
+++ b/src/core/ext/xds/xds_api.h
@@ -194,22 +194,11 @@ class XdsApi {
   };
 
   struct CommonTlsContext {
-    struct CertificateValidationContext {
-      std::vector<StringMatcher> match_subject_alt_names;
-
-      bool operator==(const CertificateValidationContext& other) const {
-        return match_subject_alt_names == other.match_subject_alt_names;
-      }
-
-      std::string ToString() const;
-      bool Empty() const;
-    };
-
-    struct CertificateProviderInstance {
+    struct CertificateProviderPluginInstance {
       std::string instance_name;
       std::string certificate_name;
 
-      bool operator==(const CertificateProviderInstance& other) const {
+      bool operator==(const CertificateProviderPluginInstance& other) const {
         return instance_name == other.instance_name &&
                certificate_name == other.certificate_name;
       }
@@ -218,28 +207,28 @@ class XdsApi {
       bool Empty() const;
     };
 
-    struct CombinedCertificateValidationContext {
-      CertificateValidationContext default_validation_context;
-      CertificateProviderInstance
-          validation_context_certificate_provider_instance;
+    struct CertificateValidationContext {
+      CertificateProviderPluginInstance ca_certificate_provider_instance;
+      std::vector<StringMatcher> match_subject_alt_names;
 
-      bool operator==(const CombinedCertificateValidationContext& other) const {
-        return default_validation_context == other.default_validation_context &&
-               validation_context_certificate_provider_instance ==
-                   other.validation_context_certificate_provider_instance;
+      bool operator==(const CertificateValidationContext& other) const {
+        return ca_certificate_provider_instance ==
+                   other.ca_certificate_provider_instance &&
+               match_subject_alt_names == other.match_subject_alt_names;
       }
 
       std::string ToString() const;
       bool Empty() const;
     };
 
-    CertificateProviderInstance tls_certificate_certificate_provider_instance;
-    CombinedCertificateValidationContext combined_validation_context;
+    CertificateValidationContext certificate_validation_context;
+    CertificateProviderPluginInstance tls_certificate_provider_instance;
 
     bool operator==(const CommonTlsContext& other) const {
-      return tls_certificate_certificate_provider_instance ==
-                 other.tls_certificate_certificate_provider_instance &&
-             combined_validation_context == other.combined_validation_context;
+      return certificate_validation_context ==
+                 other.certificate_validation_context &&
+             tls_certificate_provider_instance ==
+                 other.tls_certificate_provider_instance;
     }
 
     std::string ToString() const;

--- a/src/core/ext/xds/xds_server_config_fetcher.cc
+++ b/src/core/ext/xds/xds_server_config_fetcher.cc
@@ -259,12 +259,12 @@ FilterChainMatchManager::CreateOrGetXdsCertificateProviderFromFilterChainData(
   // Configure root cert.
   absl::string_view root_provider_instance_name =
       filter_chain->downstream_tls_context.common_tls_context
-          .combined_validation_context
-          .validation_context_certificate_provider_instance.instance_name;
+          .certificate_validation_context.ca_certificate_provider_instance
+          .instance_name;
   absl::string_view root_provider_cert_name =
       filter_chain->downstream_tls_context.common_tls_context
-          .combined_validation_context
-          .validation_context_certificate_provider_instance.certificate_name;
+          .certificate_validation_context.ca_certificate_provider_instance
+          .certificate_name;
   if (!root_provider_instance_name.empty()) {
     certificate_providers.root =
         xds_client_->certificate_provider_store()
@@ -278,10 +278,10 @@ FilterChainMatchManager::CreateOrGetXdsCertificateProviderFromFilterChainData(
   // Configure identity cert.
   absl::string_view identity_provider_instance_name =
       filter_chain->downstream_tls_context.common_tls_context
-          .tls_certificate_certificate_provider_instance.instance_name;
+          .tls_certificate_provider_instance.instance_name;
   absl::string_view identity_provider_cert_name =
       filter_chain->downstream_tls_context.common_tls_context
-          .tls_certificate_certificate_provider_instance.certificate_name;
+          .tls_certificate_provider_instance.certificate_name;
   if (!identity_provider_instance_name.empty()) {
     certificate_providers.instance =
         xds_client_->certificate_provider_store()

--- a/src/proto/grpc/testing/xds/v3/tls.proto
+++ b/src/proto/grpc/testing/xds/v3/tls.proto
@@ -153,8 +153,6 @@ message CertificateValidationContext {
   config.core.v3.TypedExtensionConfig custom_validator_config = 12;
 }
 
-message SdsSecretConfig {}
-
 message UpstreamTlsContext {
   // Common TLS context settings.
   //

--- a/src/proto/grpc/testing/xds/v3/tls.proto
+++ b/src/proto/grpc/testing/xds/v3/tls.proto
@@ -24,7 +24,33 @@ import "src/proto/grpc/testing/xds/v3/string.proto";
 
 import "google/protobuf/wrappers.proto";
 
+// Indicates a certificate to be obtained from a named CertificateProvider plugin instance.
+// The plugin instances are defined in the client's bootstrap file.
+// The plugin allows certificates to be fetched/refreshed over the network asynchronously with
+// respect to the TLS handshake.
+// [#not-implemented-hide:]
+message CertificateProviderPluginInstance {
+  // Provider instance name. If not present, defaults to "default".
+  //
+  // Instance names should generally be defined not in terms of the underlying provider
+  // implementation (e.g., "file_watcher") but rather in terms of the function of the
+  // certificates (e.g., "foo_deployment_identity").
+  string instance_name = 1;
+
+  // Opaque name used to specify certificate instances or types. For example, "ROOTCA" to specify
+  // a root-certificate (validation context) or "example.com" to specify a certificate for a
+  // particular domain. Not all provider instances will actually use this field, so the value
+  // defaults to the empty string.
+  string certificate_name = 2;
+}
+
 message CertificateValidationContext {
+  // Certificate provider instance for fetching TLS certificates.
+  //
+  // Only one of *trusted_ca* and *ca_certificate_provider_instance* may be specified.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance ca_certificate_provider_instance = 13;
+
   // An optional list of base64-encoded SHA-256 hashes. If specified, Envoy will verify that the
   // SHA-256 of the DER-encoded Subject Public Key Information (SPKI) of the presented certificate
   // matches one of the specified values.
@@ -127,6 +153,8 @@ message CertificateValidationContext {
   config.core.v3.TypedExtensionConfig custom_validator_config = 12;
 }
 
+message SdsSecretConfig {}
+
 message UpstreamTlsContext {
   // Common TLS context settings.
   //
@@ -212,10 +240,55 @@ message CommonTlsContext {
     CertificateProviderInstance validation_context_certificate_provider_instance = 4;
   }
 
+  message TlsCertificate {}
+
+  // :ref:`Multiple TLS certificates <arch_overview_ssl_cert_select>` can be associated with the
+  // same context to allow both RSA and ECDSA certificates.
+  //
+  // Only a single TLS certificate is supported in client contexts. In server contexts, the first
+  // RSA certificate is used for clients that only support RSA and the first ECDSA certificate is
+  // used for clients that support ECDSA.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
+  // this to avoid this problem.]
+  repeated TlsCertificate tls_certificates = 2;
+
+  message SdsSecretConfig {}
+
+  // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
+  // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+  //
+  // The same number and types of certificates as :ref:`tls_certificates <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CommonTlsContext.tls_certificates>`
+  // are valid in the the certificates fetched through this setting.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // and *tls_certificate_provider_instance* may be used.
+  // [#next-major-version: These mutually exclusive fields should ideally be in a oneof, but it's
+  // not legal to put a repeated field in a oneof. In the next major version, we should rework
+  // this to avoid this problem.]
+  repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6;
+
+  // Certificate provider instance for fetching TLS certs.
+  //
+  // Only one of *tls_certificates*, *tls_certificate_sds_secret_configs*,
+  // and *tls_certificate_provider_instance* may be used.
+  // [#not-implemented-hide:]
+  CertificateProviderPluginInstance tls_certificate_provider_instance = 14;
+
   // Certificate provider instance for fetching TLS certificates.
   CertificateProviderInstance tls_certificate_certificate_provider_instance = 11;
 
   oneof validation_context_type {
+    // How to validate peer certificates.
+    CertificateValidationContext validation_context = 3;
+
+    // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
+    // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
+    SdsSecretConfig validation_context_sds_secret_config = 7;
+
     // Combined certificate validation context holds a default CertificateValidationContext
     // and SDS config. When SDS server returns dynamic CertificateValidationContext, both dynamic
     // and default CertificateValidationContext are merged into a new CertificateValidationContext

--- a/src/proto/grpc/testing/xds/v3/tls.proto
+++ b/src/proto/grpc/testing/xds/v3/tls.proto
@@ -238,6 +238,11 @@ message CommonTlsContext {
     CertificateProviderInstance validation_context_certificate_provider_instance = 4;
   }
 
+  message TlsParameters {}
+
+  // TLS protocol versions, cipher suites etc.
+  TlsParameters tls_params = 1;
+
   message TlsCertificate {}
 
   // :ref:`Multiple TLS certificates <arch_overview_ssl_cert_select>` can be associated with the
@@ -296,4 +301,8 @@ message CommonTlsContext {
     // CertificateValidationContext, and logical OR is applied to boolean fields.
     CombinedCertificateValidationContext combined_validation_context = 8;
   }
+
+  // Custom TLS handshaker. If empty, defaults to native TLS handshaking
+  // behavior.
+  config.core.v3.TypedExtensionConfig custom_handshaker = 13;
 }


### PR DESCRIPTION
The new method is documented at https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md and based on https://github.com/envoyproxy/envoy/pull/17201

Note that the older fields are still used as a fallback mechanism since our current infrastructure still depends on those fields. 

All existing tests have been modified to use the newer fields and some basic tests have been added to test the old fields.

Also performing a quick check on all the cases mentioned in the gRFC for NACKing behavior. Cases NACKed-

1. Unrecognized certificate provider instance names
2. Bad `StringMatcher` for `match_subject_alt_names`
3. `CertificateValidationContext`:`verify_certificate_spki` (unsupported)
4. `CertificateValidationContext`:`verify_certificate_hash` (unsupported)
5. `CertificateValidationContext`:`require_signed_certificate_timestamp` (unsupported)
6. `CertificateValidationContext`:`crl` (unsupported)
7. `CertificateValidationContext`:`custom_validator_config` (unsupported)
8. `CommonTlsContext`:`validation_context_sds_secret_config` (unsupported)
9. `CommonTlsContext`:`tls_certificates` (Only NACKed if TLS certificate provider not provided in the supported fields)
10. `CommonTlsContext`:`tls_certificate_sds_secret_configs` (Only NACKed if TLS certificate provider not provided in the supported fields)
11. `CommonTlsContext`:`tls_params` (unsupported)
12. `CommonTlsContext`:`custom_handshaker` (unsupported)
11. `DownstreamTlsContext`/`UpstreamTlsContext`:Unrecognized transport socket
12. `DownstreamTlsContext`:`require_sni` (unsupported)
13. `DownstreamTlsContext`:unsupported `ocsp_staple_policy` (only LENIENT_STAPLING supported)
14. `DownstreamTlsContext`:TLS configuration without configuration to fetch TLS certs
15. `DownstreamTlsContext`:Tls configuration requires client certs but no validation certs configuration provided.
16. `DownstreamTlsContext`:`match_subject_alt_names` (unsupported on servers)
17. `UpstreamTlsContext`:TLS configuration provided without validation certs configuration


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/27264)
<!-- Reviewable:end -->
