### PR TITLE
Fix load test name format for more than 10 runs per test.

### DIFF
--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -112,7 +112,7 @@ def gen_run_indices(runs_per_test: int) -> Iterable[str]:
         yield ''
         return
     prefix_length = len('{:d}'.format(runs_per_test - 1))
-    prefix_fmt = '{{:{:d}d}}'.format(prefix_length)
+    prefix_fmt = '{{:0{:d}d}}'.format(prefix_length)
     for i in range(runs_per_test):
         yield prefix_fmt.format(i)
 


### PR DESCRIPTION
Index in test name must be '016' rather than ' 16'.
