### PR TITLE
Convenience scripts for local testing under docker (+ examples how to run GDB and use coredump under docker)

### DIFF
--- a/tools/docker_runners/examples/bazel_test_in_docker.sh
+++ b/tools/docker_runners/examples/bazel_test_in_docker.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd "$(dirname "$0")/../../.."
+
+# TODO(jtattermusch): make sure bazel cache is persisted between runs
+
+# Note that the port server must be running so that the bazel tests can pass.
+
+# use the default docker image used for bazel builds
+export DOCKERFILE_DIR=tools/dockerfile/test/bazel
+# TODO(jtattermusch): interestingly, the bazel build fails when "--privileged" docker arg is used (it probably has to do with sandboxing)
+export DOCKER_EXTRA_ARGS="--privileged=false"
+tools/docker_runners/run_in_docker.sh bazel test //test/...

--- a/tools/docker_runners/examples/coredump_in_docker.sh
+++ b/tools/docker_runners/examples/coredump_in_docker.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd "$(dirname "$0")/../../.."
+
+# use the docker image used as the default for C++ by run_tests.py
+# TODO(jtattermusch): document how to get the right docker image name
+# for given run_tests.py --compiler/--arch params.
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian9_x64
+
+# add extra docker args if needed
+export DOCKER_EXTRA_ARGS=""
+
+# start the docker container with interactive shell
+tools/docker_runners/run_in_docker.sh bash
+
+# Run these commands under the docker container
+#
+# Install gdb (or similar command for non-debian based distros)
+# $ apt-get update && apt-get install -y gdb
+#
+# No limit for coredump size
+# $ ulimit -c unlimited
+#
+# Coredumps will be stored to /tmp/coredumps (inside the docker container)
+# mkdir /tmp/coredumps
+# echo "/tmp/coredumps/core.%p" | tee /proc/sys/kernel/core_pattern
+#
+# Build e.g. the C tests
+# $ ./tools/run_tests/run_tests.py -l c -c dbg --build_only
+#
+# Run a test that crashes, it will create a coredump.
+# $ cmake/build/foo_bar_test
+#
+# Open coredump under gdb
+# $ gdb cmake/build/foo_bar_test /tmp/coredumps/core.XYZ

--- a/tools/docker_runners/examples/gdb_in_docker.sh
+++ b/tools/docker_runners/examples/gdb_in_docker.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd "$(dirname "$0")/../../.."
+
+# use the docker image used as the default for C++ by run_tests.py
+# TODO(jtattermusch): document how to get the right docker image name
+# for given run_tests.py --compiler/--arch params.
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian9_x64
+
+# add extra docker args if needed
+export DOCKER_EXTRA_ARGS=""
+
+# start the docker container with interactive shell
+tools/docker_runners/run_in_docker.sh bash
+
+# Run these commands under the docker container
+#
+# Install gdb (or similar command for non-debian based distros)
+# $ apt-get update && apt-get install -y gdb
+#
+# Build e.g. the C tests
+# $ ./tools/run_tests/run_tests.py -l c -c dbg --build_only
+#
+# Run a test under gdb
+# NOTE: Some old distros (e.g. debian 8 "jessie") might have a gdb version
+# that doesn't work with C++11 symbols properly and crashes when
+# loading the symbols.
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61233
+# $ gdb cmake/build/histogram_test

--- a/tools/docker_runners/examples/run_tests_c_cpp_in_docker.sh
+++ b/tools/docker_runners/examples/run_tests_c_cpp_in_docker.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd "$(dirname "$0")/../../.."
+
+# use the docker image used as the default for C++ by run_tests.py
+# TODO(jtattermusch): document how to get the right docker image name
+# for given run_tests.py --compiler/--arch params.
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian9_x64
+tools/docker_runners/run_in_docker.sh tools/run_tests/run_tests.py -l c c++ -c dbg

--- a/tools/docker_runners/examples/run_tests_csharp_in_docker.sh
+++ b/tools/docker_runners/examples/run_tests_csharp_in_docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd "$(dirname "$0")/../../.."
+
+# use the docker image used as the default for C# by run_tests.py
+export DOCKERFILE_DIR=tools/dockerfile/test/csharp_buster_x64
+tools/docker_runners/run_in_docker.sh tools/run_tests/run_tests.py -l csharp -c dbg --compiler coreclr

