### PR TITLE
[objc] Clean up +load and switch to imperative transport registry 

### DIFF
--- a/src/objective-c/BUILD
+++ b/src/objective-c/BUILD
@@ -85,7 +85,6 @@ grpc_objc_library(
 grpc_objc_library(
     name = "grpc_objc_interface",
     srcs = [
-        "GRPCClient/GRPCCall.m",
         "GRPCClient/GRPCCall+Interceptor.m",
         "GRPCClient/GRPCCallOptions.m",
         "GRPCClient/GRPCInterceptor.m",
@@ -114,6 +113,7 @@ grpc_objc_library(
 grpc_objc_library(
     name = "grpc_objc_client",
     srcs = [
+        "GRPCClient/GRPCCall.m",
         "GRPCClient/GRPCCall+ChannelArg.m",
         "GRPCClient/GRPCCall+ChannelCredentials.m",
         "GRPCClient/GRPCCall+Cronet.m",

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -23,6 +23,7 @@
 #import "GRPCInterceptor.h"
 
 #import "GRPCTransport.h"
+#import "private/GRPCCore/GRPCCoreTransportFactoryLoader.h"
 #import "private/GRPCTransport+Private.h"
 
 /**
@@ -138,6 +139,12 @@
    * call options when the user provided a NULL call options object.
    */
   GRPCCallOptions *_actualCallOptions;
+}
+
++ (void)initialize {
+  if (self == [GRPCCall2 self]) {
+    [[GRPCCoreTransportFactoryLoader sharedInstance] loadCoreFactories];
+  }
 }
 
 - (instancetype)initWithRequestOptions:(GRPCRequestOptions *)requestOptions

--- a/src/objective-c/GRPCClient/GRPCCallLegacy.m
+++ b/src/objective-c/GRPCClient/GRPCCallLegacy.m
@@ -24,6 +24,7 @@
 
 #import "private/GRPCCore/GRPCChannelPool.h"
 #import "private/GRPCCore/GRPCCompletionQueue.h"
+#import "private/GRPCCore/GRPCCoreTransportFactoryLoader.h"
 #import "private/GRPCCore/GRPCHost.h"
 #import "private/GRPCCore/GRPCWrappedCall.h"
 #import "private/GRPCCore/NSData+GRPC.h"
@@ -134,6 +135,7 @@ static NSString *const kBearerPrefix = @"Bearer ";
   if (self == [GRPCCall self]) {
     grpc_init();
     callFlags = [NSMutableDictionary dictionary];
+    [[GRPCCoreTransportFactoryLoader sharedInstance] loadCoreFactories];
   }
 }
 

--- a/src/objective-c/GRPCClient/GRPCTransport.m
+++ b/src/objective-c/GRPCClient/GRPCTransport.m
@@ -110,6 +110,11 @@ NSUInteger TransportIDHash(GRPCTransportID transportID) {
   return transportFactory;
 }
 
+- (BOOL)isRegisteredForTransportID:(GRPCTransportID)transportID {
+  NSString *nsTransportID = [NSString stringWithUTF8String:transportID];
+  return [_registry objectForKey:nsTransportID] != nil;
+}
+
 @end
 
 @implementation GRPCTransport

--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreFactory.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreFactory.m
@@ -38,12 +38,6 @@ static dispatch_once_t gInitGRPCCoreInsecureFactory;
   return gGRPCCoreSecureFactory;
 }
 
-+ (void)load {
-  [[GRPCTransportRegistry sharedInstance]
-      registerTransportWithID:GRPCDefaultTransportImplList.core_secure
-                      factory:[self sharedInstance]];
-}
-
 - (GRPCTransport *)createTransportWithManager:(GRPCTransportManager *)transportManager {
   return [[GRPCCall2Internal alloc] initWithTransportManager:transportManager];
 }
@@ -75,12 +69,6 @@ static dispatch_once_t gInitGRPCCoreInsecureFactory;
     gGRPCCoreInsecureFactory = [[GRPCCoreInsecureFactory alloc] init];
   });
   return gGRPCCoreInsecureFactory;
-}
-
-+ (void)load {
-  [[GRPCTransportRegistry sharedInstance]
-      registerTransportWithID:GRPCDefaultTransportImplList.core_insecure
-                      factory:[self sharedInstance]];
 }
 
 - (GRPCTransport *)createTransportWithManager:(GRPCTransportManager *)transportManager {

--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreTransportFactoryLoader.h
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreTransportFactoryLoader.h
@@ -1,0 +1,35 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GRPCCoreTransportFactoryLoader : NSObject
+
+// Shared singleton access to factory loader.
++ (instancetype)sharedInstance;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+// Load default core transports factories.
+- (void)loadCoreFactories;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreTransportFactoryLoader.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreTransportFactoryLoader.m
@@ -1,0 +1,45 @@
+
+#import "GRPCCoreTransportFactoryLoader.h"
+
+#import <GRPCClient/GRPCCall+Cronet.h>
+
+#import "../GRPCTransport+Private.h"
+#import "GRPCCoreFactory.h"
+
+#define NSStringFromUTF8String(cstr) [NSString stringWithUTF8String:cstr]
+#define TransportIdFromNSString(str) ((GRPCTransportID)[str UTF8String])
+
+@implementation GRPCCoreTransportFactoryLoader
+
++ (instancetype)sharedInstance {
+  static dispatch_once_t initOnce;
+  static GRPCCoreTransportFactoryLoader *gTransportLoader = nil;
+  dispatch_once(&initOnce, ^{
+    gTransportLoader = [[GRPCCoreTransportFactoryLoader alloc] init];
+    NSAssert(gTransportLoader != nil, @"Unable to initialize transport loader.");
+  });
+  return gTransportLoader;
+}
+
+- (NSDictionary<NSString *, Class> *)coreTransports {
+  return @{
+    NSStringFromUTF8String(GRPCDefaultTransportImplList.core_secure) :
+        [GRPCCoreSecureFactory class],
+    NSStringFromUTF8String(GRPCDefaultTransportImplList.core_insecure) :
+        [GRPCCoreInsecureFactory class]
+  };
+}
+
+- (void)loadCoreFactories {
+  GRPCTransportRegistry *registry = [GRPCTransportRegistry sharedInstance];
+  NSDictionary *coreTransports = [self coreTransports];
+  for (NSString *transportId in coreTransports) {
+    GRPCTransportID tid = TransportIdFromNSString(transportId);
+    Class factoryCls = coreTransports[transportId];
+    if (factoryCls && ![registry isRegisteredForTransportID:tid]) {
+      [[GRPCTransportRegistry sharedInstance] registerTransportWithID:tid factory:[factoryCls new]];
+    }
+  }
+}
+
+@end

--- a/src/objective-c/GRPCClient/private/GRPCTransport+Private.h
+++ b/src/objective-c/GRPCClient/private/GRPCTransport+Private.h
@@ -33,6 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (id<GRPCTransportFactory>)getTransportFactoryWithID:(GRPCTransportID)transportID;
 
+/**
+ * Returns true if there exists a registered transport factory associated with the specified transport ID.
+ */
+- (BOOL)isRegisteredForTransportID:(GRPCTransportID)transportID;
+
 @end
 
 /**

--- a/src/objective-c/tests/Tests.xcodeproj/project.pbxproj
+++ b/src/objective-c/tests/Tests.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		5EA4770522736AC4000F72FC /* TestCertificates.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 63E240CF1B6C63DC005F3B0E /* TestCertificates.bundle */; };
 		5ECFED8623030DCC00626501 /* TestCertificates.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 63E240CF1B6C63DC005F3B0E /* TestCertificates.bundle */; };
 		65EB19E418B39A8374D407BB /* libPods-CronetTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B1511C20E16A8422B58D61A /* libPods-CronetTests.a */; };
