### PR TITLE
absl::Status support to service_config_test

### DIFF
--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -43,6 +43,9 @@ namespace testing {
 // Set this channel arg to true to disable parsing.
 #define GRPC_ARG_DISABLE_PARSING "disable_parsing"
 
+// A regular expression to enter referenced or child errors.
+#define CHILD_ERROR_TAG ".*(referenced_errors|children).*"
+
 class TestParsedConfig1 : public ServiceConfigParser::ParsedConfig {
  public:
   explicit TestParsedConfig1(int value) : value_(value) {}
@@ -204,12 +207,11 @@ TEST_F(ServiceConfigTest, ErrorDuplicateMethodConfigNames) {
       "]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(
-      grpc_error_std_string(error),
-      ::testing::ContainsRegex("Service config parsing error.*referenced_errors"
-                               ".*Method Params.*referenced_errors"
-                               ".*methodConfig.*referenced_errors"
-                               ".*multiple method configs with same name"));
+  EXPECT_THAT(grpc_error_std_string(error),
+              ::testing::ContainsRegex(
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "multiple method configs with same name"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -221,12 +223,11 @@ TEST_F(ServiceConfigTest, ErrorDuplicateMethodConfigNamesWithNullMethod) {
       "]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(
-      grpc_error_std_string(error),
-      ::testing::ContainsRegex("Service config parsing error.*referenced_errors"
-                               ".*Method Params.*referenced_errors"
-                               ".*methodConfig.*referenced_errors"
-                               ".*multiple method configs with same name"));
+  EXPECT_THAT(grpc_error_std_string(error),
+              ::testing::ContainsRegex(
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "multiple method configs with same name"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -238,12 +239,11 @@ TEST_F(ServiceConfigTest, ErrorDuplicateMethodConfigNamesWithEmptyMethod) {
       "]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(
-      grpc_error_std_string(error),
-      ::testing::ContainsRegex("Service config parsing error.*referenced_errors"
-                               ".*Method Params.*referenced_errors"
-                               ".*methodConfig.*referenced_errors"
-                               ".*multiple method configs with same name"));
+  EXPECT_THAT(grpc_error_std_string(error),
+              ::testing::ContainsRegex(
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "multiple method configs with same name"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -255,12 +255,11 @@ TEST_F(ServiceConfigTest, ErrorDuplicateDefaultMethodConfigs) {
       "]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(
-      grpc_error_std_string(error),
-      ::testing::ContainsRegex("Service config parsing error.*referenced_errors"
-                               ".*Method Params.*referenced_errors"
-                               ".*methodConfig.*referenced_errors"
-                               ".*multiple default method configs"));
+  EXPECT_THAT(grpc_error_std_string(error),
+              ::testing::ContainsRegex(
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "multiple default method configs"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -272,12 +271,11 @@ TEST_F(ServiceConfigTest, ErrorDuplicateDefaultMethodConfigsWithNullService) {
       "]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(
-      grpc_error_std_string(error),
-      ::testing::ContainsRegex("Service config parsing error.*referenced_errors"
-                               ".*Method Params.*referenced_errors"
-                               ".*methodConfig.*referenced_errors"
-                               ".*multiple default method configs"));
+  EXPECT_THAT(grpc_error_std_string(error),
+              ::testing::ContainsRegex(
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "multiple default method configs"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -289,12 +287,11 @@ TEST_F(ServiceConfigTest, ErrorDuplicateDefaultMethodConfigsWithEmptyService) {
       "]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(
-      grpc_error_std_string(error),
-      ::testing::ContainsRegex("Service config parsing error.*referenced_errors"
-                               ".*Method Params.*referenced_errors"
-                               ".*methodConfig.*referenced_errors"
-                               ".*multiple default method configs"));
+  EXPECT_THAT(grpc_error_std_string(error),
+              ::testing::ContainsRegex(
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "multiple default method configs"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -345,10 +342,10 @@ TEST_F(ServiceConfigTest, Parser1ErrorInvalidType) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(absl::StrCat(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*",
-                  TestParser1::InvalidTypeErrorMessage())));
+              ::testing::ContainsRegex(
+                  absl::StrCat("Service config parsing error" CHILD_ERROR_TAG
+                               "Global Params" CHILD_ERROR_TAG,
+                               TestParser1::InvalidTypeErrorMessage())));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -357,10 +354,10 @@ TEST_F(ServiceConfigTest, Parser1ErrorInvalidValue) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(absl::StrCat(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*",
-                  TestParser1::InvalidValueErrorMessage())));
+              ::testing::ContainsRegex(
+                  absl::StrCat("Service config parsing error" CHILD_ERROR_TAG
+                               "Global Params" CHILD_ERROR_TAG,
+                               TestParser1::InvalidValueErrorMessage())));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -401,12 +398,12 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidType) {
       "\"method_param\":\"5\"}]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(absl::StrCat(
-                  "Service config parsing error.*referenced_errors\":\\[.*"
-                  "Method Params.*referenced_errors.*methodConfig.*"
-                  "referenced_errors.*",
-                  TestParser2::InvalidTypeErrorMessage())));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex(absl::StrCat(
+          "Service config parsing error" CHILD_ERROR_TAG
+          "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG,
+          TestParser2::InvalidTypeErrorMessage())));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -416,12 +413,12 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidValue) {
       "\"method_param\":-5}]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(absl::StrCat(
-                  "Service config parsing error.*referenced_errors\":\\[.*"
-                  "Method Params.*referenced_errors.*methodConfig.*"
-                  "referenced_errors.*",
-                  TestParser2::InvalidValueErrorMessage())));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex(absl::StrCat(
+          "Service config parsing error" CHILD_ERROR_TAG
+          "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG,
+          TestParser2::InvalidValueErrorMessage())));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -447,8 +444,8 @@ TEST_F(ErroredParsersScopingTest, GlobalParams) {
   EXPECT_THAT(
       grpc_error_std_string(error),
       ::testing::ContainsRegex(absl::StrCat(
-          "Service config parsing error.*referenced_errors\":\\[.*"
-          "Global Params.*referenced_errors.*",
+          "Service config parsing error" CHILD_ERROR_TAG
+          "Global Params" CHILD_ERROR_TAG,
           ErrorParser::GlobalError(), ".*", ErrorParser::GlobalError())));
   GRPC_ERROR_UNREF(error);
 }
@@ -460,11 +457,10 @@ TEST_F(ErroredParsersScopingTest, MethodParams) {
   EXPECT_THAT(
       grpc_error_std_string(error),
       ::testing::ContainsRegex(absl::StrCat(
-          "Service config parsing error.*referenced_errors\":\\[.*"
-          "Global Params.*referenced_errors.*",
+          "Service config parsing error" CHILD_ERROR_TAG
+          "Global Params" CHILD_ERROR_TAG,
           ErrorParser::GlobalError(), ".*", ErrorParser::GlobalError(),
-          ".*Method Params.*referenced_errors.*methodConfig.*"
-          "referenced_errors.*",
+          ".*Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG,
           ErrorParser::MethodError(), ".*", ErrorParser::MethodError())));
   GRPC_ERROR_UNREF(error);
 }
@@ -551,13 +547,13 @@ TEST_F(ClientChannelParserTest, UnknownLoadBalancingConfig) {
   const char* test_json = "{\"loadBalancingConfig\": [{\"unknown\":{}}]}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "Client channel global parser.*referenced_errors.*"
-                  "field:loadBalancingConfig.*referenced_errors.*"
-                  "No known policies in list: unknown"));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex("Service config parsing error" CHILD_ERROR_TAG
+                               "Global Params" CHILD_ERROR_TAG
+                               "Client channel global parser" CHILD_ERROR_TAG
+                               "field:loadBalancingConfig" CHILD_ERROR_TAG
+                               "No known policies in list: unknown"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -571,13 +567,12 @@ TEST_F(ClientChannelParserTest, InvalidGrpclbLoadBalancingConfig) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "Client channel global parser.*referenced_errors.*"
-                  "field:loadBalancingConfig.*referenced_errors.*"
-                  "GrpcLb Parser.*referenced_errors.*"
-                  "field:childPolicy.*referenced_errors.*"
-                  "type should be array"));
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Global Params" CHILD_ERROR_TAG
+                  "Client channel global parser" CHILD_ERROR_TAG
+                  "field:loadBalancingConfig" CHILD_ERROR_TAG
+                  "GrpcLb Parser" CHILD_ERROR_TAG
+                  "field:childPolicy" CHILD_ERROR_TAG "type should be array"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -609,9 +604,9 @@ TEST_F(ClientChannelParserTest, UnknownLoadBalancingPolicy) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "Client channel global parser.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Global Params" CHILD_ERROR_TAG
+                  "Client channel global parser" CHILD_ERROR_TAG
                   "field:loadBalancingPolicy error:Unknown lb policy"));
   GRPC_ERROR_UNREF(error);
 }
