### PR TITLE
Revert hotfix; use more permanent fix

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -57,10 +57,8 @@ GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master |
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
-WORKER_POOL_8CORE_NUM_CORES=8
 # c2-standard-30 is the closest machine spec to 32 core there is
 WORKER_POOL_32CORE=workers-c2-30core-ci
-WORKER_POOL_32CORE_NUM_CORES=30
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1
@@ -80,17 +78,13 @@ popd
 buildConfigs() {
     local -r pool="$1"
     local -r table="$2"
-    local -r num_cores="$3"
-    shift 3
-    # TODO(jtattermusch): find a better solution for detecting number of cores in java
-    # then setting the "java_worker_command_prefix"
+    shift 2
     tools/run_tests/performance/loadtest_config.py "$@" \
         -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
         -s driver_pool="${DRIVER_POOL}" -s driver_image= \
         -s client_pool="${pool}" -s server_pool="${pool}" \
         -s big_query_table="${table}" -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
-        -s java_worker_command_prefix='BENCHMARK_WORKER_OPTS="-XX:ActiveProcessorCount='${num_cores}'"' \
         -a ci_buildNumber="${KOKORO_BUILD_NUMBER}" \
         -a ci_buildUrl="${CLOUD_LOGGING_URL}" \
         -a ci_jobName="${KOKORO_JOB_NAME}" \
@@ -105,8 +99,8 @@ buildConfigs() {
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${WORKER_POOL_8CORE_NUM_CORES}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${WORKER_POOL_32CORE_NUM_CORES}" -l c++ -l csharp -l go -l java
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" -l c++ -l csharp -l go -l java
 
 # Delete prebuilt images on exit.
 deleteImages() {

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -55,10 +55,8 @@ GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master |
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
-WORKER_POOL_8CORE_NUM_CORES=8
 # c2-standard-30 is the closest machine spec to 32 core there is
 WORKER_POOL_32CORE=workers-c2-30core-ci
-WORKER_POOL_32CORE_NUM_CORES=30
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1
@@ -78,10 +76,7 @@ popd
 buildConfigs() {
     local -r pool="$1"
     local -r table="$2"
-    local -r num_cores="$3"
-    shift 3
-    # TODO(jtattermusch): find a better solution for detecting number of cores in java
-    # then setting the "java_worker_command_prefix"
+    shift 2
     tools/run_tests/performance/loadtest_config.py "$@" \
         -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
         -s driver_pool="${DRIVER_POOL}" -s driver_image= \
@@ -89,7 +84,6 @@ buildConfigs() {
         -s big_query_table="${table}" -s timeout_seconds=900 \
         -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
         -s prebuilt_image_tag="${UNIQUE_IDENTIFIER}" \
-        -s java_worker_command_prefix='BENCHMARK_WORKER_OPTS="-XX:ActiveProcessorCount='${num_cores}'"' \
         -a ci_buildNumber="${KOKORO_BUILD_NUMBER}" \
         -a ci_buildUrl="${CLOUD_LOGGING_URL}" \
         -a ci_jobName="${KOKORO_JOB_NAME}" \
@@ -103,8 +97,8 @@ buildConfigs() {
         -o "./loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${WORKER_POOL_8CORE_NUM_CORES}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${WORKER_POOL_32CORE_NUM_CORES}" -l c++ -l csharp -l go -l java
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" -l c++ -l csharp -l go -l java -l php7 -l php7_protobuf_c -l python -l ruby
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" -l c++ -l csharp -l go -l java
 
 # Delete prebuilt images on exit.
 deleteImages() {

--- a/tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_basic_all_languages.yaml
@@ -91,8 +91,7 @@ spec:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker \
-            --driver_port="${DRIVER_PORT}"
+            /run_scripts/run_worker.sh
       command:
       - bash
   - build:
@@ -292,8 +291,7 @@ spec:
       - -c
       - |
         timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            benchmarks/build/install/grpc-benchmarks/bin/benchmark_worker \
-            --driver_port="${DRIVER_PORT}"
+            /run_scripts/run_worker.sh
       command:
       - bash
   - build:

--- a/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml
@@ -56,9 +56,8 @@ spec:
       args:
       - -c
       - |
-        ${java_worker_command_prefix} timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /execute/bin/benchmark_worker \
-            --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
       command:
       - bash
       image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
@@ -182,9 +181,8 @@ spec:
       args:
       - -c
       - |
-        ${java_worker_command_prefix} timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
-            /execute/bin/benchmark_worker \
-            --driver_port="${DRIVER_PORT}"
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
       command:
       - bash
       image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}


### PR DESCRIPTION
Changes `loadtest_template_prebuilt_all_languages.yaml` to call `run_worker.sh` added in grpc/test-infra/pull/231