--- a/tools/docker_runners/run_in_docker.sh
+++ b/tools/docker_runners/run_in_docker.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs C# build in a docker container, but using the local workspace.
+# Example usage:
+# src/csharp/run_in_docker.sh tools/run_tests/run_tests.py -l csharp
+
+set -e
+
+# Environment variable used as inputs:
+# DOCKERFILE_DIR - Directory in which Dockerfile file is located.
+# DOCKER_EXTRA_ARGS - Extra arguments to pass to the "docker run" command.
+
+readonly grpc_rootdir="$(dirname "$(readlink -f "$0")")/../.."
+cd ${grpc_rootdir}
+
+if [ "${DOCKERFILE_DIR}" == "" ]
+then
+    echo "You need to specify the docker image to use by setting DOCKERFILE_DIR env variable."
+    echo "See docker image definitions under tools/dockerfile."
+    echo ""
+    echo "You likely want to set DOCKERFILE_DIR to one of these values:"
+    find tools/dockerfile/test -name Dockerfile | xargs -n1 dirname
+    exit 1
+fi
+
+# Use image name based on Dockerfile location checksum
+# For simplicity, currently only testing docker images that have already been pushed
+# to dockerhub are supported (see tools/dockerfile/push_testing_images.sh)
+# TODO(jtattermusch): add support for building dockerimages locally.
+DOCKER_IMAGE=grpctesting/$(basename "$DOCKERFILE_DIR"):$(sha1sum "$DOCKERFILE_DIR/Dockerfile" | cut -f1 -d\ )
+
+# TODO: support building dockerimage locally / pulling it from dockerhub
+
+# If TTY is available, the running container can be conveniently terminated with Ctrl+C.
+if [[ -t 0 ]]; then
+  DOCKER_TTY_ARGS=("-it")
+else
+  # The input device on kokoro is not a TTY, so -it does not work.
+  DOCKER_TTY_ARGS=()
+fi
+
+# args required to be able to run gdb/strace under the docker container
+DOCKER_PRIVILEGED_ARGS=(
+  "--privileged"
+  "--cap-add=SYS_PTRACE"
+  "--security-opt=seccomp=unconfined"
+)
+
+DOCKER_NETWORK_ARGS=(
+  # enable IPv6
+  "--sysctl=net.ipv6.conf.all.disable_ipv6=0"
+  # use host network, required for the port server to work correctly
+  "--network=host"
+)
+
+DOCKER_CLEANUP_ARGS=(
+  # delete the container when the containers exits
+  # (otherwise the container will not release the disk space it used)
+  "--rm=true"
+)
+
+# Uncomment to run the docker container as current user's UID and GID.
+# That way, the files written by the container won't be owned by root (=you won't end up with polluted workspace),
+# but it can have some other disadvantages. E.g.:
+# - you won't be able install stuff inside the container
+# - the home directory inside the container will be broken (you won't be able to write in it).
+#   That may actually break some language runtimes completely (e.g. grpc python might not build)
+# DOCKER_NONROOT_ARGS=(
+#   # run under current user's UID and GID
+#   "--user=$(id -u):$(id -g)"
+# )
+
+# Enable command echo just before running the final docker command to make the docker args visible.
+set -ex
+
+# Run command inside C# docker container.
+# - the local clone of grpc repository will be mounted as /workspace.
+exec docker run "${DOCKER_TTY_ARGS[@]}" "${DOCKER_PRIVILEGED_ARGS[@]}" "${DOCKER_NETWORK_ARGS[@]}" "${DOCKER_CLEANUP_ARGS[@]}" ${DOCKER_EXTRA_ARGS} -v "${grpc_rootdir}":/workspace -w /workspace "${DOCKER_IMAGE}" bash -c "$*"


### PR DESCRIPTION
Some basic scripts that can be used for running tests under docker (using the docker images we use for testing on CI).
The local git repository can be mounted to the docker container as a volume, which allows interactively working with the source code, while running the tests under the docker container.

- provide example scripts that show how to use GDB and how to work with coredumps when running tests under the docker container.
- allow interactively running tests in various languages without needing to install prerequisites etc (which for some languages can be tricky).
- allows easy use of the same docker images we use on CI, so that one can work in an environment that's as close to the CI as possible (but without needing to resort to clumsy hack).

There are still improvements that can be made, but what I currently have is relatively convenient and quite powerful.

