### PR TITLE
[objc] Unify all interop test timeout to 64s

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -37,8 +37,7 @@
 
 #import "InteropTestsBlockCallbacks.h"
 
-#define TEST_TIMEOUT 32
-#define STREAMING_CALL_TEST_TIMEOUT 64
+#define TEST_TIMEOUT 64
 
 #define SMALL_PAYLOAD_SIZE 10
 #define LARGE_REQUEST_PAYLOAD_SIZE 271828
@@ -756,7 +755,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
     [call start];
   }
 
-  [self waitForExpectations:completeExpectations timeout:STREAMING_CALL_TEST_TIMEOUT];
+  [self waitForExpectations:completeExpectations timeout:TEST_TIMEOUT];
 }
 
 - (void)concurrentRPCsWithErrors {
@@ -942,7 +941,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
                                            [expectation fulfill];
                                          }];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 - (void)testServerStreamingRPC {
@@ -981,7 +980,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
                           }
                         }];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 - (void)testPingPongRPC {
@@ -1028,7 +1027,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
                                     [expectation fulfill];
                                   }
                                 }];
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 - (void)testPingPongRPCWithV2API {
@@ -1082,7 +1081,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [call start];
   [call writeMessage:request];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 - (void)testPingPongRPCWithFlowControl {
@@ -1143,7 +1142,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [call receiveNextMessage];
   [call writeMessage:request];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
   XCTAssertEqual(writeMessageCount, 4);
 }
 
@@ -1344,7 +1343,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
                                       }];
                    }];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 - (void)testCompressedUnaryRPC {
@@ -1474,7 +1473,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [call start];
   [call writeMessage:request];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 - (void)testLoggingInterceptor {
@@ -1715,7 +1714,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [call receiveNextMessage];
   [call writeMessage:request];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
   XCTAssertEqual(startCount, 1);
   XCTAssertEqual(writeDataCount, 4);
   XCTAssertEqual(finishCount, 1);
@@ -1826,7 +1825,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [call receiveNextMessage];
   [call writeMessage:request];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
   XCTAssertEqual(startCount, 1);
   XCTAssertEqual(writeDataCount, 4);
   XCTAssertEqual(finishCount, 1);
@@ -2007,7 +2006,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [call receiveNextMessage];
   [call writeMessage:request];
 
-  [self waitForExpectationsWithTimeout:STREAMING_CALL_TEST_TIMEOUT handler:nil];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
   XCTAssertEqual(startCount, 1);
   XCTAssertEqual(writeDataCount, 4);
   XCTAssertEqual(finishCount, 1);


### PR DESCRIPTION
Currently the only observed timeout report fails under 32s. Update all timeout limit to 64s. Will look at alternative solutions for dealing with large unary call timeout if 64s still not covering most scenarios. 