### PR TITLE
Port compute_api_version to other TD implementations

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -556,12 +556,14 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
                  *,
                  resource_prefix: str,
                  resource_suffix: Optional[str] = None,
-                 network: str = 'default'):
+                 network: str = 'default',
+                 compute_api_version: str = 'v1'):
         super().__init__(gcp_api_manager,
                          project,
                          resource_prefix=resource_prefix,
                          resource_suffix=resource_suffix,
-                         network=network)
+                         network=network,
+                         compute_api_version=compute_api_version)
 
         # API
         self.netsvc = _NetworkServicesV1Alpha1(gcp_api_manager, project)
@@ -656,12 +658,14 @@ class TrafficDirectorSecureManager(TrafficDirectorManager):
         resource_prefix: str,
         resource_suffix: Optional[str] = None,
         network: str = 'default',
+        compute_api_version: str = 'v1',
     ):
         super().__init__(gcp_api_manager,
                          project,
                          resource_prefix=resource_prefix,
                          resource_suffix=resource_suffix,
-                         network=network)
+                         network=network,
+                         compute_api_version=compute_api_version)
 
         # API
         self.netsec = _NetworkSecurityV1Beta1(gcp_api_manager, project)


### PR DESCRIPTION
As title. Fixes b/201535750.

Test run (xds_k8s): https://fusion2.corp.google.com/invocations/35b157cb-a4d9-42d2-9520-92d148c36d7a/targets