### PR TITLE
Make it possible to build Ruby gem with system OpenSSL

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -69,8 +69,13 @@ ENV['BUILDDIR'] = output_dir
 
 unless windows
   puts 'Building internal gRPC into ' + grpc_lib_dir
-  nproc = 4
-  nproc = Etc.nprocessors * 2 if Etc.respond_to? :nprocessors
+  nproc =
+    if ENV['MAKE_NPROC']
+      ENV['MAKE_NPROC']
+    else
+      nproc = 4
+      nproc = Etc.nprocessors * 2 if Etc.respond_to? :nprocessors
+    end
   make = bsd ? 'gmake' : 'make'
   system("#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q=")
   exit 1 unless $? == 0

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -45,7 +45,8 @@ if darwin && !cross_compiling
   ENV['ARFLAGS'] = '-o'
 end
 
-ENV['EMBED_OPENSSL'] = 'true'
+use_system_ssl = ENV['EMBED_OPENSSL'] == 'false' || ENV['HAS_SYSTEM_OPENSSL_ALPN'] == 'true'
+ENV['HAS_SYSTEM_OPENSSL_ALPN'] = 'true' if use_system_ssl
 ENV['EMBED_ZLIB'] = 'true'
 ENV['EMBED_CARES'] = 'true'
 
@@ -94,6 +95,7 @@ end
 $LDFLAGS << ' -Wl,-wrap,memcpy' if linux
 $LDFLAGS << ' -static-libgcc -static-libstdc++' if linux
 $LDFLAGS << ' -static' if windows
+$LDFLAGS << ' -lssl' if use_system_ssl
 
 $CFLAGS << ' -std=c99 '
 $CFLAGS << ' -Wall '

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -349,6 +349,22 @@
 
   CACHE_MK =
 
+  HAS_PKG_CONFIG ?= $(shell command -v $(PKG_CONFIG) >/dev/null 2>&1 && echo true || echo false)
+
+  ifeq ($(HAS_PKG_CONFIG), true)
+  CACHE_MK += HAS_PKG_CONFIG = true,
+  else # HAS_PKG_CONFIG
+  ifeq ($(SYSTEM),MINGW32)
+  OPENSSL_LIBS = ssl32 eay32
+  else
+  OPENSSL_LIBS = ssl crypto
+  endif
+  endif # HAS_PKG_CONFIG
+
+  ifeq ($(HAS_SYSTEM_OPENSSL_ALPN),true)
+  CACHE_MK += HAS_SYSTEM_OPENSSL_ALPN = true
+  endif
+
   ifeq ($(SYSTEM),MINGW32)
   EXECUTABLE_SUFFIX = .exe
   SHARED_EXT_CORE = dll
@@ -459,35 +475,60 @@
   UPB_MERGE_OBJS = $(LIBUPB_OBJS)
   UPB_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libupb.a
 
-  # Setup boringssl dependency
-
   ifeq ($(wildcard third_party/boringssl-with-bazel/src/include/openssl/ssl.h),)
-  HAS_EMBEDDED_OPENSSL = false
+  HAS_EMBEDDED_OPENSSL_ALPN = false
   else
-  HAS_EMBEDDED_OPENSSL = true
+  HAS_EMBEDDED_OPENSSL_ALPN = true
   endif
 
-  ifeq ($(HAS_EMBEDDED_OPENSSL),true)
+  OPENSSL_PKG_CONFIG = false
+
+  ifeq ($(HAS_SYSTEM_OPENSSL_ALPN),true)
+  EMBED_OPENSSL ?= false
+  NO_SECURE ?= false
+  else # HAS_SYSTEM_OPENSSL_ALPN=false
+  ifeq ($(HAS_EMBEDDED_OPENSSL_ALPN),true)
   EMBED_OPENSSL ?= true
-  else
-  # only support building boringssl from submodule
-  DEP_MISSING += openssl
-  EMBED_OPENSSL ?= broken
-  endif
+  NO_SECURE ?= false
+  else # HAS_EMBEDDED_OPENSSL_ALPN=false
+  NO_SECURE ?= true
+  endif # HAS_EMBEDDED_OPENSSL_ALPN=false
+  endif # HAS_SYSTEM_OPENSSL_ALPN
 
+  ifeq ($(NO_SECURE),false)
   ifeq ($(EMBED_OPENSSL),true)
