### PR TITLE
increase windows C# basictests job timeout

### DIFF
--- a/tools/internal_ci/windows/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_csharp.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_csharp.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Look like the time to run C# win tests has increased over time (more code / dependencies?) and the jobs is now timing out frequently on both master and PRs.

Examples:
https://source.cloud.google.com/results/invocations/286f1f1b-3342-4ae0-b8ae-109bf06638ce
https://source.cloud.google.com/results/invocations/756e4434-7a7e-4a4b-9e0c-3d652dd8f9e9
https://source.cloud.google.com/results/invocations/7dab21f8-e361-49f3-b3d3-cf3397d10d69
https://source.cloud.google.com/results/invocations/53e8b07a-766a-47bb-aa3d-b60aa8dffef7

Increasing the jobs timeout is the quick fix. From the logs it didn't seem that there wasn't anything more suspicious going on (even the passing jobs are close to the 1hr timeout).