### PR TITLE
Add add_error for Substitute

### DIFF
--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -114,7 +114,7 @@ class MetadataMap {
       if (GRPC_MDISNULL(new_mdelem.md)) {
         Remove(l);
       } else if (new_mdelem.md.payload != l->md.payload) {
-        Substitute(l, new_mdelem.md);
+        add_error(Substitute(l, new_mdelem.md));
       }
       l = next;
     }


### PR DESCRIPTION
To fix the error,

```
In file included from ./src/core/lib/transport/transport.h:37:
./src/core/lib/transport/metadata_batch.h:117:9: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result]
        Substitute(l, new_mdelem.md);
        ^~~~~~~~~~ ~~~~~~~~~~~~~~~~
```