### PR TITLE
Upgrade re2 to fix broken template on gcc-11.

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -260,11 +260,11 @@ def grpc_deps():
     if "com_googlesource_code_re2" not in native.existing_rules():
         http_archive(
             name = "com_googlesource_code_re2",
-            sha256 = "9f385e146410a8150b6f4cb1a57eab7ec806ced48d427554b1e754877ff26c3e",
-            strip_prefix = "re2-aecba11114cf1fac5497aeb844b6966106de3eb6",
+            sha256 = "2d3a852e4fe540f7918f501af2ec5af8daeb3eb17a6a2c644f3e6fde552fd557",
+            strip_prefix = "re2-123d379e288f3c113c26dca952d78ad5f4fc98fd",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/re2/archive/aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz",
-                "https://github.com/google/re2/archive/aecba11114cf1fac5497aeb844b6966106de3eb6.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/re2/archive/123d379e288f3c113c26dca952d78ad5f4fc98fd.tar.gz",
+                "https://github.com/google/re2/archive/123d379e288f3c113c26dca952d78ad5f4fc98fd.tar.gz",
             ],
         )
 


### PR DESCRIPTION
The fix to re2 was made here:
https://github.com/google/re2/commit/0ceda876185ab8675a57b557413efb4c3aa8a79b

The compiler error has been reproduced below:

```
...
  /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF bazel-out/k8-fastbuild/bin/external/com_googlesource_code_re2/_objs/re2/parse.pic.d '-frandom-seed=bazel-out/k8-fastbuild/bin/external/com_googlesource_code_re2/_objs/re2/parse.pic.o' -fPIC -iquote external/com_googlesource_code_re2 -iquote bazel-out/k8-fastbuild/bin/external/com_googlesource_code_re2 '-DHAVE_BAZEL_BUILD=1' '-std=c++2a' -Wall -Wreturn-type -Wuninitialized -Wunused-result '-Werror=narrowing' '-Werror=reorder' -Wunused-local-typedefs '-Werror=conversion-null' '-Werror=overlength-strings' '-Werror=pointer-arith' '-Werror=varargs' '-Werror=vla' '-Werror=write-strings' -Wmissing-declarations '-fdiagnostics-color=always' -pthread -fno-canonical-system-headers -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -c external/com_googlesource_code_re2/re2/parse.cc -o bazel-out/k8-fastbuild/bin/external/com_googlesource_code_re2/_objs/re2/parse.pic.o)
Execution platform: @local_config_platform//:host
In file included from external/com_googlesource_code_re2/re2/parse.cc:37:
external/com_googlesource_code_re2/re2/walker-inl.h:122:22: error: expected ')' before '*' token
  122 |   WalkState<T>(Regexp* re, T parent)
      |               ~      ^
      |                      )
```

@donnadionne
