### PR TITLE
[objc] Libuv pod patch to build for latest stable 1.42.0

### DIFF
--- a/src/objective-c/Libuv-gRPC.podspec
+++ b/src/objective-c/Libuv-gRPC.podspec
@@ -37,8 +37,8 @@
 
 Pod::Spec.new do |spec|
 
-  pod_version           = "0.0.10"
-  libuv_version         = "1.37.0"
+  pod_version           = "0.0.11"
+  libuv_version         = "1.42.0"
 
   spec.name         = "Libuv-gRPC"
   spec.version      = pod_version
@@ -113,6 +113,7 @@ Pod::Spec.new do |spec|
     "src/unix/fsevents.c",
     "src/unix/kqueue.c",
     "src/unix/darwin-proctitle.c",
+    "src/unix/darwin-stub.h",
     "src/unix/proctitle.c",
     "src/heap-inl.h",
     "src/idna.h",

--- a/templates/src/objective-c/Libuv-gRPC.podspec.template
+++ b/templates/src/objective-c/Libuv-gRPC.podspec.template
@@ -39,8 +39,8 @@
 
   Pod::Spec.new do |spec|
 
-    pod_version           = "0.0.10"
-    libuv_version         = "1.37.0"
+    pod_version           = "0.0.11"
+    libuv_version         = "1.42.0"
 
     spec.name         = "Libuv-gRPC"
     spec.version      = pod_version
@@ -115,6 +115,7 @@
       "src/unix/fsevents.c",
       "src/unix/kqueue.c",
       "src/unix/darwin-proctitle.c",
+      "src/unix/darwin-stub.h",
       "src/unix/proctitle.c",
       "src/heap-inl.h",
       "src/idna.h",


### PR DESCRIPTION
Also bumping version up to 0.0.11

Verify build with the following toolchain 
* Xcode 13.0  
* arm64 / armv7 / x86_64
* clang 5.5.x


Fix and closing https://github.com/grpc/grpc-ios/issues/32

**Await C-Core confirm usage of ver 1.42.0 (or else)**

cc @HannahShiSFB 