### PR TITLE
Make a suite of wakeup schedulers for tests

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4226,6 +4226,7 @@ targets:
   - src/core/lib/promise/promise.h
   - src/core/lib/promise/seq.h
   - src/core/lib/promise/wait_set.h
+  - test/core/promise/test_wakeup_schedulers.h
   src:
   - src/core/ext/upb-generated/google/api/annotations.upb.c
   - src/core/ext/upb-generated/google/api/expr/v1alpha1/checked.upb.c
@@ -5680,6 +5681,7 @@ targets:
   - src/core/lib/promise/poll.h
   - src/core/lib/promise/seq.h
   - src/core/lib/promise/wait_set.h
+  - test/core/promise/test_wakeup_schedulers.h
   src:
   - src/core/ext/upb-generated/google/api/annotations.upb.c
   - src/core/ext/upb-generated/google/api/expr/v1alpha1/checked.upb.c
@@ -6294,6 +6296,7 @@ targets:
   - src/core/lib/promise/latch.h
   - src/core/lib/promise/poll.h
   - src/core/lib/promise/seq.h
+  - test/core/promise/test_wakeup_schedulers.h
   src:
   - src/core/ext/upb-generated/google/api/annotations.upb.c
   - src/core/ext/upb-generated/google/api/expr/v1alpha1/checked.upb.c
@@ -6585,6 +6588,7 @@ targets:
   - src/core/lib/promise/promise.h
   - src/core/lib/promise/seq.h
   - src/core/lib/promise/wait_set.h
+  - test/core/promise/test_wakeup_schedulers.h
   src:
   - src/core/ext/upb-generated/google/api/annotations.upb.c
   - src/core/ext/upb-generated/google/api/expr/v1alpha1/checked.upb.c
@@ -6762,6 +6766,7 @@ targets:
   - src/core/lib/promise/poll.h
   - src/core/lib/promise/promise.h
   - src/core/lib/promise/seq.h
+  - test/core/promise/test_wakeup_schedulers.h
   src:
   - src/core/ext/upb-generated/google/api/annotations.upb.c
   - src/core/ext/upb-generated/google/api/expr/v1alpha1/checked.upb.c

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -281,7 +281,7 @@ class EnterContexts : public promise_detail::Context<Contexts>... {
 // There should exist a static function:
 // struct WakeupScheduler {
 //   template <typename ActivityType>
-//   static void ScheduleWakeup(WakeupScheduler*, ActivityType* activity);
+//   void ScheduleWakeup(ActivityType* activity);
 // };
 // This function should arrange that activity->RunScheduledWakeup() be invoked
 // at the earliest opportunity.
@@ -476,25 +476,6 @@ ActivityPtr MakeActivity(Factory promise_factory,
           std::move(promise_factory), std::move(wakeup_scheduler),
           std::move(on_done), std::move(contexts)...));
 }
