### PR TITLE
Remove redundant windows toolchain registrations in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,14 +10,6 @@ load("//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
-register_execution_platforms(
-    "//third_party/toolchains:rbe_windows",
-)
-
-register_toolchains(
-    "//third_party/toolchains/bazel_0.26.0_rbe_windows:cc-toolchain-x64_windows",
-)
-
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 
 custom_exec_properties(


### PR DESCRIPTION
These are for building with RBE windows and are registered via `--extra_execution_platforms` and `--extra_toolchains` in `windows.bazelrc`. So no need to include them in `WORKSPACE`.

Fixes https://github.com/grpc/grpc/issues/27470.

https://github.com/grpc/grpc/blob/f57a1f7d8cd6371dec57016dd69720b7ace732a8/tools/remote_build/windows.bazelrc#L10-L12
