### PR TITLE
Fix two issues with the test framework and new CSDS

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -329,15 +329,15 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         for xds_config in config.xds_config:
             seen.add(xds_config.WhichOneof('per_xds_config'))
         for generic_xds_config in config.generic_xds_configs:
-            if re.search(r'\.Listener$', generic_xds_config['typeUrl']):
+            if re.search(r'\.Listener$', generic_xds_config.type_url):
                 seen.add('listener_config')
             elif re.search(r'\.RouteConfiguration$',
-                           generic_xds_config['typeUrl']):
+                           generic_xds_config.type_url):
                 seen.add('route_config')
-            elif re.search(r'\.Cluster$', generic_xds_config['typeUrl']):
+            elif re.search(r'\.Cluster$', generic_xds_config.type_url):
                 seen.add('cluster_config')
             elif re.search(r'\.ClusterLoadAssignment$',
-                           generic_xds_config['typeUrl']):
+                           generic_xds_config.type_url):
                 seen.add('endpoint_config')
         logger.debug('Received xDS config dump: %s',
                      json_format.MessageToJson(config, indent=2))

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -115,10 +115,10 @@ class DumpedXdsConfig(dict):
                                generic_xds_config['typeUrl']):
                     self.rds = generic_xds_config["xdsConfig"]
                 elif re.search(r'\.Cluster$', generic_xds_config['typeUrl']):
-                    self.cds = generic_xds_config["xdsConfig"]
+                    self.cds.append(generic_xds_config["xdsConfig"])
                 elif re.search(r'\.ClusterLoadAssignment$',
                                generic_xds_config['typeUrl']):
-                    self.eds = generic_xds_config["xdsConfig"]
+                    self.eds.append(generic_xds_config["xdsConfig"])
             except Exception as e:
                 logging.debug('Parsing dumped xDS config failed with %s: %s',
                               type(e), e)


### PR DESCRIPTION
https://fusion2.corp.google.com/invocations/c64216ae-5272-4b4b-9bc4-74f32ac9c85f/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_xds_url_map/log

https://fusion2.corp.google.com/invocations/71ddd23c-57b4-4137-b865-9ea01b17aa42/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_xds_k8s_lb/log

This PR fixes issue in above logs.

Test runs:
- Security Tests: https://fusion2.corp.google.com/invocations/c38202ce-c2cd-4bc4-a258-1eafd6e60635/targets (ok)
- Basic LB Tests: https://fusion2.corp.google.com/invocations/07a2a64b-55ac-4cda-9a65-a58a43343643/targets (ok)
- UrlMap Tests: https://fusion2.corp.google.com/invocations/887b7325-5585-4623-85e5-466737fb4ffa/targets (timeout) (due to depleted GKE cluster resources)
- UrlMap Tests: https://fusion2.corp.google.com/invocations/705e1f6d-976a-4f46-839f-58a8171566a5