### PR TITLE
run_tests family scripts: autodetect TTY when running docker

### DIFF
--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -147,7 +147,7 @@ def build_image_jobspec(runtime, env, gcr_tag, stack_base):
   """
     basename = 'grpc_interop_%s' % runtime
     tag = '%s/%s:%s' % (args.gcr_path, basename, gcr_tag)
-    build_env = {'INTEROP_IMAGE': tag, 'BASE_NAME': basename, 'TTY_FLAG': '-t'}
+    build_env = {'INTEROP_IMAGE': tag, 'BASE_NAME': basename}
     build_env.update(env)
     image_builder_path = _IMAGE_BUILDER
     if client_matrix.should_build_docker_interop_image_from_release_tag(lang):

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -43,6 +43,13 @@ else
   docker build -t "$DOCKER_IMAGE_NAME" "$DOCKERFILE_DIR"
 fi
 
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
 # Choose random name for docker container
 CONTAINER_NAME="build_and_run_docker_$(uuidgen)"
 
@@ -61,6 +68,7 @@ docker run \
   -v "$git_root:/var/local/jenkins/grpc:ro" \
   -w /var/local/git/grpc \
   --name="$CONTAINER_NAME" \
+  $DOCKER_TTY_ARGS \
   $EXTRA_DOCKER_ARGS \
   "$DOCKER_IMAGE_NAME" \
   /bin/bash -l "/var/local/jenkins/grpc/$DOCKER_RUN_SCRIPT" || FAILED="true"

--- a/tools/run_tests/dockerize/build_docker_and_run_tests.sh
+++ b/tools/run_tests/dockerize/build_docker_and_run_tests.sh
@@ -41,6 +41,13 @@ else
   docker build -t "$DOCKER_IMAGE_NAME" "$DOCKERFILE_DIR"
 fi
 
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
 # Choose random name for docker container
 CONTAINER_NAME="run_tests_$(uuidgen)"
 
@@ -49,7 +56,7 @@ docker_instance_git_root=/var/local/jenkins/grpc
 
 # Run tests inside docker
 DOCKER_EXIT_CODE=0
-# TODO: silence complaint about $TTY_FLAG expansion in some other way
+# TODO: silence complaint about $DOCKER_TTY_ARGS expansion in some other way
 # shellcheck disable=SC2086,SC2154
 docker run \
   --cap-add SYS_PTRACE \
@@ -66,8 +73,7 @@ docker run \
   -e "KOKORO_BUILD_NUMBER=$KOKORO_BUILD_NUMBER" \
   -e "KOKORO_BUILD_URL=$KOKORO_BUILD_URL" \
   -e "KOKORO_JOB_NAME=$KOKORO_JOB_NAME" \
-  -i \
-  $TTY_FLAG \
+  $DOCKER_TTY_ARGS \
   --sysctl net.ipv6.conf.all.disable_ipv6=0 \
   -v ~/.config/gcloud:/root/.config/gcloud \
   -v "$git_root:$docker_instance_git_root" \

--- a/tools/run_tests/dockerize/build_interop_image.sh
+++ b/tools/run_tests/dockerize/build_interop_image.sh
@@ -21,7 +21,6 @@ set -ex
 # Params:
 #  INTEROP_IMAGE - name of tag of the final interop image
 #  BASE_NAME - base name used to locate the base Dockerfile and build script
-#  TTY_FLAG - optional -t flag to make docker allocate tty
 #  BUILD_INTEROP_DOCKER_EXTRA_ARGS - optional args to be passed to the
 #    docker run command
 #  GRPC_ROOT - grpc base directory, default to top of this tree.
@@ -98,20 +97,25 @@ else
   docker build -t "$BASE_IMAGE" --force-rm=true "tools/dockerfile/interoptest/$BASE_NAME" || exit $?
 fi
 
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS="-it"
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=
+fi
+
 CONTAINER_NAME="build_${BASE_NAME}_$(uuidgen)"
 
 # Prepare image for interop tests, commit it on success.
 # TODO: Figure out if is safe to eliminate the suppression. It's currently here
 # because $MOUNT_ARGS and $BUILD_INTEROP_DOCKER_EXTRA_ARGS can have legitimate
 # spaces, but the "correct" way to do this is to utilize proper arrays.
-# Same for $TTY_FLAG
 # shellcheck disable=SC2086
 (docker run \
   --cap-add SYS_PTRACE \
   -e THIS_IS_REALLY_NEEDED='see https://github.com/docker/docker/issues/14203 for why docker is awful' \
   -e THIS_IS_REALLY_NEEDED_ONCE_AGAIN='For issue 4835. See https://github.com/docker/docker/issues/14203 for why docker is awful' \
-  -i \
-  $TTY_FLAG \
+  $DOCKER_TTY_ARGS \
   $MOUNT_ARGS \
   $BUILD_INTEROP_DOCKER_EXTRA_ARGS \
   --name="$CONTAINER_NAME" \

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -779,8 +779,10 @@ DOCKER_WORKDIR_ROOT = '/var/local/git/grpc'
 def docker_run_cmdline(cmdline, image, docker_args=[], cwd=None, environ=None):
     """Wraps given cmdline array to create 'docker run' cmdline from it."""
 
-    # TODO(jtattermusch): use "-it" when TTY is available to allow Ctrl-C to work
-    docker_cmdline = ['docker', 'run', '-i', '--rm=true']
+    docker_cmdline = ['docker', 'run', '--rm=true']
+    if sys.stdout.isatty():
+        # use "-it" when TTY is available to allow Ctrl-C to work
+        docker_cmdline.append('-it')
 
     # turn environ into -e docker args
     if environ:

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -778,6 +778,8 @@ DOCKER_WORKDIR_ROOT = '/var/local/git/grpc'
 
 def docker_run_cmdline(cmdline, image, docker_args=[], cwd=None, environ=None):
     """Wraps given cmdline array to create 'docker run' cmdline from it."""
+
+    # TODO(jtattermusch): use "-it" when TTY is available to allow Ctrl-C to work
     docker_cmdline = ['docker', 'run', '-i', '--rm=true']
 
     # turn environ into -e docker args
@@ -1136,8 +1138,6 @@ def build_interop_image_jobspec(language, tag=None):
         'INTEROP_IMAGE': tag,
         'BASE_NAME': 'grpc_interop_%s' % language.safename
     }
-    if not args.travis:
-        env['TTY_FLAG'] = '-t'
     build_job = jobset.JobSpec(
         cmdline=['tools/run_tests/dockerize/build_interop_image.sh'],
         environ=env,
@@ -1239,11 +1239,14 @@ argp.add_argument(
     type=str,
     help='Default GCE service account email to use for some auth interop tests.',
     default='830293263384-compute@developer.gserviceaccount.com')
-argp.add_argument('-t',
-                  '--travis',
-                  default=False,
-                  action='store_const',
-                  const=True)
+argp.add_argument(
+    '-t',
+    '--travis',
+    default=False,
+    action='store_const',
+    const=True,
+    help='When set, indicates that the script is running on CI (= not locally).'
+)
 argp.add_argument('-v',
                   '--verbose',
                   default=False,

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1358,11 +1358,14 @@ argp.add_argument('-f',
                   default=False,
                   action='store_const',
                   const=True)
-argp.add_argument('-t',
-                  '--travis',
-                  default=False,
-                  action='store_const',
-                  const=True)
+argp.add_argument(
+    '-t',
+    '--travis',
+    default=False,
+    action='store_const',
+    const=True,
+    help='When set, indicates that the script is running on CI (= not locally).'
+)
 argp.add_argument('--newline_on_success',
                   default=False,
                   action='store_const',
@@ -1602,8 +1605,6 @@ if args.use_docker:
     env['DOCKER_RUN_SCRIPT'] = 'tools/run_tests/dockerize/docker_run_tests.sh'
     if args.xml_report:
         env['XML_REPORT'] = args.xml_report
-    if not args.travis:
-        env['TTY_FLAG'] = '-t'  # enables Ctrl-C when not on Jenkins.
 
     subprocess.check_call(
         'tools/run_tests/dockerize/build_docker_and_run_tests.sh',

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -72,7 +72,8 @@ argp.add_argument('-t',
                   '--travis',
                   default=False,
                   action='store_const',
-                  const=True)
+                  const=True,
+                  help='Deprecated. Has no effect.')
 argp.add_argument('-x',
                   '--xml_report',
                   default='report_taskrunner_sponge_log.xml',

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -68,12 +68,6 @@ argp.add_argument('-f',
                   default=[],
                   help='Filter targets to build with AND semantics.')
 argp.add_argument('-j', '--jobs', default=multiprocessing.cpu_count(), type=int)
-argp.add_argument('-t',
-                  '--travis',
-                  default=False,
-                  action='store_const',
-                  const=True,
-                  help='Deprecated. Has no effect.')
 argp.add_argument('-x',
                   '--xml_report',
                   default='report_taskrunner_sponge_log.xml',


### PR DESCRIPTION
- we currently support `--travis` arg for our run_tests.py scripts and when running "docker run", we set the "-t" flag accordingly (ironically, setting "-t/--travis" for run_tests.py REMOVES the "-t/Allocate a pseudo-tty" docker argument, whic is confusing).

changing the helper scripts that run docker to autodetect the presence of terminal automatically (which allows Ctrl+C to work when running in terminal).
This e.g. fixes the behavior of the task_runner.py script (which previously couldn't be killed with Ctrl+C).

TODO:  looks like --travis argument also affects the way jobset.py prints to the console, which needs to be revisited:
https://github.com/grpc/grpc/blob/4dd0bba12e90f490fcccef2dca1ae7e907cebbbf/tools/run_tests/python_utils/jobset.py#L573
