### PR TITLE
Teach the check-DNS script to ignore temporary files

### DIFF
--- a/tools/run_tests/sanity/check_do_not_submit.sh
+++ b/tools/run_tests/sanity/check_do_not_submit.sh
@@ -16,9 +16,8 @@
 # Checks if any file contains "DO NOT SUBMIT"
 
 cd "$(dirname "$0")/../../.." || exit 1
-grep -Irn \
-  --exclude='check_do_not_submit.sh' \
-  --exclude-dir='.git/' \
-  --exclude-dir='third_party/' \
-  'DO NOT SUBMIT'
+git grep -Irn 'DO NOT SUBMIT' -- \
+  './*' \
+  ':!*check_do_not_submit.sh' \
+  ':!third_party/'
 test $? -eq 1 || exit 1


### PR DESCRIPTION
A plain `grep` was occasionally attempting to grep temporary files that
were being created and deleted concurrently by other sanity check
scripts, leading to TOCTOU problems. This now only searches indexed
files (thanks for the suggestion, @ctiller!).

We still need to exclude `third_party` since upb is not a submodule.
`git grep` will ignore all submodules by default, so the other
third_party subfolders were already excluded.