### PR TITLE
Change the time-getting logic in xds test to what ExecCtx does

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1648,8 +1648,7 @@ class NoOpHttpFilter : public grpc_core::XdsHttpFilterImpl {
 // GPR round the number at millisecond-level. This creates a 1ms difference,
 // which could cause flake.
 grpc_millis NowFromCycleCounter() {
-  gpr_cycle_counter now = gpr_get_cycle_counter();
-  return grpc_cycle_counter_to_millis_round_up(now);
+  return grpc_timespec_to_millis_round_down(gpr_now(GPR_CLOCK_MONOTONIC));
 }
 
 // Returns the number of RPCs needed to pass error_tolerance at 99.99994%


### PR DESCRIPTION
`ExecCtx::Now` is rounding down:

https://github.com/grpc/grpc/blob/c5172a134ea4a8ba9e9615c4c5a4efa20f307fc1/src/core/lib/iomgr/exec_ctx.cc#L169

But the xDS test used to rounding up, causing this 1 millisecond difference.

Fixes b/185138304.

1000x on macOS with `opt`: https://source.cloud.google.com/results/invocations/a50ccb57-c68d-428c-8518-2287ba7a3ca1/targets