### PR TITLE
Activities: Don't execute inline

### DIFF
--- a/test/core/promise/activity_test.cc
+++ b/test/core/promise/activity_test.cc
@@ -153,7 +153,7 @@ TYPED_TEST(BarrierTest, Barrier) {
           return absl::OkStatus();
         });
       },
-      NoCallbackScheduler(),
+      InlineCallbackScheduler{},
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   // Clearing the barrier should let the activity proceed to return a result.
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
@@ -174,7 +174,7 @@ TYPED_TEST(BarrierTest, BarrierPing) {
           return absl::OkStatus();
         });
       },
-      [&scheduler](std::function<void()> f) { scheduler.Schedule(f); },
+      InlineCallbackScheduler(),
       [&on_done1](absl::Status status) { on_done1.Call(std::move(status)); });
   auto activity2 = MakeActivity(
       [&b2] {
@@ -225,7 +225,7 @@ TYPED_TEST(BarrierTest, WakeAfterDestruction) {
             return absl::OkStatus();
           });
         },
-        NoCallbackScheduler(),
+        InlineCallbackScheduler(),
         [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   }
   b.Clear();
@@ -246,7 +246,7 @@ TEST(ActivityTest, ForceWakeup) {
             abort();
         }
       },
-      NoCallbackScheduler(),
+      InlineCallbackScheduler{},
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
   activity->ForceWakeup();

--- a/test/core/promise/activity_test.cc
+++ b/test/core/promise/activity_test.cc
@@ -153,7 +153,7 @@ TYPED_TEST(BarrierTest, Barrier) {
           return absl::OkStatus();
         });
       },
-      InlineCallbackScheduler{},
+      InlineCallbackScheduler(),
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   // Clearing the barrier should let the activity proceed to return a result.
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
@@ -165,7 +165,8 @@ TYPED_TEST(BarrierTest, BarrierPing) {
   typename TestFixture::Type b2;
   StrictMock<MockFunction<void(absl::Status)>> on_done1;
   StrictMock<MockFunction<void(absl::Status)>> on_done2;
-  MockCallbackScheduler scheduler;
+  MockCallbackScheduler scheduler1;
+  MockCallbackScheduler scheduler2;
   auto activity1 = MakeActivity(
       [&b1, &b2] {
         return Seq(b1.Wait(), [&b2](typename TestFixture::Type::Result) {
@@ -174,7 +175,7 @@ TYPED_TEST(BarrierTest, BarrierPing) {
           return absl::OkStatus();
         });
       },
-      InlineCallbackScheduler(),
+      [&scheduler1](std::function<void()> f) { scheduler1.Schedule(f); },
       [&on_done1](absl::Status status) { on_done1.Call(std::move(status)); });
   auto activity2 = MakeActivity(
       [&b2] {
@@ -182,17 +183,21 @@ TYPED_TEST(BarrierTest, BarrierPing) {
           return absl::OkStatus();
         });
       },
-      [&scheduler](std::function<void()> f) { scheduler.Schedule(f); },
+      [&scheduler2](std::function<void()> f) { scheduler2.Schedule(f); },
       [&on_done2](absl::Status status) { on_done2.Call(std::move(status)); });
-  EXPECT_CALL(on_done1, Call(absl::OkStatus()));
   // Since barrier triggers inside activity1 promise, activity2 wakeup will be
   // scheduled from a callback.
-  std::function<void()> cb;
-  EXPECT_CALL(scheduler, Schedule(_)).WillOnce(SaveArg<0>(&cb));
+  std::function<void()> cb1;
+  std::function<void()> cb2;
+  EXPECT_CALL(scheduler1, Schedule(_)).WillOnce(SaveArg<0>(&cb1));
   b1.Clear();
+  Mock::VerifyAndClearExpectations(&scheduler1);
+  EXPECT_CALL(on_done1, Call(absl::OkStatus()));
+  EXPECT_CALL(scheduler2, Schedule(_)).WillOnce(SaveArg<0>(&cb2));
+  cb1();
   Mock::VerifyAndClearExpectations(&on_done1);
   EXPECT_CALL(on_done2, Call(absl::OkStatus()));
-  cb();
+  cb2();
 }
 
 TYPED_TEST(BarrierTest, WakeSelf) {
@@ -246,7 +251,7 @@ TEST(ActivityTest, ForceWakeup) {
             abort();
         }
       },
-      InlineCallbackScheduler{},
+      InlineCallbackScheduler(),
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
   activity->ForceWakeup();

--- a/test/core/promise/observable_test.cc
+++ b/test/core/promise/observable_test.cc
@@ -65,7 +65,7 @@ TEST(ObservableTest, CanPushAndGet) {
           return i == 42 ? absl::OkStatus() : absl::UnknownError("expected 42");
         });
       },
-      NoCallbackScheduler(),
+      InlineCallbackScheduler(),
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
   observable.Push(42);
@@ -88,7 +88,7 @@ TEST(ObservableTest, CanNext) {
                             : absl::UnknownError("expected 1");
             });
       },
-      NoCallbackScheduler(),
+      InlineCallbackScheduler(),
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   observable.Push(42);
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
@@ -112,7 +112,7 @@ TEST(ObservableTest, CanWatch) {
               }
             });
       },
-      NoCallbackScheduler(),
+      InlineCallbackScheduler(),
       [&on_done](absl::Status status) { on_done.Call(std::move(status)); });
   observable.Push(1);
   observable.Push(2);


### PR DESCRIPTION
Inline execution was super useful getting the initial tests up, but it's the wrong thing to do usually: we have no idea what locks are on the stack, so it's too easy to get into lock cycles with this approach. Instead, if we need to wake an activity up, always call the callback scheduler.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
