### PR TITLE
HTTP2: Set per-stream flow control window delta limit to 1MB

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -50,7 +50,7 @@ static constexpr uint32_t kFrameSize = 1024 * 1024;
 static constexpr const uint32_t kMinInitialWindowSize = 128;
 static constexpr const uint32_t kMaxInitialWindowSize = (1u << 30);
 // The maximum per-stream flow control window delta to advertise.
-static constexpr const uint32_t kMaxWindowDelta = (1u << 10);
+static constexpr const uint32_t kMaxWindowDelta = (1u << 20);
 
 class TransportFlowControl;
 class StreamFlowControl;


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/26342 incorrectly set the window delta limit to 1KB instead of 1MB