### PR TITLE
pass URI string to resolver impls

### DIFF
--- a/src/core/ext/filters/client_channel/resolver_factory.h
+++ b/src/core/ext/filters/client_channel/resolver_factory.h
@@ -36,6 +36,8 @@ namespace grpc_core {
 struct ResolverArgs {
   /// The parsed URI to resolve.
   URI uri;
+  /// The URI string.
+  std::string uri_string;
   /// Channel args to be included in resolver results.
   const grpc_channel_args* args = nullptr;
   /// Used to drive I/O in the name resolution process.


### PR DESCRIPTION
We were already passing the parsed URI, but now we pass along the URI string as well.