### PR TITLE
Work around backrefs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -365,6 +365,7 @@ grpc_cc_library(
         "grpc_trace",
         "slice",
     ],
+    alwayslink = True,
 )
 
 grpc_cc_library(
@@ -407,6 +408,7 @@ grpc_cc_library(
         "grpc_transport_chttp2_server_secure",
         "slice",
     ],
+    alwayslink = True,
 )
 
 grpc_cc_library(


### PR DESCRIPTION
Now that the core configuration work is progressing, we encounter a few build configurations that end up seeing the BuildCoreConfiguration() arrangement as an illegal backref. Work-around such by marking the top level grpc library as alwayslink.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
