### PR TITLE
Changed grpc_error_get|set_str to use std string instead of slice

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1400,6 +1400,7 @@ grpc_cc_library(
         "grpc_codegen",
         "grpc_trace",
         "slice",
+        "slice_refcount",
         "useful",
     ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,6 +711,7 @@ if(gRPC_BUILD_TESTS)
   endif()
   add_dependencies(buildtests_c test_core_gpr_time_test)
   add_dependencies(buildtests_c test_core_iomgr_resource_quota_test)
+  add_dependencies(buildtests_c test_core_security_credentials_test)
   add_dependencies(buildtests_c test_core_slice_slice_test)
   add_dependencies(buildtests_c thd_test)
   add_dependencies(buildtests_c threadpool_test)
@@ -994,7 +995,6 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx string_ref_test)
   add_dependencies(buildtests_cxx table_test)
   add_dependencies(buildtests_cxx test_core_resource_quota_resource_quota_test)
-  add_dependencies(buildtests_cxx test_core_security_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_client_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_server_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_util_slice_test)
@@ -7390,6 +7390,33 @@ target_include_directories(test_core_iomgr_resource_quota_test
 )
 
 target_link_libraries(test_core_iomgr_resource_quota_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(test_core_security_credentials_test
+  test/core/security/credentials_test.cc
+)
+
+target_include_directories(test_core_security_credentials_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+)
+
+target_link_libraries(test_core_security_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
 )
@@ -16087,41 +16114,6 @@ target_link_libraries(test_core_resource_quota_resource_quota_test
   absl::statusor
   absl::variant
   gpr
-)
-
-
-endif()
-if(gRPC_BUILD_TESTS)
-
-add_executable(test_core_security_credentials_test
-  test/core/security/credentials_test.cc
-  third_party/googletest/googletest/src/gtest-all.cc
-  third_party/googletest/googlemock/src/gmock-all.cc
-)
-
-target_include_directories(test_core_security_credentials_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-    third_party/googletest/googletest/include
-    third_party/googletest/googletest
-    third_party/googletest/googlemock/include
-    third_party/googletest/googlemock
-    ${_gRPC_PROTO_GENS_DIR}
-)
-
-target_link_libraries(test_core_security_credentials_test
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,7 +596,6 @@ if(gRPC_BUILD_TESTS)
   endif()
   add_dependencies(buildtests_c endpoint_pair_test)
   add_dependencies(buildtests_c env_test)
-  add_dependencies(buildtests_c error_test)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_c ev_epollex_linux_test)
   endif()
@@ -712,7 +711,6 @@ if(gRPC_BUILD_TESTS)
   endif()
   add_dependencies(buildtests_c test_core_gpr_time_test)
   add_dependencies(buildtests_c test_core_iomgr_resource_quota_test)
-  add_dependencies(buildtests_c test_core_security_credentials_test)
   add_dependencies(buildtests_c test_core_slice_slice_test)
   add_dependencies(buildtests_c thd_test)
   add_dependencies(buildtests_c threadpool_test)
@@ -861,6 +859,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx end2end_test)
   add_dependencies(buildtests_cxx endpoint_config_test)
   add_dependencies(buildtests_cxx error_details_test)
+  add_dependencies(buildtests_cxx error_test)
   add_dependencies(buildtests_cxx error_utils_test)
   add_dependencies(buildtests_cxx evaluate_args_test)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -995,6 +994,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx string_ref_test)
   add_dependencies(buildtests_cxx table_test)
   add_dependencies(buildtests_cxx test_core_resource_quota_resource_quota_test)
+  add_dependencies(buildtests_cxx test_core_security_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_client_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_server_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_util_slice_test)
@@ -5272,34 +5272,6 @@ target_link_libraries(env_test
 
 endif()
 if(gRPC_BUILD_TESTS)
-
-add_executable(error_test
-  test/core/iomgr/endpoint_tests.cc
-  test/core/iomgr/error_test.cc
-)
-
-target_include_directories(error_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-)
-
-target_link_libraries(error_test
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-)
-
-
-endif()
-if(gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(ev_epollex_linux_test
@@ -7418,33 +7390,6 @@ target_include_directories(test_core_iomgr_resource_quota_test
 )
 
 target_link_libraries(test_core_iomgr_resource_quota_test
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-)
-
-
-endif()
-if(gRPC_BUILD_TESTS)
-
-add_executable(test_core_security_credentials_test
-  test/core/security/credentials_test.cc
-)
-
-target_include_directories(test_core_security_credentials_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-)
-
-target_link_libraries(test_core_security_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
 )
@@ -11046,6 +10991,42 @@ target_link_libraries(error_details_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_error_details
+  grpc_test_util
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(error_test
+  test/core/iomgr/endpoint_tests.cc
+  test/core/iomgr/error_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(error_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(error_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
 )
 
@@ -16106,6 +16087,41 @@ target_link_libraries(test_core_resource_quota_resource_quota_test
   absl::statusor
   absl::variant
   gpr
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(test_core_security_credentials_test
+  test/core/security/credentials_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(test_core_security_credentials_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(test_core_security_credentials_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4176,6 +4176,14 @@ targets:
   - test/core/iomgr/resource_quota_test.cc
   deps:
   - grpc_test_util
+- name: test_core_security_credentials_test
+  build: test
+  language: c
+  headers: []
+  src:
+  - test/core/security/credentials_test.cc
+  deps:
+  - grpc_test_util
 - name: test_core_slice_slice_test
   build: test
   language: c
@@ -7944,15 +7952,6 @@ targets:
   - absl/types:variant
   - gpr
   uses_polling: false
-- name: test_core_security_credentials_test
-  gtest: true
-  build: test
-  language: c++
-  headers: []
-  src:
-  - test/core/security/credentials_test.cc
-  deps:
-  - grpc_test_util
 - name: test_cpp_client_credentials_test
   gtest: true
   build: test

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -3332,17 +3332,6 @@ targets:
   deps:
   - grpc_test_util
   uses_polling: false
-- name: error_test
-  build: test
-  language: c
-  headers:
-  - test/core/iomgr/endpoint_tests.h
-  src:
-  - test/core/iomgr/endpoint_tests.cc
-  - test/core/iomgr/error_test.cc
-  deps:
-  - grpc_test_util
-  uses_polling: false
 - name: ev_epollex_linux_test
   build: test
   language: c
@@ -4185,14 +4174,6 @@ targets:
   headers: []
   src:
   - test/core/iomgr/resource_quota_test.cc
-  deps:
-  - grpc_test_util
-- name: test_core_security_credentials_test
-  build: test
-  language: c
-  headers: []
-  src:
-  - test/core/security/credentials_test.cc
   deps:
   - grpc_test_util
 - name: test_core_slice_slice_test
@@ -5782,6 +5763,18 @@ targets:
   deps:
   - grpc++_error_details
   - grpc_test_util
+- name: error_test
+  gtest: true
+  build: test
+  language: c++
+  headers:
+  - test/core/iomgr/endpoint_tests.h
+  src:
+  - test/core/iomgr/endpoint_tests.cc
+  - test/core/iomgr/error_test.cc
+  deps:
+  - grpc_test_util
+  uses_polling: false
 - name: error_utils_test
   gtest: true
   build: test
@@ -7951,6 +7944,15 @@ targets:
   - absl/types:variant
   - gpr
   uses_polling: false
+- name: test_core_security_credentials_test
+  gtest: true
+  build: test
+  language: c++
+  headers: []
+  src:
+  - test/core/security/credentials_test.cc
+  deps:
+  - grpc_test_util
 - name: test_cpp_client_credentials_test
   gtest: true
   build: test

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2904,11 +2904,10 @@ void ClientChannel::LoadBalancedCall::RecvTrailingMetadataReady(
     if (error != GRPC_ERROR_NONE) {
       // Get status from error.
       grpc_status_code code;
-      grpc_slice message = grpc_empty_slice();
+      std::string message;
       grpc_error_get_status(error, self->deadline_, &code, &message,
                             /*http_error=*/nullptr, /*error_string=*/nullptr);
-      status = absl::Status(static_cast<absl::StatusCode>(code),
-                            StringViewFromSlice(message));
+      status = absl::Status(static_cast<absl::StatusCode>(code), message);
     } else {
       // Get status from headers.
       const auto& fields = self->recv_trailing_metadata_->legacy_index()->named;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -841,13 +841,13 @@ void grpc_dns_lookup_ares_continue_after_check_localhost_and_ip_literals_locked(
   if (host.empty()) {
     error = grpc_error_set_str(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("unparseable host:port"),
-        GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
+        GRPC_ERROR_STR_TARGET_ADDRESS, name);
     goto error_cleanup;
   } else if (port.empty()) {
     if (default_port == nullptr) {
       error = grpc_error_set_str(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("no port in name"),
-          GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
+          GRPC_ERROR_STR_TARGET_ADDRESS, name);
       goto error_cleanup;
     }
     port = default_port;
@@ -879,7 +879,7 @@ void grpc_dns_lookup_ares_continue_after_check_localhost_and_ip_literals_locked(
     } else {
       error = grpc_error_set_str(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("cannot parse authority"),
-          GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
+          GRPC_ERROR_STR_TARGET_ADDRESS, name);
       goto error_cleanup;
     }
     int status =

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -131,11 +131,10 @@ static grpc_error_handle client_filter_incoming_metadata(
               grpc_error_set_str(
                   GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                       "Received http2 :status header with non-200 OK status"),
-                  GRPC_ERROR_STR_VALUE, grpc_slice_from_copied_string(val)),
+                  GRPC_ERROR_STR_VALUE, val),
               GRPC_ERROR_INT_GRPC_STATUS,
               grpc_http2_status_to_grpc_status(atoi(val))),
-          GRPC_ERROR_STR_GRPC_MESSAGE,
-          grpc_slice_from_cpp_string(std::move(msg)));
+          GRPC_ERROR_STR_GRPC_MESSAGE, msg);
       gpr_free(val);
       return e;
     }

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -187,11 +187,10 @@ static grpc_error_handle hs_filter_incoming_metadata(grpc_call_element* elem,
     }
     b->Remove(GRPC_BATCH_METHOD);
   } else {
-    hs_add_error(
-        error_name, &error,
-        grpc_error_set_str(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
-            GRPC_ERROR_STR_KEY, grpc_slice_from_static_string(":method")));
+    hs_add_error(error_name, &error,
+                 grpc_error_set_str(
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
+                     GRPC_ERROR_STR_KEY, ":method"));
   }
 
   if (b->legacy_index()->named.te != nullptr) {
@@ -207,7 +206,7 @@ static grpc_error_handle hs_filter_incoming_metadata(grpc_call_element* elem,
     hs_add_error(error_name, &error,
                  grpc_error_set_str(
                      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
-                     GRPC_ERROR_STR_KEY, grpc_slice_from_static_string("te")));
+                     GRPC_ERROR_STR_KEY, "te"));
   }
 
   if (b->legacy_index()->named.scheme != nullptr) {
@@ -224,11 +223,10 @@ static grpc_error_handle hs_filter_incoming_metadata(grpc_call_element* elem,
     }
     b->Remove(GRPC_BATCH_SCHEME);
   } else {
-    hs_add_error(
-        error_name, &error,
-        grpc_error_set_str(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
-            GRPC_ERROR_STR_KEY, grpc_slice_from_static_string(":scheme")));
+    hs_add_error(error_name, &error,
+                 grpc_error_set_str(
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
+                     GRPC_ERROR_STR_KEY, ":scheme"));
   }
 
   if (b->legacy_index()->named.content_type != nullptr) {
@@ -265,11 +263,10 @@ static grpc_error_handle hs_filter_incoming_metadata(grpc_call_element* elem,
   }
 
   if (b->legacy_index()->named.path == nullptr) {
-    hs_add_error(
-        error_name, &error,
-        grpc_error_set_str(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
-            GRPC_ERROR_STR_KEY, grpc_slice_from_static_string(":path")));
+    hs_add_error(error_name, &error,
+                 grpc_error_set_str(
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
+                     GRPC_ERROR_STR_KEY, ":path"));
   } else if (*calld->recv_initial_metadata_flags &
              GRPC_INITIAL_METADATA_CACHEABLE_REQUEST) {
     /* We have a cacheable request made with GET verb. The path contains the
@@ -327,11 +324,10 @@ static grpc_error_handle hs_filter_incoming_metadata(grpc_call_element* elem,
   }
 
   if (b->legacy_index()->named.authority == nullptr) {
-    hs_add_error(
-        error_name, &error,
-        grpc_error_set_str(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
-            GRPC_ERROR_STR_KEY, grpc_slice_from_static_string(":authority")));
+    hs_add_error(error_name, &error,
+                 grpc_error_set_str(
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Missing header"),
+                     GRPC_ERROR_STR_KEY, ":authority"));
   }
 
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1078,7 +1078,7 @@ static void queue_setting_update(grpc_chttp2_transport* t,
 void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
                                      uint32_t goaway_error,
                                      uint32_t last_stream_id,
-                                     const grpc_slice& goaway_text) {
+                                     absl::string_view goaway_text) {
   // Discard the error from a previous goaway frame (if any)
   if (t->goaway_error != GRPC_ERROR_NONE) {
     GRPC_ERROR_UNREF(t->goaway_error);
@@ -1107,7 +1107,7 @@ void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
   // for new connections on that channel.
   if (GPR_UNLIKELY(t->is_client &&
                    goaway_error == GRPC_HTTP2_ENHANCE_YOUR_CALM &&
-                   grpc_slice_str_cmp(goaway_text, "too_many_pings") == 0)) {
+                   goaway_text == "too_many_pings")) {
     gpr_log(GPR_ERROR,
             "Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug "
             "data equal to \"too_many_pings\"");
@@ -1230,9 +1230,9 @@ void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
     if (closure->error_data.error == GRPC_ERROR_NONE) {
       closure->error_data.error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
           "Error in HTTP transport completing operation");
-      closure->error_data.error = grpc_error_set_str(
-          closure->error_data.error, GRPC_ERROR_STR_TARGET_ADDRESS,
-          grpc_slice_from_copied_string(t->peer_string.c_str()));
+      closure->error_data.error =
+          grpc_error_set_str(closure->error_data.error,
+                             GRPC_ERROR_STR_TARGET_ADDRESS, t->peer_string);
     }
     closure->error_data.error =
         grpc_error_add_child(closure->error_data.error, error);
@@ -1752,12 +1752,12 @@ static void send_goaway(grpc_chttp2_transport* t, grpc_error_handle error) {
           grpc_error_std_string(error).c_str());
   t->sent_goaway_state = GRPC_CHTTP2_GOAWAY_SEND_SCHEDULED;
   grpc_http2_error_code http_error;
-  grpc_slice slice;
-  grpc_error_get_status(error, GRPC_MILLIS_INF_FUTURE, nullptr, &slice,
+  std::string message;
+  grpc_error_get_status(error, GRPC_MILLIS_INF_FUTURE, nullptr, &message,
                         &http_error, nullptr);
-  grpc_chttp2_goaway_append(t->last_new_stream_id,
-                            static_cast<uint32_t>(http_error),
-                            grpc_slice_ref_internal(slice), &t->qbuf);
+  grpc_chttp2_goaway_append(
+      t->last_new_stream_id, static_cast<uint32_t>(http_error),
+      grpc_slice_from_cpp_string(std::move(message)), &t->qbuf);
   grpc_chttp2_initiate_write(t, GRPC_CHTTP2_INITIATE_WRITE_GOAWAY_SENT);
   GRPC_ERROR_UNREF(error);
 }
@@ -2091,8 +2091,9 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 void grpc_chttp2_fake_status(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                              grpc_error_handle error) {
   grpc_status_code status;
-  grpc_slice slice;
-  grpc_error_get_status(error, s->deadline, &status, &slice, nullptr, nullptr);
+  std::string message;
+  grpc_error_get_status(error, s->deadline, &status, &message, nullptr,
+                        nullptr);
   if (status != GRPC_STATUS_OK) {
     s->seen_error = true;
   }
@@ -2110,12 +2111,12 @@ void grpc_chttp2_fake_status(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                       grpc_chttp2_incoming_metadata_buffer_replace_or_add(
                           &s->trailing_metadata_buffer, GRPC_MDSTR_GRPC_STATUS,
                           grpc_core::UnmanagedMemorySlice(status_string)));
-    if (!GRPC_SLICE_IS_EMPTY(slice)) {
-      GRPC_LOG_IF_ERROR(
-          "add_status_message",
-          grpc_chttp2_incoming_metadata_buffer_replace_or_add(
-              &s->trailing_metadata_buffer, GRPC_MDSTR_GRPC_MESSAGE,
-              grpc_slice_ref_internal(slice)));
+    if (!message.empty()) {
+      grpc_slice message_slice = grpc_slice_from_cpp_string(std::move(message));
+      GRPC_LOG_IF_ERROR("add_status_message",
+                        grpc_chttp2_incoming_metadata_buffer_replace_or_add(
+                            &s->trailing_metadata_buffer,
+                            GRPC_MDSTR_GRPC_MESSAGE, message_slice));
     }
     s->published_metadata[1] = GRPC_METADATA_SYNTHESIZED_FROM_FAKE;
     grpc_chttp2_maybe_complete_recv_trailing_metadata(t, s);
@@ -2255,8 +2256,8 @@ static void close_from_api(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
   uint8_t* p;
   uint32_t len = 0;
   grpc_status_code grpc_status;
-  grpc_slice slice;
-  grpc_error_get_status(error, s->deadline, &grpc_status, &slice, nullptr,
+  std::string message;
+  grpc_error_get_status(error, s->deadline, &grpc_status, &message, nullptr,
                         nullptr);
 
   GPR_ASSERT(grpc_status >= 0 && (int)grpc_status < 100);
@@ -2349,7 +2350,7 @@ static void close_from_api(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
   GPR_ASSERT(p == GRPC_SLICE_END_PTR(status_hdr));
   len += static_cast<uint32_t> GRPC_SLICE_LENGTH(status_hdr);
 
-  size_t msg_len = GRPC_SLICE_LENGTH(slice);
+  size_t msg_len = message.length();
   GPR_ASSERT(msg_len <= UINT32_MAX);
   grpc_core::VarintWriter<1> msg_len_writer(msg_len);
   message_pfx = GRPC_SLICE_MALLOC(14 + msg_len_writer.length());
@@ -2394,7 +2395,8 @@ static void close_from_api(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
   }
   grpc_slice_buffer_add(&t->qbuf, status_hdr);
   grpc_slice_buffer_add(&t->qbuf, message_pfx);
-  grpc_slice_buffer_add(&t->qbuf, grpc_slice_ref_internal(slice));
+  grpc_slice_buffer_add(&t->qbuf,
+                        grpc_slice_from_cpp_string(std::move(message)));
   grpc_chttp2_reset_ping_clock(t);
   grpc_chttp2_add_rst_stream_to_next_write(t, s->id, GRPC_HTTP2_NO_ERROR,
                                            &s->stats.outgoing);

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -133,10 +133,10 @@ grpc_error_handle grpc_deframe_unprocessed_incoming_frames(
                 absl::StrFormat("Bad GRPC frame type 0x%02x", p->frame_type));
             p->error = grpc_error_set_int(p->error, GRPC_ERROR_INT_STREAM_ID,
                                           static_cast<intptr_t>(s->id));
-            p->error = grpc_error_set_str(
-                p->error, GRPC_ERROR_STR_RAW_BYTES,
-                grpc_slice_from_moved_string(grpc_core::UniquePtr<char>(
-                    grpc_dump_slice(*slice, GPR_DUMP_HEX | GPR_DUMP_ASCII))));
+            grpc_core::UniquePtr<char> dmp(
+                grpc_dump_slice(*slice, GPR_DUMP_HEX | GPR_DUMP_ASCII));
+            p->error = grpc_error_set_str(p->error, GRPC_ERROR_STR_RAW_BYTES,
+                                          dmp.get());
             p->error =
                 grpc_error_set_int(p->error, GRPC_ERROR_INT_OFFSET, cur - beg);
             p->state = GRPC_CHTTP2_DATA_ERROR;

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -139,7 +139,8 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
       if (is_last) {
         grpc_chttp2_add_incoming_goaway(
             t, p->error_code, p->last_stream_id,
-            grpc_slice_new(p->debug_data, p->debug_length, gpr_free));
+            absl::string_view(p->debug_data, p->debug_length));
+        gpr_free(p->debug_data);
         p->debug_data = nullptr;
       }
       return GRPC_ERROR_NONE;

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -109,8 +109,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
           grpc_error_set_str(
               GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
               GRPC_ERROR_STR_GRPC_MESSAGE,
-              grpc_slice_from_cpp_string(absl::StrCat(
-                  "Received RST_STREAM with error code ", reason))),
+              absl::StrCat("Received RST_STREAM with error code ", reason)),
           GRPC_ERROR_INT_HTTP2_ERROR, static_cast<intptr_t>(reason));
     }
     grpc_chttp2_mark_stream_closed(t, s, true, true, error);

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -767,7 +767,7 @@ grpc_chttp2_stream* grpc_chttp2_parsing_accept_stream(grpc_chttp2_transport* t,
 void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
                                      uint32_t goaway_error,
                                      uint32_t last_stream_id,
-                                     const grpc_slice& goaway_text);
+                                     absl::string_view goaway_text);
 
 void grpc_chttp2_parsing_become_skip_parser(grpc_chttp2_transport* t);
 

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -118,8 +118,7 @@ static void append_error(internal_request* req, grpc_error_handle error) {
   std::string addr_text = grpc_sockaddr_to_uri(addr);
   req->overall_error = grpc_error_add_child(
       req->overall_error,
-      grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
-                         grpc_slice_from_cpp_string(std::move(addr_text))));
+      grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS, addr_text));
 }
 
 static void do_read(internal_request* req) {

--- a/src/core/lib/iomgr/endpoint_cfstream.cc
+++ b/src/core/lib/iomgr/endpoint_cfstream.cc
@@ -110,8 +110,7 @@ static grpc_error_handle CFStreamAnnotateError(grpc_error_handle src_error,
   return grpc_error_set_str(
       grpc_error_set_int(src_error, GRPC_ERROR_INT_GRPC_STATUS,
                          GRPC_STATUS_UNAVAILABLE),
-      GRPC_ERROR_STR_TARGET_ADDRESS,
-      grpc_slice_from_copied_string(ep->peer_string.c_str()));
+      GRPC_ERROR_STR_TARGET_ADDRESS, ep->peer_string);
 }
 
 static void CallReadCb(CFStreamEndpoint* ep, grpc_error_handle error) {

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -35,6 +35,7 @@
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/error_internal.h"
 #include "src/core/lib/slice/slice_internal.h"
+#include "src/core/lib/slice/slice_utils.h"
 
 grpc_core::DebugOnlyTraceFlag grpc_trace_error_refcount(false,
                                                         "error_refcount");
@@ -129,26 +130,23 @@ bool grpc_error_get_int(grpc_error_handle error, grpc_error_ints which,
 
 grpc_error_handle grpc_error_set_str(grpc_error_handle src,
                                      grpc_error_strs which,
-                                     const grpc_slice& str) {
+                                     absl::string_view str) {
   grpc_core::StatusSetStr(
-      &src, static_cast<grpc_core::StatusStrProperty>(which),
-      std::string(reinterpret_cast<const char*>(GRPC_SLICE_START_PTR(str)),
-                  GRPC_SLICE_LENGTH(str)));
+      &src, static_cast<grpc_core::StatusStrProperty>(which), str);
   return src;
 }
 
 bool grpc_error_get_str(grpc_error_handle error, grpc_error_strs which,
-                        grpc_slice* s) {
+                        std::string* s) {
   absl::optional<std::string> value = grpc_core::StatusGetStr(
       error, static_cast<grpc_core::StatusStrProperty>(which));
   if (value.has_value()) {
-    *s = grpc_slice_from_copied_buffer(value->c_str(), value->size());
+    *s = std::move(*value);
     return true;
   } else {
     // TODO(veblush): Remove this once absl::Status migration is done
     if (which == GRPC_ERROR_STR_DESCRIPTION && !error.message().empty()) {
-      *s = grpc_slice_from_copied_buffer(error.message().data(),
-                                         error.message().size());
+      *s = std::move(*value);
       return true;
     }
     return false;
@@ -597,27 +595,26 @@ bool grpc_error_get_int(grpc_error_handle err, grpc_error_ints which,
 
 grpc_error_handle grpc_error_set_str(grpc_error_handle src,
                                      grpc_error_strs which,
-                                     const grpc_slice& str) {
+                                     absl::string_view str) {
   grpc_error_handle new_err = copy_error_and_unref(src);
-  internal_set_str(&new_err, which, str);
+  internal_set_str(&new_err, which,
+                   grpc_slice_from_copied_buffer(str.data(), str.length()));
   return new_err;
 }
 
 bool grpc_error_get_str(grpc_error_handle err, grpc_error_strs which,
-                        grpc_slice* str) {
+                        std::string* s) {
   if (grpc_error_is_special(err)) {
     if (which != GRPC_ERROR_STR_GRPC_MESSAGE) return false;
     const special_error_status_map& msg =
         error_status_map[reinterpret_cast<size_t>(err)];
-    str->refcount = &grpc_core::kNoopRefcount;
-    str->data.refcounted.bytes =
-        reinterpret_cast<uint8_t*>(const_cast<char*>(msg.msg));
-    str->data.refcounted.length = msg.len;
+    *s = std::string(msg.msg, msg.len);
     return true;
   }
   uint8_t slot = err->strs[which];
   if (slot != UINT8_MAX) {
-    *str = *reinterpret_cast<grpc_slice*>(err->arena + slot);
+    grpc_slice* slice = reinterpret_cast<grpc_slice*>(err->arena + slot);
+    *s = std::string(grpc_core::StringViewFromSlice(*slice));
     return true;
   } else {
     return false;
@@ -903,9 +900,8 @@ grpc_error_handle grpc_os_error(const char* file, int line, int err,
                                 grpc_slice_from_static_string(strerror(err)),
                                 nullptr, 0),
               GRPC_ERROR_INT_ERRNO, err),
-          GRPC_ERROR_STR_OS_ERROR,
-          grpc_slice_from_static_string(strerror(err))),
-      GRPC_ERROR_STR_SYSCALL, grpc_slice_from_copied_string(call_name));
+          GRPC_ERROR_STR_OS_ERROR, strerror(err)),
+      GRPC_ERROR_STR_SYSCALL, call_name);
 }
 
 #ifdef GPR_WINDOWS
@@ -919,8 +915,8 @@ grpc_error_handle grpc_wsa_error(const char* file, int line, int err,
                                 grpc_slice_from_static_string("OS Error"), NULL,
                                 0),
               GRPC_ERROR_INT_WSA_ERROR, err),
-          GRPC_ERROR_STR_OS_ERROR, grpc_slice_from_copied_string(utf8_message)),
-      GRPC_ERROR_STR_SYSCALL, grpc_slice_from_static_string(call_name));
+          GRPC_ERROR_STR_OS_ERROR, utf8_message),
+      GRPC_ERROR_STR_SYSCALL, call_name);
   gpr_free(utf8_message);
   return error;
 }

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -364,15 +364,12 @@ grpc_error_handle grpc_error_set_int(grpc_error_handle src,
 /// intptr_t for `p`, even if the value of `p` is not used.
 bool grpc_error_get_int(grpc_error_handle error, grpc_error_ints which,
                         intptr_t* p);
-/// This call takes ownership of the slice; the error is responsible for
-/// eventually unref-ing it.
 grpc_error_handle grpc_error_set_str(
     grpc_error_handle src, grpc_error_strs which,
-    const grpc_slice& str) GRPC_MUST_USE_RESULT;
+    absl::string_view str) GRPC_MUST_USE_RESULT;
 /// Returns false if the specified string is not set.
-/// Caller does NOT own the slice.
 bool grpc_error_get_str(grpc_error_handle error, grpc_error_strs which,
-                        grpc_slice* s);
+                        std::string* str);
 
 /// Add a child error: an error that is believed to have contributed to this
 /// error occurring. Allows root causing high level errors from lower level

--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -71,8 +71,8 @@ end:
         grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                "Failed to load file", &error, 1),
                            GRPC_ERROR_STR_FILENAME,
-                           grpc_slice_from_copied_string(
-                               filename));  // TODO(ncteisen), always static?
+
+                           filename);
     GRPC_ERROR_UNREF(error);
     error = error_out;
   }

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -57,7 +57,7 @@ static grpc_error_handle posix_blocking_resolve_address(
   if (host.empty()) {
     err = grpc_error_set_str(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("unparseable host:port"),
-        GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
+        GRPC_ERROR_STR_TARGET_ADDRESS, name);
     goto done;
   }
 
@@ -65,7 +65,7 @@ static grpc_error_handle posix_blocking_resolve_address(
     if (default_port == nullptr) {
       err = grpc_error_set_str(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("no port in name"),
-          GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
+          GRPC_ERROR_STR_TARGET_ADDRESS, name);
       goto done;
     }
     port = default_port;
@@ -101,11 +101,9 @@ static grpc_error_handle posix_blocking_resolve_address(
                 grpc_error_set_int(
                     GRPC_ERROR_CREATE_FROM_STATIC_STRING(gai_strerror(s)),
                     GRPC_ERROR_INT_ERRNO, s),
-                GRPC_ERROR_STR_OS_ERROR,
-                grpc_slice_from_static_string(gai_strerror(s))),
-            GRPC_ERROR_STR_SYSCALL,
-            grpc_slice_from_static_string("getaddrinfo")),
-        GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(name));
+                GRPC_ERROR_STR_OS_ERROR, gai_strerror(s)),
+            GRPC_ERROR_STR_SYSCALL, "getaddrinfo"),
+        GRPC_ERROR_STR_TARGET_ADDRESS, name);
     goto done;
   }
 

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -443,8 +443,7 @@ static grpc_error_handle error_for_fd(int fd,
   if (fd >= 0) return GRPC_ERROR_NONE;
   std::string addr_str = grpc_sockaddr_to_string(addr, false);
   grpc_error_handle err = grpc_error_set_str(
-      GRPC_OS_ERROR(errno, "socket"), GRPC_ERROR_STR_TARGET_ADDRESS,
-      grpc_slice_from_copied_string(addr_str.c_str()));
+      GRPC_OS_ERROR(errno, "socket"), GRPC_ERROR_STR_TARGET_ADDRESS, addr_str);
   return err;
 }
 

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -160,8 +160,7 @@ static void on_writable(void* acp, grpc_error_handle error) {
   gpr_mu_lock(&ac->mu);
   if (error != GRPC_ERROR_NONE) {
     error =
-        grpc_error_set_str(error, GRPC_ERROR_STR_OS_ERROR,
-                           grpc_slice_from_static_string("Timeout occurred"));
+        grpc_error_set_str(error, GRPC_ERROR_STR_OS_ERROR, "Timeout occurred");
     goto finish;
   }
 
@@ -220,23 +219,16 @@ finish:
     fd = nullptr;
   }
   done = (--ac->refs == 0);
-  // Create a copy of the data from "ac" to be accessed after the unlock, as
-  // "ac" and its contents may be deallocated by the time they are read.
-  const grpc_slice addr_str_slice = grpc_slice_from_cpp_string(ac->addr_str);
   gpr_mu_unlock(&ac->mu);
   if (error != GRPC_ERROR_NONE) {
-    grpc_slice str;
+    std::string str;
     bool ret = grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &str);
     GPR_ASSERT(ret);
-    std::string description = absl::StrCat("Failed to connect to remote host: ",
-                                           grpc_core::StringViewFromSlice(str));
+    std::string description =
+        absl::StrCat("Failed to connect to remote host: ", str);
+    error = grpc_error_set_str(error, GRPC_ERROR_STR_DESCRIPTION, description);
     error =
-        grpc_error_set_str(error, GRPC_ERROR_STR_DESCRIPTION,
-                           grpc_slice_from_cpp_string(std::move(description)));
-    error = grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
-                               addr_str_slice /* takes ownership */);
-  } else {
-    grpc_slice_unref_internal(addr_str_slice);
+        grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS, ac->addr_str);
   }
   if (done) {
     // This is safe even outside the lock, because "done", the sentinel, is
@@ -309,9 +301,8 @@ void grpc_tcp_client_create_from_prepared_fd(
   if (errno != EWOULDBLOCK && errno != EINPROGRESS) {
     grpc_slice_allocator_destroy(slice_allocator);
     grpc_error_handle error = GRPC_OS_ERROR(errno, "connect");
-    error = grpc_error_set_str(
-        error, GRPC_ERROR_STR_TARGET_ADDRESS,
-        grpc_slice_from_cpp_string(grpc_sockaddr_to_uri(addr)));
+    error = grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
+                               grpc_sockaddr_to_uri(addr));
     grpc_fd_orphan(fdobj, nullptr, nullptr, "tcp_client_connect_error");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
     return;

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -225,8 +225,7 @@ failure:
   grpc_error_handle final_error =
       grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                              "Failed to connect", &error, 1),
-                         GRPC_ERROR_STR_TARGET_ADDRESS,
-                         grpc_slice_from_cpp_string(std::move(target_uri)));
+                         GRPC_ERROR_STR_TARGET_ADDRESS, target_uri);
   GRPC_ERROR_UNREF(error);
   grpc_slice_allocator_destroy(slice_allocator);
   if (socket != NULL) {

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -592,8 +592,7 @@ static grpc_error_handle tcp_annotate_error(grpc_error_handle src_error,
           /* All tcp errors are marked with UNAVAILABLE so that application may
            * choose to retry. */
           GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE),
-      GRPC_ERROR_STR_TARGET_ADDRESS,
-      grpc_slice_from_copied_string(tcp->peer_string.c_str()));
+      GRPC_ERROR_STR_TARGET_ADDRESS, tcp->peer_string);
 }
 
 static void tcp_handle_read(void* arg /* grpc_tcp */, grpc_error_handle error);

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -230,11 +230,10 @@ static grpc_error_handle prepare_socket(SOCKET sock,
 failure:
   GPR_ASSERT(error != GRPC_ERROR_NONE);
   grpc_error_set_int(
-      grpc_error_set_str(
-          GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-              "Failed to prepare server socket", &error, 1),
-          GRPC_ERROR_STR_TARGET_ADDRESS,
-          grpc_slice_from_cpp_string(grpc_sockaddr_to_uri(addr))),
+      grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                             "Failed to prepare server socket", &error, 1),
+                         GRPC_ERROR_STR_TARGET_ADDRESS,
+                         grpc_sockaddr_to_uri(addr)),
       GRPC_ERROR_INT_FD, (intptr_t)sock);
   GRPC_ERROR_UNREF(error);
   if (sock != INVALID_SOCKET) closesocket(sock);

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -290,7 +290,7 @@ static grpc_error_handle create_default_creds_from_path(
   if (json.type() != Json::Type::OBJECT) {
     error = grpc_error_set_str(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to parse JSON"),
-        GRPC_ERROR_STR_RAW_BYTES, grpc_slice_ref_internal(creds_data));
+        GRPC_ERROR_STR_RAW_BYTES, grpc_core::StringViewFromSlice(creds_data));
     goto end;
   }
 

--- a/src/core/lib/security/transport/tsi_error.cc
+++ b/src/core/lib/security/transport/tsi_error.cc
@@ -22,9 +22,7 @@
 
 grpc_error_handle grpc_set_tsi_error_result(grpc_error_handle error,
                                             tsi_result result) {
-  return grpc_error_set_int(
-      grpc_error_set_str(
-          error, GRPC_ERROR_STR_TSI_ERROR,
-          grpc_slice_from_static_string(tsi_result_to_string(result))),
-      GRPC_ERROR_INT_TSI_CODE, result);
+  return grpc_error_set_int(grpc_error_set_str(error, GRPC_ERROR_STR_TSI_ERROR,
+                                               tsi_result_to_string(result)),
+                            GRPC_ERROR_INT_TSI_CODE, result);
 }

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -182,8 +182,7 @@ grpc_channel* grpc_lame_client_channel_create(const char* target,
       grpc_error_set_int(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("lame client channel"),
           GRPC_ERROR_INT_GRPC_STATUS, error_code),
-      GRPC_ERROR_STR_GRPC_MESSAGE,
-      grpc_slice_from_static_string(error_message));
+      GRPC_ERROR_STR_GRPC_MESSAGE, error_message);
   grpc_arg error_arg = grpc_core::MakeLameClientErrorArg(&error);
   grpc_channel_args args = {1, &error_arg};
   grpc_channel* channel = grpc_channel_create(

--- a/src/core/lib/surface/validate_metadata.cc
+++ b/src/core/lib/surface/validate_metadata.cc
@@ -47,12 +47,15 @@ static grpc_error_handle conforms_to(const grpc_slice& slice,
   const uint8_t* e = GRPC_SLICE_END_PTR(slice);
   for (; p != e; p++) {
     if (!legal_bits.is_set(*p)) {
+      size_t len;
+      grpc_core::UniquePtr<char> ptr(gpr_dump_return_len(
+          reinterpret_cast<const char*> GRPC_SLICE_START_PTR(slice),
+          GRPC_SLICE_LENGTH(slice), GPR_DUMP_HEX | GPR_DUMP_ASCII, &len));
       grpc_error_handle error = grpc_error_set_str(
           grpc_error_set_int(GRPC_ERROR_CREATE_FROM_COPIED_STRING(err_desc),
                              GRPC_ERROR_INT_OFFSET,
                              p - GRPC_SLICE_START_PTR(slice)),
-          GRPC_ERROR_STR_RAW_BYTES,
-          grpc_dump_slice_to_slice(slice, GPR_DUMP_HEX | GPR_DUMP_ASCII));
+          GRPC_ERROR_STR_RAW_BYTES, absl::string_view(ptr.get(), len));
       return error;
     }
   }

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -57,22 +57,22 @@ static grpc_error_handle recursively_find_error_with_field(
 }
 
 void grpc_error_get_status(grpc_error_handle error, grpc_millis deadline,
-                           grpc_status_code* code, grpc_slice* slice,
+                           grpc_status_code* code, std::string* message,
                            grpc_http2_error_code* http_error,
                            const char** error_string) {
   // Fast path: We expect no error.
   if (GPR_LIKELY(error == GRPC_ERROR_NONE)) {
     if (code != nullptr) *code = GRPC_STATUS_OK;
-    if (slice != nullptr) {
+    if (message != nullptr) {
       // Normally, we call grpc_error_get_str(
-      //   error, GRPC_ERROR_STR_GRPC_MESSAGE, slice).
+      //   error, GRPC_ERROR_STR_GRPC_MESSAGE, message).
       // We can fastpath since we know that:
       // 1) Error is null
       // 2) which == GRPC_ERROR_STR_GRPC_MESSAGE
-      // 3) The resulting slice is statically known.
-      // 4) Said resulting slice is of length 0 ("").
+      // 3) The resulting message is statically known.
+      // 4) Said resulting message is "".
       // This means 3 movs, instead of 10s of instructions and a strlen.
-      *slice = grpc_core::ExternallyManagedSlice("");
+      *message = "";
     }
     if (http_error != nullptr) {
       *http_error = GRPC_HTTP2_NO_ERROR;
@@ -125,14 +125,15 @@ void grpc_error_get_status(grpc_error_handle error, grpc_millis deadline,
 
   // If the error has a status message, use it.  Otherwise, fall back to
   // the error description.
-  if (slice != nullptr) {
-    if (!grpc_error_get_str(found_error, GRPC_ERROR_STR_GRPC_MESSAGE, slice)) {
-      if (!grpc_error_get_str(found_error, GRPC_ERROR_STR_DESCRIPTION, slice)) {
+  if (message != nullptr) {
+    if (!grpc_error_get_str(found_error, GRPC_ERROR_STR_GRPC_MESSAGE,
+                            message)) {
+      if (!grpc_error_get_str(found_error, GRPC_ERROR_STR_DESCRIPTION,
+                              message)) {
 #ifdef GRPC_ERROR_IS_ABSEIL_STATUS
-        *slice =
-            grpc_slice_from_copied_string(grpc_error_std_string(error).c_str());
+        *message = grpc_error_std_string(error));
 #else
-        *slice = grpc_slice_from_static_string("unknown error");
+        *message = "unknown error";
 #endif
       }
     }
@@ -143,13 +144,10 @@ absl::Status grpc_error_to_absl_status(grpc_error_handle error) {
   grpc_status_code status;
   // TODO(yashykt): This should be updated once we decide on how to use the
   // absl::Status payload to capture all the contents of grpc_error.
-  grpc_slice message;
+  std::string message;
   grpc_error_get_status(error, GRPC_MILLIS_INF_FUTURE, &status, &message,
                         nullptr /* http_error */, nullptr /* error_string */);
-  return absl::Status(static_cast<absl::StatusCode>(status),
-                      absl::string_view(reinterpret_cast<const char*>(
-                                            GRPC_SLICE_START_PTR(message)),
-                                        GRPC_SLICE_LENGTH(message)));
+  return absl::Status(static_cast<absl::StatusCode>(status), message);
 }
 
 grpc_error_handle absl_status_to_grpc_error(absl::Status status) {

--- a/src/core/lib/transport/error_utils.h
+++ b/src/core/lib/transport/error_utils.h
@@ -35,7 +35,7 @@
 /// msg, http_status, error_string) are unneeded, they can be passed as
 /// NULL.
 void grpc_error_get_status(grpc_error_handle error, grpc_millis deadline,
-                           grpc_status_code* code, grpc_slice* slice,
+                           grpc_status_code* code, std::string* message,
                            grpc_http2_error_code* http_error,
                            const char** error_string);
 

--- a/src/core/lib/transport/metadata_batch.cc
+++ b/src/core/lib/transport/metadata_batch.cc
@@ -74,7 +74,7 @@ grpc_error_handle grpc_attach_md_to_error(grpc_error_handle src,
                                           grpc_mdelem md) {
   grpc_error_handle out = grpc_error_set_str(
       grpc_error_set_str(src, GRPC_ERROR_STR_KEY,
-                         grpc_slice_ref_internal(GRPC_MDKEY(md))),
-      GRPC_ERROR_STR_VALUE, grpc_slice_ref_internal(GRPC_MDVALUE(md)));
+                         grpc_core::StringViewFromSlice(GRPC_MDKEY(md))),
+      GRPC_ERROR_STR_VALUE, grpc_core::StringViewFromSlice(GRPC_MDVALUE(md)));
   return out;
 }

--- a/test/core/bad_client/tests/bad_streaming_id.cc
+++ b/test/core/bad_client/tests/bad_streaming_id.cc
@@ -124,9 +124,9 @@ TEST(BadStreamingId, ClosedStreamId) {
 }  // namespace
 
 int main(int argc, char** argv) {
-  grpc_init();
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/bad_client/tests/out_of_bounds.cc
+++ b/test/core/bad_client/tests/out_of_bounds.cc
@@ -104,9 +104,9 @@ TEST(OutOfBounds, WindowUpdate) {
 }  // namespace
 
 int main(int argc, char** argv) {
-  grpc_init();
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/bad_client/tests/unknown_frame.cc
+++ b/test/core/bad_client/tests/unknown_frame.cc
@@ -57,9 +57,9 @@ TEST(UnknownFrameType, Test) {
 }  // namespace
 
 int main(int argc, char** argv) {
-  grpc_init();
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -68,6 +68,9 @@ grpc_cc_test(
 grpc_cc_test(
     name = "error_test",
     srcs = ["error_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     language = "C++",
     uses_polling = False,
     deps = [

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -210,8 +210,8 @@ TEST(ErrorTest, Overflow) {
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
-  grpc_init();
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -20,117 +20,114 @@
 
 #include <string.h>
 
+#include <gmock/gmock.h>
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
 #include "test/core/util/test_config.h"
 
-static void test_set_get_int() {
+TEST(ErrorTest, SetGetInt) {
   grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
-  GPR_ASSERT(error != GRPC_ERROR_NONE);
+  EXPECT_NE(error, GRPC_ERROR_NONE);
   intptr_t i = 0;
-  GPR_ASSERT(grpc_error_get_int(error, GRPC_ERROR_INT_FILE_LINE, &i));
-  GPR_ASSERT(i);  // line set will never be 0
-  GPR_ASSERT(!grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));
-  GPR_ASSERT(!grpc_error_get_int(error, GRPC_ERROR_INT_SIZE, &i));
+  EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_FILE_LINE, &i));
+  EXPECT_TRUE(i);  // line set will never be 0
+  EXPECT_TRUE(!grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));
+  EXPECT_TRUE(!grpc_error_get_int(error, GRPC_ERROR_INT_SIZE, &i));
 
   intptr_t errnumber = 314;
   error = grpc_error_set_int(error, GRPC_ERROR_INT_ERRNO, errnumber);
-  GPR_ASSERT(grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));
-  GPR_ASSERT(i == errnumber);
+  EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));
+  EXPECT_EQ(i, errnumber);
 
   intptr_t http = 2;
   error = grpc_error_set_int(error, GRPC_ERROR_INT_HTTP2_ERROR, http);
-  GPR_ASSERT(grpc_error_get_int(error, GRPC_ERROR_INT_HTTP2_ERROR, &i));
-  GPR_ASSERT(i == http);
+  EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_HTTP2_ERROR, &i));
+  EXPECT_EQ(i, http);
 
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_set_get_str() {
+TEST(ErrorTest, SetGetStr) {
   grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
 
-  grpc_slice str;
-  GPR_ASSERT(!grpc_error_get_str(error, GRPC_ERROR_STR_SYSCALL, &str));
-  GPR_ASSERT(!grpc_error_get_str(error, GRPC_ERROR_STR_TSI_ERROR, &str));
+  std::string str;
+  EXPECT_TRUE(!grpc_error_get_str(error, GRPC_ERROR_STR_SYSCALL, &str));
+  EXPECT_TRUE(!grpc_error_get_str(error, GRPC_ERROR_STR_TSI_ERROR, &str));
 
-  GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_FILE, &str));
-  GPR_ASSERT(strstr((char*)GRPC_SLICE_START_PTR(str),
-                    "error_test.c"));  // __FILE__ expands differently on
-                                       // Windows. All should at least
-                                       // contain error_test.c
+  EXPECT_TRUE(grpc_error_get_str(error, GRPC_ERROR_STR_FILE, &str));
+  EXPECT_THAT(str, testing::HasSubstr("error_test.c"));
+  // __FILE__ expands differently on
+  // Windows. All should at least
+  // contain error_test.c
 
-  GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &str));
-  GPR_ASSERT(!strncmp((char*)GRPC_SLICE_START_PTR(str), "Test",
-                      GRPC_SLICE_LENGTH(str)));
+  EXPECT_TRUE(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &str));
+  EXPECT_EQ(str, "Test");
 
-  error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE,
-                             grpc_slice_from_static_string("longer message"));
-  GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
-  GPR_ASSERT(!strncmp((char*)GRPC_SLICE_START_PTR(str), "longer message",
-                      GRPC_SLICE_LENGTH(str)));
+  error =
+      grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, "longer message");
+  EXPECT_TRUE(grpc_error_get_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
+  EXPECT_EQ(str, "longer message");
 
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_copy_and_unref() {
+TEST(ErrorTest, CopyAndUnRef) {
   // error1 has one ref
-  grpc_error_handle error1 = grpc_error_set_str(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test"), GRPC_ERROR_STR_GRPC_MESSAGE,
-      grpc_slice_from_static_string("message"));
-  grpc_slice str;
-  GPR_ASSERT(grpc_error_get_str(error1, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
-  GPR_ASSERT(!strncmp((char*)GRPC_SLICE_START_PTR(str), "message",
-                      GRPC_SLICE_LENGTH(str)));
+  grpc_error_handle error1 =
+      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test"),
+                         GRPC_ERROR_STR_GRPC_MESSAGE, "message");
+  std::string str;
+  EXPECT_TRUE(grpc_error_get_str(error1, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
+  EXPECT_EQ(str, "message");
 
   // error 1 has two refs
   GRPC_ERROR_REF(error1);
   // this gives error3 a ref to the new error, and decrements error1 to one ref
-  grpc_error_handle error3 = grpc_error_set_str(
-      error1, GRPC_ERROR_STR_SYSCALL, grpc_slice_from_static_string("syscall"));
-  GPR_ASSERT(error3 != error1);  // should not be the same because of extra ref
-  GPR_ASSERT(grpc_error_get_str(error3, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
-  GPR_ASSERT(!strncmp((char*)GRPC_SLICE_START_PTR(str), "message",
-                      GRPC_SLICE_LENGTH(str)));
+  grpc_error_handle error3 =
+      grpc_error_set_str(error1, GRPC_ERROR_STR_SYSCALL, "syscall");
+  EXPECT_NE(error3, error1);  // should not be the same because of extra ref
+  EXPECT_TRUE(grpc_error_get_str(error3, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
+  EXPECT_EQ(str, "message");
 
   // error 1 should not have a syscall but 3 should
-  GPR_ASSERT(!grpc_error_get_str(error1, GRPC_ERROR_STR_SYSCALL, &str));
-  GPR_ASSERT(grpc_error_get_str(error3, GRPC_ERROR_STR_SYSCALL, &str));
-  GPR_ASSERT(!strncmp((char*)GRPC_SLICE_START_PTR(str), "syscall",
-                      GRPC_SLICE_LENGTH(str)));
+  EXPECT_TRUE(!grpc_error_get_str(error1, GRPC_ERROR_STR_SYSCALL, &str));
+  EXPECT_TRUE(grpc_error_get_str(error3, GRPC_ERROR_STR_SYSCALL, &str));
+  EXPECT_EQ(str, "syscall");
 
   GRPC_ERROR_UNREF(error1);
   GRPC_ERROR_UNREF(error3);
 }
 
-static void test_create_referencing() {
-  grpc_error_handle child = grpc_error_set_str(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child"),
-      GRPC_ERROR_STR_GRPC_MESSAGE, grpc_slice_from_static_string("message"));
+TEST(ErrorTest, CreateReferencing) {
+  grpc_error_handle child =
+      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child"),
+                         GRPC_ERROR_STR_GRPC_MESSAGE, "message");
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", &child, 1);
-  GPR_ASSERT(parent != GRPC_ERROR_NONE);
+  EXPECT_NE(parent, GRPC_ERROR_NONE);
 
   GRPC_ERROR_UNREF(child);
   GRPC_ERROR_UNREF(parent);
 }
 
-static void test_create_referencing_many() {
+TEST(ErrorTest, CreateReferencingMany) {
   grpc_error_handle children[3];
-  children[0] = grpc_error_set_str(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child1"),
-      GRPC_ERROR_STR_GRPC_MESSAGE, grpc_slice_from_static_string("message"));
+  children[0] =
+      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child1"),
+                         GRPC_ERROR_STR_GRPC_MESSAGE, "message");
   children[1] =
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child2"),
                          GRPC_ERROR_INT_HTTP2_ERROR, 5);
-  children[2] = grpc_error_set_str(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child3"),
-      GRPC_ERROR_STR_GRPC_MESSAGE, grpc_slice_from_static_string("message 3"));
+  children[2] =
+      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child3"),
+                         GRPC_ERROR_STR_GRPC_MESSAGE, "message 3");
 
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 3);
-  GPR_ASSERT(parent != GRPC_ERROR_NONE);
+  EXPECT_NE(parent, GRPC_ERROR_NONE);
 
   for (size_t i = 0; i < 3; ++i) {
     GRPC_ERROR_UNREF(children[i]);
@@ -138,29 +135,26 @@ static void test_create_referencing_many() {
   GRPC_ERROR_UNREF(parent);
 }
 
-static void print_error_string() {
+TEST(ErrorTest, PrintErrorString) {
   grpc_error_handle error =
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"),
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNIMPLEMENTED);
   error = grpc_error_set_int(error, GRPC_ERROR_INT_SIZE, 666);
-  error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE,
-                             grpc_slice_from_static_string("message"));
+  error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, "message");
   // gpr_log(GPR_DEBUG, "%s", grpc_error_std_string(error).c_str());
   GRPC_ERROR_UNREF(error);
 }
 
-static void print_error_string_reference() {
+TEST(ErrorTest, PrintErrorStringReference) {
   grpc_error_handle children[2];
   children[0] = grpc_error_set_str(
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("1"),
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNIMPLEMENTED),
-      GRPC_ERROR_STR_GRPC_MESSAGE,
-      grpc_slice_from_static_string("message for child 1"));
+      GRPC_ERROR_STR_GRPC_MESSAGE, "message for child 1");
   children[1] = grpc_error_set_str(
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("2sd"),
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_INTERNAL),
-      GRPC_ERROR_STR_GRPC_MESSAGE,
-      grpc_slice_from_static_string("message for child 2"));
+      GRPC_ERROR_STR_GRPC_MESSAGE, "message for child 2");
 
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 2);
@@ -171,23 +165,22 @@ static void print_error_string_reference() {
   GRPC_ERROR_UNREF(parent);
 }
 
-static void test_os_error() {
+TEST(ErrorTest, TestOsError) {
   int fake_errno = 5;
   const char* syscall = "syscall name";
   grpc_error_handle error = GRPC_OS_ERROR(fake_errno, syscall);
 
   intptr_t i = 0;
-  GPR_ASSERT(grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));
-  GPR_ASSERT(i == fake_errno);
+  EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));
+  EXPECT_EQ(i, fake_errno);
 
-  grpc_slice str;
-  GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_SYSCALL, &str));
-  GPR_ASSERT(!strncmp((char*)GRPC_SLICE_START_PTR(str), syscall,
-                      GRPC_SLICE_LENGTH(str)));
+  std::string str;
+  EXPECT_TRUE(grpc_error_get_str(error, GRPC_ERROR_STR_SYSCALL, &str));
+  EXPECT_EQ(str, syscall);
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_overflow() {
+TEST(ErrorTest, Overflow) {
   // absl::Status doesn't have a limit so there is no overflow
 #ifndef GRPC_ERROR_IS_ABSEIL_STATUS
   grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Overflow");
@@ -198,19 +191,18 @@ static void test_overflow() {
   }
 
   error = grpc_error_set_int(error, GRPC_ERROR_INT_HTTP2_ERROR, 5);
-  error =
-      grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE,
-                         grpc_slice_from_static_string("message for child 2"));
+  error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE,
+                             "message for child 2");
   error = grpc_error_set_int(error, GRPC_ERROR_INT_GRPC_STATUS, 5);
 
   intptr_t i;
-  GPR_ASSERT(grpc_error_get_int(error, GRPC_ERROR_INT_HTTP2_ERROR, &i));
-  GPR_ASSERT(i == 5);
-  GPR_ASSERT(!grpc_error_get_int(error, GRPC_ERROR_INT_GRPC_STATUS, &i));
+  EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_HTTP2_ERROR, &i));
+  EXPECT_EQ(i, 5);
+  EXPECT_TRUE(!grpc_error_get_int(error, GRPC_ERROR_INT_GRPC_STATUS, &i));
 
   error = grpc_error_set_int(error, GRPC_ERROR_INT_HTTP2_ERROR, 10);
-  GPR_ASSERT(grpc_error_get_int(error, GRPC_ERROR_INT_HTTP2_ERROR, &i));
-  GPR_ASSERT(i == 10);
+  EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_HTTP2_ERROR, &i));
+  EXPECT_EQ(i, 10);
 
   GRPC_ERROR_UNREF(error);
 #endif
