### PR TITLE
Restore state on call error

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -1940,6 +1940,8 @@ done_with_error:
   if (stream_op->send_message) {
     call->sending_message = false;
     call->sending_stream->Orphan();
+    call->sending_stream.Destroy();
+    stream_op_payload->send_message.send_message.reset();
   }
   if (stream_op->send_trailing_metadata) {
     call->sent_final_op = false;

--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-6703968097271808
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-6703968097271808
@@ -1,0 +1,62 @@
+actions {
+  create_server {
+  }
+}
+actions {
+  create_channel {
+    target: "dns:server"
+  }
+}
+actions {
+  create_call {
+    method {
+      value: "/foo"
+    }
+    timeout: 1000000000
+  }
+}
+actions {
+  queue_batch {
+    operations {
+      send_initial_metadata {
+      }
+    }
+  }
+}
+actions {
+  advance_time: 9541248
+}
+actions {
+  queue_batch {
+    operations {
+      send_close_from_client {
+      }
+    }
+    operations {
+      send_message {
+      }
+    }
+    operations {
+      receive_initial_metadata {
+      }
+      flags: 1895825408
+    }
+  }
+}
+actions {
+  queue_batch {
+    operations {
+      send_message {
+        message {
+          value: "grp[.default_authority"
+          intern: true
+        }
+      }
+    }
+  }
+}
+actions {
+  advance_time: 10000000
+}
+actions {
+}


### PR DESCRIPTION
Maintain the invariant that call state is invariant if a batch fails. Includes a sample from api_fuzzer demonstrating the bug.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
