### PR TITLE
Use monotonic time to avoid negative values in the Python example

### DIFF
--- a/examples/python/route_guide/route_guide_server.py
+++ b/examples/python/route_guide/route_guide_server.py
@@ -85,7 +85,7 @@ class RouteGuideServicer(route_guide_pb2_grpc.RouteGuideServicer):
         distance = 0.0
         prev_point = None
 
-        start_time = time.time()
+        start_time = time.monotonic()
         for point in request_iterator:
             point_count += 1
             if get_feature(self.db, point):
@@ -94,7 +94,7 @@ class RouteGuideServicer(route_guide_pb2_grpc.RouteGuideServicer):
                 distance += get_distance(prev_point, point)
             prev_point = point
 
-        elapsed_time = time.time() - start_time
+        elapsed_time = time.monotonic() - start_time
         return route_guide_pb2.RouteSummary(point_count=point_count,
                                             feature_count=feature_count,
                                             distance=int(distance),


### PR DESCRIPTION
Time readings are done with `time.time()`. However, the best practice for measuring time deltas is [`time.monotonic()`](https://docs.python.org/3/library/time.html#time.monotonic).

It might not be extremely important because the focus here is on gRPC, not on Python best practices. However, it will prevent strange negative time values on edge cases.

release notes: no
lang/python

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
