### PR TITLE
xds-k8s/xlang: switch to testing v1.41.x from v1.40.x

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh
@@ -25,7 +25,7 @@ readonly GKE_CLUSTER_ZONE="us-central1-a"
 readonly IMAGE_REPO="gcr.io/grpc-testing/xds-interop"
 readonly SERVER_LANG="cpp go java"
 readonly CLIENT_LANG="cpp go java"
-readonly VERSION_TAG="v1.40.x"
+readonly VERSION_TAG="v1.41.x"
 
 #######################################
 # Executes the test case


### PR DESCRIPTION
Note:
- instead of adding v1.41.x we just replace v1.40.x with v1.41.x since we are *not* interested in testing v1.40.x for cross-lang
- this PR is needed for the upcoming release so is not subject to the recent freeze directive