### PR TITLE
add APIs for creating errors from C++ strings

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1141,9 +1141,8 @@ ClientChannel::ClientChannel(grpc_channel_element_args* args,
       channel_args_, GRPC_ARG_KEEPALIVE_TIME_MS,
       {-1 /* default value, unset */, 1, INT_MAX});
   if (!ResolverRegistry::IsValidTarget(target_uri_.get())) {
-    std::string error_message =
-        absl::StrCat("the target uri is not valid: ", target_uri_.get());
-    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_message.c_str());
+    *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("the target uri is not valid: ", target_uri_.get()));
     return;
   }
   *error = GRPC_ERROR_NONE;

--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -248,10 +248,9 @@ void HttpConnectHandshaker::OnReadDone(void* arg, grpc_error_handle error) {
   // Make sure we got a 2xx response.
   if (handshaker->http_response_.status < 200 ||
       handshaker->http_response_.status >= 300) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("HTTP proxy returned response code ",
-                     handshaker->http_response_.status)
-            .c_str());
+                     handshaker->http_response_.status));
     handshaker->HandshakeFailedLocked(error);
     goto done;
   }

--- a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
@@ -812,17 +812,15 @@ class PriorityLbFactory : public LoadBalancingPolicyFactory {
         const std::string& child_name = p.first;
         const Json& element = p.second;
         if (element.type() != Json::Type::OBJECT) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
               absl::StrCat("field:children key:", child_name,
-                           " error:should be type object")
-                  .c_str()));
+                           " error:should be type object")));
         } else {
           auto it2 = element.object_value().find("config");
           if (it2 == element.object_value().end()) {
-            error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+            error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
                 absl::StrCat("field:children key:", child_name,
-                             " error:missing 'config' field")
-                    .c_str()));
+                             " error:missing 'config' field")));
           } else {
             grpc_error_handle parse_error = GRPC_ERROR_NONE;
             auto config = LoadBalancingPolicyRegistry::ParseLoadBalancingConfig(
@@ -836,11 +834,10 @@ class PriorityLbFactory : public LoadBalancingPolicyFactory {
               if (it3->second.type() == Json::Type::JSON_TRUE) {
                 ignore_resolution_requests = true;
               } else if (it3->second.type() != Json::Type::JSON_FALSE) {
-                error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+                error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
                     absl::StrCat("field:children key:", child_name,
                                  " field:ignore_reresolution_requests:should "
-                                 "be type boolean")
-                        .c_str()));
+                                 "be type boolean")));
               }
             }
             if (config == nullptr) {
@@ -872,26 +869,20 @@ class PriorityLbFactory : public LoadBalancingPolicyFactory {
       for (size_t i = 0; i < array.size(); ++i) {
         const Json& element = array[i];
         if (element.type() != Json::Type::STRING) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("field:priorities element:", i,
-                           " error:should be type string")
-                  .c_str()));
+          error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+              "field:priorities element:", i, " error:should be type string")));
         } else if (children.find(element.string_value()) == children.end()) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("field:priorities element:", i,
-                           " error:unknown child '", element.string_value(),
-                           "'")
-                  .c_str()));
+          error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+              "field:priorities element:", i, " error:unknown child '",
+              element.string_value(), "'")));
         } else {
           priorities.emplace_back(element.string_value());
         }
       }
       if (priorities.size() != children.size()) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrCat("field:priorities error:priorities size (",
-                         priorities.size(), ") != children size (",
-                         children.size(), ")")
-                .c_str()));
+        error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+            "field:priorities error:priorities size (", priorities.size(),
+            ") != children size (", children.size(), ")")));
       }
     }
     if (error_list.empty()) {

--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -655,14 +655,8 @@ class WeightedTargetLbFactory : public LoadBalancingPolicyFactory {
         std::vector<grpc_error_handle> child_errors =
             ParseChildConfig(p.second, &child_config);
         if (!child_errors.empty()) {
-          // Can't use GRPC_ERROR_CREATE_FROM_VECTOR() here, because the error
-          // string is not static in this case.
-          grpc_error_handle error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("field:targets key:", p.first).c_str());
-          for (grpc_error_handle child_error : child_errors) {
-            error = grpc_error_add_child(error, child_error);
-          }
-          error_list.push_back(error);
+          error_list.push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+              absl::StrCat("field:targets key:", p.first), &child_errors));
         } else {
           target_map[p.first] = std::move(child_config);
         }

--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -584,10 +584,9 @@ grpc_error_handle CdsLb::UpdateXdsCertificateProvider(
             .CreateOrGetCertificateProvider(root_provider_instance_name);
     if (new_root_provider == nullptr) {
       return grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          GRPC_ERROR_CREATE_FROM_CPP_STRING(
               absl::StrCat("Certificate provider instance name: \"",
-                           root_provider_instance_name, "\" not recognized.")
-                  .c_str()),
+                           root_provider_instance_name, "\" not recognized.")),
           GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
     }
   }
@@ -624,11 +623,9 @@ grpc_error_handle CdsLb::UpdateXdsCertificateProvider(
             .CreateOrGetCertificateProvider(identity_provider_instance_name);
     if (new_identity_provider == nullptr) {
       return grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("Certificate provider instance name: \"",
-                           identity_provider_instance_name,
-                           "\" not recognized.")
-                  .c_str()),
+          GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+              "Certificate provider instance name: \"",
+              identity_provider_instance_name, "\" not recognized.")),
           GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
     }
   }

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
@@ -721,8 +721,8 @@ class XdsClusterImplLbFactory : public LoadBalancingPolicyFactory {
       std::vector<grpc_error_handle> child_errors =
           ParseDropCategory(entry, drop_config);
       if (!child_errors.empty()) {
-        grpc_error_handle error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrCat("errors parsing index ", i).c_str());
+        grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+            absl::StrCat("errors parsing index ", i));
         for (size_t i = 0; i < child_errors.size(); ++i) {
           error = grpc_error_add_child(error, child_errors[i]);
         }

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -627,14 +627,8 @@ class XdsClusterManagerLbFactory : public LoadBalancingPolicyFactory {
         std::vector<grpc_error_handle> child_errors =
             ParseChildConfig(p.second, &child_config);
         if (!child_errors.empty()) {
-          // Can't use GRPC_ERROR_CREATE_FROM_VECTOR() here, because the error
-          // string is not static in this case.
-          grpc_error_handle error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("field:children name:", child_name).c_str());
-          for (grpc_error_handle child_error : child_errors) {
-            error = grpc_error_add_child(error, child_error);
-          }
-          error_list.push_back(error);
+          error_list.push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+              absl::StrCat("field:children name:", child_name), &child_errors));
         } else {
           cluster_map[child_name] = std::move(child_config);
           clusters_to_be_used.insert(child_name);

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -1169,9 +1169,8 @@ class XdsClusterResolverLbFactory : public LoadBalancingPolicyFactory {
         std::vector<grpc_error_handle> discovery_mechanism_errors =
             ParseDiscoveryMechanism(array[i], &discovery_mechanism);
         if (!discovery_mechanism_errors.empty()) {
-          grpc_error_handle error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("field:discovery_mechanism element: ", i, " error")
-                  .c_str());
+          grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+              absl::StrCat("field:discovery_mechanism element: ", i, " error"));
           for (grpc_error_handle discovery_mechanism_error :
                discovery_mechanism_errors) {
             error = grpc_error_add_child(error, discovery_mechanism_error);

--- a/src/core/ext/filters/client_channel/lb_policy_registry.cc
+++ b/src/core/ext/filters/client_channel/lb_policy_registry.cc
@@ -154,10 +154,8 @@ grpc_error_handle ParseLoadBalancingConfigHelper(
     }
     policies_tried.push_back(it->first);
   }
-  return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-      absl::StrCat("No known policies in list: ",
-                   absl::StrJoin(policies_tried, " "))
-          .c_str());
+  return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+      "No known policies in list: ", absl::StrJoin(policies_tried, " ")));
 }
 
 }  // namespace
