### PR TITLE
revert changes to not build RLS on mobile

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -440,7 +440,6 @@ grpc_cc_library(
     public_hdrs = GRPCXX_PUBLIC_HDRS,
     select_deps = {
         "grpc_no_xds": [],
-        "grpc_mobile": [],
         "//conditions:default": [
             "grpc++_xds_client",
             "grpc++_xds_server",
@@ -4037,7 +4036,6 @@ grpc_cc_library(
     hdrs = [],
     defines = select({
         "grpc_no_xds": ["GRPC_NO_XDS"],
-        "grpc_mobile": ["GRPC_NO_XDS"],
         "//conditions:default": [],
     }),
     external_deps = [
@@ -4049,7 +4047,6 @@ grpc_cc_library(
     ],
     select_deps = {
         "grpc_no_xds": [],
-        "grpc_mobile": [],
         "//conditions:default": ["//:grpcpp_csds"],
     },
     deps = [

--- a/BUILD
+++ b/BUILD
@@ -44,7 +44,7 @@ config_setting(
 )
 
 config_setting(
-    name = "grpc_no_xds",
+    name = "grpc_no_xds_define",
     values = {"define": "grpc_no_xds=true"},
 )
 
@@ -58,18 +58,23 @@ config_setting(
     values = {"apple_platform_type": "ios"},
 )
 
-selects.config_setting_group(
-    name = "grpc_mobile",
-    match_any = [
-        ":android",
-        ":ios",
-    ],
-)
-
 # Fuzzers can be built as fuzzers or as tests
 config_setting(
     name = "grpc_build_fuzzers",
     values = {"define": "grpc_build_fuzzers=true"},
+)
+
+selects.config_setting_group(
+    name = "grpc_no_xds",
+    match_any = [
+        ":grpc_no_xds_define",
+        # In addition to disabling XDS support when --define=grpc_no_xds=true is
+        # specified, we also disable it on mobile platforms where it is not
+        # likely to be needed and where reducing the binary size is more
+        # important.
+        ":android",
+        ":ios",
+    ],
 )
 
 config_setting(
@@ -363,16 +368,6 @@ grpc_cc_library(
     ],
 )
 
-GRPC_XDS_TARGETS = [
-    "grpc_lb_policy_cds",
-    "grpc_lb_policy_xds_cluster_impl",
-    "grpc_lb_policy_xds_cluster_manager",
-    "grpc_lb_policy_xds_cluster_resolver",
-    "grpc_resolver_xds",
-    "grpc_resolver_c2p",
-    "grpc_xds_server_config_fetcher",
-]
-
 grpc_cc_library(
     name = "grpc",
     srcs = [
@@ -380,25 +375,22 @@ grpc_cc_library(
         "src/core/plugin_registry/grpc_plugin_registry.cc",
     ],
     defines = select({
-        # On mobile, don't build RLS or xDS.
-        "grpc_mobile": [
-            "GRPC_NO_XDS",
-            "GRPC_NO_RLS",
-        ],
-        # Don't build xDS if --define=grpc_no_xds=true is used.
         "grpc_no_xds": ["GRPC_NO_XDS"],
-        # By default, build both RLS and xDS.
         "//conditions:default": [],
     }),
     language = "c++",
     public_hdrs = GRPC_PUBLIC_HDRS + GRPC_SECURE_PUBLIC_HDRS,
     select_deps = {
-        # On mobile, don't build RLS or xDS.
-        "grpc_mobile": [],
-        # Don't build xDS if --define=grpc_no_xds=true is used.
-        "grpc_no_xds": ["grpc_lb_policy_rls"],
-        # By default, build both RLS and xDS.
-        "//conditions:default": ["grpc_lb_policy_rls"] + GRPC_XDS_TARGETS,
+        "grpc_no_xds": [],
+        "//conditions:default": [
+            "grpc_lb_policy_cds",
+            "grpc_lb_policy_xds_cluster_impl",
+            "grpc_lb_policy_xds_cluster_manager",
+            "grpc_lb_policy_xds_cluster_resolver",
+            "grpc_resolver_xds",
+            "grpc_resolver_c2p",
+            "grpc_xds_server_config_fetcher",
+        ],
     },
     standalone = True,
     visibility = [
@@ -410,6 +402,7 @@ grpc_cc_library(
         "grpc_base",
         "grpc_common",
         "grpc_lb_policy_grpclb_secure",
+        "grpc_lb_policy_rls",
         "grpc_secure",
         "grpc_trace",
         "grpc_transport_chttp2_client_secure",

--- a/src/core/plugin_registry/grpc_plugin_registry.cc
+++ b/src/core/plugin_registry/grpc_plugin_registry.cc
@@ -54,10 +54,8 @@ void FaultInjectionFilterInit(void);
 void FaultInjectionFilterShutdown(void);
 void GrpcLbPolicyRingHashInit(void);
 void GrpcLbPolicyRingHashShutdown(void);
-#ifndef GRPC_NO_RLS
 void RlsLbPluginInit();
 void RlsLbPluginShutdown();
-#endif  // !GRPC_NO_RLS
 void ServiceConfigParserInit(void);
 void ServiceConfigParserShutdown(void);
 }  // namespace grpc_core
@@ -103,10 +101,8 @@ void grpc_register_built_in_plugins(void) {
   grpc_register_plugin(grpc_resolver_fake_init, grpc_resolver_fake_shutdown);
   grpc_register_plugin(grpc_lb_policy_grpclb_init,
                        grpc_lb_policy_grpclb_shutdown);
-#ifndef GRPC_NO_RLS
   grpc_register_plugin(grpc_core::RlsLbPluginInit,
                        grpc_core::RlsLbPluginShutdown);
-#endif  // !GRPC_NO_RLS
   grpc_register_plugin(grpc_lb_policy_priority_init,
                        grpc_lb_policy_priority_shutdown);
   grpc_register_plugin(grpc_lb_policy_weighted_target_init,

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -66,7 +66,6 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
-    tags = ["no_test_ios"],
     deps = [
         "//:grpc",
         "//test/core/util:grpc_test_util",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -484,7 +484,6 @@ grpc_cc_test(
         "gtest",
         "absl/types:optional",
     ],
-    tags = ["no_test_ios"],
     deps = [
         ":counted_service",
         ":test_service_impl",


### PR DESCRIPTION
This reverts #27855 and #27838.

This approach breaks projects that build on both mobile and non-mobile but don't want xDS, because they build with `--define=grpc_no_xds=true`, and then bazel fails with this error:

```
(07:31:17) ERROR: third_party/grpc/BUILD:435:16: Illegal ambiguous match on configurable attribute "deps" in //third_party/grpc:google/grpc++:
//third_party/grpc:grpc_no_xds
//third_party/grpc:grpc_mobile
Multiple matches are not allowed unless one is unambiguously more specialized.
```