### PR TITLE
Revert "[BinderTransport] Send correct version to server and verify it"

### DIFF
--- a/src/core/ext/transport/binder/server/binder_server.cc
+++ b/src/core/ext/transport/binder/server/binder_server.cc
@@ -196,9 +196,7 @@ class BinderServerListener : public Server::ListenerInterface {
       return status;
     }
     gpr_log(GPR_INFO, "BinderTransport client protocol version = %d", version);
-    // TODO(mingcl): Make sure we only give client a version that is not newer
-    // than the version they specify. For now, we always tell client that we
-    // only support version=1.
+    // TODO(waynetu): Check supported version.
     std::unique_ptr<grpc_binder::Binder> client_binder{};
     status = parcel->ReadBinder(&client_binder);
     if (!status.ok()) {

--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
@@ -42,8 +42,6 @@
 namespace grpc_binder {
 namespace {
 
-const int32_t kWireFormatVersion = 1;
-
 absl::StatusOr<Metadata> parse_metadata(ReadableParcel* reader) {
   int num_header;
   RETURN_IF_ERROR(reader->ReadInt32(&num_header));
@@ -116,8 +114,9 @@ void WireReaderImpl::SendSetupTransport(Binder* binder) {
   gpr_log(GPR_INFO, "prepare transaction = %d",
           binder->PrepareTransaction().ok());
   WritableParcel* writable_parcel = binder->GetWritableParcel();
+  int32_t version = 77;
   gpr_log(GPR_INFO, "write int32 = %d",
-          writable_parcel->WriteInt32(kWireFormatVersion).ok());
+          writable_parcel->WriteInt32(version).ok());
   // The lifetime of the transaction receiver is the same as the wire writer's.
   // The transaction receiver is responsible for not calling the on-transact
   // callback when it's dead.
@@ -195,15 +194,7 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
 
       int version;
       RETURN_IF_ERROR(parcel->ReadInt32(&version));
-      gpr_log(GPR_INFO, "The other end respond with version = %d", version);
-      // We only support this single lowest possible version, so server must
-      // respond that version too.
-      if (version != kWireFormatVersion) {
-        gpr_log(GPR_ERROR,
-                "The other end respond with version = %d, but we requested "
-                "version %d, trying to continue anyway",
-                version, kWireFormatVersion);
-      }
+      gpr_log(GPR_INFO, "version = %d", version);
       std::unique_ptr<Binder> binder{};
       RETURN_IF_ERROR(parcel->ReadBinder(&binder));
       if (!binder) {

--- a/test/core/transport/binder/wire_reader_test.cc
+++ b/test/core/transport/binder/wire_reader_test.cc
@@ -114,7 +114,7 @@ TEST_F(WireReaderTest, SetupTransport) {
   EXPECT_CALL(mock_binder_ref, GetWritableParcel);
 
   // Write version.
-  EXPECT_CALL(mock_binder_ref.GetWriter(), WriteInt32(1));
+  EXPECT_CALL(mock_binder_ref.GetWriter(), WriteInt32(77));
 
   // The transaction receiver immediately informs the wire writer that the
   // transport has been successfully set up.


### PR DESCRIPTION
Reverts grpc/grpc#27990

Looks like this PR introduced a high rate of flakiness in //test/core/transport/binder:binder_transport_test, //test/core/transport/binder:wire_reader_test