### PR TITLE
Start port server separately on Windows

### DIFF
--- a/tools/internal_ci/windows/grpc_run_tests_matrix.bat
+++ b/tools/internal_ci/windows/grpc_run_tests_matrix.bat
@@ -20,6 +20,8 @@ If Not "%RUN_TESTS_FLAGS%"=="%RUN_TESTS_FLAGS:python=%" (
 )
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
+python3 tools/run_tests/start_port_server.py
+
 python3 tools/run_tests/run_tests_matrix.py %RUN_TESTS_FLAGS%
 set RUNTESTS_EXITCODE=%errorlevel%
 


### PR DESCRIPTION
I've observed that the Python stdlib bug mentioned [here](https://github.com/grpc/grpc/pull/27983#issue-1048948045) only happens when the `run_tests.py` process spawns a port server on that run. This PR spawns one separately to avoid whatever bug we are running into.