### PR TITLE
Add retry example for Ruby

### DIFF
--- a/examples/ruby/retry/README.md
+++ b/examples/ruby/retry/README.md
@@ -1,0 +1,35 @@
+# Retry Example in gRPC Ruby
+
+## Prerequisite
+
+* grpcio >= 1.39.0
+* grpcio-tools >= 1.39.0
+
+## Running the example
+
+In terminal 1, start the flaky server:
+
+```sh
+ruby flaky_server.rb
+```
+
+In terminal 2, start the retry client:
+
+```sh
+ruby retry_client.rb
+```
+
+## Expect results
+
+The client RPC will succeed, even with server injecting multiple errors. Here is an example server log:
+
+```sh
+$ ruby flaky_server.rb
+INFO: Injecting error to RPC from ipv4:127.0.0.1:60076
+INFO: Injecting error to RPC from ipv4:127.0.0.1:60076
+INFO: Injecting error to RPC from ipv4:127.0.0.1:60076
+INFO: Injecting error to RPC from ipv4:127.0.0.1:60076
+INFO: Successfully responding to RPC from ipv4:127.0.0.1:60076
+INFO: Injecting error to RPC from ipv4:127.0.0.1:60078
+INFO: Successfully responding to RPC from ipv4:127.0.0.1:60078
+```

--- a/examples/ruby/retry/flaky_server.rb
+++ b/examples/ruby/retry/flaky_server.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sample gRPC server that implements the Greeter::Helloworld service.
+#
+# Usage: $ path/to/flaky_server.rb
+
+this_dir = File.expand_path(File.dirname(__FILE__))
+lib_dir = File.join(File.dirname(this_dir), 'lib')
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+
+require 'logger'
+
+require 'grpc'
+require 'helloworld_services_pb'
+
+# GreeterServer is simple server that implements the Helloworld Greeter server.
+class GreeterServer < Helloworld::Greeter::Service
+  # say_hello implements the SayHello rpc method.
+  def say_hello(hello_req, call)
+    logger = Logger.new($stdout)
+
+    if rand < 0.75
+      logger.info("Injecting error to RPC from #{call.peer}")
+      raise GRPC::Unavailable, 'injected_error'
+    end
+
+    logger.info("Successfully responding to RPC from #{call.peer}")
+
+    Helloworld::HelloReply.new(message: "Hello #{hello_req.name}")
+  end
+end
+
+# main starts an RpcServer that receives requests to GreeterServer at the sample
+# server port.
+def main
+  s = GRPC::RpcServer.new
+  s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
+  s.handle(GreeterServer)
+  # Runs the server with SIGHUP, SIGINT and SIGQUIT signal handlers to
+  #   gracefully shutdown.
+  # User could also choose to run server via call to run_till_terminated
+  s.run_till_terminated_or_interrupted([1, 'int', 'SIGQUIT'])
+end
+
+main

--- a/examples/ruby/retry/retry_client.rb
+++ b/examples/ruby/retry/retry_client.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sample app that connects to a Greeter service.
+#
+# Usage: $ path/to/retry_client.rb
+
+this_dir = File.expand_path(File.dirname(__FILE__))
+lib_dir = File.join(File.dirname(this_dir), 'lib')
+$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)
+
+require 'grpc'
+require 'json'
+
+require 'helloworld_services_pb'
+
+def main
+  user = ARGV.size > 0 ?  ARGV[0] : 'world'
+  hostname = ARGV.size > 1 ?  ARGV[1] : 'localhost:50051'
+  stub = Helloworld::Greeter::Stub.new(
+    hostname,
+    :this_channel_is_insecure,
+    {
+      channel_args: {
+        'grpc.enable_retries' => 1,
+        'grpc.service_config' => JSON.dump(
+          methodConfig: [
+            {
+              # To apply retry to all methods, put [{}] in the "name" field
+              name: [
+                {
+                  service: 'helloworld.Greeter',
+                  method: 'SayHello'
+                }
+              ],
+              retryPolicy: {
+                maxAttempts: 5,
+                initialBackoff: '0.1s',
+                maxBackoff: '1s',
+                backoffMultiplier: 2,
+                retryableStatusCodes: ['UNAVAILABLE']
+              }
+            }
+          ]
+        )
+      }
+    }
+  )
+
+  begin
+    message = stub.say_hello(Helloworld::HelloRequest.new(name: user)).message
+    p "Greeting: #{message}"
+  rescue GRPC::BadStatus => e
+    abort "ERROR: #{e.message}"
+  end
+end
+
+main

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -210,10 +210,13 @@ module GRPC
     # list, mulitple metadata for its key are sent
     def send_status(code = OK, details = '', assert_finished = false,
                     metadata: {})
