### PR TITLE
Order binaries in the correct way

### DIFF
--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -99,7 +99,7 @@ for lib in LIBS:
         sections = [
             x for x in csv.reader(
                 subprocess.check_output('bloaty-build/bloaty --csv %s -- %s' %
-                                        (old_version[0], new_version[0]),
+                                        (new_version[0], old_version[0]),
                                         shell=True).decode().splitlines())
         ]
         print(sections)


### PR DESCRIPTION
Currently we pass the old/new files to bloaty in the wrong order, meaning that we're claiming many PR's improve bloat and some make it worse when exactly the opposite is true.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