@@ -623,9 +618,9 @@ TEST_F(ClientChannelParserTest, LoadBalancingPolicyXdsNotAllowed) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "Client channel global parser.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Global Params" CHILD_ERROR_TAG
+                  "Client channel global parser" CHILD_ERROR_TAG
                   "field:loadBalancingPolicy "
                   "error:xds_cluster_resolver_experimental requires "
                   "a config. Please use loadBalancingConfig instead."));
@@ -669,10 +664,9 @@ TEST_F(ClientChannelParserTest, InvalidTimeout) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "Client channel parser.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "Client channel parser" CHILD_ERROR_TAG
                   "field:timeout error:type should be STRING of the form given "
                   "by google.proto.Duration"));
   GRPC_ERROR_UNREF(error);
@@ -721,10 +715,9 @@ TEST_F(ClientChannelParserTest, InvalidWaitForReady) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "Client channel parser.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "Client channel parser" CHILD_ERROR_TAG
                   "field:waitForReady error:Type should be true/false"));
   GRPC_ERROR_UNREF(error);
 }
@@ -761,7 +754,7 @@ TEST_F(ClientChannelParserTest, InvalidHealthCheckMultipleEntries) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "JSON parsing failed.*referenced_errors.*"
+                  "JSON parsing failed" CHILD_ERROR_TAG
                   "duplicate key \"healthCheckConfig\" at index 104"));
   GRPC_ERROR_UNREF(error);
 }
