### PR TITLE
Add Schedule and DrainQueue to WorkSerializer

### DIFF
--- a/src/core/lib/iomgr/work_serializer.cc
+++ b/src/core/lib/iomgr/work_serializer.cc
@@ -141,7 +141,7 @@ void WorkSerializer::WorkSerializerImpl::DrainQueue() {
     DrainQueueOwned();
   } else {
     // Another thread is holding the WorkSerializer, so decrement the ownership
-    // count we just added and queue a dummy callback.
+    // count we just added and queue a no-op callback.
     refs_.fetch_sub(MakeRefPair(1, 0), std::memory_order_acq_rel);
     CallbackWrapper* cb_wrapper = new CallbackWrapper([]() {}, DEBUG_LOCATION);
     queue_.Push(&cb_wrapper->mpscq_node);

--- a/src/core/lib/iomgr/work_serializer.cc
+++ b/src/core/lib/iomgr/work_serializer.cc
@@ -39,7 +39,7 @@ struct CallbackWrapper {
 // queue size (i.e., refs).
 uint64_t MakeRefPair(uint16_t owners, uint64_t size) {
   GPR_ASSERT(size >> 48 == 0);
-  return (static_cast<uint64_t>(owners) << 32) + static_cast<int64_t>(size);
+  return (static_cast<uint64_t>(owners) << 48) + static_cast<int64_t>(size);
 }
 uint32_t GetOwners(uint64_t ref_pair) {
   return static_cast<uint32_t>(ref_pair >> 48);
@@ -62,8 +62,10 @@ class WorkSerializer::WorkSerializerImpl : public Orphanable {
  private:
   // Callers of DrainQueueOwned should make sure to grab the lock on the
   // workserializer with
-  //   prev_ref_pair = refs_.fetch_add(MakeRefPair(1, 1),
-  //   std::memory_order_acq_rel);
+  //
+  //   prev_ref_pair =
+  //     refs_.fetch_add(MakeRefPair(1, 1), std::memory_order_acq_rel);
+  //
   // and only invoke DrainQueueOwned() if there was previously no owner. Note
   // that the queue size is also incremented as part of the fetch_add to allow
   // the callers to add a callback to the queue if another thread already holds

--- a/src/core/lib/iomgr/work_serializer.cc
+++ b/src/core/lib/iomgr/work_serializer.cc
@@ -58,14 +58,14 @@ class WorkSerializer::WorkSerializerImpl : public Orphanable {
 
   // First 16 bits indicate ownership of the WorkSerializer, next 48 bits are
   // queue size (i.e., refs).
-  uint64_t MakeRefPair(uint16_t owners, uint64_t size) {
+  static uint64_t MakeRefPair(uint16_t owners, uint64_t size) {
     GPR_ASSERT(size >> 48 == 0);
     return (static_cast<uint64_t>(owners) << 48) + static_cast<int64_t>(size);
   }
-  uint32_t GetOwners(uint64_t ref_pair) {
+  static uint32_t GetOwners(uint64_t ref_pair) {
     return static_cast<uint32_t>(ref_pair >> 48);
   }
-  uint32_t GetSize(uint64_t ref_pair) {
+  static uint32_t GetSize(uint64_t ref_pair) {
     return static_cast<uint32_t>(ref_pair & 0xffffffffffffu);
   }
 

--- a/src/core/lib/iomgr/work_serializer.cc
+++ b/src/core/lib/iomgr/work_serializer.cc
@@ -100,7 +100,7 @@ void WorkSerializer::WorkSerializerImpl::DrainQueue() {
       if (size_.load() == 1) {
         // There is nothing to drain.
         draining_.store(false);
-        // Check once before returning in case a callback was scheduled between
+        // Check again before returning in case a callback was scheduled between
         // the load and the store.
         if (size_.load() == 1) {
           return;

--- a/src/core/lib/iomgr/work_serializer.h
+++ b/src/core/lib/iomgr/work_serializer.h
@@ -39,12 +39,16 @@ namespace grpc_core {
 // All callbacks scheduled on a WorkSerializer instance will be executed
 // serially in a borrowed thread. The API provides a FIFO guarantee to the
 // execution of callbacks scheduled on the thread.
-// When a thread calls Schedule() with a callback, the callback is added to the
-// queue. The callback is finally executed when DrainQueue() is invoked. It is
-// possible that multiple threads invoke DrainQueue(), in which case only thread
-// will be used to drain the queue. Since an arbitrary set of callbacks might be
-// executed when DrainQueue() is called, generally no locks should be held while
-// calling DrainQueue().
+// When a thread calls Run() with a callback, the thread is considered borrowed.
+// The callback might run inline, or it might run asynchronously in a different
+// thread that is already inside of Run(). If the callback runs directly inline,
+// other callbacks from other threads might also be executed before Run()
+// returns. Since an arbitrary set of callbacks might be executed when Run() is
+// called, generally no locks should be held while calling Run().
+// If a thread wants to preclude the possibility of the callback being invoked
+// inline in Run() (for example, if a mutex lock is held and executing callbacks
+// inline would cause a deadlock), it should use Schedule() instead and then
+// invoke DrainQueue() when it is safe to invoke the callback.
 class ABSL_LOCKABLE WorkSerializer {
  public:
   WorkSerializer();

--- a/src/core/lib/iomgr/work_serializer.h
+++ b/src/core/lib/iomgr/work_serializer.h
@@ -40,11 +40,11 @@ namespace grpc_core {
 // serially in a borrowed thread. The API provides a FIFO guarantee to the
 // execution of callbacks scheduled on the thread.
 // When a thread calls Schedule() with a callback, the callback is added to the
-// queue The callback might run inline, or it might run asynchronously in a
-// different thread that is already inside of Run(). If the callback runs
-// directly inline, other callbacks from other threads might also be executed
-// before Run() returns. Since an arbitrary set of callbacks might be executed
-// when Run() is called, generally no locks should be held while calling Run().
+// queue. The callback is finally executed when DrainQueue() is invoked. It is
+// possible that multiple threads invoke DrainQueue(), in which case only thread
+// will be used to drain the queue. Since an arbitrary set of callbacks might be
+// executed when DrainQueue() is called, generally no locks should be held while
+// calling DrainQueue().
 class ABSL_LOCKABLE WorkSerializer {
  public:
   WorkSerializer();

--- a/src/core/lib/iomgr/work_serializer.h
+++ b/src/core/lib/iomgr/work_serializer.h
@@ -39,19 +39,21 @@ namespace grpc_core {
 // All callbacks scheduled on a WorkSerializer instance will be executed
 // serially in a borrowed thread. The API provides a FIFO guarantee to the
 // execution of callbacks scheduled on the thread.
-// When a thread calls Run() with a callback, the thread is considered borrowed.
-// The callback might run inline, or it might run asynchronously in a different
-// thread that is already inside of Run(). If the callback runs directly inline,
-// other callbacks from other threads might also be executed before Run()
-// returns. Since an arbitrary set of callbacks might be executed when Run() is
-// called, generally no locks should be held while calling Run().
+// When a thread calls Schedule() with a callback, the callback is added to the
+// queue The callback might run inline, or it might run asynchronously in a
+// different thread that is already inside of Run(). If the callback runs
+// directly inline, other callbacks from other threads might also be executed
+// before Run() returns. Since an arbitrary set of callbacks might be executed
+// when Run() is called, generally no locks should be held while calling Run().
 class ABSL_LOCKABLE WorkSerializer {
  public:
   WorkSerializer();
 
   ~WorkSerializer();
 
-  // Runs a given callback.
+  // Runs a given callback on the work serializer. Equivalent to -
+  //   work_serializer.Schedule(callback, location);
+  //   work_serializer.DrainQueue();
   //
   // If you want to use clang thread annotation to make sure that callback is
   // called by WorkSerializer only, you need to add the annotation to both the
@@ -69,6 +71,13 @@ class ABSL_LOCKABLE WorkSerializer {
   // once we can start using it directly.
   void Run(std::function<void()> callback,
            const grpc_core::DebugLocation& location);
+
+  // Schedule \a callback to be run later when the queue of callbacks is
+  // drained.
+  void Schedule(std::function<void()> callback,
+                const grpc_core::DebugLocation& location);
+  // Drains the queue of callbacks.
+  void DrainQueue();
 
  private:
   class WorkSerializerImpl;

--- a/src/core/lib/iomgr/work_serializer.h
+++ b/src/core/lib/iomgr/work_serializer.h
@@ -51,9 +51,10 @@ class ABSL_LOCKABLE WorkSerializer {
 
   ~WorkSerializer();
 
-  // Runs a given callback on the work serializer. Equivalent to -
-  //   work_serializer.Schedule(callback, location);
-  //   work_serializer.DrainQueue();
+  // Runs a given callback on the work serializer. If there is no other thread
+  // currently executing the WorkSerializer, the callback is run immediately. In
+  // this case, the current thread is also borrowed for draining the queue for
+  // any callbacks that get added in the meantime.
   //
   // If you want to use clang thread annotation to make sure that callback is
   // called by WorkSerializer only, you need to add the annotation to both the

--- a/test/core/iomgr/work_serializer_test.cc
+++ b/test/core/iomgr/work_serializer_test.cc
@@ -165,6 +165,19 @@ TEST(WorkSerializerTest, ExecuteManyScheduleAndDrain) {
   }
 }
 
+TEST(WorkSerializerTest, ExecuteManyMixedRunScheduleAndDrain) {
+  grpc_core::WorkSerializer lock;
+  {
+    std::vector<std::unique_ptr<TestThread>> run_threads;
+    std::vector<std::unique_ptr<TestThreadScheduleAndDrain>> schedule_threads;
+    for (size_t i = 0; i < 50; ++i) {
+      run_threads.push_back(absl::make_unique<TestThread>(&lock));
+      schedule_threads.push_back(
+          absl::make_unique<TestThreadScheduleAndDrain>(&lock));
+    }
+  }
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
The aim is to be able to schedule callbacks on the WorkSerializer without executing them immediately.

This would allow us to schedule callbacks on the queue while still staying holding on to mutex locks, and actually drain the queue after we release any such held mutex locks.