### PR TITLE
[binder] Clean up parcel interfaces

### DIFF
--- a/src/core/ext/transport/binder/server/binder_server.cc
+++ b/src/core/ext/transport/binder/server/binder_server.cc
@@ -98,10 +98,10 @@ class BinderServerListener : public Server::ListenerInterface {
 
   void Start(Server* /*server*/,
              const std::vector<grpc_pollset*>* /*pollsets*/) override {
-    tx_receiver_ = factory_([this](transaction_code_t code,
-                                   const grpc_binder::ReadableParcel* parcel) {
-      return OnSetupTransport(code, parcel);
-    });
+    tx_receiver_ = factory_(
+        [this](transaction_code_t code, grpc_binder::ReadableParcel* parcel) {
+          return OnSetupTransport(code, parcel);
+        });
     endpoint_binder_ = tx_receiver_->GetRawBinder();
     grpc_add_endpoint_binder(addr_, endpoint_binder_);
   }
@@ -127,7 +127,7 @@ class BinderServerListener : public Server::ListenerInterface {
 
  private:
   absl::Status OnSetupTransport(transaction_code_t code,
-                                const grpc_binder::ReadableParcel* parcel) {
+                                grpc_binder::ReadableParcel* parcel) {
     grpc_core::ExecCtx exec_ctx;
     if (grpc_binder::BinderTransportTxCode(code) !=
         grpc_binder::BinderTransportTxCode::SETUP_TRANSPORT) {

--- a/src/core/ext/transport/binder/wire_format/binder.h
+++ b/src/core/ext/transport/binder/wire_format/binder.h
@@ -44,9 +44,7 @@ class Binder;
 class WritableParcel {
  public:
   virtual ~WritableParcel() = default;
-  virtual int32_t GetDataPosition() const = 0;
   virtual int32_t GetDataSize() const = 0;
-  virtual absl::Status SetDataPosition(int32_t pos) = 0;
   virtual absl::Status WriteInt32(int32_t data) = 0;
   virtual absl::Status WriteInt64(int64_t data) = 0;
   virtual absl::Status WriteBinder(HasRawBinder* binder) = 0;
@@ -69,18 +67,17 @@ class ReadableParcel {
  public:
   virtual ~ReadableParcel() = default;
   virtual int32_t GetDataSize() const = 0;
-  virtual absl::Status ReadInt32(int32_t* data) const = 0;
-  virtual absl::Status ReadInt64(int64_t* data) const = 0;
-  virtual absl::Status ReadBinder(std::unique_ptr<Binder>* data) const = 0;
-  // TODO(waynetu): Provide better interfaces.
-  virtual absl::Status ReadByteArray(std::string* data) const = 0;
-  virtual absl::Status ReadString(std::string* str) const = 0;
+  virtual absl::Status ReadInt32(int32_t* data) = 0;
+  virtual absl::Status ReadInt64(int64_t* data) = 0;
+  virtual absl::Status ReadBinder(std::unique_ptr<Binder>* data) = 0;
+  virtual absl::Status ReadByteArray(std::string* data) = 0;
+  virtual absl::Status ReadString(std::string* str) = 0;
 };
 
 class TransactionReceiver : public HasRawBinder {
  public:
   using OnTransactCb =
-      std::function<absl::Status(transaction_code_t, const ReadableParcel*)>;
+      std::function<absl::Status(transaction_code_t, ReadableParcel*)>;
 
   ~TransactionReceiver() override = default;
 };
@@ -96,7 +93,6 @@ class Binder : public HasRawBinder {
   virtual absl::Status Transact(BinderTransportTxCode tx_code) = 0;
 
   virtual WritableParcel* GetWritableParcel() const = 0;
-  virtual ReadableParcel* GetReadableParcel() const = 0;
 
   // TODO(waynetu): Can we decouple the receiver from the binder?
   virtual std::unique_ptr<TransactionReceiver> ConstructTxReceiver(

--- a/src/core/ext/transport/binder/wire_format/binder_android.h
+++ b/src/core/ext/transport/binder/wire_format/binder_android.h
@@ -44,9 +44,7 @@ class WritableParcelAndroid final : public WritableParcel {
   explicit WritableParcelAndroid(AParcel* parcel) : parcel_(parcel) {}
   ~WritableParcelAndroid() override = default;
 
-  int32_t GetDataPosition() const override;
   int32_t GetDataSize() const override;
-  absl::Status SetDataPosition(int32_t pos) override;
   absl::Status WriteInt32(int32_t data) override;
   absl::Status WriteInt64(int64_t data) override;
   absl::Status WriteBinder(HasRawBinder* binder) override;
@@ -63,19 +61,18 @@ class ReadableParcelAndroid final : public ReadableParcel {
  public:
   ReadableParcelAndroid() = default;
   // TODO(waynetu): Get rid of the const_cast.
-  explicit ReadableParcelAndroid(const AParcel* parcel)
-      : parcel_(const_cast<AParcel*>(parcel)) {}
+  explicit ReadableParcelAndroid(const AParcel* parcel) : parcel_(parcel) {}
   ~ReadableParcelAndroid() override = default;
 
   int32_t GetDataSize() const override;
-  absl::Status ReadInt32(int32_t* data) const override;
-  absl::Status ReadInt64(int64_t* data) const override;
-  absl::Status ReadBinder(std::unique_ptr<Binder>* data) const override;
-  absl::Status ReadByteArray(std::string* data) const override;
-  absl::Status ReadString(std::string* str) const override;
+  absl::Status ReadInt32(int32_t* data) override;
+  absl::Status ReadInt64(int64_t* data) override;
+  absl::Status ReadBinder(std::unique_ptr<Binder>* data) override;
+  absl::Status ReadByteArray(std::string* data) override;
+  absl::Status ReadString(std::string* str) override;
 
  private:
-  AParcel* parcel_ = nullptr;
+  const AParcel* parcel_ = nullptr;
 
   friend class BinderAndroid;
 };
@@ -84,8 +81,7 @@ class BinderAndroid final : public Binder {
  public:
   explicit BinderAndroid(ndk::SpAIBinder binder)
       : binder_(binder),
-        input_parcel_(absl::make_unique<WritableParcelAndroid>()),
-        output_parcel_(absl::make_unique<ReadableParcelAndroid>()) {}
+        input_parcel_(absl::make_unique<WritableParcelAndroid>()) {}
   ~BinderAndroid() override = default;
 
   void* GetRawBinder() override { return binder_.get(); }
@@ -97,9 +93,6 @@ class BinderAndroid final : public Binder {
   WritableParcel* GetWritableParcel() const override {
     return input_parcel_.get();
   }
-  ReadableParcel* GetReadableParcel() const override {
-    return output_parcel_.get();
-  };
 
   std::unique_ptr<TransactionReceiver> ConstructTxReceiver(
       grpc_core::RefCountedPtr<WireReader> wire_reader_ref,
@@ -108,7 +101,6 @@ class BinderAndroid final : public Binder {
  private:
   ndk::SpAIBinder binder_;
   std::unique_ptr<WritableParcelAndroid> input_parcel_;
-  std::unique_ptr<ReadableParcelAndroid> output_parcel_;
 };
 
 class TransactionReceiverAndroid final : public TransactionReceiver {

--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.h
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.h
@@ -67,7 +67,7 @@ class WireReaderImpl : public WireReader {
       std::unique_ptr<Binder> binder) override;
 
   absl::Status ProcessTransaction(transaction_code_t code,
-                                  const ReadableParcel* parcel);
+                                  ReadableParcel* parcel);
 
   /// Send SETUP_TRANSPORT request through \p binder.
   ///
@@ -93,9 +93,9 @@ class WireReaderImpl : public WireReader {
 
  private:
   absl::Status ProcessStreamingTransaction(transaction_code_t code,
-                                           const ReadableParcel* parcel);
+                                           ReadableParcel* parcel);
   absl::Status ProcessStreamingTransactionImpl(transaction_code_t code,
-                                               const ReadableParcel* parcel,
+                                               ReadableParcel* parcel,
                                                int* cancellation_flags)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 

--- a/test/core/transport/binder/end2end/fake_binder.cc
+++ b/test/core/transport/binder/end2end/fake_binder.cc
@@ -24,59 +24,42 @@ namespace end2end_testing {
 
 TransactionProcessor* g_transaction_processor = nullptr;
 
-FakeWritableParcel::FakeWritableParcel() : data_(1) {}
-
-int32_t FakeWritableParcel::GetDataPosition() const { return data_position_; }
-
 int32_t FakeWritableParcel::GetDataSize() const { return data_size_; }
 
-absl::Status FakeWritableParcel::SetDataPosition(int32_t pos) {
-  if (data_.size() < static_cast<size_t>(pos) + 1) {
-    data_.resize(pos + 1);
-  }
-  data_position_ = pos;
-  return absl::OkStatus();
-}
-
 absl::Status FakeWritableParcel::WriteInt32(int32_t data) {
-  data_[data_position_] = data;
-  SetDataPosition(data_position_ + 1).IgnoreError();
-  data_size_ += 4;
+  data_.push_back(data);
+  data_size_ += sizeof(int32_t);
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteInt64(int64_t data) {
-  data_[data_position_] = data;
-  SetDataPosition(data_position_ + 1).IgnoreError();
-  data_size_ += 8;
+  data_.push_back(data);
+  data_size_ += sizeof(int64_t);
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteBinder(HasRawBinder* binder) {
-  data_[data_position_] = binder->GetRawBinder();
-  SetDataPosition(data_position_ + 1).IgnoreError();
-  data_size_ += 8;
+  data_.push_back(binder->GetRawBinder());
+  data_size_ += sizeof(void*);
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteString(absl::string_view s) {
-  data_[data_position_] = std::string(s);
-  SetDataPosition(data_position_ + 1).IgnoreError();
+  data_.push_back(std::string(s));
   data_size_ += s.size();
   return absl::OkStatus();
 }
 
 absl::Status FakeWritableParcel::WriteByteArray(const int8_t* buffer,
                                                 int32_t length) {
-  data_[data_position_] = std::vector<int8_t>(buffer, buffer + length);
-  SetDataPosition(data_position_ + 1).IgnoreError();
+  data_.push_back(std::vector<int8_t>(buffer, buffer + length));
   data_size_ += length;
   return absl::OkStatus();
 }
 
 int32_t FakeReadableParcel::GetDataSize() const { return data_size_; }
 
-absl::Status FakeReadableParcel::ReadInt32(int32_t* data) const {
+absl::Status FakeReadableParcel::ReadInt32(int32_t* data) {
   if (data_position_ >= data_.size() ||
       !absl::holds_alternative<int32_t>(data_[data_position_])) {
     return absl::InternalError("ReadInt32 failed");
@@ -85,7 +68,7 @@ absl::Status FakeReadableParcel::ReadInt32(int32_t* data) const {
   return absl::OkStatus();
 }
 
-absl::Status FakeReadableParcel::ReadInt64(int64_t* data) const {
+absl::Status FakeReadableParcel::ReadInt64(int64_t* data) {
   if (data_position_ >= data_.size() ||
       !absl::holds_alternative<int64_t>(data_[data_position_])) {
     return absl::InternalError("ReadInt64 failed");
@@ -94,8 +77,7 @@ absl::Status FakeReadableParcel::ReadInt64(int64_t* data) const {
   return absl::OkStatus();
 }
 
-absl::Status FakeReadableParcel::ReadBinder(
-    std::unique_ptr<Binder>* data) const {
+absl::Status FakeReadableParcel::ReadBinder(std::unique_ptr<Binder>* data) {
   if (data_position_ >= data_.size() ||
       !absl::holds_alternative<void*>(data_[data_position_])) {
     return absl::InternalError("ReadBinder failed");
@@ -106,7 +88,7 @@ absl::Status FakeReadableParcel::ReadBinder(
   return absl::OkStatus();
 }
 
-absl::Status FakeReadableParcel::ReadString(std::string* str) const {
+absl::Status FakeReadableParcel::ReadString(std::string* str) {
   if (data_position_ >= data_.size() ||
       !absl::holds_alternative<std::string>(data_[data_position_])) {
     return absl::InternalError("ReadString failed");
@@ -115,7 +97,7 @@ absl::Status FakeReadableParcel::ReadString(std::string* str) const {
   return absl::OkStatus();
 }
 
-absl::Status FakeReadableParcel::ReadByteArray(std::string* data) const {
+absl::Status FakeReadableParcel::ReadByteArray(std::string* data) {
   if (data_position_ >= data_.size() ||
       !absl::holds_alternative<std::vector<int8_t>>(data_[data_position_])) {
     return absl::InternalError("ReadByteArray failed");

--- a/test/core/transport/binder/end2end/fake_binder_test.cc
+++ b/test/core/transport/binder/end2end/fake_binder_test.cc
@@ -29,29 +29,6 @@
 
 namespace grpc_binder {
 namespace end2end_testing {
-
-TEST(FakeBinderTestWithoutTransaction, WritableParcelDataPosition) {
-  std::unique_ptr<WritableParcel> parcel =
-      absl::make_unique<FakeWritableParcel>();
-  EXPECT_EQ(parcel->GetDataPosition(), 0);
-  EXPECT_TRUE(parcel->WriteInt32(0).ok());
-  EXPECT_EQ(parcel->GetDataPosition(), 1);
-  EXPECT_TRUE(parcel->WriteInt32(1).ok());
-  EXPECT_TRUE(parcel->WriteInt32(2).ok());
-  EXPECT_EQ(parcel->GetDataPosition(), 3);
-  EXPECT_TRUE(parcel->WriteString("").ok());
-  EXPECT_EQ(parcel->GetDataPosition(), 4);
-  EXPECT_TRUE(parcel->SetDataPosition(0).ok());
-  const char kBuffer[] = "test";
-  EXPECT_TRUE(parcel
-                  ->WriteByteArray(reinterpret_cast<const int8_t*>(kBuffer),
-                                   strlen(kBuffer))
-                  .ok());
-  EXPECT_EQ(parcel->GetDataPosition(), 1);
-  EXPECT_TRUE(parcel->SetDataPosition(100).ok());
-  EXPECT_EQ(parcel->GetDataPosition(), 100);
-}
-
 namespace {
 
 class FakeBinderTest : public ::testing::TestWithParam<absl::Duration> {
@@ -70,8 +47,8 @@ TEST_P(FakeBinderTest, SendInt32) {
   int called = 0;
   std::unique_ptr<Binder> sender;
   std::unique_ptr<TransactionReceiver> tx_receiver;
-  std::tie(sender, tx_receiver) = NewBinderPair(
-      [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+  std::tie(sender, tx_receiver) =
+      NewBinderPair([&](transaction_code_t tx_code, ReadableParcel* parcel) {
         EXPECT_EQ(tx_code, kTxCode);
         int value = 0;
         EXPECT_TRUE(parcel->ReadInt32(&value).ok());
@@ -95,8 +72,8 @@ TEST_P(FakeBinderTest, SendString) {
   int called = 0;
   std::unique_ptr<Binder> sender;
   std::unique_ptr<TransactionReceiver> tx_receiver;
-  std::tie(sender, tx_receiver) = NewBinderPair(
-      [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+  std::tie(sender, tx_receiver) =
+      NewBinderPair([&](transaction_code_t tx_code, ReadableParcel* parcel) {
         EXPECT_EQ(tx_code, kTxCode);
         std::string value;
         EXPECT_TRUE(parcel->ReadString(&value).ok());
@@ -120,8 +97,8 @@ TEST_P(FakeBinderTest, SendByteArray) {
   int called = 0;
   std::unique_ptr<Binder> sender;
   std::unique_ptr<TransactionReceiver> tx_receiver;
-  std::tie(sender, tx_receiver) = NewBinderPair(
-      [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+  std::tie(sender, tx_receiver) =
+      NewBinderPair([&](transaction_code_t tx_code, ReadableParcel* parcel) {
         EXPECT_EQ(tx_code, kTxCode);
         std::string value;
         EXPECT_TRUE(parcel->ReadByteArray(&value).ok());
@@ -150,8 +127,8 @@ TEST_P(FakeBinderTest, SendMultipleItems) {
   int called = 0;
   std::unique_ptr<Binder> sender;
   std::unique_ptr<TransactionReceiver> tx_receiver;
-  std::tie(sender, tx_receiver) = NewBinderPair(
-      [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+  std::tie(sender, tx_receiver) =
+      NewBinderPair([&](transaction_code_t tx_code, ReadableParcel* parcel) {
         int value_result;
         EXPECT_EQ(tx_code, kTxCode);
         EXPECT_TRUE(parcel->ReadInt32(&value_result).ok());
@@ -186,8 +163,8 @@ TEST_P(FakeBinderTest, SendBinder) {
   int called = 0;
   std::unique_ptr<Binder> sender;
   std::unique_ptr<TransactionReceiver> tx_receiver;
-  std::tie(sender, tx_receiver) = NewBinderPair(
-      [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+  std::tie(sender, tx_receiver) =
+      NewBinderPair([&](transaction_code_t tx_code, ReadableParcel* parcel) {
         EXPECT_EQ(tx_code, kTxCode);
         std::unique_ptr<Binder> binder;
         EXPECT_TRUE(parcel->ReadBinder(&binder).ok());
@@ -202,8 +179,7 @@ TEST_P(FakeBinderTest, SendBinder) {
   int called2 = 0;
   std::unique_ptr<TransactionReceiver> tx_receiver2 =
       absl::make_unique<FakeTransactionReceiver>(
-          nullptr,
-          [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+          nullptr, [&](transaction_code_t tx_code, ReadableParcel* parcel) {
             int value;
             EXPECT_TRUE(parcel->ReadInt32(&value).ok());
             EXPECT_EQ(value, kValue);
@@ -228,8 +204,8 @@ TEST_P(FakeBinderTest, SendTransactionAfterDestruction) {
   int called = 0;
   {
     std::unique_ptr<TransactionReceiver> tx_receiver;
-    std::tie(sender, tx_receiver) = NewBinderPair(
-        [&](transaction_code_t tx_code, const ReadableParcel* parcel) {
+    std::tie(sender, tx_receiver) =
+        NewBinderPair([&](transaction_code_t tx_code, ReadableParcel* parcel) {
           EXPECT_EQ(tx_code, kTxCode);
           int value;
           EXPECT_TRUE(parcel->ReadInt32(&value).ok());
@@ -299,10 +275,9 @@ TEST_P(FakeBinderTest, StressTest) {
       std::unique_ptr<TransactionReceiver> tx_receiver;
       int expected_tx_code = th_arg->tx_code;
       std::vector<std::vector<int>>* cnt = th_arg->global_cnts;
-      std::tie(binder, tx_receiver) =
-          NewBinderPair([tid, p, cnt, expected_tx_code](
-                            transaction_code_t tx_code,
-                            const ReadableParcel* parcel) mutable {
+      std::tie(binder, tx_receiver) = NewBinderPair(
+          [tid, p, cnt, expected_tx_code](transaction_code_t tx_code,
+                                          ReadableParcel* parcel) mutable {
             EXPECT_EQ(tx_code, expected_tx_code);
             int value;
             EXPECT_TRUE(parcel->ReadInt32(&value).ok());

--- a/test/core/transport/binder/end2end/testing_channel_create.cc
+++ b/test/core/transport/binder/end2end/testing_channel_create.cc
@@ -35,7 +35,7 @@ class ServerSetupTransportHelper {
       : wire_reader_(absl::make_unique<WireReaderImpl>(
             /*transport_stream_receiver=*/nullptr, /*is_client=*/false)) {
     std::tie(endpoint_binder_, tx_receiver_) = NewBinderPair(
-        [this](transaction_code_t tx_code, const ReadableParcel* parcel) {
+        [this](transaction_code_t tx_code, ReadableParcel* parcel) {
           return this->wire_reader_->ProcessTransaction(tx_code, parcel);
         });
   }

--- a/test/core/transport/binder/mock_objects.cc
+++ b/test/core/transport/binder/mock_objects.cc
@@ -33,7 +33,6 @@ MockReadableParcel::MockReadableParcel() {
 }
 
 MockWritableParcel::MockWritableParcel() {
-  ON_CALL(*this, SetDataPosition).WillByDefault(Return(absl::OkStatus()));
   ON_CALL(*this, WriteInt32).WillByDefault(Return(absl::OkStatus()));
   ON_CALL(*this, WriteBinder).WillByDefault(Return(absl::OkStatus()));
   ON_CALL(*this, WriteString).WillByDefault(Return(absl::OkStatus()));
@@ -44,7 +43,6 @@ MockBinder::MockBinder() {
   ON_CALL(*this, PrepareTransaction).WillByDefault(Return(absl::OkStatus()));
   ON_CALL(*this, Transact).WillByDefault(Return(absl::OkStatus()));
   ON_CALL(*this, GetWritableParcel).WillByDefault(Return(&mock_input_));
-  ON_CALL(*this, GetReadableParcel).WillByDefault(Return(&mock_output_));
   ON_CALL(*this, ConstructTxReceiver)
       .WillByDefault(
           [this](grpc_core::RefCountedPtr<WireReader> /*wire_reader_ref*/,

--- a/test/core/transport/binder/mock_objects.h
+++ b/test/core/transport/binder/mock_objects.h
@@ -26,9 +26,7 @@ namespace grpc_binder {
 
 class MockWritableParcel : public WritableParcel {
  public:
-  MOCK_METHOD(int32_t, GetDataPosition, (), (const, override));
   MOCK_METHOD(int32_t, GetDataSize, (), (const, override));
-  MOCK_METHOD(absl::Status, SetDataPosition, (int32_t), (override));
   MOCK_METHOD(absl::Status, WriteInt32, (int32_t), (override));
   MOCK_METHOD(absl::Status, WriteInt64, (int64_t), (override));
   MOCK_METHOD(absl::Status, WriteBinder, (HasRawBinder*), (override));
@@ -42,12 +40,11 @@ class MockWritableParcel : public WritableParcel {
 class MockReadableParcel : public ReadableParcel {
  public:
   MOCK_METHOD(int32_t, GetDataSize, (), (const, override));
-  MOCK_METHOD(absl::Status, ReadInt32, (int32_t*), (const, override));
-  MOCK_METHOD(absl::Status, ReadInt64, (int64_t*), (const, override));
-  MOCK_METHOD(absl::Status, ReadBinder, (std::unique_ptr<Binder>*),
-              (const, override));
-  MOCK_METHOD(absl::Status, ReadByteArray, (std::string*), (const, override));
-  MOCK_METHOD(absl::Status, ReadString, (std::string*), (const, override));
+  MOCK_METHOD(absl::Status, ReadInt32, (int32_t*), (override));
+  MOCK_METHOD(absl::Status, ReadInt64, (int64_t*), (override));
+  MOCK_METHOD(absl::Status, ReadBinder, (std::unique_ptr<Binder>*), (override));
+  MOCK_METHOD(absl::Status, ReadByteArray, (std::string*), (override));
+  MOCK_METHOD(absl::Status, ReadString, (std::string*), (override));
 
   MockReadableParcel();
 };
@@ -58,7 +55,6 @@ class MockBinder : public Binder {
   MOCK_METHOD(absl::Status, PrepareTransaction, (), (override));
   MOCK_METHOD(absl::Status, Transact, (BinderTransportTxCode), (override));
   MOCK_METHOD(WritableParcel*, GetWritableParcel, (), (const, override));
-  MOCK_METHOD(ReadableParcel*, GetReadableParcel, (), (const, override));
   MOCK_METHOD(std::unique_ptr<TransactionReceiver>, ConstructTxReceiver,
               (grpc_core::RefCountedPtr<WireReader>,
                TransactionReceiver::OnTransactCb),
@@ -80,7 +76,7 @@ class MockTransactionReceiver : public TransactionReceiver {
  public:
   explicit MockTransactionReceiver(OnTransactCb transact_cb,
                                    BinderTransportTxCode code,
-                                   const ReadableParcel* output) {
+                                   ReadableParcel* output) {
     transact_cb(static_cast<transaction_code_t>(code), output).IgnoreError();
   }
 


### PR DESCRIPTION
Some changes:

* `OnTransactCb` now takes a non-const `ReadableParcel*` so that testing
  codes no longer have to rely on `mutable`.
* Remove `GetReadableParcel()` interface from binder since we only send
  one-way transaction and the output (readable) parcel is never used.
* Remove `GetDataPosition()` / `SetDataPosition()` interfaces since they are
  both unused.