### PR TITLE
Increase iOS test timeout from 1.5h to 2.0h

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -34,7 +34,7 @@ _DEFAULT_RUNTESTS_TIMEOUT = 1 * 60 * 60
 _CPP_RUNTESTS_TIMEOUT = 4 * 60 * 60
 
 # Set timeout high for ObjC for Cocoapods to install pods
-_OBJC_RUNTESTS_TIMEOUT = 90 * 60
+_OBJC_RUNTESTS_TIMEOUT = 2 * 60 * 60
 
 # Number of jobs assigned to each run_tests.py instance
 _DEFAULT_INNER_JOBS = 2


### PR DESCRIPTION
`grpc/core/master/macos/grpc_basictests_objc_ios` started failing with timeout with `run_tests_objc_macos_opt_native` recently and it appears to be pretty close to the timeout from the latest success cases. (5375s, 5275s). Timeout is 1.5h (5400s) and the average duration is too close to the timeout so let's bump it to 2 hour.