### PR TITLE
xds_k8s tests: Fix xlang install script sourcing.

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh
@@ -83,10 +83,9 @@ main() {
   local script_dir
   script_dir="$(dirname "$0")"
 
-  # Clone the test driver from the master branch using an external script.
-  # shellcheck source=tools/internal_ci/linux/grpc_xds_k8s_clone_driver_repo.sh
-  source "${script_dir}/grpc_xds_k8s_clone_driver_repo.sh"
-  clone_test_driver
+  # Source the test driver from the master branch.
+  echo "Sourcing test driver install script from: ${TEST_DRIVER_INSTALL_SCRIPT_URL}"
+  source /dev/stdin <<< "$(curl -s "${TEST_DRIVER_INSTALL_SCRIPT_URL}")"
 
   activate_gke_cluster GKE_CLUSTER_PSM_SECURITY
 


### PR DESCRIPTION
This change sources the test driver install script correctly for the xlang tests.

This fixes a mistake in #27462 where this was missed.

Test run from branch: https://fusion2.corp.google.com/invocations/93f8bf03-bf07-42b6-928f-398616a4c63a/targets

@sergiitk 
