### PR TITLE
run_tests_matrix.py: run workspace jobs with python3

### DIFF
--- a/tools/run_tests/helper_scripts/run_tests_in_workspace.sh
+++ b/tools/run_tests/helper_scripts/run_tests_in_workspace.sh
@@ -31,4 +31,4 @@ git submodule foreach 'cd "${repo_root}/${WORKSPACE_NAME}" \
     && git submodule update --init --reference ${repo_root}/${name} ${name}'
 
 echo "Running run_tests.py in workspace ${WORKSPACE_NAME}" 
-python "${WORKSPACE_NAME}/tools/run_tests/run_tests.py" "$@"
+python3 "${WORKSPACE_NAME}/tools/run_tests/run_tests.py" "$@"


### PR DESCRIPTION
Another of the place where python2->python3 didn't happen.
