### PR TITLE
Add podspec for libuv-grpc

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -178,6 +178,7 @@ Pod::Spec.new do |s|
     ss.libraries = 'z'
     ss.dependency "#{s.name}/Interface", version
     ss.dependency 'BoringSSL-GRPC', '0.0.20'
+    ss.dependency 'Libuv-gRPC'
     ss.dependency 'abseil/base/base', abseil_version
     ss.dependency 'abseil/base/core_headers', abseil_version
     ss.dependency 'abseil/container/flat_hash_map', abseil_version
@@ -2285,6 +2286,7 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-END_OF_COMMAND
     set -e
     find src/core -type f \\( -path '*.h' -or -path '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/(.*)>;#if COCOAPODS==1\\\n  #include <openssl_grpc/\\1>\\\n#else\\\n  #include <openssl/\\1>\\\n#endif;g'
+    find src/core -type f \\( -path '*.h' -or -path '*.cc' -or -path '*.c' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <uv.h>;#if COCOAPODS==1\\\n  #include <uv/uv.h>\\\n#else\\\n  #include  <uv.h>\\\n#endif;g'
     find third_party/upb/ -type f \\( -name '*.h' -or -name '*.hpp' -or -name '*.c' -or -name '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "third_party/(.*)";#if COCOAPODS==1\\\n  #include  "third_party/upb/third_party/\\1"\\\n#else\\\n  #include  "third_party/\\1"\\\n#endif;g'
     find src/core/ src/cpp/ third_party/upb/ -type f \\( -name '*.h' -or -name '*.hpp' -or -name '*.c' -or -name '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "upb/(.*)";#if COCOAPODS==1\\\n  #include  "third_party/upb/upb/\\1"\\\n#else\\\n  #include  "upb/\\1"\\\n#endif;g'
     find src/core/ src/cpp/ third_party/upb/ -type f -name '*.grpc_back' -print0 | xargs -0 rm

--- a/src/objective-c/Libuv-gRPC.podspec
+++ b/src/objective-c/Libuv-gRPC.podspec
@@ -1,0 +1,157 @@
+# This file has been automatically generated from a template file.
+# Please make modifications to
+# `templates/src/objective-c/libuv-gRPC.podspec.template` instead. This
+# file can be regenerated from the template by running
+# `tools/buildgen/generate_projects.sh`.
+
+# Libuv CocoaPods podspec
+
+# Copyright 2021, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Pod::Spec.new do |spec|
+
+  pod_version           = "0.0.6"
+  libuv_version         = "1.34.0"
+
+  spec.name         = "Libuv-gRPC"
+  spec.version      = pod_version
+  spec.summary      = "Cross-platform asynchronous I/O"
+
+  spec.description  = <<-DESC
+    libuv is a multi-platform support library with a focus on asynchronous I/O.
+    It was primarily developed for use by Node.js, but it's also used by Luvit,
+    Julia, pyuv, and others.
+  DESC
+
+  spec.homepage     = "https://libuv.org/"
+
+  spec.license  = { :type => 'Mixed', :file => 'LICENSE' }
+  spec.author    = "libuv"
+
+  # When using multiple platforms
+  spec.ios.deployment_target = '9.0'
+  spec.osx.deployment_target = '10.10'
+  spec.tvos.deployment_target = '10.0'
+  spec.watchos.deployment_target = '4.0'
+
+  spec.source       = { :git => "https://github.com/libuv/libuv.git", :tag => "v#{libuv_version}" }
+
+  name = 'uv'
+  spec.module_name = name
+  spec.header_mappings_dir = 'include'
+  spec.header_dir = name
+
+  spec.subspec 'Interface' do |ss|
+    ss.header_mappings_dir = 'include'
+    ss.source_files = "include/uv.h",
+                      "include/uv/errno.h",
+                      "include/uv/threadpool.h",
+                      "include/uv/version.h",
+                      "include/uv/tree.h",
+                      "include/uv/unix.h",
+                      "include/uv/darwin.h"
+  end
+
+  spec.subspec 'Implementation' do |ss|
+    ss.header_mappings_dir = 'src'
+    ss.source_files =
+    "src/fs-poll.c",
+    "src/idna.c",
+    "src/inet.c",
+    "src/strscpy.c",
+    "src/threadpool.c",
+    "src/timer.c",
+    "src/uv-data-getter-setters.c",
+    "src/uv-common.c",
+    "src/version.c",
+    "src/unix/async.c",
+    "src/unix/core.c",
+    "src/unix/dl.c",
+    "src/unix/fs.c",
+    "src/unix/getaddrinfo.c",
+    "src/unix/getnameinfo.c",
+    "src/unix/loop.c",
+    "src/unix/loop-watcher.c",
+    "src/unix/pipe.c",
+    "src/unix/poll.c",
+    "src/unix/process.c",
+    "src/unix/signal.c",
+    "src/unix/stream.c",
+    "src/unix/tcp.c",
+    "src/unix/thread.c",
+    "src/unix/tty.c",
+    "src/unix/udp.c",
+    "src/unix/bsd-ifaddrs.c",
+    "src/unix/darwin.c",
+    "src/unix/fsevents.c",
+    "src/unix/kqueue.c",
+    "src/unix/darwin-proctitle.c",
+    "src/unix/proctitle.c",
+    "src/heap-inl.h",
+    "src/idna.h",
+    "src/queue.h",
+    "src/strscpy.h",
+    "src/uv-common.h",
+    "src/unix/atomic-ops.h",
+    "src/unix/internal.h",
+    "src/unix/spinlock.h"
+
+    ss.dependency "#{spec.name}/Interface", pod_version
+  end
+
+  spec.requires_arc = false
+
+  spec.pod_target_xcconfig = {
+    'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(PODS_TARGET_SRCROOT)/include"',
+    'USER_HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)" "$(PODS_TARGET_SRCROOT)/src" "$(PODS_TARGET_SRCROOT)/include"',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
+    'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
+    'CLANG_WARN_DOCUMENTATION_COMMENTS' => 'NO',
+    'USE_HEADERMAP' => 'NO',
+    'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'NO',
+    'GCC_WARN_INHIBIT_ALL_WARNINGS' => 'YES'
+  }
+
+  spec.libraries = 'c++'
+
+  spec.compiler_flags =
+    "-D_LARGEFILE_SOURCE",
+    "-D_FILE_OFFSET_BITS=64",
+    "-D_GNU_SOURCE",
+    "-D_DARWIN_USE_64_BIT_INODE=1",
+    "-D_DARWIN_UNLIMITED_SELECT=1"
+
+  spec.prepare_command = <<-CMD
+    find include -type f \\( -path '*.h' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "uv.h";#if COCOAPODS==1\\\n #include <uv/uv.h>\\\n#else\\\n #include  "uv.h"\\\n#endif;g'
+    find include -type f \\( -path '*.h' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#\s*include "uv/(.*)";#if COCOAPODS==1\\\n  #include <uv/uv/\\1>\\\n#else\\\n  #include  "uv/\\1"\\\n#endif;g'
+  CMD
+
+end

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -206,6 +206,7 @@
       ss.libraries = 'z'
       ss.dependency "#{s.name}/Interface", version
       ss.dependency 'BoringSSL-GRPC', '0.0.20'
+      ss.dependency 'Libuv-gRPC'
       % for abseil_spec in grpc_abseil_specs:
       ss.dependency '${abseil_spec}', abseil_version
       % endfor
@@ -251,6 +252,7 @@
     s.prepare_command = <<-END_OF_COMMAND
       set -e
       find src/core -type f \\( -path '*.h' -or -path '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/(.*)>;#if COCOAPODS==1\\\n  #include <openssl_grpc/\\1>\\\n#else\\\n  #include <openssl/\\1>\\\n#endif;g'
+      find src/core -type f \\( -path '*.h' -or -path '*.cc' -or -path '*.c' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <uv.h>;#if COCOAPODS==1\\\n  #include <uv/uv.h>\\\n#else\\\n  #include  <uv.h>\\\n#endif;g'
       find third_party/upb/ -type f \\( -name '*.h' -or -name '*.hpp' -or -name '*.c' -or -name '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "third_party/(.*)";#if COCOAPODS==1\\\n  #include  "third_party/upb/third_party/\\1"\\\n#else\\\n  #include  "third_party/\\1"\\\n#endif;g'
       find src/core/ src/cpp/ third_party/upb/ -type f \\( -name '*.h' -or -name '*.hpp' -or -name '*.c' -or -name '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "upb/(.*)";#if COCOAPODS==1\\\n  #include  "third_party/upb/upb/\\1"\\\n#else\\\n  #include  "upb/\\1"\\\n#endif;g'
       find src/core/ src/cpp/ third_party/upb/ -type f -name '*.grpc_back' -print0 | xargs -0 rm

--- a/templates/src/objective-c/Libuv-gRPC.podspec.template
+++ b/templates/src/objective-c/Libuv-gRPC.podspec.template
@@ -1,0 +1,159 @@
+%YAML 1.2
+--- |
+  # This file has been automatically generated from a template file.
+  # Please make modifications to
+  # `templates/src/objective-c/libuv-gRPC.podspec.template` instead. This
+  # file can be regenerated from the template by running
+  # `tools/buildgen/generate_projects.sh`.
+
+  # Libuv CocoaPods podspec
+
+  # Copyright 2021, Google Inc.
+  # All rights reserved.
+  #
+  # Redistribution and use in source and binary forms, with or without
+  # modification, are permitted provided that the following conditions are
+  # met:
+  #
+  #     * Redistributions of source code must retain the above copyright
+  # notice, this list of conditions and the following disclaimer.
+  #     * Redistributions in binary form must reproduce the above
+  # copyright notice, this list of conditions and the following disclaimer
+  # in the documentation and/or other materials provided with the
+  # distribution.
+  #     * Neither the name of Google Inc. nor the names of its
+  # contributors may be used to endorse or promote products derived from
+  # this software without specific prior written permission.
+  #
+  # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  #   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  # OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  # LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  Pod::Spec.new do |spec|
+
+    pod_version           = "0.0.6"
+    libuv_version         = "1.34.0"
+
+    spec.name         = "Libuv-gRPC"
+    spec.version      = pod_version
+    spec.summary      = "Cross-platform asynchronous I/O"
+
+    spec.description  = <<-DESC
+      libuv is a multi-platform support library with a focus on asynchronous I/O.
+      It was primarily developed for use by Node.js, but it's also used by Luvit,
+      Julia, pyuv, and others.
+    DESC
+
+    spec.homepage     = "https://libuv.org/"
+
+    spec.license  = { :type => 'Mixed', :file => 'LICENSE' }
+    spec.author    = "libuv"
+
+    # When using multiple platforms
+    spec.ios.deployment_target = '9.0'
+    spec.osx.deployment_target = '10.10'
+    spec.tvos.deployment_target = '10.0'
+    spec.watchos.deployment_target = '4.0'
+
+    spec.source       = { :git => "https://github.com/libuv/libuv.git", :tag => "v#{libuv_version}" }
+
+    name = 'uv'
+    spec.module_name = name
+    spec.header_mappings_dir = 'include'
+    spec.header_dir = name
+
+    spec.subspec 'Interface' do |ss|
+      ss.header_mappings_dir = 'include'
+      ss.source_files = "include/uv.h",
+                        "include/uv/errno.h",
+                        "include/uv/threadpool.h",
+                        "include/uv/version.h",
+                        "include/uv/tree.h",
+                        "include/uv/unix.h",
+                        "include/uv/darwin.h"
+    end
+
+    spec.subspec 'Implementation' do |ss|
+      ss.header_mappings_dir = 'src'
+      ss.source_files =
+      "src/fs-poll.c",
+      "src/idna.c",
+      "src/inet.c",
+      "src/strscpy.c",
+      "src/threadpool.c",
+      "src/timer.c",
+      "src/uv-data-getter-setters.c",
+      "src/uv-common.c",
+      "src/version.c",
+      "src/unix/async.c",
+      "src/unix/core.c",
+      "src/unix/dl.c",
+      "src/unix/fs.c",
+      "src/unix/getaddrinfo.c",
+      "src/unix/getnameinfo.c",
+      "src/unix/loop.c",
+      "src/unix/loop-watcher.c",
+      "src/unix/pipe.c",
+      "src/unix/poll.c",
+      "src/unix/process.c",
+      "src/unix/signal.c",
+      "src/unix/stream.c",
+      "src/unix/tcp.c",
+      "src/unix/thread.c",
+      "src/unix/tty.c",
+      "src/unix/udp.c",
+      "src/unix/bsd-ifaddrs.c",
+      "src/unix/darwin.c",
+      "src/unix/fsevents.c",
+      "src/unix/kqueue.c",
+      "src/unix/darwin-proctitle.c",
+      "src/unix/proctitle.c",
+      "src/heap-inl.h",
+      "src/idna.h",
+      "src/queue.h",
+      "src/strscpy.h",
+      "src/uv-common.h",
+      "src/unix/atomic-ops.h",
+      "src/unix/internal.h",
+      "src/unix/spinlock.h"
+
+      ss.dependency "#{spec.name}/Interface", pod_version
+    end
+
+    spec.requires_arc = false
+
+    spec.pod_target_xcconfig = {
+      'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(PODS_TARGET_SRCROOT)/include"',
+      'USER_HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)" "$(PODS_TARGET_SRCROOT)/src" "$(PODS_TARGET_SRCROOT)/include"',
+      'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
+      'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
+      'CLANG_WARN_DOCUMENTATION_COMMENTS' => 'NO',
+      'USE_HEADERMAP' => 'NO',
+      'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+      'GCC_TREAT_WARNINGS_AS_ERRORS' => 'NO',
+      'GCC_WARN_INHIBIT_ALL_WARNINGS' => 'YES'
+    }
+
+    spec.libraries = 'c++'
+
+    spec.compiler_flags =
+      "-D_LARGEFILE_SOURCE",
+      "-D_FILE_OFFSET_BITS=64",
+      "-D_GNU_SOURCE",
+      "-D_DARWIN_USE_64_BIT_INODE=1",
+      "-D_DARWIN_UNLIMITED_SELECT=1"
+
+    spec.prepare_command = <<-CMD
+      find include -type f \\( -path '*.h' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "uv.h";#if COCOAPODS==1\\\n #include <uv/uv.h>\\\n#else\\\n #include  "uv.h"\\\n#endif;g'
+      find include -type f \\( -path '*.h' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#\s*include "uv/(.*)";#if COCOAPODS==1\\\n  #include <uv/uv/\\1>\\\n#else\\\n  #include  "uv/\\1"\\\n#endif;g'
+    CMD
+
+  end


### PR DESCRIPTION
Creating new podspec for bringing in libuv on iOS/Objc. Change summary as follows 

*  Libuv-gRPC.podspec:  new podspec for libuv.  Published as Libuv-gRPC on cocoapod trunk.
* gRPC-Core.podspec: adding libuv as dependency lib for gRPC-Core pod 


