### PR TITLE
[Backport v1.41.x] Disable grpc_status_test for sync stack in Python2

### DIFF
--- a/src/python/grpcio_tests/tests/status/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/status/BUILD.bazel
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("//bazel:python_rules.bzl", "py2and3_test")
 
 package(default_visibility = ["//visibility:public"])
 
-py2and3_test(
+py_test(
     name = "grpc_status_test",
     size = "small",
     srcs = ["_grpc_status_test.py"],
     imports = ["../../"],
     main = "_grpc_status_test.py",
+    python_version = "PY3",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_status/grpc_status",

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -28,6 +28,7 @@ import unittest
 
 import logging
 import traceback
+import sys
 
 import grpc
 from grpc_status import rpc_status
@@ -113,6 +114,8 @@ class _GenericHandler(grpc.GenericRpcHandler):
             return None
 
 
+@unittest.skipIf(sys.version_info[0] < 3,
+                 'ProtoBuf descriptor has moved on from Python2')
 class StatusTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
As title.