+		74DAEA8426F96FF200E867B9 /* TransportFactoryLoaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 74DAEA8326F96FF200E867B9 /* TransportFactoryLoaderTests.m */; };
 		903163C7FE885838580AEC7A /* libPods-InteropTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D457AD9797664CFA191C3280 /* libPods-InteropTests.a */; };
 		953CD2942A3A6D6CE695BE87 /* libPods-MacTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 276873A05AC5479B60DF6079 /* libPods-MacTests.a */; };
 		9BF9672E0D0BF5B42D4F2B72 /* libPods-PerfTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6F190224A515F9A4D09E4CF /* libPods-PerfTests.a */; };
@@ -158,6 +159,7 @@
 		6793C9D019CB268C5BB491A2 /* Pods-CoreCronetEnd2EndTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreCronetEnd2EndTests.test.xcconfig"; path = "Pods/Target Support Files/Pods-CoreCronetEnd2EndTests/Pods-CoreCronetEnd2EndTests.test.xcconfig"; sourceTree = "<group>"; };
 		680439AC2BC8761EDD54A1EA /* Pods-InteropTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteropTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-InteropTests/Pods-InteropTests.debug.xcconfig"; sourceTree = "<group>"; };
 		73D2DF07027835BA0FB0B1C0 /* Pods-InteropTestsCallOptions.cronet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteropTestsCallOptions.cronet.xcconfig"; path = "Pods/Target Support Files/Pods-InteropTestsCallOptions/Pods-InteropTestsCallOptions.cronet.xcconfig"; sourceTree = "<group>"; };
+		74DAEA8326F96FF200E867B9 /* TransportFactoryLoaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TransportFactoryLoaderTests.m; sourceTree = "<group>"; };
 		781089FAE980F51F88A3BE0B /* Pods-RxLibraryUnitTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxLibraryUnitTests.test.xcconfig"; path = "Pods/Target Support Files/Pods-RxLibraryUnitTests/Pods-RxLibraryUnitTests.test.xcconfig"; sourceTree = "<group>"; };
 		79C68EFFCB5533475D810B79 /* Pods-RxLibraryUnitTests.cronet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxLibraryUnitTests.cronet.xcconfig"; path = "Pods/Target Support Files/Pods-RxLibraryUnitTests/Pods-RxLibraryUnitTests.cronet.xcconfig"; sourceTree = "<group>"; };
 		7A2E97E3F469CC2A758D77DE /* Pods-InteropTestsLocalSSL.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteropTestsLocalSSL.release.xcconfig"; path = "Pods/Target Support Files/Pods-InteropTestsLocalSSL/Pods-InteropTestsLocalSSL.release.xcconfig"; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 		5E0282E7215AA697007AC99D /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				74DAEA8326F96FF200E867B9 /* TransportFactoryLoaderTests.m */,
 				5E9F1C58232302E200837469 /* TransportTests.m */,
 				5E9F1C322321AB1700837469 /* TransportRegistryTests.m */,
 				5E7F488A22778B5D006656AD /* RxLibraryUnitTests.m */,
