### PR TITLE
Fix use-after-free metadata corruption in C# when receiving response headers for streaming response calls

### DIFF
--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -62,6 +62,7 @@ namespace Grpc.Core.Internal
 
         protected bool initialMetadataSent;
         protected long streamingWritesCounter;  // Number of streaming send operations started so far.
+        protected bool receiveResponseHeadersPending;  // True if this is a call with streaming response and the recv_initial_metadata_on_client operation hasn't finished yet.
 
         public AsyncCallBase(Action<TWrite, SerializationContext> serializer, Func<DeserializationContext, TRead> deserializer)
         {
@@ -171,7 +172,7 @@ namespace Grpc.Core.Internal
             if (!disposed && call != null)
             {
                 bool noMoreSendCompletions = streamingWriteTcs == null && (halfcloseRequested || cancelRequested || finished);
-                if (noMoreSendCompletions && readingDone && finished)
+                if (noMoreSendCompletions && readingDone && finished && !receiveResponseHeadersPending)
                 {
                     ReleaseResources();
                     return true;


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/25219 and https://github.com/grpc/grpc/issues/25004 (also see internal b/158826903)

I've been trying to debug this problem for long time, and I finally found the rootcause (with help of modifications that allowed me to reproduce more consistently and with more logging, see https://github.com/grpc/grpc/pull/23564).

The problem is that for calls with streaming response (server streaming and full duplex), gRPC C# registers for "recv_response_headers_on_client" event when the call starts and when the duration of the call is very short, sometimes the "recv_response_headers_on_client" can be delivered AFTER receiving all the responses and after delivering the final status of the call. If that happens, the call handle gets disposed (which destroys the underlying grpc_call native object), which can trigger unreferencing of the metadata that hasn't yet been delivered to the C# layer.
So in the "HandleReceivedResponseHeaders", when the initial metadata is being read from the native grpc_metadata_array object, it can be already unreffed by C core and due to the "use-after-free" it's basically changing under our hands as we read it. This was the reason why malformed metadata was being encountered in the InteropClientServerTest.CustomMetadata test.

This problem only affected calls with streaming response that 1. read the response headers  2. have a very short duration (so that the response headers that happens at the very beginning of the call can be delivered after all the responses and final status have been delivered - this won't happen for long lived calls), so hopefully the bug hasn't affected many users in practice.