@@ -176,9 +174,8 @@ LoadBalancingPolicyRegistry::ParseLoadBalancingConfig(
   LoadBalancingPolicyFactory* factory =
       g_state->GetLoadBalancingPolicyFactory(policy->first.c_str());
   if (factory == nullptr) {
-    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("Factory not found for policy \"%s\"", policy->first)
-            .c_str());
+    *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrFormat("Factory not found for policy \"%s\"", policy->first));
     return nullptr;
   }
   // Parse load balancing config via factory.

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -536,10 +536,8 @@ grpc_error_handle grpc_ares_ev_driver_create_locked(
   grpc_ares_test_only_inject_config((*ev_driver)->channel);
   GRPC_CARES_TRACE_LOG("request:%p grpc_ares_ev_driver_create_locked", request);
   if (status != ARES_SUCCESS) {
-    grpc_error_handle err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Failed to init ares channel. C-ares error: ",
-                     ares_strerror(status))
-            .c_str());
+    grpc_error_handle err = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Failed to init ares channel. C-ares error: ", ares_strerror(status)));
     gpr_free(*ev_driver);
     return err;
   }
@@ -721,7 +719,7 @@ static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
     GRPC_CARES_TRACE_LOG("request:%p on_hostbyname_done_locked: %s", r,
                          error_msg.c_str());
     grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg.c_str());
+        GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error_msg));
     r->error = grpc_error_add_child(error, r->error);
   }
   destroy_hostbyname_request_locked(hr);
@@ -766,7 +764,7 @@ static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
     GRPC_CARES_TRACE_LOG("request:%p on_srv_query_done_locked: %s", r,
                          error_msg.c_str());
     grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg.c_str());
+        GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error_msg));
     r->error = grpc_error_add_child(error, r->error);
   }
   delete q;
@@ -823,9 +821,9 @@ fail:
   std::string error_msg =
       absl::StrFormat("C-ares status is not ARES_SUCCESS qtype=TXT name=%s: %s",
                       q->name(), ares_strerror(status));
-  error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg.c_str());
   GRPC_CARES_TRACE_LOG("request:%p on_txt_done_locked %s", r,
                        error_msg.c_str());
+  error = GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error_msg));
   r->error = grpc_error_add_child(error, r->error);
 }
 
@@ -887,10 +885,8 @@ void grpc_dns_lookup_ares_continue_after_check_localhost_and_ip_literals_locked(
     int status =
         ares_set_servers_ports(r->ev_driver->channel, &r->dns_server_addr);
     if (status != ARES_SUCCESS) {
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("C-ares status is not ARES_SUCCESS: ",
-                       ares_strerror(status))
-              .c_str());
+      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+          "C-ares status is not ARES_SUCCESS: ", ares_strerror(status)));
       goto error_cleanup;
     }
   }
@@ -1128,9 +1124,8 @@ void (*grpc_cancel_ares_request_locked)(grpc_ares_request* r) =
 grpc_error_handle grpc_ares_init(void) {
   int status = ares_library_init(ARES_LIB_INIT_ALL);
   if (status != ARES_SUCCESS) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("ares_library_init failed: ", ares_strerror(status))
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("ares_library_init failed: ", ares_strerror(status)));
   }
   return GRPC_ERROR_NONE;
 }

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -538,11 +538,9 @@ grpc_error_handle XdsResolver::XdsConfigSelector::CreateMethodConfig(
     auto method_config_field =
         filter_impl->GenerateServiceConfig(http_filter.config, config_override);
     if (!method_config_field.ok()) {
-      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("failed to generate method config for HTTP filter ",
-                       http_filter.name, ": ",
-                       method_config_field.status().ToString())
-              .c_str());
+      return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+          "failed to generate method config for HTTP filter ", http_filter.name,
+          ": ", method_config_field.status().ToString()));
     }
     per_filter_configs[method_config_field->service_config_field_name]
         .push_back(method_config_field->element);
@@ -848,10 +846,9 @@ void XdsResolver::OnRouteConfigUpdate(XdsApi::RdsUpdate rds_update) {
   XdsApi::RdsUpdate::VirtualHost* vhost =
       rds_update.FindVirtualHostForDomain(server_name_);
   if (vhost == nullptr) {
-    OnError(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    OnError(GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("could not find VirtualHost for ", server_name_,
-                     " in RouteConfiguration")
-            .c_str()));
+                     " in RouteConfiguration")));
     return;
   }
   // Save the virtual host in the resolver.

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -125,11 +125,10 @@ ClientChannelServiceConfigParser::ParseGlobalParams(
         error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
             "field:loadBalancingPolicy error:Unknown lb policy"));
       } else if (requires_config) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
             absl::StrCat("field:loadBalancingPolicy error:", lb_policy_name,
                          " requires a config. Please use loadBalancingConfig "
-                         "instead.")
-                .c_str()));
+                         "instead.")));
       }
     }
   }

--- a/src/core/ext/filters/fault_injection/service_config_parser.cc
+++ b/src/core/ext/filters/fault_injection/service_config_parser.cc
@@ -45,10 +45,8 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
         fault_injection_policy;
     std::vector<grpc_error_handle> sub_error_list;
     if (policies_json_array[i].type() != Json::Type::OBJECT) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("faultInjectionPolicy index ", i,
-                       " is not a JSON object")
-              .c_str()));
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+          "faultInjectionPolicy index ", i, " is not a JSON object")));
       continue;
     }
     const Json::Object& json_object = policies_json_array[i].object_value();
@@ -134,15 +132,9 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
       }
     }
     if (!sub_error_list.empty()) {
-      // Can't use GRPC_ERROR_CREATE_FROM_VECTOR() here, because the error
-      // string is not static in this case.
-      grpc_error_handle error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("failed to parse faultInjectionPolicy index ", i)
-              .c_str());
-      for (size_t i = 0; i < sub_error_list.size(); ++i) {
-        error = grpc_error_add_child(error, sub_error_list[i]);
-      }
-      error_list->push_back(error);
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+          absl::StrCat("failed to parse faultInjectionPolicy index ", i),
+          &sub_error_list));
     }
     policies.push_back(std::move(fault_injection_policy));
   }