@@ -1033,6 +1036,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5E0282E9215AA697007AC99D /* NSErrorUnitTests.m in Sources */,
+				74DAEA8426F96FF200E867B9 /* TransportFactoryLoaderTests.m in Sources */,
 				5E7F4880227782C1006656AD /* APIv2Tests.m in Sources */,
 				5E7F487D22778256006656AD /* ChannelPoolTest.m in Sources */,
 				5E9F1C59232302E200837469 /* TransportTests.m in Sources */,

--- a/src/objective-c/tests/UnitTests/TransportFactoryLoaderTests.m
+++ b/src/objective-c/tests/UnitTests/TransportFactoryLoaderTests.m
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <GRPCClient/GRPCTransport.h>
+#import "src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreTransportFactoryLoader.h"
+#import "src/objective-c/GRPCClient/private/GRPCTransport+Private.h"
+
+@interface TransportFactoryLoaderTests : XCTestCase
+
+@end
+
+@implementation TransportFactoryLoaderTests
+
+- (void)testDefaultCoreFactoriesAreLoaded {
+  [[GRPCCoreTransportFactoryLoader sharedInstance] loadCoreFactories];
+  id<GRPCTransportFactory> secureTransportFactory = [[GRPCTransportRegistry sharedInstance]
+      getTransportFactoryWithID:GRPCDefaultTransportImplList.core_secure];
+  id<GRPCTransportFactory> insecureTransportFactory = [[GRPCTransportRegistry sharedInstance]
+      getTransportFactoryWithID:GRPCDefaultTransportImplList.core_insecure];
+  XCTAssertNotNil(secureTransportFactory);
+  XCTAssertNotNil(insecureTransportFactory);
+  XCTAssertNotEqual(secureTransportFactory, insecureTransportFactory);
+}
+
+@end

