### PR TITLE
Wait for in-flight requests to complete during shutdown

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -794,6 +794,7 @@ void DonePublishedShutdown(void* /*done_arg*/, grpc_cq_completion* storage) {
 //       connection is NOT closed until the server is done with all those calls.
 //    -- Once there are no more calls in progress, the channel is closed.
 void Server::ShutdownAndNotify(grpc_completion_queue* cq, void* tag) {
+  absl::Notification* await_requests = nullptr;
   ChannelBroadcaster broadcaster;
   {
     // Wait for startup to be finished.  Locks mu_global.
@@ -820,7 +821,12 @@ void Server::ShutdownAndNotify(grpc_completion_queue* cq, void* tag) {
       KillPendingWorkLocked(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server Shutdown"));
     }
-    ShutdownUnrefOnShutdownCall();
+    await_requests = ShutdownUnrefOnShutdownCall();
+  }
+  // We expect no new requests but there can still be requests in-flight.
+  // Wait for them to complete before proceeding.
+  if (await_requests != nullptr) {
+    await_requests->WaitForNotification();
   }
   // Shutdown listeners.
   for (auto& listener : listeners_) {

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "absl/status/statusor.h"
+#include "absl/synchronization/notification.h"
 #include "absl/types/optional.h"
 
 #include <grpc/grpc.h>
@@ -364,7 +365,7 @@ class Server : public InternallyRefCounted<Server> {
   std::vector<grpc_channel*> GetChannelsLocked() const;
 
   // Take a shutdown ref for a request (increment by 2) and return if shutdown
-  // has already been called.
+  // has not been called.
   bool ShutdownRefOnRequest() {
     int old_value = shutdown_refs_.fetch_add(2, std::memory_order_acq_rel);
     return (old_value & 1) != 0;
@@ -377,12 +378,24 @@ class Server : public InternallyRefCounted<Server> {
     if (shutdown_refs_.fetch_sub(2, std::memory_order_acq_rel) == 2) {
       MutexLock lock(&mu_global_);
       MaybeFinishShutdown();
+      // The last request in-flight during shutdown is now complete.
+      if (shutdown_ready_ != nullptr) {
+        GPR_ASSERT(!shutdown_ready_->HasBeenNotified());
+        shutdown_ready_->Notify();
+      }
     }
   }
-  void ShutdownUnrefOnShutdownCall() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_global_) {
+  // Returns a notification pointer to wait on if there are requests in-flight,
+  // or null.
+  absl::Notification* ShutdownUnrefOnShutdownCall()
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_global_) {
     if (shutdown_refs_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      // There is no request in-flight.
       MaybeFinishShutdown();
+      return nullptr;
     }
+    shutdown_ready_ = absl::make_unique<absl::Notification>();
+    return shutdown_ready_.get();
   }
 
   bool ShutdownCalled() const {
@@ -433,6 +446,7 @@ class Server : public InternallyRefCounted<Server> {
   std::atomic<int> shutdown_refs_{1};
   bool shutdown_published_ ABSL_GUARDED_BY(mu_global_) = false;
   std::vector<ShutdownTag> shutdown_tags_ ABSL_GUARDED_BY(mu_global_);
+  std::unique_ptr<absl::Notification> shutdown_ready_;
 
   std::list<ChannelData*> channels_;
 


### PR DESCRIPTION
This fixes a race condition between AllocatingRequestMatcherBase::MatchOrQueue()
implementations and ShutdownAndNotify(). In MatchOrQueue(), the server may
shutdown and delete the completion queue right after the shutdown check but
before the batch call allocation, resulting in a use-after-free case.

To fix, once the shutdown ref is unrefed and no new requests are accepted, the
server can wait for all requests in-flight at the moment to complete. The last
request that unrefs the shutdown ref unblocks the shutdown.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@ctiller 
