### PR TITLE
Add v1.42.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -193,6 +193,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.39.1', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.40.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.41.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.42.0', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_"$GO_VERSION" | grep "$RELEASE_VERSION"
fe9f5b755e72  v1.42.0  2021-11-09T23:18:43  CRITICAL=1,HIGH=9,LOW=217,MEDIUM=44

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
