### PR TITLE
LameClient ready for absl::Status

### DIFF
--- a/src/core/ext/filters/client_channel/dynamic_filters.cc
+++ b/src/core/ext/filters/client_channel/dynamic_filters.cc
@@ -163,10 +163,16 @@ RefCountedPtr<DynamicFilters> DynamicFilters::Create(
     // Channel stack creation failed with requested filters.
     // Create with lame filter instead.
     grpc_error_handle error = p.second;
-    grpc_arg error_arg = MakeLameClientErrorArg(error);
+    grpc_error_handle* error_ptr = nullptr;
+    if (error != GRPC_ERROR_NONE) {
+      error_ptr = new grpc_error_handle();
+      *error_ptr = error;
+    }
+    grpc_arg error_arg = MakeLameClientErrorArg(error_ptr);
     grpc_channel_args* new_args =
         grpc_channel_args_copy_and_add(args, &error_arg, 1);
     GRPC_ERROR_UNREF(error);
+    delete error_ptr;
     p = CreateChannelStack(new_args, {&grpc_lame_filter});
     GPR_ASSERT(p.second == GRPC_ERROR_NONE);
     grpc_channel_args_destroy(new_args);

--- a/src/core/ext/filters/client_channel/dynamic_filters.cc
+++ b/src/core/ext/filters/client_channel/dynamic_filters.cc
@@ -163,16 +163,10 @@ RefCountedPtr<DynamicFilters> DynamicFilters::Create(
     // Channel stack creation failed with requested filters.
     // Create with lame filter instead.
     grpc_error_handle error = p.second;
-    grpc_error_handle* error_ptr = nullptr;
-    if (error != GRPC_ERROR_NONE) {
-      error_ptr = new grpc_error_handle();
-      *error_ptr = error;
-    }
-    grpc_arg error_arg = MakeLameClientErrorArg(error_ptr);
+    grpc_arg error_arg = MakeLameClientErrorArg(&error);
     grpc_channel_args* new_args =
         grpc_channel_args_copy_and_add(args, &error_arg, 1);
     GRPC_ERROR_UNREF(error);
-    delete error_ptr;
     p = CreateChannelStack(new_args, {&grpc_lame_filter});
     GPR_ASSERT(p.second == GRPC_ERROR_NONE);
     grpc_channel_args_destroy(new_args);

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -45,9 +45,9 @@ namespace {
 struct ChannelData {
   explicit ChannelData(grpc_channel_element_args* args)
       : state_tracker("lame_channel", GRPC_CHANNEL_SHUTDOWN) {
-    grpc_error_handle err = grpc_channel_args_find_pointer<grpc_error>(
+    grpc_error_handle* err = grpc_channel_args_find_pointer<grpc_error_handle>(
         args->channel_args, GRPC_ARG_LAME_FILTER_ERROR);
-    if (err != nullptr) error = GRPC_ERROR_REF(err);
+    if (err != nullptr) error = GRPC_ERROR_REF(*err);
   }
 
   ~ChannelData() { GRPC_ERROR_UNREF(error); }
@@ -125,12 +125,20 @@ static void lame_destroy_channel_elem(grpc_channel_element* elem) {
 
 // Channel arg vtable for a grpc_error_handle.
 void* ErrorCopy(void* p) {
-  grpc_error_handle error = static_cast<grpc_error_handle>(p);
-  return GRPC_ERROR_REF(error);
+  grpc_error_handle* new_error = nullptr;
+  if (p != nullptr) {
+    grpc_error_handle* error = static_cast<grpc_error_handle*>(p);
+    new_error = new grpc_error_handle();
+    *new_error = GRPC_ERROR_REF(*error);
+  }
+  return new_error;
 }
 void ErrorDestroy(void* p) {
-  grpc_error_handle error = static_cast<grpc_error_handle>(p);
-  GRPC_ERROR_UNREF(error);
+  if (p != nullptr) {
+    grpc_error_handle* error = static_cast<grpc_error_handle*>(p);
+    GRPC_ERROR_UNREF(*error);
+    delete error;
+  }
 }
 int ErrorCompare(void* p, void* q) { return GPR_ICMP(p, q); }
 const grpc_arg_pointer_vtable kLameFilterErrorArgVtable = {
@@ -138,7 +146,7 @@ const grpc_arg_pointer_vtable kLameFilterErrorArgVtable = {
 
 }  // namespace
 
-grpc_arg MakeLameClientErrorArg(grpc_error_handle error) {
+grpc_arg MakeLameClientErrorArg(grpc_error_handle* error) {
   return grpc_channel_arg_pointer_create(
       const_cast<char*>(GRPC_ARG_LAME_FILTER_ERROR), error,
       &kLameFilterErrorArgVtable);
@@ -176,10 +184,16 @@ grpc_channel* grpc_lame_client_channel_create(const char* target,
           GRPC_ERROR_INT_GRPC_STATUS, error_code),
       GRPC_ERROR_STR_GRPC_MESSAGE,
       grpc_slice_from_static_string(error_message));
-  grpc_arg error_arg = grpc_core::MakeLameClientErrorArg(error);
+  grpc_error_handle* error_ptr = nullptr;
+  if (error != GRPC_ERROR_NONE) {
+    error_ptr = new grpc_error_handle();
+    *error_ptr = error;
+  }
+  grpc_arg error_arg = grpc_core::MakeLameClientErrorArg(error_ptr);
   grpc_channel_args args = {1, &error_arg};
   grpc_channel* channel = grpc_channel_create(
       target, &args, GRPC_CLIENT_LAME_CHANNEL, nullptr, nullptr, 0, nullptr);
   GRPC_ERROR_UNREF(error);
+  delete error_ptr;
   return channel;
 }

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -184,16 +184,10 @@ grpc_channel* grpc_lame_client_channel_create(const char* target,
           GRPC_ERROR_INT_GRPC_STATUS, error_code),
       GRPC_ERROR_STR_GRPC_MESSAGE,
       grpc_slice_from_static_string(error_message));
-  grpc_error_handle* error_ptr = nullptr;
-  if (error != GRPC_ERROR_NONE) {
-    error_ptr = new grpc_error_handle();
-    *error_ptr = error;
-  }
-  grpc_arg error_arg = grpc_core::MakeLameClientErrorArg(error_ptr);
+  grpc_arg error_arg = grpc_core::MakeLameClientErrorArg(&error);
   grpc_channel_args args = {1, &error_arg};
   grpc_channel* channel = grpc_channel_create(
       target, &args, GRPC_CLIENT_LAME_CHANNEL, nullptr, nullptr, 0, nullptr);
   GRPC_ERROR_UNREF(error);
-  delete error_ptr;
   return channel;
 }

--- a/src/core/lib/surface/lame_client.h
+++ b/src/core/lib/surface/lame_client.h
@@ -25,7 +25,7 @@
 
 namespace grpc_core {
 // Does NOT take ownership of error.
-grpc_arg MakeLameClientErrorArg(grpc_error_handle error);
+grpc_arg MakeLameClientErrorArg(grpc_error_handle* error);
 }  // namespace grpc_core
 
 extern const grpc_channel_filter grpc_lame_filter;


### PR DESCRIPTION
Instead of storing the pointer of `grpc_error` (which is not feasible for `absl::Status`) in the channel-arg, `grpc_error_handle*` is to be stored to support `absl::Status` case.