### PR TITLE
Upgrade PHP7 docker image to use Debian 9

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../debian_8_header.include"/>
+  <%include file="../../debian_9_header.include"/>
   
   <%include file="../../php7_deps.include"/>
   <%include file="../../run_tests_addons.include"/>

--- a/templates/tools/dockerfile/php7_deps.include
+++ b/templates/tools/dockerfile/php7_deps.include
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y ${'\\'}
   ccache ${'\\'}
   curl ${'\\'}
   git ${'\\'}
+  libbison-dev ${'\\'}
   libcurl4-openssl-dev ${'\\'}
   libgmp-dev ${'\\'}
   libgmp3-dev ${'\\'}
@@ -20,17 +21,8 @@ RUN apt-get update && apt-get install -y ${'\\'}
   time ${'\\'}
   unzip ${'\\'}
   wget ${'\\'}
+  zip ${'\\'}
   zlib1g-dev && apt-get clean
-
-# Install other dependencies
-RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz -O /var/local/bison-3.4.2.tar.gz
-RUN cd /var/local ${'\\'}
-  && tar -zxvf bison-3.4.2.tar.gz ${'\\'}
-  && cd /var/local/bison-3.4.2 ${'\\'}
-  && ./configure ${'\\'}
-  && make -j4 ${'\\'}
-  && make install
 
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
@@ -41,5 +33,5 @@ RUN cd /var/local/git/php-src ${'\\'}
   --with-gmp ${'\\'}
   --with-openssl ${'\\'}
   --with-zlib ${'\\'}
-  && make -j4 ${'\\'}
+  && make -j$(nproc) ${'\\'}
   && make install

--- a/templates/tools/dockerfile/php7_deps.include
+++ b/templates/tools/dockerfile/php7_deps.include
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y ${'\\'}
   time ${'\\'}
   unzip ${'\\'}
   wget ${'\\'}
-  zip && apt-get clean
+  zlib1g-dev && apt-get clean
 
 # Install other dependencies
 RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
@@ -29,17 +29,17 @@ RUN cd /var/local ${'\\'}
   && tar -zxvf bison-3.4.2.tar.gz ${'\\'}
   && cd /var/local/bison-3.4.2 ${'\\'}
   && ./configure ${'\\'}
-  && make ${'\\'}
+  && make -j4 ${'\\'}
   && make install
 
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
 RUN cd /var/local/git/php-src ${'\\'}
-  && git checkout PHP-7.2.22 ${'\\'}
+  && git checkout PHP-7.2.34 ${'\\'}
   && ./buildconf --force ${'\\'}
   && ./configure ${'\\'}
   --with-gmp ${'\\'}
   --with-openssl ${'\\'}
   --with-zlib ${'\\'}
-  && make ${'\\'}
+  && make -j4 ${'\\'}
   && make install

--- a/templates/tools/dockerfile/test/php7_debian9_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php7_debian9_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../debian_8_header.include"/>
+  <%include file="../../debian_9_header.include"/>
   
   <%include file="../../php7_deps.include"/>
   <%include file="../../python_deps.include"/>

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:8
+FROM debian:9
 
 
 #=================
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
   time \
   unzip \
   wget \
-  zip && apt-get clean
+  zlib1g-dev && apt-get clean
 
 # Install other dependencies
 RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
@@ -46,19 +46,19 @@ RUN cd /var/local \
   && tar -zxvf bison-3.4.2.tar.gz \
   && cd /var/local/bison-3.4.2 \
   && ./configure \
-  && make \
+  && make -j4 \
   && make install
 
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
 RUN cd /var/local/git/php-src \
-  && git checkout PHP-7.2.22 \
+  && git checkout PHP-7.2.34 \
   && ./buildconf --force \
   && ./configure \
   --with-gmp \
   --with-openssl \
   --with-zlib \
-  && make \
+  && make -j4 \
   && make install
 
 

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
   ccache \
   curl \
   git \
+  libbison-dev \
   libcurl4-openssl-dev \
   libgmp-dev \
   libgmp3-dev \
@@ -37,17 +38,8 @@ RUN apt-get update && apt-get install -y \
   time \
   unzip \
   wget \
+  zip \
   zlib1g-dev && apt-get clean
-
-# Install other dependencies
-RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz -O /var/local/bison-3.4.2.tar.gz
-RUN cd /var/local \
-  && tar -zxvf bison-3.4.2.tar.gz \
-  && cd /var/local/bison-3.4.2 \
-  && ./configure \
-  && make -j4 \
-  && make install
 
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
@@ -58,7 +50,7 @@ RUN cd /var/local/git/php-src \
   --with-gmp \
   --with-openssl \
   --with-zlib \
-  && make -j4 \
+  && make -j$(nproc) \
   && make install
 
 

--- a/tools/dockerfile/test/php7_debian9_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_debian9_x64/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
   ccache \
   curl \
   git \
+  libbison-dev \
   libcurl4-openssl-dev \
   libgmp-dev \
   libgmp3-dev \
@@ -37,17 +38,8 @@ RUN apt-get update && apt-get install -y \
   time \
   unzip \
   wget \
+  zip \
   zlib1g-dev && apt-get clean
-
-# Install other dependencies
-RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
-RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz -O /var/local/bison-3.4.2.tar.gz
-RUN cd /var/local \
-  && tar -zxvf bison-3.4.2.tar.gz \
-  && cd /var/local/bison-3.4.2 \
-  && ./configure \
-  && make -j4 \
-  && make install
 
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
@@ -58,7 +50,7 @@ RUN cd /var/local/git/php-src \
   --with-gmp \
   --with-openssl \
   --with-zlib \
-  && make -j4 \
+  && make -j$(nproc) \
   && make install
 
 #====================

--- a/tools/dockerfile/test/php7_debian9_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_debian9_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:8
+FROM debian:9
 
 
 #=================
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y \
   time \
   unzip \
   wget \
-  zip && apt-get clean
+  zlib1g-dev && apt-get clean
 
 # Install other dependencies
 RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
@@ -46,19 +46,19 @@ RUN cd /var/local \
   && tar -zxvf bison-3.4.2.tar.gz \
   && cd /var/local/bison-3.4.2 \
   && ./configure \
-  && make \
+  && make -j4 \
   && make install
 
 # Compile PHP7 from source
 RUN git clone https://github.com/php/php-src /var/local/git/php-src
 RUN cd /var/local/git/php-src \
-  && git checkout PHP-7.2.22 \
+  && git checkout PHP-7.2.34 \
   && ./buildconf --force \
   && ./configure \
   --with-gmp \
   --with-openssl \
   --with-zlib \
-  && make \
+  && make -j4 \
   && make install
 
 #====================

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -590,7 +590,7 @@ class Php7Language(object):
         return 'Makefile'
 
     def dockerfile_dir(self):
-        return 'tools/dockerfile/test/php7_jessie_%s' % _docker_arch_suffix(
+        return 'tools/dockerfile/test/php7_debian9_%s' % _docker_arch_suffix(
             self.args.arch)
 
     def __str__(self):


### PR DESCRIPTION
Currently PHP7 docker image are based on Debian 8 which hit EOL last yest and PHP7 CI tests seems to be off recently by having a segment fault while gcc are compiling sources. So Let's upgrade it to use Debian 9 and the latest PHP 7.2.34.