-      send_initial_metadata
-      ops = {
-        SEND_STATUS_FROM_SERVER => Struct::Status.new(code, details, metadata)
-      }
+      ops = {}
+      @send_initial_md_mutex.synchronize do
+        ops[SEND_INITIAL_METADATA] = @metadata_to_send unless @metadata_sent
+        @metadata_sent = true
+      end
+
+      ops[SEND_STATUS_FROM_SERVER] = Struct::Status.new(code, details, metadata)
       ops[RECV_CLOSE_ON_SERVER] = nil if assert_finished
       @call.run_batch(ops)
       set_output_stream_done

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -361,6 +361,7 @@ describe GRPC::ActiveCall do
       expect(server_call.metadata_sent).to eq(false)
       blk = proc { server_call.send_status(OK) }
       expect { blk.call }.to_not raise_error
+      expect(server_call.metadata_sent).to eq(true)
     end
 
     it 'sends the status in one batch' do

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -362,6 +362,30 @@ describe GRPC::ActiveCall do
       blk = proc { server_call.send_status(OK) }
       expect { blk.call }.to_not raise_error
     end
+
+    it 'sends the status in one batch' do
+      call = make_test_call
+      ActiveCall.client_invoke(call)
+
+      recvd_rpc = @received_rpcs_queue.pop
+
+      server_call = ActiveCall.new(
+        recvd_rpc.call,
+        @pass_through,
+        @pass_through,
+        deadline,
+        started: false)
+
+      server_call.send_status(OK)
+
+      # Check that we can receive initial metadata and a status
+      call.run_batch(
+        CallOps::RECV_INITIAL_METADATA => nil)
+      batch_result = call.run_batch(
+        CallOps::RECV_STATUS_ON_CLIENT => nil)
+
+      expect(batch_result.status.code).to eq(OK)
+    end
   end
 
   describe '#remote_read', remote_read: true do


### PR DESCRIPTION
I am trying to make the Ruby server / client retries work with the native retry policy.

