### PR TITLE
Faster clang-format

### DIFF
--- a/tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
+++ b/tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
@@ -44,7 +44,7 @@ fi
 
 if [ "$TEST" == "" ]
 then
-  echo $files | xargs -P $CPU_COUNT $CLANG_FORMAT -i
+  echo $files | xargs -P $CPU_COUNT -n 10 $CLANG_FORMAT -i
 else
   ok=yes
   for file in $files

--- a/tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
+++ b/tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
@@ -24,6 +24,9 @@ GLOB="*.h *.c *.cc *.m *.mm"
 # clang format command
 CLANG_FORMAT=${CLANG_FORMAT:-clang-format}
 
+# number of CPUs available
+CPU_COUNT=`nproc`
+
 files=
 for dir in $DIRS
 do
@@ -41,7 +44,7 @@ fi
 
 if [ "$TEST" == "" ]
 then
-  echo $files | xargs $CLANG_FORMAT -i
+  echo $files | xargs -P $CPU_COUNT $CLANG_FORMAT -i
 else
   ok=yes
   for file in $files


### PR DESCRIPTION
Use parallelism to speed clang-format.

Reduces tool latency from 24 seconds to 8 seconds on my machine.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
