### PR TITLE
fix LB policy call status notification interface, and other improvements

### DIFF
--- a/src/core/ext/filters/client_channel/backend_metric.cc
+++ b/src/core/ext/filters/client_channel/backend_metric.cc
@@ -48,16 +48,16 @@ std::map<absl::string_view, double> ParseMap(
 
 }  // namespace
 
-const LoadBalancingPolicy::BackendMetricData* ParseBackendMetricData(
-    const grpc_slice& serialized_load_report, Arena* arena) {
+const LoadBalancingPolicy::BackendMetricAccessor::BackendMetricData*
+ParseBackendMetricData(const grpc_slice& serialized_load_report, Arena* arena) {
   upb::Arena upb_arena;
   xds_data_orca_v3_OrcaLoadReport* msg = xds_data_orca_v3_OrcaLoadReport_parse(
       reinterpret_cast<const char*>(
           GRPC_SLICE_START_PTR(serialized_load_report)),
       GRPC_SLICE_LENGTH(serialized_load_report), upb_arena.ptr());
   if (msg == nullptr) return nullptr;
-  LoadBalancingPolicy::BackendMetricData* backend_metric_data =
-      arena->New<LoadBalancingPolicy::BackendMetricData>();
+  auto* backend_metric_data = arena->New<
+      LoadBalancingPolicy::BackendMetricAccessor::BackendMetricData>();
   backend_metric_data->cpu_utilization =
       xds_data_orca_v3_OrcaLoadReport_cpu_utilization(msg);
   backend_metric_data->mem_utilization =

--- a/src/core/ext/filters/client_channel/backend_metric.h
+++ b/src/core/ext/filters/client_channel/backend_metric.h
@@ -28,8 +28,8 @@ namespace grpc_core {
 
 // Parses the serialized load report and allocates a BackendMetricData
 // object on the arena.
-const LoadBalancingPolicy::BackendMetricData* ParseBackendMetricData(
-    const grpc_slice& serialized_load_report, Arena* arena);
+const LoadBalancingPolicy::BackendMetricAccessor::BackendMetricData*
+ParseBackendMetricData(const grpc_slice& serialized_load_report, Arena* arena);
 
 }  // namespace grpc_core
 

--- a/src/core/ext/filters/client_channel/client_channel.h
+++ b/src/core/ext/filters/client_channel/client_channel.h
@@ -396,6 +396,7 @@ class ClientChannel::LoadBalancedCall
   class LbQueuedCallCanceller;
   class Metadata;
   class LbCallState;
+  class BackendMetricAccessor;
 
   // Returns the index into pending_batches_ to be used for batch.
   static size_t GetBatchIndex(grpc_transport_stream_op_batch* batch);
@@ -477,10 +478,10 @@ class ClientChannel::LoadBalancedCall
       ABSL_GUARDED_BY(&ClientChannel::data_plane_mu_) = nullptr;
 
   RefCountedPtr<ConnectedSubchannel> connected_subchannel_;
-  const LoadBalancingPolicy::BackendMetricData* backend_metric_data_ = nullptr;
-  std::function<void(absl::Status, LoadBalancingPolicy::MetadataInterface*,
-                     LoadBalancingPolicy::CallState*)>
-      lb_recv_trailing_metadata_ready_;
+  const LoadBalancingPolicy::BackendMetricAccessor::BackendMetricData*
+      backend_metric_data_ = nullptr;
+  std::unique_ptr<LoadBalancingPolicy::SubchannelCallTrackerInterface>
+      lb_subchannel_call_tracker_;
 
   RefCountedPtr<SubchannelCall> subchannel_call_;
 

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -1,20 +1,18 @@
-/*
- *
- * Copyright 2015 gRPC authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
+//
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 #ifndef GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_LB_POLICY_H
 #define GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_LB_POLICY_H
@@ -81,26 +79,6 @@ extern DebugOnlyTraceFlag grpc_trace_lb_policy_refcount;
 // interested_parties() hooks from the API.
 class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
  public:
-  // Represents backend metrics reported by the backend to the client.
-  struct BackendMetricData {
-    /// CPU utilization expressed as a fraction of available CPU resources.
-    double cpu_utilization;
-    /// Memory utilization expressed as a fraction of available memory
-    /// resources.
-    double mem_utilization;
-    /// Total requests per second being served by the backend.  This
-    /// should include all services that a backend is responsible for.
-    uint64_t requests_per_second;
-    /// Application-specific requests cost metrics.  Metric names are
-    /// determined by the application.  Each value is an absolute cost
-    /// (e.g. 3487 bytes of storage) associated with the request.
-    std::map<absl::string_view, double> request_cost;
-    /// Application-specific resource utilization metrics.  Metric names
-    /// are determined by the application.  Each value is expressed as a
-    /// fraction of total resources available.
-    std::map<absl::string_view, double> utilization;
-  };
-
   /// Interface for accessing per-call state.
   /// Implemented by the client channel and used by the SubchannelPicker.
   class CallState {
@@ -113,13 +91,6 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     /// It is more efficient to use this than to allocate memory directly
     /// for allocations that need to be made on a per-call basis.
     virtual void* Alloc(size_t size) = 0;
-
-    /// Returns the backend metric data returned by the server for the call,
-    /// or null if no backend metric data was returned.
-    // TODO(roth): Move this out of CallState, since it should not be
-    // accessible to the picker, only to the recv_trailing_metadata_ready
-    // callback.  It should instead be in its own interface.
-    virtual const BackendMetricData* GetBackendMetricData() = 0;
 
     /// EXPERIMENTAL API.
     /// Returns the value of the call attribute \a key.
@@ -172,6 +143,59 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     CallState* call_state;
   };
 
+  /// Interface for accessing backend metric data.
+  /// Implemented by the client channel and used by
+  /// SubchannelCallTrackerInterface.
+  class BackendMetricAccessor {
+   public:
+    // Represents backend metrics reported by the backend to the client.
+    struct BackendMetricData {
+      /// CPU utilization expressed as a fraction of available CPU resources.
+      double cpu_utilization;
+      /// Memory utilization expressed as a fraction of available memory
+      /// resources.
+      double mem_utilization;
+      /// Total requests per second being served by the backend.  This
+      /// should include all services that a backend is responsible for.
+      uint64_t requests_per_second;
+      /// Application-specific requests cost metrics.  Metric names are
+      /// determined by the application.  Each value is an absolute cost
+      /// (e.g. 3487 bytes of storage) associated with the request.
+      std::map<absl::string_view, double> request_cost;
+      /// Application-specific resource utilization metrics.  Metric names
+      /// are determined by the application.  Each value is expressed as a
+      /// fraction of total resources available.
+      std::map<absl::string_view, double> utilization;
+    };
+
+    virtual ~BackendMetricAccessor() = default;
+
+    /// Returns the backend metric data returned by the server for the call,
+    /// or null if no backend metric data was returned.
+    virtual const BackendMetricData* GetBackendMetricData() = 0;
+  };
+
+  /// Interface for tracking subchannel calls.
+  /// Implemented by LB policy and used by the channel.
+  class SubchannelCallTrackerInterface {
+   public:
+    virtual ~SubchannelCallTrackerInterface() = default;
+
+    /// Called when a subchannel call is started after an LB pick.
+    virtual void Start() = 0;
+
+    /// Called when a subchannel call is completed.
+    /// The metadata may be modified by the implementation.  However, the
+    /// implementation does not take ownership, so any data that needs to be
+    /// used after returning must be copied.
+    struct FinishArgs {
+      absl::Status status;
+      MetadataInterface* trailing_metadata;
+      BackendMetricAccessor* backend_metric_accessor;
+    };
+    virtual void Finish(FinishArgs args) = 0;
+  };
+
   /// The result of picking a subchannel for a call.
   struct PickResult {
     /// A successful pick.
@@ -179,25 +203,17 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
       /// The subchannel to be used for the call.  Must be non-null.
       RefCountedPtr<SubchannelInterface> subchannel;
 
-      /// Callback set by LB policy to be notified of trailing metadata.
-      /// If non-null, the client channel will invoke the callback
-      /// when trailing metadata is returned.
-      /// The metadata may be modified by the callback.  However, the callback
-      /// does not take ownership, so any data that needs to be used after
-      /// returning must be copied.
-      /// The call state can be used to obtain backend metric data.
-      // TODO(roth): The arguments to this callback should be moved into a
-      // struct, so that we can later add new fields without breaking
-      // existing implementations.
-      std::function<void(absl::Status, MetadataInterface*, CallState*)>
-          recv_trailing_metadata_ready;
+      /// Optionally set by the LB policy when it wishes to be notified
+      /// about the resulting subchannel call.
+      /// Note that if the pick is abandoned by the channel, this may never
+      /// be used.
+      std::unique_ptr<SubchannelCallTrackerInterface> subchannel_call_tracker;
 
       explicit Complete(
           RefCountedPtr<SubchannelInterface> sc,
-          std::function<void(absl::Status, MetadataInterface*, CallState*)> cb =
-              nullptr)
+          std::unique_ptr<SubchannelCallTrackerInterface> tracker = nullptr)
           : subchannel(std::move(sc)),
-            recv_trailing_metadata_ready(std::move(cb)) {}
+            subchannel_call_tracker(std::move(tracker)) {}
     };
 
     /// Pick cannot be completed until something changes on the control

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
@@ -201,6 +201,8 @@ class XdsClusterImplLb : public LoadBalancingPolicy {
     PickResult Pick(PickArgs args) override;
 
    private:
+    class SubchannelCallTracker;
+
     RefCountedPtr<CircuitBreakerCallCounterMap::CallCounter> call_counter_;
     uint32_t max_concurrent_requests_;
     RefCountedPtr<XdsApi::EdsUpdate::DropConfig> drop_config_;
@@ -265,6 +267,58 @@ class XdsClusterImplLb : public LoadBalancingPolicy {
 };
 
 //
+// XdsClusterImplLb::Picker::SubchannelCallTracker
+//
+
+class XdsClusterImplLb::Picker::SubchannelCallTracker
+    : public LoadBalancingPolicy::SubchannelCallTrackerInterface {
+ public:
+  SubchannelCallTracker(
+      std::unique_ptr<LoadBalancingPolicy::SubchannelCallTrackerInterface>
+          original_subchannel_call_tracker,
+      RefCountedPtr<XdsClusterLocalityStats> locality_stats,
+      RefCountedPtr<CircuitBreakerCallCounterMap::CallCounter> call_counter)
+      : original_subchannel_call_tracker_(
+            std::move(original_subchannel_call_tracker)),
+        locality_stats_(std::move(locality_stats)),
+        call_counter_(std::move(call_counter)) {}
+
+  void Start() override {
+    // Increment number of calls in flight.
+    call_counter_->Increment();
+    // Record a call started.
+    if (locality_stats_ != nullptr) {
+      locality_stats_->AddCallStarted();
+    }
+    // Delegate if needed.
+    if (original_subchannel_call_tracker_ != nullptr) {
+      original_subchannel_call_tracker_->Start();
+    }
+  }
+
+  void Finish(FinishArgs args) override {
+    // Delegate if needed.
+    if (original_subchannel_call_tracker_ != nullptr) {
+      original_subchannel_call_tracker_->Finish(args);
+    }
+    // Record call completion for load reporting.
+    if (locality_stats_ != nullptr) {
+      locality_stats_->AddCallFinished(!args.status.ok());
+      locality_stats_.reset(DEBUG_LOCATION, "LocalityStats+call");
+    }
+    // Decrement number of calls in flight.
+    call_counter_->Decrement();
+    call_counter_.reset(DEBUG_LOCATION, "call");
+  }
+
+ private:
+  std::unique_ptr<LoadBalancingPolicy::SubchannelCallTrackerInterface>
+      original_subchannel_call_tracker_;
+  RefCountedPtr<XdsClusterLocalityStats> locality_stats_;
+  RefCountedPtr<CircuitBreakerCallCounterMap::CallCounter> call_counter_;
+};
+
+//
 // XdsClusterImplLb::Picker
 //
 
@@ -291,17 +345,17 @@ LoadBalancingPolicy::PickResult XdsClusterImplLb::Picker::Pick(
     return PickResult::Drop(absl::UnavailableError(
         absl::StrCat("EDS-configured drop: ", *drop_category)));
   }
-  // Handle circuit breaking.
-  uint32_t current = call_counter_->Load();
-  // Check and see if we exceeded the max concurrent requests count.
-  if (current >= max_concurrent_requests_) {
+  // Check if we exceeded the max concurrent requests circuit breaking limit.
+  // Note: We check the value here, but we don't actually increment the
+  // counter for the current request until the channel calls the subchannel
+  // call tracker's Start() method.  This means that we may wind up
+  // allowing more concurrent requests than the configured limit.
+  if (call_counter_->Load() >= max_concurrent_requests_) {
     if (drop_stats_ != nullptr) drop_stats_->AddUncategorizedDrops();
     return PickResult::Drop(absl::UnavailableError("circuit breaker drop"));
   }
-  call_counter_->Increment();
   // If we're not dropping the call, we should always have a child picker.
   if (picker_ == nullptr) {  // Should never happen.
-    call_counter_->Decrement();
     return PickResult::Fail(absl::InternalError(
         "xds_cluster_impl picker not given any child picker"));
   }
@@ -309,46 +363,26 @@ LoadBalancingPolicy::PickResult XdsClusterImplLb::Picker::Pick(
   PickResult result = picker_->Pick(args);
   auto* complete_pick = absl::get_if<PickResult::Complete>(&result.result);
   if (complete_pick != nullptr) {
-    XdsClusterLocalityStats* locality_stats = nullptr;
+    RefCountedPtr<XdsClusterLocalityStats> locality_stats;
     if (drop_stats_ != nullptr) {  // If load reporting is enabled.
       auto* subchannel_wrapper =
           static_cast<StatsSubchannelWrapper*>(complete_pick->subchannel.get());
       // Handle load reporting.
-      locality_stats = subchannel_wrapper->locality_stats()->Ref().release();
-      // Record a call started.
-      locality_stats->AddCallStarted();
+      locality_stats = subchannel_wrapper->locality_stats()->Ref();
       // Unwrap subchannel to pass back up the stack.
       complete_pick->subchannel = subchannel_wrapper->wrapped_subchannel();
     }
-    // Intercept the recv_trailing_metadata op to record call completion.
-    auto* call_counter = call_counter_->Ref(DEBUG_LOCATION, "call").release();
-    auto original_recv_trailing_metadata_ready =
-        complete_pick->recv_trailing_metadata_ready;
-    complete_pick->recv_trailing_metadata_ready =
-        // Note: This callback does not run in either the control plane
-        // work serializer or in the data plane mutex.
-        [locality_stats, original_recv_trailing_metadata_ready, call_counter](
-            absl::Status status, MetadataInterface* metadata,
-            CallState* call_state) {
-          // Record call completion for load reporting.
-          if (locality_stats != nullptr) {
-            locality_stats->AddCallFinished(!status.ok());
-            locality_stats->Unref(DEBUG_LOCATION, "LocalityStats+call");
-          }
-          // Decrement number of calls in flight.
-          call_counter->Decrement();
-          call_counter->Unref(DEBUG_LOCATION, "call");
-          // Invoke the original recv_trailing_metadata_ready callback, if any.
-          if (original_recv_trailing_metadata_ready != nullptr) {
-            original_recv_trailing_metadata_ready(status, metadata, call_state);
-          }
-        };
+    // Inject subchannel call tracker to record call completion.
+    complete_pick->subchannel_call_tracker =
+        absl::make_unique<SubchannelCallTracker>(
+            std::move(complete_pick->subchannel_call_tracker),
+            std::move(locality_stats),
+            call_counter_->Ref(DEBUG_LOCATION, "call"));
   } else {
     // TODO(roth): We should ideally also record call failures here in the case
     // where a pick fails.  This is challenging, because we don't know which
     // picks are for wait_for_ready RPCs or how many times we'll return a
     // failure for the same wait_for_ready RPC.
-    call_counter_->Decrement();
   }
   return result;
 }

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -224,8 +224,8 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
       // Intercept trailing metadata.
       auto* complete_pick = absl::get_if<PickResult::Complete>(&result.result);
       if (complete_pick != nullptr) {
-        new (args.call_state->Alloc(sizeof(TrailingMetadataHandler)))
-            TrailingMetadataHandler(complete_pick, cb_);
+        complete_pick->subchannel_call_tracker =
+            absl::make_unique<SubchannelCallTracker>(cb_);
       }
       return result;
     }
@@ -272,29 +272,22 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
     InterceptRecvTrailingMetadataCallback cb_;
   };
 
-  class TrailingMetadataHandler {
+  class SubchannelCallTracker : public SubchannelCallTrackerInterface {
    public:
-    TrailingMetadataHandler(PickResult::Complete* result,
-                            InterceptRecvTrailingMetadataCallback cb)
-        : cb_(std::move(cb)) {
-      result->recv_trailing_metadata_ready = [this](absl::Status /*status*/,
-                                                    MetadataInterface* metadata,
-                                                    CallState* call_state) {
-        RecordRecvTrailingMetadata(metadata, call_state);
-      };
+    explicit SubchannelCallTracker(InterceptRecvTrailingMetadataCallback cb)
+        : cb_(std::move(cb)) {}
+
+    void Start() override {}
+
+    void Finish(FinishArgs args) override {
+      TrailingMetadataArgsSeen args_seen;
+      args_seen.backend_metric_data =
+          args.backend_metric_accessor->GetBackendMetricData();
+      args_seen.metadata = args.trailing_metadata->TestOnlyCopyToVector();
+      cb_(args_seen);
     }
 
    private:
-    void RecordRecvTrailingMetadata(MetadataInterface* recv_trailing_metadata,
-                                    CallState* call_state) {
-      TrailingMetadataArgsSeen args_seen;
-      args_seen.backend_metric_data = call_state->GetBackendMetricData();
-      GPR_ASSERT(recv_trailing_metadata != nullptr);
-      args_seen.metadata = recv_trailing_metadata->TestOnlyCopyToVector();
-      cb_(args_seen);
-      this->~TrailingMetadataHandler();
-    }
-
     InterceptRecvTrailingMetadataCallback cb_;
   };
 };