I have created an example server / client under `src/examples/ruby/retry` and adjusted the server to be equivalent to [`flaky_server.py` from Python](https://github.com/grpc/grpc/blob/v1.41.1/examples/python/retry/flaky_server.py) by injecting random errors. The client includes a `retryPolicy` for the `GreeterService`.

The Ruby server / client wasn't correctly retrying on `errors` and I started investigating the root cause. When I tried using the Ruby client with the Python (flaky) server the retries worked correctly. Additionally when I tried the Python client on the Ruby server it didn't work. Therefore I started digging into the Ruby server to understand what is the difference.

When running the Python example I noticed that, when a flaky response is send back, the following operations are send in one batch:

```
$ GRPC_TRACE=all GRPC_VERBOSITY=debug python ./flaky_server.py
[…]
I0910 20:42:15.883867600     538 call.cc:1573]               ops[0]: SEND_INITIAL_METADATA(nil)
I0910 20:42:15.883883900     538 call.cc:1573]               ops[1]: SEND_MESSAGE ptr=0x564ba270df40
I0910 20:42:15.883897500     538 call.cc:1573]               ops[2]: SEND_STATUS_FROM_SERVER status=0 details=(nil)
[…]
I0910 20:42:15.884151100     538 chttp2_transport.cc:1360]   HTTP:3:HDR:SVR: :status: 200
I0910 20:42:15.884159800     538 chttp2_transport.cc:1360]   HTTP:3:HDR:SVR: content-type: application/grpc
I0910 20:42:15.884167800     538 chttp2_transport.cc:1360]   HTTP:3:HDR:SVR: grpc-accept-encoding: identity,deflate,gzip
I0910 20:42:15.884235900     538 chttp2_transport.cc:1360]   HTTP:3:HDR:SVR: accept-encoding: identity,gzip
I0910 20:42:15.884310400     538 chttp2_transport.cc:1360]   HTTP:3:TRL:SVR: grpc-status: 0
I0910 20:42:15.884326100     538 chttp2_transport.cc:1360]   HTTP:3:TRL:SVR: grpc-message:
```

Both the `SEND_INITIAL_METADATA` and `SEND_STATUS_FROM_SERVER` are send in one batch.

This results in the client being able to parse the Trailing Headers and initiate a retry:

```
I0911 15:51:23.677840900    2944 tcp_posix.cc:544]           TCP:0x5644cb109200 notify_on_read
I0911 15:51:23.677862000    2944 retry_filter.cc:1392]       chand=0x5644cb205470 calld=0x5644cb2030d0 attempt=0x7f1100001540 batch_data=0x7f1100001250: got recv_initial_metadata_ready, error="No Error"
I0911 15:51:23.677882100    2944 retry_filter.cc:1419]       chand=0x5644cb205470 calld=0x5644cb2030d0 attempt=0x7f1100001540: deferring recv_initial_metadata_ready (Trailers-Only)
I0911 15:51:23.677904400    2944 retry_filter.cc:1491]       chand=0x5644cb205470 calld=0x5644cb2030d0 attempt=0x7f1100001540 batch_data=0x7f1100001250: got recv_message_ready, error="No Error"
I0911 15:51:23.677932600    2944 retry_filter.cc:1517]       chand=0x5644cb205470 calld=0x5644cb2030d0 attempt=0x7f1100001540: deferring recv_message_ready (nullptr message and recv_trailing_metadata pending)
I0911 15:51:23.678026700    2944 retry_filter.cc:1687]       chand=0x5644cb205470 calld=0x5644cb2030d0 attempt=0x7f1100001540 batch_data=0x7f1100001250: got recv_trailing_metadata_ready, error="No Error"
I0911 15:51:23.678036700    2944 retry_filter.cc:1714]       chand=0x5644cb205470 calld=0x5644cb2030d0 attempt=0x7f1100001540: call finished, status=UNAVAILABLE is_lb_drop=0
I0911 15:51:23.678057500    2944 retry_filter.cc:2565]       chand=0x5644cb205470 calld=0x5644cb2030d0: retrying failed call in 206 ms
```

On the other hand the Ruby server is sending 2 batches:

```
$ GRPC_TRACE=all GRPC_VERBOSITY=debug ruby ./flaky_server.rb
[…]
reserved=(nil))
I0911 15:47:12.533849800    2820 call.cc:1573]               ops[0]: SEND_INITIAL_METADATA(nil)
I0911 15:47:12.533865300    2820 call.cc:641]                OP[server:0x55da0efe6b20]:  SEND_INITIAL_METADATA{}
I0911 15:47:12.533877000    2820 channel_stack.cc:239]       OP[message_size:0x55da0efe6b38]:  SEND_INITIAL_METADATA{}
I0911 15:47:12.533909100    2820 channel_stack.cc:239]       OP[deadline:0x55da0efe6b50]:  SEND_INITIAL_METADATA{}
I0911 15:47:12.533924300    2820 channel_stack.cc:239]       OP[http-server:0x55da0efe6b68]:  SEND_INITIAL_METADATA{}
[…]
I0911 15:47:12.534143600    2820 chttp2_transport.cc:1360]   HTTP:1:HDR:SVR: :status: 200
I0911 15:47:12.534155900    2820 chttp2_transport.cc:1360]   HTTP:1:HDR:SVR: content-type: application/grpc
I0911 15:47:12.534188100    2820 chttp2_transport.cc:1360]   HTTP:1:HDR:SVR: grpc-accept-encoding: identity,deflate,gzip
I0911 15:47:12.534222700    2820 chttp2_transport.cc:1360]   HTTP:1:HDR:SVR: accept-encoding: identity,gzip
I0911 15:47:12.534239000    2820 stream_lists.cc:125]        0x55da0efe1c20[1][svr]: add to writable
```

Followed by:

```
I0911 15:47:12.535417000    2820 call.cc:1573]               ops[0]: SEND_STATUS_FROM_SERVER status=14 details=injected_error(nil)
[…]
I0911 15:47:12.535818100    2820 chttp2_transport.cc:1360]   HTTP:1:TRL:SVR: grpc-status: 14
I0911 15:47:12.535831500    2820 chttp2_transport.cc:1360]   HTTP:1:TRL:SVR: grpc-message: injected_error
I0911 15:47:12.535839500    2820 stream_lists.cc:125]        0x55da0efe1c20[1][svr]: add to writable
```

In this case the client is committing the retry based on the first batch and then doesn't retry the call:

```
D0911 15:54:08.129073900    2992 tcp_posix.cc:692]           DATA: 00 00 6b 01 04 00 00 00 01 88 40 0c 63 6f 6e 74 65 6e 74 2d 74 79 70 65 10 61 70 70 6c 69 63 61 74 69 6f 6e 2f 67 72 70 63 40 14 67 72 70 63 2d 61 63 63 65 70 74 2d 65 6e 63 6f 64 69 6e 67 15 69 64 65 6e 74 69 74 79 2c 64 65 66 6c 61 74 65 2c 67 7a 69 70 40 0f 61 63 63 65 70 74 2d 65 6e 63 6f 64 69 6e 67 0d 69 64 65 6e 74 69 74 79 2c 67 7a 69 70 00 00 2d 01 05 00 00 00 01 40 0b 67 72 70 63 2d 73 74 61 74 75 73 02 31 34 40 0c 67 72 70 63 2d 6d 65 73 73 61 67 65 0e 69 6e 6a 65 63 74 65 64 5f 65 72 72 6f 72 '..k.......@.content-type.application/grpc@.grpc-accept-encoding.identity,deflate,gzip@.accept-encoding.identity,gzip..-......@.grpc-status.14@.grpc-message.injected_error'
I0911 15:54:08.129004100    2987 tcp_posix.cc:1572]          WRITE 0x561d69f3ccf0 (peer=ipv4:127.0.0.1:50051)
D0911 15:54:08.129400600    2987 tcp_posix.cc:1576]          DATA: 00 00 08 06 01 00 00 00 00 00 00 00 00 00 00 00 00 '.................'
I0911 15:54:08.129764900    2987 tcp_posix.cc:1621]          write: "No Error"
I0911 15:54:08.129816800    2987 parsing.cc:686]             parsing initial_metadata
I0911 15:54:08.129841300    2987 parsing.cc:433]             HTTP:1:HDR:CLI: :status: 32 30 30 '200'
I0911 15:54:08.129880700    2987 parsing.cc:433]             HTTP:1:HDR:CLI: content-type: 61 70 70 6c 69 63 61 74 69 6f 6e 2f 67 72 70 63 'application/grpc'
I0911 15:54:08.129907000    2987 parsing.cc:433]             HTTP:1:HDR:CLI: grpc-accept-encoding: 69 64 65 6e 74 69 74 79 2c 64 65 66 6c 61 74 65 2c 67 7a 69 70 'identity,deflate,gzip'
I0911 15:54:08.130359200    2987 parsing.cc:433]             HTTP:1:HDR:CLI: accept-encoding: 69 64 65 6e 74 69 74 79 2c 67 7a 69 70 'identity,gzip'
I0911 15:54:08.130407500    2987 parsing.cc:691]             parsing trailing_metadata
I0911 15:54:08.130754400    2987 parsing.cc:545]             HTTP:1:TRL:CLI: grpc-status: 31 34 '14'
I0911 15:54:08.131115700    2987 parsing.cc:545]             HTTP:1:TRL:CLI: grpc-message: 69 6e 6a 65 63 74 65 64 5f 65 72 72 6f 72 'injected_error'
I0911 15:54:08.131152500    2987 tcp_posix.cc:544]           TCP:0x561d69f3ccf0 notify_on_read
I0911 15:54:08.131216500    2987 retry_filter.cc:1392]       chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130 batch_data=0x561d6a036680: got recv_initial_metadata_ready, error="No Error"
I0911 15:54:08.131227900    2987 retry_filter.cc:2534]       chand=0x561d6a0392b0 calld=0x561d6a036090: committing retries
I0911 15:54:08.131235600    2987 retry_filter.cc:2338]       chand=0x561d6a0392b0 calld=0x561d6a036090: destroying send_initial_metadata
I0911 15:54:08.131391200    2987 retry_filter.cc:2346]       chand=0x561d6a0392b0 calld=0x561d6a036090: destroying send_messages[0]
I0911 15:54:08.131407500    2987 retry_filter.cc:2355]       chand=0x561d6a0392b0 calld=0x561d6a036090: destroying send_trailing_metadata
I0911 15:54:08.131421100    2987 retry_filter.cc:775]        chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130: retry state no longer needed; moving LB call to parent and unreffing the call attempt
I0911 15:54:08.131518400    2987 retry_filter.cc:2516]       chand=0x561d6a0392b0 calld=0x561d6a036090: invoking recv_initial_metadata_ready for pending batch at index 0
I0911 15:54:08.131599700    2987 retry_filter.cc:1491]       chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130 batch_data=0x561d6a036680: got recv_message_ready, error="No Error"
I0911 15:54:08.131614600    2987 retry_filter.cc:2516]       chand=0x561d6a0392b0 calld=0x561d6a036090: invoking recv_message_ready for pending batch at index 0
I0911 15:54:08.131712000    2987 retry_filter.cc:1687]       chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130 batch_data=0x561d6a036680: got recv_trailing_metadata_ready, error="No Error"
I0911 15:54:08.131730600    2987 retry_filter.cc:1714]       chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130: call finished, status=UNAVAILABLE is_lb_drop=0
I0911 15:54:08.131764500    2987 retry_filter.cc:1122]       chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130: retries already committed
I0911 15:54:08.131780100    2987 retry_filter.cc:2516]       chand=0x561d6a0392b0 calld=0x561d6a036090: invoking recv_trailing_metadata_ready for pending batch at index 0
I0911 15:54:08.131793100    2987 retry_filter.cc:2460]       chand=0x561d6a0392b0 calld=0x561d6a036090: clearing pending batch
I0911 15:54:08.131826500    2987 retry_filter.cc:1307]       chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130: destroying batch 0x561d6a036680
I0911 15:54:08.131839500    2987 retry_filter.cc:709]        chand=0x561d6a0392b0 calld=0x561d6a036090 attempt=0x561d6a03a130: destroying call attempt
D0911 15:54:08.131971800    2987 call.cc:748]                set_final_status CLI
D0911 15:54:08.132008700    2987 call.cc:749]                {"created":"@1631375648.131931200","description":"Error received from peer ipv4:127.0.0.1:50051","file":"src/core/lib/surface/call.cc","file_line":1069,"grpc_message":"injected_error","grpc_status":14}
```

So I traced the Ruby server code a bit.

When an exception is raised it is [rescued](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/rpc_desc.rb#L130-L134) in [`GRPC::RpcDesc#run_server_method`](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/rpc_desc.rb#L117):

https://github.com/grpc/grpc/blob/ab6beb3f686857d687bf72e80b1fbaf7d3c3e4a4/src/ruby/lib/grpc/generic/rpc_desc.rb#L130-L134

Then [`GRPC::RpcDesc#send_status`](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/rpc_desc.rb#L195-L198):

https://github.com/grpc/grpc/blob/ab6beb3f686857d687bf72e80b1fbaf7d3c3e4a4/src/ruby/lib/grpc/generic/rpc_desc.rb#L195-L198

calls [`GRPC::ActiveCall#send_status`](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/active_call.rb#L205-L216):

https://github.com/grpc/grpc/blob/ab6beb3f686857d687bf72e80b1fbaf7d3c3e4a4/src/ruby/lib/grpc/generic/active_call.rb#L205-L216

which in turn calls [`GRPC::ActiveCall#send_initial_metadata`](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/active_call.rb#L118-L125):

https://github.com/grpc/grpc/blob/ab6beb3f686857d687bf72e80b1fbaf7d3c3e4a4/src/ruby/lib/grpc/generic/active_call.rb#L118-L125

finally resulting in a call to [`GRPC::ActiveCall.client_invoke`](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/active_call.rb#L63-L66):

https://github.com/grpc/grpc/blob/ab6beb3f686857d687bf72e80b1fbaf7d3c3e4a4/src/ruby/lib/grpc/generic/active_call.rb#L63-L66

The `.client_invoke` call sends a batch with only `SEND_INITIAL_METADATA`.

Subsequently back in [`GRPC::ActiveCall#send_status`](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/active_call.rb#L205-L216) the `SEND_STATUS_FROM_SERVER` is [sent as another batch](https://github.com/grpc/grpc/blob/v1.40.0/src/ruby/lib/grpc/generic/active_call.rb#L208-L212):

https://github.com/grpc/grpc/blob/ab6beb3f686857d687bf72e80b1fbaf7d3c3e4a4/src/ruby/lib/grpc/generic/active_call.rb#L208-L212

The above sequence explains the 2 batches seen in the server logs.

Changing `GRPC::ActiveCall#send_status`, per this diff, to send the initial metadata along with the server status, makes the client correctly retry failing responses:

```diff
diff --git a/src/ruby/lib/grpc/generic/active_call.rb b/src/ruby/lib/grpc/generic/active_call.rb
index 11db1f448c..0c19e5c8c5 100644
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -204,8 +204,9 @@ module GRPC
     # list, mulitple metadata for its key are sent
     def send_status(code = OK, details = '', assert_finished = false,
                     metadata: {})
-      send_initial_metadata
+      #send_initial_metadata
       ops = {
+        SEND_INITIAL_METADATA => metadata,
         SEND_STATUS_FROM_SERVER => Struct::Status.new(code, details, metadata)
       }
       ops[RECV_CLOSE_ON_SERVER] = nil if assert_finished
```

The above results in a response similar to the Python server and the client correctly retries the request.

I believe this is a bug in the Ruby server yet I'm not sure about the implications of the change (e.g. the mutex `@send_initial_md_mutex` access around an object instance variable which seems unnecessary? 🤔) or the the proper way to fix the issue. That's why I'm asking for a confirmation of the issue and guidance. 😊 

@drfloob 