### PR TITLE
Fix event engine timer test suite

### DIFF
--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -31,6 +31,7 @@ grpc_cc_test(
 
 grpc_cc_library(
     name = "event_engine_test_suite",
+    testonly = 1,
     srcs = [
         "test_suite/event_engine_test.cc",
         "test_suite/timer_test.cc",

--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -54,14 +54,14 @@ TEST_F(EventEngineTimerTest, ImmediateCallbackIsExecutedQuickly) {
 
 TEST_F(EventEngineTimerTest, SupportsCancellation) {
   auto engine = this->NewEventEngine();
-  auto handle = engine->RunAt(absl::InfiniteFuture(), []() {});
+  auto handle = engine->RunAt(absl::Now() + absl::Seconds(10000), []() {});
   ASSERT_TRUE(engine->Cancel(handle));
 }
 
 TEST_F(EventEngineTimerTest, CancelledCallbackIsNotExecuted) {
   {
     auto engine = this->NewEventEngine();
-    auto handle = engine->RunAt(absl::InfiniteFuture(), [this]() {
+    auto handle = engine->RunAt(absl::Now() + absl::Seconds(10000), [this]() {
       grpc_core::MutexLock lock(&mu_);
       signaled_ = true;
     });

--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -54,14 +54,14 @@ TEST_F(EventEngineTimerTest, ImmediateCallbackIsExecutedQuickly) {
 
 TEST_F(EventEngineTimerTest, SupportsCancellation) {
   auto engine = this->NewEventEngine();
-  auto handle = engine->RunAt(absl::Now() + absl::Seconds(10000), []() {});
+  auto handle = engine->RunAt(absl::InfiniteFuture(), []() {});
   ASSERT_TRUE(engine->Cancel(handle));
 }
 
 TEST_F(EventEngineTimerTest, CancelledCallbackIsNotExecuted) {
   {
     auto engine = this->NewEventEngine();
-    auto handle = engine->RunAt(absl::Now() + absl::Seconds(10000), [this]() {
+    auto handle = engine->RunAt(absl::InfiniteFuture(), [this]() {
       grpc_core::MutexLock lock(&mu_);
       signaled_ = true;
     });


### PR DESCRIPTION
Fixes event engine timer test suite to handle internal build and check failures.
@ctiller