-
-// A wakeup scheduler that simply crashes.
-// Useful for very limited tests.
-struct NoWakeupScheduler {
-  template <typename ActivityType>
-  void ScheduleWakeup(ActivityType*) {
-    abort();
-  }
-};
-
-// A wakeup scheduler that simply runs the callback immediately.
-// Useful for unit testing, probably not so much for real systems due to lock
-// ordering problems.
-struct InlineWakeupScheduler {
-  template <typename ActivityType>
-  void ScheduleWakeup(ActivityType* activity) {
-    activity->RunScheduledWakeup();
-  }
-};
 
 }  // namespace grpc_core
 

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -12,13 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])
 
 grpc_package(name = "test/core/promise")
 
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
+
+grpc_cc_library(
+    name = "test_wakeup_schedulers",
+    testonly = True,
+    hdrs = ["test_wakeup_schedulers.h"],
+    external_deps = ["gtest"],
+    deps = [
+        "//:gpr_base",
+        "//test/core/util:grpc_suppressions",
+    ],
+)
 
 grpc_cc_test(
     name = "poll_test",
@@ -183,6 +194,7 @@ grpc_cc_test(
     language = "c++",
     uses_polling = False,
     deps = [
+        "test_wakeup_schedulers",
         "//:activity",
         "//:join",
         "//:promise",
@@ -199,6 +211,7 @@ grpc_cc_test(
     language = "c++",
     uses_polling = False,
     deps = [
+        "test_wakeup_schedulers",
         "//:join",
         "//:latch",
         "//:seq",
@@ -213,6 +226,7 @@ grpc_cc_test(
     language = "c++",
     uses_polling = False,
     deps = [
+        "test_wakeup_schedulers",
         "//:observable",
         "//:promise",
         "//:seq",
@@ -227,6 +241,7 @@ grpc_cc_test(
     language = "c++",
     uses_polling = False,
     deps = [
+        "test_wakeup_schedulers",
         "//:for_each",
         "//:join",
         "//:map",
@@ -244,6 +259,7 @@ grpc_cc_test(
     language = "c++",
     uses_polling = False,
     deps = [
+        "test_wakeup_schedulers",
         "//:join",
         "//:pipe",
         "//:promise",

--- a/test/core/promise/activity_test.cc
+++ b/test/core/promise/activity_test.cc
@@ -21,6 +21,7 @@
 #include "src/core/lib/promise/promise.h"
 #include "src/core/lib/promise/seq.h"
 #include "src/core/lib/promise/wait_set.h"
+#include "test/core/promise/test_wakeup_schedulers.h"
 
 using testing::_;
 using testing::Mock;
@@ -29,19 +30,6 @@ using testing::SaveArg;
 using testing::StrictMock;
 
 namespace grpc_core {
-
-class MockCallbackScheduler {
- public:
-  MOCK_METHOD(void, Schedule, (std::function<void()>));
-};
-
-struct UseMockCallbackScheduler {
-  MockCallbackScheduler* scheduler;
-  template <typename ActivityType>
-  void ScheduleWakeup(ActivityType* activity) {
-    scheduler->Schedule([activity] { activity->RunScheduledWakeup(); });
-  }
-};
 
 // A simple Barrier type: stalls progress until it is 'cleared'.
 class Barrier {

--- a/test/core/promise/for_each_test.cc
+++ b/test/core/promise/for_each_test.cc
@@ -22,6 +22,7 @@
 #include "src/core/lib/promise/observable.h"
 #include "src/core/lib/promise/pipe.h"
 #include "src/core/lib/promise/seq.h"
+#include "test/core/promise/test_wakeup_schedulers.h"
 
 using testing::Mock;
 using testing::MockFunction;

--- a/test/core/promise/latch_test.cc
+++ b/test/core/promise/latch_test.cc
@@ -19,6 +19,7 @@
 
 #include "src/core/lib/promise/join.h"
 #include "src/core/lib/promise/seq.h"
+#include "test/core/promise/test_wakeup_schedulers.h"
 
 using testing::MockFunction;
 using testing::StrictMock;

--- a/test/core/promise/observable_test.cc
+++ b/test/core/promise/observable_test.cc
@@ -19,6 +19,7 @@
 
 #include "src/core/lib/promise/promise.h"
 #include "src/core/lib/promise/seq.h"
+#include "test/core/promise/test_wakeup_schedulers.h"
 
 using testing::MockFunction;
 using testing::StrictMock;

--- a/test/core/promise/pipe_test.cc
+++ b/test/core/promise/pipe_test.cc
@@ -22,6 +22,7 @@
 #include "src/core/lib/promise/join.h"
 #include "src/core/lib/promise/promise.h"
 #include "src/core/lib/promise/seq.h"
+#include "test/core/promise/test_wakeup_schedulers.h"
 
 using testing::MockFunction;
 using testing::StrictMock;

--- a/test/core/promise/test_wakeup_schedulers.h
+++ b/test/core/promise/test_wakeup_schedulers.h
@@ -1,0 +1,64 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_TEST_CORE_PROMISE_TEST_WAKEUP_SCHEDULERS_H
+#define GRPC_TEST_CORE_PROMISE_TEST_WAKEUP_SCHEDULERS_H
+
+#include <gmock/gmock.h>
+
+namespace grpc_core {
+
+// A wakeup scheduler that simply crashes.
+// Useful for very limited tests.
+struct NoWakeupScheduler {
+  template <typename ActivityType>
+  void ScheduleWakeup(ActivityType*) {
+    abort();
+  }
+};
+
+// A wakeup scheduler that simply runs the callback immediately.
+// Useful for unit testing, probably not so much for real systems due to lock
+// ordering problems.
+struct InlineWakeupScheduler {
+  template <typename ActivityType>
+  void ScheduleWakeup(ActivityType* activity) {
+    activity->RunScheduledWakeup();
+  }
+};
+
+// Mock for something that can schedule callbacks.
+class MockCallbackScheduler {
+ public:
+  MOCK_METHOD(void, Schedule, (std::function<void()>));
+};
+
+// WakeupScheduler that schedules wakeups against a MockCallbackScheduler.
+// Usage:
+// TEST(..., ...) {
+//   MockCallbackScheduler scheduler;
+//   auto activity = MakeActivity(...,
+//                                UseMockCallbackScheduler(&scheduler),
+//                                ...);
+struct UseMockCallbackScheduler {
+  MockCallbackScheduler* scheduler;
+  template <typename ActivityType>
+  void ScheduleWakeup(ActivityType* activity) {
+    scheduler->Schedule([activity] { activity->RunScheduledWakeup(); });
+  }
+};
+
+}  // namespace grpc_core
+
+#endif


### PR DESCRIPTION
Moved all the wakeup schedulers used in tests into a small header only library.

Also fixed up a comment from the last PR that was kinda wrong.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
