### PR TITLE
C#: metadata.Get and GetAll should accept uppercase keys

### DIFF
--- a/src/csharp/Grpc.Core.Api/Metadata.cs
+++ b/src/csharp/Grpc.Core.Api/Metadata.cs
@@ -83,7 +83,7 @@ namespace Grpc.Core
         {
             for (int i = entries.Count - 1; i >= 0; i--)
             {
-                if (entries[i].Key == key)
+                if (entries[i].KeyEqualsIgnoreCase(key))
                 {
                     return entries[i];
                 }
@@ -119,7 +119,7 @@ namespace Grpc.Core
         {
             for (int i = 0; i < entries.Count; i++)
             {
-                if (entries[i].Key == key)
+                if (entries[i].KeyEqualsIgnoreCase(key))
                 {
                     yield return entries[i];
                 }
@@ -391,6 +391,16 @@ namespace Grpc.Core
             internal byte[] GetSerializedValueUnsafe()
             {
                 return valueBytes ?? EncodingASCII.GetBytes(value);
+            }
+
+            internal bool KeyEqualsIgnoreCase(string key)
+            {
+                // NormalizeKey() uses ToLowerInvariant() to lowercase keys, so we'd like to use the same invariant culture
+                // for comparisons to get valid results. StringComparison.InvariantCultureIgnoreCase isn't available
+                // on all the frameworks we're targeting, but since we know that the Entry's key has already
+                // been checked by IsValidKey and it only contains a subset of ASCII, using StringComparison.OrdinalIgnoreCase
+                // is also fine.
+                return string.Equals(this.key, key, StringComparison.OrdinalIgnoreCase);
             }
 
             /// <summary>

--- a/src/csharp/Grpc.Core.Tests/MetadataTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MetadataTest.cs
@@ -262,6 +262,10 @@ namespace Grpc.Core.Tests
             var xyzEntries = metadata.GetAll("xyz").ToList();
             Assert.AreEqual(1, xyzEntries.Count);
             Assert.AreEqual("xyz-value1", xyzEntries[0].Value);
+
+            var xyzUppercaseEntries = metadata.GetAll("XYZ").ToList();
+            Assert.AreEqual(1, xyzUppercaseEntries.Count);
+            Assert.AreEqual("xyz-value1", xyzUppercaseEntries[0].Value);
         }
 
         [Test]
@@ -280,8 +284,12 @@ namespace Grpc.Core.Tests
             var xyzEntry = metadata.Get("xyz");
             Assert.AreEqual("xyz-value1", xyzEntry.Value);
 
+            var abcUppercaseEntry = metadata.Get("AbC");
+            Assert.AreEqual("abc-value2", abcUppercaseEntry.Value);
+
             var notFound = metadata.Get("not-found");
             Assert.AreEqual(null, notFound);
+
         }
 
         [Test]
@@ -300,6 +308,9 @@ namespace Grpc.Core.Tests
 
             var xyzValue = metadata.GetValue("xyz");
             Assert.AreEqual("xyz-value1", xyzValue);
+
+            var abcUppercaseValue = metadata.GetValue("ABC");
+            Assert.AreEqual("abc-value2", abcUppercaseValue);
 
             var notFound = metadata.GetValue("not-found");
             Assert.AreEqual(null, notFound);
@@ -331,6 +342,9 @@ namespace Grpc.Core.Tests
 
             var xyzValue = metadata.GetValueBytes("xyz-bin");
             Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzValue);
+
+            var xyzUppercaseValue = metadata.GetValueBytes("XYZ-BIN");
+            Assert.AreEqual(Encoding.ASCII.GetBytes("xyz-value1"), xyzUppercaseValue);
 
             var notFound = metadata.GetValueBytes("not-found");
             Assert.AreEqual(null, notFound);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/26551.

Similar to https://github.com/grpc/grpc/pull/26552, but the implementation is cleaner and it adds tests.

Note that this is mostly a cosmetic change, since according to the gRPC spec, the metadata keys are supposed to be lowercase.  But at this point, creating a `new Metadata.Entry("KEY", "value")` does lowercasing of the key under the hood,
and a subsequent `metadata.Get("KEY")` won't find the entry.  (it's basically a cornercase since there's no real reason to use uppercase metadata keys with gRPC when the spec only allows lowercase.