### PR TITLE
Fix stdout handling in jobset.py

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -357,7 +357,7 @@ class Job(object):
                 if measure_cpu_costs:
                     m = re.search(
                         r'real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)',
-                        strip_non_ascii_characters(stdout()).decode("ascii"))
+                        (stdout()).decode("utf8", errors="replace"))
                     real = float(m.group(1))
                     user = float(m.group(2))
                     sys = float(m.group(3))

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -357,7 +357,7 @@ class Job(object):
                 if measure_cpu_costs:
                     m = re.search(
                         r'real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)',
-                        stdout().decode("utf8"))
+                        strip_non_ascii_characters(stdout()).decode("ascii"))
                     real = float(m.group(1))
                     user = float(m.group(2))
                     sys = float(m.group(3))

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -357,7 +357,7 @@ class Job(object):
                 if measure_cpu_costs:
                     m = re.search(
                         r'real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)',
-                        stdout())
+                        stdout().decode("ascii"))
                     real = float(m.group(1))
                     user = float(m.group(2))
                     sys = float(m.group(3))

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -357,7 +357,7 @@ class Job(object):
                 if measure_cpu_costs:
                     m = re.search(
                         r'real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)',
-                        stdout().decode("ascii"))
+                        stdout().decode("utf8"))
                     real = float(m.group(1))
                     user = float(m.group(2))
                     sys = float(m.group(3))

--- a/tools/run_tests/python_utils/upload_test_results.py
+++ b/tools/run_tests/python_utils/upload_test_results.py
@@ -88,7 +88,7 @@ def _get_build_metadata(test_results):
 def _insert_rows_with_retries(bq, bq_table, bq_rows):
     """Insert rows to bq table. Retry on error."""
     # BigQuery sometimes fails with large uploads, so batch 1,000 rows at a time.
-    for i in range((len(bq_rows) / 1000) + 1):
+    for i in range((len(bq_rows) // 1000) + 1):
         max_retries = 3
         for attempt in range(max_retries):
             if big_query_utils.insert_rows(bq, _PROJECT_ID, _DATASET_ID,


### PR DESCRIPTION
Still trying to get the portability tests green.

This time, I'm fixing only the point that failed rather than assuming the text encoding of the standard output of any particular test. The only assumption I'm making is that log lines for CPU usage are in ASCII.

Context:
 - https://github.com/grpc/grpc/pull/27415
 - https://github.com/grpc/grpc/pull/27464
 - https://github.com/grpc/grpc/pull/27485

Manually Triggered Test Runs (still running):
 - [grpc_portability](https://sponge2.corp.google.com/a592d67b-7b5c-4d64-b5ad-1c682a0399fb)
 - [C++ Basic Tests Debug](https://sponge2.corp.google.com/880257e2-41f9-4bdb-b2af-5e4e8efc2f5c)