--- a/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
@@ -196,12 +196,12 @@ void CallData::OnRecvMessageReady(void* arg, grpc_error_handle error) {
       if (calld->max_recv_message_length_ >= 0 &&
           (*calld->recv_message_)->length() >
               static_cast<uint32_t>(calld->max_recv_message_length_)) {
-        std::string message_string = absl::StrFormat(
-            "Received message larger than max (%u vs. %d)",
-            (*calld->recv_message_)->length(), calld->max_recv_message_length_);
         GPR_DEBUG_ASSERT(calld->error_ == GRPC_ERROR_NONE);
         calld->error_ = grpc_error_set_int(
-            GRPC_ERROR_CREATE_FROM_COPIED_STRING(message_string.c_str()),
+            GRPC_ERROR_CREATE_FROM_CPP_STRING(
+                absl::StrFormat("Received message larger than max (%u vs. %d)",
+                                (*calld->recv_message_)->length(),
+                                calld->max_recv_message_length_)),
             GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_RESOURCE_EXHAUSTED);
         return calld->ContinueRecvMessageReadyCallback(
             GRPC_ERROR_REF(calld->error_));
@@ -260,11 +260,10 @@ void CallData::FinishRecvMessage() {
   if (grpc_msg_decompress(algorithm_, &recv_slices_, &decompressed_slices) ==
       0) {
     GPR_DEBUG_ASSERT(error_ == GRPC_ERROR_NONE);
-    error_ = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error_ = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("Unexpected error decompressing data for algorithm with "
                      "enum value ",
-                     algorithm_)
-            .c_str());
+                     algorithm_));
     grpc_slice_buffer_destroy_internal(&decompressed_slices);
   } else {
     uint32_t recv_flags =

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -203,11 +203,9 @@ static void recv_message_ready(void* user_data, grpc_error_handle error) {
       (*calld->recv_message)->length() >
           static_cast<size_t>(calld->limits.max_recv_size)) {
     grpc_error_handle new_error = grpc_error_set_int(
-        GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrFormat("Received message larger than max (%u vs. %d)",
-                            (*calld->recv_message)->length(),
-                            calld->limits.max_recv_size)
-                .c_str()),
+        GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+            "Received message larger than max (%u vs. %d)",
+            (*calld->recv_message)->length(), calld->limits.max_recv_size)),
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_RESOURCE_EXHAUSTED);
     error = grpc_error_add_child(GRPC_ERROR_REF(error), new_error);
     GRPC_ERROR_UNREF(calld->error);
@@ -264,14 +262,12 @@ static void message_size_start_transport_stream_op_batch(
           static_cast<size_t>(calld->limits.max_send_size)) {
     grpc_transport_stream_op_batch_finish_with_failure(
         op,
-        grpc_error_set_int(
-            GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                absl::StrFormat(
-                    "Sent message larger than max (%u vs. %d)",
-                    op->payload->send_message.send_message->length(),
-                    calld->limits.max_send_size)
-                    .c_str()),
-            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_RESOURCE_EXHAUSTED),
+        grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                               "Sent message larger than max (%u vs. %d)",
+                               op->payload->send_message.send_message->length(),
+                               calld->limits.max_send_size)),
+                           GRPC_ERROR_INT_GRPC_STATUS,
+                           GRPC_STATUS_RESOURCE_EXHAUSTED),
         calld->call_combiner);
     return;
   }

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -753,8 +753,8 @@ void Chttp2ServerListener::OnAccept(void* arg, grpc_endpoint* tcp,
     if (!args_result.ok()) {
       gpr_log(GPR_DEBUG, "Closing connection: %s",
               args_result.status().ToString().c_str());
-      endpoint_cleanup(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          args_result.status().ToString().c_str()));
+      endpoint_cleanup(
+          GRPC_ERROR_CREATE_FROM_CPP_STRING(args_result.status().ToString()));
       return;
     }
     grpc_error_handle error = GRPC_ERROR_NONE;

--- a/src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc
+++ b/src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc
@@ -49,10 +49,9 @@ grpc_channel_args* ModifyArgsForConnection(grpc_channel_args* args,
   }
   auto security_connector = server_credentials->create_security_connector(args);
   if (security_connector == nullptr) {
-    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("Unable to create secure server with credentials of type ",
-                     server_credentials->type())
-            .c_str());
+                     server_credentials->type()));
     return args;
   }
   grpc_arg arg_to_add =
@@ -100,11 +99,9 @@ int grpc_server_add_secure_http2_port(grpc_server* server, const char* addr,
   } else {
     sc = creds->create_security_connector(nullptr);
     if (sc == nullptr) {
-      err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat(
-              "Unable to create secure server with credentials of type ",
-              creds->type())
-              .c_str());
+      err = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+          "Unable to create secure server with credentials of type ",
+          creds->type()));
       goto done;
     }
     grpc_arg args_to_add[2];

--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -208,11 +208,9 @@ uint32_t TransportFlowControl::MaybeSendUpdate(bool writing_anyway) {
 grpc_error_handle TransportFlowControl::ValidateRecvData(
     int64_t incoming_frame_size) {
   if (incoming_frame_size > announced_window_) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("frame of size %" PRId64
-                        " overflows local window of %" PRId64,
-                        incoming_frame_size, announced_window_)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "frame of size %" PRId64 " overflows local window of %" PRId64,
+        incoming_frame_size, announced_window_));
   }
   return GRPC_ERROR_NONE;
 }
