### PR TITLE
Remove the TaskHandle return type from EventEngine::Run

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -286,9 +286,10 @@ class EventEngine {
   /// Run a callback as soon as possible.
   ///
   /// The \a fn callback's \a status argument is used to indicate whether it was
-  /// executed normally. For example, the status may be CANCELLED if
-  /// \a TryCancel was called, or if the EventEngine is being shut down.
-  virtual TaskHandle Run(Callback fn, RunOptions opts) = 0;
+  /// executed normally. For example, the status may be CANCELLED if the
+  /// EventEngine is being shut down. \a fn is guaranteed to be called exactly
+  /// once.
+  virtual void Run(Callback fn, RunOptions opts) = 0;
   /// Synonymous with scheduling an alarm to run at time \a when.
   ///
   /// The callback \a fn will execute when either when time \a when arrives

--- a/src/core/lib/iomgr/event_engine/iomgr.cc
+++ b/src/core/lib/iomgr/event_engine/iomgr.cc
@@ -41,7 +41,6 @@ namespace {
 
 using ::grpc_event_engine::experimental::DefaultEventEngineFactory;
 using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::Promise;
 
 EventEngine* g_event_engine = nullptr;
 


### PR DESCRIPTION
It isn't used in gRPC currently, and would be difficult to implement
efficiently in some scenarios.

The API changes to remove `RunOptions` is out for review here: https://github.com/grpc/grpc/pull/27220