### PR TITLE
[xDS Interop] Remove sleep between configure and send

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -437,8 +437,6 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
         test_client.update_config.configure(rpc_types=rpc_types,
                                             metadata=metadata,
                                             app_timeout=app_timeout)
-        # Configure RPC might race with get stats RPC on slower machines.
-        time.sleep(_CLIENT_CONFIGURE_WAIT_SEC)
         json_lb_stats = json_format.MessageToDict(
             test_client.get_load_balancer_stats(num_rpcs=num_rpcs))
         logging.info(


### PR DESCRIPTION
This sleep is used to prevent a racey behavior found during the initial edition of xDS url-map tests. See https://github.com/grpc/grpc-java/issues/8213.

The root cause is still unclear. Preparing this PR, in case, we are not exposed to the race anymore.