### PR TITLE
Speed up portability tests

### DIFF
--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux c++ --inner_jobs 16 -j 4 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 8 -j 4 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux c++ --inner_jobs 64 -j 2 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 16 -j 4 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux c++ --inner_jobs 8 -j 4 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 8 -j 4 --internal_ci --build_only --extra_args -r xds_end2end_test"
 }

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux --inner_jobs 8 -j 4 --internal_ci --build_only"
+  value: "-f portability linux --inner_jobs 32 -j 2 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux --inner_jobs 32 -j 2 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 32 -j 2 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux c++ --inner_jobs 32 -j 2 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 64 -j 2 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/linux/grpc_run_tests_matrix.sh
@@ -22,7 +22,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ] && [ -n "$RUN_TESTS_FLAGS" ]; then
-  export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
+  export RUN_TESTS_FLAGS="--filter_pr_tests --base_branch origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH $RUN_TESTS_FLAGS"
 fi
 
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -320,6 +320,7 @@ def _create_portability_test_jobs(extra_args=[],
                                 labels=['portability', 'corelang'],
                                 extra_args=extra_args,
                                 extra_envs={'GRPC_DNS_RESOLVER': 'ares'},
+                                inner_jobs=inner_jobs,
                                 timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     # C and C++ with no-exceptions on Linux
@@ -328,6 +329,7 @@ def _create_portability_test_jobs(extra_args=[],
                                 platforms=['linux'],
                                 labels=['portability', 'corelang'],
                                 extra_args=extra_args,
+                                inner_jobs=inner_jobs,
                                 timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     test_jobs += _generate_jobs(languages=['python'],

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Copyright 2015 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- set inner_jobs in a few places it was missing
- omit building c tests
- build only xds_end2end_test for c++

Reasoning: we only care that our implementations build on older compilers, less so our tests (or we'd be running them...), and so since C++ depends on core, there's no reason to build core as a separate step.

We do want to hit most of our code generation, and the xds end2end tests cover most of the surface here.

Saves about 50 minutes.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
