### PR TITLE
Fix RBE upload

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -127,7 +127,10 @@ def _get_resultstore_data(api_key, invocation_id):
             'https://resultstore.googleapis.com/v2/invocations/%s/targets/-/configuredTargets/-/actions?key=%s&pageToken=%s&fields=next_page_token,actions.id,actions.status_attributes,actions.timing,actions.test_action'
             % (invocation_id, api_key, page_token),
             headers={'Content-Type': 'application/json'})
-        results = json.loads(urllib.request.urlopen(req).read())
+        raw_resp = urllib.request.urlopen(req).read()
+        decoded_resp = raw_resp if isinstance(
+            raw_resp, str) else raw_resp.decode('utf-8', 'ignore')
+        results = json.loads(decoded_resp)
         all_actions.extend(results['actions'])
         if 'nextPageToken' not in results:
             break


### PR DESCRIPTION
Follow-up to https://github.com/grpc/grpc/pull/27135

This code only runs on master.
```
Traceback (most recent call last):
  File "./tools/run_tests/python_utils/upload_rbe_results.py", line 169, in <module>
    resultstore_actions = _get_resultstore_data(api_key, invocation_id)
  File "./tools/run_tests/python_utils/upload_rbe_results.py", line 130, in _get_resultstore_data
    results = json.loads(urllib.request.urlopen(req).read())
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

This change enables this script to run under either Python 2 or Python 3.

Adding @lidizheng as reviewer as build nurse.

[Manual run](https://fusion2.corp.google.com/invocations/783f3266-8c29-4e83-8b9f-5c0aea298cd0/targets) (passed)