### PR TITLE
Remove redundant work serializer usage in c-ares windows code

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -150,8 +150,7 @@ class GrpcPolledFdWindows {
     GPR_ASSERT(!read_buf_has_data_);
     read_buf_ = GRPC_SLICE_MALLOC(4192);
     if (connect_done_) {
-      work_serializer_->Run([this]() { ContinueRegisterForOnReadableLocked(); },
-                            DEBUG_LOCATION);
+      ContinueRegisterForOnReadableLocked();
     } else {
       GPR_ASSERT(pending_continue_register_for_on_readable_locked_ == false);
       pending_continue_register_for_on_readable_locked_ = true;
@@ -207,8 +206,7 @@ class GrpcPolledFdWindows {
     GPR_ASSERT(write_closure_ == nullptr);
     write_closure_ = write_closure;
     if (connect_done_) {
-      work_serializer_->Run(
-          [this]() { ContinueRegisterForOnWriteableLocked(); }, DEBUG_LOCATION);
+      ContinueRegisterForOnWriteableLocked();
     } else {
       GPR_ASSERT(pending_continue_register_for_on_writeable_locked_ == false);
       pending_continue_register_for_on_writeable_locked_ = true;
@@ -466,12 +464,10 @@ class GrpcPolledFdWindows {
       wsa_connect_error_ = WSA_OPERATION_ABORTED;
     }
     if (pending_continue_register_for_on_readable_locked_) {
-      work_serializer_->Run([this]() { ContinueRegisterForOnReadableLocked(); },
-                            DEBUG_LOCATION);
+      ContinueRegisterForOnReadableLocked();
     }
     if (pending_continue_register_for_on_writeable_locked_) {
-      work_serializer_->Run(
-          [this]() { ContinueRegisterForOnWriteableLocked(); }, DEBUG_LOCATION);
+      ContinueRegisterForOnWriteableLocked();
     }
     GRPC_ERROR_UNREF(error);
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -159,7 +159,7 @@ class GrpcPolledFdWindows {
 
   void ContinueRegisterForOnReadableLocked() {
     GRPC_CARES_TRACE_LOG(
-        "fd:|%s| InnerContinueRegisterForOnReadableLocked "
+        "fd:|%s| ContinueRegisterForOnReadableLocked "
         "wsa_connect_error_:%d",
         GetName(), wsa_connect_error_);
     GPR_ASSERT(connect_done_);
@@ -215,7 +215,7 @@ class GrpcPolledFdWindows {
 
   void ContinueRegisterForOnWriteableLocked() {
     GRPC_CARES_TRACE_LOG(
-        "fd:|%s| InnerContinueRegisterForOnWriteableLocked "
+        "fd:|%s| ContinueRegisterForOnWriteableLocked "
         "wsa_connect_error_:%d",
         GetName(), wsa_connect_error_);
     GPR_ASSERT(connect_done_);


### PR DESCRIPTION
This is extracted from the changes to c-ares windows code in https://github.com/grpc/grpc/pull/27858/files.

I'm not 100% sure why we were explicitly scheduling these methods on the work serializer when we were already running under it.

I think it's because these methods were originally added back in https://github.com/grpc/grpc/commit/03797e0ec36e76f08ecb51c74ebec0531d24fac4#, which was before the change to use `WorkSerializer`s in https://github.com/grpc/grpc/commit/e05417db32266a18c8c611054a8c452c96eca49d#diff-22089b08a43cdad7a2fcf577721907568fe29a57024bf600d137c69996fed567. In the former PR, the `pending_continue_register_for_on_{readable,writable}_locked_` fields were pointers to closures, and code would schedule their underlying closures on the combiner, even if we were already running under the combiner. The change to use work serializer also changed these fields from pointers to booleans, and also changed code to explicitly schedule their methods on the work serializer in the case these flags were set. But, explicitly scheduling on the work serializer remained redundant.
