### PR TITLE
Bazel distribtest fixes

### DIFF
--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -42,4 +42,6 @@ EXCLUDED_TARGETS=(
 )
 
 export OVERRIDE_BAZEL_VERSION="$VERSION"
+# when running under bazel docker image, the workspace is read only.
+export OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp
 bazel build -- //... "${EXCLUDED_TARGETS[@]}"

--- a/tools/bazel
+++ b/tools/bazel
@@ -49,7 +49,8 @@ echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version
 BASEURL_MIRROR="https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/bazel/releases/download"
 BASEURL="https://github.com/bazelbuild/bazel/releases/download"
 pushd "$(dirname "$0")" >/dev/null
-TOOLDIR=$(pwd)
+# bazel binary will be downloaded to GRPC_REPO_ROOT/tools directory by default
+DOWNLOAD_DIR=${OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR:-$(pwd)}
 
 case $(uname -sm) in
   "Linux x86_64")
@@ -68,13 +69,14 @@ case $(uname -sm) in
 esac
 
 filename="bazel-$VERSION-$suffix"
+filename_abs="${DOWNLOAD_DIR}/${filename}"
 
-if [ ! -x "$filename" ] ; then
+if [ ! -x "${filename_abs}" ] ; then
   # first try to download using mirror, fallback to download from github
   echo "Downloading bazel, will try URLs: ${BASEURL_MIRROR}/${VERSION}/${filename} ${BASEURL}/${VERSION}/${filename}" >&2
-  curl --fail -L --output "${filename}" "${BASEURL_MIRROR}/${VERSION}/${filename}" || curl --fail -L --output "${filename}" "${BASEURL}/${VERSION}/${filename}"
-  chmod a+x "$filename"
+  curl --fail -L --output "${filename_abs}" "${BASEURL_MIRROR}/${VERSION}/${filename}" || curl --fail -L --output "${filename_abs}" "${BASEURL}/${VERSION}/${filename}"
+  chmod a+x "${filename_abs}"
 fi
 
 popd >/dev/null
-exec "$TOOLDIR/$filename" "$@"
+exec "${filename_abs}" "$@"

--- a/tools/bazel
+++ b/tools/bazel
@@ -25,7 +25,7 @@
 set -e
 
 # DISABLE_BAZEL_WRAPPER can be set to eliminate the wrapper logic
-if [ "${DISABLE_BAZEL_WRAPPER}" != "" ]
+if [ "${DISABLE_BAZEL_WRAPPER}" != "" ] && [ "${OVERRIDE_BAZEL_VERSION}" == "" ]
 then
   if [ "${BAZEL_REAL}" != "" ]
   then

--- a/tools/internal_ci/linux/grpc_bazel_distribtest.sh
+++ b/tools/internal_ci/linux/grpc_bazel_distribtest.sh
@@ -22,4 +22,6 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-./test/distrib/bazel/run_bazel_distrib_test.sh
+export DOCKERFILE_DIR=tools/dockerfile/test/bazel
+export DOCKER_RUN_SCRIPT=test/distrib/bazel/run_bazel_distrib_test.sh
+exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_bazel_distribtest_latest.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_distribtest_latest.cfg
@@ -15,7 +15,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "tools/internal_ci/linux/grpc_bazel_distribtest_latest.sh"
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel_distribtest_latest.sh"
 timeout_mins: 120
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/grpc_bazel_distribtest_latest.sh
+++ b/tools/internal_ci/linux/grpc_bazel_distribtest_latest.sh
@@ -22,4 +22,6 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-./test/distrib/bazel/test_latest_bazel_version.sh
+export DOCKERFILE_DIR=tools/dockerfile/test/bazel
+export DOCKER_RUN_SCRIPT=/test/distrib/bazel/test_latest_bazel_version.sh
+exec tools/run_tests/dockerize/build_and_run_docker.sh


### PR DESCRIPTION
- bazel distribtests need to run under docker since on bare kokoro workers, some prerequisites are missing.

https://source.cloud.google.com/results/invocations/38c35215-68ad-43f2-9750-d5235d65b7d2/log