@@ -219,16 +211,8 @@ static void test_overflow() {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
-  test_set_get_int();
-  test_set_get_str();
-  test_copy_and_unref();
-  print_error_string();
-  print_error_string_reference();
-  test_os_error();
-  test_create_referencing();
-  test_create_referencing_many();
-  test_overflow();
+  ::testing::InitGoogleTest(&argc, argv);
+  int retval = RUN_ALL_TESTS();
   grpc_shutdown();
-
-  return 0;
+  return retval;
 }

--- a/test/core/iomgr/work_serializer_test.cc
+++ b/test/core/iomgr/work_serializer_test.cc
@@ -107,8 +107,8 @@ TEST(WorkSerializerTest, ExecuteMany) {
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
-  grpc_init();
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -88,7 +88,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "credentials_test",
     srcs = ["credentials_test.cc"],
-    external_deps = ["gtest"],
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -88,6 +88,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "credentials_test",
     srcs = ["credentials_test.cc"],
+    external_deps = ["gtest"],
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/core/security/aws_request_signer_test.cc
+++ b/test/core/security/aws_request_signer_test.cc
@@ -246,13 +246,10 @@ TEST(GrpcAwsRequestSignerTest, InvalidUrl) {
   grpc_core::AwsRequestSigner signer("access_key_id", "secret_access_key",
                                      "token", "POST", "invalid_url",
                                      "us-east-1", "", {}, &error);
-  grpc_slice expected_error_description =
-      grpc_slice_from_static_string("Invalid Aws request url.");
-  grpc_slice actual_error_description;
+  std::string actual_error_description;
   GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION,
                                 &actual_error_description));
-  EXPECT_TRUE(grpc_slice_cmp(expected_error_description,
-                             actual_error_description) == 0);
+  EXPECT_EQ(actual_error_description, "Invalid Aws request url.");
   GRPC_ERROR_UNREF(error);
 }
 
@@ -262,13 +259,11 @@ TEST(GrpcAwsRequestSignerTest, DuplicateRequestDate) {
       "access_key_id", "secret_access_key", "token", "POST", "invalid_url",
       "us-east-1", "", {{"date", kBotoTestDate}, {"x-amz-date", kAmzTestDate}},
       &error);
-  grpc_slice expected_error_description = grpc_slice_from_static_string(
-      "Only one of {date, x-amz-date} can be specified, not both.");
-  grpc_slice actual_error_description;
+  std::string actual_error_description;
   GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION,
                                 &actual_error_description));
