### PR TITLE
Activities: allow empty wakers

### DIFF
--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -78,7 +78,7 @@ class Waker {
  private:
   class Unwakeable final : public Wakeable {
    public:
-    void Wakeup() final { abort(); }
+    void Wakeup() final {}
     void Drop() final {}
   };
 

--- a/test/core/promise/activity_test.cc
+++ b/test/core/promise/activity_test.cc
@@ -252,6 +252,11 @@ TEST(ActivityTest, WithContext) {
   EXPECT_TRUE(done);
 }
 
+TEST(WakerTest, CanWakeupEmptyWaker) {
+  // Empty wakers should not do anything upon wakeup.
+  Waker().Wakeup();
+}
+
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
It was probably an oversight not to allow this originally: allowing this makes writing waker users much easier in some cases.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
