### PR TITLE
xds/interop: Authz principal present is now working more, but not entirely

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
@@ -279,8 +279,8 @@ class AuthzTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
                                       grpc.StatusCode.PERMISSION_DENIED)
 
         with self.subTest('03_principal_present'):
-            self.configure_and_assert(
-                test_client, 'principal-present', grpc.StatusCode.OK)
+            self.configure_and_assert(test_client, 'principal-present',
+                                      grpc.StatusCode.OK)
 
         with self.subTest('04_match_principal'):
             self.configure_and_assert(test_client, 'match-principal',


### PR DESCRIPTION
The control plane was updated to more properly match the principal being
present, so now plaintext and mTLS are working properly. But the change
is using slightly the wrong semantics for TLS, so we get to change which
tests are commented out.