### PR TITLE
[objc] Clean pod cache in CI build and set verbose

### DIFF
--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -16,7 +16,7 @@
 # Don't run this script standalone. Instead, run from the repository root:
 # ./tools/run_tests/run_tests.py -l objc
 
-set -e
+set -ev
 
 # CocoaPods requires the terminal to be using UTF-8 encoding.
 export LANG=en_US.UTF-8
@@ -29,12 +29,20 @@ hash xcodebuild 2>/dev/null || {
     exit 1
 }
 
-# clean the directory
-rm -rf Pods
-rm -rf Tests.xcworkspace
-rm -f Podfile.lock
+# clean pod cache and prior pods
+rm -Rf Pods Podfile.lock Tests.xcworkspace
 rm -f RemoteTestClient/*.{h,m}
+pod cache clean --all
 
 echo "TIME:  $(date)"
-pod install | ./verbose_time.sh
+pod install --verbose | ./verbose_time.sh
 
+# verify pod header installation
+if [ -d "./Pods/Headers/Public/gRPC-Core/grpc/impl/codegen" ]
+then
+    echo "grpc/impl/codegen/ has been imported."
+    number_of_files=$(find Pods/Headers/Public/gRPC-Core/grpc/impl/codegen -name "*.h" | wc -l)
+    echo "The number of files in Pods/Headers/Public/gRPC-Core/grpc/impl/codegen/ is $number_of_files"
+else
+    echo "Error: grpc/impl/codegen/ hasn't been imported."
+fi

--- a/test/core/iomgr/ios/CFStreamTests/build_tests.sh
+++ b/test/core/iomgr/ios/CFStreamTests/build_tests.sh
@@ -16,7 +16,7 @@
 # Don't run this script standalone. Instead, run from the repository root:
 # ./tools/run_tests/run_tests.py -l objc
 
-set -e
+set -ev
 
 # CocoaPods requires the terminal to be using UTF-8 encoding.
 export LANG=en_US.UTF-8
@@ -29,19 +29,18 @@ hash xcodebuild 2>/dev/null || {
     exit 1
 }
 
-# clean the directory
-rm -rf Pods
-rm -rf CFStreamTests.xcworkspace
-rm -f Podfile.lock
+# clean up pod cache and existing pods
+rm -Rf Pods Podfile.lock CFStreamTests.xcworkspace
+pod cache clean --all
 
 echo "TIME:  $(date)"
-pod install
+pod install --verbose
 
 # ios-test-cfstream-tests flakes sometimes because of missing files in gRPC-Core,
 # add some log to help find out the root cause.
 # TODO(yulinliang): Delete it after solving the issue.
 if [ -d "./Pods/Headers/Public/gRPC-Core/grpc/impl/codegen" ]
-then 
+then
     echo "grpc/impl/codegen/ has been imported."
     number_of_files=$(find Pods/Headers/Public/gRPC-Core/grpc/impl/codegen -name "*.h" | wc -l)
     echo "The number of files in Pods/Headers/Public/gRPC-Core/grpc/impl/codegen/ is $number_of_files"


### PR DESCRIPTION
A number of build script changes to help debugging build flake and missing header issues 
 * Making sure pod cache is cleared prior to CI build. 
 * Turn on verbose pod install mod
 * Verify Pod headers are present prior to build start 
 