### PR TITLE
Enable affinity and retry tests for Python

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -58,7 +58,7 @@ class TestHeaderBasedAffinity(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def is_supported(config: TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java']:
+        if config.client_lang in ['cpp', 'java', 'python']:
             return config.version_ge('v1.40.x')
         if config.client_lang in ['go']:
             return config.version_ge('v1.41.x')
@@ -127,7 +127,7 @@ class TestHeaderBasedAffinityMultipleHeaders(
 
     @staticmethod
     def is_supported(config: TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java']:
+        if config.client_lang in ['cpp', 'java', 'python']:
             return config.version_ge('v1.40.x')
         if config.client_lang in ['go']:
             return config.version_ge('v1.41.x')

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -68,7 +68,7 @@ class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def is_supported(config: TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java']:
+        if config.client_lang in ['cpp', 'java', 'python']:
             return config.version_ge('v1.40.x')
         elif config.client_lang == 'go':
             return config.version_ge('v1.41.x')
@@ -111,7 +111,7 @@ class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def is_supported(config: TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java']:
+        if config.client_lang in ['cpp', 'java', 'python']:
             return config.version_ge('v1.40.x')
         elif config.client_lang == 'go':
             return config.version_ge('v1.41.x')


### PR DESCRIPTION
As title.

There were a little complication for Affinity tests. The affinity is asserting how many underlying connections (subchannel) were created in different scenarios. But for each method handler, Python client creates a separate thread. So, unlike other languages, there might be multiple channels, hence the number of connections is multiplied. This PR loosen the affinity test assertions to focus on how the RPC is distributed.

Test run:
- Python: https://fusion2.corp.google.com/invocations/f534e983-1b7d-4881-946e-8b28be452466