### PR TITLE
[objc] Remove pre install header search path patch in core test

### DIFF
--- a/src/objective-c/tests/CoreTests/Podfile
+++ b/src/objective-c/tests/CoreTests/Podfile
@@ -14,18 +14,6 @@ target 'CoreTests' do
   grpc_deps
 end
 
-pre_install do |installer|
-  grpc_core_spec = installer.pod_targets.find{|t| t.name.start_with?('gRPC-Core')}.root_spec
-  src_root = "$(PODS_ROOT)/../#{GRPC_LOCAL_SRC}"
-  grpc_core_spec.pod_target_xcconfig = {
-    'GRPC_SRC_ROOT' => src_root,
-    'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(GRPC_SRC_ROOT)/include"',
-    'USER_HEADER_SEARCH_PATHS' => '"$(GRPC_SRC_ROOT)"',
-    'USE_HEADERMAP' => 'NO',
-    'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-  }
-end
-
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     if target.name == "CoreTests"


### PR DESCRIPTION
No longer needed after #27609 clean up merged. 

cc @HannahShiSFB 