### PR TITLE
Memory leak fix on windows in grpc_tcp_create()

### DIFF
--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -500,8 +500,7 @@ static grpc_endpoint_vtable vtable = {win_read,
 grpc_endpoint* grpc_tcp_create(grpc_winsocket* socket,
                                grpc_channel_args* channel_args,
                                absl::string_view peer_string) {
-  grpc_tcp* tcp = new grpc_tcp;
-  memset(tcp, 0, sizeof(grpc_tcp));
+  grpc_tcp* tcp = new grpc_tcp {};
   tcp->base.vtable = &vtable;
   tcp->socket = socket;
   gpr_mu_init(&tcp->mu);

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -500,7 +500,9 @@ static grpc_endpoint_vtable vtable = {win_read,
 grpc_endpoint* grpc_tcp_create(grpc_winsocket* socket,
                                grpc_channel_args* channel_args,
                                absl::string_view peer_string) {
-  grpc_tcp* tcp = new grpc_tcp {};
+  // TODO(jtattermusch): C++ize grpc_tcp and its dependencies (i.e. add
+  // constructors) to ensure proper initialization
+  grpc_tcp* tcp = new grpc_tcp{};
   tcp->base.vtable = &vtable;
   tcp->socket = socket;
   gpr_mu_init(&tcp->mu);


### PR DESCRIPTION
There's a memory leak in [grpc/src/core/lib/iomgr/tcp_windows.cc](https://github.com/grpc/grpc/blob/0042c2b86ffc20dd806b9da9d442f57d652a9e34/src/core/lib/iomgr/tcp_windows.cc#L507-L508).

A grpc_tcp struct is allocated and immediately after initialized to zero with a call to memset. This causes a memory leak since two members in that struct are std::string's(peer_string and local_address) and in my case, with Visual Studio 2017, std::string allocates a capacity in the constructor which gets overwritten by the memset.

In any case it's an error using memset with non POD data types.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
