### PR TITLE
PHP: fix ChannelCredentials\createSsl parameter phpdocs

### DIFF
--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -139,10 +139,10 @@ PHP_METHOD(ChannelCredentials, createDefault) {
 
 /**
  * Create SSL credentials.
- * @param string $pem_root_certs = "" PEM encoding of the server root certificates (optional)
- * @param string $private_key = "" PEM encoding of the client's
+ * @param string|null $pem_root_certs = null PEM encoding of the server root certificates (optional)
+ * @param string|null $private_key = null PEM encoding of the client's
  *                                              private key (optional)
- * @param string $cert_chain = "" PEM encoding of the client's
+ * @param string|null $cert_chain = null PEM encoding of the client's
  *                                             certificate chain (optional)
  * @return ChannelCredentials The new SSL credentials object
  */


### PR DESCRIPTION
> PHP: fix ChannelCredentials\createSsl parameter phpdocs to optional and default null

```c
  /* "|s!s!s!" == 3 optional nullable strings */
  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!",
```

`|s!s!s!` In zend_parse_parameters used in the method indicates that "all are optional and nullable", and the source code seems to work that way 🐔


[JetBrains/phpstorm-stubs](https://github.com/JetBrains/phpstorm-stubs/) is converting the current PhpDoc like this
```php
        /**
         * Create SSL credentials.
         *
         * @param string $pem_root_certs  PEM encoding of the server root certificates
         * @param string $pem_private_key PEM encoding of the client's private key
         * @param string $pem_cert_chain  PEM encoding of the client's certificate chain
         *
         * @return ChannelCredentials The new SSL credentials object
         * @throws \InvalidArgumentException
         */
        public static function createSsl(
            $pem_root_certs = '',
            $pem_private_key = '',
            $pem_cert_chain = ''
        ) {}
```

However, `ChannelCredentials::createSsl()` is not equal to `ChannelCredentials::createSsl('', '', '')` and is actually `ChannelCredentials::createSsl(null, null, null)`. 🤔