### PR TITLE
Upgrade Abseil to LTS 20210324, Patch 2

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -190,7 +190,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     ss.dependency "#{s.name}/Interface", version
     ss.dependency 'gRPC-Core', version
-    abseil_version = '1.20210324.2'
+    abseil_version = '1.20210324.0'
     ss.dependency 'abseil/base/base', abseil_version
     ss.dependency 'abseil/base/core_headers', abseil_version
     ss.dependency 'abseil/container/flat_hash_map', abseil_version

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.requires_arc = false
 
   name = 'grpc'
-  abseil_version = '1.20210324.2'
+  abseil_version = '1.20210324.0'
 
   # When creating a dynamic framework, name it grpc.framework instead of gRPC-Core.framework.
   # This lets users write their includes like `#include <grpc/grpc.h>` as opposed to `#include

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -168,7 +168,7 @@
       ss.header_mappings_dir = '.'
       ss.dependency "#{s.name}/Interface", version
       ss.dependency 'gRPC-Core', version
-      abseil_version = '1.20210324.2'
+      abseil_version = '1.20210324.0'
       % for abseil_spec in grpcpp_abseil_specs:
       ss.dependency '${abseil_spec}', abseil_version
       % endfor

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -132,7 +132,7 @@
     s.requires_arc = false
 
     name = 'grpc'
-    abseil_version = '1.20210324.2'
+    abseil_version = '1.20210324.0'
 
     # When creating a dynamic framework, name it grpc.framework instead of gRPC-Core.framework.
     # This lets users write their includes like `#include <grpc/grpc.h>` as opposed to `#include


### PR DESCRIPTION
Upgrade abseil submodule and bazel dependency to 20210324.2 https://github.com/abseil/abseil-cpp/commit/278e0a071885a22dcd2fd1b5576cc44757299343

I've reverted the podspec change since that needs some additional work that @veblush is working on. The podspec will be upgraded once that is done. 