### PR TITLE
Added a safe Zalloc

### DIFF
--- a/src/core/ext/filters/client_channel/backup_poller.cc
+++ b/src/core/ext/filters/client_channel/backup_poller.cc
@@ -28,6 +28,7 @@
 #include "src/core/ext/filters/client_channel/client_channel.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/global_config.h"
+#include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/core/lib/iomgr/pollset.h"
@@ -138,7 +139,7 @@ static void run_poller(void* arg, grpc_error_handle error) {
 
 static void g_poller_init_locked() {
   if (g_poller == nullptr) {
-    g_poller = static_cast<backup_poller*>(gpr_zalloc(sizeof(backup_poller)));
+    g_poller = grpc_core::Zalloc<backup_poller>();
     g_poller->pollset =
         static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
     g_poller->shutting_down = false;

--- a/src/core/lib/channel/channel_stack_builder.cc
+++ b/src/core/lib/channel/channel_stack_builder.cc
@@ -25,6 +25,8 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 
+#include "src/core/lib/gprpp/memory.h"
+
 typedef struct filter_node {
   struct filter_node* next;
   struct filter_node* prev;
@@ -53,15 +55,13 @@ struct grpc_channel_stack_builder_iterator {
 
 grpc_channel_stack_builder* grpc_channel_stack_builder_create(void) {
   grpc_channel_stack_builder* b =
-      static_cast<grpc_channel_stack_builder*>(gpr_zalloc(sizeof(*b)));
-
+      grpc_core::Zalloc<grpc_channel_stack_builder>();
   b->begin.filter = nullptr;
   b->end.filter = nullptr;
   b->begin.next = &b->end;
   b->begin.prev = &b->end;
   b->end.next = &b->begin;
   b->end.prev = &b->begin;
-
   return b;
 }
 

--- a/src/core/lib/gprpp/memory.h
+++ b/src/core/lib/gprpp/memory.h
@@ -46,6 +46,17 @@ class DefaultDeleteChar {
 template <typename T>
 using UniquePtr = std::unique_ptr<T, DefaultDeleteChar>;
 
+template <class T>
+T* Zalloc(size_t size) {
+  static_assert(std::is_trivial<T>::value, "Type should be trivial");
+  return static_cast<T*>(gpr_zalloc(size));
+}
+
+template <class T>
+T* Zalloc() {
+  return Zalloc<T>(sizeof(T));
+}
+
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_GPRPP_MEMORY_H */

--- a/src/core/lib/security/credentials/plugin/plugin_credentials.cc
+++ b/src/core/lib/security/credentials/plugin/plugin_credentials.cc
@@ -29,6 +29,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 
+#include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/slice/slice_string_helpers.h"
 #include "src/core/lib/surface/api_trace.h"
@@ -159,8 +160,7 @@ bool grpc_plugin_credentials::get_request_metadata(
   bool retval = true;  // Synchronous return.
   if (plugin_.get_metadata != nullptr) {
     // Create pending_request object.
-    pending_request* request =
-        static_cast<pending_request*>(gpr_zalloc(sizeof(*request)));
+    pending_request* request = grpc_core::Zalloc<pending_request>();
     request->creds = this;
     request->md_array = md_array;
     request->on_request_metadata = on_request_metadata;


### PR DESCRIPTION
One of recurring errors found in gRPC is using `zalloc` & `free` for a non-trivial struct, resulting in not calling the d'tor of its members. Sometime it could be benign but it could be nightmare on a bad day. To address this problem, new template function `grpc_core::Zalloc` is added. It makes sure that given T is trivial and will throws an error otherwise.

Once this PR is merged, I will follow up on changing all zalloc usage to either using `grpc_core::Zalloc` or using C++ new or free for non-trivial types.