### PR TITLE
Increase the timeout of xds_k8s test to 180

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s.cfg
+++ b/tools/internal_ci/linux/grpc_xds_k8s.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
b/206110432

Recent runs for the entire C++ xds_k8s test suite takes around 110 minutes, and one run exceeds the deadline. No obvious regression was found. Before we have more concrete improvement, this PR increases the timeout to stop similar flakes.