### PR TITLE
Hotfix for low java throughput in e2e GKE benchmarks

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -57,8 +57,10 @@ GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master |
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
+WORKER_POOL_8CORE_NUM_CORES=8
 # c2-standard-30 is the closest machine spec to 32 core there is
 WORKER_POOL_32CORE=workers-c2-30core-ci
+WORKER_POOL_32CORE_NUM_CORES=30
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1
@@ -78,13 +80,17 @@ popd
 buildConfigs() {
     local -r pool="$1"
     local -r table="$2"
-    shift 2
+    local -r num_cores="$3"
+    shift 3
+    # TODO(jtattermusch): find a better solution for detecting number of cores in java
+    # then setting the "java_worker_command_prefix"
     tools/run_tests/performance/loadtest_config.py "$@" \
         -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
         -s driver_pool="${DRIVER_POOL}" -s driver_image= \
         -s client_pool="${pool}" -s server_pool="${pool}" \
         -s big_query_table="${table}" -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
+        -s java_worker_command_prefix='BENCHMARK_WORKER_OPTS="-XX:ActiveProcessorCount='${num_cores}'"' \
         -a ci_buildNumber="${KOKORO_BUILD_NUMBER}" \
         -a ci_buildUrl="${CLOUD_LOGGING_URL}" \
         -a ci_jobName="${KOKORO_JOB_NAME}" \
@@ -99,8 +105,8 @@ buildConfigs() {
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" -l c++ -l csharp -l go -l java
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${WORKER_POOL_8CORE_NUM_CORES}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${WORKER_POOL_32CORE_NUM_CORES}" -l c++ -l csharp -l go -l java
 
 # Delete prebuilt images on exit.
 deleteImages() {

--- a/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_v2.sh
@@ -55,8 +55,10 @@ GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master |
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
+WORKER_POOL_8CORE_NUM_CORES=8
 # c2-standard-30 is the closest machine spec to 32 core there is
 WORKER_POOL_32CORE=workers-c2-30core-ci
+WORKER_POOL_32CORE_NUM_CORES=30
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1
@@ -76,7 +78,10 @@ popd
 buildConfigs() {
     local -r pool="$1"
     local -r table="$2"
-    shift 2
+    local -r num_cores="$3"
+    shift 3
+    # TODO(jtattermusch): find a better solution for detecting number of cores in java
+    # then setting the "java_worker_command_prefix"
     tools/run_tests/performance/loadtest_config.py "$@" \
         -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
         -s driver_pool="${DRIVER_POOL}" -s driver_image= \
@@ -84,6 +89,7 @@ buildConfigs() {
         -s big_query_table="${table}" -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
         -s prebuilt_image_tag="${UNIQUE_IDENTIFIER}" \
+        -s java_worker_command_prefix='BENCHMARK_WORKER_OPTS="-XX:ActiveProcessorCount='${num_cores}'"' \
         -a ci_buildNumber="${KOKORO_BUILD_NUMBER}" \
         -a ci_buildUrl="${CLOUD_LOGGING_URL}" \
         -a ci_jobName="${KOKORO_JOB_NAME}" \
@@ -97,8 +103,8 @@ buildConfigs() {
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" -l c++ -l csharp -l go -l java
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${WORKER_POOL_8CORE_NUM_CORES}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${WORKER_POOL_32CORE_NUM_CORES}" -l c++ -l csharp -l go -l java
 
 # Delete prebuilt images on exit.
 deleteImages() {

--- a/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
@@ -56,7 +56,7 @@ spec:
       args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        ${java_worker_command_prefix} timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
             /execute/bin/benchmark_worker \
             --driver_port="${DRIVER_PORT}"
       command:
@@ -182,7 +182,7 @@ spec:
       args:
       - -c
       - |
-        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        ${java_worker_command_prefix} timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
             /execute/bin/benchmark_worker \
             --driver_port="${DRIVER_PORT}"
       command:


### PR DESCRIPTION
Addresses b/203547571.

Make sure that java workers know the right number of cores available on the machine (so they can correctly size their internal event processing threadpool).