+  # Setup boringssl dependency
   OPENSSL_DEP += $(LIBDIR)/$(CONFIG)/libboringssl.a
   OPENSSL_MERGE_LIBS += $(LIBDIR)/$(CONFIG)/libboringssl.a
   OPENSSL_MERGE_OBJS += $(LIBBORINGSSL_OBJS)
   # need to prefix these to ensure overriding system libraries
-  CPPFLAGS := -Ithird_party/boringssl-with-bazel/src/include $(CPPFLAGS)  
+  CPPFLAGS := -Ithird_party/boringssl-with-bazel/src/include $(CPPFLAGS)
+  else # EMBED_OPENSSL=false
+  ifeq ($(HAS_PKG_CONFIG),true)
+  OPENSSL_PKG_CONFIG = true
+  CPPFLAGS := $(shell $(PKG_CONFIG) --cflags openssl) $(CPPFLAGS)
+  LDFLAGS_OPENSSL_PKG_CONFIG = $(shell $(PKG_CONFIG) --libs-only-L openssl)
+  ifeq ($(SYSTEM),Linux)
+  ifneq ($(LDFLAGS_OPENSSL_PKG_CONFIG),)
+  LDFLAGS_OPENSSL_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L openssl | sed s/L/Wl,-rpath,/)
+  endif # LDFLAGS_OPENSSL_PKG_CONFIG=''
+  endif # System=Linux
+  LDFLAGS := $(LDFLAGS_OPENSSL_PKG_CONFIG) $(LDFLAGS)
+  else # HAS_PKG_CONFIG=false
+  LIBS_SECURE = $(OPENSSL_LIBS)
+  endif # HAS_PKG_CONFIG
   ifeq ($(DISABLE_ALPN),true)
   CPPFLAGS += -DTSI_OPENSSL_ALPN_SUPPORT=0
   LIBS_SECURE = $(OPENSSL_LIBS)
   endif # DISABLE_ALPN
   endif # EMBED_OPENSSL
-  
+  endif # NO_SECURE
+
+  ifeq ($(OPENSSL_PKG_CONFIG),true)
+  LDLIBS_SECURE += $(shell $(PKG_CONFIG) --libs-only-l openssl)
+  else
   LDLIBS_SECURE += $(addprefix -l, $(LIBS_SECURE))
+  endif
 
   ifeq ($(MAKECMDGOALS),clean)
   NO_DEPS = true

--- a/templates/src/ruby/ext/grpc/extconf.rb.template
+++ b/templates/src/ruby/ext/grpc/extconf.rb.template
@@ -47,7 +47,8 @@
     ENV['ARFLAGS'] = '-o'
   end
   
-  ENV['EMBED_OPENSSL'] = 'true'
+  use_system_ssl = ENV['EMBED_OPENSSL'] == 'false' || ENV['HAS_SYSTEM_OPENSSL_ALPN'] == 'true'
+  ENV['HAS_SYSTEM_OPENSSL_ALPN'] = 'true' if use_system_ssl
   ENV['EMBED_ZLIB'] = 'true'
   ENV['EMBED_CARES'] = 'true'
   
@@ -96,6 +97,7 @@
   $LDFLAGS << ' -Wl,-wrap,memcpy' if linux
   $LDFLAGS << ' -static-libgcc -static-libstdc++' if linux
   $LDFLAGS << ' -static' if windows
+  $LDFLAGS << ' -lssl' if use_system_ssl
   
   $CFLAGS << ' -std=c99 '
   $CFLAGS << ' -Wall '


### PR DESCRIPTION
This pull request adds a number of changes to enable compiling gRPC for s390x:

1. Bring back ability to compile against system OpenSSL

https://github.com/grpc/grpc/pull/23957 removed the ability to build against the system OpenSSL libraries. However, BoringSSL is not supported on such platforms as the IBM s390x. This commits restores the behavior of that merge request just for OpenSSL.

2. Make it possible to build Ruby gem with system OpenSSL

By installing the gem with `EMBED_OPENSSL=false`, the Ruby gem can be compiled using the system OpenSSL library. This is needed on systems where BoringSSL doesn't compile (e.g. s390x).

3. Allow configuration of number of jobs to build Ruby gem

Some systems may be memory-constrained, so launching N jobs for N processors will cause the compilation to run out of memory.  We add an environment variable, `MAKE_NPROC`, that allows users to use a custom number of jobs.

For example, I was able to build on s390x via:

```sh
MAKE_NPROC=1 EMBED_OPENSSL=false gem install pkg/grpc-1.42.0.dev.gem
```

Closes https://github.com/grpc/grpc/issues/15997

@veblush @jtattermusch 