### PR TITLE
Add timeout parameter to TestingChannel.take_* methods

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/_channel/_channel.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_channel.py
@@ -71,17 +71,21 @@ class TestingChannel(grpc_testing.Channel):
     def close(self):
         self._close()
 
-    def take_unary_unary(self, method_descriptor):
-        return _channel_rpc.unary_unary(self._state, method_descriptor)
+    def take_unary_unary(self, method_descriptor, timeout=None):
+        '''Take a unary request and return a unary response.'''
+        return _channel_rpc.unary_unary(self._state, method_descriptor, timeout)
 
-    def take_unary_stream(self, method_descriptor):
-        return _channel_rpc.unary_stream(self._state, method_descriptor)
+    def take_unary_stream(self, method_descriptor, timeout=None):
+        '''Take a unary request and return a streaming response.'''
+        return _channel_rpc.unary_stream(self._state, method_descriptor, timeout)
 
-    def take_stream_unary(self, method_descriptor):
-        return _channel_rpc.stream_unary(self._state, method_descriptor)
+    def take_stream_unary(self, method_descriptor, timeout=None):
+        '''Take a streaming request and return a unary response.'''
+        return _channel_rpc.stream_unary(self._state, method_descriptor, timeout)
 
-    def take_stream_stream(self, method_descriptor):
-        return _channel_rpc.stream_stream(self._state, method_descriptor)
+    def take_stream_stream(self, method_descriptor, timeout=None):
+        '''Take a streaming request and return a streaming response.'''
+        return _channel_rpc.stream_stream(self._state, method_descriptor, timeout)
 
 
 # pylint: enable=unused-argument

--- a/src/python/grpcio_testing/grpc_testing/_channel/_channel_rpc.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_channel_rpc.py
@@ -95,25 +95,25 @@ class _StreamStream(grpc_testing.StreamStreamChannelRpc):
         self._rpc_state.terminate(trailing_metadata, code, details)
 
 
-def unary_unary(channel_state, method_descriptor):
-    rpc_state = channel_state.take_rpc_state(method_descriptor)
+def unary_unary(channel_state, method_descriptor, timeout):
+    rpc_state = channel_state.take_rpc_state(method_descriptor, timeout)
     invocation_metadata, request = (
         rpc_state.take_invocation_metadata_and_request())
     return invocation_metadata, request, _UnaryUnary(rpc_state)
 
 
-def unary_stream(channel_state, method_descriptor):
-    rpc_state = channel_state.take_rpc_state(method_descriptor)
+def unary_stream(channel_state, method_descriptor, timeout):
+    rpc_state = channel_state.take_rpc_state(method_descriptor, timeout)
     invocation_metadata, request = (
         rpc_state.take_invocation_metadata_and_request())
     return invocation_metadata, request, _UnaryStream(rpc_state)
 
 
-def stream_unary(channel_state, method_descriptor):
-    rpc_state = channel_state.take_rpc_state(method_descriptor)
+def stream_unary(channel_state, method_descriptor, timeout):
+    rpc_state = channel_state.take_rpc_state(method_descriptor, timeout)
     return rpc_state.take_invocation_metadata(), _StreamUnary(rpc_state)
 
 
-def stream_stream(channel_state, method_descriptor):
-    rpc_state = channel_state.take_rpc_state(method_descriptor)
+def stream_stream(channel_state, method_descriptor, timeout):
+    rpc_state = channel_state.take_rpc_state(method_descriptor, timeout)
     return rpc_state.take_invocation_metadata(), _StreamStream(rpc_state)

--- a/src/python/grpcio_testing/grpc_testing/_channel/_channel_state.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_channel_state.py
@@ -34,7 +34,7 @@ class State(_common.ChannelHandler):
             self._condition.notify_all()
         return rpc_state
 
-    def take_rpc_state(self, method_descriptor):
+    def take_rpc_state(self, method_descriptor, timeout):
         method_full_rpc_name = '/{}/{}'.format(
             method_descriptor.containing_service.full_name,
             method_descriptor.name)
@@ -44,4 +44,5 @@ class State(_common.ChannelHandler):
                 if method_rpc_states:
                     return method_rpc_states.pop(0)
                 else:
-                    self._condition.wait()
+                    if not self._condition.wait(timeout=timeout):
+                        raise Exception("Timeout while waiting for rpc.")

--- a/src/python/grpcio_testing/grpc_testing/_channel/_channel_state.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_channel_state.py
@@ -19,6 +19,10 @@ from grpc_testing import _common
 from grpc_testing._channel import _rpc_state
 
 
+class TimeoutException(Exception):
+    pass
+
+
 class State(_common.ChannelHandler):
 
     def __init__(self):
@@ -45,4 +49,4 @@ class State(_common.ChannelHandler):
                     return method_rpc_states.pop(0)
                 else:
                     if not self._condition.wait(timeout=timeout):
-                        raise Exception("Timeout while waiting for rpc.")
+                        raise TimeoutException("Timeout while waiting for rpc.")


### PR DESCRIPTION
Added a timeout parameter to the take_* methods in TestingChannel so unit tests don't hang if the client never sends the request to the dummy server.

Also added a brief docstrings to the take_* functions as well.

@drfloob
