### PR TITLE
ExecCtxWorkSerializer

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1546,6 +1546,21 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "exec_ctx_work_serializer",
+    srcs = [
+        "src/core/lib/iomgr/exec_ctx_work_serializer.cc",
+    ],
+    hdrs = [
+        "src/core/lib/iomgr/exec_ctx_work_serializer.h",
+    ],
+    deps = [
+        "exec_ctx",
+        "gpr_base",
+        "orphanable",
+    ],
+)
+
+grpc_cc_library(
     name = "grpc_base",
     srcs = [
         "src/core/lib/address_utils/parse_address.cc",

--- a/src/core/lib/iomgr/exec_ctx_work_serializer.cc
+++ b/src/core/lib/iomgr/exec_ctx_work_serializer.cc
@@ -1,0 +1,159 @@
+//
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/lib/iomgr/exec_ctx_work_serializer.h"
+
+namespace grpc_core {
+
+DebugOnlyTraceFlag grpc_exec_ctx_work_serializer_trace(
+    false, "exec_ctx_work_serializer");
+
+namespace {
+struct CallbackWrapper {
+  CallbackWrapper(std::function<void()> cb, const grpc_core::DebugLocation& loc)
+      : callback(std::move(cb)), location(loc) {}
+
+  MultiProducerSingleConsumerQueue::Node mpscq_node;
+  const std::function<void()> callback;
+  const DebugLocation location;
+};
+}  // namespace
+
+class ExecCtxWorkSerializer::ExecCtxWorkSerializerImpl : public Orphanable {
+ public:
+  ExecCtxWorkSerializerImpl() {
+    GRPC_CLOSURE_INIT(
+        &closure_,
+        [](void* arg, grpc_error_handle /* error */) {
+          static_cast<ExecCtxWorkSerializerImpl*>(arg)->DrainQueue();
+        },
+        this, nullptr);
+  }
+
+  void Run(std::function<void()> callback,
+           const grpc_core::DebugLocation& location);
+
+  void Orphan() override;
+
+ private:
+  void DrainQueue();
+
+  // An initial size of 1 keeps track of whether the exec ctx work serializer
+  // has been orphaned.
+  std::atomic<size_t> size_{1};
+  MultiProducerSingleConsumerQueue queue_;
+  grpc_closure closure_;
+};
+
+void ExecCtxWorkSerializer::ExecCtxWorkSerializerImpl::Run(
+    std::function<void()> callback, const grpc_core::DebugLocation& location) {
+  CallbackWrapper* cb_wrapper =
+      new CallbackWrapper(std::move(callback), location);
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+    gpr_log(GPR_INFO,
+            "ExecCtxWorkSerializer::Run() %p Scheduling callback %p [%s:%d]",
+            this, cb_wrapper, location.file(), location.line());
+  }
+  queue_.Push(&cb_wrapper->mpscq_node);
+  const size_t prev_size = size_.fetch_add(1);
+  // The work serializer should not have been orphaned.
+  GPR_DEBUG_ASSERT(prev_size > 0);
+  if (prev_size == 1) {
+    // This is the first closure on the queue. Schedule the queue to be drained
+    // on ExecCtx
+    ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+    if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+      gpr_log(GPR_INFO, "  Begin draining");
+    }
+  }
+}
+
+void ExecCtxWorkSerializer::ExecCtxWorkSerializerImpl::Orphan() {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+    gpr_log(GPR_INFO, "ExecCtxWorkSerializer::Orphan() %p", this);
+  }
+  size_t prev_size = size_.fetch_sub(1);
+  if (prev_size == 1) {
+    if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+      gpr_log(GPR_INFO, "  Destroying");
+    }
+    delete this;
+  }
+}
+
+// This is invoked from a thread's ExecCtx
+void ExecCtxWorkSerializer::ExecCtxWorkSerializerImpl::DrainQueue() {
+  while (true) {
+    if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+      gpr_log(GPR_INFO, "ExecCtxWorkSerializer::DrainQueue() %p", this);
+    }
+    // There is at least one callback on the queue. Pop the callback from the
+    // queue and execute it.
+    CallbackWrapper* cb_wrapper = nullptr;
+    bool empty_unused;
+    while ((cb_wrapper = reinterpret_cast<CallbackWrapper*>(
+                queue_.PopAndCheckEnd(&empty_unused))) == nullptr) {
+      // This can happen either due to a race condition within the mpscq
+      // implementation.
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+        gpr_log(GPR_INFO, "  Queue returned nullptr, trying again");
+      }
+    }
+    if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+      gpr_log(GPR_INFO, "  Running item %p : callback scheduled at [%s:%d]",
+              cb_wrapper, cb_wrapper->location.file(),
+              cb_wrapper->location.line());
+    }
+    cb_wrapper->callback();
+    delete cb_wrapper;
+    size_t prev_size = size_.fetch_sub(1);
+    GPR_DEBUG_ASSERT(prev_size >= 1);
+    // It is possible that while draining the queue, one of the callbacks ended
+    // up orphaning the exec ctx work serializer. In that case, delete the
+    // object.
+    if (prev_size == 1) {
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+        gpr_log(GPR_INFO, "  Queue Drained. Destroying");
+      }
+      delete this;
+      return;
+    }
+    if (prev_size == 2) {
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_exec_ctx_work_serializer_trace)) {
+        gpr_log(GPR_INFO, "  Queue Drained");
+      }
+      return;
+    }
+  }
+}
+
+//
+// ExecCtxWorkSerializer
+//
+
+ExecCtxWorkSerializer::ExecCtxWorkSerializer()
+    : impl_(MakeOrphanable<ExecCtxWorkSerializerImpl>()) {}
+
+ExecCtxWorkSerializer::~ExecCtxWorkSerializer() {}
+
+void ExecCtxWorkSerializer::Run(std::function<void()> callback,
+                                const grpc_core::DebugLocation& location) {
+  impl_->Run(std::move(callback), location);
+}
+
+}  // namespace grpc_core

