### PR TITLE
Replace grpc_error* with grpc_error_handle

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -236,7 +236,7 @@ class RingHash : public LoadBalancingPolicy {
       }
 
      private:
-      static void RunInExecCtx(void* arg, grpc_error* /*error*/) {
+      static void RunInExecCtx(void* arg, grpc_error_handle /*error*/) {
         auto* self = static_cast<SubchannelConnectionAttempter*>(arg);
         self->ring_hash_lb_->work_serializer()->Run(
             [self]() {
@@ -730,7 +730,7 @@ class RingHashFactory : public LoadBalancingPolicyFactory {
   const char* name() const override { return kRingHash; }
 
   RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
-      const Json& json, grpc_error** error) const override {
+      const Json& json, grpc_error_handle* error) const override {
     size_t min_ring_size;
     size_t max_ring_size;
     std::vector<grpc_error_handle> error_list;

--- a/src/core/lib/iomgr/event_engine/endpoint.cc
+++ b/src/core/lib/iomgr/event_engine/endpoint.cc
@@ -96,12 +96,12 @@ void endpoint_delete_from_pollset_set(grpc_endpoint* /* ep */,
 /// and will return some kind of sane default (empty strings, nullptrs, etc). It
 /// is the caller's responsibility to ensure that calls to endpoint_shutdown are
 /// synchronized.
-void endpoint_shutdown(grpc_endpoint* ep, grpc_error* why) {
+void endpoint_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
   auto* eeep = reinterpret_cast<grpc_event_engine_endpoint*>(ep);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
-    const char* str = grpc_error_string(why);
+    std::string str = grpc_error_std_string(why);
     gpr_log(GPR_INFO, "TCP Endpoint %p shutdown why=%s", eeep->endpoint.get(),
-            str);
+            str.c_str());
   }
   eeep->endpoint.reset();
 }

--- a/src/core/lib/iomgr/event_engine/iomgr.cc
+++ b/src/core/lib/iomgr/event_engine/iomgr.cc
@@ -60,7 +60,7 @@ bool iomgr_platform_is_any_background_poller_thread(void) {
 }
 
 bool iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* /* closure */, grpc_error* /* error */) {
+    grpc_closure* /* closure */, grpc_error_handle /* error */) {
   return false;
 }
 

--- a/src/core/lib/iomgr/event_engine/pollset.cc
+++ b/src/core/lib/iomgr/event_engine/pollset.cc
@@ -40,15 +40,16 @@ void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
 }
 void pollset_destroy(grpc_pollset* pollset) {}
-grpc_error* pollset_work(grpc_pollset* pollset, grpc_pollset_worker** worker,
-                         grpc_millis deadline) {
+grpc_error_handle pollset_work(grpc_pollset* pollset,
+                               grpc_pollset_worker** worker,
+                               grpc_millis deadline) {
   (void)worker;
   gpr_cv_wait(&g_cv, &g_mu,
               grpc_millis_to_timespec(deadline, GPR_CLOCK_REALTIME));
   return GRPC_ERROR_NONE;
 }
-grpc_error* pollset_kick(grpc_pollset* pollset,
-                         grpc_pollset_worker* specific_worker) {
+grpc_error_handle pollset_kick(grpc_pollset* pollset,
+                               grpc_pollset_worker* specific_worker) {
   (void)pollset;
   (void)specific_worker;
   return GRPC_ERROR_NONE;

--- a/src/core/lib/iomgr/event_engine/resolver.cc
+++ b/src/core/lib/iomgr/event_engine/resolver.cc
@@ -93,8 +93,9 @@ void blocking_handle_async_resolve_done(void* arg, grpc_error_handle error) {
   static_cast<Promise<grpc_error_handle>*>(arg)->Set(std::move(error));
 }
 
-grpc_error* blocking_resolve_address(const char* name, const char* default_port,
-                                     grpc_resolved_addresses** addresses) {
+grpc_error_handle blocking_resolve_address(
+    const char* name, const char* default_port,
+    grpc_resolved_addresses** addresses) {
   grpc_closure on_done;
   Promise<grpc_error_handle> evt;
   GRPC_CLOSURE_INIT(&on_done, blocking_handle_async_resolve_done, &evt,

--- a/src/core/lib/iomgr/event_engine/tcp.cc
+++ b/src/core/lib/iomgr/event_engine/tcp.cc
@@ -164,7 +164,7 @@ void tcp_connect(grpc_closure* on_connect, grpc_endpoint** endpoint,
   }
 }
 
-grpc_error* tcp_server_create(
+grpc_error_handle tcp_server_create(
     grpc_closure* shutdown_complete, const grpc_channel_args* args,
     grpc_slice_allocator_factory* slice_allocator_factory,
     grpc_tcp_server** server) {
@@ -210,9 +210,9 @@ void tcp_server_start(grpc_tcp_server* server,
   GPR_ASSERT(server->listener->Start().ok());
 }
 
-grpc_error* tcp_server_add_port(grpc_tcp_server* s,
-                                const grpc_resolved_address* addr,
-                                int* out_port) {
+grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
+                                      const grpc_resolved_address* addr,
+                                      int* out_port) {
   EventEngine::ResolvedAddress ra(reinterpret_cast<const sockaddr*>(addr->addr),
                                   addr->len);
   auto port = s->listener->Bind(ra);

--- a/src/core/lib/iomgr/pollset_custom.cc
+++ b/src/core/lib/iomgr/pollset_custom.cc
@@ -76,7 +76,7 @@ static grpc_error_handle pollset_work(grpc_pollset* pollset,
   // control back to the application
   grpc_core::ExecCtx* curr = grpc_core::ExecCtx::Get();
   grpc_core::ExecCtx::Set(nullptr);
-  grpc_error* err = poller_vtable->poll(static_cast<size_t>(timeout));
+  grpc_error_handle err = poller_vtable->poll(static_cast<size_t>(timeout));
   grpc_core::ExecCtx::Set(curr);
   grpc_core::ExecCtx::Get()->InvalidateNow();
   if (grpc_core::ExecCtx::Get()->HasWork()) {

--- a/src/core/lib/iomgr/pollset_custom.h
+++ b/src/core/lib/iomgr/pollset_custom.h
@@ -27,7 +27,7 @@
 
 typedef struct grpc_custom_poller_vtable {
   void (*init)();
-  grpc_error* (*poll)(size_t timeout_ms);
+  grpc_error_handle (*poll)(size_t timeout_ms);
   void (*kick)();
   void (*shutdown)();
 } grpc_custom_poller_vtable;

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -702,4 +702,5 @@ cdef extern from "grpc/grpc_security_constants.h":
 
 
 cdef extern from "src/core/lib/iomgr/error.h":
+  ctypedef grpc_error* grpc_error_handle
   grpc_error_handle GRPC_ERROR_CANCELLED

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -702,4 +702,4 @@ cdef extern from "grpc/grpc_security_constants.h":
 
 
 cdef extern from "src/core/lib/iomgr/error.h":
-  const grpc_error* GRPC_ERROR_CANCELLED
+  grpc_error_handle GRPC_ERROR_CANCELLED

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
@@ -357,7 +357,7 @@ def _run_loop(timeout_ms):
     finally:
       g_event.clear()
 
-cdef grpc_error* run_loop(size_t timeout_ms) with gil:
+cdef grpc_error_handle run_loop(size_t timeout_ms) with gil:
   try:
     _run_loop(timeout_ms)
     return grpc_error_none()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
@@ -110,7 +110,7 @@ cdef extern from "src/core/lib/iomgr/timer_custom.h":
 cdef extern from "src/core/lib/iomgr/pollset_custom.h":
   struct grpc_custom_poller_vtable:
     void (*init)()
-    grpc_error* (*poll)(size_t timeout_ms)
+    grpc_error_handle (*poll)(size_t timeout_ms)
     void (*kick)()
     void (*shutdown)()
 

--- a/test/core/transport/chttp2/hpack_parser_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_test.cc
@@ -67,7 +67,8 @@ static void test_vector(grpc_core::HPackParser* parser,
     grpc_core::ExecCtx exec_ctx;
     auto err = parser->Parse(slices[i], i == nslices - 1);
     if (err != GRPC_ERROR_NONE) {
-      gpr_log(GPR_ERROR, "Unexpected parse error: %s", grpc_error_string(err));
+      gpr_log(GPR_ERROR, "Unexpected parse error: %s",
+              grpc_error_std_string(err).c_str());
       abort();
     }
   }

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -50,6 +50,8 @@ BANNED_EXCEPT = {
     'grpc_closure_sched(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_run(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_list_sched(': ['src/core/lib/iomgr/closure.cc'],
+    'grpc_error*': ['src/core/lib/iomgr/error.cc'],
+    'grpc_error_string': ['src/core/lib/iomgr/error.cc'],
 }
 
 errors = 0


### PR DESCRIPTION
gRPC started using `grpc_error_handle` only as part of `absl::Status` migration but some code got `grpc_error*` since there is no test forcing it. So this PR updates all source to use `grpc_error_handle` only and adds new test forcing this rule.