### PR TITLE
Don't use //external package in grpc

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -187,7 +187,7 @@ _generate_cc = rule(
             mandatory = False,
         ),
         "_protoc": attr.label(
-            default = Label("//external:protocol_compiler"),
+            default = Label("//third_party:protocol_compiler"),
             executable = True,
             cfg = "host",
         ),

--- a/bazel/generate_objc.bzl
+++ b/bazel/generate_objc.bzl
@@ -180,7 +180,7 @@ generate_objc = rule(
             default = "@com_google_protobuf//:well_known_protos",
         ),
         "_protoc": attr.label(
-            default = Label("//external:protocol_compiler"),
+            default = Label("//third_party:protocol_compiler"),
             executable = True,
             cfg = "host",
         ),

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -58,14 +58,14 @@ def _get_external_deps(external_deps):
         elif dep == "cares":
             ret += select({
                 "//:grpc_no_ares": [],
-                "//conditions:default": ["//external:cares"],
+                "//conditions:default": ["//third_party:cares"],
             })
         elif dep == "cronet_c_for_grpc":
             ret.append("//third_party/objective_c/Cronet:cronet_c_for_grpc")
         elif dep.startswith("absl/"):
             ret.append("@com_google_absl//" + dep)
         else:
-            ret.append("//external:" + dep)
+            ret.append("//third_party:" + dep)
     return ret
 
 def _update_visibility(visibility):

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -104,7 +104,7 @@ _gen_py_aspect = aspect(
     fragments = ["py"],
     attrs = {
         "_protoc": attr.label(
-            default = Label("//external:protocol_compiler"),
+            default = Label("//third_party:protocol_compiler"),
             providers = ["files_to_run"],
             executable = True,
             cfg = "host",
@@ -160,7 +160,7 @@ py_proto_library = rule(
             aspects = [_gen_py_aspect],
         ),
         "_protoc": attr.label(
-            default = Label("//external:protocol_compiler"),
+            default = Label("//third_party:protocol_compiler"),
             providers = ["files_to_run"],
             executable = True,
             cfg = "host",
@@ -248,7 +248,7 @@ _generate_pb2_grpc_src = rule(
             executable = True,
             providers = ["files_to_run"],
             cfg = "host",
-            default = Label("//external:protocol_compiler"),
+            default = Label("//third_party:protocol_compiler"),
         ),
         "_grpc_library": attr.label(
             default = Label("//src/python/grpcio/grpc:grpcio"),

--- a/grpc.bzl
+++ b/grpc.bzl
@@ -41,7 +41,7 @@ def _protoc_invocation(srcs, flags):
 
     Uses the given sources and flags. Suitable for use in a genrule.
     """
-    protoc_command = "$(location //external:protoc) -I . "
+    protoc_command = "$(location //third_party:protoc) -I . "
     srcs_params = ""
     for src in srcs:
         srcs_params += " $(location %s)" % (src)
@@ -69,7 +69,7 @@ def objc_proto_library(name, srcs, visibility = None):
 
     native.genrule(
         name = name + "_codegen",
-        srcs = srcs + ["//external:protoc"],
+        srcs = srcs + ["//third_party:protoc"],
         outs = h_files + m_files,
         cmd = _protoc_invocation(srcs, protoc_flags),
     )
@@ -78,7 +78,7 @@ def objc_proto_library(name, srcs, visibility = None):
         hdrs = h_files,
         includes = ["."],
         non_arc_srcs = m_files,
-        deps = ["//external:protobuf_objc"],
+        deps = ["//third_party:protobuf_objc"],
         visibility = visibility,
     )
 
@@ -103,13 +103,13 @@ def objc_grpc_library(name, services, other_messages, visibility = None):
         m_files.append(_file_with_extension(src, ".pbrpc.m"))
 
     protoc_flags = ("--grpc_out=$(GENDIR) --plugin=" +
-                    "protoc-gen-grpc=$(location //external:grpc_protoc_plugin_objc)")
+                    "protoc-gen-grpc=$(location //third_party:grpc_protoc_plugin_objc)")
 
     native.genrule(
         name = name + "_codegen",
         srcs = services + [
-            "//external:grpc_protoc_plugin_objc",
-            "//external:protoc",
+            "//third_party:grpc_protoc_plugin_objc",
+            "//third_party:protoc",
         ],
         outs = h_files + m_files,
         cmd = _protoc_invocation(services, protoc_flags),
@@ -121,7 +121,7 @@ def objc_grpc_library(name, services, other_messages, visibility = None):
         srcs = m_files,
         deps = [
             ":" + name + "_messages",
-            "//external:proto_objc_rpc",
+            "//third_party:proto_objc_rpc",
         ],
         visibility = visibility,
     )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -14,3 +14,170 @@ exports_files([
     "protobuf.patch",
     "rules_python.patch",
 ])
+
+package(default_visibility = ["//:__subpackages__"])
+
+alias(
+    name = "upb_lib",
+    actual = "@upb//:upb",
+)
+
+alias(
+    name = "upb_reflection",
+    actual = "@upb//:reflection",
+)
+
+alias(
+    name = "upb_lib_descriptor",
+    actual = "@upb//:descriptor_upb_proto",
+)
+
+alias(
+    name = "upb_lib_descriptor_reflection",
+    actual = "@upb//:descriptor_upb_proto_reflection",
+)
+
+alias(
+    name = "upb_textformat_lib",
+    actual = "@upb//:textformat",
+)
+
+alias(
+    name = "upb_json_lib",
+    actual = "@upb//:json",
+)
+
+alias(
+    name = "upb_generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
+    actual = "@upb//:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
+)
+
+alias(
+    name = "absl",
+    actual = "@com_google_absl//absl",
+)
+
+alias(
+    name = "absl-base",
+    actual = "@com_google_absl//absl/base",
+)
+
+alias(
+    name = "absl-time",
+    actual = "@com_google_absl//absl/time:time",
+)
+
+alias(
+    name = "libssl",
+    actual = "@boringssl//:ssl",
+)
+
+alias(
+    name = "libcrypto",
+    actual = "@boringssl//:crypto",
+)
+
+alias(
+    name = "madler_zlib",
+    actual = "@zlib//:zlib",
+)
+
+alias(
+    name = "protobuf",
+    actual = "@com_google_protobuf//:protobuf",
+)
+
+alias(
+    name = "protobuf_clib",
+    actual = "@com_google_protobuf//:protoc_lib",
+)
+
+alias(
+    name = "protobuf_headers",
+    actual = "@com_google_protobuf//:protobuf_headers",
+)
+
+alias(
+    name = "protocol_compiler",
+    actual = "@com_google_protobuf//:protoc",
+)
+
+alias(
+    name = "cares",
+    actual = "@com_github_cares_cares//:ares",
+)
+
+alias(
+    name = "gtest",
+    actual = "@com_google_googletest//:gtest",
+)
+
+alias(
+    name = "benchmark",
+    actual = "@com_github_google_benchmark//:benchmark",
+)
+
+alias(
+    name = "re2",
+    actual = "@com_googlesource_code_re2//:re2",
+)
+
+alias(
+    name = "grpc_cpp_plugin",
+    actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+)
+
+alias(
+    name = "grpc++_codegen_proto",
+    actual = "@com_github_grpc_grpc//:grpc++_codegen_proto",
+)
+
+alias(
+    name = "opencensus-context",
+    actual = "@io_opencensus_cpp//opencensus/context:context",
+)
+
+alias(
+    name = "opencensus-trace",
+    actual = "@io_opencensus_cpp//opencensus/trace:trace",
+)
+
+alias(
+    name = "opencensus-trace-context_util",
+    actual = "@io_opencensus_cpp//opencensus/trace:context_util",
+)
+
+alias(
+    name = "opencensus-trace-propagation",
+    actual = "@io_opencensus_cpp//opencensus/trace:grpc_trace_bin",
+)
+
+alias(
+    name = "opencensus-stats",
+    actual = "@io_opencensus_cpp//opencensus/stats:stats",
+)
+
+alias(
+    name = "opencensus-stats-test",
+    actual = "@io_opencensus_cpp//opencensus/stats:test_utils",
+)
+
+alias(
+    name = "opencensus-with-tag-map",
+    actual = "@io_opencensus_cpp//opencensus/tags:with_tag_map",
+)
+
+alias(
+    name = "opencensus-tags",
+    actual = "@io_opencensus_cpp//opencensus/tags:tags",
+)
+
+alias(
+    name = "opencensus-tags-context_util",
+    actual = "@io_opencensus_cpp//opencensus/tags:context_util",
+)
+
+alias(
+    name = "libuv",
+    actual = "@libuv//:libuv",
+)

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -181,3 +181,14 @@ alias(
     name = "libuv",
     actual = "@libuv//:libuv",
 )
+
+# For test only
+alias(
+    name = "twisted",
+    actual = "@com_github_twisted_twisted//:twisted",
+)
+
+alias(
+    name = "yaml",
+    actual = "@com_github_yaml_pyyaml//:yaml",
+)

--- a/third_party/objective_c/google_toolbox_for_mac/BUILD
+++ b/third_party/objective_c/google_toolbox_for_mac/BUILD
@@ -24,6 +24,6 @@ objc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//external:gtest",
+        "//third_party:gtest",
     ],
 )

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -191,11 +191,11 @@ def _external_dep_name_from_bazel_dependency(bazel_dep: str) -> Optional[str]:
         # special case for add dependency on one of the absl libraries (there is not just one absl library)
         prefixlen = len('@com_google_absl//')
         return bazel_dep[prefixlen:]
-    elif bazel_dep == '//external:upb_lib':
+    elif bazel_dep == '//third_party:upb_lib':
         return 'upb'
-    elif bazel_dep == '//external:benchmark':
+    elif bazel_dep == '//third_party:benchmark':
         return 'benchmark'
-    elif bazel_dep == '//external:libssl':
+    elif bazel_dep == '//third_party:libssl':
         return 'libssl'
     else:
         # all the other external deps such as protobuf, cares, zlib
@@ -372,11 +372,11 @@ def update_test_metadata_with_transitive_metadata(
 
         bazel_rule = bazel_rules[_get_bazel_label(lib_name)]
 
-        if '//external:benchmark' in bazel_rule['_TRANSITIVE_DEPS']:
+        if '//third_party:benchmark' in bazel_rule['_TRANSITIVE_DEPS']:
             lib_dict['benchmark'] = True
             lib_dict['defaults'] = 'benchmark'
 
-        if '//external:gtest' in bazel_rule['_TRANSITIVE_DEPS']:
+        if '//third_party:gtest' in bazel_rule['_TRANSITIVE_DEPS']:
             lib_dict['gtest'] = True
             lib_dict['language'] = 'c++'
 

--- a/tools/run_tests/sanity/check_bad_dependencies.sh
+++ b/tools/run_tests/sanity/check_bad_dependencies.sh
@@ -18,10 +18,10 @@ set -e
 # Make sure that there is no path from known unsecure libraries and targets
 # to an SSL library. Any failure among these will make the script fail.
 
-test "$(bazel query 'somepath("//:grpc_unsecure", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
-test "$(bazel query 'somepath("//:grpc++_unsecure", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
-test "$(bazel query 'somepath("//:grpc++_codegen_proto", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
-test "$(bazel query 'somepath("//test/cpp/microbenchmarks:helpers", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//:grpc_unsecure", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//:grpc++_unsecure", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//:grpc++_codegen_proto", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//test/cpp/microbenchmarks:helpers", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
 
 # Make sure that core doesn't depend on anything in C++ library
 


### PR DESCRIPTION
//external:* requries the repo to define [bind](https://docs.bazel.build/versions/main/be/workspace.html#bind) rules in WORKSPACE to make the
target available. But bind rule is not recommmended and will be removed
in future. This PR makes the same targets available in //third_party
with the alias rule.

We still need to keep the bind rules in grpc_deps.bzl to not break
downstream projects that depend on those //external:* targets.

@veblush 