--- a/src/objective-c/tests/UnitTests/TransportRegistryTests.m
+++ b/src/objective-c/tests/UnitTests/TransportRegistryTests.m
@@ -20,6 +20,7 @@
 
 #import <GRPCClient/GRPCCall+Cronet.h>
 #import <GRPCClient/GRPCTransport.h>
+#import "src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreTransportFactoryLoader.h"
 #import "src/objective-c/GRPCClient/private/GRPCTransport+Private.h"
 
 @interface TransportRegistryTests : XCTestCase
@@ -28,13 +29,21 @@
 
 @implementation TransportRegistryTests
 
++ (void)setUp {
+  [[GRPCCoreTransportFactoryLoader sharedInstance] loadCoreFactories];
+}
+
 - (void)testDefaultImplementationsExist {
-  id<GRPCTransportFactory> secureTransportFactory = [[GRPCTransportRegistry sharedInstance]
-      getTransportFactoryWithID:GRPCDefaultTransportImplList.core_secure];
-  id<GRPCTransportFactory> insecureTransportFactory = [[GRPCTransportRegistry sharedInstance]
-      getTransportFactoryWithID:GRPCDefaultTransportImplList.core_insecure];
+  GRPCTransportRegistry *registry = [GRPCTransportRegistry sharedInstance];
+  id<GRPCTransportFactory> secureTransportFactory =
+      [registry getTransportFactoryWithID:GRPCDefaultTransportImplList.core_secure];
+  id<GRPCTransportFactory> insecureTransportFactory =
+      [registry getTransportFactoryWithID:GRPCDefaultTransportImplList.core_insecure];
+
   XCTAssertNotNil(secureTransportFactory);
+  XCTAssertTrue([registry isRegisteredForTransportID:GRPCDefaultTransportImplList.core_secure]);
   XCTAssertNotNil(insecureTransportFactory);
+  XCTAssertTrue([registry isRegisteredForTransportID:GRPCDefaultTransportImplList.core_insecure]);
   XCTAssertNotEqual(secureTransportFactory, insecureTransportFactory);
 }
 


### PR DESCRIPTION
Internal cleanup to remove core transport factory registration off +load.  

**Context** 
* [+load ](https://developer.apple.com/documentation/objectivec/nsobject/1418815-load?language=objc) should generally be avoided due to a number of caveats ([ref1](https://www.mikeash.com/pyblog/friday-qa-2009-05-22-objective-c-class-loading-and-initialization.html)) ([ref2](https://gcc.gnu.org/onlinedocs/gcc/What-you-can-and-what-you-cannot-do-in-_002bload.html)), in particular the possibility of crashing caused by undetermined class load ordering. Internally +load also caused issues for mem & CPU drain due to overuse. 

**Change**
Here we removed transport factory registration from each factory's +load, and instead switch to imperatively loading them in the higher level GRPC call object, in particular the following 
 - V2:  GRPCCall2::initialize
 - Legacy: GRPCCall::initialize

[NSObject::Initialize](https://developer.apple.com/documentation/objectivec/nsobject/1418639-initialize?language=objc) is guaranteed to be thread-safe, and is invoked once per class and before any class/instance methods are invoked; this ensures core's default transport factories are (lazily) registered before any GRPC call objects are used. 

**Alternatives**
Considered another different approach by embedding the factory loading logic directly inside [GRPCTransportRegistry's singleton initialization](https://github.com/grpc/grpc/blob/fd3bd70939fb4239639fbd26143ec416366e4157/src/objective-c/GRPCClient/GRPCTransport.m#L50-L60); didn't go this route as this has too much coupling between the transport registry and core factory loading logic. 

**Todos**
Currently there is one outlier from Cronet's [GRPCCoreCronetFactory registration](https://github.com/grpc/grpc/blob/fd3bd70939fb4239639fbd26143ec416366e4157/src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreCronet/GRPCCoreCronetFactory.m#L40). However, this cannot be directly moved into core's loader, as gRPC user may/may not have linked against the cronet [static lib module](https://github.com/grpc/grpc/blob/d10b2a677dc5a34595cf8338c99f2d772c2047a7/gRPC.podspec#L150-L161).  Will deal with this later when we clean up cronet.  