### PR TITLE
Remove extra ';' after member function definition

### DIFF
--- a/include/grpcpp/security/tls_certificate_verifier.h
+++ b/include/grpcpp/security/tls_certificate_verifier.h
@@ -112,7 +112,7 @@ class CertificateVerifier {
   void Cancel(TlsCustomVerificationCheckRequest* request);
 
   // Gets the core verifier used internally.
-  grpc_tls_certificate_verifier* c_verifier() { return verifier_; };
+  grpc_tls_certificate_verifier* c_verifier() { return verifier_; }
 
  private:
   static void AsyncCheckDone(


### PR DESCRIPTION
Some user of gRPC library have [-Werror,-Wextra-semi] set and this extra
';' makes the code uncompilable

@donnadionne