--- a/test/core/util/test_lb_policies.h
+++ b/test/core/util/test_lb_policies.h
@@ -36,7 +36,8 @@ void RegisterTestPickArgsLoadBalancingPolicy(
     TestPickArgsCallback cb, const char* delegate_policy_name = "pick_first");
 
 struct TrailingMetadataArgsSeen {
-  const LoadBalancingPolicy::BackendMetricData* backend_metric_data;
+  const LoadBalancingPolicy::BackendMetricAccessor::BackendMetricData*
+      backend_metric_data;
   MetadataVector metadata;
 };
 


### PR DESCRIPTION
This fixes a bug being triggered in #27860, which seems to be just because that PR alters the timing enough to trigger this pre-existing problem, the possibility of which was introduced in #26428.

The problem occurs when a picker assumes that a call would be started and returns a `recv_trailing_metadata_ready` callback to be notified when the call finishes, but the subchannel returned by the picker has no connected subchannel, so we abandon the pick.  In that case, we were failing to execute the `recv_trailing_metadata_ready` callback, so the picker was never informed that the call had terminated.  This caused a memory leak in the case where the callback was holding a ref that was never released, but more generally it can cause problems for cases like load reporting and circuit breaking, where the LB policy needs an accurate view of when a call starts and ends.

To fix this, we replace the `recv_trailing_metadata_ready` callback with a new `SubchannelCallTrackerInterface`.  The interface has two methods, `Start()`, which will be called by the channel when it actually starts a call (i.e., the pick is not abandoned), and `Finish()`, which will be called by the channel when the call is complete.  This allows LB policies to not consider a call started until `Start()` is called, so that if the pick is abandoned, there are no dangling refs or call counters.

Note that one implication of this is that for xDS circuit breakers, we may now allow slightly more concurrent requests than the configured limit, since we are checking the counter in the picker but not incrementing it until `SubchannelCallTrackerInterface::Start()` is called.  But this is expected to be acceptable, since Envoy itself allows slightly exceeding the limit due to its threading model, and other gRPC implementations also allow this.

While I was at it, I also addressed a couple of other long-standing TODOs in the LB policy API, such as putting the args of `Finish()` into a struct for extensibility and moving the backend metric API into its own interface.