### PR TITLE
Set BinderTransport connectivity state tracker initial state to READY

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -699,8 +699,9 @@ grpc_binder_transport::grpc_binder_transport(
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy)
     : is_client(is_client),
       combiner(grpc_combiner_create()),
-      state_tracker(is_client ? "binder_transport_client"
-                              : "binder_transport_server"),
+      state_tracker(
+          is_client ? "binder_transport_client" : "binder_transport_server",
+          GRPC_CHANNEL_READY),
       refs(1, nullptr) {
   gpr_log(GPR_INFO, __func__);
   base.vtable = get_vtable();


### PR DESCRIPTION
By default the state is set to IDLE, which is not desired because

1. The actual connectivity state when transport is created is READY
2. The binder tansport channel won't be able to recover from IDLE state
for some reason and cause the channel to stuck when used on multiple
thread. We have an internal bug tracking this issue.
