### PR TITLE
gtest-ify credentials_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,7 +711,6 @@ if(gRPC_BUILD_TESTS)
   endif()
   add_dependencies(buildtests_c test_core_gpr_time_test)
   add_dependencies(buildtests_c test_core_iomgr_resource_quota_test)
-  add_dependencies(buildtests_c test_core_security_credentials_test)
   add_dependencies(buildtests_c test_core_slice_slice_test)
   add_dependencies(buildtests_c thd_test)
   add_dependencies(buildtests_c threadpool_test)
@@ -995,6 +994,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx string_ref_test)
   add_dependencies(buildtests_cxx table_test)
   add_dependencies(buildtests_cxx test_core_resource_quota_resource_quota_test)
+  add_dependencies(buildtests_cxx test_core_security_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_client_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_server_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_util_slice_test)
@@ -7390,33 +7390,6 @@ target_include_directories(test_core_iomgr_resource_quota_test
 )
 
 target_link_libraries(test_core_iomgr_resource_quota_test
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-)
-
-
-endif()
-if(gRPC_BUILD_TESTS)
-
-add_executable(test_core_security_credentials_test
-  test/core/security/credentials_test.cc
-)
-
-target_include_directories(test_core_security_credentials_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-)
-
-target_link_libraries(test_core_security_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
 )
@@ -16114,6 +16087,41 @@ target_link_libraries(test_core_resource_quota_resource_quota_test
   absl::statusor
   absl::variant
   gpr
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(test_core_security_credentials_test
+  test/core/security/credentials_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(test_core_security_credentials_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(test_core_security_credentials_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4176,14 +4176,6 @@ targets:
   - test/core/iomgr/resource_quota_test.cc
   deps:
   - grpc_test_util
-- name: test_core_security_credentials_test
-  build: test
-  language: c
-  headers: []
-  src:
-  - test/core/security/credentials_test.cc
-  deps:
-  - grpc_test_util
 - name: test_core_slice_slice_test
   build: test
   language: c
@@ -7952,6 +7944,15 @@ targets:
   - absl/types:variant
   - gpr
   uses_polling: false
+- name: test_core_security_credentials_test
+  gtest: true
+  build: test
+  language: c++
+  headers: []
+  src:
+  - test/core/security/credentials_test.cc
+  deps:
+  - grpc_test_util
 - name: test_cpp_client_credentials_test
   gtest: true
   build: test

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -88,6 +88,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "credentials_test",
     srcs = ["credentials_test.cc"],
+    external_deps = ["gtest"],
     language = "C++",
     deps = [
         "//:gpr",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -2806,30 +2806,6 @@
     "flaky": false,
     "gtest": false,
     "language": "c",
-    "name": "test_core_security_credentials_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": false,
-    "language": "c",
     "name": "test_core_slice_slice_test",
     "platforms": [
       "linux",
@@ -7078,6 +7054,30 @@
       "windows"
     ],
     "uses_polling": false
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
+    "name": "test_core_security_credentials_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
   },
   {
     "args": [],


### PR DESCRIPTION
This is a pulled-over part from https://github.com/grpc/grpc/pull/27466. This gtestification causes OSX to have an error as follows.

[log](https://source.cloud.google.com/results/invocations/853921dd-8d61-455b-b681-5668a3bb6698/targets/github%2Fgrpc%2Frun_tests%2Fcpp_macos_dbg_native/tests).

```
[ RUN      ] CredentialsTest.google_default_creds_external_account_credentials
I0928 17:37:17.688600000 4388369856 check_gcp_environment_no_op.cc:28] ALTS: Platforms other than Linux and Windows are not supported
E0928 17:37:17.699525000 4388369856 google_default_credentials.cc:429] Could not create google default credentials: {"created":"@1632875837.688407000","description":"Invalid external account credentials format.","file":"/Volumes/BuildData/tmpfs/src/github/grpc/workspace_c++_macos_dbg_native/src/core/lib/security/credentials/google_default/google_default_credentials.cc","file_line":327,"referenced_errors":[{"created":"@1632875837.688592000","description":"Failed to load file","file":"/Volumes/BuildData/tmpfs/src/github/grpc/workspace_c++_macos_dbg_native/src/core/lib/iomgr/load_file.cc","file_line":72,"filename":"/Users/kbuilder/.config/gcloud/application_default_credentials.json","referenced_errors":[{"created":"@1632875837.688583000","description":"No such file or directory","errno":2,"file":"/Volumes/BuildData/tmpfs/src/github/grpc/workspace_c++_macos_dbg_native/src/core/lib/iomgr/load_file.cc","file_line":45,"os_error":"No such file or directory","syscall":"fopen"}]}]}
*** SIGSEGV received at time=1632875837 ***
PC: @        0x1021fcf8c  (unknown)  grpc_core::RefCountedPtr<>::get()
```