### PR TITLE
Check if memory owner available prior to polling it

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -341,7 +341,9 @@ static double AdjustForMemoryPressure(double memory_pressure, double target) {
 }
 
 double TransportFlowControl::TargetLogBdp() {
-  return AdjustForMemoryPressure(t_->memory_owner.InstantaneousPressure(),
+  return AdjustForMemoryPressure(t_->memory_owner.is_valid()
+                                     ? t_->memory_owner.InstantaneousPressure()
+                                     : 0.0,
                                  1 + log2(bdp_estimator_.EstimateBdp()));
 }
 

--- a/src/core/lib/resource_quota/memory_quota.h
+++ b/src/core/lib/resource_quota/memory_quota.h
@@ -363,6 +363,11 @@ class MemoryOwner final : public MemoryAllocator {
   // Name of this object
   absl::string_view name() const { return impl()->name(); }
 
+  // Is this object valid (ie has not been moved out of or reset)
+  bool is_valid() const {
+    return impl() != nullptr;
+  }
+
  private:
   const GrpcMemoryAllocatorImpl* impl() const {
     return static_cast<const GrpcMemoryAllocatorImpl*>(get_internal_impl_ptr());


### PR DESCRIPTION
The transport may drop the memory owner during its destruction sequence




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