@@ -250,11 +248,9 @@ grpc_error_handle StreamFlowControl::RecvData(int64_t incoming_frame_size) {
               "See (for example) https://github.com/netty/netty/issues/6520.",
               incoming_frame_size, acked_stream_window, sent_stream_window);
     } else {
-      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrFormat("frame of size %" PRId64
-                          " overflows local window of %" PRId64,
-                          incoming_frame_size, acked_stream_window)
-              .c_str());
+      return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+          "frame of size %" PRId64 " overflows local window of %" PRId64,
+          incoming_frame_size, acked_stream_window));
     }
   }
 

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -46,10 +46,10 @@ grpc_error_handle grpc_chttp2_data_parser_begin_frame(
     grpc_chttp2_data_parser* /*parser*/, uint8_t flags, uint32_t stream_id,
     grpc_chttp2_stream* s) {
   if (flags & ~GRPC_CHTTP2_DATA_FLAG_END_STREAM) {
-    return grpc_error_set_int(
-        GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrFormat("unsupported data flags: 0x%02x", flags).c_str()),
-        GRPC_ERROR_INT_STREAM_ID, static_cast<intptr_t>(stream_id));
+    return grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                                  "unsupported data flags: 0x%02x", flags)),
+                              GRPC_ERROR_INT_STREAM_ID,
+                              static_cast<intptr_t>(stream_id));
   }
 
   if (flags & GRPC_CHTTP2_DATA_FLAG_END_STREAM) {
@@ -129,9 +129,8 @@ grpc_error_handle grpc_deframe_unprocessed_incoming_frames(
             p->is_frame_compressed = true; /* GPR_TRUE */
             break;
           default:
-            p->error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                absl::StrFormat("Bad GRPC frame type 0x%02x", p->frame_type)
-                    .c_str());
+            p->error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+                absl::StrFormat("Bad GRPC frame type 0x%02x", p->frame_type));
             p->error = grpc_error_set_int(p->error, GRPC_ERROR_INT_STREAM_ID,
                                           static_cast<intptr_t>(s->id));
             p->error = grpc_error_set_str(

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -40,8 +40,8 @@ void grpc_chttp2_goaway_parser_destroy(grpc_chttp2_goaway_parser* p) {
 grpc_error_handle grpc_chttp2_goaway_parser_begin_frame(
     grpc_chttp2_goaway_parser* p, uint32_t length, uint8_t /*flags*/) {
   if (length < 8) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("goaway frame too short (%d bytes)", length).c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrFormat("goaway frame too short (%d bytes)", length));
   }
 
   gpr_free(p->debug_data);

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -59,9 +59,8 @@ grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
 grpc_error_handle grpc_chttp2_ping_parser_begin_frame(
     grpc_chttp2_ping_parser* parser, uint32_t length, uint8_t flags) {
   if (flags & 0xfe || length != 8) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("invalid ping: length=%d, flags=%02x", length, flags)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrFormat("invalid ping: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;
   parser->is_ack = flags;

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -71,10 +71,8 @@ void grpc_chttp2_add_rst_stream_to_next_write(
 grpc_error_handle grpc_chttp2_rst_stream_parser_begin_frame(
     grpc_chttp2_rst_stream_parser* parser, uint32_t length, uint8_t flags) {
   if (length != 4) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("invalid rst_stream: length=%d, flags=%02x", length,
-                        flags)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "invalid rst_stream: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;
   return GRPC_ERROR_NONE;

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -225,10 +225,8 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
                     t->last_new_stream_id, sp->error_value,
                     grpc_slice_from_static_string("HTTP2 settings error"),
                     &t->qbuf);
-                return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                    absl::StrFormat("invalid value %u passed for %s",
-                                    parser->value, sp->name)
-                        .c_str());
+                return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                    "invalid value %u passed for %s", parser->value, sp->name));
             }
           }
           if (id == GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE &&

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -57,10 +57,8 @@ grpc_slice grpc_chttp2_window_update_create(
 grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
     grpc_chttp2_window_update_parser* parser, uint32_t length, uint8_t flags) {
   if (flags || length != 4) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("invalid window update: length=%d, flags=%02x", length,
-                        flags)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "invalid window update: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;
   parser->amount = 0;
@@ -90,8 +88,8 @@ grpc_error_handle grpc_chttp2_window_update_parser_parse(
     // top bit is reserved and must be ignored.
     uint32_t received_update = p->amount & 0x7fffffffu;
     if (received_update == 0) {
-      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("invalid window update bytes: ", p->amount).c_str());
+      return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("invalid window update bytes: ", p->amount));
     }
     GPR_ASSERT(is_last);
 

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -623,12 +623,10 @@ class HPackParser::Input {
                                                  uint8_t last_byte) {
     return MaybeSetErrorAndReturn(
         [value, last_byte] {
-          return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrFormat(
-                  "integer overflow in hpack integer decoding: have 0x%08x, "
-                  "got byte 0x%02x on byte 5",
-                  value, last_byte)
-                  .c_str());
+          return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+              "integer overflow in hpack integer decoding: have 0x%08x, "
+              "got byte 0x%02x on byte 5",
+              value, last_byte));
         },
         absl::optional<uint32_t>());
   }

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -87,11 +87,9 @@ grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
     return GRPC_ERROR_NONE;
   }
   if (bytes > max_bytes_) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat(
-            "Attempt to make hpack table %d bytes when max is %d bytes", bytes,
-            max_bytes_)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "Attempt to make hpack table %d bytes when max is %d bytes", bytes,
+        max_bytes_));
   }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace)) {
     gpr_log(GPR_INFO, "Update hpack parser table size to %d", bytes);
@@ -122,12 +120,10 @@ grpc_error_handle HPackTable::Add(grpc_mdelem md) {
                       hpack_constants::kEntryOverhead;
 
   if (current_table_bytes_ > max_bytes_) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat(
-            "HPACK max table size reduced to %d but not reflected by hpack "
-            "stream (still at %d)",
-            max_bytes_, current_table_bytes_)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "HPACK max table size reduced to %d but not reflected by hpack "
+        "stream (still at %d)",
+        max_bytes_, current_table_bytes_));
   }
 
   // we can't add elements bigger than the max table size

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -90,15 +90,13 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
     case GRPC_DTS_CLIENT_PREFIX_23:
       while (cur != end && t->deframe_state != GRPC_DTS_FH_0) {
         if (*cur != GRPC_CHTTP2_CLIENT_CONNECT_STRING[t->deframe_state]) {
-          return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrFormat(
-                  "Connect string mismatch: expected '%c' (%d) got '%c' (%d) "
-                  "at byte %d",
-                  GRPC_CHTTP2_CLIENT_CONNECT_STRING[t->deframe_state],
-                  static_cast<int>(static_cast<uint8_t>(
-                      GRPC_CHTTP2_CLIENT_CONNECT_STRING[t->deframe_state])),
-                  *cur, static_cast<int>(*cur), t->deframe_state)
-                  .c_str());
+          return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+              "Connect string mismatch: expected '%c' (%d) got '%c' (%d) "
+              "at byte %d",
+              GRPC_CHTTP2_CLIENT_CONNECT_STRING[t->deframe_state],
+              static_cast<int>(static_cast<uint8_t>(
+                  GRPC_CHTTP2_CLIENT_CONNECT_STRING[t->deframe_state])),
+              *cur, static_cast<int>(*cur), t->deframe_state));
         }
         ++cur;
         // NOLINTNEXTLINE(bugprone-misplaced-widening-cast)
@@ -197,12 +195,11 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
                  t->incoming_frame_size >
                      t->settings[GRPC_ACKED_SETTINGS]
                                 [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE]) {
-        return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+        return GRPC_ERROR_CREATE_FROM_CPP_STRING(
             absl::StrFormat("Frame size %d is larger than max frame size %d",
                             t->incoming_frame_size,
                             t->settings[GRPC_ACKED_SETTINGS]
-                                       [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE])
-                .c_str());
+                                       [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE]));
       }
       if (++cur == end) {
         return GRPC_ERROR_NONE;
@@ -256,27 +253,22 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
 static grpc_error_handle init_frame_parser(grpc_chttp2_transport* t) {
   if (t->is_first_frame &&
       t->incoming_frame_type != GRPC_CHTTP2_FRAME_SETTINGS) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat(
-            "Expected SETTINGS frame as the first frame, got frame type ",
-            t->incoming_frame_type)
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Expected SETTINGS frame as the first frame, got frame type ",
+        t->incoming_frame_type));
   }
   t->is_first_frame = false;
   if (t->expect_continuation_stream_id != 0) {
     if (t->incoming_frame_type != GRPC_CHTTP2_FRAME_CONTINUATION) {
-      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+      return GRPC_ERROR_CREATE_FROM_CPP_STRING(
           absl::StrFormat("Expected CONTINUATION frame, got frame type %02x",
-                          t->incoming_frame_type)
-              .c_str());
+                          t->incoming_frame_type));
     }
     if (t->expect_continuation_stream_id != t->incoming_stream_id) {
-      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrFormat(
-              "Expected CONTINUATION frame for grpc_chttp2_stream %08x, got "
-              "grpc_chttp2_stream %08x",
-              t->expect_continuation_stream_id, t->incoming_stream_id)
-              .c_str());
+      return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+          "Expected CONTINUATION frame for grpc_chttp2_stream %08x, got "
+          "grpc_chttp2_stream %08x",
+          t->expect_continuation_stream_id, t->incoming_stream_id));
     }
     return init_header_frame_parser(t, 1);
   }

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -309,13 +309,10 @@ static void read_grpc_header(stream_obj* s) {
 static grpc_error_handle make_error_with_desc(int error_code,
                                               int cronet_internal_error_code,
                                               const char* desc) {
-  std::string error_message =
-      absl::StrFormat("Cronet error code:%d, Cronet error detail:%s",
-                      cronet_internal_error_code, desc);
-  grpc_error_handle error =
-      GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_message.c_str());
-  error = grpc_error_set_int(error, GRPC_ERROR_INT_GRPC_STATUS, error_code);
-  return error;
+  return grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                                "Cronet error code:%d, Cronet error detail:%s",
+                                cronet_internal_error_code, desc)),
+                            GRPC_ERROR_INT_GRPC_STATUS, error_code);
 }
 
 inline op_and_state::op_and_state(stream_obj* s,

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -194,11 +194,10 @@ class XdsClient::ChannelState::AdsCallState
         ABSL_EXCLUSIVE_LOCKS_REQUIRED(&XdsClient::mu_) {
       if (error == GRPC_ERROR_NONE && timer_pending_) {
         timer_pending_ = false;
-        grpc_error_handle watcher_error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrFormat(
+        grpc_error_handle watcher_error =
+            GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
                 "timeout obtaining resource {type=%s name=%s} from xds server",
-                type_url_, name_)
-                .c_str());
+                type_url_, name_));
         watcher_error = grpc_error_set_int(
             watcher_error, GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
         if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -87,10 +87,8 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
       reinterpret_cast<struct sockaddr_un*>(resolved_addr->addr);
   const size_t maxlen = sizeof(un->sun_path) - 1;
   if (path.size() > maxlen) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Path name should not have more than ", maxlen,
-                     " characters")
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Path name should not have more than ", maxlen, " characters"));
   }
   un->sun_family = AF_UNIX;
   path.copy(un->sun_path, path.size());
