### PR TITLE
Flush auto fixer cache once per week

### DIFF
--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -5,13 +5,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Cache bazel build
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%W')"
       - name: Cache bazel
         uses: actions/cache@v2
         env:
           cache-name: bazel-cache
         with:
           path: ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.cache-name }}
+          key: ${{ runner.os }}-${{ steps.date.output.date }}
       # Cancel current runs if they're still running
       # (saves processing on fast pushes)
       - name: Cancel Previous Runs

--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Cache bazel build
-       - name: Get current time
-         uses: srfrnk/current-time@master
-         id: current-time
-         with:
-           format: YYYYWW
+      - name: Get current time
+        uses: srfrnk/current-time@master
+        id: current-time
+        with:
+          format: YYYYWW
       - name: Cache bazel
         uses: actions/cache@v2
         env:

--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -5,16 +5,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Cache bazel build
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%W')"
+       - name: Get current time
+         uses: srfrnk/current-time@master
+         id: current-time
+         with:
+           format: YYYYWW
       - name: Cache bazel
         uses: actions/cache@v2
         env:
           cache-name: bazel-cache
         with:
           path: ~/.cache/bazel
-          key: ${{ runner.os }}-${{ steps.date.output.date }}
+          key: ${{ runner.os }}-${{ steps.current-time.outputs.formattedTime }}
       # Cancel current runs if they're still running
       # (saves processing on fast pushes)
       - name: Cancel Previous Runs


### PR DESCRIPTION
As originally written the autofixer cached bazel results for clang-tidy to save time... but eventually those cached results get stale.

We could probably do something more precise, but just creating a new cache once a week seems fine and ought to be low maintenance.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
