### PR TITLE
[C#] Add cancellation token overloads to streaming interfaces

### DIFF
--- a/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj
+++ b/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/csharp/Grpc.Core.Api/IAsyncStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IAsyncStreamWriter.cs
@@ -45,6 +45,14 @@ namespace Grpc.Core
         /// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
         Task WriteAsync(T message, CancellationToken cancellationToken)
         {
+            if (cancellationToken.CanBeCanceled)
+            {
+                // Note to implementors:
+                // Add a netstandard2.1 or greater target to your library and override
+                // WriteAsync(T, CancellationToken) on stream writer to use the cancellation token.
+                throw new NotSupportedException("Cancellation of stream writes is not supported by this gRPC implementation.");
+            }
+
             return WriteAsync(message);
         }
 #endif

--- a/src/csharp/Grpc.Core.Api/IAsyncStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IAsyncStreamWriter.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Grpc.Core
@@ -35,6 +36,18 @@ namespace Grpc.Core
         /// </summary>
         /// <param name="message">The message to be written. Cannot be null.</param>
         Task WriteAsync(T message);
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Writes a message asynchronously. Only one write can be pending at a time.
+        /// </summary>
+        /// <param name="message">The message to be written. Cannot be null.</param>
+        /// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
+        Task WriteAsync(T message, CancellationToken cancellationToken)
+        {
+            return WriteAsync(message);
+        }
+#endif
 
         /// <summary>
         /// Write options that will be used for the next write.

--- a/src/csharp/Grpc.Core.Api/IClientStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IClientStreamWriter.cs
@@ -20,7 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Grpc.Core
@@ -35,16 +34,5 @@ namespace Grpc.Core
         /// Completes/closes the stream. Can only be called once there is no pending write. No writes should follow calling this.
         /// </summary>
         Task CompleteAsync();
-
-#if NETSTANDARD2_1_OR_GREATER
-        /// <summary>
-        /// Completes/closes the stream. Can only be called once there is no pending write. No writes should follow calling this.
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
-        Task CompleteAsync(CancellationToken cancellationToken)
-        {
-            return CompleteAsync();
-        }
-#endif
     }
 }

--- a/src/csharp/Grpc.Core.Api/IClientStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IClientStreamWriter.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Grpc.Core
@@ -34,5 +35,16 @@ namespace Grpc.Core
         /// Completes/closes the stream. Can only be called once there is no pending write. No writes should follow calling this.
         /// </summary>
         Task CompleteAsync();
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Completes/closes the stream. Can only be called once there is no pending write. No writes should follow calling this.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token that can be used to cancel the operation.</param>
+        Task CompleteAsync(CancellationToken cancellationToken)
+        {
+            return CompleteAsync();
+        }
+#endif
     }
 }


### PR DESCRIPTION
See https://github.com/grpc/grpc-dotnet/issues/1422#issuecomment-943771494

* Adds default interface implementation with cancellation token overloads
* Default implementation calls the current interface method. grpc-dotnet will override default implementation to use the cancellation token
* Feature requires C# 8.0
* Feature isn't supported on .NET Framework. Overloads will only be available with .NET Standard 2.1 target (i.e. .NET Core 3 or later)

@jtattermusch @captainsafia