@@ -105,10 +103,8 @@ grpc_error_handle UnixAbstractSockaddrPopulate(
       reinterpret_cast<struct sockaddr_un*>(resolved_addr->addr);
   const size_t maxlen = sizeof(un->sun_path) - 1;
   if (path.size() > maxlen) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Path name should not have more than ", maxlen,
-                     " characters")
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Path name should not have more than ", maxlen, " characters"));
   }
   un->sun_family = AF_UNIX;
   un->sun_path[0] = '\0';

--- a/src/core/lib/address_utils/sockaddr_utils.cc
+++ b/src/core/lib/address_utils/sockaddr_utils.cc
@@ -212,8 +212,8 @@ grpc_error_handle grpc_string_to_sockaddr(grpc_resolved_address* out,
     addr4->sin_family = GRPC_AF_INET;
     out->len = sizeof(grpc_sockaddr_in);
   } else {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Failed to parse address:", addr).c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("Failed to parse address:", addr));
   }
   grpc_sockaddr_set_port(out, port);
   return GRPC_ERROR_NONE;

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -95,10 +95,8 @@ class grpc_httpcli_ssl_channel_security_connector final
     /* Check the peer name. */
     if (secure_peer_name_ != nullptr &&
         !tsi_ssl_peer_matches_name(&peer, secure_peer_name_)) {
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("Peer name ", secure_peer_name_,
-                       " is not in peer certificate")
-              .c_str());
+      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+          "Peer name ", secure_peer_name_, " is not in peer certificate"));
     }
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
     tsi_peer_destruct(&peer);

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -33,6 +33,7 @@
 
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/status_helper.h"
+#include "src/core/lib/slice/slice_internal.h"
 
 /// Opaque representation of an error.
 /// See https://github.com/grpc/grpc/blob/master/doc/core/grpc-error.md for a

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -165,6 +165,8 @@ void grpc_enable_error_creation();
   StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
 #define GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc) \
   StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
+#define GRPC_ERROR_CREATE_FROM_CPP_STRING(desc) \
+  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
 #define GRPC_ERROR_CREATE_FROM_STRING_VIEW(desc) \
   StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
 
@@ -198,6 +200,8 @@ static absl::Status grpc_status_create_from_vector(
 }
 
 #define GRPC_ERROR_CREATE_FROM_VECTOR(desc, error_list) \
+  grpc_status_create_from_vector(DEBUG_LOCATION, desc, error_list)
+#define GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(desc, error_list) \
   grpc_status_create_from_vector(DEBUG_LOCATION, desc, error_list)
 
 absl::Status grpc_os_error(const grpc_core::DebugLocation& location, int err,
@@ -286,6 +290,9 @@ grpc_error_handle grpc_error_create(const char* file, int line,
 #define GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc)                           \
   grpc_error_create(__FILE__, __LINE__, grpc_slice_from_copied_string(desc), \
                     NULL, 0)
+#define GRPC_ERROR_CREATE_FROM_CPP_STRING(desc)                           \
+  grpc_error_create(__FILE__, __LINE__, grpc_slice_from_cpp_string(desc), \
+                    NULL, 0)
 #define GRPC_ERROR_CREATE_FROM_STRING_VIEW(desc) \
   grpc_error_create(                             \
       __FILE__, __LINE__,                        \
@@ -301,18 +308,24 @@ grpc_error_handle grpc_error_create(const char* file, int line,
                     errs, count)
 
 #define GRPC_ERROR_CREATE_FROM_VECTOR(desc, error_list) \
-  grpc_error_create_from_vector(__FILE__, __LINE__, desc, error_list)
+  grpc_error_create_from_vector(                        \
+      __FILE__, __LINE__, grpc_slice_from_static_string, desc, error_list)
+#define GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(desc, error_list) \
+  grpc_error_create_from_vector(__FILE__, __LINE__,                    \
+                                grpc_slice_from_cpp_string, desc, error_list)
 
 // Consumes all the errors in the vector and forms a referencing error from
 // them. If the vector is empty, return GRPC_ERROR_NONE.
-template <typename VectorType>
-static grpc_error_handle grpc_error_create_from_vector(const char* file,
-                                                       int line,
-                                                       const char* desc,
-                                                       VectorType* error_list) {
+template <typename VectorType, typename StringType,
+          typename SliceFromStringFunction>
+static grpc_error_handle grpc_error_create_from_vector(
+    const char* file, int line,
+    SliceFromStringFunction slice_from_string_function, StringType desc,
+    VectorType* error_list) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   if (error_list->size() != 0) {
-    error = grpc_error_create(file, line, grpc_slice_from_static_string(desc),
+    error = grpc_error_create(file, line,
+                              slice_from_string_function(std::move(desc)),
                               error_list->data(), error_list->size());
     // Remove refs to all errors in error_list.
     for (size_t i = 0; i < error_list->size(); i++) {

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -93,14 +93,14 @@ static grpc_error_handle try_split_host_port(const char* name,
   /* parse name, splitting it into host and port parts */
   grpc_core::SplitHostPort(name, host, port);
   if (host->empty()) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("unparseable host:port: '%s'", name).c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrFormat("unparseable host:port: '%s'", name));
   }
   if (port->empty()) {
     // TODO(murgatroid99): add tests for this case
     if (default_port == nullptr) {
-      return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrFormat("no port in name '%s'", name).c_str());
+      return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrFormat("no port in name '%s'", name));
     }
     *port = default_port;
   }

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -67,14 +67,14 @@ static grpc_error_handle windows_blocking_resolve_address(
   std::string port;
   grpc_core::SplitHostPort(name, &host, &port);
   if (host.empty()) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("unparseable host:port: '%s'", name).c_str());
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrFormat("unparseable host:port: '%s'", name));
     goto done;
   }
   if (port.empty()) {
     if (default_port == NULL) {
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrFormat("no port in name '%s'", name).c_str());
+      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrFormat("no port in name '%s'", name));
       goto done;
     }
     port = default_port;

--- a/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
@@ -145,8 +145,8 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     }
     if ((err = grpc_tcp_server_add_addr(s, &addr, port_index, fd_index, &dsmode,
                                         &new_sp)) != GRPC_ERROR_NONE) {
-      grpc_error_handle root_err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("Failed to add listener: ", addr_str).c_str());
+      grpc_error_handle root_err = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("Failed to add listener: ", addr_str));
       err = grpc_error_add_child(root_err, err);
       break;
     } else {

--- a/src/core/lib/json/json_reader.cc
+++ b/src/core/lib/json/json_reader.cc
@@ -180,10 +180,9 @@ Json* JsonReader::CreateAndLinkValue() {
         if (errors_.size() == GRPC_JSON_MAX_ERRORS) {
           truncated_errors_ = true;
         } else {
-          errors_.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+          errors_.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
               absl::StrFormat("duplicate key \"%s\" at index %" PRIuPTR, key_,
-                              CurrentIndex())
-                  .c_str()));
+                              CurrentIndex())));
         }
       }
       value = &(*parent->mutable_object())[std::move(key_)];
