### PR TITLE
Normalize load test prefixes, and update go version automatically.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -32,6 +32,9 @@ gcloud container clusters get-credentials benchmarks-prod2 \
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
 # BEGIN differentiate experimental configuration from master configuration.
+if [[ "${KOKORO_BUILD_INITIATOR%%-*}" == kokoro ]]; then
+    LOAD_TEST_PREFIX=kokoro
+fi
 # Use the "official" BQ tables so that the measurements will show up in the
 # "official" public dashboard.
 BIGQUERY_TABLE_8CORE=e2e_benchmarks.ci_master_results_8core
@@ -55,7 +58,7 @@ WORKER_POOL_8CORE=workers-8core-ci
 WORKER_POOL_32CORE=workers-32core-ci
 
 # Update go version.
-TEST_INFRA_GOVERSION=go1.17
+TEST_INFRA_GOVERSION=go1.17.1
 go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -32,7 +32,7 @@ gcloud container clusters get-credentials benchmarks-prod2 \
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
 # BEGIN differentiate experimental configuration from master configuration.
-if [[ "${KOKORO_BUILD_INITIATOR}" == kokoro ]]; then
+if [[ "${KOKORO_BUILD_INITIATOR%%-*}" == kokoro ]]; then
     LOAD_TEST_PREFIX=kokoro-test
 fi
 BIGQUERY_TABLE_8CORE=e2e_benchmarks.experimental_results
@@ -56,7 +56,7 @@ WORKER_POOL_8CORE=workers-8core-ci
 WORKER_POOL_32CORE=workers-32core-ci
 
 # Update go version.
-TEST_INFRA_GOVERSION=go1.17
+TEST_INFRA_GOVERSION=go1.17.1
 go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 


### PR DESCRIPTION
* Set the prefix to a constant value for test runs initiated by users with names that start with `kokoro`. Prefixes for master and experimental jobs are `kokoro` and `kokoro-test` respectively. This compensates for the fact that scheduled runs are initiated by `kokoro`, but CI runs are initated by `kokoro-github-subscriber`.
* Fetch the go version to be installed for each run from golang.org before downloading, instead of hardcoding it.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
