### PR TITLE
Report Python xDS Interop Client SIGINTs

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -123,6 +123,7 @@ _global_rpc_statuses: Mapping[str, Mapping[int, int]] = collections.defaultdict(
 
 
 def _handle_sigint(sig, frame) -> None:
+    logger.warning("Received SIGINT")
     _stop_event.set()
     _global_server.stop(None)
 

--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -64,6 +64,7 @@ bazel build //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client
 
 # Test cases "path_matching" and "header_matching" are not included in "all",
 # because not all interop clients in all languages support these new tests.
+export PYTHONUNBUFFERED=true
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
   tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
@@ -75,4 +76,4 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,c
     --gcp_suffix=$(date '+%s') \
     --verbose \
     ${XDS_V3_OPT-} \
-    --client_cmd='bazel run --test_env="PYTHONUNBUFFERED=true" //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client -- --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps} {rpcs_to_send} {metadata_to_send}'
+    --client_cmd='bazel run //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client -- --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps} {rpcs_to_send} {metadata_to_send}'


### PR DESCRIPTION
Previously, `--test_env` was being used, but `--test_env` only works with `bazel run`, not `bazel test`.

This is speculative. I will backport to other branches if we find instances of this happening on master.