### PR TITLE
xds_k8s_test: increase timeout to 3 hours due to recent timeout failure

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s.cfg
+++ b/tools/internal_ci/linux/grpc_xds_k8s.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
There was a timeout failure in the recent test run (https://fusion2.corp.google.com/invocations/3def5479-9a7d-4c22-a65f-529298f6e49d/targets/grpc%2Fjava%2Fv1.41.x%2Fbranch%2Fxds-k8s/log) which shows:

I1004 03:49:29.278968 140116066653952 client_app.py:179] Server channel: ManagedChannelImpl{logId=5, target=xds:///psm-grpc-server:35133}, state: TRANSIENT_FAILURE


ERROR: Aborting VM command due to timeout of 7200 seconds


Note that all the security tests underneath passed but the top level test grpc/java/v1.41.x/branch/xds-k8s (baseline test?) didn't pass in the dashboard https://testgrid.corp.google.com/grpc-psm-sec-java#v1.41.x

We'll probably need this for getting a clean dashboard going forward.