### PR TITLE
Update bazel version to 4.2.1 in binder_transport_apk docker image

### DIFF
--- a/tools/dockerfile/test/binder_transport_apk/Dockerfile
+++ b/tools/dockerfile/test/binder_transport_apk/Dockerfile
@@ -56,7 +56,7 @@ ENV ANDROID_NDK_HOME=/opt/android-sdk/ndk/21.4.7075529
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 3.7.1
+ENV BAZEL_VERSION 4.2.1
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1


### PR DESCRIPTION
This image is for testing binder transport Android APK build

The updated image has been uploaded to

https://hub.docker.com/layers/grpctesting/binder_transport_apk/f97d8ca071ac3355dded02a142fd2b98870a7f93/images/sha256-0f38d71530fca96ba3f53d63dce82def734fd51a4537f87e9e33b1314f890ef6?context=explore