### PR TITLE
Added a double-call trap to closure

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -36,6 +36,14 @@ static void exec_ctx_run(grpc_closure* closure, grpc_error_handle error) {
             closure->run ? "run" : "scheduled", closure->file_initiated,
             closure->line_initiated);
   }
+  if (closure->called) {
+    gpr_log(GPR_ERROR, "double-call closure %p: created [%s:%d]: %s [%s:%d]",
+            closure, closure->file_created, closure->line_created,
+            closure->run ? "run" : "scheduled", closure->file_initiated,
+            closure->line_initiated);
+    abort();
+  }
+  closure->called = true;
 #endif
   closure->cb(closure->cb_arg, error);
 #ifndef NDEBUG

--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -119,6 +119,13 @@ size_t Executor::RunClosures(const char* executor_name,
     EXECUTOR_TRACE("(%s) run %p [created by %s:%d]", executor_name, c,
                    c->file_created, c->line_created);
     c->scheduled = false;
+    if (c->called) {
+      gpr_log(GPR_ERROR, "double-call closure %p: created [%s:%d]: %s [%s:%d]",
+              c, c->file_created, c->line_created, c->run ? "run" : "scheduled",
+              c->file_initiated, c->line_initiated);
+      abort();
+    }
+    c->called = true;
 #else
     EXECUTOR_TRACE("(%s) run %p", executor_name, c);
 #endif

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -280,6 +280,8 @@ static bool rq_reclaim(grpc_resource_quota* resource_quota, bool destructive);
 static void rq_step(void* rq, grpc_error_handle /*error*/) {
   grpc_resource_quota* resource_quota = static_cast<grpc_resource_quota*>(rq);
   resource_quota->step_scheduled = false;
+  GRPC_CLOSURE_INIT(&resource_quota->rq_step_closure, rq_step, resource_quota,
+                    nullptr);
   do {
     if (rq_alloc(resource_quota)) goto done;
   } while (rq_reclaim_from_per_user_free_pool(resource_quota));


### PR DESCRIPTION
Closure is supposed to be called once and it should be reinited to be used again. To prevent this, a new trap is added.