### PR TITLE
[objc] Adding lightweight generic to GPRCCallOptions's initialMetadata prop 

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCallOptions.h
+++ b/src/objective-c/GRPCClient/GRPCCallOptions.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Immutable user configurable options for a gRPC call.
+ * Caller can obtain a mutable copy of type \b GRPCMutableCallOptions by calling [option
+ * mutableCopy]
  */
 @interface GRPCCallOptions : NSObject <NSCopying, NSMutableCopying>
 
@@ -80,8 +82,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Initial metadata key-value pairs that should be included in the request.
+ * Dictionary key is of type NSString, value should be either NSString or NSData containing binary
+ * bytes data.
  */
-@property(copy, readonly, nullable) NSDictionary *initialMetadata;
+@property(copy, readonly, nullable) NSDictionary<NSString *, id> *initialMetadata;
 
 // Channel parameters; take into account of channel signature.
 
@@ -211,6 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Mutable user configurable options for a gRPC call.
+ * Caller can obtain an immutable copy of type \b GRPCCallOptions by calling [option copy]
  */
 @interface GRPCMutableCallOptions : GRPCCallOptions <NSCopying, NSMutableCopying>
 
@@ -271,8 +276,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Initial metadata key-value pairs that should be included in the request.
+ * Dictionary key is of type NSString, value should be either NSString or NSData containing binary
+ * bytes data.
  */
-@property(copy, readwrite, nullable) NSDictionary *initialMetadata;
+@property(copy, readwrite, nullable) NSDictionary<NSString *, id> *initialMetadata;
 
 // Channel parameters; take into account of channel signature.
 

--- a/src/objective-c/GRPCClient/GRPCCallOptions.m
+++ b/src/objective-c/GRPCClient/GRPCCallOptions.m
@@ -25,7 +25,7 @@ static NSString *const kDefaultServerAuthority = nil;
 static const NSTimeInterval kDefaultTimeout = 0;
 static const BOOL kDefaultFlowControlEnabled = NO;
 static NSArray<id<GRPCInterceptorFactory>> *const kDefaultInterceptorFactories = nil;
-static NSDictionary *const kDefaultInitialMetadata = nil;
+static NSDictionary<NSString *, id> *const kDefaultInitialMetadata = nil;
 static NSString *const kDefaultUserAgentPrefix = nil;
 static NSString *const kDefaultUserAgentSuffix = nil;
 static const NSUInteger kDefaultResponseSizeLimit = 0;
@@ -68,7 +68,7 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
   NSArray<id<GRPCInterceptorFactory>> *_interceptorFactories;
   NSString *_oauth2AccessToken;
   id<GRPCAuthorizationProtocol> _authTokenProvider;
-  NSDictionary *_initialMetadata;
+  NSDictionary<NSString *, id> *_initialMetadata;
   NSString *_userAgentPrefix;
   NSString *_userAgentSuffix;
   NSUInteger _responseSizeLimit;
@@ -155,7 +155,7 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
                    interceptorFactories:(NSArray<id<GRPCInterceptorFactory>> *)interceptorFactories
                       oauth2AccessToken:(NSString *)oauth2AccessToken
                       authTokenProvider:(id<GRPCAuthorizationProtocol>)authTokenProvider
-                        initialMetadata:(NSDictionary *)initialMetadata
+                        initialMetadata:(NSDictionary<NSString *, id> *)initialMetadata
                         userAgentPrefix:(NSString *)userAgentPrefix
                         userAgentSuffix:(NSString *)userAgentSuffix
                       responseSizeLimit:(NSUInteger)responseSizeLimit
@@ -486,7 +486,7 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
   _authTokenProvider = authTokenProvider;
 }
 
-- (void)setInitialMetadata:(NSDictionary *)initialMetadata {
+- (void)setInitialMetadata:(NSDictionary<NSString *, id> *)initialMetadata {
   _initialMetadata = [[NSDictionary alloc] initWithDictionary:initialMetadata copyItems:YES];
 }
 


### PR DESCRIPTION
Adding basic lightweight generic to initialMetadata field with improved documentation comments for types.  

https://github.com/grpc/grpc-ios/issues/42