### PR TITLE
Use WorkSerializer in XdsClient to propagate updates in a synchronized manner

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -75,7 +75,7 @@ class CdsLb : public LoadBalancingPolicy {
       RefCountedPtr<CdsLb> cds_lb = parent_;
       std::string name = name_;
       parent_->work_serializer()->Run(
-          [cds_lb, name, cluster_data]() {
+          [cds_lb, name, cluster_data]() mutable {
             cds_lb->OnClusterChanged(name, std::move(cluster_data));
           },
           DEBUG_LOCATION);

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -224,6 +224,10 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
       RefCountedPtr<EdsDiscoveryMechanism> discovery_mechanism_;
     };
 
+    // This is necessary only because of a bug in msvc where nested class
+    // cannot access protected member in base class.
+    friend class EndpointWatcher;
+
     absl::string_view GetEdsResourceName() const {
       if (!parent()->is_xds_uri_) return parent()->server_name_;
       if (!parent()

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -179,7 +179,7 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
         RefCountedPtr<EdsDiscoveryMechanism> discovery_mechanism =
             discovery_mechanism_;
         discovery_mechanism->parent()->work_serializer()->Run(
-            [discovery_mechanism, update]() {
+            [discovery_mechanism, update]() mutable {
               discovery_mechanism->parent()->OnEndpointChanged(
                   discovery_mechanism->index(), std::move(update));
             },

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -145,7 +145,9 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
           parent_->config_->discovery_mechanisms()[index_].eds_service_name};
     }
 
-   protected:
+    // parent() and index() could have been protected methods but a bug in msvc
+    // disallows accessing protected members of the base class through a nested
+    // class.
     XdsClusterResolverLb* parent() const { return parent_.get(); }
     size_t index() const { return index_; }
 
@@ -258,10 +260,6 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
      private:
       RefCountedPtr<LogicalDNSDiscoveryMechanism> discovery_mechanism_;
     };
-
-    // This is necessary only because of a bug in msvc where nested class cannot
-    // access protected member in base class.
-    friend class ResolverResultHandler;
 
     OrphanablePtr<Resolver> resolver_;
   };

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -926,6 +926,7 @@ void XdsResolver::NotifyError(grpc_error_handle error,
   work_serializer_->Run(
       [resolver, error]() {
         if (resolver->xds_client_ == nullptr) {
+          GRPC_ERROR_UNREF(error);
           return;
         }
         resolver->OnError(error);

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -898,7 +898,7 @@ void XdsResolver::NotifyLdsUpdate(XdsApi::LdsUpdate update,
                                   const DebugLocation& location) {
   RefCountedPtr<XdsResolver> resolver = Ref();
   work_serializer_->Run(
-      [resolver, update]() {
+      [resolver, update]() mutable {
         if (resolver->xds_client_ == nullptr) {
           return;
         }
@@ -911,7 +911,7 @@ void XdsResolver::NotifyRdsUpdate(XdsApi::RdsUpdate update,
                                   const DebugLocation& location) {
   RefCountedPtr<XdsResolver> resolver = Ref();
   work_serializer_->Run(
-      [resolver, update]() {
+      [resolver, update]() mutable {
         if (resolver->xds_client_ == nullptr) {
           return;
         }

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2622,6 +2622,8 @@ void XdsClient::NotifyOnErrorLocked(grpc_error_handle error) {
     }
   }
   work_serializer_.Schedule(
+      // TODO(yashykt): When we move to C++14, capture *_watchers using
+      // std::move()
       [listener_watchers, route_config_watchers, cluster_watchers,
        endpoint_watchers, error]()
           ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer_) {

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2320,11 +2320,9 @@ void XdsClient::WatchClusterData(
     }
     grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
         "Unable to parse resource name for cluster %s", cluster_name));
-    work_serializer_.Run(
-        [watcher, error]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer_) {
-          watcher->OnError(error);
-        },
-        DEBUG_LOCATION);
+    work_serializer_.Run([watcher, error]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(
+                             work_serializer_) { watcher->OnError(error); },
+                         DEBUG_LOCATION);
     return;
   }
   {
@@ -2399,11 +2397,9 @@ void XdsClient::WatchEndpointData(
     grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrFormat("Unable to parse resource name for endpoint service %s",
                         eds_service_name));
-    work_serializer_.Run(
-        [watcher, error]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer_) {
-          watcher->OnError(error);
-        },
-        DEBUG_LOCATION);
+    work_serializer_.Run([watcher, error]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(
+                             work_serializer_) { watcher->OnError(error); },
+                         DEBUG_LOCATION);
     return;
   }
   {

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2320,7 +2320,7 @@ void XdsClient::WatchClusterData(
     MutexLock lock(&mu_);
     auto& authority_state = authority_state_map_[resource->authority];
     ClusterState& cluster_state = authority_state.cluster_map[resource->id];
-    cluster_state.watchers[w] = std::move(watcher);
+    cluster_state.watchers[w] = watcher;
     // If we've already received a CDS update, notify the new watcher
     // immediately.
     if (cluster_state.update.has_value()) {

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2170,7 +2170,7 @@ void XdsClient::WatchListenerData(
     MutexLock lock(&mu_);
     AuthorityState& authority_state = authority_state_map_[resource->authority];
     ListenerState& listener_state = authority_state.listener_map[resource->id];
-    listener_state.watchers[w] = std::move(watcher);
+    listener_state.watchers[w] = watcher;
     // If we've already received an LDS update, notify the new watcher
     // immediately.
     if (listener_state.update.has_value()) {
@@ -2247,7 +2247,7 @@ void XdsClient::WatchRouteConfigData(
     auto& authority_state = authority_state_map_[resource->authority];
     RouteConfigState& route_config_state =
         authority_state.route_config_map[resource->id];
-    route_config_state.watchers[w] = std::move(watcher);
+    route_config_state.watchers[w] = watcher;
     // If we've already received an RDS update, notify the new watcher
     // immediately.
     if (route_config_state.update.has_value()) {

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2322,7 +2322,6 @@ void XdsClient::WatchClusterData(
         "Unable to parse resource name for cluster %s", cluster_name));
     work_serializer_.Run(
         [watcher, error]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer_) {
-          // review_note: this should fix a leak
           watcher->OnError(error);
         },
         DEBUG_LOCATION);
@@ -2402,7 +2401,6 @@ void XdsClient::WatchEndpointData(
                         eds_service_name));
     work_serializer_.Run(
         [watcher, error]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer_) {
-          // review_note: this should fix a leak
           watcher->OnError(error);
         },
         DEBUG_LOCATION);

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -47,11 +47,11 @@ class XdsClient : public DualRefCounted<XdsClient> {
   class ListenerWatcherInterface : public RefCounted<ListenerWatcherInterface> {
    public:
     virtual void OnListenerChanged(XdsApi::LdsUpdate listener)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnError(grpc_error_handle error)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnResourceDoesNotExist()
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
   };
 
   // RouteConfiguration data watcher interface.  Implemented by callers.
@@ -59,33 +59,33 @@ class XdsClient : public DualRefCounted<XdsClient> {
       : public RefCounted<RouteConfigWatcherInterface> {
    public:
     virtual void OnRouteConfigChanged(XdsApi::RdsUpdate route_config)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnError(grpc_error_handle error)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnResourceDoesNotExist()
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
   };
 
   // Cluster data watcher interface.  Implemented by callers.
   class ClusterWatcherInterface : public RefCounted<ClusterWatcherInterface> {
    public:
     virtual void OnClusterChanged(XdsApi::CdsUpdate cluster_data)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnError(grpc_error_handle error)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnResourceDoesNotExist()
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
   };
 
   // Endpoint data watcher interface.  Implemented by callers.
   class EndpointWatcherInterface : public RefCounted<EndpointWatcherInterface> {
    public:
     virtual void OnEndpointChanged(XdsApi::EdsUpdate update)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnError(grpc_error_handle error)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
     virtual void OnResourceDoesNotExist()
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) = 0;
   };
 
   // Factory function to get or create the global XdsClient instance.
@@ -324,6 +324,8 @@ class XdsClient : public DualRefCounted<XdsClient> {
         locality_stats;
     grpc_millis last_report_time = ExecCtx::Get()->Now();
   };
+
+  class Notifier;
 
   // Sends an error notification to all watchers.
   void NotifyOnErrorLocked(grpc_error_handle error)

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -48,7 +48,6 @@ class XdsClient : public DualRefCounted<XdsClient> {
    public:
     // TODO(review_note): Tried adding ABSL_EXCLUSIVE_LOCKS_REQUIRED but that
     // did not work. Tried work_serializer_, XdsClient::work_serializer_
-    virtual ~ListenerWatcherInterface() = default;
     virtual void OnListenerChanged(XdsApi::LdsUpdate listener) = 0;
     virtual void OnError(grpc_error_handle error) = 0;
     virtual void OnResourceDoesNotExist() = 0;
@@ -58,7 +57,6 @@ class XdsClient : public DualRefCounted<XdsClient> {
   class RouteConfigWatcherInterface
       : public RefCounted<RouteConfigWatcherInterface> {
    public:
-    virtual ~RouteConfigWatcherInterface() = default;
     virtual void OnRouteConfigChanged(XdsApi::RdsUpdate route_config) = 0;
     virtual void OnError(grpc_error_handle error) = 0;
     virtual void OnResourceDoesNotExist() = 0;
@@ -67,7 +65,6 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // Cluster data watcher interface.  Implemented by callers.
   class ClusterWatcherInterface : public RefCounted<ClusterWatcherInterface> {
    public:
-    virtual ~ClusterWatcherInterface() = default;
     virtual void OnClusterChanged(XdsApi::CdsUpdate cluster_data) = 0;
     virtual void OnError(grpc_error_handle error) = 0;
     virtual void OnResourceDoesNotExist() = 0;
@@ -76,7 +73,6 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // Endpoint data watcher interface.  Implemented by callers.
   class EndpointWatcherInterface : public RefCounted<EndpointWatcherInterface> {
    public:
-    virtual ~EndpointWatcherInterface() = default;
     virtual void OnEndpointChanged(XdsApi::EdsUpdate update) = 0;
     virtual void OnError(grpc_error_handle error) = 0;
     virtual void OnResourceDoesNotExist() = 0;

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -46,36 +46,46 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // Listener data watcher interface.  Implemented by callers.
   class ListenerWatcherInterface : public RefCounted<ListenerWatcherInterface> {
    public:
-    // TODO(review_note): Tried adding ABSL_EXCLUSIVE_LOCKS_REQUIRED but that
-    // did not work. Tried work_serializer_, XdsClient::work_serializer_
-    virtual void OnListenerChanged(XdsApi::LdsUpdate listener) = 0;
-    virtual void OnError(grpc_error_handle error) = 0;
-    virtual void OnResourceDoesNotExist() = 0;
+    virtual void OnListenerChanged(XdsApi::LdsUpdate listener)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnError(grpc_error_handle error)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnResourceDoesNotExist()
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
   };
 
   // RouteConfiguration data watcher interface.  Implemented by callers.
   class RouteConfigWatcherInterface
       : public RefCounted<RouteConfigWatcherInterface> {
    public:
-    virtual void OnRouteConfigChanged(XdsApi::RdsUpdate route_config) = 0;
-    virtual void OnError(grpc_error_handle error) = 0;
-    virtual void OnResourceDoesNotExist() = 0;
+    virtual void OnRouteConfigChanged(XdsApi::RdsUpdate route_config)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnError(grpc_error_handle error)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnResourceDoesNotExist()
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
   };
 
   // Cluster data watcher interface.  Implemented by callers.
   class ClusterWatcherInterface : public RefCounted<ClusterWatcherInterface> {
    public:
-    virtual void OnClusterChanged(XdsApi::CdsUpdate cluster_data) = 0;
-    virtual void OnError(grpc_error_handle error) = 0;
-    virtual void OnResourceDoesNotExist() = 0;
+    virtual void OnClusterChanged(XdsApi::CdsUpdate cluster_data)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnError(grpc_error_handle error)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnResourceDoesNotExist()
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
   };
 
   // Endpoint data watcher interface.  Implemented by callers.
   class EndpointWatcherInterface : public RefCounted<EndpointWatcherInterface> {
    public:
-    virtual void OnEndpointChanged(XdsApi::EdsUpdate update) = 0;
-    virtual void OnError(grpc_error_handle error) = 0;
-    virtual void OnResourceDoesNotExist() = 0;
+    virtual void OnEndpointChanged(XdsApi::EdsUpdate update)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnError(grpc_error_handle error)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
+    virtual void OnResourceDoesNotExist()
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(XdsClient::work_serializer_) = 0;
   };
 
   // Factory function to get or create the global XdsClient instance.

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -44,8 +44,10 @@ extern TraceFlag grpc_xds_client_refcount_trace;
 class XdsClient : public DualRefCounted<XdsClient> {
  public:
   // Listener data watcher interface.  Implemented by callers.
-  class ListenerWatcherInterface {
+  class ListenerWatcherInterface : public RefCounted<ListenerWatcherInterface> {
    public:
+    // TODO(review_note): Tried adding ABSL_EXCLUSIVE_LOCKS_REQUIRED but that
+    // did not work. Tried work_serializer_, XdsClient::work_serializer_
     virtual ~ListenerWatcherInterface() = default;
     virtual void OnListenerChanged(XdsApi::LdsUpdate listener) = 0;
     virtual void OnError(grpc_error_handle error) = 0;
@@ -53,7 +55,8 @@ class XdsClient : public DualRefCounted<XdsClient> {
   };
 
   // RouteConfiguration data watcher interface.  Implemented by callers.
-  class RouteConfigWatcherInterface {
+  class RouteConfigWatcherInterface
+      : public RefCounted<RouteConfigWatcherInterface> {
    public:
     virtual ~RouteConfigWatcherInterface() = default;
     virtual void OnRouteConfigChanged(XdsApi::RdsUpdate route_config) = 0;
@@ -62,7 +65,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   };
 
   // Cluster data watcher interface.  Implemented by callers.
-  class ClusterWatcherInterface {
+  class ClusterWatcherInterface : public RefCounted<ClusterWatcherInterface> {
    public:
     virtual ~ClusterWatcherInterface() = default;
     virtual void OnClusterChanged(XdsApi::CdsUpdate cluster_data) = 0;
@@ -71,7 +74,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   };
 
   // Endpoint data watcher interface.  Implemented by callers.
-  class EndpointWatcherInterface {
+  class EndpointWatcherInterface : public RefCounted<EndpointWatcherInterface> {
    public:
     virtual ~EndpointWatcherInterface() = default;
     virtual void OnEndpointChanged(XdsApi::EdsUpdate update) = 0;
@@ -112,7 +115,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // If the caller is going to start a new watch after cancelling the
   // old one, it should set delay_unsubscription to true.
   void WatchListenerData(absl::string_view listener_name,
-                         std::unique_ptr<ListenerWatcherInterface> watcher);
+                         RefCountedPtr<ListenerWatcherInterface> watcher);
   void CancelListenerDataWatch(absl::string_view listener_name,
                                ListenerWatcherInterface* watcher,
                                bool delay_unsubscription = false);
@@ -124,9 +127,8 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // pointer must not be used for any other purpose.)
   // If the caller is going to start a new watch after cancelling the
   // old one, it should set delay_unsubscription to true.
-  void WatchRouteConfigData(
-      absl::string_view route_config_name,
-      std::unique_ptr<RouteConfigWatcherInterface> watcher);
+  void WatchRouteConfigData(absl::string_view route_config_name,
+                            RefCountedPtr<RouteConfigWatcherInterface> watcher);
   void CancelRouteConfigDataWatch(absl::string_view route_config_name,
                                   RouteConfigWatcherInterface* watcher,
                                   bool delay_unsubscription = false);
@@ -139,7 +141,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // If the caller is going to start a new watch after cancelling the
   // old one, it should set delay_unsubscription to true.
   void WatchClusterData(absl::string_view cluster_name,
-                        std::unique_ptr<ClusterWatcherInterface> watcher);
+                        RefCountedPtr<ClusterWatcherInterface> watcher);
   void CancelClusterDataWatch(absl::string_view cluster_name,
                               ClusterWatcherInterface* watcher,
                               bool delay_unsubscription = false);
@@ -152,7 +154,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   // If the caller is going to start a new watch after cancelling the
   // old one, it should set delay_unsubscription to true.
   void WatchEndpointData(absl::string_view eds_service_name,
-                         std::unique_ptr<EndpointWatcherInterface> watcher);
+                         RefCountedPtr<EndpointWatcherInterface> watcher);
   void CancelEndpointDataWatch(absl::string_view eds_service_name,
                                EndpointWatcherInterface* watcher,
                                bool delay_unsubscription = false);
@@ -257,8 +259,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   };
 
   struct ListenerState {
-    std::map<ListenerWatcherInterface*,
-             std::unique_ptr<ListenerWatcherInterface>>
+    std::map<ListenerWatcherInterface*, RefCountedPtr<ListenerWatcherInterface>>
         watchers;
     // The latest data seen from LDS.
     absl::optional<XdsApi::LdsUpdate> update;
@@ -267,7 +268,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
 
   struct RouteConfigState {
     std::map<RouteConfigWatcherInterface*,
-             std::unique_ptr<RouteConfigWatcherInterface>>
+             RefCountedPtr<RouteConfigWatcherInterface>>
         watchers;
     // The latest data seen from RDS.
     absl::optional<XdsApi::RdsUpdate> update;
@@ -275,7 +276,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   };
 
   struct ClusterState {
-    std::map<ClusterWatcherInterface*, std::unique_ptr<ClusterWatcherInterface>>
+    std::map<ClusterWatcherInterface*, RefCountedPtr<ClusterWatcherInterface>>
         watchers;
     // The latest data seen from CDS.
     absl::optional<XdsApi::CdsUpdate> update;
@@ -283,8 +284,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   };
 
   struct EndpointState {
-    std::map<EndpointWatcherInterface*,
-             std::unique_ptr<EndpointWatcherInterface>>
+    std::map<EndpointWatcherInterface*, RefCountedPtr<EndpointWatcherInterface>>
         watchers;
     // The latest data seen from EDS.
     absl::optional<XdsApi::EdsUpdate> update;
@@ -336,6 +336,7 @@ class XdsClient : public DualRefCounted<XdsClient> {
   grpc_pollset_set* interested_parties_;
   OrphanablePtr<CertificateProviderStore> certificate_provider_store_;
   XdsApi api_;
+  WorkSerializer work_serializer_;
 
   Mutex mu_;
 
@@ -354,14 +355,14 @@ class XdsClient : public DualRefCounted<XdsClient> {
 
   // Stores started watchers whose resource name was not parsed successfully,
   // waiting to be cancelled or reset in Orphan().
-  std::map<ListenerWatcherInterface*, std::unique_ptr<ListenerWatcherInterface>>
+  std::map<ListenerWatcherInterface*, RefCountedPtr<ListenerWatcherInterface>>
       invalid_listener_watchers_ ABSL_GUARDED_BY(mu_);
   std::map<RouteConfigWatcherInterface*,
-           std::unique_ptr<RouteConfigWatcherInterface>>
+           RefCountedPtr<RouteConfigWatcherInterface>>
       invalid_route_config_watchers_ ABSL_GUARDED_BY(mu_);
-  std::map<ClusterWatcherInterface*, std::unique_ptr<ClusterWatcherInterface>>
+  std::map<ClusterWatcherInterface*, RefCountedPtr<ClusterWatcherInterface>>
       invalid_cluster_watchers_ ABSL_GUARDED_BY(mu_);
-  std::map<EndpointWatcherInterface*, std::unique_ptr<EndpointWatcherInterface>>
+  std::map<EndpointWatcherInterface*, RefCountedPtr<EndpointWatcherInterface>>
       invalid_endpoint_watchers_ ABSL_GUARDED_BY(mu_);
 
   bool shutting_down_ ABSL_GUARDED_BY(mu_) = false;

--- a/src/core/ext/xds/xds_server_config_fetcher.cc
+++ b/src/core/ext/xds/xds_server_config_fetcher.cc
@@ -357,7 +357,7 @@ class XdsServerConfigFetcher : public grpc_server_config_fetcher {
                   std::unique_ptr<grpc_server_config_fetcher::WatcherInterface>
                       watcher) override {
     grpc_server_config_fetcher::WatcherInterface* watcher_ptr = watcher.get();
-    auto listener_watcher = absl::make_unique<ListenerWatcher>(
+    auto listener_watcher = MakeRefCounted<ListenerWatcher>(
         std::move(watcher), xds_client_, serving_status_notifier_,
         listening_address);
     auto* listener_watcher_ptr = listener_watcher.get();


### PR DESCRIPTION
XdsClient watcher notifications callbacks are currently invoked inline while still holding onto the XdsClient mutex. These callbacks often require to invoke an API on `XdsClient`. To do this in a way that avoids deadlocks, the callbacks schedule themselves on ExecCtx. The issue with this is that the callbacks can be pushed on `ExecCtx`s of different threads which can mess up the ordering of these notifications.

Using `WorkSerializer::Schedule` and `WorkSerializer::DrainQueue`, we always invoke the callbacks outside the `XdsClient::mu_` so that the callbacks do not need to delay the callbacks. We additionally get the advantage of being able to execute code outside the critical region which should be a performance win (though it's probably not so critical).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/27975)
<!-- Reviewable:end -->
