### PR TITLE
[objc] Debug logging and reduce flake in CFNetwork test

### DIFF
--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -135,7 +135,8 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
     r = accept(svr_fd, reinterpret_cast<struct sockaddr *>(addr),
                reinterpret_cast<socklen_t *>(&resolved_addr.len));
   } while (r == -1 && errno == EINTR);
-  XCTAssertGreaterThanOrEqual(r, 0);
+  XCTAssertGreaterThanOrEqual(r, 0, @"connection failed with return code %@ and errno %@", @(r),
+                              @(errno));
   svr_fd_ = r;
 
   /* wait for the connection callback to finish */


### PR DESCRIPTION
From [test log](https://source.cloud.google.com/results/invocations/8f9f5d20-7673-4f2a-90f2-0bdd2e1e5ef5/targets/github%2Fgrpc%2Ftoplevel_run_tests_invocations%2Frun_tests_objc_macos_opt_native/tests) it looks like we run into socket connection refuse error  "nw_socket_handle_socket_event [C6:1] Socket SO_ERROR [61: Connection refused]".  Though this might be a transient issue, added the following to help w/ future debug and flakiness 

* Debug logging to identify exact errno code when endpoint connection fails. Complete list of potential failure reason can be identified from [here](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/accept.2.html)


Closes #21592