### PR TITLE
Implemented abort_with_status in ServicerContext

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
@@ -76,6 +76,9 @@ class Rpc(object):
 
     def _abort(self, code, details):
         self._terminate(_common.FUSSED_EMPTY_METADATA, code, details)
+    
+    def _abort_with_status(self, status):
+        self._terminate(status.trailing_metadata, status.code, status.details)
 
     def add_rpc_error(self, rpc_error):
         with self._condition:

--- a/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
@@ -79,7 +79,9 @@ class ServicerContext(grpc.ServicerContext):
         raise Exception()
 
     def abort_with_status(self, status):
-        raise NotImplementedError()
+        with self._rpc._condition:
+            self._rpc._abort_with_status(status)
+        raise Exception()
 
     def set_code(self, code):
         self._rpc.set_code(code)


### PR DESCRIPTION


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
 
`abort_with_status` isn't implemented in the Python `grpc_testing` library, which will cause related issues such as https://github.com/grpc/grpc/issues/19153, except it's with `abort_with_status`.

Implemented the function similarly to #20077.

Note: This is the first PR that I have submitted to grpc/grpc, please let me know if I'm missing something.