### PR TITLE
Fixup layering

### DIFF
--- a/src/core/lib/iomgr/iomgr.cc
+++ b/src/core/lib/iomgr/iomgr.cc
@@ -53,7 +53,9 @@ static bool g_grpc_abort_on_leaks;
 
 void grpc_iomgr_init() {
   grpc_core::ExecCtx exec_ctx;
-  grpc_determine_iomgr_platform();
+  if (!grpc_have_determined_iomgr_platform()) {
+    grpc_set_default_iomgr_platform();
+  }
   g_shutdown = 0;
   gpr_mu_init(&g_mu);
   gpr_cv_init(&g_rcv);

--- a/src/core/lib/iomgr/iomgr_internal.cc
+++ b/src/core/lib/iomgr/iomgr_internal.cc
@@ -24,14 +24,12 @@
 
 static grpc_iomgr_platform_vtable* iomgr_platform_vtable = nullptr;
 
-void grpc_set_iomgr_platform_vtable(grpc_iomgr_platform_vtable* vtable) {
-  iomgr_platform_vtable = vtable;
+bool grpc_have_determined_iomgr_platform() {
+  return iomgr_platform_vtable != nullptr;
 }
 
-void grpc_determine_iomgr_platform() {
-  if (iomgr_platform_vtable == nullptr) {
-    grpc_set_default_iomgr_platform();
-  }
+void grpc_set_iomgr_platform_vtable(grpc_iomgr_platform_vtable* vtable) {
+  iomgr_platform_vtable = vtable;
 }
 
 void grpc_iomgr_platform_init() { iomgr_platform_vtable->init(); }
@@ -53,3 +51,4 @@ bool grpc_iomgr_platform_add_closure_to_background_poller(
   return iomgr_platform_vtable->add_closure_to_background_poller(closure,
                                                                  error);
 }
+

--- a/src/core/lib/iomgr/iomgr_internal.h
+++ b/src/core/lib/iomgr/iomgr_internal.h
@@ -45,7 +45,7 @@ typedef struct grpc_iomgr_platform_vtable {
 void grpc_iomgr_register_object(grpc_iomgr_object* obj, const char* name);
 void grpc_iomgr_unregister_object(grpc_iomgr_object* obj);
 
-void grpc_determine_iomgr_platform();
+bool grpc_have_determined_iomgr_platform();
 
 void grpc_set_iomgr_platform_vtable(grpc_iomgr_platform_vtable* vtable);
 

--- a/test/core/iomgr/timer_list_test.cc
+++ b/test/core/iomgr/timer_list_test.cc
@@ -224,7 +224,7 @@ int main(int argc, char** argv) {
     grpc::testing::TestEnvironment env(argc, argv);
     grpc_core::ExecCtx::GlobalInit();
     grpc_core::ExecCtx exec_ctx;
-    grpc_determine_iomgr_platform();
+    grpc_set_default_iomgr_platform();
     grpc_iomgr_platform_init();
     gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
     add_test();
@@ -245,7 +245,7 @@ int main(int argc, char** argv) {
                                          gpr_clock_type::GPR_CLOCK_MONOTONIC));
     grpc_core::ExecCtx::TestOnlyGlobalInit(new_start);
     grpc_core::ExecCtx exec_ctx;
-    grpc_determine_iomgr_platform();
+    grpc_set_default_iomgr_platform();
     grpc_iomgr_platform_init();
     gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
     long_running_service_cleanup_test();

--- a/test/core/promise/exec_ctx_wakeup_scheduler_test.cc
+++ b/test/core/promise/exec_ctx_wakeup_scheduler_test.cc
@@ -57,9 +57,6 @@ TEST(ExecCtxWakeupSchedulerTest, Works) {
 
 }  // namespace grpc_core
 
-// Hook needed to run ExecCtx outside of iomgr.
-void grpc_set_default_iomgr_platform() {}
-
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc_core::ExecCtx::GlobalInit();


### PR DESCRIPTION
#27446 split some basics of iomgr into their own target, however this has caused the undesired effect of having to spray `grpc_set_default_iomgr_platform` all over the place in targets that use the lower level library, and worse - causes a select few builds to fail internally.

We don't actually need the calling function to live in iomgr_internal -- all we actually need is the null pointer check therein, so leave that piece, and then lift the setting out to the main iomgr lib.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