--- a/src/core/lib/iomgr/exec_ctx_work_serializer.h
+++ b/src/core/lib/iomgr/exec_ctx_work_serializer.h
@@ -1,0 +1,86 @@
+//
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <grpc/support/port_platform.h>
+
+#include <atomic>
+#include <functional>
+
+#include "absl/synchronization/mutex.h"
+
+#include "src/core/lib/debug/trace.h"
+#include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/gprpp/mpscq.h"
+#include "src/core/lib/gprpp/orphanable.h"
+#include "src/core/lib/gprpp/ref_counted.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+
+#ifndef GRPC_CORE_LIB_IOMGR_EXEC_CTX_WORK_SERIALIZER_H
+#define GRPC_CORE_LIB_IOMGR_EXEC_CTX_WORK_SERIALIZER_H
+
+namespace grpc_core {
+
+// ExecCtxWorkSerializer is a mechanism to schedule callbacks in a synchronized
+// manner through ExecCtx. 
+//
+// All callbacks scheduled on an ExecCtxWorkSerializer instance will be executed serially on a thread's ExecCtx. The API provides a
+// FIFO guarantee to the execution of callbacks scheduled on the thread. 
+
+// When Run() is invoked with a callback, it is added on to a queue which is drained
+// when ExecCtx is flushed. The ExecCtx used for drained the callbacks is
+// determined by the size of the queue of callbacks. If the queue is empty, the
+// thread invoking `Run()` to add a callback to the queue shares its ExecCtx. If
+// the queue already has other callbacks, the current callback is simply added
+// to the queue. 
+//
+// The prime reason to use ExecCtxWorkSerializer instead of WorkSerializer is for the ability to execute callbacks without worrying about
+// the locks being held when scheduling a callback.
+class ABSL_LOCKABLE ExecCtxWorkSerializer {
+ public:
+  ExecCtxWorkSerializer();
+
+  ~ExecCtxWorkSerializer();
+
+  // Runs a given callback.
+  //
+  // If you want to use clang thread annotation to make sure that callback is
+  // called by ExecCtxWorkSerializer only, you need to add the annotation to
+  // both the lambda function given to Run and the actual callback function
+  // like;
+  //
+  //   void run_callback() {
+  //     exec_ctx_work_serializer.Run(
+  //         []() ABSL_EXCLUSIVE_LOCKS_REQUIRED(exec_ctx_work_serializer) {
+  //            callback();
+  //         }, DEBUG_LOCATION);
+  //   }
+  //   void callback() ABSL_EXCLUSIVE_LOCKS_REQUIRED(exec_ctx_work_serializer) {
+  //   ... }
+  //
+  // TODO(yashkt): Replace grpc_core::DebugLocation with absl::SourceLocation
+  // once we can start using it directly.
+  void Run(std::function<void()> callback,
+           const grpc_core::DebugLocation& location);
+
+ private:
+  class ExecCtxWorkSerializerImpl;
+
+  OrphanablePtr<ExecCtxWorkSerializerImpl> impl_;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_CORE_LIB_IOMGR_EXEC_CTX_WORK_SERIALIZER_H

--- a/src/core/lib/iomgr/exec_ctx_work_serializer.h
+++ b/src/core/lib/iomgr/exec_ctx_work_serializer.h
@@ -34,20 +34,22 @@
 namespace grpc_core {
 
 // ExecCtxWorkSerializer is a mechanism to schedule callbacks in a synchronized
-// manner through ExecCtx. 
+// manner through ExecCtx.
 //
-// All callbacks scheduled on an ExecCtxWorkSerializer instance will be executed serially on a thread's ExecCtx. The API provides a
-// FIFO guarantee to the execution of callbacks scheduled on the thread. 
+// All callbacks scheduled on an ExecCtxWorkSerializer instance will be executed
+// serially on a thread's ExecCtx. The API provides a FIFO guarantee to the
+// execution of callbacks scheduled on the thread.
 
-// When Run() is invoked with a callback, it is added on to a queue which is drained
-// when ExecCtx is flushed. The ExecCtx used for drained the callbacks is
-// determined by the size of the queue of callbacks. If the queue is empty, the
-// thread invoking `Run()` to add a callback to the queue shares its ExecCtx. If
-// the queue already has other callbacks, the current callback is simply added
-// to the queue. 
+// When Run() is invoked with a callback, it is added on to a queue which is
+// drained when ExecCtx is flushed. The ExecCtx used for drained the callbacks
+// is determined by the size of the queue of callbacks. If the queue is empty,
+// the thread invoking `Run()` to add a callback to the queue shares its
+// ExecCtx. If the queue already has other callbacks, the current callback is
+// simply added to the queue.
 //
-// The prime reason to use ExecCtxWorkSerializer instead of WorkSerializer is for the ability to execute callbacks without worrying about
-// the locks being held when scheduling a callback.
+// The prime reason to use ExecCtxWorkSerializer instead of WorkSerializer is
+// for the ability to execute callbacks without worrying about the locks being
+// held when scheduling a callback.
 class ABSL_LOCKABLE ExecCtxWorkSerializer {
  public:
   ExecCtxWorkSerializer();

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -369,3 +369,22 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
     ],
 )
+
+grpc_cc_test(
+    name = "exec_ctx_work_serializer_test",
+    srcs = ["exec_ctx_work_serializer_test.cc"],
+    exec_properties = LARGE_MACHINE,
+    external_deps = [
+        "gtest",
+    ],
+    language = "C++",
+    tags = [
+        "no_windows",  # LARGE_MACHINE is not configured for windows RBE
+    ],
+    deps = [
+        "//:exec_ctx_work_serializer",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:grpc_test_util",
+    ],
+)

--- a/test/core/iomgr/exec_ctx_work_serializer_test.cc
+++ b/test/core/iomgr/exec_ctx_work_serializer_test.cc
@@ -1,0 +1,123 @@
+//
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/core/lib/iomgr/exec_ctx_work_serializer.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "absl/memory/memory.h"
+
+#include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/gprpp/thd.h"
+#include "test/core/util/test_config.h"
+
+namespace grpc_core {
+namespace {
+TEST(ExecCtxWorkSerializerTest, NoOp) { grpc_core::ExecCtxWorkSerializer lock; }
+
+TEST(ExecCtxWorkSerializerTest, ExecuteOne) {
+  ExecCtxWorkSerializer lock;
+  gpr_event done;
+  gpr_event_init(&done);
+  {
+    ExecCtx exec_ctx;
+    lock.Run([&done]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(
+                 lock) { gpr_event_set(&done, reinterpret_cast<void*>(1)); },
+             DEBUG_LOCATION);
+  }
+  EXPECT_TRUE(gpr_event_wait(&done, grpc_timeout_seconds_to_deadline(5)) !=
+              nullptr);
+}
+
+class TestThread {
+ public:
+  explicit TestThread(grpc_core::ExecCtxWorkSerializer* lock)
+      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this) {
+    gpr_event_init(&done_);
+    thread_.Start();
+  }
+
+  ~TestThread() {
+    EXPECT_NE(gpr_event_wait(&done_, gpr_inf_future(GPR_CLOCK_REALTIME)),
+              nullptr);
+    thread_.Join();
+  }
+
+ private:
+  static void ExecuteManyLoop(void* arg) {
+    TestThread* self = static_cast<TestThread*>(arg);
+    ExecCtx exec_ctx;
+    size_t n = 1;
+    for (size_t i = 0; i < 10; i++) {
+      for (size_t j = 0; j < 10000; j++) {
+        struct ExecutionArgs {
+          size_t* counter;
+          size_t value;
+        };
+        ExecutionArgs* c = new ExecutionArgs;
+        c->counter = &self->counter_;
+        c->value = n++;
+        self->lock_->Run(
+            [c]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(self->lock_) {
+              EXPECT_TRUE(*c->counter == c->value - 1);
+              *c->counter = c->value;
+              delete c;
+            },
+            DEBUG_LOCATION);
+        grpc_core::ExecCtx::Get()->Flush();
+      }
+      // sleep for a little bit, to test other threads picking it up
+      gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(100));
+    }
+    self->lock_->Run(
+        [self]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(self->lock_) {
+          gpr_event_set(&self->done_, reinterpret_cast<void*>(1));
+        },
+        DEBUG_LOCATION);
+  }
+
+  grpc_core::ExecCtxWorkSerializer* lock_ = nullptr;
+  grpc_core::Thread thread_;
+  size_t counter_ = 0;
+  gpr_event done_;
+};
+
+TEST(WorkSerializerTest, ExecuteMany) {
+  grpc_core::ExecCtxWorkSerializer lock;
+  {
+    std::vector<std::unique_ptr<TestThread>> threads;
+    for (size_t i = 0; i < 100; ++i) {
+      threads.push_back(absl::make_unique<TestThread>(&lock));
+    }
+  }
+}
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
+  int retval = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return retval;
+}


### PR DESCRIPTION
Ability to run functions in a synchronized manner on ExecCtx. 
Based on WorkSerializer and very similar in its working with the only difference being that the callbacks are invoked on ExecCtx instead.
