### PR TITLE
Log info about mac workers in the kokoro mac jobs.

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash
 # Copyright 2017 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -14,6 +14,18 @@
 # limitations under the License.
 # Source this rc script to prepare the environment for macos builds
 
+# Print basic info about the mac worker
+echo "kokoro pool: \"$KOKORO_JOB_POOL\""
+echo "OS: $(sw_vers -productName) $(sw_vers -productVersion) $(sw_vers -buildVersion)"
+echo "CPU type: $(sysctl -n machdep.cpu.brand_string)"
+echo "CPU: $(sysctl -n machdep.cpu.vendor) $(uname -m) Family $(sysctl -n machdep.cpu.family) Model $(sysctl -n machdep.cpu.brand_string)"
+echo "CPU Cores: $(sysctl -n hw.ncpu)"
+echo "Memory: $(sysctl -n hw.memsize)"
+
+# Info on disk usage and mounted volumes
+mount
+df -h /tmpfs /
+
 # show original open file limit values
 launchctl limit maxfiles
 ulimit -a


### PR DESCRIPTION
The logged info is going to be useful in migrating the mac workers to macservice.
