### PR TITLE
[objc] GRPCErrorCode enum base type to int32_t

### DIFF
--- a/src/objective-c/GRPCClient/GRPCTypes.h
+++ b/src/objective-c/GRPCClient/GRPCTypes.h
@@ -23,7 +23,7 @@
  * Note that a few of these are never produced by the gRPC libraries, but are of
  * general utility for server applications to produce.
  */
-typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
+typedef NS_ENUM(int32_t, GRPCErrorCode) {
   /** The operation was cancelled (typically by the caller). */
   GRPCErrorCodeCancelled = 1,
 


### PR DESCRIPTION
Updating GRPCErrorCode base enum type from NSUInteger to int32_t to have better integer size consistency across various architectures (32/64). 