@@ -808,13 +801,13 @@ TEST_F(RetryParserTest, RetryThrottlingMissingFields) {
       "}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "retryThrottling.*referenced_errors.*"
-                  "field:retryThrottling field:maxTokens error:Not found.*"
-                  "field:retryThrottling field:tokenRatio error:Not found"));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex(
+          "Service config parsing error" CHILD_ERROR_TAG
+          "Global Params" CHILD_ERROR_TAG "retryThrottling" CHILD_ERROR_TAG
+          "field:retryThrottling field:maxTokens error:Not found"
+          ".*field:retryThrottling field:tokenRatio error:Not found"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -828,13 +821,13 @@ TEST_F(RetryParserTest, InvalidRetryThrottlingNegativeMaxTokens) {
       "}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "retryThrottling.*referenced_errors.*"
-                  "field:retryThrottling field:maxTokens error:should "
-                  "be greater than zero"));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex(
+          "Service config parsing error" CHILD_ERROR_TAG
+          "Global Params" CHILD_ERROR_TAG "retryThrottling" CHILD_ERROR_TAG
+          "field:retryThrottling field:maxTokens error:should "
+          "be greater than zero"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -848,13 +841,13 @@ TEST_F(RetryParserTest, InvalidRetryThrottlingInvalidTokenRatio) {
       "}";
   grpc_error_handle error = GRPC_ERROR_NONE;
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Global Params.*referenced_errors.*"
-                  "retryThrottling.*referenced_errors.*"
-                  "field:retryThrottling field:tokenRatio "
-                  "error:Failed parsing"));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex("Service config parsing error" CHILD_ERROR_TAG
+                               "Global Params" CHILD_ERROR_TAG
+                               "retryThrottling" CHILD_ERROR_TAG
+                               "field:retryThrottling field:tokenRatio "
+                               "error:Failed parsing"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -907,9 +900,8 @@ TEST_F(RetryParserTest, InvalidRetryPolicyWrongType) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
                   "field:retryPolicy error:should be of type object"));
   GRPC_ERROR_UNREF(error);
 }
@@ -930,14 +922,13 @@ TEST_F(RetryParserTest, InvalidRetryPolicyRequiredFieldsMissing) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
-                  "field:maxAttempts error:required field missing.*"
-                  "field:initialBackoff error:does not exist.*"
-                  "field:maxBackoff error:does not exist.*"
-                  "field:backoffMultiplier error:required field missing"));
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
+                  ".*field:maxAttempts error:required field missing"
+                  ".*field:initialBackoff error:does not exist"
+                  ".*field:maxBackoff error:does not exist"
+                  ".*field:backoffMultiplier error:required field missing"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -961,10 +952,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyMaxAttemptsWrongType) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:maxAttempts error:should be of type number"));
   GRPC_ERROR_UNREF(error);
 }