@@ -201,10 +200,9 @@ bool JsonReader::StartContainer(Json::Type type) {
     if (errors_.size() == GRPC_JSON_MAX_ERRORS) {
       truncated_errors_ = true;
     } else {
-      errors_.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+      errors_.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
           absl::StrFormat("exceeded max stack depth (%d) at index %" PRIuPTR,
-                          GRPC_JSON_MAX_DEPTH, CurrentIndex())
-              .c_str()));
+                          GRPC_JSON_MAX_DEPTH, CurrentIndex())));
     }
     return false;
   }
@@ -826,14 +824,11 @@ grpc_error_handle JsonReader::Parse(absl::string_view input, Json* output) {
         "errors and try again to see additional errors"));
   }
   if (status == Status::GRPC_JSON_INTERNAL_ERROR) {
-    reader.errors_.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("internal error in JSON parser at index ",
-                     reader.CurrentIndex())
-            .c_str()));
+    reader.errors_.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "internal error in JSON parser at index ", reader.CurrentIndex())));
   } else if (status == Status::GRPC_JSON_PARSE_ERROR) {
-    reader.errors_.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("JSON parse error at index ", reader.CurrentIndex())
-            .c_str()));
+    reader.errors_.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("JSON parse error at index ", reader.CurrentIndex())));
   }
   if (!reader.errors_.empty()) {
     return GRPC_ERROR_CREATE_FROM_VECTOR("JSON parsing failed",

--- a/src/core/lib/json/json_util.h
+++ b/src/core/lib/json/json_util.h
@@ -46,14 +46,13 @@ inline bool ExtractJsonNumber(const Json& json, const std::string& field_name,
                               ErrorVectorType* error_list) {
   static_assert(std::is_integral<NumericType>::value, "Integral required");
   if (json.type() != Json::Type::NUMBER) {
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("field:", field_name, " error:type should be NUMBER")
-            .c_str()));
+    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("field:", field_name, " error:type should be NUMBER")));
     return false;
   }
   if (!absl::SimpleAtoi(json.string_value(), output)) {
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("field:", field_name, " error:failed to parse.").c_str()));
+    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("field:", field_name, " error:failed to parse.")));
     return false;
   }
   return true;
@@ -70,9 +69,8 @@ inline bool ExtractJsonBool(const Json& json, const std::string& field_name,
       *output = false;
       return true;
     default:
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("field:", field_name, " error:type should be BOOLEAN")
-              .c_str()));
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("field:", field_name, " error:type should be BOOLEAN")));
       return false;
   }
 }
@@ -83,9 +81,8 @@ inline bool ExtractJsonString(const Json& json, const std::string& field_name,
                               ErrorVectorType* error_list) {
   if (json.type() != Json::Type::STRING) {
     *output = "";
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("field:", field_name, " error:type should be STRING")
-            .c_str()));
+    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("field:", field_name, " error:type should be STRING")));
     return false;
   }
   *output = json.string_value();
@@ -98,9 +95,8 @@ inline bool ExtractJsonArray(const Json& json, const std::string& field_name,
                              ErrorVectorType* error_list) {
   if (json.type() != Json::Type::ARRAY) {
     *output = nullptr;
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("field:", field_name, " error:type should be ARRAY")
-            .c_str()));
+    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("field:", field_name, " error:type should be ARRAY")));
     return false;
   }
   *output = &json.array_value();
@@ -113,9 +109,8 @@ inline bool ExtractJsonObject(const Json& json, const std::string& field_name,
                               ErrorVectorType* error_list) {
   if (json.type() != Json::Type::OBJECT) {
     *output = nullptr;
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("field:", field_name, " error:type should be OBJECT")
-            .c_str()));
+    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("field:", field_name, " error:type should be OBJECT")));
     return false;
   }
   *output = &json.object_value();
@@ -162,9 +157,8 @@ inline bool ParseJsonObjectField(const Json::Object& object,
   auto it = object.find(field_name);
   if (it == object.end()) {
     if (required) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("field:", field_name, " error:does not exist.")
-              .c_str()));
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("field:", field_name, " error:does not exist.")));
     }
     return false;
   }
@@ -181,19 +175,17 @@ inline bool ParseJsonObjectFieldAsDuration(const Json::Object& object,
   auto it = object.find(field_name);
   if (it == object.end()) {
     if (required) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("field:", field_name, " error:does not exist.")
-              .c_str()));
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("field:", field_name, " error:does not exist.")));
     }
     return false;
   }
   if (!ParseDurationFromJson(it->second, output)) {
     *output = GRPC_MILLIS_INF_PAST;
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("field:", field_name,
                      " error:type should be STRING of the form given by "
-                     "google.proto.Duration.")
-            .c_str()));
+                     "google.proto.Duration.")));
     return false;
   }
   return true;

--- a/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
@@ -155,10 +155,9 @@ void AwsExternalAccountCredentials::RetrieveRegion() {
   }
   absl::StatusOr<URI> uri = URI::Parse(region_url_);
   if (!uri.ok()) {
-    FinishRetrieveSubjectToken("", GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                                       absl::StrFormat("Invalid region url. %s",
-                                                       uri.status().ToString())
-                                           .c_str()));
+    FinishRetrieveSubjectToken(
+        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                "Invalid region url. %s", uri.status().ToString())));
     return;
   }
   grpc_httpcli_request request;
@@ -205,9 +204,8 @@ void AwsExternalAccountCredentials::RetrieveRoleName() {
   absl::StatusOr<URI> uri = URI::Parse(url_);
   if (!uri.ok()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                absl::StrFormat("Invalid url: %s.", uri.status().ToString())
-                    .c_str()));
+        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(
+                absl::StrFormat("Invalid url: %s.", uri.status().ToString())));
     return;
   }
   grpc_httpcli_request request;
