### PR TITLE
[objc]Setup ios bazel test to run c-core's existing event_engine unit test

### DIFF
--- a/tools/internal_ci/macos/grpc_bazel_core_ios_tests.cfg
+++ b/tools/internal_ci/macos/grpc_bazel_core_ios_tests.cfg
@@ -1,0 +1,19 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_core_ios_tests.sh"
+

--- a/tools/internal_ci/macos/grpc_run_bazel_core_ios_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_core_ios_tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+./tools/run_tests/start_port_server.py
+
+dirs=(event_engine)
+for dir in ${dirs[*]}; do
+  echo $dir
+  out=`tools/bazel query "kind(ios_unit_test, tests(//test/core/$dir/...))" 2>/dev/null | grep '^//'`
+  for test in $out; do
+    echo "Running: $test"
+    tools/bazel test --test_summary=detailed --test_output=all $test
+  done
+done


### PR DESCRIPTION
According to https://github.com/grpc/grpc/blob/master/tools/internal_ci/README.md,
there is an internal repository to add CI jobs, the new scripts need to be configured to run from there.

refer: https://github.com/grpc/grpc-ios/issues/35
@dennycd 
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
