### PR TITLE
cherry-pick prep_xds.sh changes from v1.37.x into v1.34.x

### DIFF
--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -20,7 +20,8 @@ cd "$(dirname "$0")/../../.."
 
 sudo apt-get install -y python3-pip
 sudo python3 -m pip install --upgrade pip
-sudo python3 -m pip install grpcio==1.31.0 grpcio-tools==1.31.0 google-api-python-client google-auth-httplib2 oauth2client
+sudo python3 -m pip install --upgrade setuptools
+sudo python3 -m pip install --upgrade grpcio==1.31.0 grpcio-tools==1.31.0 protobuf google-api-python-client google-auth-httplib2 oauth2client xds-protos
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests


### PR DESCRIPTION
Should unbreak go xds tests for v1.34.x branch.

https://source.cloud.google.com/results/invocations/055aa485-ed3b-4510-bcac-1ef747918f2e/targets