@@ -989,10 +979,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyMaxAttemptsBadValue) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:maxAttempts error:should be at least 2"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1017,10 +1006,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyInitialBackoffWrongType) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:initialBackoff error:type should be STRING of the "
                   "form given by google.proto.Duration"));
   GRPC_ERROR_UNREF(error);
@@ -1046,10 +1034,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyInitialBackoffBadValue) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:initialBackoff error:must be greater than 0"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1074,10 +1061,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyMaxBackoffWrongType) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:maxBackoff error:type should be STRING of the form "
                   "given by google.proto.Duration"));
   GRPC_ERROR_UNREF(error);
@@ -1103,10 +1089,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyMaxBackoffBadValue) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:maxBackoff error:must be greater than 0"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1131,10 +1116,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyBackoffMultiplierWrongType) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:backoffMultiplier error:should be of type number"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1159,10 +1143,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyBackoffMultiplierBadValue) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:backoffMultiplier error:must be greater than 0"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1187,10 +1170,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyEmptyRetryableStatusCodes) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:retryableStatusCodes error:must be non-empty"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1215,10 +1197,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyRetryableStatusCodesWrongType) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:retryableStatusCodes error:must be of type array"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1243,13 +1224,11 @@ TEST_F(RetryParserTest, InvalidRetryPolicyUnparseableRetryableStatusCodes) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
-                  "field:retryableStatusCodes "
-                  "error:failed to parse status code.*"
-                  "field:retryableStatusCodes "
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG "field:retryableStatusCodes "
+                  "error:failed to parse status code"
+                  ".*field:retryableStatusCodes "
                   "error:status codes should be of type string"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1392,10 +1371,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyPerAttemptRecvTimeoutUnparseable) {
   auto svc_cfg = ServiceConfig::Create(&args, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:perAttemptRecvTimeout error:type must be STRING "
                   "of the form given by google.proto.Duration."));
   GRPC_ERROR_UNREF(error);
@@ -1425,10 +1403,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyPerAttemptRecvTimeoutWrongType) {
   auto svc_cfg = ServiceConfig::Create(&args, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:perAttemptRecvTimeout error:type must be STRING "
                   "of the form given by google.proto.Duration."));
   GRPC_ERROR_UNREF(error);
@@ -1458,10 +1435,9 @@ TEST_F(RetryParserTest, InvalidRetryPolicyPerAttemptRecvTimeoutBadValue) {
   auto svc_cfg = ServiceConfig::Create(&args, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "retryPolicy.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "retryPolicy" CHILD_ERROR_TAG
                   "field:perAttemptRecvTimeout error:must be greater than 0"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1519,10 +1495,9 @@ TEST_F(MessageSizeParserTest, InvalidMaxRequestMessageBytes) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "Message size parser.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "Message size parser" CHILD_ERROR_TAG
                   "field:maxRequestMessageBytes error:should be non-negative"));
   GRPC_ERROR_UNREF(error);
 }
@@ -1541,10 +1516,9 @@ TEST_F(MessageSizeParserTest, InvalidMaxResponseMessageBytes) {
   auto svc_cfg = ServiceConfig::Create(nullptr, test_json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
-                  "Service config parsing error.*referenced_errors.*"
-                  "Method Params.*referenced_errors.*"
-                  "methodConfig.*referenced_errors.*"
-                  "Message size parser.*referenced_errors.*"
+                  "Service config parsing error" CHILD_ERROR_TAG
+                  "Method Params" CHILD_ERROR_TAG "methodConfig" CHILD_ERROR_TAG
+                  "Message size parser" CHILD_ERROR_TAG
                   "field:maxResponseMessageBytes error:should be of type "
                   "number"));
   GRPC_ERROR_UNREF(error);

--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -44,7 +44,11 @@ namespace testing {
 #define GRPC_ARG_DISABLE_PARSING "disable_parsing"
 
 // A regular expression to enter referenced or child errors.
-#define CHILD_ERROR_TAG ".*(referenced_errors|children).*"
+#ifdef GRPC_ERROR_IS_ABSEIL_STATUS
+#define CHILD_ERROR_TAG ".*children.*"
+#else
+#define CHILD_ERROR_TAG ".*referenced_errors.*"
+#endif
 
 class TestParsedConfig1 : public ServiceConfigParser::ParsedConfig {
  public:


### PR DESCRIPTION
Updated the service-config-test to be aware of `absl::Status` type. Previously it used to use `referenced_errors` tag to enter into child error. absl::Status uses `children` tag so regular expression is expanded to support both by using `.*(referenced_errors|children).*` -> This is modified because some environment don't support `|` operator.