### PR TITLE
Switch main benchmark CI job to c2 class worker pools

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -56,8 +56,9 @@ GRPC_GO_GITREF="$(git ls-remote https://github.com/grpc/grpc-go.git master | cut
 GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master | cut -f1)"
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
-WORKER_POOL_8CORE=workers-8core-ci
-WORKER_POOL_32CORE=workers-32core-ci
+WORKER_POOL_8CORE=workers-c2-8core-ci
+# c2-standard-30 is the closest machine spec to 32 core there is
+WORKER_POOL_32CORE=workers-c2-30core-ci
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1


### PR DESCRIPTION
The experiment https://github.com/grpc/grpc/pull/27627 seems to be showing a big improvement in data stability,
so switching our main job to c2 now makes sense IMHO.

- before the switch, we need to make sure that the worker pools are correctly sized and configured.