### PR TITLE
[objc] Re-enable watch os support

### DIFF
--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -107,11 +107,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
-
-  # watchOS is disabled due to #20258.
-  # TODO (mxyan): Enable watchos when !ProtoCompiler.podspec is updated for
-  # support of watchos in the next release
-  # s.watchos.deployment_target = '4.0'
+  s.watchos.deployment_target = '4.0'
 
   # Restrict the gRPC runtime version to the one supported by this plugin.
   s.dependency 'gRPC-ProtoRPC', v

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -109,11 +109,7 @@
     s.ios.deployment_target = '9.0'
     s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '10.0'
-
-    # watchOS is disabled due to #20258.
-    # TODO (mxyan): Enable watchos when !ProtoCompiler.podspec is updated for
-    # support of watchos in the next release
-    # s.watchos.deployment_target = '4.0'
+    s.watchos.deployment_target = '4.0'
 
     # Restrict the gRPC runtime version to the one supported by this plugin.
     s.dependency 'gRPC-ProtoRPC', v


### PR DESCRIPTION
Re-enabling watchos deployment support (#20258) after [!ProtoCompiler](https://cocoapods.org/pods/!ProtoCompiler ) pod recovered.  


Closes #20258