### PR TITLE
doc, xds_k8s_tests: fix command `--enable-mesh-certificates` doc

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -69,7 +69,7 @@ gcloud container clusters create "${CLUSTER_NAME}" \
  --zone="${ZONE}" \
  --enable-ip-alias \
  --workload-pool="${PROJECT_ID}.svc.id.goog" \
- --enable-workload-certificates \
+ --enable-mesh-certificates \
  --workload-metadata=GKE_METADATA \
  --tags=allow-health-checks
 ```


### PR DESCRIPTION
cl/395721766
replace `--enable-workload-certificates` with `--enable-mesh-certificates`

failure:
```
(venv) zivy-macbookpro:xds_k8s_test_driver zivy$ gcloud container clusters create "${CLUSTER_NAME}"  --scopes=cloud-platform  --zone="${ZONE}"  --enable-ip-alias  --workload-pool="${PROJECT_ID}.svc.id.goog"  --enable-workload-certificates  --workload-metadata=GKE_METADATA  --tags=allow-health-checks
ERROR: (gcloud.container.clusters.create) unrecognized arguments: --enable-workload-certificates (did you mean '--workload-metadata'?)

```

