### PR TITLE
Unified host name terminology across c# client / server example code.

### DIFF
--- a/examples/csharp/Helloworld/GreeterClient/Program.cs
+++ b/examples/csharp/Helloworld/GreeterClient/Program.cs
@@ -22,7 +22,7 @@ namespace GreeterClient
     {
         public static void Main(string[] args)
         {
-            Channel channel = new Channel("127.0.0.1:30051", ChannelCredentials.Insecure);
+            Channel channel = new Channel("localhost:30051", ChannelCredentials.Insecure);
 
             var client = new Greeter.GreeterClient(channel);
             String user = "you";

--- a/examples/csharp/HelloworldLegacyCsproj/GreeterClient/Program.cs
+++ b/examples/csharp/HelloworldLegacyCsproj/GreeterClient/Program.cs
@@ -22,7 +22,7 @@ namespace GreeterClient
     {
         public static void Main(string[] args)
         {
-            Channel channel = new Channel("127.0.0.1:30051", ChannelCredentials.Insecure);
+            Channel channel = new Channel("localhost:30051", ChannelCredentials.Insecure);
 
             var client = new Greeter.GreeterClient(channel);
             String user = "you";


### PR DESCRIPTION
Updated host name value in client example from "127.0.0.1" to "localhost". 
This unifies the terminology with the adjacent server examples (which use "localhost").




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
