### PR TITLE
Improve directory handling for py_proto_library

### DIFF
--- a/bazel/test/python_test_repo/BUILD
+++ b/bazel/test/python_test_repo/BUILD
@@ -29,9 +29,16 @@ proto_library(
     name = "helloworld_proto",
     srcs = ["helloworld.proto"],
     deps = [
+        ":hello_dep_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
+)
+
+# Test that .proto files can be located in strict subdiretories of the package.
+proto_library(
+    name = "hello_dep_proto",
+    srcs = ["subdir/hello_dep.proto"],
 )
 
 py_proto_library(
@@ -79,6 +86,7 @@ proto_library(
     import_prefix = "google/cloud",
     strip_import_prefix = "",
     deps = [
+        ":hello_dep_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],

--- a/bazel/test/python_test_repo/helloworld.proto
+++ b/bazel/test/python_test_repo/helloworld.proto
@@ -23,6 +23,7 @@ package helloworld;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
+import "subdir/hello_dep.proto";
 
 // The greeting service definition.
 service Greeter {
@@ -36,8 +37,10 @@ message HelloRequest {
   google.protobuf.Timestamp request_initiation = 2;
 }
 
-// The response message containing the greetings
+// The response message containing the greetings, plus some additional
+// data of a type defined in a separate .proto file.
 message HelloReply {
   string message = 1;
   google.protobuf.Duration request_duration = 2;
+  HelloDep dep = 3;
 }

--- a/bazel/test/python_test_repo/subdir/hello_dep.proto
+++ b/bazel/test/python_test_repo/subdir/hello_dep.proto
@@ -1,0 +1,21 @@
+// Copyright 2019 The gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package helloworld;
+
+message HelloDep {
+  repeated int64 numbers = 1;
+}


### PR DESCRIPTION
With this change, `py_proto_library` should work in cases where the input proto_library has a source file that is in a strict subdirectory of its package. We do this by replacing `basename` with a more general "remove prefix" logic.

@donnadionne
