### PR TITLE
Disable grpc_status_test for sync stack in Python2

### DIFF
--- a/src/python/grpcio_tests/tests/status/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/status/BUILD.bazel
@@ -16,12 +16,13 @@ load("//bazel:python_rules.bzl", "py2and3_test")
 
 package(default_visibility = ["//visibility:public"])
 
-py2and3_test(
+py_test(
     name = "grpc_status_test",
     size = "small",
     srcs = ["_grpc_status_test.py"],
     imports = ["../../"],
     main = "_grpc_status_test.py",
+    python_version = "PY3",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_status/grpc_status",

--- a/src/python/grpcio_tests/tests/status/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/status/BUILD.bazel
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("//bazel:python_rules.bzl", "py2and3_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -114,7 +114,7 @@ class _GenericHandler(grpc.GenericRpcHandler):
             return None
 
 
-@unittest.skipIf(sys.version_info[0] >= 3,
+@unittest.skipIf(sys.version_info[0] < 3,
                  'ProtoBuf descriptor has moved on from Python2')
 class StatusTest(unittest.TestCase):
 

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -28,6 +28,7 @@ import unittest
 
 import logging
 import traceback
+import sys
 
 import grpc
 from grpc_status import rpc_status
@@ -113,6 +114,8 @@ class _GenericHandler(grpc.GenericRpcHandler):
             return None
 
 
+@unittest.skipIf(sys.version_info[0] >= 3,
+                 'ProtoBuf descriptor has moved on from Python2')
 class StatusTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
As title.

https://source.cloud.google.com/results/invocations/08560702-3166-46f9-8c40-d554025c2838/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_python_bazel_test/log

```
INFO: From Testing //src/python/grpcio_tests/tests/status:grpc_status_test.python2:
==================== Test output for //src/python/grpcio_tests/tests/status:grpc_status_test.python2:
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/d2dc70c3d9da3fab488ba0dcbbd35051/sandbox/processwrapper-sandbox/3161/execroot/com_github_grpc_grpc/bazel-out/k8-py2-fastbuild/bin/src/python/grpcio_tests/tests/status/grpc_status_test.python2.runfiles/com_github_grpc_grpc/src/python/grpcio_tests/tests/status/_grpc_status_test.py", line 33, in <module>
    from grpc_status import rpc_status
  File "/root/.cache/bazel/_bazel_root/d2dc70c3d9da3fab488ba0dcbbd35051/sandbox/processwrapper-sandbox/3161/execroot/com_github_grpc_grpc/bazel-out/k8-py2-fastbuild/bin/src/python/grpcio_tests/tests/status/grpc_status_test.python2.runfiles/com_github_grpc_grpc/src/python/grpcio_status/grpc_status/rpc_status.py", line 19, in <module>
    from google.rpc import status_pb2
  File "/root/.cache/bazel/_bazel_root/d2dc70c3d9da3fab488ba0dcbbd35051/sandbox/processwrapper-sandbox/3161/execroot/com_github_grpc_grpc/bazel-out/k8-py2-fastbuild/bin/src/python/grpcio_tests/tests/status/grpc_status_test.python2.runfiles/pypi__googleapis_common_protos_1_5_5/google/rpc/status_pb2.py", line 6, in <module>
    from google.protobuf import descriptor as _descriptor
  File "/root/.cache/bazel/_bazel_root/d2dc70c3d9da3fab488ba0dcbbd35051/sandbox/processwrapper-sandbox/3161/execroot/com_github_grpc_grpc/bazel-out/k8-py2-fastbuild/bin/src/python/grpcio_tests/tests/status/grpc_status_test.python2.runfiles/pypi__protobuf_3_18_0/google/protobuf/descriptor.py", line 113
    class DescriptorBase(metaclass=DescriptorMetaclass):
                                  ^
SyntaxError: invalid syntax
================================================================================
```

It seems to be broken since the ProtoBuf upgrade.