### PR TITLE
disable authorization_policy_provider_test on iOS

### DIFF
--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -90,6 +90,9 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    # Test seems to be failing on iOS, but shouldn't be needed there anyway,
+    # since we don't support servers on iOS.
+    tags = ["no_test_ios"],
     deps = [
         "//:gpr",
         "//:grpc",


### PR DESCRIPTION
This test is failing on iOS and shouldn't be needed there anyway, since we don't support servers on iOS.