### PR TITLE
Revert "[objc] switch to official protobuf podspec"

### DIFF
--- a/src/cpp/Protobuf-C++.podspec
+++ b/src/cpp/Protobuf-C++.podspec
@@ -1,0 +1,43 @@
+Pod::Spec.new do |s|
+  s.name     = 'Protobuf-C++'
+  s.version  = '3.18.1'
+  s.summary  = 'Protocol Buffers v3 runtime library for C++.'
+  s.homepage = 'https://github.com/protocolbuffers/protobuf'
+  s.license  = '3-Clause BSD License'
+  s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
+  s.cocoapods_version = '>= 1.0'
+
+  s.source = { :git => 'https://github.com/protocolbuffers/protobuf.git',
+               :tag => "v#{s.version}" }
+
+  s.source_files = 'src/google/protobuf/*.{h,cc,inc}',
+                   'src/google/protobuf/stubs/*.{h,cc}',
+                   'src/google/protobuf/io/*.{h,cc}',
+                   'src/google/protobuf/util/*.{h,cc}',
+                   'src/google/protobuf/util/internal/*.{h,cc}'
+
+  # Excluding all the tests in the directories above
+  s.exclude_files = 'src/google/**/*_test.{h,cc,inc}',
+                    'src/google/**/*_unittest.{h,cc}',
+                    'src/google/protobuf/test_util*.{h,cc}',
+                    'src/google/protobuf/map_lite_test_util.{h,cc}',
+                    'src/google/protobuf/map_test_util*.{h,cc,inc}',
+                    'src/google/protobuf/reflection_tester.{h,cc}'
+
+  s.header_mappings_dir = 'src'
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
+
+  s.pod_target_xcconfig = {
+    # Do not let src/google/protobuf/stubs/time.h override system API
+    'USE_HEADERMAP' => 'NO',
+    'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+
+    # Configure tool is not being used for Xcode. When building, assume pthread is supported.
+    'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "HAVE_PTHREAD=1"',
+  }
+
+end

--- a/test/cpp/ios/Podfile
+++ b/test/cpp/ios/Podfile
@@ -12,7 +12,7 @@ target 'CronetTests' do
 
   pod '!ProtoCompiler',            :path => "#{GRPC_LOCAL_SRC}/src/objective-c"
   pod '!ProtoCompiler-gRPCCppPlugin', :path => "#{GRPC_LOCAL_SRC}/src/objective-c"
-  pod 'Protobuf-C++', :podspec => "#{GRPC_LOCAL_SRC}/third_party/protobuf", :inhibit_warnings => true
+  pod 'Protobuf-C++', :podspec => "#{GRPC_LOCAL_SRC}/src/cpp", :inhibit_warnings => true
 
   pod 'BoringSSL-GRPC',       :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
 


### PR DESCRIPTION
Reverts grpc/grpc#27830

testing revert to check if this is causing grpc_basictests_objc_ios timeout 