### PR TITLE
Run experimental 8core job on c2-standard-8 instances

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -55,7 +55,8 @@ GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master |
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
-WORKER_POOL_32CORE=workers-32core-ci
+# c2-standard-30 is the closest machine spec to 32 core there is
+WORKER_POOL_32CORE=workers-c2-30core-ci
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1


### PR DESCRIPTION
I've seen promising results (much better data stability) when running experiments on a worker pool consisting of `c2-standard-8` instances (instead of `e2-standard-8`).

I think it's worth trying out how c2 worker pool would do in our experimental job.
We can then compare the data uploaded to `e2e_benchmarks.experimental_results` with the master results.