### PR TITLE
[objc] Switch to proto forward declare for gRPC codegen plugin

### DIFF
--- a/bazel/objc_grpc_library.bzl
+++ b/bazel/objc_grpc_library.bzl
@@ -67,7 +67,6 @@ def objc_grpc_library(name, deps, srcs = [], use_well_known_protos = False, **kw
         srcs = arc_srcs,
         defines = [
             "GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=0",
-            "GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO=0",
         ],
         includes = [
             "_generated_protos",

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -132,8 +132,6 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     static const ::std::string kNonNullBegin = "NS_ASSUME_NONNULL_BEGIN\n";
     static const ::std::string kNonNullEnd = "NS_ASSUME_NONNULL_END\n";
     static const ::std::string kProtocolOnly = "GPB_GRPC_PROTOCOL_ONLY";
-    static const ::std::string kForwardDeclare =
-        "GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO";
 
     ::std::string file_name =
         google::protobuf::compiler::objectivec::FilePath(file);
@@ -162,13 +160,6 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     {
       // Generate .pbrpc.h
-
-      ::std::string imports;
-      if (framework.empty()) {
-        imports = LocalImport(file_name + ".pbobjc.h");
-      } else {
-        imports = FrameworkImport(file_name + ".pbobjc.h", framework);
-      }
 
       ::std::string system_imports;
       if (grpc_local_import) {
@@ -209,12 +200,6 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       ::std::string class_declarations =
           grpc_objective_c_generator::GetAllMessageClasses(file);
 
-      ::std::string class_imports;
-      for (int i = 0; i < file->dependency_count(); i++) {
-        class_imports += ImportProtoHeaders(
-            file->dependency(i), "  ", framework, pb_runtime_import_prefix);
-      }
-
       ::std::string ng_protocols;
       for (int i = 0; i < file->service_count(); i++) {
         const grpc::protobuf::ServiceDescriptor* service = file->service(i);
@@ -237,12 +222,9 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
       Write(context, file_name + ".pbrpc.h",
             file_header + SystemImport("Foundation/Foundation.h") + "\n" +
-                PreprocIfNot(kForwardDeclare, imports) + "\n" +
                 PreprocIfNot(kProtocolOnly, system_imports) + "\n" +
-                class_declarations + "\n" +
-                PreprocIfNot(kForwardDeclare, class_imports) + "\n" +
-                forward_declarations + "\n" + kNonNullBegin + "\n" +
-                ng_protocols + protocols + "\n" +
+                class_declarations + "\n" + forward_declarations + "\n" +
+                kNonNullBegin + "\n" + ng_protocols + protocols + "\n" +
                 PreprocIfNot(kProtocolOnly, interfaces) + "\n" + kNonNullEnd +
                 "\n");
     }

--- a/src/objective-c/grpc_objc_internal_library.bzl
+++ b/src/objective-c/grpc_objc_internal_library.bzl
@@ -166,7 +166,6 @@ def local_objc_grpc_library(name, deps, testing = True, srcs = [], use_well_know
         srcs = arc_srcs,
         defines = [
             "GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=0",
-            "GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO=0",
         ],
         includes = ["_generated_protos"],
         deps = library_deps,

--- a/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     # This is needed by all pods that depend on Protobuf:
-    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO=1',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1',
     # This is needed by all pods that depend on gRPC-RxLibrary:
     'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
   }

--- a/test/cpp/ios/RemoteTestClientCpp/RemoteTestCpp.podspec
+++ b/test/cpp/ios/RemoteTestClientCpp/RemoteTestCpp.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     # This is needed by all pods that depend on Protobuf:
-    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO=1',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1',
     # This is needed by all pods that depend on gRPC-RxLibrary:
     'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
   }


### PR DESCRIPTION
Internal clean up to remove direct proto header import and switch to proto forward declaration in codgen grpc service header. This prevents grpc service header from directly importing protobuf headers which should be avoid 

Follow up steps to complete removal of GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO macro in upstream callers. 
