### PR TITLE
MetadataCredentialsPluginWrapper: Create thread pool only if needed

### DIFF
--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -523,6 +523,10 @@ void MetadataCredentialsPluginWrapper::InvokePlugin(
 
 MetadataCredentialsPluginWrapper::MetadataCredentialsPluginWrapper(
     std::unique_ptr<MetadataCredentialsPlugin> plugin)
-    : thread_pool_(CreateDefaultThreadPool()), plugin_(std::move(plugin)) {}
+    : plugin_(std::move(plugin)) {
+  if (plugin_->IsBlocking()) {
+    thread_pool_.reset(CreateDefaultThreadPool());
+  }
+}
 
 }  // namespace grpc


### PR DESCRIPTION
Non-blocking metadata credentials plugins do not use a thread pool.

Creating a thread pool can be relatively expensive as it always spawns one thread per core, even if the thread pool is never used. This is especially a concern on systems with many cores.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
