### PR TITLE
Fix AWS arm64 C++ build

### DIFF
--- a/tools/internal_ci/linux/aws/grpc_aws_experiment_remote.sh
+++ b/tools/internal_ci/linux/aws/grpc_aws_experiment_remote.sh
@@ -15,14 +15,15 @@
 
 set -ex
 
-#install ubuntu pre-requisites
+# install pre-requisites for gRPC C core build
 sudo apt update
 sudo apt install -y build-essential autoconf libtool pkg-config cmake python3 python3-pip clang
-sudo pip install six
+
+python3 --version
 
 cd grpc
 
-# without port server running, many tests will fail
+# tests require port server to be running
 python3 tools/run_tests/start_port_server.py
 
 # build with bazel

--- a/tools/internal_ci/linux/aws/grpc_bazel_test_c_cpp_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_bazel_test_c_cpp_aarch64.sh
@@ -18,16 +18,13 @@ set -ex
 # install pre-requisites for gRPC C core build
 sudo apt update
 sudo apt install -y build-essential autoconf libtool pkg-config cmake python3 python3-pip clang
-sudo pip install six
 
-# install python3.6 and pip
-sudo apt install -y python3 python3-pip
 python3 --version
 
 cd grpc
 
 # tests require port server to be running
-python tools/run_tests/start_port_server.py
+python3 tools/run_tests/start_port_server.py
 
 # test gRPC C/C++ with bazel
 tools/bazel test --config=opt --test_output=errors --test_tag_filters=-no_linux,-no_arm64 --build_tag_filters=-no_linux,-no_arm64 --flaky_test_attempts=1 --runs_per_test=1 //test/...


### PR DESCRIPTION

Failure log example:
https://source.cloud.google.com/results/invocations/821ee767-106e-4712-8810-2e987ac4ac19/log

The change that introduced the problem is here:
https://github.com/grpc/grpc/pull/27135/files#diff-0c342e3092c150199bcfa74b763a9ac118864290bc70fa8febaf13ebd6c9c01fL20

- also cleanup tools/internal_ci/linux/aws/grpc_aws_experiment_remote.sh at bit.
