### PR TITLE
Allow generated proto sources in remote repositories for py_proto_library

### DIFF
--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -299,11 +299,11 @@ def get_out_dir(protos, context):
     if at_least_one_virtual:
         out_dir = get_include_directory(protos[0])
         ws_root = protos[0].owner.workspace_root
-        if ws_root and out_dir.find(ws_root) >= 0:
-            out_dir = "".join(out_dir.rsplit(ws_root, 1))
+        prefix = "/" + _make_prefix(protos[0].owner) + _VIRTUAL_IMPORTS[1:]
+
         return struct(
             path = out_dir,
-            import_path = out_dir[out_dir.find(_VIRTUAL_IMPORTS) + 1:],
+            import_path = out_dir[out_dir.find(prefix) + 1:],
         )
 
     out_dir = context.genfiles_dir.path

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -85,7 +85,7 @@ def _gen_py_aspect_impl(target, context):
 
     imports = []
     if out_dir.import_path:
-        imports.append("%s/%s/%s" % (context.workspace_name, context.label.package, out_dir.import_path))
+        imports.append("{}/{}".format(context.workspace_name, out_dir.import_path))
 
     py_info = PyInfo(transitive_sources = depset(direct = out_files), imports = depset(direct = imports))
     return PyProtoInfo(

--- a/bazel/test/python_second_test_repo/WORKSPACE
+++ b/bazel/test/python_second_test_repo/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "my_messages")

--- a/bazel/test/python_second_test_repo/proto/BUILD
+++ b/bazel/test/python_second_test_repo/proto/BUILD
@@ -14,15 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_proto//proto:defs.bzl", "proto_library")
-
-package(
-    default_testonly = 1,
-    default_visibility = ["//:__subpackages__"],
+proto_library(
+    name = "my_proto",
+    srcs = ["my.proto"],
+    visibility = ["//visibility:public"],
 )
 
-proto_library(
-    name = "subpackage_proto",
-    srcs = ["subpackage.proto"],
-    deps = ["@some_other_repo//proto:my_proto"],
+genrule(
+    name = "make_my_proto",
+    outs = ["my.proto"],
+    cmd = """
+      echo -e "syntax = \\"proto3\\";\npackage somewhere_else;\nmessage MyMessage {};" > $@
+    """,
 )

--- a/bazel/test/python_test_repo/WORKSPACE
+++ b/bazel/test/python_test_repo/WORKSPACE
@@ -13,3 +13,8 @@ grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
+
+local_repository(
+    name = "some_other_repo",
+    path = "../python_second_test_repo",
+)

--- a/bazel/test/python_test_repo/in_subpackage/subpackage.proto
+++ b/bazel/test/python_test_repo/in_subpackage/subpackage.proto
@@ -21,7 +21,9 @@ option objc_class_prefix = "SP";
 
 package subpackage;
 
+import "proto/my.proto";
+
 message Subpackaged {
   string name = 1;
+  somewhere_else.MyMessage msg = 2;
 }
-


### PR DESCRIPTION
Currently, a `py_proto_library` does not set the correct Python import path when a Python module is generated for a proto in an external repository whose sources are computed. This change should fix that.

This is an extension of #28040, which should go in first.

@donnadionne
