### PR TITLE
[objc] Fix firestone linux cocoapod grpc install issue

### DIFF
--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -153,14 +153,15 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-END_OF_COMMAND
     # Add a module map and an umbrella header
+    mkdir -p src/include/openssl
     cat > src/include/openssl/umbrella.h <<EOF
       #include "ssl.h"
       #include "crypto.h"
       #include "aes.h"
-      /* The following macros are defined by base.h. The latter is the first file included by the    
-         other headers. */    
-      #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)    
-      #  include "arm_arch.h"   
+      /* The following macros are defined by base.h. The latter is the first file included by the
+         other headers. */
+      #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+      #  include "arm_arch.h"
       #endif
       #include "asn1.h"
       #include "asn1_mac.h"
@@ -212,7 +213,11 @@ Pod::Spec.new do |s|
     # limit on the 'prepare_command' field length. The encoded header is generated from
     # /src/boringssl/boringssl_prefix_symbols.h. Here we decode the content and inject the header to
     # the correct location in BoringSSL.
-    base64 -D <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
+    case "$(uname)" in
+      Darwin) opts="" ;;
+           *) opts="--ignore-garbage" ;;
+    esac
+    base64 --decode $opts <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
       H4sICAAAAAAC/2JvcmluZ3NzbF9wcmVmaXhfc3ltYm9scy5oAKydXXPbuJZo3+dXuO683Kk6NRM77bT7
       vim20tG0Y/tISk9nXliURNk8oUiFoOy4f/0FQErEx94g94arTs10LK21KQDEF0Hgv/7r7DErszptss3Z
       6vX0j2RV1Xn5KESR7Otsm/9MnrJ0k9X/KZ7OqvLso/50sbg9W1e7Xd78v7Pt+pdfPlxepL9crN7/9iE7

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -183,14 +183,15 @@
 
     s.prepare_command = <<-END_OF_COMMAND
       # Add a module map and an umbrella header
+      mkdir -p src/include/openssl
       cat > src/include/openssl/umbrella.h <<EOF
         #include "ssl.h"
         #include "crypto.h"
         #include "aes.h"
-        /* The following macros are defined by base.h. The latter is the first file included by the    
-           other headers. */    
-        #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)    
-        #  include "arm_arch.h"   
+        /* The following macros are defined by base.h. The latter is the first file included by the
+           other headers. */
+        #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+        #  include "arm_arch.h"
         #endif
         #include "asn1.h"
         #include "asn1_mac.h"
@@ -242,7 +243,11 @@
       # limit on the 'prepare_command' field length. The encoded header is generated from
       # /src/boringssl/boringssl_prefix_symbols.h. Here we decode the content and inject the header to
       # the correct location in BoringSSL.
-      base64 -D <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
+      case "$(uname)" in
+        Darwin) opts="" ;;
+             *) opts="--ignore-garbage" ;;
+      esac
+      base64 --decode $opts <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
         % for line in compress_boringssl_prefix_header():
         ${line.decode('utf-8')}
         % endfor


### PR DESCRIPTION
Fixing gRPC cocoapod installation issue on GNU/Linux which are previously mentioned in the following 

https://github.com/grpc/grpc/pull/26630
https://github.com/firebase/quickstart-ios/issues/1099
https://github.com/firebase/firebase-ios-sdk/issues/736#issuecomment-362338481

Currently this is preventing firebase/firestone cocoapod to install on linux for internal users but may potentially affect anyone who want to use gRPC cocoapod on GNU/Linux.  Manually tested the installation on linux box of the following spec 

Linux # 1 SMP Debian 5.10.40-1rodete2 (2021-06-22) x86_64 GNU/Linux

Clients need to update to latest next gRPC release v1.41.x in order to pick up this patch. ([Firebase/Firestore currently on v1.28.0](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseFirestore.podspec#L100))

