### PR TITLE
Include "linux_extra" python artifacts in regular linux build

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -107,6 +107,11 @@ class PythonArtifact:
         self.py_version = py_version
         if 'manylinux' in platform:
             self.labels.append('linux')
+        if 'linux_extra' in platform:
+            # linux_extra wheels used to be built by a separate kokoro job.
+            # Their build is now much faster, so they can be included
+            # in the regular artifact build.
+            self.labels.append('linux')
 
     def pre_build_jobspecs(self):
         return []


### PR DESCRIPTION
The "linux_extra" artifacts used to be build in a fully emulated environment (which made for a terribly slow build), but now they are being crosscompiled, so their build time is comparable to other python wheels.

If we add linux_extra artifacts back to the "linux" artifacts, it will simplify the release process (avoiding the need to run a separate "linux_extra" kokoro job).

(We still need to check if adding more python artifacts will fit into the build_artifact job timeout, since we're already building a large number of linux wheels there).