### PR TITLE
xds-k8s: fix typo to remove _java from the script name

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_xlang.cfg
+++ b/tools/internal_ci/linux/grpc_xds_k8s_xlang.cfg
@@ -15,7 +15,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s_xlang_java.sh"
+build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh"
 timeout_mins: 120
 action {
   define_artifacts {


### PR DESCRIPTION
the cfg file referenced the wrong .sh file. Removed _java from the .sh file name
