### PR TITLE
[objc] Exclude libuv build source from c-core

### DIFF
--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -62,18 +62,24 @@
   # ObjectiveC doesn't use c-ares so we don't need address_sorting files at all
   address_sorting_unwanted_files = list_lib_files("address_sorting", ("public_headers", "headers", "src"))
 
+  # ObjectiveC doesn't use c-core's libuv source at the moment, as it is pulling libuv dependency from cocoapod.
+  libuv_unwanted_files = list_lib_files("uv", ("public_headers", "headers", "src"))
+
   # ObjectiveC needs to obtain re2 explicitly unlike other languages; TODO @donnadionne make ObjC more consistent with others
   grpc_private_files = list(
       sorted((set(list_lib_files("grpc", ("headers", "src"))) -
-              set(address_sorting_unwanted_files))
+              set(address_sorting_unwanted_files) -
+              set(libuv_unwanted_files))
             | set(list_lib_files("re2", ("headers", "src")))))
   grpc_public_headers = list(
       sorted((set(list_lib_files("grpc", ("public_headers", ))) -
-              set(address_sorting_unwanted_files))
+              set(address_sorting_unwanted_files) -
+              set(libuv_unwanted_files))
              | set(list_lib_files("re2", ("public_headers", )))))
   grpc_private_headers = list(
       sorted((set(list_lib_files("grpc", ("headers", ))) -
-              set(address_sorting_unwanted_files))
+              set(address_sorting_unwanted_files) -
+              set(libuv_unwanted_files))
              | set(list_lib_files("re2", ("headers", )))))
   grpc_abseil_specs = list_abseil_specs("grpc")
   grpc_tests_abseil_specs = list(sorted(set(list_abseil_specs("end2end_tests")) - set(grpc_abseil_specs)))
@@ -100,6 +106,7 @@
     set(list_lib_files("end2end_tests", ("src", "headers")))
     - set(grpc_private_files)
     - set(address_sorting_unwanted_files)
+    - set(libuv_unwanted_files)
     - set([
       # Subprocess is not supported in tvOS and not needed by our tests.
       "test/core/util/subprocess_posix.cc",


### PR DESCRIPTION
This will prevent build break as current bazel-based libuv build rule not buildable for iOS. To follow up with https://github.com/grpc/grpc-ios/issues/25 

Pending #27513 to merge