### PR TITLE
[binder] Fix Android guard in binder server

### DIFF
--- a/src/core/ext/transport/binder/client/channel_create.h
+++ b/src/core/ext/transport/binder/client/channel_create.h
@@ -19,8 +19,6 @@
 
 #ifdef GPR_ANDROID
 
-#include <grpc/support/port_platform.h>
-
 #include <jni.h>
 
 #include "absl/strings/string_view.h"

--- a/src/core/ext/transport/binder/server/binder_server_credentials.cc
+++ b/src/core/ext/transport/binder/server/binder_server_credentials.cc
@@ -26,7 +26,7 @@ namespace {
 
 class BinderServerCredentialsImpl final : public ServerCredentials {
  public:
-#ifdef GPR_ANDROID
+#ifdef GPR_SUPPORT_BINDER_TRANSPORT
   int AddPortToServer(const std::string& addr, grpc_server* server) override {
     return grpc_core::AddBinderPort(
         std::string(addr), server,
@@ -40,7 +40,7 @@ class BinderServerCredentialsImpl final : public ServerCredentials {
                       grpc_server* /*server*/) override {
     return 0;
   }
-#endif  // GPR_ANDROID
+#endif  // GPR_SUPPORT_BINDER_TRANSPORT
 
   void SetAuthMetadataProcessor(
       const std::shared_ptr<AuthMetadataProcessor>& /*processor*/) override {

--- a/test/core/transport/binder/end2end/binder_server_test.cc
+++ b/test/core/transport/binder/end2end/binder_server_test.cc
@@ -96,8 +96,9 @@ class BinderServerTest : public ::testing::Test {
   static void TearDownTestSuite() { grpc_shutdown(); }
 };
 
-#ifndef GPR_ANDROID
-TEST(BinderServerCredentialsTest, FailedInNonAndroidEnvironments) {
+#ifndef GPR_SUPPORT_BINDER_TRANSPORT
+TEST(BinderServerCredentialsTest,
+     FailedInEnvironmentsNotSupportingBinderTransport) {
   grpc::ServerBuilder server_builder;
   grpc::testing::TestServiceImpl service;
   server_builder.RegisterService(&service);
@@ -105,7 +106,7 @@ TEST(BinderServerCredentialsTest, FailedInNonAndroidEnvironments) {
       "binder://fail", grpc::experimental::BinderServerCredentials());
   EXPECT_EQ(server_builder.BuildAndStart(), nullptr);
 }
-#endif  // !GPR_ANDROID
+#endif  // !GPR_SUPPORT_BINDER_TRANSPORT
 
 TEST_F(BinderServerTest, BuildAndStart) {
   grpc::ServerBuilder server_builder;


### PR DESCRIPTION
Android-related binder classes are only available if
GPR_SUPPORT_BINDER_TRANSPORT is defined. Thus, BinderServerCredentials
should only work if GPR_SUPPORT_BINDER_TRANSPORT (instead of
GPR_ANDROID) is defined as well.

