### PR TITLE
xds_end2end_test: allow setting Listener to use in SetRouteConfiguration()

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -1355,9 +1355,8 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
     if (GetParam().enable_rds_testing()) {
       balancers_[idx]->ads_service()->SetRdsResource(route_config);
     } else {
-      Listener listener(listener_to_copy == nullptr
-                            ? default_listener_
-                            : *listener_to_copy);
+      Listener listener(listener_to_copy == nullptr ? default_listener_
+                                                    : *listener_to_copy);
       HttpConnectionManager http_connection_manager;
       listener.mutable_api_listener()->mutable_api_listener()->UnpackTo(
           &http_connection_manager);


### PR DESCRIPTION
This will allow it to be used for server-side tests.

Also reorder the methods a bit.