### PR TITLE
Add Java v1.40.2 and v1.41.1 to the interop test client matrix.

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -267,7 +267,9 @@ LANG_RELEASE_MATRIX = {
             ('v1.38.1', ReleaseInfo()),
             ('v1.39.0', ReleaseInfo()),
             ('v1.40.1', ReleaseInfo()),
+            ('v1.40.2', ReleaseInfo()),
             ('v1.41.0', ReleaseInfo()),
+            ('v1.41.1', ReleaseInfo()),
             ('v1.42.1', ReleaseInfo()),
         ]),
     'python':


### PR DESCRIPTION
Successful run: https://fusion2.corp.google.com/invocations/a225e937-e3e1-468a-b1b4-f19a6c35aabe/targets

@markdroth 