### PR TITLE
[ios] rls_end2end_test fix

### DIFF
--- a/test/cpp/end2end/rls_end2end_test.cc
+++ b/test/cpp/end2end/rls_end2end_test.cc
@@ -248,7 +248,11 @@ class RlsEnd2endTest : public ::testing::Test {
     gpr_setenv("GRPC_EXPERIMENTAL_ENABLE_RLS_LB_POLICY", "true");
     GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
     grpc_init();
-    grpc_core::RegisterFixedAddressLoadBalancingPolicy();
+
+    if (!is_fixed_address_load_balancing_policy_registered_) {
+      grpc_core::RegisterFixedAddressLoadBalancingPolicy();
+      is_fixed_address_load_balancing_policy_registered_ = true;
+    }
   }
 
   static void TearDownTestSuite() {
@@ -560,6 +564,7 @@ class RlsEnd2endTest : public ::testing::Test {
     bool running_ = false;
   };
 
+  static bool is_fixed_address_load_balancing_policy_registered_;
   bool ipv6_only_;
   std::vector<std::unique_ptr<ServerThread<MyTestServiceImpl>>> backends_;
   std::unique_ptr<ServerThread<RlsServiceImpl>> rls_server_;
@@ -568,6 +573,8 @@ class RlsEnd2endTest : public ::testing::Test {
   std::shared_ptr<grpc::Channel> channel_;
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub_;
 };
+
+bool RlsEnd2endTest::is_fixed_address_load_balancing_policy_registered_ = false;
 
 TEST_F(RlsEnd2endTest, Basic) {
   StartBackends(1);


### PR DESCRIPTION
Turns out when bazel run ios unit test,  gtest's [SetupTestSuite](https://github.com/grpc/grpc/blob/master/test/cpp/end2end/rls_end2end_test.cc#L251) are invoked per unit test case, which would trigger assertion failure on [duplicate registry](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/lb_policy_registry.cc#L45
) on the 2nd and subsequent test case runs.  

Alternative fix for calling [ShutdownRegistry](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/lb_policy_registry.cc#L77) in test suite teardown doesn't seem to work as this seems to have reset internal states and causes all test case failures.

Follow up with https://github.com/grpc/grpc-ios/issues/41  for investigating into why iOS is loading / running test this way. 
