### PR TITLE
const absl::Status& instead of absl::Status for StatusToProto 

### DIFF
--- a/src/core/lib/gprpp/status_helper.cc
+++ b/src/core/lib/gprpp/status_helper.cc
@@ -331,7 +331,7 @@ std::string StatusToString(const absl::Status& status) {
 
 namespace internal {
 
-google_rpc_Status* StatusToProto(absl::Status status, upb_arena* arena) {
+google_rpc_Status* StatusToProto(const absl::Status& status, upb_arena* arena) {
   google_rpc_Status* msg = google_rpc_Status_new(arena);
   google_rpc_Status_set_code(msg, int32_t(status.code()));
   google_rpc_Status_set_message(

--- a/src/core/lib/gprpp/status_helper.h
+++ b/src/core/lib/gprpp/status_helper.h
@@ -153,7 +153,7 @@ namespace internal {
 
 /// Builds a upb message, google_rpc_Status from a status
 /// This is for internal implementation & test only
-google_rpc_Status* StatusToProto(absl::Status status,
+google_rpc_Status* StatusToProto(const absl::Status& status,
                                  upb_arena* arena) GRPC_MUST_USE_RESULT;
 
 /// Builds a status from a upb message, google_rpc_Status


### PR DESCRIPTION
This is minor but `StatusToProto` should use `const absl::Status&` for its augment type. This function uses buffers from `absl::Status` assuming the caller can still access them. Practically this holds true even with `absl::Status` because `absl::Status` uses a reference-counting and shares the same buffer between a caller and callee. But this isn't true any longer when the implementation changes (e.g. no more reference-counting). To make it more resilient, it's changed to use `const absl::Status&` which passes the status as a reference, a caller and callee shares the same object all the time.