### PR TITLE
[binder] End-to-end callback benchmark app

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_stream.h
+++ b/src/core/ext/transport/binder/transport/binder_stream.h
@@ -51,7 +51,6 @@ struct grpc_binder_stream {
       : t(t),
         refcount(refcount),
         arena(arena),
-        seq(0),
         tx_code(tx_code),
         is_client(is_client) {
     // TODO(waynetu): Should this be protected?
@@ -74,13 +73,11 @@ struct grpc_binder_stream {
   }
 
   int GetTxCode() const { return tx_code; }
-  int GetThenIncSeq() { return seq++; }
 
   grpc_binder_transport* t;
   grpc_stream_refcount* refcount;
   grpc_core::Arena* arena;
   grpc_core::ManualConstructor<grpc_core::SliceBufferByteStream> sbs;
-  int seq;
   int tx_code;
   bool is_client;
   bool is_closed = false;

--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -324,8 +324,7 @@ static void perform_stream_op_locked(void* stream_op,
     if (!gbs->is_client) {
       // Send trailing metadata to inform the other end about the cancellation,
       // regardless if we'd already done that or not.
-      grpc_binder::Transaction cancel_tx(gbs->GetTxCode(), gbs->GetThenIncSeq(),
-                                         gbt->is_client);
+      grpc_binder::Transaction cancel_tx(gbs->GetTxCode(), gbt->is_client);
       cancel_tx.SetSuffix(grpc_binder::Metadata{});
       cancel_tx.SetStatus(1);
       absl::Status status = gbt->wire_writer->RpcCall(cancel_tx);
@@ -368,20 +367,13 @@ static void perform_stream_op_locked(void* stream_op,
     return;
   }
 
-  std::unique_ptr<grpc_binder::Transaction> tx;
   int tx_code = gbs->tx_code;
+  grpc_binder::Transaction tx(tx_code, gbt->is_client);
 
-  if (op->send_initial_metadata || op->send_message ||
-      op->send_trailing_metadata) {
-    // Only increment sequence number when there's a send operation.
-    tx = absl::make_unique<grpc_binder::Transaction>(
-        /*tx_code=*/tx_code, /*seq_num=*/gbs->GetThenIncSeq(), gbt->is_client);
-  }
   if (op->send_initial_metadata) {
     gpr_log(GPR_INFO, "send_initial_metadata");
     grpc_binder::Metadata init_md;
     auto batch = op->payload->send_initial_metadata.send_initial_metadata;
-    GPR_ASSERT(tx);
 
     for (grpc_linked_mdelem* md = batch->list.head; md != nullptr;
          md = md->next) {
@@ -399,12 +391,12 @@ static void perform_stream_op_locked(void* stream_op,
 
         // Only client send method ref.
         GPR_ASSERT(gbt->is_client);
-        tx->SetMethodRef(path);
+        tx.SetMethodRef(path);
       } else {
         init_md.emplace_back(std::string(key), std::string(value));
       }
     }
-    tx->SetPrefix(init_md);
+    tx.SetPrefix(init_md);
   }
   if (op->send_message) {
     gpr_log(GPR_INFO, "send_message");
@@ -426,8 +418,7 @@ static void perform_stream_op_locked(void* stream_op,
       grpc_slice_unref_internal(message_slice);
     }
     gpr_log(GPR_INFO, "message_data = %s", message_data.c_str());
-    GPR_ASSERT(tx);
-    tx->SetData(message_data);
+    tx.SetData(message_data);
     // TODO(b/192369787): Are we supposed to reset here to avoid
     // use-after-free issue in call.cc?
     op->payload->send_message.send_message.reset();
@@ -437,7 +428,6 @@ static void perform_stream_op_locked(void* stream_op,
     gpr_log(GPR_INFO, "send_trailing_metadata");
     auto batch = op->payload->send_trailing_metadata.send_trailing_metadata;
     grpc_binder::Metadata trailing_metadata;
-    GPR_ASSERT(tx);
 
     for (grpc_linked_mdelem* md = batch->list.head; md != nullptr;
          md = md->next) {
@@ -447,7 +437,7 @@ static void perform_stream_op_locked(void* stream_op,
       if (grpc_slice_eq(GRPC_MDKEY(md->md), GRPC_MDSTR_GRPC_STATUS)) {
         int status = grpc_get_status_code_from_metadata(md->md);
         gpr_log(GPR_INFO, "send trailing metadata status = %d", status);
-        tx->SetStatus(status);
+        tx.SetStatus(status);
       } else {
         absl::string_view key =
             grpc_core::StringViewFromSlice(GRPC_MDKEY(md->md));
@@ -460,7 +450,7 @@ static void perform_stream_op_locked(void* stream_op,
     }
     // TODO(mingcl): Will we ever has key-value pair here? According to
     // wireformat client suffix data is always empty.
-    tx->SetSuffix(trailing_metadata);
+    tx.SetSuffix(trailing_metadata);
   }
   if (op->recv_initial_metadata) {
     gpr_log(GPR_INFO, "recv_initial_metadata");
@@ -540,8 +530,12 @@ static void perform_stream_op_locked(void* stream_op,
   }
   // Only send transaction when there's a send op presented.
   absl::Status status = absl::OkStatus();
-  if (tx) {
-    status = gbt->wire_writer->RpcCall(*tx);
+  if (op->send_initial_metadata || op->send_message ||
+      op->send_trailing_metadata) {
+    // TODO(waynetu): RpcCall() is doing a lot of work (including waiting for
+    // acknowledgements from the other side). Consider delaying this operation
+    // with combiner.
+    status = gbt->wire_writer->RpcCall(tx);
     if (!gbs->is_client && op->send_trailing_metadata) {
       gbs->trailing_metadata_sent = true;
       // According to transport explaineer - "Server extra: This op shouldn't

--- a/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.cc
+++ b/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.cc
@@ -31,10 +31,10 @@ const absl::string_view
 void TransportStreamReceiverImpl::RegisterRecvInitialMetadata(
     StreamIdentifier id, InitialMetadataCallbackType cb) {
   gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
-  GPR_ASSERT(initial_metadata_cbs_.count(id) == 0);
   absl::StatusOr<Metadata> initial_metadata{};
   {
     grpc_core::MutexLock l(&m_);
+    GPR_ASSERT(initial_metadata_cbs_.count(id) == 0);
     auto iter = pending_initial_metadata_.find(id);
     if (iter == pending_initial_metadata_.end()) {
       if (trailing_metadata_recvd_.count(id)) {
@@ -59,10 +59,10 @@ void TransportStreamReceiverImpl::RegisterRecvInitialMetadata(
 void TransportStreamReceiverImpl::RegisterRecvMessage(
     StreamIdentifier id, MessageDataCallbackType cb) {
   gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
-  GPR_ASSERT(message_cbs_.count(id) == 0);
   absl::StatusOr<std::string> message{};
   {
     grpc_core::MutexLock l(&m_);
+    GPR_ASSERT(message_cbs_.count(id) == 0);
     auto iter = pending_message_.find(id);
     if (iter == pending_message_.end()) {
       // If we'd already received trailing-metadata and there's no pending
@@ -93,10 +93,10 @@ void TransportStreamReceiverImpl::RegisterRecvMessage(
 void TransportStreamReceiverImpl::RegisterRecvTrailingMetadata(
     StreamIdentifier id, TrailingMetadataCallbackType cb) {
   gpr_log(GPR_INFO, "%s id = %d is_client = %d", __func__, id, is_client_);
-  GPR_ASSERT(trailing_metadata_cbs_.count(id) == 0);
   std::pair<absl::StatusOr<Metadata>, int> trailing_metadata{};
   {
     grpc_core::MutexLock l(&m_);
+    GPR_ASSERT(trailing_metadata_cbs_.count(id) == 0);
     auto iter = pending_trailing_metadata_.find(id);
     if (iter == pending_trailing_metadata_.end()) {
       trailing_metadata_cbs_[id] = std::move(cb);

--- a/src/core/ext/transport/binder/wire_format/BUILD
+++ b/src/core/ext/transport/binder/wire_format/BUILD
@@ -86,6 +86,7 @@ grpc_cc_library(
     srcs = ["wire_writer.cc"],
     hdrs = ["wire_writer.h"],
     external_deps = [
+        "absl/container:flat_hash_map",
         "absl/strings",
     ],
     deps = [

--- a/src/core/ext/transport/binder/wire_format/binder.h
+++ b/src/core/ext/transport/binder/wire_format/binder.h
@@ -45,6 +45,7 @@ class WritableParcel {
  public:
   virtual ~WritableParcel() = default;
   virtual int32_t GetDataPosition() const = 0;
+  virtual int32_t GetDataSize() const = 0;
   virtual absl::Status SetDataPosition(int32_t pos) = 0;
   virtual absl::Status WriteInt32(int32_t data) = 0;
   virtual absl::Status WriteInt64(int64_t data) = 0;
@@ -67,6 +68,7 @@ class WritableParcel {
 class ReadableParcel {
  public:
   virtual ~ReadableParcel() = default;
+  virtual int32_t GetDataSize() const = 0;
   virtual absl::Status ReadInt32(int32_t* data) const = 0;
   virtual absl::Status ReadInt64(int64_t* data) const = 0;
   virtual absl::Status ReadBinder(std::unique_ptr<Binder>* data) const = 0;

--- a/src/core/ext/transport/binder/wire_format/binder_android.h
+++ b/src/core/ext/transport/binder/wire_format/binder_android.h
@@ -45,6 +45,7 @@ class WritableParcelAndroid final : public WritableParcel {
   ~WritableParcelAndroid() override = default;
 
   int32_t GetDataPosition() const override;
+  int32_t GetDataSize() const override;
   absl::Status SetDataPosition(int32_t pos) override;
   absl::Status WriteInt32(int32_t data) override;
   absl::Status WriteInt64(int64_t data) override;
@@ -66,6 +67,7 @@ class ReadableParcelAndroid final : public ReadableParcel {
       : parcel_(const_cast<AParcel*>(parcel)) {}
   ~ReadableParcelAndroid() override = default;
 
+  int32_t GetDataSize() const override;
   absl::Status ReadInt32(int32_t* data) const override;
   absl::Status ReadInt64(int64_t* data) const override;
   absl::Status ReadBinder(std::unique_ptr<Binder>* data) const override;

--- a/src/core/ext/transport/binder/wire_format/transaction.h
+++ b/src/core/ext/transport/binder/wire_format/transaction.h
@@ -39,8 +39,8 @@ using Metadata = std::vector<std::pair<std::string, std::string>>;
 
 class Transaction {
  public:
-  Transaction(int tx_code, int seq_num, bool is_client)
-      : tx_code_(tx_code), seq_num_(seq_num), is_client_(is_client) {}
+  Transaction(int tx_code, bool is_client)
+      : tx_code_(tx_code), is_client_(is_client) {}
   // TODO(mingcl): Consider using string_view
   void SetPrefix(Metadata prefix_metadata) {
     prefix_metadata_ = prefix_metadata;
@@ -77,7 +77,6 @@ class Transaction {
   bool IsClient() const { return is_client_; }
   bool IsServer() const { return !is_client_; }
   int GetTxCode() const { return tx_code_; }
-  int GetSeqNum() const { return seq_num_; }
   int GetFlags() const { return flags_; }
 
   absl::string_view GetMethodRef() const { return method_ref_; }
@@ -88,7 +87,6 @@ class Transaction {
 
  private:
   int tx_code_;
-  int seq_num_;
   bool is_client_;
   Metadata prefix_metadata_;
   Metadata suffix_metadata_;

--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
@@ -254,6 +254,7 @@ absl::Status WireReaderImpl::ProcessStreamingTransactionImpl(
     transaction_code_t code, const ReadableParcel* parcel,
     int* cancellation_flags) {
   GPR_ASSERT(cancellation_flags);
+  num_incoming_bytes_ += parcel->GetDataSize();
 
   int flags;
   RETURN_IF_ERROR(parcel->ReadInt32(&flags));
@@ -321,8 +322,6 @@ absl::Status WireReaderImpl::ProcessStreamingTransactionImpl(
     }
     gpr_log(GPR_INFO, "msg_data = %s", msg_data.c_str());
     message_buffer_[code] += msg_data;
-    // TODO(waynetu): This should be parcel->GetDataSize().
-    num_incoming_bytes_ += count;
     if ((flags & kFlagMessageDataIsPartial) == 0) {
       std::string s = std::move(message_buffer_[code]);
       message_buffer_.erase(code);

--- a/src/core/ext/transport/binder/wire_format/wire_writer.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_writer.cc
@@ -164,10 +164,9 @@ absl::Status WireWriterImpl::RpcCall(const Transaction& tx) {
     if (flags & kFlagSuffix) {
       RETURN_IF_ERROR(WriteTrailingMetadata(tx, parcel));
     }
+    num_outgoing_bytes_ += parcel->GetDataSize();
     RETURN_IF_ERROR(binder_->Transact(BinderTransportTxCode(tx.GetTxCode())));
     ptr += size;
-    // TODO(waynetu): This should be parcel->GetDataSize().
-    num_outgoing_bytes_ += size;
   }
   return absl::OkStatus();
 }

--- a/src/core/ext/transport/binder/wire_format/wire_writer.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_writer.cc
@@ -30,60 +30,160 @@ namespace grpc_binder {
 WireWriterImpl::WireWriterImpl(std::unique_ptr<Binder> binder)
     : binder_(std::move(binder)) {}
 
-absl::Status WireWriterImpl::RpcCall(const Transaction& tx) {
-  // TODO(mingcl): check tx_code <= last call id
-  grpc_core::MutexLock lock(&mu_);
-  GPR_ASSERT(tx.GetTxCode() >= kFirstCallId);
+absl::Status WireWriterImpl::WriteInitialMetadata(const Transaction& tx,
+                                                  WritableParcel* parcel) {
+  if (tx.IsClient()) {
+    // Only client sends method ref.
+    RETURN_IF_ERROR(parcel->WriteString(tx.GetMethodRef()));
+  }
+  RETURN_IF_ERROR(parcel->WriteInt32(tx.GetPrefixMetadata().size()));
+  for (const auto& md : tx.GetPrefixMetadata()) {
+    RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.first));
+    RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.second));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status WireWriterImpl::WriteTrailingMetadata(const Transaction& tx,
+                                                   WritableParcel* parcel) {
+  if (tx.IsServer()) {
+    if (tx.GetFlags() & kFlagStatusDescription) {
+      RETURN_IF_ERROR(parcel->WriteString(tx.GetStatusDesc()));
+    }
+    RETURN_IF_ERROR(parcel->WriteInt32(tx.GetSuffixMetadata().size()));
+    for (const auto& md : tx.GetSuffixMetadata()) {
+      RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.first));
+      RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.second));
+    }
+  } else {
+    // client suffix currently is always empty according to the wireformat
+    if (!tx.GetSuffixMetadata().empty()) {
+      gpr_log(GPR_ERROR, "Got non-empty suffix metadata from client.");
+    }
+  }
+  return absl::OkStatus();
+}
+
+const int64_t WireWriterImpl::kBlockSize = 16 * 1024;
+const int64_t WireWriterImpl::kFlowControlWindowSize = 128 * 1024;
+
+bool WireWriterImpl::CanBeSentInOneTransaction(const Transaction& tx) const {
+  return (tx.GetFlags() & kFlagMessageData) == 0 ||
+         tx.GetMessageData().size() <= kBlockSize;
+}
+
+absl::Status WireWriterImpl::RpcCallFastPath(const Transaction& tx) {
+  int& seq = seq_num_[tx.GetTxCode()];
+  // Fast path: send data in one transaction.
   RETURN_IF_ERROR(binder_->PrepareTransaction());
   WritableParcel* parcel = binder_->GetWritableParcel();
-  {
-    //  fill parcel
-    RETURN_IF_ERROR(parcel->WriteInt32(tx.GetFlags()));
-    RETURN_IF_ERROR(parcel->WriteInt32(tx.GetSeqNum()));
-    if (tx.GetFlags() & kFlagPrefix) {
-      // prefix set
-      if (tx.IsClient()) {
-        // Only client sends method ref.
-        RETURN_IF_ERROR(parcel->WriteString(tx.GetMethodRef()));
-      }
-      RETURN_IF_ERROR(parcel->WriteInt32(tx.GetPrefixMetadata().size()));
-      for (const auto& md : tx.GetPrefixMetadata()) {
-        RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.first));
-        RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.second));
-      }
-    }
-    if (tx.GetFlags() & kFlagMessageData) {
-      RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(tx.GetMessageData()));
-    }
-    if (tx.GetFlags() & kFlagSuffix) {
-      if (tx.IsServer()) {
-        if (tx.GetFlags() & kFlagStatusDescription) {
-          RETURN_IF_ERROR(parcel->WriteString(tx.GetStatusDesc()));
-        }
-        RETURN_IF_ERROR(parcel->WriteInt32(tx.GetSuffixMetadata().size()));
-        for (const auto& md : tx.GetSuffixMetadata()) {
-          RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.first));
-          RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(md.second));
-        }
-      } else {
-        // client suffix currently is always empty according to the wireformat
-        if (!tx.GetSuffixMetadata().empty()) {
-          gpr_log(GPR_ERROR, "Got non-empty suffix metadata from client.");
-        }
-      }
-    }
+  RETURN_IF_ERROR(parcel->WriteInt32(tx.GetFlags()));
+  RETURN_IF_ERROR(parcel->WriteInt32(seq++));
+  if (tx.GetFlags() & kFlagPrefix) {
+    RETURN_IF_ERROR(WriteInitialMetadata(tx, parcel));
+  }
+  if (tx.GetFlags() & kFlagMessageData) {
+    RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(tx.GetMessageData()));
+  }
+  if (tx.GetFlags() & kFlagSuffix) {
+    RETURN_IF_ERROR(WriteTrailingMetadata(tx, parcel));
   }
   // FIXME(waynetu): Construct BinderTransportTxCode from an arbitrary integer
   // is an undefined behavior.
   return binder_->Transact(BinderTransportTxCode(tx.GetTxCode()));
 }
 
-absl::Status WireWriterImpl::Ack(int64_t num_bytes) {
+bool WireWriterImpl::WaitForAcknowledgement() {
+  if (num_outgoing_bytes_ < num_acknowledged_bytes_ + kFlowControlWindowSize) {
+    return true;
+  }
+  absl::Time deadline = absl::Now() + absl::Seconds(1);
+  do {
+    if (cv_.WaitWithDeadline(&mu_, deadline)) {
+      return false;
+    }
+    if (absl::Now() >= deadline) {
+      return false;
+    }
+  } while (num_outgoing_bytes_ >=
+           num_acknowledged_bytes_ + kFlowControlWindowSize);
+  return true;
+}
+
+int WireWriterImpl::GetFlagForCurrentTransaction(int original_flags,
+                                                 int sent_length,
+                                                 int remaining_length) const {
+  int flags = kFlagMessageData;
+  if (sent_length == 0) {
+    // This is the first transaction. Include initial metadata if there's any.
+    if (original_flags & kFlagPrefix) {
+      flags |= kFlagPrefix;
+    }
+  }
+  if (remaining_length == 0) {
+    // This is the last transaction. Include trailing metadata if there's any.
+    if (original_flags & kFlagSuffix) {
+      flags |= kFlagSuffix;
+    }
+  } else {
+    // There are more messages to send.
+    flags |= kFlagMessageDataIsPartial;
+  }
+  return flags;
+}
+
+absl::Status WireWriterImpl::RpcCall(const Transaction& tx) {
+  // TODO(mingcl): check tx_code <= last call id
+  grpc_core::MutexLock lock(&mu_);
+  GPR_ASSERT(tx.GetTxCode() >= kFirstCallId);
+  if (CanBeSentInOneTransaction(tx)) {
+    return RpcCallFastPath(tx);
+  }
+  // Slow path: the message data is too large to fit in one transaction.
+  int& seq = seq_num_[tx.GetTxCode()];
+  int original_flags = tx.GetFlags();
+  GPR_ASSERT(original_flags & kFlagMessageData);
+  absl::string_view data = tx.GetMessageData();
+  size_t ptr = 0;
+  while (ptr < data.size()) {
+    if (!WaitForAcknowledgement()) {
+      return absl::InternalError("Timeout waiting for acknowledgement");
+    }
+    RETURN_IF_ERROR(binder_->PrepareTransaction());
+    WritableParcel* parcel = binder_->GetWritableParcel();
+    size_t size = std::min(static_cast<size_t>(kBlockSize), data.size() - ptr);
+    int flags = GetFlagForCurrentTransaction(
+        original_flags, /*sent_length=*/ptr,
+        /*remaining_length=*/data.size() - ptr - size);
+    RETURN_IF_ERROR(parcel->WriteInt32(flags));
+    RETURN_IF_ERROR(parcel->WriteInt32(seq++));
+    if (flags & kFlagPrefix) {
+      RETURN_IF_ERROR(WriteInitialMetadata(tx, parcel));
+    }
+    RETURN_IF_ERROR(parcel->WriteByteArrayWithLength(data.substr(ptr, size)));
+    if (flags & kFlagSuffix) {
+      RETURN_IF_ERROR(WriteTrailingMetadata(tx, parcel));
+    }
+    RETURN_IF_ERROR(binder_->Transact(BinderTransportTxCode(tx.GetTxCode())));
+    ptr += size;
+    // TODO(waynetu): This should be parcel->GetDataSize().
+    num_outgoing_bytes_ += size;
+  }
+  return absl::OkStatus();
+}
+
+absl::Status WireWriterImpl::SendAck(int64_t num_bytes) {
   grpc_core::MutexLock lock(&mu_);
   RETURN_IF_ERROR(binder_->PrepareTransaction());
   WritableParcel* parcel = binder_->GetWritableParcel();
   RETURN_IF_ERROR(parcel->WriteInt64(num_bytes));
   return binder_->Transact(BinderTransportTxCode::ACKNOWLEDGE_BYTES);
+}
+
+void WireWriterImpl::RecvAck(int64_t num_bytes) {
+  grpc_core::MutexLock lock(&mu_);
+  num_acknowledged_bytes_ = std::max(num_acknowledged_bytes_, num_bytes);
+  cv_.Signal();
 }
 
 }  // namespace grpc_binder

--- a/src/core/ext/transport/binder/wire_format/wire_writer.h
+++ b/src/core/ext/transport/binder/wire_format/wire_writer.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#include <grpc/support/log.h>
+#include "absl/container/flat_hash_map.h"
 
 #include "src/core/ext/transport/binder/wire_format/binder.h"
 #include "src/core/ext/transport/binder/wire_format/transaction.h"
@@ -32,18 +32,53 @@ class WireWriter {
  public:
   virtual ~WireWriter() = default;
   virtual absl::Status RpcCall(const Transaction& call) = 0;
-  virtual absl::Status Ack(int64_t num_bytes) = 0;
+  virtual absl::Status SendAck(int64_t num_bytes) = 0;
+  virtual void RecvAck(int64_t num_bytes) = 0;
 };
 
 class WireWriterImpl : public WireWriter {
  public:
   explicit WireWriterImpl(std::unique_ptr<Binder> binder);
   absl::Status RpcCall(const Transaction& tx) override;
-  absl::Status Ack(int64_t num_bytes) override;
+  absl::Status SendAck(int64_t num_bytes) override;
+  void RecvAck(int64_t num_bytes) override;
+
+  // Split long message into chunks of size 16k. This doesn't necessarily have
+  // to be the same as the flow control acknowledgement size, but it should not
+  // exceed 128k.
+  static const int64_t kBlockSize;
+  // Flow control allows sending at most 128k between acknowledgements.
+  static const int64_t kFlowControlWindowSize;
 
  private:
+  absl::Status WriteInitialMetadata(const Transaction& tx,
+                                    WritableParcel* parcel)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  absl::Status WriteTrailingMetadata(const Transaction& tx,
+                                     WritableParcel* parcel)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  bool CanBeSentInOneTransaction(const Transaction& tx) const;
+  absl::Status RpcCallFastPath(const Transaction& tx)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  // Wait for acknowledgement from the other side for a while (the timeout is
+  // currently set to 10ms for debugability). Returns true if we are able to
+  // proceed, and false otherwise.
+  //
+  // TODO(waynetu): Currently, RpcCall() will fail if we are blocked for 10ms.
+  // In the future, we should queue the transactions and release them later when
+  // acknowledgement comes.
+  bool WaitForAcknowledgement() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  int GetFlagForCurrentTransaction(int original_flags, int sent_length,
+                                   int remaining_length) const;
+
   grpc_core::Mutex mu_;
+  grpc_core::CondVar cv_;
   std::unique_ptr<Binder> binder_ ABSL_GUARDED_BY(mu_);
+  absl::flat_hash_map<int, int> seq_num_ ABSL_GUARDED_BY(mu_);
+  int64_t num_outgoing_bytes_ ABSL_GUARDED_BY(mu_) = 0;
+  int64_t num_acknowledged_bytes_ ABSL_GUARDED_BY(mu_) = 0;
 };
 
 }  // namespace grpc_binder

--- a/test/core/transport/binder/binder_transport_test.cc
+++ b/test/core/transport/binder/binder_transport_test.cc
@@ -332,74 +332,12 @@ TEST_F(BinderTransportTest, TransactionIdIncrement) {
   grpc_binder_stream* gbs0 = InitNewBinderStream();
   EXPECT_EQ(gbs0->t, GetBinderTransport());
   EXPECT_EQ(gbs0->tx_code, kFirstCallId);
-  EXPECT_EQ(gbs0->seq, 0);
   grpc_binder_stream* gbs1 = InitNewBinderStream();
   EXPECT_EQ(gbs1->t, GetBinderTransport());
   EXPECT_EQ(gbs1->tx_code, kFirstCallId + 1);
-  EXPECT_EQ(gbs1->seq, 0);
   grpc_binder_stream* gbs2 = InitNewBinderStream();
   EXPECT_EQ(gbs2->t, GetBinderTransport());
   EXPECT_EQ(gbs2->tx_code, kFirstCallId + 2);
-  EXPECT_EQ(gbs2->seq, 0);
-}
-
-TEST_F(BinderTransportTest, SeqNumIncrement) {
-  grpc_core::ExecCtx exec_ctx;
-  grpc_binder_stream* gbs = InitNewBinderStream();
-  EXPECT_EQ(gbs->t, GetBinderTransport());
-  EXPECT_EQ(gbs->tx_code, kFirstCallId);
-  // A simple batch that contains only "send_initial_metadata"
-  grpc_transport_stream_op_batch op{};
-  grpc_transport_stream_op_batch_payload payload(nullptr);
-  op.payload = &payload;
-  MakeSendInitialMetadata send_initial_metadata(kDefaultMetadata, "", &op);
-  EXPECT_EQ(gbs->seq, 0);
-  PerformStreamOp(gbs, &op);
-  grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_EQ(gbs->tx_code, kFirstCallId);
-  EXPECT_EQ(gbs->seq, 1);
-  PerformStreamOp(gbs, &op);
-  grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_EQ(gbs->tx_code, kFirstCallId);
-  EXPECT_EQ(gbs->seq, 2);
-}
-
-TEST_F(BinderTransportTest, SeqNumNotIncrementWithoutSend) {
-  grpc_core::ExecCtx exec_ctx;
-  {
-    grpc_binder_stream* gbs = InitNewBinderStream();
-    EXPECT_EQ(gbs->t, GetBinderTransport());
-    EXPECT_EQ(gbs->tx_code, kFirstCallId);
-    // No-op batch.
-    grpc_transport_stream_op_batch op{};
-    EXPECT_EQ(gbs->seq, 0);
-    PerformStreamOp(gbs, &op);
-    grpc_core::ExecCtx::Get()->Flush();
-    EXPECT_EQ(gbs->tx_code, kFirstCallId);
-    EXPECT_EQ(gbs->seq, 0);
-  }
-  {
-    grpc_binder_stream* gbs = InitNewBinderStream();
-    EXPECT_EQ(gbs->t, GetBinderTransport());
-    EXPECT_EQ(gbs->tx_code, kFirstCallId + 1);
-    // Batch with only receiving operations.
-    grpc_transport_stream_op_batch op{};
-    grpc_transport_stream_op_batch_payload payload(nullptr);
-    op.payload = &payload;
-    MakeRecvInitialMetadata recv_initial_metadata(&op);
-    EXPECT_EQ(gbs->seq, 0);
-    PerformStreamOp(gbs, &op);
-    EXPECT_EQ(gbs->tx_code, kFirstCallId + 1);
-    EXPECT_EQ(gbs->seq, 0);
-
-    // Just to trigger the callback.
-    auto* gbt = reinterpret_cast<grpc_binder_transport*>(transport_);
-    gbt->transport_stream_receiver->NotifyRecvInitialMetadata(gbs->tx_code,
-                                                              kDefaultMetadata);
-    PerformStreamOp(gbs, &op);
-    grpc_core::ExecCtx::Get()->Flush();
-    recv_initial_metadata.notification.WaitForNotification();
-  }
 }
 
 TEST_F(BinderTransportTest, PerformSendInitialMetadata) {

--- a/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
+++ b/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
@@ -293,7 +293,7 @@ TEST_P(End2EndBinderTransportTest, BiDirStreamingCallThroughFakeBinderChannel) {
   server->Shutdown();
 }
 
-TEST_P(End2EndBinderTransportTest, LargeMessage) {
+TEST_P(End2EndBinderTransportTest, LargeMessages) {
   grpc::ChannelArguments args;
   grpc::ServerBuilder builder;
   end2end_testing::EchoServer service;
@@ -301,14 +301,17 @@ TEST_P(End2EndBinderTransportTest, LargeMessage) {
   std::unique_ptr<grpc::Server> server = builder.BuildAndStart();
   std::shared_ptr<grpc::Channel> channel = BinderChannel(server.get(), args);
   std::unique_ptr<EchoService::Stub> stub = EchoService::NewStub(channel);
-  grpc::ClientContext context;
-  EchoRequest request;
-  EchoResponse response;
-  request.set_text(std::string(1000000, 'a'));
-  grpc::Status status = stub->EchoUnaryCall(&context, request, &response);
-  EXPECT_TRUE(status.ok());
-  EXPECT_EQ(response.text(), std::string(1000000, 'a'));
-
+  for (size_t size = 1; size <= 1024 * 1024; size *= 4) {
+    grpc::ClientContext context;
+    EchoRequest request;
+    EchoResponse response;
+    request.set_text(std::string(size, 'a'));
+    grpc::Status status = stub->EchoUnaryCall(&context, request, &response);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(response.text().size(), size);
+    EXPECT_TRUE(std::all_of(response.text().begin(), response.text().end(),
+                            [](char c) { return c == 'a'; }));
+  }
   server->Shutdown();
 }
 

--- a/test/core/transport/binder/end2end/fake_binder.cc
+++ b/test/core/transport/binder/end2end/fake_binder.cc
@@ -28,6 +28,8 @@ FakeWritableParcel::FakeWritableParcel() : data_(1) {}
 
 int32_t FakeWritableParcel::GetDataPosition() const { return data_position_; }
 
+int32_t FakeWritableParcel::GetDataSize() const { return data_size_; }
+
 absl::Status FakeWritableParcel::SetDataPosition(int32_t pos) {
   if (data_.size() < static_cast<size_t>(pos) + 1) {
     data_.resize(pos + 1);
@@ -39,24 +41,28 @@ absl::Status FakeWritableParcel::SetDataPosition(int32_t pos) {
 absl::Status FakeWritableParcel::WriteInt32(int32_t data) {
   data_[data_position_] = data;
   SetDataPosition(data_position_ + 1).IgnoreError();
+  data_size_ += 4;
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteInt64(int64_t data) {
   data_[data_position_] = data;
   SetDataPosition(data_position_ + 1).IgnoreError();
+  data_size_ += 8;
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteBinder(HasRawBinder* binder) {
   data_[data_position_] = binder->GetRawBinder();
   SetDataPosition(data_position_ + 1).IgnoreError();
+  data_size_ += 8;
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteString(absl::string_view s) {
   data_[data_position_] = std::string(s);
   SetDataPosition(data_position_ + 1).IgnoreError();
+  data_size_ += s.size();
   return absl::OkStatus();
 }
 
@@ -64,8 +70,11 @@ absl::Status FakeWritableParcel::WriteByteArray(const int8_t* buffer,
                                                 int32_t length) {
   data_[data_position_] = std::vector<int8_t>(buffer, buffer + length);
   SetDataPosition(data_position_ + 1).IgnoreError();
+  data_size_ += length;
   return absl::OkStatus();
 }
+
+int32_t FakeReadableParcel::GetDataSize() const { return data_size_; }
 
 absl::Status FakeReadableParcel::ReadInt32(int32_t* data) const {
   if (data_position_ >= data_.size() ||

--- a/test/core/transport/binder/mock_objects.h
+++ b/test/core/transport/binder/mock_objects.h
@@ -88,7 +88,8 @@ class MockTransactionReceiver : public TransactionReceiver {
 class MockWireWriter : public WireWriter {
  public:
   MOCK_METHOD(absl::Status, RpcCall, (const Transaction&), (override));
-  MOCK_METHOD(absl::Status, Ack, (int64_t), (override));
+  MOCK_METHOD(absl::Status, SendAck, (int64_t), (override));
+  MOCK_METHOD(void, RecvAck, (int64_t), (override));
 };
 
 class MockTransportStreamReceiver : public TransportStreamReceiver {

--- a/test/core/transport/binder/mock_objects.h
+++ b/test/core/transport/binder/mock_objects.h
@@ -27,6 +27,7 @@ namespace grpc_binder {
 class MockWritableParcel : public WritableParcel {
  public:
   MOCK_METHOD(int32_t, GetDataPosition, (), (const, override));
+  MOCK_METHOD(int32_t, GetDataSize, (), (const, override));
   MOCK_METHOD(absl::Status, SetDataPosition, (int32_t), (override));
   MOCK_METHOD(absl::Status, WriteInt32, (int32_t), (override));
   MOCK_METHOD(absl::Status, WriteInt64, (int64_t), (override));
@@ -40,6 +41,7 @@ class MockWritableParcel : public WritableParcel {
 
 class MockReadableParcel : public ReadableParcel {
  public:
+  MOCK_METHOD(int32_t, GetDataSize, (), (const, override));
   MOCK_METHOD(absl::Status, ReadInt32, (int32_t*), (const, override));
   MOCK_METHOD(absl::Status, ReadInt64, (int64_t*), (const, override));
   MOCK_METHOD(absl::Status, ReadBinder, (std::unique_ptr<Binder>*),

--- a/test/core/transport/binder/wire_reader_test.cc
+++ b/test/core/transport/binder/wire_reader_test.cc
@@ -72,7 +72,7 @@ class WireReaderTest : public ::testing::Test {
   std::shared_ptr<StrictMock<MockTransportStreamReceiver>>
       transport_stream_receiver_;
   WireReaderImpl wire_reader_;
-  StrictMock<MockReadableParcel> mock_readable_parcel_;
+  MockReadableParcel mock_readable_parcel_;
 };
 
 MATCHER_P(StatusOrStrEq, target, "") {
@@ -273,6 +273,8 @@ TEST_F(WireReaderTest, ProcessTransactionServerRpcDataFlagSuffixWithoutStatus) {
 TEST_F(WireReaderTest, InBoundFlowControl) {
   ::testing::InSequence sequence;
 
+  // data size
+  EXPECT_CALL(mock_readable_parcel_, GetDataSize).WillOnce(Return(1000));
   // flag
   ExpectReadInt32(kFlagMessageData | kFlagMessageDataIsPartial);
   // sequence number
@@ -286,6 +288,7 @@ TEST_F(WireReaderTest, InBoundFlowControl) {
   // Data is not completed. No callback will be triggered.
   EXPECT_TRUE(CallProcessTransaction(kFirstCallId).ok());
 
+  EXPECT_CALL(mock_readable_parcel_, GetDataSize).WillOnce(Return(1000));
   // flag
   ExpectReadInt32(kFlagMessageData);
   // sequence number

--- a/test/core/transport/binder/wire_writer_test.cc
+++ b/test/core/transport/binder/wire_writer_test.cc
@@ -27,7 +27,6 @@
 namespace grpc_binder {
 
 using ::testing::Return;
-using ::testing::StrictMock;
 
 MATCHER_P(StrEqInt8Ptr, target, "") {
   return std::string(reinterpret_cast<const char*>(arg), target.size()) ==
@@ -37,7 +36,7 @@ MATCHER_P(StrEqInt8Ptr, target, "") {
 TEST(WireWriterTest, RpcCall) {
   auto mock_binder = absl::make_unique<MockBinder>();
   MockBinder& mock_binder_ref = *mock_binder;
-  StrictMock<MockWritableParcel> mock_writable_parcel;
+  MockWritableParcel mock_writable_parcel;
   ON_CALL(mock_binder_ref, GetWritableParcel)
       .WillByDefault(Return(&mock_writable_parcel));
   WireWriterImpl wire_writer(std::move(mock_binder));
@@ -176,6 +175,8 @@ TEST(WireWriterTest, RpcCall) {
                 WriteInt32(kFlagMessageData | kFlagMessageDataIsPartial));
     EXPECT_CALL(mock_writable_parcel, WriteInt32(0));
     ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_writable_parcel, GetDataSize)
+        .WillOnce(Return(WireWriterImpl::kBlockSize));
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 2)));
 
@@ -183,12 +184,15 @@ TEST(WireWriterTest, RpcCall) {
                 WriteInt32(kFlagMessageData | kFlagMessageDataIsPartial));
     EXPECT_CALL(mock_writable_parcel, WriteInt32(1));
     ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_writable_parcel, GetDataSize)
+        .WillOnce(Return(WireWriterImpl::kBlockSize));
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 2)));
 
     EXPECT_CALL(mock_writable_parcel, WriteInt32(kFlagMessageData));
     EXPECT_CALL(mock_writable_parcel, WriteInt32(2));
     ExpectWriteByteArray("a");
+    EXPECT_CALL(mock_writable_parcel, GetDataSize).WillOnce(Return(1));
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 2)));
 
@@ -206,6 +210,8 @@ TEST(WireWriterTest, RpcCall) {
     EXPECT_CALL(mock_writable_parcel, WriteString(absl::string_view("123")));
     EXPECT_CALL(mock_writable_parcel, WriteInt32(0));
     ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_writable_parcel, GetDataSize)
+        .WillOnce(Return(WireWriterImpl::kBlockSize));
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 3)));
 
@@ -213,6 +219,8 @@ TEST(WireWriterTest, RpcCall) {
                 WriteInt32(kFlagMessageData | kFlagMessageDataIsPartial));
     EXPECT_CALL(mock_writable_parcel, WriteInt32(1));
     ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_writable_parcel, GetDataSize)
+        .WillOnce(Return(WireWriterImpl::kBlockSize));
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 3)));
 
@@ -220,6 +228,7 @@ TEST(WireWriterTest, RpcCall) {
                 WriteInt32(kFlagMessageData | kFlagSuffix));
     EXPECT_CALL(mock_writable_parcel, WriteInt32(2));
     ExpectWriteByteArray("a");
+    EXPECT_CALL(mock_writable_parcel, GetDataSize).WillOnce(Return(1));
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 3)));
 

--- a/test/core/transport/binder/wire_writer_test.cc
+++ b/test/core/transport/binder/wire_writer_test.cc
@@ -30,7 +30,8 @@ using ::testing::Return;
 using ::testing::StrictMock;
 
 MATCHER_P(StrEqInt8Ptr, target, "") {
-  return std::string(reinterpret_cast<const char*>(arg)) == target;
+  return std::string(reinterpret_cast<const char*>(arg), target.size()) ==
+         target;
 }
 
 TEST(WireWriterTest, RpcCall) {
@@ -53,7 +54,6 @@ TEST(WireWriterTest, RpcCall) {
 
   ::testing::InSequence sequence;
   int sequence_number = 0;
-  int tx_code = kFirstCallId;
 
   {
     // flag
@@ -61,18 +61,18 @@ TEST(WireWriterTest, RpcCall) {
     // sequence number
     EXPECT_CALL(mock_writable_parcel, WriteInt32(sequence_number));
 
-    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(tx_code)));
+    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(kFirstCallId)));
 
-    Transaction tx(tx_code, sequence_number, /*is_client=*/true);
+    Transaction tx(kFirstCallId, /*is_client=*/true);
     EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
     sequence_number++;
-    tx_code++;
   }
   {
     // flag
     EXPECT_CALL(mock_writable_parcel, WriteInt32(kFlagPrefix));
-    // sequence number
-    EXPECT_CALL(mock_writable_parcel, WriteInt32(sequence_number));
+    // sequence number. This is another stream so the sequence number starts
+    // with 0.
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(0));
 
     EXPECT_CALL(mock_writable_parcel,
                 WriteString(absl::string_view("/example/method/ref")));
@@ -96,12 +96,10 @@ TEST(WireWriterTest, RpcCall) {
     EXPECT_CALL(mock_binder_ref,
                 Transact(BinderTransportTxCode(kFirstCallId + 1)));
 
-    Transaction tx(kFirstCallId + 1, 1, /*is_client=*/true);
+    Transaction tx(kFirstCallId + 1, /*is_client=*/true);
     tx.SetPrefix(kMetadata);
     tx.SetMethodRef("/example/method/ref");
     EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
-    sequence_number++;
-    tx_code++;
   }
   {
     // flag
@@ -110,11 +108,12 @@ TEST(WireWriterTest, RpcCall) {
     EXPECT_CALL(mock_writable_parcel, WriteInt32(sequence_number));
 
     ExpectWriteByteArray("data");
-    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(tx_code)));
+    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(kFirstCallId)));
 
-    Transaction tx(tx_code, sequence_number, /*is_client=*/true);
+    Transaction tx(kFirstCallId, /*is_client=*/true);
     tx.SetData("data");
     EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
+    sequence_number++;
   }
   {
     // flag
@@ -122,13 +121,12 @@ TEST(WireWriterTest, RpcCall) {
     // sequence number
     EXPECT_CALL(mock_writable_parcel, WriteInt32(sequence_number));
 
-    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(tx_code)));
+    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(kFirstCallId)));
 
-    Transaction tx(tx_code, sequence_number, /*is_client=*/true);
+    Transaction tx(kFirstCallId, /*is_client=*/true);
     tx.SetSuffix({});
     EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
     sequence_number++;
-    tx_code++;
   }
   {
     // flag
@@ -159,9 +157,9 @@ TEST(WireWriterTest, RpcCall) {
     // Empty message data
     ExpectWriteByteArray("");
 
-    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(tx_code)));
+    EXPECT_CALL(mock_binder_ref, Transact(BinderTransportTxCode(kFirstCallId)));
 
-    Transaction tx(tx_code, sequence_number, /*is_client=*/true);
+    Transaction tx(kFirstCallId, /*is_client=*/true);
     // TODO(waynetu): Implement a helper function that automatically creates
     // EXPECT_CALL based on the tx object.
     tx.SetPrefix(kMetadata);
@@ -170,7 +168,68 @@ TEST(WireWriterTest, RpcCall) {
     tx.SetSuffix({});
     EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
     sequence_number++;
-    tx_code++;
+  }
+
+  // Really large message
+  {
+    EXPECT_CALL(mock_writable_parcel,
+                WriteInt32(kFlagMessageData | kFlagMessageDataIsPartial));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(0));
+    ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_binder_ref,
+                Transact(BinderTransportTxCode(kFirstCallId + 2)));
+
+    EXPECT_CALL(mock_writable_parcel,
+                WriteInt32(kFlagMessageData | kFlagMessageDataIsPartial));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(1));
+    ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_binder_ref,
+                Transact(BinderTransportTxCode(kFirstCallId + 2)));
+
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(kFlagMessageData));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(2));
+    ExpectWriteByteArray("a");
+    EXPECT_CALL(mock_binder_ref,
+                Transact(BinderTransportTxCode(kFirstCallId + 2)));
+
+    // Use a new stream.
+    Transaction tx(kFirstCallId + 2, /*is_client=*/true);
+    tx.SetData(std::string(2 * WireWriterImpl::kBlockSize + 1, 'a'));
+    EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
+  }
+  // Really large message with metadata
+  {
+    EXPECT_CALL(
+        mock_writable_parcel,
+        WriteInt32(kFlagPrefix | kFlagMessageData | kFlagMessageDataIsPartial));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(0));
+    EXPECT_CALL(mock_writable_parcel, WriteString(absl::string_view("123")));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(0));
+    ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_binder_ref,
+                Transact(BinderTransportTxCode(kFirstCallId + 3)));
+
+    EXPECT_CALL(mock_writable_parcel,
+                WriteInt32(kFlagMessageData | kFlagMessageDataIsPartial));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(1));
+    ExpectWriteByteArray(std::string(WireWriterImpl::kBlockSize, 'a'));
+    EXPECT_CALL(mock_binder_ref,
+                Transact(BinderTransportTxCode(kFirstCallId + 3)));
+
+    EXPECT_CALL(mock_writable_parcel,
+                WriteInt32(kFlagMessageData | kFlagSuffix));
+    EXPECT_CALL(mock_writable_parcel, WriteInt32(2));
+    ExpectWriteByteArray("a");
+    EXPECT_CALL(mock_binder_ref,
+                Transact(BinderTransportTxCode(kFirstCallId + 3)));
+
+    // Use a new stream.
+    Transaction tx(kFirstCallId + 3, /*is_client=*/true);
+    tx.SetPrefix({});
+    tx.SetMethodRef("123");
+    tx.SetData(std::string(2 * WireWriterImpl::kBlockSize + 1, 'a'));
+    tx.SetSuffix({});
+    EXPECT_TRUE(wire_writer.RpcCall(tx).ok());
   }
 }
 

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -250,6 +250,28 @@ grpc_cc_test(
     deps = [":fullstack_unary_ping_pong_h"],
 )
 
+grpc_cc_library(
+    name = "bm_callback_ping_pong_binder",
+    testonly = 1,
+    srcs = [
+        "bm_callback_ping_pong_binder.cc",
+    ],
+    hdrs = [
+        "bm_callback_ping_pong_binder.h",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":callback_streaming_ping_pong_h",
+        ":callback_unary_ping_pong_h",
+        ":helpers",
+        "//:gpr_platform",
+        "//src/core/ext/transport/binder/client:grpc_transport_binder_client",
+        "//src/core/ext/transport/binder/server:grpc_transport_binder_server",
+    ],
+)
+
 grpc_cc_test(
     name = "bm_metadata",
     srcs = ["bm_metadata.cc"],

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/AndroidManifest.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.grpc.binder.cpp.benchmarks.client"
+    android:versionCode="1"
+    android:versionName="1.0" >
+
+  <uses-sdk
+      android:minSdkVersion="29"
+      android:targetSdkVersion="30" />
+
+   <queries>
+      <package android:name="io.grpc.binder.cpp.benchmarks.server" />
+   </queries>
+
+  <application
+      android:label="gRPC BinderTransport Benchmark Client">
+    <activity
+        android:name=".MainActivity"
+        android:label="gRPC BinderTransport Benchmark Client" >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/BUILD
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/BUILD
@@ -1,0 +1,58 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary", "android_library")
+
+cc_library(
+    name = "jni_lib",
+    testonly = 1,
+    srcs = ["native.cc"],
+    linkopts = [
+        "-ldl",
+        "-llog",
+        "-lm",
+        "-lbinder_ndk",
+        "-Wl,--no-undefined",
+    ],
+    deps = [
+        # Temporarily directly depend on this target before we expose a public API
+        "//src/core/ext/transport/binder/client:grpc_transport_binder_client",
+        "//test/cpp/microbenchmarks:bm_callback_ping_pong_binder",
+    ],
+    alwayslink = True,
+)
+
+android_library(
+    name = "activity",
+    testonly = 1,
+    srcs = [
+        "ButtonPressHandler.java",
+        "MainActivity.java",
+    ],
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**"]),
+    deps = [
+        ":jni_lib",
+        "@binder_transport_android_helper//io/grpc/binder/cpp:connection_helper",
+    ],
+)
+
+android_binary(
+    name = "app",
+    testonly = 1,
+    manifest = "AndroidManifest.xml",
+    deps = [
+        ":activity",
+    ],
+)

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/ButtonPressHandler.java
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/ButtonPressHandler.java
@@ -1,0 +1,15 @@
+package io.grpc.binder.cpp.benchmarks.client;
+
+import android.app.Application;
+
+public class ButtonPressHandler {
+  static {
+    System.loadLibrary("app");
+  }
+
+  public native String native_entry(Application application);
+
+  public String onPressed(Application application) {
+    return native_entry(application);
+  }
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/MainActivity.java
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/MainActivity.java
@@ -1,0 +1,26 @@
+package io.grpc.binder.cpp.benchmarks.client;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+
+/** Main class for the example app. */
+public class MainActivity extends Activity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Log.v("Example", "hello, world");
+
+    setContentView(R.layout.activity_main);
+
+    Button clickMeButton = findViewById(R.id.clickMeButton);
+    TextView exampleTextView = findViewById(R.id.exampleTextView);
+
+    ButtonPressHandler h = new ButtonPressHandler();
+
+    clickMeButton.setOnClickListener(
+        v -> exampleTextView.setText(h.onPressed(getApplication())));
+  }
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/native.cc
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/native.cc
@@ -1,0 +1,34 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+#include "src/core/ext/transport/binder/client/channel_create.h"
+#include "test/cpp/microbenchmarks/bm_callback_ping_pong_binder.h"
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_io_grpc_binder_cpp_benchmarks_client_ButtonPressHandler_native_1entry(
+    JNIEnv* env, jobject /*this*/, jobject application) {
+  static bool first = true;
+  if (first) {
+    first = false;
+    grpc::experimental::BindToOnDeviceServerService(
+        env, application, "io.grpc.binder.cpp.benchmarks.server",
+        "io.grpc.binder.cpp.benchmarks.server.ExportedEndpointService");
+    return env->NewStringUTF("Clicked 1 time");
+  } else {
+    grpc::testing::RunCallbackPingPongBinderBenchmarks(env, application);
+    return env->NewStringUTF("Clicked more than 1 time. Status not ok");
+  }
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/res/layout/activity_main.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/res/layout/activity_main.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:padding="16dp"
+    android:orientation="vertical"
+    android:gravity="center_vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <TextView
+      android:id="@+id/exampleTextView"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:textSize="32dp"
+      android:text="@string/thinking_face"/>
+
+  <Button
+      android:id="@+id/clickMeButton"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:layout_marginTop="16dp"
+      android:text="@string/click_me_button"/>
+</LinearLayout>

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/res/values/strings.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/client/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="click_me_button">Run benchmark</string>
+  <string name="thinking_face">🤔</string>
+</resources>

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/AndroidManifest.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.grpc.binder.cpp.benchmarks.server"
+    android:versionCode="1"
+    android:versionName="1.0" >
+
+  <uses-sdk
+      android:minSdkVersion="29"
+      android:targetSdkVersion="30" />
+
+  <application
+      android:label="gRPC BinderTransport Benchmark Server">
+    <activity
+        android:name=".MainActivity"
+        android:label="gRPC BinderTransport Benchmark Server" >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/AndroidManifest_endpoint.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/AndroidManifest_endpoint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="io.grpc.binder.cpp.benchmarks.server">
+  <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="30"/>
+  <application>
+    <service
+        android:name=".ExportedEndpointService"
+        android:exported="true"/>
+  </application>
+</manifest>

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/BUILD
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/BUILD
@@ -1,0 +1,69 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary", "android_library")
+
+cc_library(
+    name = "jni_lib",
+    testonly = 1,
+    srcs = ["native.cc"],
+    linkopts = [
+        "-ldl",
+        "-llog",
+        "-lm",
+        "-lbinder_ndk",
+        "-Wl,--no-undefined",
+    ],
+    deps = [
+        # Temporarily directly depend on this target before we expose a public API
+        "//:grpc++",
+        "//examples/protos:helloworld_cc_grpc",
+        "//src/core/ext/transport/binder/server:grpc_transport_binder_server",
+        "//test/cpp/microbenchmarks:bm_callback_ping_pong_binder",
+    ],
+    alwayslink = True,
+)
+
+android_library(
+    name = "activity",
+    testonly = 1,
+    srcs = [
+        "ButtonPressHandler.java",
+        "MainActivity.java",
+    ],
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**"]),
+    deps = [
+        ":endpoint",
+        ":jni_lib",
+    ],
+)
+
+android_library(
+    name = "endpoint",
+    testonly = 1,
+    srcs = ["ExportedEndpointService.java"],
+    exports_manifest = True,
+    manifest = "AndroidManifest_endpoint.xml",
+    deps = [],
+)
+
+android_binary(
+    name = "app",
+    testonly = 1,
+    manifest = "AndroidManifest.xml",
+    deps = [
+        ":activity",
+    ],
+)

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/ButtonPressHandler.java
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/ButtonPressHandler.java
@@ -1,0 +1,13 @@
+package io.grpc.binder.cpp.benchmarks.server;
+
+import android.app.Application;
+
+public class ButtonPressHandler {
+  static {
+    System.loadLibrary("app");
+  }
+
+  public String onPressed(Application application) {
+    return "Server Button Pressed";
+  }
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/ExportedEndpointService.java
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/ExportedEndpointService.java
@@ -1,0 +1,28 @@
+package io.grpc.binder.cpp.benchmarks.server;
+
+import android.app.Service;
+import android.os.IBinder;
+import android.content.Intent;
+
+/** Exposes gRPC services running in the main process */
+public final class ExportedEndpointService extends Service {
+  private final IBinder binder;
+
+  static {
+    System.loadLibrary("app");
+  }
+
+  public ExportedEndpointService() {
+    init_grpc_server();
+    binder = get_endpoint_binder();
+  }
+
+  @Override
+  public IBinder onBind(Intent intent) {
+    return binder;
+  }
+
+  public native void init_grpc_server();
+
+  public native IBinder get_endpoint_binder();
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/MainActivity.java
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/MainActivity.java
@@ -1,0 +1,27 @@
+package io.grpc.binder.cpp.benchmarks.server;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.TextView;
+import io.grpc.binder.cpp.benchmarks.server.R;
+
+/** Main class for the example app. */
+public class MainActivity extends Activity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Log.v("Example", "hello, world");
+
+    setContentView(R.layout.activity_main);
+
+    Button clickMeButton = findViewById(R.id.clickMeButton);
+    TextView exampleTextView = findViewById(R.id.exampleTextView);
+
+    ButtonPressHandler h = new ButtonPressHandler();
+
+    clickMeButton.setOnClickListener(
+        v -> exampleTextView.setText(h.onPressed(getApplication())));
+  }
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/native.cc
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/native.cc
@@ -1,0 +1,45 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <android/binder_auto_utils.h>
+#include <android/binder_ibinder.h>
+#include <android/binder_ibinder_jni.h>
+#include <android/binder_interface_utils.h>
+#include <jni.h>
+
+#include <grpcpp/grpcpp.h>
+
+#include "src/core/ext/transport/binder/server/binder_server.h"
+#include "test/cpp/microbenchmarks/bm_callback_ping_pong_binder.h"
+
+grpc::testing::CallbackPingPongBinderServer* server = nullptr;
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_grpc_binder_cpp_benchmarks_server_ExportedEndpointService_init_1grpc_1server(
+    JNIEnv* env, jobject /*this*/) {
+  if (server != nullptr) {
+    return;
+  }
+  server = new grpc::testing::CallbackPingPongBinderServer(
+      "binder://callback.ping.pong.benchmark");
+}
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_io_grpc_binder_cpp_benchmarks_server_ExportedEndpointService_get_1endpoint_1binder(
+    JNIEnv* env, jobject /*this*/) {
+  AIBinder* ai_binder =
+      static_cast<AIBinder*>(grpc::experimental::binder::GetEndpointBinder(
+          "callback.ping.pong.benchmark"));
+  return AIBinder_toJavaBinder(env, ai_binder);
+}

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/res/layout/activity_main.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/res/layout/activity_main.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:padding="16dp"
+    android:orientation="vertical"
+    android:gravity="center_vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <TextView
+      android:id="@+id/exampleTextView"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:textSize="32dp"
+      android:text="@string/thinking_face"/>
+
+  <Button
+      android:id="@+id/clickMeButton"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:layout_marginTop="16dp"
+      android:text="@string/click_me_button"/>
+</LinearLayout>

--- a/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/res/values/strings.xml
+++ b/test/cpp/microbenchmarks/bm_binder/java/io/grpc/binder/cpp/benchmarks/server/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="click_me_button">Run example</string>
+  <string name="thinking_face">🤔</string>
+</resources>

--- a/test/cpp/microbenchmarks/bm_callback_ping_pong_binder.cc
+++ b/test/cpp/microbenchmarks/bm_callback_ping_pong_binder.cc
@@ -1,0 +1,94 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/cpp/microbenchmarks/bm_callback_ping_pong_binder.h"
+
+#ifdef GPR_ANDROID
+
+#include <android/log.h>
+
+namespace grpc {
+namespace testing {
+
+static void SweepSizesArgs(benchmark::internal::Benchmark* b) {
+  b->Args({0, 0});
+  for (int i = 1; i <= 128 * 1024 * 1024; i *= 8) {
+    b->Args({i, 0});
+    b->Args({0, i});
+    b->Args({i, i});
+  }
+}
+
+static void StreamingPingPongMsgSizeArgs(benchmark::internal::Benchmark* b) {
+  // base case: 0 byte ping-pong msgs
+  b->Args({0, 1});
+  b->Args({0, 2});
+
+  for (int msg_size = 1; msg_size <= 128 * 1024 * 1024; msg_size *= 8) {
+    b->Args({msg_size, 1});
+    b->Args({msg_size, 2});
+  }
+}
+
+static void StreamingPingPongMsgsNumberArgs(benchmark::internal::Benchmark* b) {
+  for (int msg_number = 1; msg_number <= 256 * 1024; msg_number *= 8) {
+    b->Args({0, msg_number});
+    b->Args({1024, msg_number});
+  }
+}
+
+namespace {
+
+class AndroidReporter : public benchmark::BenchmarkReporter {
+ public:
+  bool ReportContext(const Context& /*context*/) override { return true; }
+  void ReportRuns(const std::vector<Run>& report) override {
+    for (Run run : report) {
+      const std::string time_label =
+          benchmark::GetTimeUnitString(run.time_unit);
+      __android_log_print(
+          ANDROID_LOG_INFO, "Benchmark",
+          "name = %-30s\treal-time = %10.0f %-4s\tcpu-time = %10.0f "
+          "%-4s\titerations = %10lld",
+          run.benchmark_name().c_str(), run.GetAdjustedRealTime(),
+          time_label.c_str(), run.GetAdjustedCPUTime(), time_label.c_str(),
+          run.iterations);
+    }
+  }
+};
+
+}  // namespace
+
+void RunCallbackPingPongBinderBenchmarks(JNIEnv* env, jobject application) {
+  benchmark::RegisterBenchmark("binder-unary", BM_CallbackUnaryPingPongBinder,
+                               env, application)
+      ->Apply(SweepSizesArgs);
+  benchmark::RegisterBenchmark("binder-streaming",
+                               BM_CallbackBidiStreamingBinder, env, application)
+      ->Apply(StreamingPingPongMsgSizeArgs);
+  benchmark::RegisterBenchmark("binder-streaming",
+                               BM_CallbackBidiStreamingBinder, env, application)
+      ->Apply(StreamingPingPongMsgsNumberArgs);
+  int argc = 1;
+  char* argv[] = {const_cast<char*>("benchmark")};
+  std::unique_ptr<benchmark::BenchmarkReporter> reporter =
+      absl::make_unique<AndroidReporter>();
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks(reporter.get());
+}
+
+}  // namespace testing
+}  // namespace grpc
+
+#endif  // GPR_ANDROID

--- a/test/cpp/microbenchmarks/bm_callback_ping_pong_binder.h
+++ b/test/cpp/microbenchmarks/bm_callback_ping_pong_binder.h
@@ -1,0 +1,139 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_TEST_CPP_MICROBENCHMARKS_BM_CALLBACK_PING_PONG_BINDER_H
+#define GRPC_TEST_CPP_MICROBENCHMARKS_BM_CALLBACK_PING_PONG_BINDER_H
+
+#include <grpc/impl/codegen/port_platform.h>
+
+#ifdef GPR_ANDROID
+
+#include <sstream>
+
+#include <benchmark/benchmark.h>
+
+#include "absl/time/time.h"
+
+#include "src/core/ext/transport/binder/client/channel_create.h"
+#include "src/core/ext/transport/binder/server/binder_server_credentials.h"
+#include "src/proto/grpc/testing/echo.grpc.pb.h"
+#include "test/cpp/microbenchmarks/callback_streaming_ping_pong.h"
+#include "test/cpp/microbenchmarks/callback_unary_ping_pong.h"
+
+namespace grpc {
+namespace testing {
+
+class BinderFixture {
+ public:
+  explicit BinderFixture(
+      JNIEnv* env, jobject application,
+      const FixtureConfiguration& config = FixtureConfiguration()) {
+    ChannelArguments args;
+    config.ApplyCommonChannelArguments(&args);
+    channel_ = ::grpc::experimental::CreateCustomBinderChannel(env, application,
+                                                               "", "", args);
+  }
+
+  std::shared_ptr<Channel> channel() { return channel_; }
+
+ private:
+  std::shared_ptr<Channel> channel_;
+};
+
+class CallbackPingPongBinderServer {
+ public:
+  explicit CallbackPingPongBinderServer(
+      const std::string& binder_address,
+      const FixtureConfiguration& config = FixtureConfiguration()) {
+    ServerBuilder b;
+    if (!binder_address.empty()) {
+      b.AddListeningPort(binder_address,
+                         experimental::BinderServerCredentials());
+    }
+    cq_ = b.AddCompletionQueue(true);
+    b.RegisterService(&service_);
+    config.ApplyCommonServerBuilderConfig(&b);
+    server_ = b.BuildAndStart();
+  }
+
+ private:
+  std::unique_ptr<ServerCompletionQueue> cq_;
+  std::unique_ptr<Server> server_;
+  CallbackStreamingTestService service_;
+};
+
+static void BM_CallbackUnaryPingPongBinder(benchmark::State& state, JNIEnv* env,
+                                           jobject application) {
+  std::unique_ptr<BinderFixture> fixture(new BinderFixture(env, application));
+  std::unique_ptr<EchoTestService::Stub> stub(
+      EchoTestService::NewStub(fixture->channel()));
+  EchoRequest request;
+  EchoResponse response;
+  ClientContext cli_ctx;
+
+  if (state.range(0) > 0) {
+    request.set_message(std::string(state.range(0), 'a'));
+  } else {
+    request.set_message("");
+  }
+
+  std::mutex mu;
+  std::condition_variable cv;
+  bool done = false;
+  if (state.KeepRunning()) {
+    SendCallbackUnaryPingPong(&state, &cli_ctx, &request, &response, stub.get(),
+                              &done, &mu, &cv);
+  }
+  std::unique_lock<std::mutex> l(mu);
+  while (!done) {
+    cv.wait(l);
+  }
+  gpr_log(GPR_ERROR, "Done");
+  fixture.reset();
+  state.SetBytesProcessed(state.range(0) * state.iterations() +
+                          state.range(1) * state.iterations());
+}
+
+static void BM_CallbackBidiStreamingBinder(benchmark::State& state, JNIEnv* env,
+                                           jobject application) {
+  int message_size = state.range(0);
+  int max_ping_pongs = state.range(1);
+  CallbackStreamingTestService service;
+  std::unique_ptr<BinderFixture> fixture(new BinderFixture(env, application));
+  std::unique_ptr<EchoTestService::Stub> stub_(
+      EchoTestService::NewStub(fixture->channel()));
+  EchoRequest request;
+  EchoResponse response;
+  ClientContext cli_ctx;
+  if (message_size > 0) {
+    request.set_message(std::string(message_size, 'a'));
+  } else {
+    request.set_message("");
+  }
+  if (state.KeepRunning()) {
+    BidiClient test{&state, stub_.get(), &cli_ctx, &request, &response};
+    test.Await();
+  }
+  fixture.reset();
+  state.SetBytesProcessed(2 * message_size * max_ping_pongs *
+                          state.iterations());
+}
+
+void RunCallbackPingPongBinderBenchmarks(JNIEnv* env, jobject application);
+
+}  // namespace testing
+}  // namespace grpc
+
+#endif  // GPR_ANDROID
+#endif  // GRPC_TEST_CPP_MICROBENCHMARKS_BM_CALLBACK_PING_PONG_H

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -27,8 +27,8 @@ cd /var/local/git/grpc
 
 # Build all basic targets using the strict warning option which leverages the
 # clang compiler to check if sources can pass a set of warning options.
-# For now //examples/android/binder/ are excluded because it needs Android
-# SDK/NDK to be installed to build
+# For now //examples/android/binder/ and //test/cpp/microbenchmarks/bm_binder
+# are excluded because they need Android SDK/NDK to be installed to build.
 bazel build --define=use_strict_warning=true \
 	-- \
 	:all \
@@ -36,7 +36,8 @@ bazel build --define=use_strict_warning=true \
 	//src/compiler/... \
 	//test/... \
 	//examples/... \
-	-//examples/android/binder/...
+	-//examples/android/binder/... \
+	-//test/cpp/microbenchmarks/bm_binder/...
 
 # TODO(jtattersmusch): Adding a build here for --define=grpc_no_xds is not ideal
 # and we should find a better place for this. Refer


### PR DESCRIPTION
Benchmark output can be retrieved with `adb logcat '*:S Benchmark:I'`

Depends on https://github.com/grpc/grpc/pull/27257.