@@ -266,10 +264,8 @@ void AwsExternalAccountCredentials::RetrieveSigningKeys() {
   absl::StatusOr<URI> uri = URI::Parse(url_with_role_name);
   if (!uri.ok()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                absl::StrFormat("Invalid url with role name: %s.",
-                                uri.status().ToString())
-                    .c_str()));
+        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                "Invalid url with role name: %s.", uri.status().ToString())));
     return;
   }
   grpc_httpcli_request request;
@@ -317,10 +313,8 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
     access_key_id_ = it->second.string_value();
   } else {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                absl::StrFormat("Missing or invalid AccessKeyId in %s.",
-                                response_body)
-                    .c_str()));
+        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                "Missing or invalid AccessKeyId in %s.", response_body)));
     return;
   }
   it = json.object_value().find("SecretAccessKey");
@@ -329,10 +323,8 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
     secret_access_key_ = it->second.string_value();
   } else {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-                absl::StrFormat("Missing or invalid SecretAccessKey in %s.",
-                                response_body)
-                    .c_str()));
+        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                "Missing or invalid SecretAccessKey in %s.", response_body)));
     return;
   }
   it = json.object_value().find("Token");
@@ -341,10 +333,8 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
     token_ = it->second.string_value();
   } else {
     FinishRetrieveSubjectToken(
-        "",
-        GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrFormat("Missing or invalid Token in %s.", response_body)
-                .c_str()));
+        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                "Missing or invalid Token in %s.", response_body)));
     return;
   }
   BuildSubjectToken();

--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -232,10 +232,9 @@ void ExternalAccountCredentials::ExchangeToken(
     absl::string_view subject_token) {
   absl::StatusOr<URI> uri = URI::Parse(options_.token_url);
   if (!uri.ok()) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrFormat("Invalid token url: %s. Error: %s", options_.token_url,
-                        uri.status().ToString())
-            .c_str()));
+                        uri.status().ToString())));
     return;
   }
   grpc_httpcli_request request;
@@ -344,20 +343,17 @@ void ExternalAccountCredentials::ImpersenateServiceAccount() {
   auto it = json.object_value().find("access_token");
   if (it == json.object_value().end() ||
       it->second.type() != Json::Type::STRING) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("Missing or invalid access_token in %s.", response_body)
-            .c_str()));
+    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "Missing or invalid access_token in %s.", response_body)));
     return;
   }
   std::string access_token = it->second.string_value();
   absl::StatusOr<URI> uri =
       URI::Parse(options_.service_account_impersonation_url);
   if (!uri.ok()) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat(
-            "Invalid service account impersonation url: %s. Error: %s",
-            options_.service_account_impersonation_url, uri.status().ToString())
-            .c_str()));
+    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "Invalid service account impersonation url: %s. Error: %s",
+        options_.service_account_impersonation_url, uri.status().ToString())));
     return;
   }
   grpc_httpcli_request request;
@@ -413,18 +409,16 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
   auto it = json.object_value().find("accessToken");
   if (it == json.object_value().end() ||
       it->second.type() != Json::Type::STRING) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("Missing or invalid accessToken in %s.", response_body)
-            .c_str()));
+    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "Missing or invalid accessToken in %s.", response_body)));
     return;
   }
   std::string access_token = it->second.string_value();
   it = json.object_value().find("expireTime");
   if (it == json.object_value().end() ||
       it->second.type() != Json::Type::STRING) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrFormat("Missing or invalid expireTime in %s.", response_body)
-            .c_str()));
+    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "Missing or invalid expireTime in %s.", response_body)));
     return;
   }
   std::string expire_time = it->second.string_value();

--- a/src/core/lib/security/credentials/external/url_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/url_external_account_credentials.cc
@@ -51,10 +51,9 @@ UrlExternalAccountCredentials::UrlExternalAccountCredentials(
   }
   absl::StatusOr<URI> tmp_url = URI::Parse(it->second.string_value());
   if (!tmp_url.ok()) {
-    *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrFormat("Invalid credential source url. Error: %s",
-                        tmp_url.status().ToString())
-            .c_str());
+                        tmp_url.status().ToString()));
     return;
   }
   url_ = *tmp_url;

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -660,10 +660,9 @@ absl::StatusOr<URI> ValidateStsCredentialsOptions(
                      ? ""
                      : options->token_exchange_service_uri);
   if (!sts_url.ok()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrFormat("Invalid or missing STS endpoint URL. Error: %s",
-                        sts_url.status().ToString())
-            .c_str()));
+                        sts_url.status().ToString())));
   } else if (sts_url->scheme() != "https" && sts_url->scheme() != "http") {
     error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Invalid URI scheme, must be https to http."));

--- a/src/core/lib/security/credentials/plugin/plugin_credentials.cc
+++ b/src/core/lib/security/credentials/plugin/plugin_credentials.cc
@@ -87,10 +87,8 @@ static grpc_error_handle process_plugin_result(
     size_t num_md, grpc_status_code status, const char* error_details) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   if (status != GRPC_STATUS_OK) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Getting metadata from plugin failed with error: ",
-                     error_details)
-            .c_str());
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Getting metadata from plugin failed with error: ", error_details));
   } else {
     bool seen_illegal_header = false;
     for (size_t i = 0; i < num_md; ++i) {

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -229,10 +229,9 @@ static void fake_check_peer(
   prop_name = peer.properties[0].name;
   if (prop_name == nullptr ||
       strcmp(prop_name, TSI_CERTIFICATE_TYPE_PEER_PROPERTY) != 0) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("Unexpected property in fake peer: ",
-                     prop_name == nullptr ? "<EMPTY>" : prop_name)
-            .c_str());
+                     prop_name == nullptr ? "<EMPTY>" : prop_name));
     goto end;
   }
   if (strncmp(peer.properties[0].value.data, TSI_FAKE_CERTIFICATE_TYPE,
@@ -244,10 +243,9 @@ static void fake_check_peer(
   prop_name = peer.properties[1].name;
   if (prop_name == nullptr ||
       strcmp(prop_name, TSI_SECURITY_LEVEL_PEER_PROPERTY) != 0) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("Unexpected property in fake peer: ",
-                     prop_name == nullptr ? "<EMPTY>" : prop_name)
-            .c_str());
+                     prop_name == nullptr ? "<EMPTY>" : prop_name));
     goto end;
   }
   if (strncmp(peer.properties[1].value.data, TSI_FAKE_SECURITY_LEVEL,

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -54,9 +54,8 @@ grpc_error_handle ssl_check_peer(
   }
   /* Check the peer name if specified. */
   if (peer_name != nullptr && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Peer name ", peer_name, " is not in peer certificate")
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("Peer name ", peer_name, " is not in peer certificate"));
   }
   *auth_context =
       grpc_ssl_peer_to_auth_context(peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
@@ -162,10 +161,8 @@ class grpc_ssl_channel_security_connector final
             verify_options_->verify_peer_callback_userdata);
         gpr_free(peer_pem);
         if (callback_status) {
-          error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrFormat("Verify peer callback returned a failure (%d)",
-                              callback_status)
-                  .c_str());
+          error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+              "Verify peer callback returned a failure (%d)", callback_status));
         }
       }
     }

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -173,9 +173,8 @@ grpc_error_handle grpc_ssl_check_peer_name(absl::string_view peer_name,
                                            const tsi_peer* peer) {
   /* Check the peer name if specified. */
   if (!peer_name.empty() && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Peer name ", peer_name, " is not in peer certificate")
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("Peer name ", peer_name, " is not in peer certificate"));
   }
   return GRPC_ERROR_NONE;
 }

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -421,27 +421,23 @@ TlsChannelSecurityConnector::ProcessServerAuthorizationCheckResult(
   grpc_error_handle error = GRPC_ERROR_NONE;
   /* Server authorization check is cancelled by caller. */
   if (arg->status == GRPC_STATUS_CANCELLED) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("Server authorization check is cancelled by the caller "
                      "with error: ",
-                     arg->error_details->error_details())
-            .c_str());
+                     arg->error_details->error_details()));
   } else if (arg->status == GRPC_STATUS_OK) {
     /* Server authorization check completed successfully but returned check
      * failure. */
     if (!arg->success) {
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
           absl::StrCat("Server authorization check failed with error: ",
-                       arg->error_details->error_details())
-              .c_str());
+                       arg->error_details->error_details()));
     }
     /* Server authorization check did not complete correctly. */
   } else {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat(
-            "Server authorization check did not finish correctly with error: ",
-            arg->error_details->error_details())
-            .c_str());
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Server authorization check did not finish correctly with error: ",
+        arg->error_details->error_details()));
   }
   return error;
 }
