### PR TITLE
Add python_requires >=3.6 to grpcio-* packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -536,6 +536,7 @@ setuptools.setup(
     packages=list(PACKAGES),
     package_dir=PACKAGE_DIRECTORIES,
     package_data=PACKAGE_DATA,
+    python_requires='>=3.6',
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRES,
     setup_requires=SETUP_REQUIRES,

--- a/src/python/grpcio_admin/setup.py
+++ b/src/python/grpcio_admin/setup.py
@@ -55,5 +55,6 @@ setuptools.setup(name='grpcio-admin',
                  url='https://grpc.io',
                  package_dir=PACKAGE_DIRECTORIES,
                  packages=setuptools.find_packages('.'),
+                 python_requires='>=3.6',
                  install_requires=INSTALL_REQUIRES,
                  setup_requires=SETUP_REQUIRES)

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -98,6 +98,7 @@ setuptools.setup(
     url='https://grpc.io',
     package_dir=PACKAGE_DIRECTORIES,
     packages=setuptools.find_packages('.'),
+    python_requires='>=3.6',
     install_requires=INSTALL_REQUIRES,
     setup_requires=SETUP_REQUIRES,
     cmdclass=COMMAND_CLASS)

--- a/src/python/grpcio_csds/setup.py
+++ b/src/python/grpcio_csds/setup.py
@@ -56,5 +56,6 @@ setuptools.setup(name='grpcio-csds',
                  url='https://grpc.io',
                  package_dir=PACKAGE_DIRECTORIES,
                  packages=setuptools.find_packages('.'),
+                 python_requires='>=3.6',
                  install_requires=INSTALL_REQUIRES,
                  setup_requires=SETUP_REQUIRES)

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -96,6 +96,7 @@ setuptools.setup(name='grpcio-health-checking',
                  classifiers=CLASSIFIERS,
                  package_dir=PACKAGE_DIRECTORIES,
                  packages=setuptools.find_packages('.'),
+                 python_requires='>=3.6',
                  install_requires=INSTALL_REQUIRES,
                  setup_requires=SETUP_REQUIRES,
                  cmdclass=COMMAND_CLASS)

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -97,6 +97,7 @@ setuptools.setup(name='grpcio-reflection',
                  url='https://grpc.io',
                  package_dir=PACKAGE_DIRECTORIES,
                  packages=setuptools.find_packages('.'),
+                 python_requires='>=3.6',
                  install_requires=INSTALL_REQUIRES,
                  setup_requires=SETUP_REQUIRES,
                  cmdclass=COMMAND_CLASS)

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -94,5 +94,6 @@ setuptools.setup(name='grpcio-status',
                  classifiers=CLASSIFIERS,
                  package_dir=PACKAGE_DIRECTORIES,
                  packages=setuptools.find_packages('.'),
+                 python_requires='>=3.6',
                  install_requires=INSTALL_REQUIRES,
                  cmdclass=COMMAND_CLASS)

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -288,6 +288,7 @@ setuptools.setup(name='grpcio-tools',
                  classifiers=CLASSIFIERS,
                  ext_modules=extension_modules(),
                  packages=setuptools.find_packages('.'),
+                 python_requires='>=3.6',
                  install_requires=[
                      'protobuf>=3.5.0.post1, < 4.0dev',
                      'grpcio>={version}'.format(version=grpc_version.VERSION),

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',
     license='Apache License 2.0',
+    python_requires='>=3.6',
     install_requires=INSTALL_REQUIRES,
     setup_requires=SETUP_REQUIRES,
     classifiers=CLASSIFIERS)

--- a/tools/dockerfile/distribtest/python_dev_buster_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_buster_x64/Dockerfile
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM i386/debian:jessie
+FROM debian:buster
 
 RUN apt-get update && apt-get install -y python3 python3-pip
-
 RUN pip3 install virtualenv==16.7.9
 
 RUN apt-get install -y build-essential
 RUN apt-get install -y python3-dev
-
-# docker is running on a 64-bit machine, so we need to
-# override "uname -m" to report i686 instead of x86_64, otherwise
-# python will choose a wrong binary package to install.
-ENTRYPOINT ["linux32"]

--- a/tools/dockerfile/distribtest/python_dev_buster_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_buster_x86/Dockerfile
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM i386/debian:buster
 
 RUN apt-get update && apt-get install -y python3 python3-pip
+
 RUN pip3 install virtualenv==16.7.9
 
 RUN apt-get install -y build-essential
 RUN apt-get install -y python3-dev
+
+# docker is running on a 64-bit machine, so we need to
+# override "uname -m" to report i686 instead of x86_64, otherwise
+# python will choose a wrong binary package to install.
+ENTRYPOINT ["linux32"]

--- a/tools/dockerfile/distribtest/python_dev_fedora34_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_fedora34_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2021 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:23
+FROM fedora:34
 
 RUN yum clean all && yum update -y && yum install -y python3 python3-pip
 RUN pip3 install virtualenv==16.7.9

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -353,10 +353,10 @@ def targets():
         PythonDistribTest('linux', 'x64', 'ubuntu1804'),
         PythonDistribTest('linux', 'aarch64', 'python38_buster'),
         PythonDistribTest('linux', 'x64', 'alpine3.7', source=True),
-        PythonDistribTest('linux', 'x64', 'jessie', source=True),
-        PythonDistribTest('linux', 'x86', 'jessie', source=True),
+        PythonDistribTest('linux', 'x64', 'buster', source=True),
+        PythonDistribTest('linux', 'x86', 'buster', source=True),
         PythonDistribTest('linux', 'x64', 'centos7', source=True),
-        PythonDistribTest('linux', 'x64', 'fedora23', source=True),
+        PythonDistribTest('linux', 'x64', 'fedora34', source=True),
         PythonDistribTest('linux', 'x64', 'arch', source=True),
         PythonDistribTest('linux', 'x64', 'ubuntu1804', source=True),
         # Ruby

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -675,9 +675,7 @@ class PythonLanguage(object):
 
     def _python_manager_name(self):
         """Choose the docker image to use based on python version."""
-        if self.args.compiler in [
-                'python2.7', 'python3.5', 'python3.6', 'python3.7', 'python3.8'
-        ]:
+        if self.args.compiler in ['python3.6', 'python3.7', 'python3.8']:
             return 'stretch_' + self.args.compiler[len('python'):]
         elif self.args.compiler == 'python_alpine':
             return 'alpine'
@@ -729,16 +727,6 @@ class PythonLanguage(object):
                                         builder_prefix_arguments,
                                         venv_relative_python, toolchain, runner,
                                         test_command, args.iomgr_platform)
-        python27_config = _python_config_generator(name='py27',
-                                                   major='2',
-                                                   minor='7',
-                                                   bits=bits,
-                                                   config_vars=config_vars)
-        python35_config = _python_config_generator(name='py35',
-                                                   major='3',
-                                                   minor='5',
-                                                   bits=bits,
-                                                   config_vars=config_vars)
         python36_config = _python_config_generator(name='py36',
                                                    major='3',
                                                    minor='6',
@@ -791,14 +779,9 @@ class PythonLanguage(object):
                     return (python38_config,)
                 else:
                     return (
-                        python35_config,
                         python37_config,
                         python38_config,
                     )
-        elif args.compiler == 'python2.7':
-            return (python27_config,)
-        elif args.compiler == 'python3.5':
-            return (python35_config,)
         elif args.compiler == 'python3.6':
             return (python36_config,)
         elif args.compiler == 'python3.7':
@@ -815,8 +798,6 @@ class PythonLanguage(object):
             return (python38_config,)
         elif args.compiler == 'all_the_cpythons':
             return (
-                python27_config,
-                python35_config,
                 python36_config,
                 python37_config,
                 python38_config,


### PR DESCRIPTION
The origin of this PR: https://github.com/grpc/grpc/issues/27284#issuecomment-928271816

This PR would explicitly tell `pip` to not pull a specific version of grpcio for older Pythons (2.7, 3.5). This should reduce the chance for users to accidental compile gRPC from source. This PR also updated:

- The supported Python versions in run_tests.py, since it always use setuptools to compile;
- The compile from source distribution base images (removed jessie 64/32, and old fedora; added buster 64/32, and fedora34)