### PR TITLE
Ruby 3 compatibility in tests

### DIFF
--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -17,7 +17,7 @@ describe 'Server Interceptors' do
   let(:interceptor) { TestServerInterceptor.new }
   let(:request) { EchoMsg.new }
   let(:trailing_metadata) { {} }
-  let(:service) { EchoService.new(trailing_metadata) }
+  let(:service) { EchoService.new(**trailing_metadata) }
   let(:interceptors) { [] }
 
   before(:each) do

--- a/src/ruby/spec/user_agent_spec.rb
+++ b/src/ruby/spec/user_agent_spec.rb
@@ -48,8 +48,7 @@ describe 'user agent' do
 
   it 'client sends expected user agent' do
     stub = UserAgentEchoServiceStub.new("localhost:#{@port}",
-                                        :this_channel_is_insecure,
-                                        {})
+                                        :this_channel_is_insecure)
     response = stub.an_rpc(EchoMsg.new)
     expected_user_agent_prefix = "grpc-ruby/#{GRPC::VERSION}"
     expect(response.msg.start_with?(expected_user_agent_prefix)).to be true


### PR DESCRIPTION
Ruby 3 removed support for using the last argument of a method call
as keyword arguments.

@yashykt