@@ -659,9 +655,8 @@ grpc_error_handle TlsCheckHostName(const char* peer_name,
                                    const tsi_peer* peer) {
   /* Check the peer name if specified. */
   if (peer_name != nullptr && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    return GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("Peer name ", peer_name, " is not in peer certificate")
-            .c_str());
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("Peer name ", peer_name, " is not in peer certificate"));
   }
   return GRPC_ERROR_NONE;
 }

--- a/src/core/lib/security/transport/client_auth_filter.cc
+++ b/src/core/lib/security/transport/client_auth_filter.cc
@@ -338,13 +338,12 @@ static void on_host_checked(void* arg, grpc_error_handle error) {
   if (error == GRPC_ERROR_NONE) {
     send_security_metadata(elem, batch);
   } else {
-    std::string error_msg = absl::StrCat(
-        "Invalid host ", grpc_core::StringViewFromSlice(calld->host),
-        " set in :authority metadata.");
     grpc_transport_stream_op_batch_finish_with_failure(
         batch,
         grpc_error_set_int(
-            GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_msg.c_str()),
+            GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+                "Invalid host ", grpc_core::StringViewFromSlice(calld->host),
+                " set in :authority metadata.")),
             GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAUTHENTICATED),
         calld->call_combiner);
   }

--- a/src/core/lib/security/util/json_util.cc
+++ b/src/core/lib/security/util/json_util.cc
@@ -42,18 +42,15 @@ const char* grpc_json_get_string_property(const grpc_core::Json& json,
   auto it = json.object_value().find(prop_name);
   if (it == json.object_value().end()) {
     if (error != nullptr) {
-      *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("Property ", prop_name, " not found in JSON object.")
-              .c_str());
+      *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("Property ", prop_name, " not found in JSON object."));
     }
     return nullptr;
   }
   if (it->second.type() != grpc_core::Json::Type::STRING) {
     if (error != nullptr) {
-      *error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-          absl::StrCat("Property ", prop_name,
-                       " n JSON object is not a string.")
-              .c_str());
+      *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+          "Property ", prop_name, " n JSON object is not a string."));
     }
     return nullptr;
   }

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -1066,10 +1066,10 @@ static void recv_trailing_filter(void* args, grpc_metadata_batch* b,
     grpc_error_handle error = GRPC_ERROR_NONE;
     if (status_code != GRPC_STATUS_OK) {
       char* peer = grpc_call_get_peer(call);
-      error = grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-              absl::StrCat("Error received from peer ", peer).c_str()),
-          GRPC_ERROR_INT_GRPC_STATUS, static_cast<intptr_t>(status_code));
+      error = grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+                                     "Error received from peer ", peer)),
+                                 GRPC_ERROR_INT_GRPC_STATUS,
+                                 static_cast<intptr_t>(status_code));
       gpr_free(peer);
     }
     if (b->idx.named.grpc_message != nullptr) {

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -489,10 +489,8 @@ static void on_read_request_done_locked(void* arg, grpc_error_handle error) {
   }
   // Make sure we got a CONNECT request.
   if (strcmp(conn->http_request.method, "CONNECT") != 0) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-        absl::StrCat("HTTP proxy got request method ",
-                     conn->http_request.method)
-            .c_str());
+    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "HTTP proxy got request method ", conn->http_request.method));
     proxy_connection_failed(conn, SETUP_FAILED, "HTTP proxy read request",
                             GRPC_ERROR_REF(error));
     GRPC_ERROR_UNREF(error);

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -1948,10 +1948,11 @@ static void test_metadata_plugin_failure(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
-  std::string expected_error = absl::StrCat(
-      "Getting metadata from plugin failed with error: ", plugin_error_details);
   request_metadata_state* md_state = make_request_metadata_state(
-      GRPC_ERROR_CREATE_FROM_COPIED_STRING(expected_error.c_str()), nullptr, 0);
+      GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          absl::StrCat("Getting metadata from plugin failed with error: ",
+                       plugin_error_details)),
+      nullptr, 0);
 
   plugin.state = &state;
   plugin.get_metadata = plugin_get_metadata_failure;

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1489,10 +1489,9 @@ class FakeCertificateProvider final : public grpc_tls_certificate_provider {
       if (!root_being_watched && !identity_being_watched) return;
       auto it = cert_data_map_.find(cert_name);
       if (it == cert_data_map_.end()) {
-        grpc_error_handle error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
-            absl::StrCat("No certificates available for cert_name \"",
-                         cert_name, "\"")
-                .c_str());
+        grpc_error_handle error =
+            GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+                "No certificates available for cert_name \"", cert_name, "\""));
         distributor_->SetErrorForCert(cert_name, GRPC_ERROR_REF(error),
                                       GRPC_ERROR_REF(error));
         GRPC_ERROR_UNREF(error);


### PR DESCRIPTION
In the vast majority of cases where we call `GRPC_ERROR_CREATE_FROM_COPIED_STRING()`, we are constructing a C++ string, and then calling its `c_str()` method to create the error.  This API is not very ergonomic, because it requires calling `c_str()` all over the place.  It may also be slightly less efficient, since it requires reallocating the string and copying it.

To address this, I have added a `GRPC_ERROR_CREATE_FROM_CPP_STRING()` method, which takes ownership of the C++ string that you pass to it.  Under the hood, this uses `grpc_slice_from_cpp_string()`, which I added back in #23157.  (Note that this still makes a second allocation for the slice ref-count, so it winds up holding two different memory allocations for the lifetime of the slice, but there is no time during which the string is double-allocated, and it does not need to make a copy.)

I have also added a `GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING()` function to address the less pervasive but still common use-case where we want to use `GRPC_ERROR_CREATE_FROM_VECTOR()` but the string is a dynamically generated `std::string` instead of a static string.