### PR TITLE
Fix the packaging.version issue on newer "packaging" library

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -29,7 +29,7 @@ from absl import logging
 from absl.testing import absltest
 from google.protobuf import json_format
 import grpc
-import packaging
+import packaging.version
 
 from framework import xds_k8s_testcase
 from framework import xds_url_map_test_resources


### PR DESCRIPTION
The import supposed to be broken by `packaging >= 21.0`, which released in July. But it didn't break, until this week. https://github.com/pypa/packaging/releases.

This PR fixes the issue.

```
AttributeError: module 'packaging' has no attribute 'version'
```

Internal bug: b/205848399.

Test runs:
- https://fusion2.corp.google.com/invocations/e1a5cd67-0a4f-4979-b2f2-06a51fe5457d/targets
- https://fusion2.corp.google.com/invocations/f78e2d93-7af4-45fb-acbe-8535cdca15a8/targets
- https://fusion2.corp.google.com/invocations/c269adf2-466f-4264-ad0c-f96b13fede78/targets