-  EXPECT_TRUE(grpc_slice_cmp(expected_error_description,
-                             actual_error_description) == 0);
+  EXPECT_EQ(actual_error_description,
+            "Only one of {date, x-amz-date} can be specified, not both.");
   GRPC_ERROR_UNREF(error);
 }
 

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -3447,8 +3447,8 @@ TEST(
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
-  grpc_init();
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
   int retval = RUN_ALL_TESTS();
   grpc_shutdown();
   return retval;

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -25,6 +25,7 @@
 
 #include <string>
 
+#include <gmock/gmock.h>
 #include <openssl/rsa.h>
 
 #include "absl/strings/match.h"
@@ -307,16 +308,16 @@ static grpc_httpcli_response http_response(int status, const char* body) {
 
 /* -- Tests. -- */
 
-static void test_empty_md_array(void) {
+TEST(CredentialsTest, empty_md_array) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
   md_array = {};
-  GPR_ASSERT(md_array.md == nullptr);
-  GPR_ASSERT(md_array.size == 0);
+  EXPECT_EQ(md_array.md, nullptr);
+  EXPECT_EQ(md_array.size, 0);
   grpc_credentials_mdelem_array_destroy(&md_array);
 }
 
-static void test_add_to_empty_md_array(void) {
+TEST(CredentialsTest, add_to_empty_md_array) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
   md_array = {};
@@ -325,13 +326,13 @@ static void test_add_to_empty_md_array(void) {
   grpc_mdelem md = grpc_mdelem_from_slices(
       grpc_slice_from_copied_string(key), grpc_slice_from_copied_string(value));
   grpc_credentials_mdelem_array_add(&md_array, md);
-  GPR_ASSERT(md_array.size == 1);
-  GPR_ASSERT(grpc_mdelem_eq(md, md_array.md[0]));
+  EXPECT_EQ(md_array.size, 1);
+  EXPECT_TRUE(grpc_mdelem_eq(md, md_array.md[0]));
   GRPC_MDELEM_UNREF(md);
   grpc_credentials_mdelem_array_destroy(&md_array);
 }
 
-static void test_add_abunch_to_md_array(void) {
+TEST(CredentialsTest, add_abunch_to_md_array) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
   md_array = {};
@@ -344,53 +345,54 @@ static void test_add_abunch_to_md_array(void) {
     grpc_credentials_mdelem_array_add(&md_array, md);
   }
   for (size_t i = 0; i < num_entries; ++i) {
-    GPR_ASSERT(grpc_mdelem_eq(md_array.md[i], md));
+    EXPECT_TRUE(grpc_mdelem_eq(md_array.md[i], md));
   }
   GRPC_MDELEM_UNREF(md);
   grpc_credentials_mdelem_array_destroy(&md_array);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_ok(void) {
+TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_ok) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
   grpc_httpcli_response response =
       http_response(200, valid_oauth2_json_response);
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) == GRPC_CREDENTIALS_OK);
-  GPR_ASSERT(token_lifetime == 3599 * GPR_MS_PER_SEC);
-  GPR_ASSERT(grpc_slice_str_cmp(GRPC_MDKEY(token_md), "authorization") == 0);
-  GPR_ASSERT(grpc_slice_str_cmp(GRPC_MDVALUE(token_md),
-                                "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_") ==
-             0);
+  EXPECT_TRUE(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                  &response, &token_md, &token_lifetime) ==
+              GRPC_CREDENTIALS_OK);
+  EXPECT_EQ(token_lifetime, 3599 * GPR_MS_PER_SEC);
+  EXPECT_EQ(grpc_slice_str_cmp(GRPC_MDKEY(token_md), "authorization"), 0);
+  EXPECT_EQ(grpc_slice_str_cmp(GRPC_MDVALUE(token_md),
+                               "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"),
+            0);
   GRPC_MDELEM_UNREF(token_md);
   grpc_http_response_destroy(&response);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_bad_http_status(void) {
+TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_bad_http_status) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
   grpc_httpcli_response response =
       http_response(401, valid_oauth2_json_response);
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) ==
-             GRPC_CREDENTIALS_ERROR);
+  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                &response, &token_md, &token_lifetime),
+            GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_empty_http_body(void) {
+TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_empty_http_body) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
   grpc_httpcli_response response = http_response(200, "");
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) ==
-             GRPC_CREDENTIALS_ERROR);
+  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                &response, &token_md, &token_lifetime),
+            GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_invalid_json(void) {
+TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_invalid_json) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -399,13 +401,13 @@ static void test_oauth2_token_fetcher_creds_parsing_invalid_json(void) {
                     "{\"access_token\":\"ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_\","
                     " \"expires_in\":3599, "
                     " \"token_type\":\"Bearer\"");
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) ==
-             GRPC_CREDENTIALS_ERROR);
+  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                &response, &token_md, &token_lifetime),
+            GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_missing_token(void) {
+TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_missing_token) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -413,13 +415,13 @@ static void test_oauth2_token_fetcher_creds_parsing_missing_token(void) {
                                                  "{"
                                                  " \"expires_in\":3599, "
                                                  " \"token_type\":\"Bearer\"}");
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) ==
-             GRPC_CREDENTIALS_ERROR);
+  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                &response, &token_md, &token_lifetime),
+            GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_missing_token_type(void) {
+TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_missing_token_type) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -428,14 +430,14 @@ static void test_oauth2_token_fetcher_creds_parsing_missing_token_type(void) {
                     "{\"access_token\":\"ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_\","
                     " \"expires_in\":3599, "
                     "}");
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) ==
-             GRPC_CREDENTIALS_ERROR);
+  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                &response, &token_md, &token_lifetime),
+            GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-static void test_oauth2_token_fetcher_creds_parsing_missing_token_lifetime(
-    void) {
+TEST(CredentialsTest,
+     oauth2_token_fetcher_creds_parsing_missing_token_lifetime) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -443,9 +445,9 @@ static void test_oauth2_token_fetcher_creds_parsing_missing_token_lifetime(
       http_response(200,
                     "{\"access_token\":\"ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_\","
                     " \"token_type\":\"Bearer\"}");
-  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                 &response, &token_md, &token_lifetime) ==
-             GRPC_CREDENTIALS_ERROR);
+  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                &response, &token_md, &token_lifetime),
+            GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
@@ -471,14 +473,14 @@ static void check_metadata(const expected_md* expected,
     for (j = 0; j < md_array->size; ++j) {
       if (0 ==
           grpc_slice_str_cmp(GRPC_MDKEY(md_array->md[j]), expected[i].key)) {
-        GPR_ASSERT(grpc_slice_str_cmp(GRPC_MDVALUE(md_array->md[j]),
-                                      expected[i].value) == 0);
+        EXPECT_TRUE(grpc_slice_str_cmp(GRPC_MDVALUE(md_array->md[j]),
+                                       expected[i].value) == 0);
         break;
       }
     }
     if (j == md_array->size) {
       gpr_log(GPR_ERROR, "key %s not found", expected[i].key);
-      GPR_ASSERT(0);
+      EXPECT_TRUE(0);
     }
   }
 }
@@ -489,20 +491,20 @@ static void check_request_metadata(void* arg, grpc_error_handle error) {
           grpc_error_std_string(state->expected_error).c_str());
   gpr_log(GPR_INFO, "actual_error: %s", grpc_error_std_string(error).c_str());
   if (state->expected_error == GRPC_ERROR_NONE) {
-    GPR_ASSERT(error == GRPC_ERROR_NONE);
+    EXPECT_EQ(error, GRPC_ERROR_NONE);
   } else {
-    grpc_slice expected_error;
-    GPR_ASSERT(grpc_error_get_str(state->expected_error,
-                                  GRPC_ERROR_STR_DESCRIPTION, &expected_error));
-    grpc_slice actual_error;
-    GPR_ASSERT(
+    std::string expected_error;
+    EXPECT_TRUE(grpc_error_get_str(
+        state->expected_error, GRPC_ERROR_STR_DESCRIPTION, &expected_error));
+    std::string actual_error;
+    EXPECT_TRUE(
         grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &actual_error));
-    GPR_ASSERT(grpc_slice_cmp(expected_error, actual_error) == 0);
+    EXPECT_EQ(expected_error, actual_error);
     GRPC_ERROR_UNREF(state->expected_error);
   }
   gpr_log(GPR_INFO, "expected_size=%" PRIdPTR " actual_size=%" PRIdPTR,
           state->expected_size, state->md_array.size);
-  GPR_ASSERT(state->md_array.size == state->expected_size);
+  EXPECT_EQ(state->md_array.size, state->expected_size);
   check_metadata(state->expected, &state->md_array);
   grpc_credentials_mdelem_array_destroy(&state->md_array);
   grpc_pollset_set_destroy(grpc_polling_entity_pollset_set(&state->pollent));
@@ -537,7 +539,7 @@ static void run_request_metadata_test(grpc_call_credentials* creds,
   }
 }
 
