### PR TITLE
Fix memory leak in get code

### DIFF
--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -344,10 +344,12 @@ static grpc_error_handle update_path_for_get(
                           true /* url_safe */, false /* multi_line */);
   gpr_free(payload_bytes);
   /* remove trailing unused memory and add trailing 0 to terminate string */
-  char* t = reinterpret_cast<char*> GRPC_SLICE_START_PTR(path_with_query_slice);
+  char* t =
+      reinterpret_cast<char*> GRPC_SLICE_START_PTR(path_with_query_slice) +
+      GRPC_SLICE_LENGTH(path_slice);
   /* safe to use strlen since base64_encode will always add '\0' */
-  path_with_query_slice =
-      grpc_slice_sub_no_ref(path_with_query_slice, 0, strlen(t));
+  path_with_query_slice = grpc_slice_sub_no_ref(
+      path_with_query_slice, 0, GRPC_SLICE_LENGTH(path_slice) + strlen(t));
   /* substitute previous path with the new path+query */
   grpc_mdelem mdelem_path_and_query =
       grpc_mdelem_from_slices(GRPC_MDSTR_PATH, path_with_query_slice);

--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/get-leak
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/get-leak
@@ -1,0 +1,32 @@
+actions {
+  create_server {}
+}
+actions {
+  create_channel {
+  target:
+    "unix:\360\32367\227Go\254"
+  }
+}
+actions {
+  create_call {
+    method {
+      value: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+    }
+    timeout: 1000000000
+  }
+}
+actions {
+  queue_batch {
+    operations{
+      send_initial_metadata {} 
+      flags: 64
+    } 
+    operations {
+      send_message {}
+    }
+  }
+}
+actions {
+  advance_time : 10000000
+}
+actions {}


### PR DESCRIPTION
That we can pass down an all-nulls path is probably wrong, but for now let's just not leak memory by doing the string ops correctly.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
