### PR TITLE
Fix rbe_upload SSL issue

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -129,7 +129,7 @@ def _get_resultstore_data(api_key, invocation_id):
             % (invocation_id, api_key, page_token),
             headers={'Content-Type': 'application/json'})
         ctx_dict = {}
-        if os.getenv("PYTHONHTTPSVERIFY") == 0:
+        if os.getenv("PYTHONHTTPSVERIFY") == "0":
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE

--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -17,6 +17,7 @@
 import argparse
 import json
 import os
+import ssl
 import sys
 import urllib.error
 import urllib.parse
@@ -127,7 +128,13 @@ def _get_resultstore_data(api_key, invocation_id):
             'https://resultstore.googleapis.com/v2/invocations/%s/targets/-/configuredTargets/-/actions?key=%s&pageToken=%s&fields=next_page_token,actions.id,actions.status_attributes,actions.timing,actions.test_action'
             % (invocation_id, api_key, page_token),
             headers={'Content-Type': 'application/json'})
-        raw_resp = urllib.request.urlopen(req).read()
+        ctx_dict = {}
+        if os.getenv("PYTHONHTTPSVERIFY") == 0:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            ctx_dict = {"context": ctx}
+        raw_resp = urllib.request.urlopen(req, **ctx_dict).read()
         decoded_resp = raw_resp if isinstance(
             raw_resp, str) else raw_resp.decode('utf-8', 'ignore')
         results = json.loads(decoded_resp)


### PR DESCRIPTION
It seems that the `PYTHONHTTPSVERIFY` variable is no longer respected in Python 3, causing issues in the RBE results upload on Mac OS:

```
Traceback (most recent call last):
  File "./tools/run_tests/python_utils/upload_rbe_results.py", line 169, in <module>
    resultstore_actions = _get_resultstore_data(api_key, invocation_id)
  File "./tools/run_tests/python_utils/upload_rbe_results.py", line 130, in _get_resultstore_data
    results = json.loads(urllib.request.urlopen(req).read())
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 525, in open
    response = self._open(req, data)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 543, in _open
    '_open', req)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 1360, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 1319, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)>
```

This PR attempts to reintroduce it in a limited scope.

[Manual run](https://sponge2.corp.google.com/f73d11ab-a6f7-4077-bfaa-bd9af312988b) (ongoing)