-static void test_google_iam_creds(void) {
+TEST(CredentialsTest, google_iam_creds) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {{GRPC_IAM_AUTHORIZATION_TOKEN_METADATA_KEY,
                         test_google_iam_authorization_token},
@@ -549,14 +551,14 @@ static void test_google_iam_creds(void) {
       test_google_iam_authorization_token, test_google_iam_authority_selector,
       nullptr);
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
   run_request_metadata_test(creds, auth_md_ctx, state);
   creds->Unref();
 }
 
-static void test_access_token_creds(void) {
+TEST(CredentialsTest, access_token_creds) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {{GRPC_AUTHORIZATION_METADATA_KEY, "Bearer blah"}};
   request_metadata_state* state =
@@ -565,9 +567,9 @@ static void test_access_token_creds(void) {
       grpc_access_token_credentials_create("blah", nullptr);
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
-  GPR_ASSERT(strcmp(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) == 0);
+  EXPECT_STREQ(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   run_request_metadata_test(creds, auth_md_ctx, state);
   creds->Unref();
 }
@@ -583,16 +585,15 @@ class check_channel_oauth2 final : public grpc_channel_credentials {
       grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
       const char* /*target*/, const grpc_channel_args* /*args*/,
       grpc_channel_args** /*new_args*/) override {
-    GPR_ASSERT(strcmp(type(), "mock") == 0);
-    GPR_ASSERT(call_creds != nullptr);
-    GPR_ASSERT(strcmp(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) ==
-               0);
+    EXPECT_STREQ(type(), "mock");
+    EXPECT_NE(call_creds, nullptr);
+    EXPECT_STREQ(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
     return nullptr;
   }
 };
 }  // namespace
 
-static void test_channel_oauth2_composite_creds(void) {
+TEST(CredentialsTest, channel_oauth2_composite_creds) {
   grpc_core::ExecCtx exec_ctx;
   grpc_channel_args* new_args;
   grpc_channel_credentials* channel_creds = new check_channel_oauth2();
@@ -608,7 +609,7 @@ static void test_channel_oauth2_composite_creds(void) {
   grpc_channel_credentials_release(channel_oauth2_creds);
 }
 
-static void test_oauth2_google_iam_composite_creds(void) {
+TEST(CredentialsTest, oauth2_google_iam_composite_creds) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {GRPC_AUTHORIZATION_METADATA_KEY, test_oauth2_bearer_token},
@@ -624,7 +625,7 @@ static void test_oauth2_google_iam_composite_creds(void) {
       "authorization", test_oauth2_bearer_token, false);
 
   /* Check security level of fake credentials. */
-  GPR_ASSERT(oauth2_creds->min_security_level() == GRPC_SECURITY_NONE);
+  EXPECT_EQ(oauth2_creds->min_security_level(), GRPC_SECURITY_NONE);
 
   grpc_call_credentials* google_iam_creds = grpc_google_iam_credentials_create(
       test_google_iam_authorization_token, test_google_iam_authority_selector,
@@ -633,21 +634,17 @@ static void test_oauth2_google_iam_composite_creds(void) {
       grpc_composite_call_credentials_create(oauth2_creds, google_iam_creds,
                                              nullptr);
   /* Check security level of composite credentials. */
-  GPR_ASSERT(composite_creds->min_security_level() ==
-             GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(composite_creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
 
   oauth2_creds->Unref();
   google_iam_creds->Unref();
-  GPR_ASSERT(strcmp(composite_creds->type(),
-                    GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE) == 0);
+  EXPECT_STREQ(composite_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE);
   const grpc_composite_call_credentials::CallCredentialsList& creds_list =
       static_cast<const grpc_composite_call_credentials*>(composite_creds)
           ->inner();
-  GPR_ASSERT(creds_list.size() == 2);
-  GPR_ASSERT(strcmp(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) ==
-             0);
-  GPR_ASSERT(strcmp(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM) ==
-             0);
+  EXPECT_EQ(creds_list.size(), 2);
+  EXPECT_STREQ(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
+  EXPECT_STREQ(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM);
   run_request_metadata_test(composite_creds, auth_md_ctx, state);
   composite_creds->Unref();
 }
@@ -663,23 +660,20 @@ class check_channel_oauth2_google_iam final : public grpc_channel_credentials {
       grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
       const char* /*target*/, const grpc_channel_args* /*args*/,
       grpc_channel_args** /*new_args*/) override {
-    GPR_ASSERT(strcmp(type(), "mock") == 0);
-    GPR_ASSERT(call_creds != nullptr);
-    GPR_ASSERT(
-        strcmp(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE) == 0);
+    EXPECT_STREQ(type(), "mock");
+    EXPECT_NE(call_creds, nullptr);
+    EXPECT_STREQ(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE);
     const grpc_composite_call_credentials::CallCredentialsList& creds_list =
         static_cast<const grpc_composite_call_credentials*>(call_creds.get())
             ->inner();
-    GPR_ASSERT(
-        strcmp(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) == 0);
-    GPR_ASSERT(strcmp(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM) ==
-               0);
+    EXPECT_STREQ(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
+    EXPECT_STREQ(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM);
     return nullptr;
   }
 };
 }  // namespace
 
-static void test_channel_oauth2_google_iam_composite_creds(void) {
+TEST(CredentialsTest, channel_oauth2_google_iam_composite_creds) {
   grpc_core::ExecCtx exec_ctx;
   grpc_channel_args* new_args;
   grpc_channel_credentials* channel_creds =
@@ -709,15 +703,13 @@ static void test_channel_oauth2_google_iam_composite_creds(void) {
 
 static void validate_compute_engine_http_request(
     const grpc_httpcli_request* request) {
-  GPR_ASSERT(request->handshaker != &grpc_httpcli_ssl);
-  GPR_ASSERT(strcmp(request->host, "metadata.google.internal.") == 0);
-  GPR_ASSERT(
-      strcmp(request->http.path,
-             "/computeMetadata/v1/instance/service-accounts/default/token") ==
-      0);
-  GPR_ASSERT(request->http.hdr_count == 1);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Metadata-Flavor") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value, "Google") == 0);
+  EXPECT_NE(request->handshaker, &grpc_httpcli_ssl);
+  EXPECT_STREQ(request->host, "metadata.google.internal.");
+  EXPECT_STREQ(request->http.path,
+               "/computeMetadata/v1/instance/service-accounts/default/token");
+  EXPECT_EQ(request->http.hdr_count, 1);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Metadata-Flavor");
+  EXPECT_STREQ(request->http.hdrs[0].value, "Google");
 }
 
 static int compute_engine_httpcli_get_success_override(
@@ -742,18 +734,18 @@ static int httpcli_post_should_not_be_called(
     const grpc_httpcli_request* /*request*/, const char* /*body_bytes*/,
     size_t /*body_size*/, grpc_millis /*deadline*/, grpc_closure* /*on_done*/,
     grpc_httpcli_response* /*response*/) {
-  GPR_ASSERT("HTTP POST should not be called" == nullptr);
+  EXPECT_EQ("HTTP POST should not be called", nullptr);
   return 1;
 }
 
 static int httpcli_get_should_not_be_called(
     const grpc_httpcli_request* /*request*/, grpc_millis /*deadline*/,
     grpc_closure* /*on_done*/, grpc_httpcli_response* /*response*/) {
-  GPR_ASSERT("HTTP GET should not be called" == nullptr);
+  EXPECT_EQ("HTTP GET should not be called", nullptr);
   return 1;
 }
 
-static void test_compute_engine_creds_success() {
+TEST(CredentialsTest, compute_engine_creds_success) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -765,7 +757,7 @@ static void test_compute_engine_creds_success() {
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http get should be called. */
   request_metadata_state* state =
@@ -783,13 +775,12 @@ static void test_compute_engine_creds_success() {
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
 
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_compute_engine_creds_failure(void) {
+TEST(CredentialsTest, compute_engine_creds_failure) {
   grpc_core::ExecCtx exec_ctx;
   const char expected_creds_debug_string[] =
       "GoogleComputeEngineTokenFetcherCredentials{"
@@ -805,8 +796,7 @@ static void test_compute_engine_creds_failure(void) {
   grpc_httpcli_set_override(compute_engine_httpcli_get_failure_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
@@ -814,22 +804,21 @@ static void test_compute_engine_creds_failure(void) {
 static void validate_refresh_token_http_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size) {
   /* The content of the assertion is tested extensively in json_token_test. */
-  GPR_ASSERT(body != nullptr);
-  GPR_ASSERT(body_size != 0);
+  EXPECT_NE(body, nullptr);
+  EXPECT_NE(body_size, 0);
   std::string expected_body = absl::StrFormat(
       GRPC_REFRESH_TOKEN_POST_BODY_FORMAT_STRING,
       "32555999999.apps.googleusercontent.com", "EmssLNjJy1332hD4KFsecret",
       "1/Blahblasj424jladJDSGNf-u4Sua3HDA2ngjd42");
-  GPR_ASSERT(expected_body.size() == body_size);
-  GPR_ASSERT(memcmp(expected_body.data(), body, body_size) == 0);
-  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
-  GPR_ASSERT(strcmp(request->host, GRPC_GOOGLE_OAUTH2_SERVICE_HOST) == 0);
-  GPR_ASSERT(
-      strcmp(request->http.path, GRPC_GOOGLE_OAUTH2_SERVICE_TOKEN_PATH) == 0);
-  GPR_ASSERT(request->http.hdr_count == 1);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
-                    "application/x-www-form-urlencoded") == 0);
+  EXPECT_EQ(expected_body.size(), body_size);
+  EXPECT_EQ(memcmp(expected_body.data(), body, body_size), 0);
+  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
+  EXPECT_STREQ(request->host, GRPC_GOOGLE_OAUTH2_SERVICE_HOST);
+  EXPECT_STREQ(request->http.path, GRPC_GOOGLE_OAUTH2_SERVICE_TOKEN_PATH);
+  EXPECT_EQ(request->http.hdr_count, 1);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
+  EXPECT_STREQ(request->http.hdrs[0].value,
+               "application/x-www-form-urlencoded");
 }
 
 static int refresh_token_httpcli_post_success(
@@ -853,7 +842,7 @@ static int token_httpcli_post_failure(const grpc_httpcli_request* /*request*/,
   return 1;
 }
 
-static void test_refresh_token_creds_success(void) {
+TEST(CredentialsTest, refresh_token_creds_success) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -866,7 +855,7 @@ static void test_refresh_token_creds_success(void) {
       test_refresh_token_str, nullptr);
 
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
   request_metadata_state* state =
@@ -883,14 +872,13 @@ static void test_refresh_token_creds_success(void) {
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_refresh_token_creds_failure(void) {
+TEST(CredentialsTest, refresh_token_creds_failure) {
   grpc_core::ExecCtx exec_ctx;
   const char expected_creds_debug_string[] =
       "GoogleRefreshToken{ClientID:32555999999.apps.googleusercontent.com,"
@@ -906,14 +894,13 @@ static void test_refresh_token_creds_failure(void) {
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             token_httpcli_post_failure);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_valid_sts_creds_options(void) {
+TEST(CredentialsTest, valid_sts_creds_options) {
   grpc_sts_credentials_options valid_options = {
       test_sts_endpoint_url,        // sts_endpoint_url
       nullptr,                      // resource
@@ -927,15 +914,15 @@ static void test_valid_sts_creds_options(void) {
   };
   absl::StatusOr<grpc_core::URI> sts_url =
       grpc_core::ValidateStsCredentialsOptions(&valid_options);
-  GPR_ASSERT(sts_url.ok());
+  EXPECT_TRUE(sts_url.ok());
   absl::string_view host;
   absl::string_view port;
-  GPR_ASSERT(grpc_core::SplitHostPort(sts_url->authority(), &host, &port));
-  GPR_ASSERT(host == "foo.com");
-  GPR_ASSERT(port == "5555");
+  EXPECT_TRUE(grpc_core::SplitHostPort(sts_url->authority(), &host, &port));
+  EXPECT_EQ(host, "foo.com");
+  EXPECT_EQ(port, "5555");
 }
 
-static void test_invalid_sts_creds_options(void) {
+TEST(CredentialsTest, invalid_sts_creds_options) {
   grpc_sts_credentials_options invalid_options = {
       test_sts_endpoint_url,       // sts_endpoint_url
       nullptr,                     // resource
@@ -949,7 +936,7 @@ static void test_invalid_sts_creds_options(void) {
   };
   absl::StatusOr<grpc_core::URI> url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  GPR_ASSERT(!url_should_be_invalid.ok());
+  EXPECT_TRUE(!url_should_be_invalid.ok());
 
   invalid_options = {
       test_sts_endpoint_url,        // sts_endpoint_url
@@ -964,7 +951,7 @@ static void test_invalid_sts_creds_options(void) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  GPR_ASSERT(!url_should_be_invalid.ok());
+  EXPECT_TRUE(!url_should_be_invalid.ok());
 
   invalid_options = {
       nullptr,                      // sts_endpoint_url (Required)
@@ -979,7 +966,7 @@ static void test_invalid_sts_creds_options(void) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  GPR_ASSERT(!url_should_be_invalid.ok());
+  EXPECT_TRUE(!url_should_be_invalid.ok());
 
   invalid_options = {
       "not_a_valid_uri",            // sts_endpoint_url
@@ -994,7 +981,7 @@ static void test_invalid_sts_creds_options(void) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  GPR_ASSERT(!url_should_be_invalid.ok());
+  EXPECT_TRUE(!url_should_be_invalid.ok());
 
   invalid_options = {
       "ftp://ftp.is.not.a.valid.scheme/bar",  // sts_endpoint_url
@@ -1009,35 +996,35 @@ static void test_invalid_sts_creds_options(void) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  GPR_ASSERT(!url_should_be_invalid.ok());
+  EXPECT_TRUE(!url_should_be_invalid.ok());
 }
 
 static void assert_query_parameters(const grpc_core::URI& uri,
                                     absl::string_view expected_key,
                                     absl::string_view expected_val) {
   const auto it = uri.query_parameter_map().find(expected_key);
-  GPR_ASSERT(it != uri.query_parameter_map().end());
+  EXPECT_NE(it, uri.query_parameter_map().end());
   if (it->second != expected_val) {
     gpr_log(GPR_ERROR, "%s!=%s", std::string(it->second).c_str(),
             std::string(expected_val).c_str());
   }
-  GPR_ASSERT(it->second == expected_val);
+  EXPECT_EQ(it->second, expected_val);
 }
 
 static void validate_sts_token_http_request(const grpc_httpcli_request* request,
                                             const char* body, size_t body_size,
                                             bool expect_actor_token) {
   // Check that the body is constructed properly.
-  GPR_ASSERT(body != nullptr);
-  GPR_ASSERT(body_size != 0);
-  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
+  EXPECT_NE(body, nullptr);
+  EXPECT_NE(body_size, 0);
+  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
   std::string get_url_equivalent =
       absl::StrFormat("%s?%s", test_sts_endpoint_url, body);
   absl::StatusOr<grpc_core::URI> url =
       grpc_core::URI::Parse(get_url_equivalent);
   if (!url.ok()) {
     gpr_log(GPR_ERROR, "%s", url.status().ToString().c_str());
-    GPR_ASSERT(url.ok());
+    EXPECT_TRUE(url.ok());
   }
   assert_query_parameters(*url, "resource", "resource");
   assert_query_parameters(*url, "audience", "audience");
@@ -1051,19 +1038,19 @@ static void validate_sts_token_http_request(const grpc_httpcli_request* request,
     assert_query_parameters(*url, "actor_token_type",
                             test_signed_jwt_token_type2);
   } else {
-    GPR_ASSERT(url->query_parameter_map().find("actor_token") ==
-               url->query_parameter_map().end());
-    GPR_ASSERT(url->query_parameter_map().find("actor_token_type") ==
-               url->query_parameter_map().end());
+    EXPECT_TRUE(url->query_parameter_map().find("actor_token") ==
+                url->query_parameter_map().end());
+    EXPECT_TRUE(url->query_parameter_map().find("actor_token_type") ==
+                url->query_parameter_map().end());
   }
 
   // Check the rest of the request.
-  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
-  GPR_ASSERT(strcmp(request->http.path, "/v1/token-exchange") == 0);
-  GPR_ASSERT(request->http.hdr_count == 1);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
-                    "application/x-www-form-urlencoded") == 0);
+  EXPECT_STREQ(request->host, "foo.com:5555");
+  EXPECT_STREQ(request->http.path, "/v1/token-exchange");
+  EXPECT_EQ(request->http.hdr_count, 1);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
+  EXPECT_STREQ(request->http.hdrs[0].value,
+               "application/x-www-form-urlencoded");
 }
 
 static int sts_token_httpcli_post_success(const grpc_httpcli_request* request,
@@ -1090,15 +1077,15 @@ static int sts_token_httpcli_post_success_no_actor_token(
 static char* write_tmp_jwt_file(const char* jwt_contents) {
   char* path;
   FILE* tmp = gpr_tmpfile(test_signed_jwt_path_prefix, &path);
-  GPR_ASSERT(path != nullptr);
-  GPR_ASSERT(tmp != nullptr);
+  EXPECT_NE(path, nullptr);
+  EXPECT_NE(tmp, nullptr);
   size_t jwt_length = strlen(jwt_contents);
-  GPR_ASSERT(fwrite(jwt_contents, 1, jwt_length, tmp) == jwt_length);
+  EXPECT_EQ(fwrite(jwt_contents, 1, jwt_length, tmp), jwt_length);
   fclose(tmp);
   return path;
 }
 
-static void test_sts_creds_success(void) {
+TEST(CredentialsTest, sts_creds_success) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1124,7 +1111,7 @@ static void test_sts_creds_success(void) {
       grpc_sts_credentials_create(&valid_options, nullptr);
 
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
   request_metadata_state* state =
@@ -1141,8 +1128,7 @@ static void test_sts_creds_success(void) {
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
@@ -1150,7 +1136,7 @@ static void test_sts_creds_success(void) {
   gpr_free(actor_token_path);
 }
 
-static void test_sts_creds_token_file_not_found(void) {
+TEST(CredentialsTest, sts_creds_token_file_not_found) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -1169,7 +1155,7 @@ static void test_sts_creds_token_file_not_found(void) {
       grpc_sts_credentials_create(&valid_options, nullptr);
 
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
 
   request_metadata_state* state = make_request_metadata_state(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -1185,7 +1171,7 @@ static void test_sts_creds_token_file_not_found(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_sts_creds_no_actor_token_success(void) {
+TEST(CredentialsTest, sts_creds_no_actor_token_success) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1210,7 +1196,7 @@ static void test_sts_creds_no_actor_token_success(void) {
       grpc_sts_credentials_create(&valid_options, nullptr);
 
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
   request_metadata_state* state =
@@ -1227,15 +1213,14 @@ static void test_sts_creds_no_actor_token_success(void) {
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
   gpr_free(subject_token_path);
 }
 
-static void test_sts_creds_load_token_failure(void) {
+TEST(CredentialsTest, sts_creds_load_token_failure) {
   const char expected_creds_debug_string[] =
       "StsTokenFetcherCredentials{Path:/v1/"
       "token-exchange,Authority:foo.com:5555,OAuth2TokenFetcherCredentials}";
@@ -1262,15 +1247,14 @@ static void test_sts_creds_load_token_failure(void) {
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
   gpr_free(test_signed_jwt_path);
 }
 
-static void test_sts_creds_http_failure(void) {
+TEST(CredentialsTest, sts_creds_http_failure) {
   const char expected_creds_debug_string[] =
       "StsTokenFetcherCredentials{Path:/v1/"
       "token-exchange,Authority:foo.com:5555,OAuth2TokenFetcherCredentials}";
@@ -1298,8 +1282,7 @@ static void test_sts_creds_http_failure(void) {
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             token_httpcli_post_failure);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
   gpr_free(test_signed_jwt_path);
@@ -1308,24 +1291,20 @@ static void test_sts_creds_http_failure(void) {
 static void validate_jwt_encode_and_sign_params(
     const grpc_auth_json_key* json_key, const char* scope,
     gpr_timespec token_lifetime) {
-  GPR_ASSERT(grpc_auth_json_key_is_valid(json_key));
-  GPR_ASSERT(json_key->private_key != nullptr);
-  GPR_ASSERT(RSA_check_key(json_key->private_key));
-  GPR_ASSERT(json_key->type != nullptr &&
-             strcmp(json_key->type, "service_account") == 0);
-  GPR_ASSERT(json_key->private_key_id != nullptr &&
-             strcmp(json_key->private_key_id,
-                    "e6b5137873db8d2ef81e06a47289e6434ec8a165") == 0);
-  GPR_ASSERT(json_key->client_id != nullptr &&
-             strcmp(json_key->client_id,
-                    "777-abaslkan11hlb6nmim3bpspl31ud.apps."
-                    "googleusercontent.com") == 0);
-  GPR_ASSERT(json_key->client_email != nullptr &&
-             strcmp(json_key->client_email,
-                    "777-abaslkan11hlb6nmim3bpspl31ud@developer."
-                    "gserviceaccount.com") == 0);
-  if (scope != nullptr) GPR_ASSERT(strcmp(scope, test_scope) == 0);
-  GPR_ASSERT(gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime()) == 0);
+  EXPECT_TRUE(grpc_auth_json_key_is_valid(json_key));
+  EXPECT_NE(json_key->private_key, nullptr);
+  EXPECT_TRUE(RSA_check_key(json_key->private_key));
+  EXPECT_STREQ(json_key->type, "service_account");
+  EXPECT_STREQ(json_key->private_key_id,
+               "e6b5137873db8d2ef81e06a47289e6434ec8a165");
+  EXPECT_STREQ(json_key->client_id,
+               "777-abaslkan11hlb6nmim3bpspl31ud.apps."
+               "googleusercontent.com");
+  EXPECT_STREQ(json_key->client_email,
+               "777-abaslkan11hlb6nmim3bpspl31ud@developer."
+               "gserviceaccount.com");
+  if (scope != nullptr) EXPECT_STREQ(scope, test_scope);
+  EXPECT_EQ(gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime()), 0);
 }
 
 static char* encode_and_sign_jwt_success(const grpc_auth_json_key* json_key,
@@ -1351,18 +1330,18 @@ static char* encode_and_sign_jwt_failure(const grpc_auth_json_key* json_key,
 static char* encode_and_sign_jwt_should_not_be_called(
     const grpc_auth_json_key* /*json_key*/, const char* /*audience*/,
     gpr_timespec /*token_lifetime*/, const char* /*scope*/) {
-  GPR_ASSERT("grpc_jwt_encode_and_sign should not be called" == nullptr);
+  EXPECT_EQ("grpc_jwt_encode_and_sign should not be called", nullptr);
   return nullptr;
 }
 
 static grpc_service_account_jwt_access_credentials* creds_as_jwt(
     grpc_call_credentials* creds) {
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(strcmp(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_JWT) == 0);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_STREQ(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_JWT);
   return reinterpret_cast<grpc_service_account_jwt_access_credentials*>(creds);
 }
 
-static void test_jwt_creds_lifetime(void) {
+TEST(CredentialsTest, jwt_creds_lifetime) {
   char* json_key_string = test_json_key_str();
   const char expected_creds_debug_string_prefix[] =
       "JWTAccessCredentials{ExpirationTime:";
@@ -1370,25 +1349,25 @@ static void test_jwt_creds_lifetime(void) {
   grpc_call_credentials* jwt_creds =
       grpc_service_account_jwt_access_credentials_create(
           json_key_string, grpc_max_auth_token_lifetime(), nullptr);
-  GPR_ASSERT(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
-                          grpc_max_auth_token_lifetime()) == 0);
+  EXPECT_TRUE(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
+                           grpc_max_auth_token_lifetime()) == 0);
   /* Check security level. */
-  GPR_ASSERT(jwt_creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
-  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
-                     jwt_creds->debug_string().c_str(),
-                     strlen(expected_creds_debug_string_prefix)) == 0);
+  EXPECT_EQ(jwt_creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
+                      jwt_creds->debug_string().c_str(),
+                      strlen(expected_creds_debug_string_prefix)) == 0);
   grpc_call_credentials_release(jwt_creds);
 
   // Shorter lifetime.
   gpr_timespec token_lifetime = {10, 0, GPR_TIMESPAN};
-  GPR_ASSERT(gpr_time_cmp(grpc_max_auth_token_lifetime(), token_lifetime) > 0);
+  EXPECT_TRUE(gpr_time_cmp(grpc_max_auth_token_lifetime(), token_lifetime) > 0);
   jwt_creds = grpc_service_account_jwt_access_credentials_create(
       json_key_string, token_lifetime, nullptr);
-  GPR_ASSERT(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
-                          token_lifetime) == 0);
-  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
-                     jwt_creds->debug_string().c_str(),
-                     strlen(expected_creds_debug_string_prefix)) == 0);
+  EXPECT_TRUE(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
+                           token_lifetime) == 0);
+  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
+                      jwt_creds->debug_string().c_str(),
+                      strlen(expected_creds_debug_string_prefix)) == 0);
   grpc_call_credentials_release(jwt_creds);
 
   // Cropped lifetime.
@@ -1396,27 +1375,27 @@ static void test_jwt_creds_lifetime(void) {
   token_lifetime = gpr_time_add(grpc_max_auth_token_lifetime(), add_to_max);
   jwt_creds = grpc_service_account_jwt_access_credentials_create(
       json_key_string, token_lifetime, nullptr);
-  GPR_ASSERT(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
-                          grpc_max_auth_token_lifetime()) == 0);
-  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
-                     jwt_creds->debug_string().c_str(),
-                     strlen(expected_creds_debug_string_prefix)) == 0);
+  EXPECT_TRUE(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
+                           grpc_max_auth_token_lifetime()) == 0);
+  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
+                      jwt_creds->debug_string().c_str(),
+                      strlen(expected_creds_debug_string_prefix)) == 0);
   grpc_call_credentials_release(jwt_creds);
 
   gpr_free(json_key_string);
 }
 
-static void test_remove_service_from_jwt_uri(void) {
+TEST(CredentialsTest, remove_service_from_jwt_uri) {
   const char wrong_uri[] = "hello world";
-  GPR_ASSERT(!grpc_core::RemoveServiceNameFromJwtUri(wrong_uri).ok());
+  EXPECT_TRUE(!grpc_core::RemoveServiceNameFromJwtUri(wrong_uri).ok());
   const char valid_uri[] = "https://foo.com/get/";
   const char expected_uri[] = "https://foo.com/";
   auto output = grpc_core::RemoveServiceNameFromJwtUri(valid_uri);
-  GPR_ASSERT(output.ok());
-  GPR_ASSERT(strcmp(output->c_str(), expected_uri) == 0);
+  EXPECT_TRUE(output.ok());
+  EXPECT_STREQ(output->c_str(), expected_uri);
 }
 
-static void test_jwt_creds_success(void) {
+TEST(CredentialsTest, jwt_creds_success) {
   const char expected_creds_debug_string_prefix[] =
       "JWTAccessCredentials{ExpirationTime:";
 
@@ -1453,16 +1432,16 @@ static void test_jwt_creds_success(void) {
   grpc_jwt_encode_and_sign_set_override(encode_and_sign_jwt_success);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
-                     creds->debug_string().c_str(),
-                     strlen(expected_creds_debug_string_prefix)) == 0);
+  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
+                      creds->debug_string().c_str(),
+                      strlen(expected_creds_debug_string_prefix)) == 0);
 
   creds->Unref();
   gpr_free(json_key_string);
   grpc_jwt_encode_and_sign_set_override(nullptr);
 }
 
-static void test_jwt_creds_signing_failure(void) {
+TEST(CredentialsTest, jwt_creds_signing_failure) {
   const char expected_creds_debug_string_prefix[] =
       "JWTAccessCredentials{ExpirationTime:";
   char* json_key_string = test_json_key_str();
@@ -1480,9 +1459,9 @@ static void test_jwt_creds_signing_failure(void) {
   run_request_metadata_test(creds, auth_md_ctx, state);
 
   gpr_free(json_key_string);
-  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
-                     creds->debug_string().c_str(),
-                     strlen(expected_creds_debug_string_prefix)) == 0);
+  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
+                      creds->debug_string().c_str(),
+                      strlen(expected_creds_debug_string_prefix)) == 0);
 
   creds->Unref();
   grpc_jwt_encode_and_sign_set_override(nullptr);
@@ -1493,9 +1472,9 @@ static void set_google_default_creds_env_var_with_file_contents(
   size_t contents_len = strlen(contents);
   char* creds_file_name;
   FILE* creds_file = gpr_tmpfile(file_prefix, &creds_file_name);
-  GPR_ASSERT(creds_file_name != nullptr);
-  GPR_ASSERT(creds_file != nullptr);
-  GPR_ASSERT(fwrite(contents, 1, contents_len, creds_file) == contents_len);
+  EXPECT_NE(creds_file_name, nullptr);
+  EXPECT_NE(creds_file, nullptr);
+  EXPECT_EQ(fwrite(contents, 1, contents_len, creds_file), contents_len);
   fclose(creds_file);
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, creds_file_name);
   gpr_free(creds_file_name);
@@ -1506,7 +1485,7 @@ static bool test_gce_tenancy_checker(void) {
   return g_test_is_on_gce;
 }
 
-static void test_google_default_creds_auth_key(void) {
+TEST(CredentialsTest, google_default_creds_auth_key) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   char* json_key = test_json_key_str();
@@ -1514,109 +1493,106 @@ static void test_google_default_creds_auth_key(void) {
   set_gce_tenancy_checker_for_testing(test_gce_tenancy_checker);
   g_test_gce_tenancy_checker_called = false;
   g_test_is_on_gce = true;
-  set_google_default_creds_env_var_with_file_contents(
-      "json_key_google_default_creds", json_key);
+  set_google_default_creds_env_var_with_file_contents("json_key", json_key);
   gpr_free(json_key);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
+  EXPECT_NE(default_creds->ssl_creds(), nullptr);
   auto* jwt =
       reinterpret_cast<const grpc_service_account_jwt_access_credentials*>(
           creds->call_creds());
-  GPR_ASSERT(
-      strcmp(jwt->key().client_id,
-             "777-abaslkan11hlb6nmim3bpspl31ud.apps.googleusercontent.com") ==
-      0);
-  GPR_ASSERT(g_test_gce_tenancy_checker_called == false);
+  EXPECT_STREQ(jwt->key().client_id,
+               "777-abaslkan11hlb6nmim3bpspl31ud.apps.googleusercontent.com");
+  EXPECT_EQ(g_test_gce_tenancy_checker_called, false);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-static void test_google_default_creds_refresh_token(void) {
+TEST(CredentialsTest, google_default_creds_refresh_token) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
-  set_google_default_creds_env_var_with_file_contents(
-      "refresh_token_google_default_creds", test_refresh_token_str);
+  set_google_default_creds_env_var_with_file_contents("test_refresh_token_str",
+                                                      test_refresh_token_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
+  EXPECT_NE(default_creds->ssl_creds(), nullptr);
   auto* refresh =
       reinterpret_cast<const grpc_google_refresh_token_credentials*>(
           creds->call_creds());
-  GPR_ASSERT(strcmp(refresh->refresh_token().client_id,
-                    "32555999999.apps.googleusercontent.com") == 0);
+  EXPECT_STREQ(refresh->refresh_token().client_id,
+               "32555999999.apps.googleusercontent.com");
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-static void test_google_default_creds_external_account_credentials(void) {
+TEST(CredentialsTest, google_default_creds_external_account_credentials) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
   set_google_default_creds_env_var_with_file_contents(
-      "google_default_creds_external_account_credentials",
+      "test_external_account_credentials_str",
       test_external_account_credentials_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
+  EXPECT_NE(default_creds->ssl_creds(), nullptr);
   auto* external =
       reinterpret_cast<const grpc_core::ExternalAccountCredentials*>(
           creds->call_creds());
-  GPR_ASSERT(external != nullptr);
+  EXPECT_NE(external, nullptr);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-static void
-test_google_default_creds_external_account_credentials_multi_pattern_sts(void) {
+TEST(CredentialsTest,
+     google_default_creds_external_account_credentials_multi_pattern_sts) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
   set_google_default_creds_env_var_with_file_contents(
-      "google_default_creds_external_account_credentials",
+      "test_external_account_credentials_multi_pattern_sts_str",
       test_external_account_credentials_multi_pattern_sts_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
+  EXPECT_NE(default_creds->ssl_creds(), nullptr);
   auto* external =
       reinterpret_cast<const grpc_core::ExternalAccountCredentials*>(
           creds->call_creds());
-  GPR_ASSERT(external != nullptr);
+  EXPECT_NE(external, nullptr);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-static void
-test_google_default_creds_external_account_credentials_multi_pattern_iam(void) {
+TEST(CredentialsTest,
+     google_default_creds_external_account_credentials_multi_pattern_iam) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
   set_google_default_creds_env_var_with_file_contents(
-      "google_default_creds_external_account_credentials",
+      "test_external_account_credentials_multi_pattern_iam_str",
       test_external_account_credentials_multi_pattern_iam_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
+  EXPECT_NE(default_creds->ssl_creds(), nullptr);
   auto* external =
       reinterpret_cast<const grpc_core::ExternalAccountCredentials*>(
           creds->call_creds());
-  GPR_ASSERT(external != nullptr);
+  EXPECT_NE(external, nullptr);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
@@ -1631,15 +1607,15 @@ static int default_creds_metadata_server_detection_httpcli_get_success_override(
   headers[0].value = gpr_strdup("Google");
   response->hdr_count = 1;
   response->hdrs = headers;
-  GPR_ASSERT(strcmp(request->http.path, "/") == 0);
-  GPR_ASSERT(strcmp(request->host, "metadata.google.internal.") == 0);
+  EXPECT_STREQ(request->http.path, "/");
+  EXPECT_STREQ(request->host, "metadata.google.internal.");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
   return 1;
 }
 
 static std::string null_well_known_creds_path_getter(void) { return ""; }
 
-static void test_google_default_creds_gce(void) {
+TEST(CredentialsTest, google_default_creds_gce) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1661,14 +1637,14 @@ static void test_google_default_creds_gce(void) {
           grpc_google_default_credentials_create(nullptr));
 
   /* Verify that the default creds actually embeds a GCE creds. */
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(creds->call_creds() != nullptr);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_NE(creds->call_creds(), nullptr);
   grpc_httpcli_set_override(compute_engine_httpcli_get_success_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds->mutable_call_creds(), auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
 
-  GPR_ASSERT(g_test_gce_tenancy_checker_called == true);
+  EXPECT_EQ(g_test_gce_tenancy_checker_called, true);
 
   /* Cleanup. */
   creds->Unref();
@@ -1676,7 +1652,7 @@ static void test_google_default_creds_gce(void) {
   grpc_override_well_known_credentials_path_getter(nullptr);
 }
 
-static void test_google_default_creds_non_gce(void) {
+TEST(CredentialsTest, google_default_creds_non_gce) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1699,13 +1675,13 @@ static void test_google_default_creds_non_gce(void) {
       reinterpret_cast<grpc_composite_channel_credentials*>(
           grpc_google_default_credentials_create(nullptr));
   /* Verify that the default creds actually embeds a GCE creds. */
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(creds->call_creds() != nullptr);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_NE(creds->call_creds(), nullptr);
   grpc_httpcli_set_override(compute_engine_httpcli_get_success_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds->mutable_call_creds(), auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  GPR_ASSERT(g_test_gce_tenancy_checker_called == true);
+  EXPECT_EQ(g_test_gce_tenancy_checker_called, true);
   /* Cleanup. */
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
@@ -1716,14 +1692,14 @@ static int default_creds_gce_detection_httpcli_get_failure_override(
     const grpc_httpcli_request* request, grpc_millis /*deadline*/,
     grpc_closure* on_done, grpc_httpcli_response* response) {
   /* No magic header. */
-  GPR_ASSERT(strcmp(request->http.path, "/") == 0);
-  GPR_ASSERT(strcmp(request->host, "metadata.google.internal.") == 0);
+  EXPECT_STREQ(request->http.path, "/");
+  EXPECT_STREQ(request->host, "metadata.google.internal.");
   *response = http_response(200, "");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
   return 1;
 }
 
-static void test_no_google_default_creds(void) {
+TEST(CredentialsTest, no_google_default_creds) {
   grpc_flush_cached_google_default_credentials();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
   grpc_override_well_known_credentials_path_getter(
@@ -1735,17 +1711,17 @@ static void test_no_google_default_creds(void) {
       default_creds_gce_detection_httpcli_get_failure_override,
       httpcli_post_should_not_be_called);
   /* Simulate a successful detection of GCE. */
-  GPR_ASSERT(grpc_google_default_credentials_create(nullptr) == nullptr);
+  EXPECT_EQ(grpc_google_default_credentials_create(nullptr), nullptr);
   /* Try a second one. GCE detection should occur again. */
   g_test_gce_tenancy_checker_called = false;
-  GPR_ASSERT(grpc_google_default_credentials_create(nullptr) == nullptr);
-  GPR_ASSERT(g_test_gce_tenancy_checker_called == true);
+  EXPECT_EQ(grpc_google_default_credentials_create(nullptr), nullptr);
+  EXPECT_EQ(g_test_gce_tenancy_checker_called, true);
   /* Cleanup. */
   grpc_override_well_known_credentials_path_getter(nullptr);
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_google_default_creds_call_creds_specified(void) {
+TEST(CredentialsTest, google_default_creds_call_creds_specified) {
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
   request_metadata_state* state =
@@ -1765,9 +1741,9 @@ static void test_google_default_creds_call_creds_specified(void) {
   grpc_composite_channel_credentials* channel_creds =
       reinterpret_cast<grpc_composite_channel_credentials*>(
           grpc_google_default_credentials_create(call_creds));
-  GPR_ASSERT(g_test_gce_tenancy_checker_called == false);
-  GPR_ASSERT(channel_creds != nullptr);
-  GPR_ASSERT(channel_creds->call_creds() != nullptr);
+  EXPECT_EQ(g_test_gce_tenancy_checker_called, false);
+  EXPECT_NE(channel_creds, nullptr);
+  EXPECT_NE(channel_creds->call_creds(), nullptr);
   grpc_httpcli_set_override(compute_engine_httpcli_get_success_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(channel_creds->mutable_call_creds(), auth_md_ctx,
@@ -1805,7 +1781,7 @@ struct fake_call_creds : public grpc_call_credentials {
   grpc_mdelem phony_md_;
 };
 
-static void test_google_default_creds_not_default(void) {
+TEST(CredentialsTest, google_default_creds_not_default) {
   expected_md emd[] = {{"foo", "oof"}};
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
@@ -1824,9 +1800,9 @@ static void test_google_default_creds_not_default(void) {
   grpc_composite_channel_credentials* channel_creds =
       reinterpret_cast<grpc_composite_channel_credentials*>(
           grpc_google_default_credentials_create(call_creds.release()));
-  GPR_ASSERT(g_test_gce_tenancy_checker_called == false);
-  GPR_ASSERT(channel_creds != nullptr);
-  GPR_ASSERT(channel_creds->call_creds() != nullptr);
+  EXPECT_EQ(g_test_gce_tenancy_checker_called, false);
+  EXPECT_NE(channel_creds, nullptr);
+  EXPECT_NE(channel_creds->call_creds(), nullptr);
   run_request_metadata_test(channel_creds->mutable_call_creds(), auth_md_ctx,
                             state);
   grpc_core::ExecCtx::Get()->Flush();
@@ -1848,12 +1824,12 @@ static int plugin_get_metadata_success(
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t* num_creds_md, grpc_status_code* /*status*/,
     const char** /*error_details*/) {
-  GPR_ASSERT(strcmp(context.service_url, test_service_url) == 0);
-  GPR_ASSERT(strcmp(context.method_name, test_method) == 0);
-  GPR_ASSERT(context.channel_auth_context == nullptr);
-  GPR_ASSERT(context.reserved == nullptr);
-  GPR_ASSERT(GPR_ARRAY_SIZE(plugin_md) <
-             GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX);
+  EXPECT_STREQ(context.service_url, test_service_url);
+  EXPECT_STREQ(context.method_name, test_method);
+  EXPECT_EQ(context.channel_auth_context, nullptr);
+  EXPECT_EQ(context.reserved, nullptr);
+  EXPECT_TRUE(GPR_ARRAY_SIZE(plugin_md) <
+              GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX);
   plugin_state* s = static_cast<plugin_state*>(state);
   *s = PLUGIN_GET_METADATA_CALLED_STATE;
   for (size_t i = 0; i < GPR_ARRAY_SIZE(plugin_md); ++i) {
@@ -1873,10 +1849,10 @@ static int plugin_get_metadata_failure(
     grpc_metadata /*creds_md*/[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t* /*num_creds_md*/, grpc_status_code* status,
     const char** error_details) {
-  GPR_ASSERT(strcmp(context.service_url, test_service_url) == 0);
-  GPR_ASSERT(strcmp(context.method_name, test_method) == 0);
-  GPR_ASSERT(context.channel_auth_context == nullptr);
-  GPR_ASSERT(context.reserved == nullptr);
+  EXPECT_STREQ(context.service_url, test_service_url);
+  EXPECT_STREQ(context.method_name, test_method);
+  EXPECT_EQ(context.channel_auth_context, nullptr);
+  EXPECT_EQ(context.reserved, nullptr);
   plugin_state* s = static_cast<plugin_state*>(state);
   *s = PLUGIN_GET_METADATA_CALLED_STATE;
   *status = GRPC_STATUS_UNAUTHENTICATED;
@@ -1909,7 +1885,7 @@ static char* plugin_debug_string(void* state) {
   return ret;
 }
 
-static void test_metadata_plugin_success(void) {
+TEST(CredentialsTest, metadata_plugin_success) {
   const char expected_creds_debug_string[] =
       "TestPluginCredentials{state:GET_METADATA_CALLED}";
   plugin_state state = PLUGIN_INITIAL_STATE;
@@ -1928,18 +1904,17 @@ static void test_metadata_plugin_success(void) {
   grpc_call_credentials* creds = grpc_metadata_credentials_create_from_plugin(
       plugin, GRPC_PRIVACY_AND_INTEGRITY, nullptr);
   /* Check security level. */
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
-  GPR_ASSERT(state == PLUGIN_INITIAL_STATE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(state, PLUGIN_INITIAL_STATE);
   run_request_metadata_test(creds, auth_md_ctx, md_state);
-  GPR_ASSERT(state == PLUGIN_GET_METADATA_CALLED_STATE);
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_EQ(state, PLUGIN_GET_METADATA_CALLED_STATE);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
   creds->Unref();
 
-  GPR_ASSERT(state == PLUGIN_DESTROY_CALLED_STATE);
+  EXPECT_EQ(state, PLUGIN_DESTROY_CALLED_STATE);
 }
 
-static void test_metadata_plugin_failure(void) {
+TEST(CredentialsTest, metadata_plugin_failure) {
   const char expected_creds_debug_string[] =
       "TestPluginCredentials{state:GET_METADATA_CALLED}";
 
@@ -1961,17 +1936,16 @@ static void test_metadata_plugin_failure(void) {
 
   grpc_call_credentials* creds = grpc_metadata_credentials_create_from_plugin(
       plugin, GRPC_PRIVACY_AND_INTEGRITY, nullptr);
-  GPR_ASSERT(state == PLUGIN_INITIAL_STATE);
+  EXPECT_EQ(state, PLUGIN_INITIAL_STATE);
   run_request_metadata_test(creds, auth_md_ctx, md_state);
-  GPR_ASSERT(state == PLUGIN_GET_METADATA_CALLED_STATE);
-  GPR_ASSERT(
-      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
+  EXPECT_EQ(state, PLUGIN_GET_METADATA_CALLED_STATE);
+  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
   creds->Unref();
 
-  GPR_ASSERT(state == PLUGIN_DESTROY_CALLED_STATE);
+  EXPECT_EQ(state, PLUGIN_DESTROY_CALLED_STATE);
 }
 
-static void test_get_well_known_google_credentials_file_path(void) {
+TEST(CredentialsTest, get_well_known_google_credentials_file_path) {
   char* home = gpr_getenv("HOME");
   bool restore_home_env = false;
 #if defined(GRPC_BAZEL_BUILD) && \
@@ -1983,12 +1957,12 @@ static void test_get_well_known_google_credentials_file_path(void) {
 #endif /* defined(GRPC_BAZEL_BUILD) && (defined(GPR_POSIX_ENV) || \
           defined(GPR_LINUX_ENV)) */
   std::string path = grpc_get_well_known_google_credentials_file_path();
-  GPR_ASSERT(!path.empty());
+  EXPECT_TRUE(!path.empty());
 #if defined(GPR_POSIX_ENV) || defined(GPR_LINUX_ENV)
   restore_home_env = true;
   gpr_unsetenv("HOME");
   path = grpc_get_well_known_google_credentials_file_path();
-  GPR_ASSERT(path.empty());
+  EXPECT_TRUE(path.empty());
 #endif /* GPR_POSIX_ENV || GPR_LINUX_ENV */
   if (restore_home_env) {
     if (home) {
@@ -2000,7 +1974,7 @@ static void test_get_well_known_google_credentials_file_path(void) {
   gpr_free(home);
 }
 
-static void test_channel_creds_duplicate_without_call_creds(void) {
+TEST(CredentialsTest, channel_creds_duplicate_without_call_creds) {
   const char expected_creds_debug_string[] =
       "AccessTokenCredentials{Token:present}";
   grpc_core::ExecCtx exec_ctx;
@@ -2010,7 +1984,7 @@ static void test_channel_creds_duplicate_without_call_creds(void) {
 
   grpc_core::RefCountedPtr<grpc_channel_credentials> dup =
       channel_creds->duplicate_without_call_credentials();
-  GPR_ASSERT(dup == channel_creds);
+  EXPECT_EQ(dup, channel_creds);
   dup.reset();
 
   grpc_call_credentials* call_creds =
@@ -2018,12 +1992,11 @@ static void test_channel_creds_duplicate_without_call_creds(void) {
   grpc_channel_credentials* composite_creds =
       grpc_composite_channel_credentials_create(channel_creds, call_creds,
                                                 nullptr);
-  GPR_ASSERT(strcmp(call_creds->debug_string().c_str(),
-                    expected_creds_debug_string) == 0);
+  EXPECT_STREQ(call_creds->debug_string().c_str(), expected_creds_debug_string);
 
   call_creds->Unref();
   dup = composite_creds->duplicate_without_call_credentials();
-  GPR_ASSERT(dup == channel_creds);
+  EXPECT_EQ(dup, channel_creds);
   dup.reset();
 
   channel_creds->Unref();
@@ -2038,7 +2011,7 @@ typedef struct {
   const char* desired_method_name;
 } auth_metadata_context_test_case;
 
-static void test_auth_metadata_context(void) {
+TEST(CredentialsTest, auth_metadata_context) {
   auth_metadata_context_test_case test_cases[] = {
       // No service nor method.
       {"https", "www.foo.com", "", "https://www.foo.com", ""},
@@ -2086,15 +2059,15 @@ static void test_auth_metadata_context(void) {
                test_cases[i].desired_service_url) != 0) {
       gpr_log(GPR_ERROR, "Invalid service url, want: %s, got %s.",
               test_cases[i].desired_service_url, auth_md_context.service_url);
-      GPR_ASSERT(false);
+      EXPECT_TRUE(false);
     }
     if (strcmp(auth_md_context.method_name,
                test_cases[i].desired_method_name) != 0) {
       gpr_log(GPR_ERROR, "Invalid method name, want: %s, got %s.",
               test_cases[i].desired_method_name, auth_md_context.method_name);
-      GPR_ASSERT(false);
+      EXPECT_TRUE(false);
     }
-    GPR_ASSERT(auth_md_context.channel_auth_context == nullptr);
+    EXPECT_EQ(auth_md_context.channel_auth_context, nullptr);
     grpc_slice_unref(call_host);
     grpc_slice_unref(call_method);
     grpc_auth_metadata_context_reset(&auth_md_context);
@@ -2105,16 +2078,16 @@ static void validate_external_account_creds_token_exchage_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  GPR_ASSERT(body != nullptr);
-  GPR_ASSERT(body_size != 0);
-  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
+  EXPECT_NE(body, nullptr);
+  EXPECT_NE(body_size, 0);
+  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
   std::string get_url_equivalent =
       absl::StrFormat("%s?%s", "https://foo.com:5555/token", body);
   absl::StatusOr<grpc_core::URI> uri =
       grpc_core::URI::Parse(get_url_equivalent);
   if (!uri.ok()) {
     gpr_log(GPR_ERROR, "%s", uri.status().ToString().c_str());
-    GPR_ASSERT(uri.ok());
+    EXPECT_TRUE(uri.ok());
   }
   assert_query_parameters(*uri, "audience", "audience");
   assert_query_parameters(*uri, "grant_type",
@@ -2127,15 +2100,15 @@ static void validate_external_account_creds_token_exchage_request(
                           "https://www.googleapis.com/auth/cloud-platform");
 
   // Check the rest of the request.
-  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
-  GPR_ASSERT(strcmp(request->http.path, "/token") == 0);
-  GPR_ASSERT(request->http.hdr_count == 2);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
-                    "application/x-www-form-urlencoded") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
-                    "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=") == 0);
+  EXPECT_STREQ(request->host, "foo.com:5555");
+  EXPECT_STREQ(request->http.path, "/token");
+  EXPECT_EQ(request->http.hdr_count, 2);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
+  EXPECT_STREQ(request->http.hdrs[0].value,
+               "application/x-www-form-urlencoded");
+  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
+  EXPECT_STREQ(request->http.hdrs[1].value,
+               "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=");
 }
 
 static void
@@ -2143,29 +2116,28 @@ validate_external_account_creds_token_exchage_request_with_url_encode(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  GPR_ASSERT(body != nullptr);
-  GPR_ASSERT(body_size != 0);
-  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
-  GPR_ASSERT(
-      strcmp(
-          std::string(body, body_size).c_str(),
-          "audience=audience_!%40%23%24&grant_type=urn%3Aietf%3Aparams%3Aoauth%"
-          "3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%"
-          "3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&subject_token_type="
-          "subject_token_type_!%40%23%24&subject_token=test_subject_token&"
-          "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform") ==
-      0);
+  EXPECT_NE(body, nullptr);
+  EXPECT_NE(body_size, 0);
+  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
+  EXPECT_EQ(
+
+      std::string(body, body_size),
+      "audience=audience_!%40%23%24&grant_type=urn%3Aietf%3Aparams%3Aoauth%"
+      "3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%"
+      "3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&subject_token_type="
+      "subject_token_type_!%40%23%24&subject_token=test_subject_token&"
+      "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform");
 
   // Check the rest of the request.
-  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
-  GPR_ASSERT(strcmp(request->http.path, "/token_url_encode") == 0);
-  GPR_ASSERT(request->http.hdr_count == 2);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
-                    "application/x-www-form-urlencoded") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
-                    "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=") == 0);
+  EXPECT_STREQ(request->host, "foo.com:5555");
+  EXPECT_STREQ(request->http.path, "/token_url_encode");
+  EXPECT_EQ(request->http.hdr_count, 2);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
+  EXPECT_STREQ(request->http.hdrs[0].value,
+               "application/x-www-form-urlencoded");
+  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
+  EXPECT_STREQ(request->http.hdrs[1].value,
+               "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=");
 }
 
 static void
@@ -2173,20 +2145,20 @@ validate_external_account_creds_service_account_impersonation_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  GPR_ASSERT(body != nullptr);
-  GPR_ASSERT(body_size != 0);
-  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
-  GPR_ASSERT(strcmp(body, "scope=scope_1 scope_2") == 0);
+  EXPECT_NE(body, nullptr);
+  EXPECT_NE(body_size, 0);
+  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
+  EXPECT_STREQ(body, "scope=scope_1 scope_2");
   // Check the rest of the request.
-  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
-  GPR_ASSERT(strcmp(request->http.path, "/service_account_impersonation") == 0);
-  GPR_ASSERT(request->http.hdr_count == 2);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
-                    "application/x-www-form-urlencoded") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
-                    "Bearer token_exchange_access_token") == 0);
+  EXPECT_STREQ(request->host, "foo.com:5555");
+  EXPECT_STREQ(request->http.path, "/service_account_impersonation");
+  EXPECT_EQ(request->http.hdr_count, 2);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
+  EXPECT_STREQ(request->http.hdrs[0].value,
+               "application/x-www-form-urlencoded");
+  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
+  EXPECT_STREQ(request->http.hdrs[1].value,
+               "Bearer token_exchange_access_token");
 }
 
 static int external_account_creds_httpcli_post_success(
@@ -2261,17 +2233,17 @@ static void validate_aws_external_account_creds_token_exchage_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  GPR_ASSERT(body != nullptr);
-  GPR_ASSERT(body_size != 0);
+  EXPECT_NE(body, nullptr);
+  EXPECT_NE(body_size, 0);
   // Check that the regional_cred_verification_url got constructed
   // with the correct AWS Region ("test_regionz" or "test_region").
-  GPR_ASSERT(strstr(body, "regional_cred_verification_url_test_region"));
-  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
+  EXPECT_TRUE(strstr(body, "regional_cred_verification_url_test_region"));
+  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
   std::string get_url_equivalent =
       absl::StrFormat("%s?%s", "https://foo.com:5555/token", body);
   absl::StatusOr<grpc_core::URI> uri =
       grpc_core::URI::Parse(get_url_equivalent);
-  GPR_ASSERT(uri.ok());
+  EXPECT_TRUE(uri.ok());
   assert_query_parameters(*uri, "audience", "audience");
   assert_query_parameters(*uri, "grant_type",
                           "urn:ietf:params:oauth:grant-type:token-exchange");
@@ -2281,15 +2253,15 @@ static void validate_aws_external_account_creds_token_exchage_request(
   assert_query_parameters(*uri, "scope",
                           "https://www.googleapis.com/auth/cloud-platform");
   // Check the rest of the request.
-  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
-  GPR_ASSERT(strcmp(request->http.path, "/token") == 0);
-  GPR_ASSERT(request->http.hdr_count == 2);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
-                    "application/x-www-form-urlencoded") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
-  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
-                    "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=") == 0);
+  EXPECT_STREQ(request->host, "foo.com:5555");
+  EXPECT_STREQ(request->http.path, "/token");
+  EXPECT_EQ(request->http.hdr_count, 2);
+  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
+  EXPECT_STREQ(request->http.hdrs[0].value,
+               "application/x-www-form-urlencoded");
+  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
+  EXPECT_STREQ(request->http.hdrs[1].value,
+               "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=");
 }
 
 static int aws_external_account_creds_httpcli_get_success(
@@ -2341,7 +2313,7 @@ class TestExternalAccountCredentials final
   }
 };
 
-static void test_external_account_creds_success(void) {
+TEST(CredentialsTest, external_account_creds_success) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2361,7 +2333,7 @@ static void test_external_account_creds_success(void) {
   };
   TestExternalAccountCredentials creds(options, {});
   /* Check security level. */
-  GPR_ASSERT(creds.min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds.min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   /* First request: http put should be called. */
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
@@ -2379,7 +2351,7 @@ static void test_external_account_creds_success(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_external_account_creds_success_with_url_encode(void) {
+TEST(CredentialsTest, external_account_creds_success_with_url_encode) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2407,8 +2379,8 @@ static void test_external_account_creds_success_with_url_encode(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void
-test_external_account_creds_success_with_service_account_impersonation(void) {
+TEST(CredentialsTest,
+     external_account_creds_success_with_service_account_impersonation) {
   expected_md emd[] = {
       {"authorization", "Bearer service_account_impersonation_access_token"}};
   grpc_core::ExecCtx exec_ctx;
@@ -2429,7 +2401,7 @@ test_external_account_creds_success_with_service_account_impersonation(void) {
   };
   TestExternalAccountCredentials creds(options, {"scope_1", "scope_2"});
   /* Check security level. */
-  GPR_ASSERT(creds.min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_EQ(creds.min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   /* First request: http put should be called. */
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
@@ -2440,7 +2412,7 @@ test_external_account_creds_success_with_service_account_impersonation(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_external_account_creds_failure_invalid_token_url(void) {
+TEST(CredentialsTest, external_account_creds_failure_invalid_token_url) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2473,9 +2445,8 @@ static void test_external_account_creds_failure_invalid_token_url(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void
-test_external_account_creds_failure_invalid_service_account_impersonation_url(
-    void) {
+TEST(CredentialsTest,
+     external_account_creds_failure_invalid_service_account_impersonation_url) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2509,9 +2480,9 @@ test_external_account_creds_failure_invalid_service_account_impersonation_url(
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void
-test_external_account_creds_failure_token_exchange_response_missing_access_token(
-    void) {
+TEST(
+    CredentialsTest,
+    external_account_creds_failure_token_exchange_response_missing_access_token) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2547,7 +2518,7 @@ test_external_account_creds_failure_token_exchange_response_missing_access_token
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_url_external_account_creds_success_format_text(void) {
+TEST(CredentialsTest, url_external_account_creds_success_format_text) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2556,7 +2527,7 @@ static void test_url_external_account_creds_success_format_text(void) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_url_external_account_creds_options_credential_source_format_text,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2571,9 +2542,9 @@ static void test_url_external_account_creds_success_format_text(void) {
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(url_external_account_creds_httpcli_get_success,
@@ -2583,8 +2554,8 @@ static void test_url_external_account_creds_success_format_text(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void
-test_url_external_account_creds_success_with_qurey_params_format_text(void) {
+TEST(CredentialsTest,
+     url_external_account_creds_success_with_qurey_params_format_text) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2593,7 +2564,7 @@ test_url_external_account_creds_success_with_qurey_params_format_text(void) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_url_external_account_creds_options_credential_source_with_qurey_params_format_text,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2608,9 +2579,9 @@ test_url_external_account_creds_success_with_qurey_params_format_text(void) {
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(url_external_account_creds_httpcli_get_success,
@@ -2620,7 +2591,7 @@ test_url_external_account_creds_success_with_qurey_params_format_text(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_url_external_account_creds_success_format_json(void) {
+TEST(CredentialsTest, url_external_account_creds_success_format_json) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2629,7 +2600,7 @@ static void test_url_external_account_creds_success_format_json(void) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_url_external_account_creds_options_credential_source_format_json,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2644,9 +2615,9 @@ static void test_url_external_account_creds_success_format_json(void) {
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(url_external_account_creds_httpcli_get_success,
@@ -2656,12 +2627,12 @@ static void test_url_external_account_creds_success_format_json(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void
-test_url_external_account_creds_failure_invalid_credential_source_url(void) {
+TEST(CredentialsTest,
+     url_external_account_creds_failure_invalid_credential_source_url) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_url_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2676,17 +2647,15 @@ test_url_external_account_creds_failure_invalid_credential_source_url(void) {
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds == nullptr);
-  grpc_slice actual_error_slice;
-  GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION,
-                                &actual_error_slice));
-  absl::string_view actual_error =
-      grpc_core::StringViewFromSlice(actual_error_slice);
-  GPR_ASSERT(absl::StartsWith(actual_error, "Invalid credential source url."));
+  EXPECT_EQ(creds, nullptr);
+  std::string actual_error;
+  EXPECT_TRUE(
+      grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &actual_error));
+  EXPECT_TRUE(absl::StartsWith(actual_error, "Invalid credential source url."));
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_file_external_account_creds_success_format_text(void) {
+TEST(CredentialsTest, file_external_account_creds_success_format_text) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2698,7 +2667,7 @@ static void test_file_external_account_creds_success_format_text(void) {
           "{\"file\":\"%s\"}",
           absl::StrReplaceAll(subject_token_path, {{"\\", "\\\\"}})),
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2713,9 +2682,9 @@ static void test_file_external_account_creds_success_format_text(void) {
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
@@ -2727,7 +2696,7 @@ static void test_file_external_account_creds_success_format_text(void) {
   gpr_free(subject_token_path);
 }
 
-static void test_file_external_account_creds_success_format_json(void) {
+TEST(CredentialsTest, file_external_account_creds_success_format_json) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2747,7 +2716,7 @@ static void test_file_external_account_creds_success_format_json(void) {
           "}",
           absl::StrReplaceAll(subject_token_path, {{"\\", "\\\\"}})),
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2762,9 +2731,9 @@ static void test_file_external_account_creds_success_format_json(void) {
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
@@ -2776,14 +2745,14 @@ static void test_file_external_account_creds_success_format_json(void) {
   gpr_free(subject_token_path);
 }
 
-static void test_file_external_account_creds_failure_file_not_found(void) {
+TEST(CredentialsTest, file_external_account_creds_failure_file_not_found) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source =
       grpc_core::Json::Parse("{\"file\":\"non_exisiting_file\"}", &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2798,8 +2767,8 @@ static void test_file_external_account_creds_failure_file_not_found(void) {
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             httpcli_post_should_not_be_called);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to load file");
@@ -2814,8 +2783,8 @@ static void test_file_external_account_creds_failure_file_not_found(void) {
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_file_external_account_creds_failure_invalid_json_content(
-    void) {
+TEST(CredentialsTest,
+     file_external_account_creds_failure_invalid_json_content) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2833,7 +2802,7 @@ static void test_file_external_account_creds_failure_invalid_json_content(
           "}",
           absl::StrReplaceAll(subject_token_path, {{"\\", "\\\\"}})),
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2848,8 +2817,8 @@ static void test_file_external_account_creds_failure_invalid_json_content(
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             httpcli_post_should_not_be_called);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -2866,7 +2835,7 @@ static void test_file_external_account_creds_failure_invalid_json_content(
   gpr_free(subject_token_path);
 }
 
-static void test_aws_external_account_creds_success(void) {
+TEST(CredentialsTest, aws_external_account_creds_success) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2874,7 +2843,7 @@ static void test_aws_external_account_creds_success(void) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2889,9 +2858,9 @@ static void test_aws_external_account_creds_success(void) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2901,8 +2870,8 @@ static void test_aws_external_account_creds_success(void) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-static void test_aws_external_account_creds_success_path_region_env_keys_url(
-    void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_region_env_keys_url) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2911,7 +2880,7 @@ static void test_aws_external_account_creds_success_path_region_env_keys_url(
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2926,9 +2895,9 @@ static void test_aws_external_account_creds_success_path_region_env_keys_url(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2939,8 +2908,8 @@ static void test_aws_external_account_creds_success_path_region_env_keys_url(
   gpr_unsetenv("AWS_REGION");
 }
 
-static void
-test_aws_external_account_creds_success_path_default_region_env_keys_url(void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_default_region_env_keys_url) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2949,7 +2918,7 @@ test_aws_external_account_creds_success_path_default_region_env_keys_url(void) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2964,9 +2933,9 @@ test_aws_external_account_creds_success_path_default_region_env_keys_url(void) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2977,9 +2946,8 @@ test_aws_external_account_creds_success_path_default_region_env_keys_url(void) {
   gpr_unsetenv("AWS_DEFAULT_REGION");
 }
 
-static void
-test_aws_external_account_creds_success_path_duplicate_region_env_keys_url(
-    void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_duplicate_region_env_keys_url) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2990,7 +2958,7 @@ test_aws_external_account_creds_success_path_duplicate_region_env_keys_url(
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3005,9 +2973,9 @@ test_aws_external_account_creds_success_path_duplicate_region_env_keys_url(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3019,8 +2987,8 @@ test_aws_external_account_creds_success_path_duplicate_region_env_keys_url(
   gpr_unsetenv("AWS_DEFAULT_REGION");
 }
 
-static void test_aws_external_account_creds_success_path_region_url_keys_env(
-    void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_region_url_keys_env) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3031,7 +2999,7 @@ static void test_aws_external_account_creds_success_path_region_url_keys_env(
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3046,9 +3014,9 @@ static void test_aws_external_account_creds_success_path_region_url_keys_env(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3061,8 +3029,8 @@ static void test_aws_external_account_creds_success_path_region_url_keys_env(
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-static void test_aws_external_account_creds_success_path_region_env_keys_env(
-    void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_region_env_keys_env) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3074,7 +3042,7 @@ static void test_aws_external_account_creds_success_path_region_env_keys_env(
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3089,9 +3057,9 @@ static void test_aws_external_account_creds_success_path_region_env_keys_env(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3105,8 +3073,8 @@ static void test_aws_external_account_creds_success_path_region_env_keys_env(
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-static void
-test_aws_external_account_creds_success_path_default_region_env_keys_env(void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_default_region_env_keys_env) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3118,7 +3086,7 @@ test_aws_external_account_creds_success_path_default_region_env_keys_env(void) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3133,9 +3101,9 @@ test_aws_external_account_creds_success_path_default_region_env_keys_env(void) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3149,9 +3117,8 @@ test_aws_external_account_creds_success_path_default_region_env_keys_env(void) {
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-static void
-test_aws_external_account_creds_success_path_duplicate_region_env_keys_env(
-    void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_success_path_duplicate_region_env_keys_env) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3165,7 +3132,7 @@ test_aws_external_account_creds_success_path_duplicate_region_env_keys_env(
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3180,9 +3147,9 @@ test_aws_external_account_creds_success_path_duplicate_region_env_keys_env(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3197,13 +3164,13 @@ test_aws_external_account_creds_success_path_duplicate_region_env_keys_env(
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-static void test_aws_external_account_creds_failure_unmatched_environment_id(
-    void) {
+TEST(CredentialsTest,
+     aws_external_account_creds_failure_unmatched_environment_id) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_unmatched_environment_id,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3218,17 +3185,16 @@ static void test_aws_external_account_creds_failure_unmatched_environment_id(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds == nullptr);
-  grpc_slice expected_error_slice =
-      grpc_slice_from_static_string("environment_id does not match.");
-  grpc_slice actual_error_slice;
-  GPR_ASSERT(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION,
-                                &actual_error_slice));
-  GPR_ASSERT(grpc_slice_cmp(expected_error_slice, actual_error_slice) == 0);
+  EXPECT_EQ(creds, nullptr);
+  std::string expected_error = "environment_id does not match.";
+  std::string actual_error;
+  EXPECT_TRUE(
+      grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &actual_error));
+  EXPECT_EQ(expected_error, actual_error);
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_aws_external_account_creds_failure_invalid_region_url(void) {
+TEST(CredentialsTest, aws_external_account_creds_failure_invalid_region_url) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3236,7 +3202,7 @@ static void test_aws_external_account_creds_failure_invalid_region_url(void) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_invalid_region_url,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3251,9 +3217,9 @@ static void test_aws_external_account_creds_failure_invalid_region_url(void) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Invalid region url: invalid_region_url.");
   grpc_error_handle expected_error =
@@ -3269,7 +3235,7 @@ static void test_aws_external_account_creds_failure_invalid_region_url(void) {
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_aws_external_account_creds_failure_invalid_url(void) {
+TEST(CredentialsTest, aws_external_account_creds_failure_invalid_url) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3277,7 +3243,7 @@ static void test_aws_external_account_creds_failure_invalid_url(void) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_invalid_url,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3292,9 +3258,9 @@ static void test_aws_external_account_creds_failure_invalid_url(void) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Invalid url: invalid_url.");
   grpc_error_handle expected_error =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
@@ -3309,7 +3275,7 @@ static void test_aws_external_account_creds_failure_invalid_url(void) {
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_aws_external_account_creds_failure_missing_role_name(void) {
+TEST(CredentialsTest, aws_external_account_creds_failure_missing_role_name) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3317,7 +3283,7 @@ static void test_aws_external_account_creds_failure_missing_role_name(void) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_missing_role_name,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3332,9 +3298,9 @@ static void test_aws_external_account_creds_failure_missing_role_name(void) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Missing role name when retrieving signing keys.");
   grpc_error_handle expected_error =
@@ -3350,9 +3316,9 @@ static void test_aws_external_account_creds_failure_missing_role_name(void) {
   GRPC_ERROR_UNREF(error);
 }
 
-static void
-test_aws_external_account_creds_failure_invalid_regional_cred_verification_url(
-    void) {
+TEST(
+    CredentialsTest,
+    aws_external_account_creds_failure_invalid_regional_cred_verification_url) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3360,7 +3326,7 @@ test_aws_external_account_creds_failure_invalid_regional_cred_verification_url(
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_invalid_regional_cred_verification_url,
       &error);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3375,9 +3341,9 @@ test_aws_external_account_creds_failure_invalid_regional_cred_verification_url(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  GPR_ASSERT(creds != nullptr);
-  GPR_ASSERT(error == GRPC_ERROR_NONE);
-  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  EXPECT_NE(creds, nullptr);
+  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Creating aws request signer failed.");
   grpc_error_handle expected_error =
@@ -3393,7 +3359,7 @@ test_aws_external_account_creds_failure_invalid_regional_cred_verification_url(
   GRPC_ERROR_UNREF(error);
 }
 
-static void test_external_account_credentials_create_success(void) {
+TEST(CredentialsTest, external_account_credentials_create_success) {
   // url credentials
   const char* url_options_string =
       "{\"type\":\"external_account\",\"audience\":\"audience\",\"subject_"
@@ -3409,7 +3375,7 @@ static void test_external_account_credentials_create_success(void) {
   const char* url_scopes_string = "scope1,scope2";
   grpc_call_credentials* url_creds = grpc_external_account_credentials_create(
       url_options_string, url_scopes_string);
-  GPR_ASSERT(url_creds != nullptr);
+  EXPECT_NE(url_creds, nullptr);
   url_creds->Unref();
   // file credentials
   const char* file_options_string =
@@ -3424,7 +3390,7 @@ static void test_external_account_credentials_create_success(void) {
   const char* file_scopes_string = "scope1,scope2";
   grpc_call_credentials* file_creds = grpc_external_account_credentials_create(
       file_options_string, file_scopes_string);
-  GPR_ASSERT(file_creds != nullptr);
+  EXPECT_NE(file_creds, nullptr);
   file_creds->Unref();
   // aws credentials
   const char* aws_options_string =
@@ -3442,29 +3408,29 @@ static void test_external_account_credentials_create_success(void) {
   const char* aws_scopes_string = "scope1,scope2";
   grpc_call_credentials* aws_creds = grpc_external_account_credentials_create(
       aws_options_string, aws_scopes_string);
-  GPR_ASSERT(aws_creds != nullptr);
+  EXPECT_NE(aws_creds, nullptr);
   aws_creds->Unref();
 }
 
-static void
-test_external_account_credentials_create_failure_invalid_json_format(void) {
+TEST(CredentialsTest,
+     external_account_credentials_create_failure_invalid_json_format) {
   const char* options_string = "invalid_json";
   grpc_call_credentials* creds =
       grpc_external_account_credentials_create(options_string, "");
-  GPR_ASSERT(creds == nullptr);
+  EXPECT_EQ(creds, nullptr);
 }
 
-static void
-test_external_account_credentials_create_failure_invalid_options_format(void) {
+TEST(CredentialsTest,
+     external_account_credentials_create_failure_invalid_options_format) {
   const char* options_string = "{\"random_key\":\"random_value\"}";
   grpc_call_credentials* creds =
       grpc_external_account_credentials_create(options_string, "");
-  GPR_ASSERT(creds == nullptr);
+  EXPECT_EQ(creds, nullptr);
 }
 
-static void
-test_external_account_credentials_create_failure_invalid_options_credential_source(
-    void) {
+TEST(
+    CredentialsTest,
+    external_account_credentials_create_failure_invalid_options_credential_source) {
   const char* options_string =
       "{\"type\":\"external_account\",\"audience\":\"audience\",\"subject_"
       "token_type\":\"subject_token_type\",\"service_account_impersonation_"
@@ -3476,88 +3442,14 @@ test_external_account_credentials_create_failure_invalid_options_credential_sour
       "secret\"}";
   grpc_call_credentials* creds =
       grpc_external_account_credentials_create(options_string, "");
-  GPR_ASSERT(creds == nullptr);
+  EXPECT_EQ(creds, nullptr);
 }
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
-  test_empty_md_array();
-  test_add_to_empty_md_array();
-  test_add_abunch_to_md_array();
-  test_oauth2_token_fetcher_creds_parsing_ok();
-  test_oauth2_token_fetcher_creds_parsing_bad_http_status();
-  test_oauth2_token_fetcher_creds_parsing_empty_http_body();
-  test_oauth2_token_fetcher_creds_parsing_invalid_json();
-  test_oauth2_token_fetcher_creds_parsing_missing_token();
-  test_oauth2_token_fetcher_creds_parsing_missing_token_type();
-  test_oauth2_token_fetcher_creds_parsing_missing_token_lifetime();
-  test_google_iam_creds();
-  test_access_token_creds();
-  test_channel_oauth2_composite_creds();
-  test_oauth2_google_iam_composite_creds();
-  test_channel_oauth2_google_iam_composite_creds();
-  test_compute_engine_creds_success();
-  test_compute_engine_creds_failure();
-  test_refresh_token_creds_success();
-  test_refresh_token_creds_failure();
-  test_valid_sts_creds_options();
-  test_invalid_sts_creds_options();
-  test_sts_creds_success();
-  test_sts_creds_no_actor_token_success();
-  test_sts_creds_load_token_failure();
-  test_sts_creds_http_failure();
-  test_sts_creds_token_file_not_found();
-  test_jwt_creds_lifetime();
-  test_jwt_creds_success();
-  test_jwt_creds_signing_failure();
-  test_remove_service_from_jwt_uri();
-  test_google_default_creds_auth_key();
-  test_google_default_creds_refresh_token();
-  test_google_default_creds_external_account_credentials();
-  test_google_default_creds_external_account_credentials_multi_pattern_sts();
-  test_google_default_creds_external_account_credentials_multi_pattern_iam();
-  test_google_default_creds_gce();
-  test_google_default_creds_non_gce();
-  test_no_google_default_creds();
-  test_google_default_creds_call_creds_specified();
-  test_google_default_creds_not_default();
-  test_metadata_plugin_success();
-  test_metadata_plugin_failure();
-  test_get_well_known_google_credentials_file_path();
-  test_channel_creds_duplicate_without_call_creds();
-  test_auth_metadata_context();
-  test_external_account_creds_success();
-  test_external_account_creds_success_with_url_encode();
-  test_external_account_creds_success_with_service_account_impersonation();
-  test_external_account_creds_failure_invalid_token_url();
-  test_external_account_creds_failure_invalid_service_account_impersonation_url();
-  test_external_account_creds_failure_token_exchange_response_missing_access_token();
-  test_url_external_account_creds_success_format_text();
-  test_url_external_account_creds_success_format_json();
-  test_url_external_account_creds_failure_invalid_credential_source_url();
-  test_url_external_account_creds_success_with_qurey_params_format_text();
-  test_file_external_account_creds_success_format_text();
-  test_file_external_account_creds_success_format_json();
-  test_file_external_account_creds_failure_file_not_found();
-  test_file_external_account_creds_failure_invalid_json_content();
-  test_aws_external_account_creds_success();
-  test_aws_external_account_creds_success_path_region_env_keys_url();
-  test_aws_external_account_creds_success_path_default_region_env_keys_url();
-  test_aws_external_account_creds_success_path_duplicate_region_env_keys_url();
-  test_aws_external_account_creds_success_path_region_url_keys_env();
-  test_aws_external_account_creds_success_path_region_env_keys_env();
-  test_aws_external_account_creds_success_path_default_region_env_keys_env();
-  test_aws_external_account_creds_success_path_duplicate_region_env_keys_env();
-  test_aws_external_account_creds_failure_unmatched_environment_id();
-  test_aws_external_account_creds_failure_invalid_region_url();
-  test_aws_external_account_creds_failure_invalid_url();
-  test_aws_external_account_creds_failure_missing_role_name();
-  test_aws_external_account_creds_failure_invalid_regional_cred_verification_url();
-  test_external_account_credentials_create_success();
-  test_external_account_credentials_create_failure_invalid_json_format();
-  test_external_account_credentials_create_failure_invalid_options_format();
-  test_external_account_credentials_create_failure_invalid_options_credential_source();
+  ::testing::InitGoogleTest(&argc, argv);
+  int retval = RUN_ALL_TESTS();
   grpc_shutdown();
-  return 0;
+  return retval;
 }

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -25,7 +25,6 @@
 
 #include <string>
 
-#include <gmock/gmock.h>
 #include <openssl/rsa.h>
 
 #include "absl/strings/match.h"
@@ -308,16 +307,16 @@ static grpc_httpcli_response http_response(int status, const char* body) {
 
 /* -- Tests. -- */
 
-TEST(CredentialsTest, empty_md_array) {
+static void test_empty_md_array(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
   md_array = {};
-  EXPECT_EQ(md_array.md, nullptr);
-  EXPECT_EQ(md_array.size, 0);
+  GPR_ASSERT(md_array.md == nullptr);
+  GPR_ASSERT(md_array.size == 0);
   grpc_credentials_mdelem_array_destroy(&md_array);
 }
 
-TEST(CredentialsTest, add_to_empty_md_array) {
+static void test_add_to_empty_md_array(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
   md_array = {};
@@ -326,13 +325,13 @@ TEST(CredentialsTest, add_to_empty_md_array) {
   grpc_mdelem md = grpc_mdelem_from_slices(
       grpc_slice_from_copied_string(key), grpc_slice_from_copied_string(value));
   grpc_credentials_mdelem_array_add(&md_array, md);
-  EXPECT_EQ(md_array.size, 1);
-  EXPECT_TRUE(grpc_mdelem_eq(md, md_array.md[0]));
+  GPR_ASSERT(md_array.size == 1);
+  GPR_ASSERT(grpc_mdelem_eq(md, md_array.md[0]));
   GRPC_MDELEM_UNREF(md);
   grpc_credentials_mdelem_array_destroy(&md_array);
 }
 
-TEST(CredentialsTest, add_abunch_to_md_array) {
+static void test_add_abunch_to_md_array(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
   md_array = {};
@@ -345,54 +344,53 @@ TEST(CredentialsTest, add_abunch_to_md_array) {
     grpc_credentials_mdelem_array_add(&md_array, md);
   }
   for (size_t i = 0; i < num_entries; ++i) {
-    EXPECT_TRUE(grpc_mdelem_eq(md_array.md[i], md));
+    GPR_ASSERT(grpc_mdelem_eq(md_array.md[i], md));
   }
   GRPC_MDELEM_UNREF(md);
   grpc_credentials_mdelem_array_destroy(&md_array);
 }
 
-TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_ok) {
+static void test_oauth2_token_fetcher_creds_parsing_ok(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
   grpc_httpcli_response response =
       http_response(200, valid_oauth2_json_response);
-  EXPECT_TRUE(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                  &response, &token_md, &token_lifetime) ==
-              GRPC_CREDENTIALS_OK);
-  EXPECT_EQ(token_lifetime, 3599 * GPR_MS_PER_SEC);
-  EXPECT_EQ(grpc_slice_str_cmp(GRPC_MDKEY(token_md), "authorization"), 0);
-  EXPECT_EQ(grpc_slice_str_cmp(GRPC_MDVALUE(token_md),
-                               "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"),
-            0);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) == GRPC_CREDENTIALS_OK);
+  GPR_ASSERT(token_lifetime == 3599 * GPR_MS_PER_SEC);
+  GPR_ASSERT(grpc_slice_str_cmp(GRPC_MDKEY(token_md), "authorization") == 0);
+  GPR_ASSERT(grpc_slice_str_cmp(GRPC_MDVALUE(token_md),
+                                "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_") ==
+             0);
   GRPC_MDELEM_UNREF(token_md);
   grpc_http_response_destroy(&response);
 }
 
-TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_bad_http_status) {
+static void test_oauth2_token_fetcher_creds_parsing_bad_http_status(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
   grpc_httpcli_response response =
       http_response(401, valid_oauth2_json_response);
-  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &response, &token_md, &token_lifetime),
-            GRPC_CREDENTIALS_ERROR);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) ==
+             GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_empty_http_body) {
+static void test_oauth2_token_fetcher_creds_parsing_empty_http_body(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
   grpc_httpcli_response response = http_response(200, "");
-  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &response, &token_md, &token_lifetime),
-            GRPC_CREDENTIALS_ERROR);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) ==
+             GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_invalid_json) {
+static void test_oauth2_token_fetcher_creds_parsing_invalid_json(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -401,13 +399,13 @@ TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_invalid_json) {
                     "{\"access_token\":\"ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_\","
                     " \"expires_in\":3599, "
                     " \"token_type\":\"Bearer\"");
-  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &response, &token_md, &token_lifetime),
-            GRPC_CREDENTIALS_ERROR);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) ==
+             GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_missing_token) {
+static void test_oauth2_token_fetcher_creds_parsing_missing_token(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -415,13 +413,13 @@ TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_missing_token) {
                                                  "{"
                                                  " \"expires_in\":3599, "
                                                  " \"token_type\":\"Bearer\"}");
-  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &response, &token_md, &token_lifetime),
-            GRPC_CREDENTIALS_ERROR);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) ==
+             GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_missing_token_type) {
+static void test_oauth2_token_fetcher_creds_parsing_missing_token_type(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -430,14 +428,14 @@ TEST(CredentialsTest, oauth2_token_fetcher_creds_parsing_missing_token_type) {
                     "{\"access_token\":\"ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_\","
                     " \"expires_in\":3599, "
                     "}");
-  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &response, &token_md, &token_lifetime),
-            GRPC_CREDENTIALS_ERROR);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) ==
+             GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
-TEST(CredentialsTest,
-     oauth2_token_fetcher_creds_parsing_missing_token_lifetime) {
+static void test_oauth2_token_fetcher_creds_parsing_missing_token_lifetime(
+    void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem token_md = GRPC_MDNULL;
   grpc_millis token_lifetime;
@@ -445,9 +443,9 @@ TEST(CredentialsTest,
       http_response(200,
                     "{\"access_token\":\"ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_\","
                     " \"token_type\":\"Bearer\"}");
-  EXPECT_EQ(grpc_oauth2_token_fetcher_credentials_parse_server_response(
-                &response, &token_md, &token_lifetime),
-            GRPC_CREDENTIALS_ERROR);
+  GPR_ASSERT(grpc_oauth2_token_fetcher_credentials_parse_server_response(
+                 &response, &token_md, &token_lifetime) ==
+             GRPC_CREDENTIALS_ERROR);
   grpc_http_response_destroy(&response);
 }
 
@@ -473,14 +471,14 @@ static void check_metadata(const expected_md* expected,
     for (j = 0; j < md_array->size; ++j) {
       if (0 ==
           grpc_slice_str_cmp(GRPC_MDKEY(md_array->md[j]), expected[i].key)) {
-        EXPECT_TRUE(grpc_slice_str_cmp(GRPC_MDVALUE(md_array->md[j]),
-                                       expected[i].value) == 0);
+        GPR_ASSERT(grpc_slice_str_cmp(GRPC_MDVALUE(md_array->md[j]),
+                                      expected[i].value) == 0);
         break;
       }
     }
     if (j == md_array->size) {
       gpr_log(GPR_ERROR, "key %s not found", expected[i].key);
-      EXPECT_TRUE(0);
+      GPR_ASSERT(0);
     }
   }
 }
@@ -491,20 +489,20 @@ static void check_request_metadata(void* arg, grpc_error_handle error) {
           grpc_error_std_string(state->expected_error).c_str());
   gpr_log(GPR_INFO, "actual_error: %s", grpc_error_std_string(error).c_str());
   if (state->expected_error == GRPC_ERROR_NONE) {
-    EXPECT_EQ(error, GRPC_ERROR_NONE);
+    GPR_ASSERT(error == GRPC_ERROR_NONE);
   } else {
     std::string expected_error;
-    EXPECT_TRUE(grpc_error_get_str(
-        state->expected_error, GRPC_ERROR_STR_DESCRIPTION, &expected_error));
+    GPR_ASSERT(grpc_error_get_str(state->expected_error,
+                                  GRPC_ERROR_STR_DESCRIPTION, &expected_error));
     std::string actual_error;
-    EXPECT_TRUE(
+    GPR_ASSERT(
         grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &actual_error));
-    EXPECT_EQ(expected_error, actual_error);
+    GPR_ASSERT(expected_error == actual_error);
     GRPC_ERROR_UNREF(state->expected_error);
   }
   gpr_log(GPR_INFO, "expected_size=%" PRIdPTR " actual_size=%" PRIdPTR,
           state->expected_size, state->md_array.size);
-  EXPECT_EQ(state->md_array.size, state->expected_size);
+  GPR_ASSERT(state->md_array.size == state->expected_size);
   check_metadata(state->expected, &state->md_array);
   grpc_credentials_mdelem_array_destroy(&state->md_array);
   grpc_pollset_set_destroy(grpc_polling_entity_pollset_set(&state->pollent));
@@ -539,7 +537,7 @@ static void run_request_metadata_test(grpc_call_credentials* creds,
   }
 }
 
-TEST(CredentialsTest, google_iam_creds) {
+static void test_google_iam_creds(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {{GRPC_IAM_AUTHORIZATION_TOKEN_METADATA_KEY,
                         test_google_iam_authorization_token},
@@ -551,14 +549,14 @@ TEST(CredentialsTest, google_iam_creds) {
       test_google_iam_authorization_token, test_google_iam_authority_selector,
       nullptr);
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
   run_request_metadata_test(creds, auth_md_ctx, state);
   creds->Unref();
 }
 
-TEST(CredentialsTest, access_token_creds) {
+static void test_access_token_creds(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {{GRPC_AUTHORIZATION_METADATA_KEY, "Bearer blah"}};
   request_metadata_state* state =
@@ -567,9 +565,9 @@ TEST(CredentialsTest, access_token_creds) {
       grpc_access_token_credentials_create("blah", nullptr);
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
-  EXPECT_STREQ(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
+  GPR_ASSERT(strcmp(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) == 0);
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   run_request_metadata_test(creds, auth_md_ctx, state);
   creds->Unref();
 }
@@ -585,15 +583,16 @@ class check_channel_oauth2 final : public grpc_channel_credentials {
       grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
       const char* /*target*/, const grpc_channel_args* /*args*/,
       grpc_channel_args** /*new_args*/) override {
-    EXPECT_STREQ(type(), "mock");
-    EXPECT_NE(call_creds, nullptr);
-    EXPECT_STREQ(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
+    GPR_ASSERT(strcmp(type(), "mock") == 0);
+    GPR_ASSERT(call_creds != nullptr);
+    GPR_ASSERT(strcmp(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) ==
+               0);
     return nullptr;
   }
 };
 }  // namespace
 
-TEST(CredentialsTest, channel_oauth2_composite_creds) {
+static void test_channel_oauth2_composite_creds(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_channel_args* new_args;
   grpc_channel_credentials* channel_creds = new check_channel_oauth2();
@@ -609,7 +608,7 @@ TEST(CredentialsTest, channel_oauth2_composite_creds) {
   grpc_channel_credentials_release(channel_oauth2_creds);
 }
 
-TEST(CredentialsTest, oauth2_google_iam_composite_creds) {
+static void test_oauth2_google_iam_composite_creds(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {GRPC_AUTHORIZATION_METADATA_KEY, test_oauth2_bearer_token},
@@ -625,7 +624,7 @@ TEST(CredentialsTest, oauth2_google_iam_composite_creds) {
       "authorization", test_oauth2_bearer_token, false);
 
   /* Check security level of fake credentials. */
-  EXPECT_EQ(oauth2_creds->min_security_level(), GRPC_SECURITY_NONE);
+  GPR_ASSERT(oauth2_creds->min_security_level() == GRPC_SECURITY_NONE);
 
   grpc_call_credentials* google_iam_creds = grpc_google_iam_credentials_create(
       test_google_iam_authorization_token, test_google_iam_authority_selector,
@@ -634,17 +633,21 @@ TEST(CredentialsTest, oauth2_google_iam_composite_creds) {
       grpc_composite_call_credentials_create(oauth2_creds, google_iam_creds,
                                              nullptr);
   /* Check security level of composite credentials. */
-  EXPECT_EQ(composite_creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(composite_creds->min_security_level() ==
+             GRPC_PRIVACY_AND_INTEGRITY);
 
   oauth2_creds->Unref();
   google_iam_creds->Unref();
-  EXPECT_STREQ(composite_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE);
+  GPR_ASSERT(strcmp(composite_creds->type(),
+                    GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE) == 0);
   const grpc_composite_call_credentials::CallCredentialsList& creds_list =
       static_cast<const grpc_composite_call_credentials*>(composite_creds)
           ->inner();
-  EXPECT_EQ(creds_list.size(), 2);
-  EXPECT_STREQ(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
-  EXPECT_STREQ(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM);
+  GPR_ASSERT(creds_list.size() == 2);
+  GPR_ASSERT(strcmp(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) ==
+             0);
+  GPR_ASSERT(strcmp(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM) ==
+             0);
   run_request_metadata_test(composite_creds, auth_md_ctx, state);
   composite_creds->Unref();
 }
@@ -660,20 +663,23 @@ class check_channel_oauth2_google_iam final : public grpc_channel_credentials {
       grpc_core::RefCountedPtr<grpc_call_credentials> call_creds,
       const char* /*target*/, const grpc_channel_args* /*args*/,
       grpc_channel_args** /*new_args*/) override {
-    EXPECT_STREQ(type(), "mock");
-    EXPECT_NE(call_creds, nullptr);
-    EXPECT_STREQ(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE);
+    GPR_ASSERT(strcmp(type(), "mock") == 0);
+    GPR_ASSERT(call_creds != nullptr);
+    GPR_ASSERT(
+        strcmp(call_creds->type(), GRPC_CALL_CREDENTIALS_TYPE_COMPOSITE) == 0);
     const grpc_composite_call_credentials::CallCredentialsList& creds_list =
         static_cast<const grpc_composite_call_credentials*>(call_creds.get())
             ->inner();
-    EXPECT_STREQ(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2);
-    EXPECT_STREQ(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM);
+    GPR_ASSERT(
+        strcmp(creds_list[0]->type(), GRPC_CALL_CREDENTIALS_TYPE_OAUTH2) == 0);
+    GPR_ASSERT(strcmp(creds_list[1]->type(), GRPC_CALL_CREDENTIALS_TYPE_IAM) ==
+               0);
     return nullptr;
   }
 };
 }  // namespace
 
-TEST(CredentialsTest, channel_oauth2_google_iam_composite_creds) {
+static void test_channel_oauth2_google_iam_composite_creds(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_channel_args* new_args;
   grpc_channel_credentials* channel_creds =
@@ -703,13 +709,15 @@ TEST(CredentialsTest, channel_oauth2_google_iam_composite_creds) {
 
 static void validate_compute_engine_http_request(
     const grpc_httpcli_request* request) {
-  EXPECT_NE(request->handshaker, &grpc_httpcli_ssl);
-  EXPECT_STREQ(request->host, "metadata.google.internal.");
-  EXPECT_STREQ(request->http.path,
-               "/computeMetadata/v1/instance/service-accounts/default/token");
-  EXPECT_EQ(request->http.hdr_count, 1);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Metadata-Flavor");
-  EXPECT_STREQ(request->http.hdrs[0].value, "Google");
+  GPR_ASSERT(request->handshaker != &grpc_httpcli_ssl);
+  GPR_ASSERT(strcmp(request->host, "metadata.google.internal.") == 0);
+  GPR_ASSERT(
+      strcmp(request->http.path,
+             "/computeMetadata/v1/instance/service-accounts/default/token") ==
+      0);
+  GPR_ASSERT(request->http.hdr_count == 1);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Metadata-Flavor") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value, "Google") == 0);
 }
 
 static int compute_engine_httpcli_get_success_override(
@@ -734,18 +742,18 @@ static int httpcli_post_should_not_be_called(
     const grpc_httpcli_request* /*request*/, const char* /*body_bytes*/,
     size_t /*body_size*/, grpc_millis /*deadline*/, grpc_closure* /*on_done*/,
     grpc_httpcli_response* /*response*/) {
-  EXPECT_EQ("HTTP POST should not be called", nullptr);
+  GPR_ASSERT("HTTP POST should not be called" == nullptr);
   return 1;
 }
 
 static int httpcli_get_should_not_be_called(
     const grpc_httpcli_request* /*request*/, grpc_millis /*deadline*/,
     grpc_closure* /*on_done*/, grpc_httpcli_response* /*response*/) {
-  EXPECT_EQ("HTTP GET should not be called", nullptr);
+  GPR_ASSERT("HTTP GET should not be called" == nullptr);
   return 1;
 }
 
-TEST(CredentialsTest, compute_engine_creds_success) {
+static void test_compute_engine_creds_success() {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -757,7 +765,7 @@ TEST(CredentialsTest, compute_engine_creds_success) {
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http get should be called. */
   request_metadata_state* state =
@@ -775,12 +783,13 @@ TEST(CredentialsTest, compute_engine_creds_success) {
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
 
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, compute_engine_creds_failure) {
+static void test_compute_engine_creds_failure(void) {
   grpc_core::ExecCtx exec_ctx;
   const char expected_creds_debug_string[] =
       "GoogleComputeEngineTokenFetcherCredentials{"
@@ -796,7 +805,8 @@ TEST(CredentialsTest, compute_engine_creds_failure) {
   grpc_httpcli_set_override(compute_engine_httpcli_get_failure_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
@@ -804,21 +814,22 @@ TEST(CredentialsTest, compute_engine_creds_failure) {
 static void validate_refresh_token_http_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size) {
   /* The content of the assertion is tested extensively in json_token_test. */
-  EXPECT_NE(body, nullptr);
-  EXPECT_NE(body_size, 0);
+  GPR_ASSERT(body != nullptr);
+  GPR_ASSERT(body_size != 0);
   std::string expected_body = absl::StrFormat(
       GRPC_REFRESH_TOKEN_POST_BODY_FORMAT_STRING,
       "32555999999.apps.googleusercontent.com", "EmssLNjJy1332hD4KFsecret",
       "1/Blahblasj424jladJDSGNf-u4Sua3HDA2ngjd42");
-  EXPECT_EQ(expected_body.size(), body_size);
-  EXPECT_EQ(memcmp(expected_body.data(), body, body_size), 0);
-  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
-  EXPECT_STREQ(request->host, GRPC_GOOGLE_OAUTH2_SERVICE_HOST);
-  EXPECT_STREQ(request->http.path, GRPC_GOOGLE_OAUTH2_SERVICE_TOKEN_PATH);
-  EXPECT_EQ(request->http.hdr_count, 1);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
-  EXPECT_STREQ(request->http.hdrs[0].value,
-               "application/x-www-form-urlencoded");
+  GPR_ASSERT(expected_body.size() == body_size);
+  GPR_ASSERT(memcmp(expected_body.data(), body, body_size) == 0);
+  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
+  GPR_ASSERT(strcmp(request->host, GRPC_GOOGLE_OAUTH2_SERVICE_HOST) == 0);
+  GPR_ASSERT(
+      strcmp(request->http.path, GRPC_GOOGLE_OAUTH2_SERVICE_TOKEN_PATH) == 0);
+  GPR_ASSERT(request->http.hdr_count == 1);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
 }
 
 static int refresh_token_httpcli_post_success(
@@ -842,7 +853,7 @@ static int token_httpcli_post_failure(const grpc_httpcli_request* /*request*/,
   return 1;
 }
 
-TEST(CredentialsTest, refresh_token_creds_success) {
+static void test_refresh_token_creds_success(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -855,7 +866,7 @@ TEST(CredentialsTest, refresh_token_creds_success) {
       test_refresh_token_str, nullptr);
 
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
   request_metadata_state* state =
@@ -872,13 +883,14 @@ TEST(CredentialsTest, refresh_token_creds_success) {
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, refresh_token_creds_failure) {
+static void test_refresh_token_creds_failure(void) {
   grpc_core::ExecCtx exec_ctx;
   const char expected_creds_debug_string[] =
       "GoogleRefreshToken{ClientID:32555999999.apps.googleusercontent.com,"
@@ -894,13 +906,14 @@ TEST(CredentialsTest, refresh_token_creds_failure) {
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             token_httpcli_post_failure);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, valid_sts_creds_options) {
+static void test_valid_sts_creds_options(void) {
   grpc_sts_credentials_options valid_options = {
       test_sts_endpoint_url,        // sts_endpoint_url
       nullptr,                      // resource
@@ -914,15 +927,15 @@ TEST(CredentialsTest, valid_sts_creds_options) {
   };
   absl::StatusOr<grpc_core::URI> sts_url =
       grpc_core::ValidateStsCredentialsOptions(&valid_options);
-  EXPECT_TRUE(sts_url.ok());
+  GPR_ASSERT(sts_url.ok());
   absl::string_view host;
   absl::string_view port;
-  EXPECT_TRUE(grpc_core::SplitHostPort(sts_url->authority(), &host, &port));
-  EXPECT_EQ(host, "foo.com");
-  EXPECT_EQ(port, "5555");
+  GPR_ASSERT(grpc_core::SplitHostPort(sts_url->authority(), &host, &port));
+  GPR_ASSERT(host == "foo.com");
+  GPR_ASSERT(port == "5555");
 }
 
-TEST(CredentialsTest, invalid_sts_creds_options) {
+static void test_invalid_sts_creds_options(void) {
   grpc_sts_credentials_options invalid_options = {
       test_sts_endpoint_url,       // sts_endpoint_url
       nullptr,                     // resource
@@ -936,7 +949,7 @@ TEST(CredentialsTest, invalid_sts_creds_options) {
   };
   absl::StatusOr<grpc_core::URI> url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  EXPECT_TRUE(!url_should_be_invalid.ok());
+  GPR_ASSERT(!url_should_be_invalid.ok());
 
   invalid_options = {
       test_sts_endpoint_url,        // sts_endpoint_url
@@ -951,7 +964,7 @@ TEST(CredentialsTest, invalid_sts_creds_options) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  EXPECT_TRUE(!url_should_be_invalid.ok());
+  GPR_ASSERT(!url_should_be_invalid.ok());
 
   invalid_options = {
       nullptr,                      // sts_endpoint_url (Required)
@@ -966,7 +979,7 @@ TEST(CredentialsTest, invalid_sts_creds_options) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  EXPECT_TRUE(!url_should_be_invalid.ok());
+  GPR_ASSERT(!url_should_be_invalid.ok());
 
   invalid_options = {
       "not_a_valid_uri",            // sts_endpoint_url
@@ -981,7 +994,7 @@ TEST(CredentialsTest, invalid_sts_creds_options) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  EXPECT_TRUE(!url_should_be_invalid.ok());
+  GPR_ASSERT(!url_should_be_invalid.ok());
 
   invalid_options = {
       "ftp://ftp.is.not.a.valid.scheme/bar",  // sts_endpoint_url
@@ -996,35 +1009,35 @@ TEST(CredentialsTest, invalid_sts_creds_options) {
   };
   url_should_be_invalid =
       grpc_core::ValidateStsCredentialsOptions(&invalid_options);
-  EXPECT_TRUE(!url_should_be_invalid.ok());
+  GPR_ASSERT(!url_should_be_invalid.ok());
 }
 
 static void assert_query_parameters(const grpc_core::URI& uri,
                                     absl::string_view expected_key,
                                     absl::string_view expected_val) {
   const auto it = uri.query_parameter_map().find(expected_key);
-  EXPECT_NE(it, uri.query_parameter_map().end());
+  GPR_ASSERT(it != uri.query_parameter_map().end());
   if (it->second != expected_val) {
     gpr_log(GPR_ERROR, "%s!=%s", std::string(it->second).c_str(),
             std::string(expected_val).c_str());
   }
-  EXPECT_EQ(it->second, expected_val);
+  GPR_ASSERT(it->second == expected_val);
 }
 
 static void validate_sts_token_http_request(const grpc_httpcli_request* request,
                                             const char* body, size_t body_size,
                                             bool expect_actor_token) {
   // Check that the body is constructed properly.
-  EXPECT_NE(body, nullptr);
-  EXPECT_NE(body_size, 0);
-  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
+  GPR_ASSERT(body != nullptr);
+  GPR_ASSERT(body_size != 0);
+  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
   std::string get_url_equivalent =
       absl::StrFormat("%s?%s", test_sts_endpoint_url, body);
   absl::StatusOr<grpc_core::URI> url =
       grpc_core::URI::Parse(get_url_equivalent);
   if (!url.ok()) {
     gpr_log(GPR_ERROR, "%s", url.status().ToString().c_str());
-    EXPECT_TRUE(url.ok());
+    GPR_ASSERT(url.ok());
   }
   assert_query_parameters(*url, "resource", "resource");
   assert_query_parameters(*url, "audience", "audience");
@@ -1038,19 +1051,19 @@ static void validate_sts_token_http_request(const grpc_httpcli_request* request,
     assert_query_parameters(*url, "actor_token_type",
                             test_signed_jwt_token_type2);
   } else {
-    EXPECT_TRUE(url->query_parameter_map().find("actor_token") ==
-                url->query_parameter_map().end());
-    EXPECT_TRUE(url->query_parameter_map().find("actor_token_type") ==
-                url->query_parameter_map().end());
+    GPR_ASSERT(url->query_parameter_map().find("actor_token") ==
+               url->query_parameter_map().end());
+    GPR_ASSERT(url->query_parameter_map().find("actor_token_type") ==
+               url->query_parameter_map().end());
   }
 
   // Check the rest of the request.
-  EXPECT_STREQ(request->host, "foo.com:5555");
-  EXPECT_STREQ(request->http.path, "/v1/token-exchange");
-  EXPECT_EQ(request->http.hdr_count, 1);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
-  EXPECT_STREQ(request->http.hdrs[0].value,
-               "application/x-www-form-urlencoded");
+  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
+  GPR_ASSERT(strcmp(request->http.path, "/v1/token-exchange") == 0);
+  GPR_ASSERT(request->http.hdr_count == 1);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
 }
 
 static int sts_token_httpcli_post_success(const grpc_httpcli_request* request,
@@ -1077,15 +1090,15 @@ static int sts_token_httpcli_post_success_no_actor_token(
 static char* write_tmp_jwt_file(const char* jwt_contents) {
   char* path;
   FILE* tmp = gpr_tmpfile(test_signed_jwt_path_prefix, &path);
-  EXPECT_NE(path, nullptr);
-  EXPECT_NE(tmp, nullptr);
+  GPR_ASSERT(path != nullptr);
+  GPR_ASSERT(tmp != nullptr);
   size_t jwt_length = strlen(jwt_contents);
-  EXPECT_EQ(fwrite(jwt_contents, 1, jwt_length, tmp), jwt_length);
+  GPR_ASSERT(fwrite(jwt_contents, 1, jwt_length, tmp) == jwt_length);
   fclose(tmp);
   return path;
 }
 
-TEST(CredentialsTest, sts_creds_success) {
+static void test_sts_creds_success(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1111,7 +1124,7 @@ TEST(CredentialsTest, sts_creds_success) {
       grpc_sts_credentials_create(&valid_options, nullptr);
 
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
   request_metadata_state* state =
@@ -1128,7 +1141,8 @@ TEST(CredentialsTest, sts_creds_success) {
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
@@ -1136,7 +1150,7 @@ TEST(CredentialsTest, sts_creds_success) {
   gpr_free(actor_token_path);
 }
 
-TEST(CredentialsTest, sts_creds_token_file_not_found) {
+static void test_sts_creds_token_file_not_found(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -1155,7 +1169,7 @@ TEST(CredentialsTest, sts_creds_token_file_not_found) {
       grpc_sts_credentials_create(&valid_options, nullptr);
 
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   request_metadata_state* state = make_request_metadata_state(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -1171,7 +1185,7 @@ TEST(CredentialsTest, sts_creds_token_file_not_found) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, sts_creds_no_actor_token_success) {
+static void test_sts_creds_no_actor_token_success(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1196,7 +1210,7 @@ TEST(CredentialsTest, sts_creds_no_actor_token_success) {
       grpc_sts_credentials_create(&valid_options, nullptr);
 
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
   request_metadata_state* state =
@@ -1213,14 +1227,15 @@ TEST(CredentialsTest, sts_creds_no_actor_token_success) {
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
   gpr_free(subject_token_path);
 }
 
-TEST(CredentialsTest, sts_creds_load_token_failure) {
+static void test_sts_creds_load_token_failure(void) {
   const char expected_creds_debug_string[] =
       "StsTokenFetcherCredentials{Path:/v1/"
       "token-exchange,Authority:foo.com:5555,OAuth2TokenFetcherCredentials}";
@@ -1247,14 +1262,15 @@ TEST(CredentialsTest, sts_creds_load_token_failure) {
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
 
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
   gpr_free(test_signed_jwt_path);
 }
 
-TEST(CredentialsTest, sts_creds_http_failure) {
+static void test_sts_creds_http_failure(void) {
   const char expected_creds_debug_string[] =
       "StsTokenFetcherCredentials{Path:/v1/"
       "token-exchange,Authority:foo.com:5555,OAuth2TokenFetcherCredentials}";
@@ -1282,7 +1298,8 @@ TEST(CredentialsTest, sts_creds_http_failure) {
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             token_httpcli_post_failure);
   run_request_metadata_test(creds, auth_md_ctx, state);
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
   gpr_free(test_signed_jwt_path);
@@ -1291,20 +1308,24 @@ TEST(CredentialsTest, sts_creds_http_failure) {
 static void validate_jwt_encode_and_sign_params(
     const grpc_auth_json_key* json_key, const char* scope,
     gpr_timespec token_lifetime) {
-  EXPECT_TRUE(grpc_auth_json_key_is_valid(json_key));
-  EXPECT_NE(json_key->private_key, nullptr);
-  EXPECT_TRUE(RSA_check_key(json_key->private_key));
-  EXPECT_STREQ(json_key->type, "service_account");
-  EXPECT_STREQ(json_key->private_key_id,
-               "e6b5137873db8d2ef81e06a47289e6434ec8a165");
-  EXPECT_STREQ(json_key->client_id,
-               "777-abaslkan11hlb6nmim3bpspl31ud.apps."
-               "googleusercontent.com");
-  EXPECT_STREQ(json_key->client_email,
-               "777-abaslkan11hlb6nmim3bpspl31ud@developer."
-               "gserviceaccount.com");
-  if (scope != nullptr) EXPECT_STREQ(scope, test_scope);
-  EXPECT_EQ(gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime()), 0);
+  GPR_ASSERT(grpc_auth_json_key_is_valid(json_key));
+  GPR_ASSERT(json_key->private_key != nullptr);
+  GPR_ASSERT(RSA_check_key(json_key->private_key));
+  GPR_ASSERT(json_key->type != nullptr &&
+             strcmp(json_key->type, "service_account") == 0);
+  GPR_ASSERT(json_key->private_key_id != nullptr &&
+             strcmp(json_key->private_key_id,
+                    "e6b5137873db8d2ef81e06a47289e6434ec8a165") == 0);
+  GPR_ASSERT(json_key->client_id != nullptr &&
+             strcmp(json_key->client_id,
+                    "777-abaslkan11hlb6nmim3bpspl31ud.apps."
+                    "googleusercontent.com") == 0);
+  GPR_ASSERT(json_key->client_email != nullptr &&
+             strcmp(json_key->client_email,
+                    "777-abaslkan11hlb6nmim3bpspl31ud@developer."
+                    "gserviceaccount.com") == 0);
+  if (scope != nullptr) GPR_ASSERT(strcmp(scope, test_scope) == 0);
+  GPR_ASSERT(gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime()) == 0);
 }
 
 static char* encode_and_sign_jwt_success(const grpc_auth_json_key* json_key,
@@ -1330,18 +1351,18 @@ static char* encode_and_sign_jwt_failure(const grpc_auth_json_key* json_key,
 static char* encode_and_sign_jwt_should_not_be_called(
     const grpc_auth_json_key* /*json_key*/, const char* /*audience*/,
     gpr_timespec /*token_lifetime*/, const char* /*scope*/) {
-  EXPECT_EQ("grpc_jwt_encode_and_sign should not be called", nullptr);
+  GPR_ASSERT("grpc_jwt_encode_and_sign should not be called" == nullptr);
   return nullptr;
 }
 
 static grpc_service_account_jwt_access_credentials* creds_as_jwt(
     grpc_call_credentials* creds) {
-  EXPECT_NE(creds, nullptr);
-  EXPECT_STREQ(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_JWT);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(strcmp(creds->type(), GRPC_CALL_CREDENTIALS_TYPE_JWT) == 0);
   return reinterpret_cast<grpc_service_account_jwt_access_credentials*>(creds);
 }
 
-TEST(CredentialsTest, jwt_creds_lifetime) {
+static void test_jwt_creds_lifetime(void) {
   char* json_key_string = test_json_key_str();
   const char expected_creds_debug_string_prefix[] =
       "JWTAccessCredentials{ExpirationTime:";
@@ -1349,25 +1370,25 @@ TEST(CredentialsTest, jwt_creds_lifetime) {
   grpc_call_credentials* jwt_creds =
       grpc_service_account_jwt_access_credentials_create(
           json_key_string, grpc_max_auth_token_lifetime(), nullptr);
-  EXPECT_TRUE(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
-                           grpc_max_auth_token_lifetime()) == 0);
+  GPR_ASSERT(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
+                          grpc_max_auth_token_lifetime()) == 0);
   /* Check security level. */
-  EXPECT_EQ(jwt_creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
-  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
-                      jwt_creds->debug_string().c_str(),
-                      strlen(expected_creds_debug_string_prefix)) == 0);
+  GPR_ASSERT(jwt_creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
+                     jwt_creds->debug_string().c_str(),
+                     strlen(expected_creds_debug_string_prefix)) == 0);
   grpc_call_credentials_release(jwt_creds);
 
   // Shorter lifetime.
   gpr_timespec token_lifetime = {10, 0, GPR_TIMESPAN};
-  EXPECT_TRUE(gpr_time_cmp(grpc_max_auth_token_lifetime(), token_lifetime) > 0);
+  GPR_ASSERT(gpr_time_cmp(grpc_max_auth_token_lifetime(), token_lifetime) > 0);
   jwt_creds = grpc_service_account_jwt_access_credentials_create(
       json_key_string, token_lifetime, nullptr);
-  EXPECT_TRUE(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
-                           token_lifetime) == 0);
-  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
-                      jwt_creds->debug_string().c_str(),
-                      strlen(expected_creds_debug_string_prefix)) == 0);
+  GPR_ASSERT(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
+                          token_lifetime) == 0);
+  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
+                     jwt_creds->debug_string().c_str(),
+                     strlen(expected_creds_debug_string_prefix)) == 0);
   grpc_call_credentials_release(jwt_creds);
 
   // Cropped lifetime.
@@ -1375,27 +1396,27 @@ TEST(CredentialsTest, jwt_creds_lifetime) {
   token_lifetime = gpr_time_add(grpc_max_auth_token_lifetime(), add_to_max);
   jwt_creds = grpc_service_account_jwt_access_credentials_create(
       json_key_string, token_lifetime, nullptr);
-  EXPECT_TRUE(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
-                           grpc_max_auth_token_lifetime()) == 0);
-  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
-                      jwt_creds->debug_string().c_str(),
-                      strlen(expected_creds_debug_string_prefix)) == 0);
+  GPR_ASSERT(gpr_time_cmp(creds_as_jwt(jwt_creds)->jwt_lifetime(),
+                          grpc_max_auth_token_lifetime()) == 0);
+  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
+                     jwt_creds->debug_string().c_str(),
+                     strlen(expected_creds_debug_string_prefix)) == 0);
   grpc_call_credentials_release(jwt_creds);
 
   gpr_free(json_key_string);
 }
 
-TEST(CredentialsTest, remove_service_from_jwt_uri) {
+static void test_remove_service_from_jwt_uri(void) {
   const char wrong_uri[] = "hello world";
-  EXPECT_TRUE(!grpc_core::RemoveServiceNameFromJwtUri(wrong_uri).ok());
+  GPR_ASSERT(!grpc_core::RemoveServiceNameFromJwtUri(wrong_uri).ok());
   const char valid_uri[] = "https://foo.com/get/";
   const char expected_uri[] = "https://foo.com/";
   auto output = grpc_core::RemoveServiceNameFromJwtUri(valid_uri);
-  EXPECT_TRUE(output.ok());
-  EXPECT_STREQ(output->c_str(), expected_uri);
+  GPR_ASSERT(output.ok());
+  GPR_ASSERT(strcmp(output->c_str(), expected_uri) == 0);
 }
 
-TEST(CredentialsTest, jwt_creds_success) {
+static void test_jwt_creds_success(void) {
   const char expected_creds_debug_string_prefix[] =
       "JWTAccessCredentials{ExpirationTime:";
 
@@ -1432,16 +1453,16 @@ TEST(CredentialsTest, jwt_creds_success) {
   grpc_jwt_encode_and_sign_set_override(encode_and_sign_jwt_success);
   run_request_metadata_test(creds, auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
-                      creds->debug_string().c_str(),
-                      strlen(expected_creds_debug_string_prefix)) == 0);
+  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
+                     creds->debug_string().c_str(),
+                     strlen(expected_creds_debug_string_prefix)) == 0);
 
   creds->Unref();
   gpr_free(json_key_string);
   grpc_jwt_encode_and_sign_set_override(nullptr);
 }
 
-TEST(CredentialsTest, jwt_creds_signing_failure) {
+static void test_jwt_creds_signing_failure(void) {
   const char expected_creds_debug_string_prefix[] =
       "JWTAccessCredentials{ExpirationTime:";
   char* json_key_string = test_json_key_str();
@@ -1459,9 +1480,9 @@ TEST(CredentialsTest, jwt_creds_signing_failure) {
   run_request_metadata_test(creds, auth_md_ctx, state);
 
   gpr_free(json_key_string);
-  EXPECT_TRUE(strncmp(expected_creds_debug_string_prefix,
-                      creds->debug_string().c_str(),
-                      strlen(expected_creds_debug_string_prefix)) == 0);
+  GPR_ASSERT(strncmp(expected_creds_debug_string_prefix,
+                     creds->debug_string().c_str(),
+                     strlen(expected_creds_debug_string_prefix)) == 0);
 
   creds->Unref();
   grpc_jwt_encode_and_sign_set_override(nullptr);
@@ -1472,9 +1493,9 @@ static void set_google_default_creds_env_var_with_file_contents(
   size_t contents_len = strlen(contents);
   char* creds_file_name;
   FILE* creds_file = gpr_tmpfile(file_prefix, &creds_file_name);
-  EXPECT_NE(creds_file_name, nullptr);
-  EXPECT_NE(creds_file, nullptr);
-  EXPECT_EQ(fwrite(contents, 1, contents_len, creds_file), contents_len);
+  GPR_ASSERT(creds_file_name != nullptr);
+  GPR_ASSERT(creds_file != nullptr);
+  GPR_ASSERT(fwrite(contents, 1, contents_len, creds_file) == contents_len);
   fclose(creds_file);
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, creds_file_name);
   gpr_free(creds_file_name);
@@ -1485,7 +1506,7 @@ static bool test_gce_tenancy_checker(void) {
   return g_test_is_on_gce;
 }
 
-TEST(CredentialsTest, google_default_creds_auth_key) {
+static void test_google_default_creds_auth_key(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   char* json_key = test_json_key_str();
@@ -1493,106 +1514,109 @@ TEST(CredentialsTest, google_default_creds_auth_key) {
   set_gce_tenancy_checker_for_testing(test_gce_tenancy_checker);
   g_test_gce_tenancy_checker_called = false;
   g_test_is_on_gce = true;
-  set_google_default_creds_env_var_with_file_contents("json_key", json_key);
+  set_google_default_creds_env_var_with_file_contents(
+      "json_key_google_default_creds", json_key);
   gpr_free(json_key);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  EXPECT_NE(default_creds->ssl_creds(), nullptr);
+  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
   auto* jwt =
       reinterpret_cast<const grpc_service_account_jwt_access_credentials*>(
           creds->call_creds());
-  EXPECT_STREQ(jwt->key().client_id,
-               "777-abaslkan11hlb6nmim3bpspl31ud.apps.googleusercontent.com");
-  EXPECT_EQ(g_test_gce_tenancy_checker_called, false);
+  GPR_ASSERT(
+      strcmp(jwt->key().client_id,
+             "777-abaslkan11hlb6nmim3bpspl31ud.apps.googleusercontent.com") ==
+      0);
+  GPR_ASSERT(g_test_gce_tenancy_checker_called == false);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-TEST(CredentialsTest, google_default_creds_refresh_token) {
+static void test_google_default_creds_refresh_token(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
-  set_google_default_creds_env_var_with_file_contents("test_refresh_token_str",
-                                                      test_refresh_token_str);
+  set_google_default_creds_env_var_with_file_contents(
+      "refresh_token_google_default_creds", test_refresh_token_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  EXPECT_NE(default_creds->ssl_creds(), nullptr);
+  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
   auto* refresh =
       reinterpret_cast<const grpc_google_refresh_token_credentials*>(
           creds->call_creds());
-  EXPECT_STREQ(refresh->refresh_token().client_id,
-               "32555999999.apps.googleusercontent.com");
+  GPR_ASSERT(strcmp(refresh->refresh_token().client_id,
+                    "32555999999.apps.googleusercontent.com") == 0);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-TEST(CredentialsTest, google_default_creds_external_account_credentials) {
+static void test_google_default_creds_external_account_credentials(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
   set_google_default_creds_env_var_with_file_contents(
-      "test_external_account_credentials_str",
+      "google_default_creds_external_account_credentials",
       test_external_account_credentials_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  EXPECT_NE(default_creds->ssl_creds(), nullptr);
+  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
   auto* external =
       reinterpret_cast<const grpc_core::ExternalAccountCredentials*>(
           creds->call_creds());
-  EXPECT_NE(external, nullptr);
+  GPR_ASSERT(external != nullptr);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-TEST(CredentialsTest,
-     google_default_creds_external_account_credentials_multi_pattern_sts) {
+static void
+test_google_default_creds_external_account_credentials_multi_pattern_sts(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
   set_google_default_creds_env_var_with_file_contents(
-      "test_external_account_credentials_multi_pattern_sts_str",
+      "google_default_creds_external_account_credentials",
       test_external_account_credentials_multi_pattern_sts_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  EXPECT_NE(default_creds->ssl_creds(), nullptr);
+  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
   auto* external =
       reinterpret_cast<const grpc_core::ExternalAccountCredentials*>(
           creds->call_creds());
-  EXPECT_NE(external, nullptr);
+  GPR_ASSERT(external != nullptr);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
 
-TEST(CredentialsTest,
-     google_default_creds_external_account_credentials_multi_pattern_iam) {
+static void
+test_google_default_creds_external_account_credentials_multi_pattern_iam(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_composite_channel_credentials* creds;
   grpc_flush_cached_google_default_credentials();
   set_google_default_creds_env_var_with_file_contents(
-      "test_external_account_credentials_multi_pattern_iam_str",
+      "google_default_creds_external_account_credentials",
       test_external_account_credentials_multi_pattern_iam_str);
   creds = reinterpret_cast<grpc_composite_channel_credentials*>(
       grpc_google_default_credentials_create(nullptr));
   auto* default_creds =
       reinterpret_cast<const grpc_google_default_channel_credentials*>(
           creds->inner_creds());
-  EXPECT_NE(default_creds->ssl_creds(), nullptr);
+  GPR_ASSERT(default_creds->ssl_creds() != nullptr);
   auto* external =
       reinterpret_cast<const grpc_core::ExternalAccountCredentials*>(
           creds->call_creds());
-  EXPECT_NE(external, nullptr);
+  GPR_ASSERT(external != nullptr);
   creds->Unref();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
 }
@@ -1607,15 +1631,15 @@ static int default_creds_metadata_server_detection_httpcli_get_success_override(
   headers[0].value = gpr_strdup("Google");
   response->hdr_count = 1;
   response->hdrs = headers;
-  EXPECT_STREQ(request->http.path, "/");
-  EXPECT_STREQ(request->host, "metadata.google.internal.");
+  GPR_ASSERT(strcmp(request->http.path, "/") == 0);
+  GPR_ASSERT(strcmp(request->host, "metadata.google.internal.") == 0);
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
   return 1;
 }
 
 static std::string null_well_known_creds_path_getter(void) { return ""; }
 
-TEST(CredentialsTest, google_default_creds_gce) {
+static void test_google_default_creds_gce(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1637,14 +1661,14 @@ TEST(CredentialsTest, google_default_creds_gce) {
           grpc_google_default_credentials_create(nullptr));
 
   /* Verify that the default creds actually embeds a GCE creds. */
-  EXPECT_NE(creds, nullptr);
-  EXPECT_NE(creds->call_creds(), nullptr);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(creds->call_creds() != nullptr);
   grpc_httpcli_set_override(compute_engine_httpcli_get_success_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds->mutable_call_creds(), auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
 
-  EXPECT_EQ(g_test_gce_tenancy_checker_called, true);
+  GPR_ASSERT(g_test_gce_tenancy_checker_called == true);
 
   /* Cleanup. */
   creds->Unref();
@@ -1652,7 +1676,7 @@ TEST(CredentialsTest, google_default_creds_gce) {
   grpc_override_well_known_credentials_path_getter(nullptr);
 }
 
-TEST(CredentialsTest, google_default_creds_non_gce) {
+static void test_google_default_creds_non_gce(void) {
   grpc_core::ExecCtx exec_ctx;
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
@@ -1675,13 +1699,13 @@ TEST(CredentialsTest, google_default_creds_non_gce) {
       reinterpret_cast<grpc_composite_channel_credentials*>(
           grpc_google_default_credentials_create(nullptr));
   /* Verify that the default creds actually embeds a GCE creds. */
-  EXPECT_NE(creds, nullptr);
-  EXPECT_NE(creds->call_creds(), nullptr);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(creds->call_creds() != nullptr);
   grpc_httpcli_set_override(compute_engine_httpcli_get_success_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(creds->mutable_call_creds(), auth_md_ctx, state);
   grpc_core::ExecCtx::Get()->Flush();
-  EXPECT_EQ(g_test_gce_tenancy_checker_called, true);
+  GPR_ASSERT(g_test_gce_tenancy_checker_called == true);
   /* Cleanup. */
   creds->Unref();
   grpc_httpcli_set_override(nullptr, nullptr);
@@ -1692,14 +1716,14 @@ static int default_creds_gce_detection_httpcli_get_failure_override(
     const grpc_httpcli_request* request, grpc_millis /*deadline*/,
     grpc_closure* on_done, grpc_httpcli_response* response) {
   /* No magic header. */
-  EXPECT_STREQ(request->http.path, "/");
-  EXPECT_STREQ(request->host, "metadata.google.internal.");
+  GPR_ASSERT(strcmp(request->http.path, "/") == 0);
+  GPR_ASSERT(strcmp(request->host, "metadata.google.internal.") == 0);
   *response = http_response(200, "");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
   return 1;
 }
 
-TEST(CredentialsTest, no_google_default_creds) {
+static void test_no_google_default_creds(void) {
   grpc_flush_cached_google_default_credentials();
   gpr_setenv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
   grpc_override_well_known_credentials_path_getter(
@@ -1711,17 +1735,17 @@ TEST(CredentialsTest, no_google_default_creds) {
       default_creds_gce_detection_httpcli_get_failure_override,
       httpcli_post_should_not_be_called);
   /* Simulate a successful detection of GCE. */
-  EXPECT_EQ(grpc_google_default_credentials_create(nullptr), nullptr);
+  GPR_ASSERT(grpc_google_default_credentials_create(nullptr) == nullptr);
   /* Try a second one. GCE detection should occur again. */
   g_test_gce_tenancy_checker_called = false;
-  EXPECT_EQ(grpc_google_default_credentials_create(nullptr), nullptr);
-  EXPECT_EQ(g_test_gce_tenancy_checker_called, true);
+  GPR_ASSERT(grpc_google_default_credentials_create(nullptr) == nullptr);
+  GPR_ASSERT(g_test_gce_tenancy_checker_called == true);
   /* Cleanup. */
   grpc_override_well_known_credentials_path_getter(nullptr);
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, google_default_creds_call_creds_specified) {
+static void test_google_default_creds_call_creds_specified(void) {
   expected_md emd[] = {
       {"authorization", "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"}};
   request_metadata_state* state =
@@ -1741,9 +1765,9 @@ TEST(CredentialsTest, google_default_creds_call_creds_specified) {
   grpc_composite_channel_credentials* channel_creds =
       reinterpret_cast<grpc_composite_channel_credentials*>(
           grpc_google_default_credentials_create(call_creds));
-  EXPECT_EQ(g_test_gce_tenancy_checker_called, false);
-  EXPECT_NE(channel_creds, nullptr);
-  EXPECT_NE(channel_creds->call_creds(), nullptr);
+  GPR_ASSERT(g_test_gce_tenancy_checker_called == false);
+  GPR_ASSERT(channel_creds != nullptr);
+  GPR_ASSERT(channel_creds->call_creds() != nullptr);
   grpc_httpcli_set_override(compute_engine_httpcli_get_success_override,
                             httpcli_post_should_not_be_called);
   run_request_metadata_test(channel_creds->mutable_call_creds(), auth_md_ctx,
@@ -1781,7 +1805,7 @@ struct fake_call_creds : public grpc_call_credentials {
   grpc_mdelem phony_md_;
 };
 
-TEST(CredentialsTest, google_default_creds_not_default) {
+static void test_google_default_creds_not_default(void) {
   expected_md emd[] = {{"foo", "oof"}};
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
@@ -1800,9 +1824,9 @@ TEST(CredentialsTest, google_default_creds_not_default) {
   grpc_composite_channel_credentials* channel_creds =
       reinterpret_cast<grpc_composite_channel_credentials*>(
           grpc_google_default_credentials_create(call_creds.release()));
-  EXPECT_EQ(g_test_gce_tenancy_checker_called, false);
-  EXPECT_NE(channel_creds, nullptr);
-  EXPECT_NE(channel_creds->call_creds(), nullptr);
+  GPR_ASSERT(g_test_gce_tenancy_checker_called == false);
+  GPR_ASSERT(channel_creds != nullptr);
+  GPR_ASSERT(channel_creds->call_creds() != nullptr);
   run_request_metadata_test(channel_creds->mutable_call_creds(), auth_md_ctx,
                             state);
   grpc_core::ExecCtx::Get()->Flush();
@@ -1824,12 +1848,12 @@ static int plugin_get_metadata_success(
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t* num_creds_md, grpc_status_code* /*status*/,
     const char** /*error_details*/) {
-  EXPECT_STREQ(context.service_url, test_service_url);
-  EXPECT_STREQ(context.method_name, test_method);
-  EXPECT_EQ(context.channel_auth_context, nullptr);
-  EXPECT_EQ(context.reserved, nullptr);
-  EXPECT_TRUE(GPR_ARRAY_SIZE(plugin_md) <
-              GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX);
+  GPR_ASSERT(strcmp(context.service_url, test_service_url) == 0);
+  GPR_ASSERT(strcmp(context.method_name, test_method) == 0);
+  GPR_ASSERT(context.channel_auth_context == nullptr);
+  GPR_ASSERT(context.reserved == nullptr);
+  GPR_ASSERT(GPR_ARRAY_SIZE(plugin_md) <
+             GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX);
   plugin_state* s = static_cast<plugin_state*>(state);
   *s = PLUGIN_GET_METADATA_CALLED_STATE;
   for (size_t i = 0; i < GPR_ARRAY_SIZE(plugin_md); ++i) {
@@ -1849,10 +1873,10 @@ static int plugin_get_metadata_failure(
     grpc_metadata /*creds_md*/[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t* /*num_creds_md*/, grpc_status_code* status,
     const char** error_details) {
-  EXPECT_STREQ(context.service_url, test_service_url);
-  EXPECT_STREQ(context.method_name, test_method);
-  EXPECT_EQ(context.channel_auth_context, nullptr);
-  EXPECT_EQ(context.reserved, nullptr);
+  GPR_ASSERT(strcmp(context.service_url, test_service_url) == 0);
+  GPR_ASSERT(strcmp(context.method_name, test_method) == 0);
+  GPR_ASSERT(context.channel_auth_context == nullptr);
+  GPR_ASSERT(context.reserved == nullptr);
   plugin_state* s = static_cast<plugin_state*>(state);
   *s = PLUGIN_GET_METADATA_CALLED_STATE;
   *status = GRPC_STATUS_UNAUTHENTICATED;
@@ -1885,7 +1909,7 @@ static char* plugin_debug_string(void* state) {
   return ret;
 }
 
-TEST(CredentialsTest, metadata_plugin_success) {
+static void test_metadata_plugin_success(void) {
   const char expected_creds_debug_string[] =
       "TestPluginCredentials{state:GET_METADATA_CALLED}";
   plugin_state state = PLUGIN_INITIAL_STATE;
@@ -1904,17 +1928,18 @@ TEST(CredentialsTest, metadata_plugin_success) {
   grpc_call_credentials* creds = grpc_metadata_credentials_create_from_plugin(
       plugin, GRPC_PRIVACY_AND_INTEGRITY, nullptr);
   /* Check security level. */
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
-  EXPECT_EQ(state, PLUGIN_INITIAL_STATE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(state == PLUGIN_INITIAL_STATE);
   run_request_metadata_test(creds, auth_md_ctx, md_state);
-  EXPECT_EQ(state, PLUGIN_GET_METADATA_CALLED_STATE);
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(state == PLUGIN_GET_METADATA_CALLED_STATE);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
   creds->Unref();
 
-  EXPECT_EQ(state, PLUGIN_DESTROY_CALLED_STATE);
+  GPR_ASSERT(state == PLUGIN_DESTROY_CALLED_STATE);
 }
 
-TEST(CredentialsTest, metadata_plugin_failure) {
+static void test_metadata_plugin_failure(void) {
   const char expected_creds_debug_string[] =
       "TestPluginCredentials{state:GET_METADATA_CALLED}";
 
@@ -1936,16 +1961,17 @@ TEST(CredentialsTest, metadata_plugin_failure) {
 
   grpc_call_credentials* creds = grpc_metadata_credentials_create_from_plugin(
       plugin, GRPC_PRIVACY_AND_INTEGRITY, nullptr);
-  EXPECT_EQ(state, PLUGIN_INITIAL_STATE);
+  GPR_ASSERT(state == PLUGIN_INITIAL_STATE);
   run_request_metadata_test(creds, auth_md_ctx, md_state);
-  EXPECT_EQ(state, PLUGIN_GET_METADATA_CALLED_STATE);
-  EXPECT_STREQ(creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(state == PLUGIN_GET_METADATA_CALLED_STATE);
+  GPR_ASSERT(
+      strcmp(creds->debug_string().c_str(), expected_creds_debug_string) == 0);
   creds->Unref();
 
-  EXPECT_EQ(state, PLUGIN_DESTROY_CALLED_STATE);
+  GPR_ASSERT(state == PLUGIN_DESTROY_CALLED_STATE);
 }
 
-TEST(CredentialsTest, get_well_known_google_credentials_file_path) {
+static void test_get_well_known_google_credentials_file_path(void) {
   char* home = gpr_getenv("HOME");
   bool restore_home_env = false;
 #if defined(GRPC_BAZEL_BUILD) && \
@@ -1957,12 +1983,12 @@ TEST(CredentialsTest, get_well_known_google_credentials_file_path) {
 #endif /* defined(GRPC_BAZEL_BUILD) && (defined(GPR_POSIX_ENV) || \
           defined(GPR_LINUX_ENV)) */
   std::string path = grpc_get_well_known_google_credentials_file_path();
-  EXPECT_TRUE(!path.empty());
+  GPR_ASSERT(!path.empty());
 #if defined(GPR_POSIX_ENV) || defined(GPR_LINUX_ENV)
   restore_home_env = true;
   gpr_unsetenv("HOME");
   path = grpc_get_well_known_google_credentials_file_path();
-  EXPECT_TRUE(path.empty());
+  GPR_ASSERT(path.empty());
 #endif /* GPR_POSIX_ENV || GPR_LINUX_ENV */
   if (restore_home_env) {
     if (home) {
@@ -1974,7 +2000,7 @@ TEST(CredentialsTest, get_well_known_google_credentials_file_path) {
   gpr_free(home);
 }
 
-TEST(CredentialsTest, channel_creds_duplicate_without_call_creds) {
+static void test_channel_creds_duplicate_without_call_creds(void) {
   const char expected_creds_debug_string[] =
       "AccessTokenCredentials{Token:present}";
   grpc_core::ExecCtx exec_ctx;
@@ -1984,7 +2010,7 @@ TEST(CredentialsTest, channel_creds_duplicate_without_call_creds) {
 
   grpc_core::RefCountedPtr<grpc_channel_credentials> dup =
       channel_creds->duplicate_without_call_credentials();
-  EXPECT_EQ(dup, channel_creds);
+  GPR_ASSERT(dup == channel_creds);
   dup.reset();
 
   grpc_call_credentials* call_creds =
@@ -1992,11 +2018,12 @@ TEST(CredentialsTest, channel_creds_duplicate_without_call_creds) {
   grpc_channel_credentials* composite_creds =
       grpc_composite_channel_credentials_create(channel_creds, call_creds,
                                                 nullptr);
-  EXPECT_STREQ(call_creds->debug_string().c_str(), expected_creds_debug_string);
+  GPR_ASSERT(strcmp(call_creds->debug_string().c_str(),
+                    expected_creds_debug_string) == 0);
 
   call_creds->Unref();
   dup = composite_creds->duplicate_without_call_credentials();
-  EXPECT_EQ(dup, channel_creds);
+  GPR_ASSERT(dup == channel_creds);
   dup.reset();
 
   channel_creds->Unref();
@@ -2011,7 +2038,7 @@ typedef struct {
   const char* desired_method_name;
 } auth_metadata_context_test_case;
 
-TEST(CredentialsTest, auth_metadata_context) {
+static void test_auth_metadata_context(void) {
   auth_metadata_context_test_case test_cases[] = {
       // No service nor method.
       {"https", "www.foo.com", "", "https://www.foo.com", ""},
@@ -2059,15 +2086,15 @@ TEST(CredentialsTest, auth_metadata_context) {
                test_cases[i].desired_service_url) != 0) {
       gpr_log(GPR_ERROR, "Invalid service url, want: %s, got %s.",
               test_cases[i].desired_service_url, auth_md_context.service_url);
-      EXPECT_TRUE(false);
+      GPR_ASSERT(false);
     }
     if (strcmp(auth_md_context.method_name,
                test_cases[i].desired_method_name) != 0) {
       gpr_log(GPR_ERROR, "Invalid method name, want: %s, got %s.",
               test_cases[i].desired_method_name, auth_md_context.method_name);
-      EXPECT_TRUE(false);
+      GPR_ASSERT(false);
     }
-    EXPECT_EQ(auth_md_context.channel_auth_context, nullptr);
+    GPR_ASSERT(auth_md_context.channel_auth_context == nullptr);
     grpc_slice_unref(call_host);
     grpc_slice_unref(call_method);
     grpc_auth_metadata_context_reset(&auth_md_context);
@@ -2078,16 +2105,16 @@ static void validate_external_account_creds_token_exchage_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  EXPECT_NE(body, nullptr);
-  EXPECT_NE(body_size, 0);
-  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
+  GPR_ASSERT(body != nullptr);
+  GPR_ASSERT(body_size != 0);
+  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
   std::string get_url_equivalent =
       absl::StrFormat("%s?%s", "https://foo.com:5555/token", body);
   absl::StatusOr<grpc_core::URI> uri =
       grpc_core::URI::Parse(get_url_equivalent);
   if (!uri.ok()) {
     gpr_log(GPR_ERROR, "%s", uri.status().ToString().c_str());
-    EXPECT_TRUE(uri.ok());
+    GPR_ASSERT(uri.ok());
   }
   assert_query_parameters(*uri, "audience", "audience");
   assert_query_parameters(*uri, "grant_type",
@@ -2100,15 +2127,15 @@ static void validate_external_account_creds_token_exchage_request(
                           "https://www.googleapis.com/auth/cloud-platform");
 
   // Check the rest of the request.
-  EXPECT_STREQ(request->host, "foo.com:5555");
-  EXPECT_STREQ(request->http.path, "/token");
-  EXPECT_EQ(request->http.hdr_count, 2);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
-  EXPECT_STREQ(request->http.hdrs[0].value,
-               "application/x-www-form-urlencoded");
-  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
-  EXPECT_STREQ(request->http.hdrs[1].value,
-               "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=");
+  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
+  GPR_ASSERT(strcmp(request->http.path, "/token") == 0);
+  GPR_ASSERT(request->http.hdr_count == 2);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
+                    "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=") == 0);
 }
 
 static void
@@ -2116,28 +2143,29 @@ validate_external_account_creds_token_exchage_request_with_url_encode(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  EXPECT_NE(body, nullptr);
-  EXPECT_NE(body_size, 0);
-  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
-  EXPECT_EQ(
-
-      std::string(body, body_size),
-      "audience=audience_!%40%23%24&grant_type=urn%3Aietf%3Aparams%3Aoauth%"
-      "3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%"
-      "3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&subject_token_type="
-      "subject_token_type_!%40%23%24&subject_token=test_subject_token&"
-      "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform");
+  GPR_ASSERT(body != nullptr);
+  GPR_ASSERT(body_size != 0);
+  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
+  GPR_ASSERT(
+      strcmp(
+          std::string(body, body_size).c_str(),
+          "audience=audience_!%40%23%24&grant_type=urn%3Aietf%3Aparams%3Aoauth%"
+          "3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%"
+          "3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&subject_token_type="
+          "subject_token_type_!%40%23%24&subject_token=test_subject_token&"
+          "scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform") ==
+      0);
 
   // Check the rest of the request.
-  EXPECT_STREQ(request->host, "foo.com:5555");
-  EXPECT_STREQ(request->http.path, "/token_url_encode");
-  EXPECT_EQ(request->http.hdr_count, 2);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
-  EXPECT_STREQ(request->http.hdrs[0].value,
-               "application/x-www-form-urlencoded");
-  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
-  EXPECT_STREQ(request->http.hdrs[1].value,
-               "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=");
+  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
+  GPR_ASSERT(strcmp(request->http.path, "/token_url_encode") == 0);
+  GPR_ASSERT(request->http.hdr_count == 2);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
+                    "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=") == 0);
 }
 
 static void
@@ -2145,20 +2173,20 @@ validate_external_account_creds_service_account_impersonation_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  EXPECT_NE(body, nullptr);
-  EXPECT_NE(body_size, 0);
-  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
-  EXPECT_STREQ(body, "scope=scope_1 scope_2");
+  GPR_ASSERT(body != nullptr);
+  GPR_ASSERT(body_size != 0);
+  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
+  GPR_ASSERT(strcmp(body, "scope=scope_1 scope_2") == 0);
   // Check the rest of the request.
-  EXPECT_STREQ(request->host, "foo.com:5555");
-  EXPECT_STREQ(request->http.path, "/service_account_impersonation");
-  EXPECT_EQ(request->http.hdr_count, 2);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
-  EXPECT_STREQ(request->http.hdrs[0].value,
-               "application/x-www-form-urlencoded");
-  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
-  EXPECT_STREQ(request->http.hdrs[1].value,
-               "Bearer token_exchange_access_token");
+  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
+  GPR_ASSERT(strcmp(request->http.path, "/service_account_impersonation") == 0);
+  GPR_ASSERT(request->http.hdr_count == 2);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
+                    "Bearer token_exchange_access_token") == 0);
 }
 
 static int external_account_creds_httpcli_post_success(
@@ -2233,17 +2261,17 @@ static void validate_aws_external_account_creds_token_exchage_request(
     const grpc_httpcli_request* request, const char* body, size_t body_size,
     bool /*expect_actor_token*/) {
   // Check that the body is constructed properly.
-  EXPECT_NE(body, nullptr);
-  EXPECT_NE(body_size, 0);
+  GPR_ASSERT(body != nullptr);
+  GPR_ASSERT(body_size != 0);
   // Check that the regional_cred_verification_url got constructed
   // with the correct AWS Region ("test_regionz" or "test_region").
-  EXPECT_TRUE(strstr(body, "regional_cred_verification_url_test_region"));
-  EXPECT_EQ(request->handshaker, &grpc_httpcli_ssl);
+  GPR_ASSERT(strstr(body, "regional_cred_verification_url_test_region"));
+  GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
   std::string get_url_equivalent =
       absl::StrFormat("%s?%s", "https://foo.com:5555/token", body);
   absl::StatusOr<grpc_core::URI> uri =
       grpc_core::URI::Parse(get_url_equivalent);
-  EXPECT_TRUE(uri.ok());
+  GPR_ASSERT(uri.ok());
   assert_query_parameters(*uri, "audience", "audience");
   assert_query_parameters(*uri, "grant_type",
                           "urn:ietf:params:oauth:grant-type:token-exchange");
@@ -2253,15 +2281,15 @@ static void validate_aws_external_account_creds_token_exchage_request(
   assert_query_parameters(*uri, "scope",
                           "https://www.googleapis.com/auth/cloud-platform");
   // Check the rest of the request.
-  EXPECT_STREQ(request->host, "foo.com:5555");
-  EXPECT_STREQ(request->http.path, "/token");
-  EXPECT_EQ(request->http.hdr_count, 2);
-  EXPECT_STREQ(request->http.hdrs[0].key, "Content-Type");
-  EXPECT_STREQ(request->http.hdrs[0].value,
-               "application/x-www-form-urlencoded");
-  EXPECT_STREQ(request->http.hdrs[1].key, "Authorization");
-  EXPECT_STREQ(request->http.hdrs[1].value,
-               "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=");
+  GPR_ASSERT(strcmp(request->host, "foo.com:5555") == 0);
+  GPR_ASSERT(strcmp(request->http.path, "/token") == 0);
+  GPR_ASSERT(request->http.hdr_count == 2);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].key, "Authorization") == 0);
+  GPR_ASSERT(strcmp(request->http.hdrs[1].value,
+                    "Basic Y2xpZW50X2lkOmNsaWVudF9zZWNyZXQ=") == 0);
 }
 
 static int aws_external_account_creds_httpcli_get_success(
@@ -2313,7 +2341,7 @@ class TestExternalAccountCredentials final
   }
 };
 
-TEST(CredentialsTest, external_account_creds_success) {
+static void test_external_account_creds_success(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2333,7 +2361,7 @@ TEST(CredentialsTest, external_account_creds_success) {
   };
   TestExternalAccountCredentials creds(options, {});
   /* Check security level. */
-  EXPECT_EQ(creds.min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds.min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   /* First request: http put should be called. */
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
@@ -2351,7 +2379,7 @@ TEST(CredentialsTest, external_account_creds_success) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, external_account_creds_success_with_url_encode) {
+static void test_external_account_creds_success_with_url_encode(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2379,8 +2407,8 @@ TEST(CredentialsTest, external_account_creds_success_with_url_encode) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest,
-     external_account_creds_success_with_service_account_impersonation) {
+static void
+test_external_account_creds_success_with_service_account_impersonation(void) {
   expected_md emd[] = {
       {"authorization", "Bearer service_account_impersonation_access_token"}};
   grpc_core::ExecCtx exec_ctx;
@@ -2401,7 +2429,7 @@ TEST(CredentialsTest,
   };
   TestExternalAccountCredentials creds(options, {"scope_1", "scope_2"});
   /* Check security level. */
-  EXPECT_EQ(creds.min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds.min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   /* First request: http put should be called. */
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
@@ -2412,7 +2440,7 @@ TEST(CredentialsTest,
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, external_account_creds_failure_invalid_token_url) {
+static void test_external_account_creds_failure_invalid_token_url(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2445,8 +2473,9 @@ TEST(CredentialsTest, external_account_creds_failure_invalid_token_url) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest,
-     external_account_creds_failure_invalid_service_account_impersonation_url) {
+static void
+test_external_account_creds_failure_invalid_service_account_impersonation_url(
+    void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2480,9 +2509,9 @@ TEST(CredentialsTest,
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(
-    CredentialsTest,
-    external_account_creds_failure_token_exchange_response_missing_access_token) {
+static void
+test_external_account_creds_failure_token_exchange_response_missing_access_token(
+    void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2518,7 +2547,7 @@ TEST(
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, url_external_account_creds_success_format_text) {
+static void test_url_external_account_creds_success_format_text(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2527,7 +2556,7 @@ TEST(CredentialsTest, url_external_account_creds_success_format_text) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_url_external_account_creds_options_credential_source_format_text,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2542,9 +2571,9 @@ TEST(CredentialsTest, url_external_account_creds_success_format_text) {
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(url_external_account_creds_httpcli_get_success,
@@ -2554,8 +2583,8 @@ TEST(CredentialsTest, url_external_account_creds_success_format_text) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest,
-     url_external_account_creds_success_with_qurey_params_format_text) {
+static void
+test_url_external_account_creds_success_with_qurey_params_format_text(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2564,7 +2593,7 @@ TEST(CredentialsTest,
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_url_external_account_creds_options_credential_source_with_qurey_params_format_text,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2579,9 +2608,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(url_external_account_creds_httpcli_get_success,
@@ -2591,7 +2620,7 @@ TEST(CredentialsTest,
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest, url_external_account_creds_success_format_json) {
+static void test_url_external_account_creds_success_format_json(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2600,7 +2629,7 @@ TEST(CredentialsTest, url_external_account_creds_success_format_json) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_url_external_account_creds_options_credential_source_format_json,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2615,9 +2644,9 @@ TEST(CredentialsTest, url_external_account_creds_success_format_json) {
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(url_external_account_creds_httpcli_get_success,
@@ -2627,12 +2656,12 @@ TEST(CredentialsTest, url_external_account_creds_success_format_json) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest,
-     url_external_account_creds_failure_invalid_credential_source_url) {
+static void
+test_url_external_account_creds_failure_invalid_credential_source_url(void) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_url_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2647,15 +2676,15 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::UrlExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_EQ(creds, nullptr);
+  GPR_ASSERT(creds == nullptr);
   std::string actual_error;
-  EXPECT_TRUE(
+  GPR_ASSERT(
       grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &actual_error));
-  EXPECT_TRUE(absl::StartsWith(actual_error, "Invalid credential source url."));
+  GPR_ASSERT(absl::StartsWith(actual_error, "Invalid credential source url."));
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(CredentialsTest, file_external_account_creds_success_format_text) {
+static void test_file_external_account_creds_success_format_text(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2667,7 +2696,7 @@ TEST(CredentialsTest, file_external_account_creds_success_format_text) {
           "{\"file\":\"%s\"}",
           absl::StrReplaceAll(subject_token_path, {{"\\", "\\\\"}})),
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2682,9 +2711,9 @@ TEST(CredentialsTest, file_external_account_creds_success_format_text) {
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
@@ -2696,7 +2725,7 @@ TEST(CredentialsTest, file_external_account_creds_success_format_text) {
   gpr_free(subject_token_path);
 }
 
-TEST(CredentialsTest, file_external_account_creds_success_format_json) {
+static void test_file_external_account_creds_success_format_json(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2716,7 +2745,7 @@ TEST(CredentialsTest, file_external_account_creds_success_format_json) {
           "}",
           absl::StrReplaceAll(subject_token_path, {{"\\", "\\\\"}})),
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2731,9 +2760,9 @@ TEST(CredentialsTest, file_external_account_creds_success_format_json) {
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
@@ -2745,14 +2774,14 @@ TEST(CredentialsTest, file_external_account_creds_success_format_json) {
   gpr_free(subject_token_path);
 }
 
-TEST(CredentialsTest, file_external_account_creds_failure_file_not_found) {
+static void test_file_external_account_creds_failure_file_not_found(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source =
       grpc_core::Json::Parse("{\"file\":\"non_exisiting_file\"}", &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2767,8 +2796,8 @@ TEST(CredentialsTest, file_external_account_creds_failure_file_not_found) {
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             httpcli_post_should_not_be_called);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to load file");
@@ -2783,8 +2812,8 @@ TEST(CredentialsTest, file_external_account_creds_failure_file_not_found) {
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(CredentialsTest,
-     file_external_account_creds_failure_invalid_json_content) {
+static void test_file_external_account_creds_failure_invalid_json_content(
+    void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -2802,7 +2831,7 @@ TEST(CredentialsTest,
           "}",
           absl::StrReplaceAll(subject_token_path, {{"\\", "\\\\"}})),
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2817,8 +2846,8 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::FileExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_httpcli_set_override(httpcli_get_should_not_be_called,
                             httpcli_post_should_not_be_called);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -2835,7 +2864,7 @@ TEST(CredentialsTest,
   gpr_free(subject_token_path);
 }
 
-TEST(CredentialsTest, aws_external_account_creds_success) {
+static void test_aws_external_account_creds_success(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2843,7 +2872,7 @@ TEST(CredentialsTest, aws_external_account_creds_success) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2858,9 +2887,9 @@ TEST(CredentialsTest, aws_external_account_creds_success) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2870,8 +2899,8 @@ TEST(CredentialsTest, aws_external_account_creds_success) {
   grpc_httpcli_set_override(nullptr, nullptr);
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_region_env_keys_url) {
+static void test_aws_external_account_creds_success_path_region_env_keys_url(
+    void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2880,7 +2909,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2895,9 +2924,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2908,8 +2937,8 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_REGION");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_default_region_env_keys_url) {
+static void
+test_aws_external_account_creds_success_path_default_region_env_keys_url(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2918,7 +2947,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2933,9 +2962,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2946,8 +2975,9 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_DEFAULT_REGION");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_duplicate_region_env_keys_url) {
+static void
+test_aws_external_account_creds_success_path_duplicate_region_env_keys_url(
+    void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2958,7 +2988,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -2973,9 +3003,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -2987,8 +3017,8 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_DEFAULT_REGION");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_region_url_keys_env) {
+static void test_aws_external_account_creds_success_path_region_url_keys_env(
+    void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -2999,7 +3029,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3014,9 +3044,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3029,8 +3059,8 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_region_env_keys_env) {
+static void test_aws_external_account_creds_success_path_region_env_keys_env(
+    void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3042,7 +3072,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3057,9 +3087,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3073,8 +3103,8 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_default_region_env_keys_env) {
+static void
+test_aws_external_account_creds_success_path_default_region_env_keys_env(void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3086,7 +3116,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3101,9 +3131,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3117,8 +3147,9 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_success_path_duplicate_region_env_keys_env) {
+static void
+test_aws_external_account_creds_success_path_duplicate_region_env_keys_env(
+    void) {
   expected_md emd[] = {{"authorization", "Bearer token_exchange_access_token"}};
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
@@ -3132,7 +3163,7 @@ TEST(CredentialsTest,
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       valid_aws_external_account_creds_options_credential_source, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3147,9 +3178,9 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   request_metadata_state* state =
       make_request_metadata_state(GRPC_ERROR_NONE, emd, GPR_ARRAY_SIZE(emd));
   grpc_httpcli_set_override(aws_external_account_creds_httpcli_get_success,
@@ -3164,13 +3195,13 @@ TEST(CredentialsTest,
   gpr_unsetenv("AWS_SESSION_TOKEN");
 }
 
-TEST(CredentialsTest,
-     aws_external_account_creds_failure_unmatched_environment_id) {
+static void test_aws_external_account_creds_failure_unmatched_environment_id(
+    void) {
   grpc_error_handle error = GRPC_ERROR_NONE;
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_unmatched_environment_id,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3185,16 +3216,16 @@ TEST(CredentialsTest,
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_EQ(creds, nullptr);
+  GPR_ASSERT(creds == nullptr);
   std::string expected_error = "environment_id does not match.";
   std::string actual_error;
-  EXPECT_TRUE(
+  GPR_ASSERT(
       grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &actual_error));
-  EXPECT_EQ(expected_error, actual_error);
+  GPR_ASSERT(expected_error == actual_error);
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(CredentialsTest, aws_external_account_creds_failure_invalid_region_url) {
+static void test_aws_external_account_creds_failure_invalid_region_url(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3202,7 +3233,7 @@ TEST(CredentialsTest, aws_external_account_creds_failure_invalid_region_url) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_invalid_region_url,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3217,9 +3248,9 @@ TEST(CredentialsTest, aws_external_account_creds_failure_invalid_region_url) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Invalid region url: invalid_region_url.");
   grpc_error_handle expected_error =
@@ -3235,7 +3266,7 @@ TEST(CredentialsTest, aws_external_account_creds_failure_invalid_region_url) {
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(CredentialsTest, aws_external_account_creds_failure_invalid_url) {
+static void test_aws_external_account_creds_failure_invalid_url(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3243,7 +3274,7 @@ TEST(CredentialsTest, aws_external_account_creds_failure_invalid_url) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_invalid_url,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3258,9 +3289,9 @@ TEST(CredentialsTest, aws_external_account_creds_failure_invalid_url) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Invalid url: invalid_url.");
   grpc_error_handle expected_error =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
@@ -3275,7 +3306,7 @@ TEST(CredentialsTest, aws_external_account_creds_failure_invalid_url) {
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(CredentialsTest, aws_external_account_creds_failure_missing_role_name) {
+static void test_aws_external_account_creds_failure_missing_role_name(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3283,7 +3314,7 @@ TEST(CredentialsTest, aws_external_account_creds_failure_missing_role_name) {
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_missing_role_name,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3298,9 +3329,9 @@ TEST(CredentialsTest, aws_external_account_creds_failure_missing_role_name) {
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Missing role name when retrieving signing keys.");
   grpc_error_handle expected_error =
@@ -3316,9 +3347,9 @@ TEST(CredentialsTest, aws_external_account_creds_failure_missing_role_name) {
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(
-    CredentialsTest,
-    aws_external_account_creds_failure_invalid_regional_cred_verification_url) {
+static void
+test_aws_external_account_creds_failure_invalid_regional_cred_verification_url(
+    void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_auth_metadata_context auth_md_ctx = {test_service_url, test_method,
                                             nullptr, nullptr};
@@ -3326,7 +3357,7 @@ TEST(
   grpc_core::Json credential_source = grpc_core::Json::Parse(
       invalid_aws_external_account_creds_options_credential_source_invalid_regional_cred_verification_url,
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_core::ExternalAccountCredentials::Options options = {
       "external_account",                 // type;
       "audience",                         // audience;
@@ -3341,9 +3372,9 @@ TEST(
   };
   auto creds =
       grpc_core::AwsExternalAccountCredentials::Create(options, {}, &error);
-  EXPECT_NE(creds, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
-  EXPECT_EQ(creds->min_security_level(), GRPC_PRIVACY_AND_INTEGRITY);
+  GPR_ASSERT(creds != nullptr);
+  GPR_ASSERT(error == GRPC_ERROR_NONE);
+  GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "Creating aws request signer failed.");
   grpc_error_handle expected_error =
@@ -3359,7 +3390,7 @@ TEST(
   GRPC_ERROR_UNREF(error);
 }
 
-TEST(CredentialsTest, external_account_credentials_create_success) {
+static void test_external_account_credentials_create_success(void) {
   // url credentials
   const char* url_options_string =
       "{\"type\":\"external_account\",\"audience\":\"audience\",\"subject_"
@@ -3375,7 +3406,7 @@ TEST(CredentialsTest, external_account_credentials_create_success) {
   const char* url_scopes_string = "scope1,scope2";
   grpc_call_credentials* url_creds = grpc_external_account_credentials_create(
       url_options_string, url_scopes_string);
-  EXPECT_NE(url_creds, nullptr);
+  GPR_ASSERT(url_creds != nullptr);
   url_creds->Unref();
   // file credentials
   const char* file_options_string =
@@ -3390,7 +3421,7 @@ TEST(CredentialsTest, external_account_credentials_create_success) {
   const char* file_scopes_string = "scope1,scope2";
   grpc_call_credentials* file_creds = grpc_external_account_credentials_create(
       file_options_string, file_scopes_string);
-  EXPECT_NE(file_creds, nullptr);
+  GPR_ASSERT(file_creds != nullptr);
   file_creds->Unref();
   // aws credentials
   const char* aws_options_string =
@@ -3408,29 +3439,29 @@ TEST(CredentialsTest, external_account_credentials_create_success) {
   const char* aws_scopes_string = "scope1,scope2";
   grpc_call_credentials* aws_creds = grpc_external_account_credentials_create(
       aws_options_string, aws_scopes_string);
-  EXPECT_NE(aws_creds, nullptr);
+  GPR_ASSERT(aws_creds != nullptr);
   aws_creds->Unref();
 }
 
-TEST(CredentialsTest,
-     external_account_credentials_create_failure_invalid_json_format) {
+static void
+test_external_account_credentials_create_failure_invalid_json_format(void) {
   const char* options_string = "invalid_json";
   grpc_call_credentials* creds =
       grpc_external_account_credentials_create(options_string, "");
-  EXPECT_EQ(creds, nullptr);
+  GPR_ASSERT(creds == nullptr);
 }
 
-TEST(CredentialsTest,
-     external_account_credentials_create_failure_invalid_options_format) {
+static void
+test_external_account_credentials_create_failure_invalid_options_format(void) {
   const char* options_string = "{\"random_key\":\"random_value\"}";
   grpc_call_credentials* creds =
       grpc_external_account_credentials_create(options_string, "");
-  EXPECT_EQ(creds, nullptr);
+  GPR_ASSERT(creds == nullptr);
 }
 
-TEST(
-    CredentialsTest,
-    external_account_credentials_create_failure_invalid_options_credential_source) {
+static void
+test_external_account_credentials_create_failure_invalid_options_credential_source(
+    void) {
   const char* options_string =
       "{\"type\":\"external_account\",\"audience\":\"audience\",\"subject_"
       "token_type\":\"subject_token_type\",\"service_account_impersonation_"
@@ -3442,14 +3473,88 @@ TEST(
       "secret\"}";
   grpc_call_credentials* creds =
       grpc_external_account_credentials_create(options_string, "");
-  EXPECT_EQ(creds, nullptr);
+  GPR_ASSERT(creds == nullptr);
 }
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
-  ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
-  int retval = RUN_ALL_TESTS();
+  test_empty_md_array();
+  test_add_to_empty_md_array();
+  test_add_abunch_to_md_array();
+  test_oauth2_token_fetcher_creds_parsing_ok();
+  test_oauth2_token_fetcher_creds_parsing_bad_http_status();
+  test_oauth2_token_fetcher_creds_parsing_empty_http_body();
+  test_oauth2_token_fetcher_creds_parsing_invalid_json();
+  test_oauth2_token_fetcher_creds_parsing_missing_token();
+  test_oauth2_token_fetcher_creds_parsing_missing_token_type();
+  test_oauth2_token_fetcher_creds_parsing_missing_token_lifetime();
+  test_google_iam_creds();
+  test_access_token_creds();
+  test_channel_oauth2_composite_creds();
+  test_oauth2_google_iam_composite_creds();
+  test_channel_oauth2_google_iam_composite_creds();
+  test_compute_engine_creds_success();
+  test_compute_engine_creds_failure();
+  test_refresh_token_creds_success();
+  test_refresh_token_creds_failure();
+  test_valid_sts_creds_options();
+  test_invalid_sts_creds_options();
+  test_sts_creds_success();
+  test_sts_creds_no_actor_token_success();
+  test_sts_creds_load_token_failure();
+  test_sts_creds_http_failure();
+  test_sts_creds_token_file_not_found();
+  test_jwt_creds_lifetime();
+  test_jwt_creds_success();
+  test_jwt_creds_signing_failure();
+  test_remove_service_from_jwt_uri();
+  test_google_default_creds_auth_key();
+  test_google_default_creds_refresh_token();
+  test_google_default_creds_external_account_credentials();
+  test_google_default_creds_external_account_credentials_multi_pattern_sts();
+  test_google_default_creds_external_account_credentials_multi_pattern_iam();
+  test_google_default_creds_gce();
+  test_google_default_creds_non_gce();
+  test_no_google_default_creds();
+  test_google_default_creds_call_creds_specified();
+  test_google_default_creds_not_default();
+  test_metadata_plugin_success();
+  test_metadata_plugin_failure();
+  test_get_well_known_google_credentials_file_path();
+  test_channel_creds_duplicate_without_call_creds();
+  test_auth_metadata_context();
+  test_external_account_creds_success();
+  test_external_account_creds_success_with_url_encode();
+  test_external_account_creds_success_with_service_account_impersonation();
+  test_external_account_creds_failure_invalid_token_url();
+  test_external_account_creds_failure_invalid_service_account_impersonation_url();
+  test_external_account_creds_failure_token_exchange_response_missing_access_token();
+  test_url_external_account_creds_success_format_text();
+  test_url_external_account_creds_success_format_json();
+  test_url_external_account_creds_failure_invalid_credential_source_url();
+  test_url_external_account_creds_success_with_qurey_params_format_text();
+  test_file_external_account_creds_success_format_text();
+  test_file_external_account_creds_success_format_json();
+  test_file_external_account_creds_failure_file_not_found();
+  test_file_external_account_creds_failure_invalid_json_content();
+  test_aws_external_account_creds_success();
+  test_aws_external_account_creds_success_path_region_env_keys_url();
+  test_aws_external_account_creds_success_path_default_region_env_keys_url();
+  test_aws_external_account_creds_success_path_duplicate_region_env_keys_url();
+  test_aws_external_account_creds_success_path_region_url_keys_env();
+  test_aws_external_account_creds_success_path_region_env_keys_env();
+  test_aws_external_account_creds_success_path_default_region_env_keys_env();
+  test_aws_external_account_creds_success_path_duplicate_region_env_keys_env();
+  test_aws_external_account_creds_failure_unmatched_environment_id();
+  test_aws_external_account_creds_failure_invalid_region_url();
+  test_aws_external_account_creds_failure_invalid_url();
+  test_aws_external_account_creds_failure_missing_role_name();
+  test_aws_external_account_creds_failure_invalid_regional_cred_verification_url();
+  test_external_account_credentials_create_success();
+  test_external_account_credentials_create_failure_invalid_json_format();
+  test_external_account_credentials_create_failure_invalid_options_format();
+  test_external_account_credentials_create_failure_invalid_options_credential_source();
   grpc_shutdown();
-  return retval;
+  return 0;
 }

--- a/test/core/security/grpc_tls_certificate_distributor_test.cc
+++ b/test/core/security/grpc_tls_certificate_distributor_test.cc
@@ -137,18 +137,13 @@ class GrpcTlsCertificateDistributorTest : public ::testing::Test {
       std::string root_error_str;
       std::string identity_error_str;
       if (root_cert_error != GRPC_ERROR_NONE) {
-        grpc_slice root_error_slice;
         GPR_ASSERT(grpc_error_get_str(
-            root_cert_error, GRPC_ERROR_STR_DESCRIPTION, &root_error_slice));
-        root_error_str = std::string(StringViewFromSlice(root_error_slice));
+            root_cert_error, GRPC_ERROR_STR_DESCRIPTION, &root_error_str));
       }
       if (identity_cert_error != GRPC_ERROR_NONE) {
-        grpc_slice identity_error_slice;
         GPR_ASSERT(grpc_error_get_str(identity_cert_error,
                                       GRPC_ERROR_STR_DESCRIPTION,
-                                      &identity_error_slice));
-        identity_error_str =
-            std::string(StringViewFromSlice(identity_error_slice));
+                                      &identity_error_str));
       }
       state_->error_queue.emplace_back(std::move(root_error_str),
                                        std::move(identity_error_str));

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -139,18 +139,13 @@ class GrpcTlsCertificateProviderTest : public ::testing::Test {
       std::string root_error_str;
       std::string identity_error_str;
       if (root_cert_error != GRPC_ERROR_NONE) {
-        grpc_slice root_error_slice;
         GPR_ASSERT(grpc_error_get_str(
-            root_cert_error, GRPC_ERROR_STR_DESCRIPTION, &root_error_slice));
-        root_error_str = std::string(StringViewFromSlice(root_error_slice));
+            root_cert_error, GRPC_ERROR_STR_DESCRIPTION, &root_error_str));
       }
       if (identity_cert_error != GRPC_ERROR_NONE) {
-        grpc_slice identity_error_slice;
         GPR_ASSERT(grpc_error_get_str(identity_cert_error,
                                       GRPC_ERROR_STR_DESCRIPTION,
-                                      &identity_error_slice));
-        identity_error_str =
-            std::string(StringViewFromSlice(identity_error_slice));
+                                      &identity_error_str));
       }
       state_->error_queue.emplace_back(std::move(root_error_str),
                                        std::move(identity_error_str));

--- a/test/core/transport/error_utils_test.cc
+++ b/test/core/transport/error_utils_test.cc
@@ -67,11 +67,9 @@ TEST(ErrorUtilsTest, AbslUnavailableToGrpcError) {
   ASSERT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_GRPC_STATUS, &code));
   ASSERT_EQ(static_cast<grpc_status_code>(code), GRPC_STATUS_UNAVAILABLE);
   // Status message checks
-  grpc_slice message;
+  std::string message;
   ASSERT_TRUE(grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &message));
-  absl::string_view str = grpc_core::StringViewFromSlice(message);
-  ASSERT_EQ(str, "Making tea");
-  grpc_slice_unref(message);
+  ASSERT_EQ(message, "Making tea");
   GRPC_ERROR_UNREF(error);
 }
 

--- a/test/cpp/microbenchmarks/bm_error.cc
+++ b/test/cpp/microbenchmarks/bm_error.cc
@@ -74,7 +74,7 @@ static void BM_ErrorCreateAndSetIntAndStr(benchmark::State& state) {
         grpc_error_set_int(
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("GOAWAY received"),
             GRPC_ERROR_INT_HTTP2_ERROR, (intptr_t)0),
-        GRPC_ERROR_STR_RAW_BYTES, grpc_slice_from_static_string("raw bytes")));
+        GRPC_ERROR_STR_RAW_BYTES, "raw bytes"));
   }
   track_counters.Finish(state);
 }
@@ -97,8 +97,7 @@ static void BM_ErrorCreateAndSetStrLoop(benchmark::State& state) {
   grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error");
   const char* str = "hello";
   for (auto _ : state) {
-    error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE,
-                               grpc_slice_from_static_string(str));
+    error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, str);
   }
   GRPC_ERROR_UNREF(error);
   track_counters.Finish(state);
@@ -253,9 +252,9 @@ static void BM_ErrorGetStatus(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
     grpc_status_code status;
-    grpc_slice slice;
-    grpc_error_get_status(fixture.error(), fixture.deadline(), &status, &slice,
-                          nullptr, nullptr);
+    std::string message;
+    grpc_error_get_status(fixture.error(), fixture.deadline(), &status,
+                          &message, nullptr, nullptr);
   }
 
   track_counters.Finish(state);

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -1057,30 +1057,6 @@
     "ci_platforms": [
       "linux",
       "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": false,
-    "language": "c",
-    "name": "error_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": false
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
       "posix"
     ],
     "cpu_cost": 1.0,
@@ -2807,30 +2783,6 @@
     "gtest": false,
     "language": "c",
     "name": "test_core_iomgr_resource_quota_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": false,
-    "language": "c",
-    "name": "test_core_security_credentials_test",
     "platforms": [
       "linux",
       "mac",
@@ -4676,6 +4628,30 @@
       "windows"
     ],
     "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
+    "name": "error_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": false
   },
   {
     "args": [],
@@ -7078,6 +7054,30 @@
       "windows"
     ],
     "uses_polling": false
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
+    "name": "test_core_security_credentials_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
   },
   {
     "args": [],

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -2806,6 +2806,30 @@
     "flaky": false,
     "gtest": false,
     "language": "c",
+    "name": "test_core_security_credentials_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": false,
+    "language": "c",
     "name": "test_core_slice_slice_test",
     "platforms": [
       "linux",
@@ -7054,30 +7078,6 @@
       "windows"
     ],
     "uses_polling": false
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": true,
-    "language": "c++",
-    "name": "test_core_security_credentials_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": true
   },
   {
     "args": [],


### PR DESCRIPTION
Currently `grpc_error_get_str` and `grpc_error_set_str`use a `slice` type value for a string. This isn't compatible with `absl::Status` since `grpc_error_get_str` returns a slice without increasing a reference counter, which is not possible to implement with `absl::Status`. Therefore, `std::string` and `absl::string_view` are used for these functions as a type of value. This may introduce a bit of overhead in case of `grpc_error` (not `absl::Status`) but this isn't on a critical path so it'd be acceptable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/27466)
<!-- Reviewable:end -->
