### PR TITLE
Speed up microbenchmark tests

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4738,6 +4738,8 @@ targets:
   - test/cpp/microbenchmarks/bm_alarm.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4751,6 +4753,8 @@ targets:
   - test/cpp/microbenchmarks/bm_arena.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4765,6 +4769,8 @@ targets:
   - test/cpp/microbenchmarks/bm_byte_buffer.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4779,6 +4785,8 @@ targets:
   - test/cpp/microbenchmarks/bm_call_create.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4803,6 +4811,8 @@ targets:
   - test/cpp/util/subprocess.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4826,6 +4836,8 @@ targets:
   - test/cpp/util/subprocess.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4839,6 +4851,8 @@ targets:
   - test/cpp/microbenchmarks/bm_channel.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4853,6 +4867,8 @@ targets:
   - test/cpp/microbenchmarks/bm_chttp2_hpack.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4867,6 +4883,8 @@ targets:
   - test/cpp/microbenchmarks/bm_chttp2_transport.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4880,6 +4898,8 @@ targets:
   - test/cpp/microbenchmarks/bm_closure.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4893,6 +4913,8 @@ targets:
   - test/cpp/microbenchmarks/bm_cq.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4906,6 +4928,8 @@ targets:
   - test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4920,6 +4944,8 @@ targets:
   - test/cpp/microbenchmarks/bm_error.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4935,6 +4961,8 @@ targets:
   - test/cpp/microbenchmarks/bm_fullstack_streaming_ping_pong.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4949,6 +4977,8 @@ targets:
   - test/cpp/microbenchmarks/bm_fullstack_streaming_pump.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4964,6 +4994,8 @@ targets:
   deps:
   - absl/flags:flag
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4979,6 +5011,8 @@ targets:
   - test/cpp/microbenchmarks/bm_fullstack_unary_ping_pong.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -4992,6 +5026,8 @@ targets:
   - test/cpp/microbenchmarks/bm_metadata.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5006,6 +5042,8 @@ targets:
   - test/cpp/microbenchmarks/bm_pollset.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5020,6 +5058,8 @@ targets:
   - test/cpp/microbenchmarks/bm_threadpool.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5035,6 +5075,8 @@ targets:
   - test/cpp/microbenchmarks/bm_timer.cc
   deps:
   - benchmark_helpers
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:
@@ -5609,6 +5651,8 @@ targets:
   - absl/types:variant
   - benchmark
   - upb
+  args:
+  - --benchmark_min_time=0.001
   benchmark: true
   defaults: benchmark
   platforms:

--- a/test/core/promise/benchmark/BUILD
+++ b/test/core/promise/benchmark/BUILD
@@ -18,6 +18,8 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/promise/benchmark")
 
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+
 grpc_cc_test(
     name = "competition",
     srcs = [
@@ -25,6 +27,7 @@ grpc_cc_test(
         "filter_stack.cc",
         "filter_stack.h",
     ],
+    args = grpc_benchmark_args(),
     external_deps = [
         "benchmark",
         "absl/synchronization",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -18,6 +18,8 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_p
 
 grpc_package(name = "test/cpp/microbenchmarks")
 
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+
 grpc_cc_test(
     name = "noop-benchmark",
     srcs = ["noop-benchmark.cc"],
@@ -71,6 +73,7 @@ grpc_cc_library(
 grpc_cc_test(
     name = "bm_closure",
     srcs = ["bm_closure.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -81,6 +84,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_alarm",
     srcs = ["bm_alarm.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -92,6 +96,7 @@ grpc_cc_test(
     name = "bm_arena",
     size = "large",
     srcs = ["bm_arena.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -104,6 +109,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_byte_buffer",
     srcs = ["bm_byte_buffer.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -115,6 +121,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_channel",
     srcs = ["bm_channel.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -126,6 +133,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_call_create",
     srcs = ["bm_call_create.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -137,6 +145,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_cq",
     srcs = ["bm_cq.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -147,6 +156,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_cq_multiple_threads",
     srcs = ["bm_cq_multiple_threads.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -158,6 +168,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_error",
     srcs = ["bm_error.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -185,6 +196,7 @@ grpc_cc_test(
     srcs = [
         "bm_fullstack_streaming_ping_pong.cc",
     ],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",
@@ -206,6 +218,7 @@ grpc_cc_test(
     srcs = [
         "bm_fullstack_streaming_pump.cc",
     ],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",
@@ -217,6 +230,7 @@ grpc_cc_test(
     name = "bm_fullstack_trickle",
     size = "large",
     srcs = ["bm_fullstack_trickle.cc"],
+    args = grpc_benchmark_args(),
     external_deps = [
         "absl/flags:flag",
     ],
@@ -243,6 +257,7 @@ grpc_cc_test(
     srcs = [
         "bm_fullstack_unary_ping_pong.cc",
     ],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",
@@ -253,6 +268,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_metadata",
     srcs = ["bm_metadata.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -264,6 +280,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_chttp2_hpack",
     srcs = ["bm_chttp2_hpack.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -275,6 +292,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_chttp2_transport",
     srcs = ["bm_chttp2_transport.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -286,6 +304,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_opencensus_plugin",
     srcs = ["bm_opencensus_plugin.cc"],
+    args = grpc_benchmark_args(),
     language = "C++",
     deps = [
         ":helpers_secure",
@@ -297,6 +316,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_timer",
     srcs = ["bm_timer.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -308,6 +328,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_pollset",
     srcs = ["bm_pollset.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
@@ -319,6 +340,7 @@ grpc_cc_test(
     name = "bm_threadpool",
     size = "large",
     srcs = ["bm_threadpool.cc"],
+    args = grpc_benchmark_args(),
     tags = [
         "manual",
         "no_windows",
@@ -361,6 +383,7 @@ grpc_cc_test(
     srcs = [
         "bm_callback_unary_ping_pong.cc",
     ],
+    args = grpc_benchmark_args(),
     tags = [
         "manual",
         "no_mac",
@@ -388,6 +411,7 @@ grpc_cc_test(
     srcs = [
         "bm_callback_streaming_ping_pong.cc",
     ],
+    args = grpc_benchmark_args(),
     tags = [
         "manual",
         "no_mac",

--- a/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
+++ b/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
@@ -1,0 +1,18 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration macros for grpc microbenchmarking"""
+
+def grpc_benchmark_args():
+    """Command line arguments for running a microbenchmark under bazel"""
+    return ["--benchmark_min_time=0.001"]

--- a/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
+++ b/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
@@ -14,5 +14,5 @@
 """Configuration macros for grpc microbenchmarking"""
 
 def grpc_benchmark_args():
-    """Command line arguments for running a microbenchmark under bazel"""
+    """Command line arguments for running a microbenchmark as a test"""
     return ["--benchmark_min_time=0.001"]

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3522,7 +3522,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3542,7 +3544,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3562,7 +3566,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3582,7 +3588,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3602,7 +3610,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3622,7 +3632,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3642,7 +3654,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3662,7 +3676,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3682,7 +3698,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3702,7 +3720,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3722,7 +3742,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3742,7 +3764,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3762,7 +3786,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3782,7 +3808,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3802,7 +3830,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3822,7 +3852,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -3842,7 +3874,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -4342,7 +4376,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",


### PR DESCRIPTION
For bazel testing we need this code to run, but we do not need it to run for long enough to get sensible numbers from.

Speeds up `bm_fullstack_streaming_ping_pong` from 370 seconds to 29 seconds in my test run.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
