### PR TITLE
DO NOT MERGE: experiment for collecting netperf stats in GKE worker pool

### DIFF
--- a/netperf/k8s-netperf.yaml
+++ b/netperf/k8s-netperf.yaml
@@ -1,0 +1,157 @@
+# workers-8core pool nodes:
+# gke-benchmarks-prod2-workers-8core-e40a1489-5kgi
+# gke-benchmarks-prod2-workers-8core-e40a1489-6at4	
+# gke-benchmarks-prod2-workers-8core-e40a1489-cjox
+# gke-benchmarks-prod2-workers-8core-e40a1489-cwrb
+# gke-benchmarks-prod2-workers-8core-e40a1489-dve5
+# gke-benchmarks-prod2-workers-8core-e40a1489-k2qx
+# gke-benchmarks-prod2-workers-8core-e40a1489-navq
+# gke-benchmarks-prod2-workers-8core-e40a1489-tzlu
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-0
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-5kgi
+  hostNetwork: true
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-1
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-6at4
+  hostNetwork: true
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-2
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-cjox
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-3
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-cwrb
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-4
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-dve5
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-5
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-k2qx
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-6
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-navq
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netperf-test-pod-7
+spec:
+  nodeSelector:
+    pool: workers-8core
+    kubernetes.io/hostname: gke-benchmarks-prod2-workers-8core-e40a1489-tzlu
+  containers:
+  - name: netperf-pod
+    image: leannet/k8s-netperf:latest
+    ports:
+    - containerPort: 5001
+    - containerPort: 8079
+    - containerPort: 8080
+    - containerPort: 8081
+    - containerPort: 12865
+---

--- a/netperf/run_netperf.sh
+++ b/netperf/run_netperf.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+
+rm netperf_stats.txt
+
+#CLIENT_POD_NUM=0
+#SERVER_POD_NUM=$2
+
+for CLIENT_POD_NUM in 0 #1 #2 3 #4 5 6 7
+do
+    for SERVER_POD_NUM in 1 # 2 3 #4 5 6 7
+    do
+    #CLIENT_POD_NUM=0
+    #SERVER_POD_NUM=num
+    POD_NAME_PREFIX="netperf-test-pod-"
+    CLIENT_POD="${POD_NAME_PREFIX}${CLIENT_POD_NUM}"
+    CLIENT_NODE="$(kubectl get pods ${CLIENT_POD} -o custom-columns=NODENAME:.spec.nodeName --no-headers)"
+    SERVER_POD="${POD_NAME_PREFIX}${SERVER_POD_NUM}"
+    SERVER_NODE="$(kubectl get pods ${SERVER_POD} -o custom-columns=NODENAME:.spec.nodeName --no-headers)"
+    SERVER_POD_IP=$(kubectl get pods ${SERVER_POD} -o custom-columns=IP:.status.podIP --no-headers)
+    
+    for iter in 1 2 3
+    do
+        # same command as here:
+        # https://github.com/grpc/grpc/blob/fd3bd70939fb4239639fbd26143ec416366e4157/tools/run_tests/performance/run_netperf.sh#L20
+        NETPERF_RESULT=$(kubectl exec -it ${CLIENT_POD} -- netperf -P 0 -t TCP_RR -H "${SERVER_POD_IP}" -- -r 1,1 -o P50_LATENCY,P90_LATENCY,P99_LATENCY)
+        echo $NETPERF_RESULT
+
+        echo "$CLIENT_POD_NUM,$SERVER_POD_NUM,$CLIENT_NODE,$SERVER_NODE,${NETPERF_RESULT}" >> netperf_stats.txt
+    done
+    done
+done


### PR DESCRIPTION

To deploy the pods to all workers:
`kubectl apply -f k8s-netperf.yaml`

Then run the script that collects the latency data.
