### PR TITLE
Revert "use CppImplOf for grpc_server"

### DIFF
--- a/src/core/ext/transport/binder/server/binder_server.cc
+++ b/src/core/ext/transport/binder/server/binder_server.cc
@@ -238,7 +238,7 @@ bool AddBinderPort(const std::string& addr, grpc_server* server,
     return false;
   }
   std::string conn_id = addr.substr(kBinderUriScheme.size());
-  Server* core_server = Server::FromC(server);
+  Server* core_server = server->core_server.get();
   core_server->AddListener(
       OrphanablePtr<Server::ListenerInterface>(new BinderServerListener(
           core_server, conn_id, std::move(factory), security_policy)));

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2.cc
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2.cc
@@ -40,12 +40,13 @@ int grpc_server_add_insecure_http2_port(grpc_server* server, const char* addr) {
   int port_num = 0;
   GRPC_API_TRACE("grpc_server_add_insecure_http2_port(server=%p, addr=%s)", 2,
                  (server, addr));
-  grpc_core::Server* core_server = grpc_core::Server::FromC(server);
   grpc_error_handle err = grpc_core::Chttp2ServerAddPort(
-      core_server, addr, grpc_channel_args_copy(core_server->channel_args()),
+      server->core_server.get(), addr,
+      grpc_channel_args_copy(server->core_server->channel_args()),
       ModifyArgsForConnection, &port_num);
   if (err != GRPC_ERROR_NONE) {
     gpr_log(GPR_ERROR, "%s", grpc_error_std_string(err).c_str());
+
     GRPC_ERROR_UNREF(err);
   }
   return port_num;

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.cc
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.cc
@@ -42,7 +42,7 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server* server,
   GPR_ASSERT(reserved == nullptr);
 
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::Server* core_server = grpc_core::Server::FromC(server);
+  grpc_core::Server* core_server = server->core_server.get();
 
   const grpc_channel_args* server_args = core_server->channel_args();
   std::string name = absl::StrCat("fd:", fd);

--- a/src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc
+++ b/src/core/ext/transport/chttp2/server/secure/server_secure_chttp2.cc
@@ -75,7 +75,6 @@ int grpc_server_add_secure_http2_port(grpc_server* server, const char* addr,
       "grpc_server_add_secure_http2_port("
       "server=%p, addr=%s, creds=%p)",
       3, (server, addr, creds));
-  grpc_core::Server* core_server = grpc_core::Server::FromC(server);
   // Create security context.
   if (creds == nullptr) {
     err = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -92,10 +91,10 @@ int grpc_server_add_secure_http2_port(grpc_server* server, const char* addr,
   // rewritten, we would be able to make this workaround go away by removing
   // that assumption. As an immediate drawback of this workaround, config
   // fetchers need to be registered before adding ports to the server.
-  if (core_server->config_fetcher() != nullptr) {
+  if (server->core_server->config_fetcher() != nullptr) {
     // Create channel args.
     grpc_arg arg_to_add = grpc_server_credentials_to_arg(creds);
-    args = grpc_channel_args_copy_and_add(core_server->channel_args(),
+    args = grpc_channel_args_copy_and_add(server->core_server->channel_args(),
                                           &arg_to_add, 1);
   } else {
     sc = creds->create_security_connector(nullptr);
@@ -108,11 +107,12 @@ int grpc_server_add_secure_http2_port(grpc_server* server, const char* addr,
     grpc_arg args_to_add[2];
     args_to_add[0] = grpc_server_credentials_to_arg(creds);
     args_to_add[1] = grpc_security_connector_to_arg(sc.get());
-    args = grpc_channel_args_copy_and_add(
-        core_server->channel_args(), args_to_add, GPR_ARRAY_SIZE(args_to_add));
+    args = grpc_channel_args_copy_and_add(server->core_server->channel_args(),
+                                          args_to_add,
+                                          GPR_ARRAY_SIZE(args_to_add));
   }
   // Add server port.
-  err = grpc_core::Chttp2ServerAddPort(core_server, addr, args,
+  err = grpc_core::Chttp2ServerAddPort(server->core_server.get(), addr, args,
                                        ModifyArgsForConnection, &port_num);
 done:
   sc.reset(DEBUG_LOCATION, "server");

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -1288,13 +1288,12 @@ grpc_channel* grpc_inproc_channel_create(grpc_server* server,
 
   grpc_core::ExecCtx exec_ctx;
 
-  grpc_core::Server* core_server = grpc_core::Server::FromC(server);
   // Remove max_connection_idle and max_connection_age channel arguments since
   // those do not apply to inproc transports.
   const char* args_to_remove[] = {GRPC_ARG_MAX_CONNECTION_IDLE_MS,
                                   GRPC_ARG_MAX_CONNECTION_AGE_MS};
   const grpc_channel_args* server_args = grpc_channel_args_copy_and_remove(
-      core_server->channel_args(), args_to_remove,
+      server->core_server->channel_args(), args_to_remove,
       GPR_ARRAY_SIZE(args_to_remove));
   // Add a default authority channel argument for the client
   grpc_arg default_authority_arg;
@@ -1311,7 +1310,7 @@ grpc_channel* grpc_inproc_channel_create(grpc_server* server,
                            client_args);
 
   // TODO(ncteisen): design and support channelz GetSocket for inproc.
-  grpc_error_handle error = core_server->SetupTransport(
+  grpc_error_handle error = server->core_server->SetupTransport(
       server_transport, nullptr, server_args, nullptr);
   grpc_channel* channel = nullptr;
   if (error == GRPC_ERROR_NONE) {

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -33,7 +33,6 @@
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/gprpp/cpp_impl_of.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/resource_quota/memory_quota.h"
 #include "src/core/lib/surface/completion_queue.h"
@@ -43,8 +42,7 @@ namespace grpc_core {
 
 extern TraceFlag grpc_server_channel_trace;
 
-class Server : public InternallyRefCounted<Server>,
-               public CppImplOf<Server, grpc_server> {
+class Server : public InternallyRefCounted<Server> {
  public:
   // Filter vtable.
   static const grpc_channel_filter kServerTopFilter;
@@ -460,6 +458,10 @@ class Server : public InternallyRefCounted<Server>,
 };
 
 }  // namespace grpc_core
+
+struct grpc_server {
+  grpc_core::OrphanablePtr<grpc_core::Server> core_server;
+};
 
 struct grpc_server_config_fetcher {
  public:

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -792,8 +792,8 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
   }
 
   void AddSyncMethod(grpc::internal::RpcServiceMethod* method, void* tag) {
-    grpc_core::Server::FromC(server_->server())
-        ->SetRegisteredMethodAllocator(server_cq_->cq(), tag, [this, method] {
+    server_->server()->core_server->SetRegisteredMethodAllocator(
+        server_cq_->cq(), tag, [this, method] {
           grpc_core::Server::RegisteredCallAllocation result;
           new SyncRequest(server_, method, &result);
           return result;
@@ -806,8 +806,8 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
       unknown_method_ = absl::make_unique<grpc::internal::RpcServiceMethod>(
           "unknown", grpc::internal::RpcMethod::BIDI_STREAMING,
           new grpc::internal::UnknownMethodHandler(kUnknownRpcMethod));
-      grpc_core::Server::FromC(server_->server())
-          ->SetBatchMethodAllocator(server_cq_->cq(), [this] {
+      server_->server()->core_server->SetBatchMethodAllocator(
+          server_cq_->cq(), [this] {
             grpc_core::Server::BatchCallAllocation result;
             new SyncRequest(server_, unknown_method_.get(), &result);
             return result;
@@ -1031,7 +1031,7 @@ bool Server::RegisterService(const std::string* addr, grpc::Service* service) {
       has_callback_methods_ = true;
       grpc::internal::RpcServiceMethod* method_value = method.get();
       grpc::CompletionQueue* cq = CallbackCQ();
-      grpc_core::Server::FromC(server_)->SetRegisteredMethodAllocator(
+      server_->core_server->SetRegisteredMethodAllocator(
           cq->cq(), method_registration_tag, [this, cq, method_value] {
             grpc_core::Server::RegisteredCallAllocation result;
             new CallbackRequest<grpc::CallbackServerContext>(this, method_value,
@@ -1072,8 +1072,7 @@ void Server::RegisterCallbackGenericService(
   generic_handler_.reset(service->Handler());
 
   grpc::CompletionQueue* cq = CallbackCQ();
-  grpc_core::Server::FromC(server_)->SetBatchMethodAllocator(cq->cq(), [this,
-                                                                        cq] {
+  server_->core_server->SetBatchMethodAllocator(cq->cq(), [this, cq] {
     grpc_core::Server::BatchCallAllocation result;
     new CallbackRequest<grpc::GenericCallbackServerContext>(this, cq, &result);
     return result;

--- a/test/core/bad_client/bad_client.cc
+++ b/test/core/bad_client/bad_client.cc
@@ -66,12 +66,12 @@ static void set_done_write(void* arg, grpc_error_handle /*error*/) {
 static void server_setup_transport(void* ts, grpc_transport* transport) {
   thd_args* a = static_cast<thd_args*>(ts);
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::Server* core_server = grpc_core::Server::FromC(a->server);
   GPR_ASSERT(GRPC_LOG_IF_ERROR(
       "SetupTransport",
-      core_server->SetupTransport(transport, /*accepting_pollset=*/nullptr,
-                                  core_server->channel_args(),
-                                  /*socket_node=*/nullptr)));
+      a->server->core_server->SetupTransport(
+          transport,
+          /*accepting_pollset=*/nullptr, a->server->core_server->channel_args(),
+          /*socket_node=*/nullptr)));
 }
 
 /* Sets the read_done event */
@@ -224,7 +224,7 @@ void grpc_run_bad_client_test(
   grpc_endpoint_add_to_pollset(sfd.server, grpc_cq_pollset(a.cq));
 
   /* Check a ground truth */
-  GPR_ASSERT(grpc_core::Server::FromC(a.server)->HasOpenConnections());
+  GPR_ASSERT(a.server->core_server->HasOpenConnections());
 
   gpr_event_init(&a.done_thd);
   a.validator = server_validator;

--- a/test/core/bad_client/tests/bad_streaming_id.cc
+++ b/test/core/bad_client/tests/bad_streaming_id.cc
@@ -77,7 +77,7 @@ namespace {
 
 void verifier(grpc_server* server, grpc_completion_queue* cq,
               void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/badreq.cc
+++ b/test/core/bad_client/tests/badreq.cc
@@ -30,7 +30,7 @@
 
 static void verifier(grpc_server* server, grpc_completion_queue* cq,
                      void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/connection_prefix.cc
+++ b/test/core/bad_client/tests/connection_prefix.cc
@@ -21,7 +21,7 @@
 
 static void verifier(grpc_server* server, grpc_completion_queue* cq,
                      void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/headers.cc
+++ b/test/core/bad_client/tests/headers.cc
@@ -25,7 +25,7 @@
 
 static void verifier(grpc_server* server, grpc_completion_queue* cq,
                      void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/initial_settings_frame.cc
+++ b/test/core/bad_client/tests/initial_settings_frame.cc
@@ -24,7 +24,7 @@
 
 static void verifier(grpc_server* server, grpc_completion_queue* cq,
                      void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/out_of_bounds.cc
+++ b/test/core/bad_client/tests/out_of_bounds.cc
@@ -32,7 +32,7 @@ namespace {
 
 void verifier(grpc_server* server, grpc_completion_queue* cq,
               void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/server_registered_method.cc
+++ b/test/core/bad_client/tests/server_registered_method.cc
@@ -67,7 +67,7 @@ static void verifier_succeeds(grpc_server* server, grpc_completion_queue* cq,
 
 static void verifier_fails(grpc_server* server, grpc_completion_queue* cq,
                            void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/simple_request.cc
+++ b/test/core/bad_client/tests/simple_request.cc
@@ -114,7 +114,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
 
 static void failure_verifier(grpc_server* server, grpc_completion_queue* cq,
                              void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/unknown_frame.cc
+++ b/test/core/bad_client/tests/unknown_frame.cc
@@ -27,7 +27,7 @@
 
 static void verifier(grpc_server* server, grpc_completion_queue* cq,
                      void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_client/tests/window_overflow.cc
+++ b/test/core/bad_client/tests/window_overflow.cc
@@ -43,7 +43,7 @@
 
 static void verifier(grpc_server* server, grpc_completion_queue* cq,
                      void* /*registered_method*/) {
-  while (grpc_core::Server::FromC(server)->HasOpenConnections()) {
+  while (server->core_server->HasOpenConnections()) {
     GPR_ASSERT(grpc_completion_queue_next(
                    cq, grpc_timeout_milliseconds_to_deadline(20), nullptr)
                    .type == GRPC_QUEUE_TIMEOUT);

--- a/test/core/bad_connection/close_fd_test.cc
+++ b/test/core/bad_connection/close_fd_test.cc
@@ -73,11 +73,11 @@ static test_ctx g_ctx;
 static void server_setup_transport(grpc_transport* transport) {
   grpc_core::ExecCtx exec_ctx;
   grpc_endpoint_add_to_pollset(g_ctx.ep->server, grpc_cq_pollset(g_ctx.cq));
-  grpc_core::Server* core_server = grpc_core::Server::FromC(g_ctx.server);
   GPR_ASSERT(GRPC_LOG_IF_ERROR(
       "SetupTransport",
-      core_server->SetupTransport(transport, nullptr,
-                                  core_server->channel_args(), nullptr)));
+      g_ctx.server->core_server->SetupTransport(
+          transport, nullptr, g_ctx.server->core_server->channel_args(),
+          nullptr)));
 }
 
 static void client_setup_transport(grpc_transport* transport) {

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -518,7 +518,7 @@ TEST_F(ChannelzRegistryBasedTest, InternalChannelTest) {
 TEST(ChannelzServerTest, BasicServerAPIFunctionality) {
   ExecCtx exec_ctx;
   ServerFixture server(10);
-  ServerNode* channelz_server = Server::FromC(server.server())->channelz_node();
+  ServerNode* channelz_server = server.server()->core_server->channelz_node();
   channelz_server->RecordCallStarted();
   channelz_server->RecordCallFailed();
   channelz_server->RecordCallSucceeded();

--- a/test/core/end2end/fixtures/h2_sockpair+trace.cc
+++ b/test/core/end2end/fixtures/h2_sockpair+trace.cc
@@ -56,9 +56,8 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
   custom_fixture_data* fixture_data =
       static_cast<custom_fixture_data*>(f->fixture_data);
   grpc_endpoint_add_to_pollset(fixture_data->ep.server, grpc_cq_pollset(f->cq));
-  grpc_core::Server* core_server = grpc_core::Server::FromC(f->server);
-  grpc_error_handle error = core_server->SetupTransport(
-      transport, nullptr, core_server->channel_args(), nullptr);
+  grpc_error_handle error = f->server->core_server->SetupTransport(
+      transport, nullptr, f->server->core_server->channel_args(), nullptr);
   if (error == GRPC_ERROR_NONE) {
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
   } else {

--- a/test/core/end2end/fixtures/h2_sockpair.cc
+++ b/test/core/end2end/fixtures/h2_sockpair.cc
@@ -51,9 +51,8 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
   custom_fixture_data* fixture_data =
       static_cast<custom_fixture_data*>(f->fixture_data);
   grpc_endpoint_add_to_pollset(fixture_data->ep.server, grpc_cq_pollset(f->cq));
-  grpc_core::Server* core_server = grpc_core::Server::FromC(f->server);
-  grpc_error_handle error = core_server->SetupTransport(
-      transport, nullptr, core_server->channel_args(), nullptr);
+  grpc_error_handle error = f->server->core_server->SetupTransport(
+      transport, nullptr, f->server->core_server->channel_args(), nullptr);
   if (error == GRPC_ERROR_NONE) {
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
   } else {

--- a/test/core/end2end/fixtures/h2_sockpair_1byte.cc
+++ b/test/core/end2end/fixtures/h2_sockpair_1byte.cc
@@ -51,9 +51,8 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
   custom_fixture_data* fixture_data =
       static_cast<custom_fixture_data*>(f->fixture_data);
   grpc_endpoint_add_to_pollset(fixture_data->ep.server, grpc_cq_pollset(f->cq));
-  grpc_core::Server* core_server = grpc_core::Server::FromC(f->server);
-  grpc_error_handle error = core_server->SetupTransport(
-      transport, nullptr, core_server->channel_args(), nullptr);
+  grpc_error_handle error = f->server->core_server->SetupTransport(
+      transport, nullptr, f->server->core_server->channel_args(), nullptr);
   if (error == GRPC_ERROR_NONE) {
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
   } else {

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -182,12 +182,11 @@ static void do_connect(void* arg, grpc_error_handle error) {
     start_scheduling_grpc_passthru_endpoint_channel_effects(
         client, g_channel_actions, [&]() { g_channel_force_delete = true; });
 
-    grpc_core::Server* core_server = grpc_core::Server::FromC(g_server);
     grpc_transport* transport = grpc_create_chttp2_transport(
-        core_server->channel_args(), server, false);
-    GPR_ASSERT(GRPC_LOG_IF_ERROR(
-        "SetupTransport",
-        core_server->SetupTransport(transport, nullptr, nullptr, nullptr)));
+        g_server->core_server->channel_args(), server, false);
+    GPR_ASSERT(GRPC_LOG_IF_ERROR("SetupTransport",
+                                 g_server->core_server->SetupTransport(
+                                     transport, nullptr, nullptr, nullptr)));
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
 
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, fc->closure, GRPC_ERROR_NONE);

--- a/test/core/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/end2end/fuzzers/server_fuzzer.cc
@@ -58,9 +58,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
         grpc_create_chttp2_transport(channel_args, mock_endpoint, false);
     grpc_channel_args_destroy(channel_args);
     grpc_resource_quota_unref(resource_quota);
-    GPR_ASSERT(GRPC_LOG_IF_ERROR(
-        "SetupTransport", grpc_core::Server::FromC(server)->SetupTransport(
-                              transport, nullptr, nullptr, nullptr)));
+    GPR_ASSERT(GRPC_LOG_IF_ERROR("SetupTransport",
+                                 server->core_server->SetupTransport(
+                                     transport, nullptr, nullptr, nullptr)));
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
 
     grpc_call* call1 = nullptr;

--- a/test/core/end2end/tests/channelz.cc
+++ b/test/core/end2end/tests/channelz.cc
@@ -213,7 +213,7 @@ static void test_channelz(grpc_end2end_test_config config) {
   GPR_ASSERT(channelz_channel != nullptr);
 
   grpc_core::channelz::ServerNode* channelz_server =
-      grpc_core::Server::FromC(f.server)->channelz_node();
+      f.server->core_server->channelz_node();
   GPR_ASSERT(channelz_server != nullptr);
 
   std::string json = channelz_channel->RenderJsonString();
@@ -274,7 +274,7 @@ static void test_channelz_with_channel_trace(grpc_end2end_test_config config) {
   GPR_ASSERT(channelz_channel != nullptr);
 
   grpc_core::channelz::ServerNode* channelz_server =
-      grpc_core::Server::FromC(f.server)->channelz_node();
+      f.server->core_server->channelz_node();
   GPR_ASSERT(channelz_server != nullptr);
 
   run_one_request(config, f, true);

--- a/test/core/transport/binder/end2end/testing_channel_create.cc
+++ b/test/core/transport/binder/end2end/testing_channel_create.cc
@@ -121,7 +121,7 @@ grpc_channel* grpc_binder_channel_create_for_testing(grpc_server* server,
   grpc_transport *client_transport, *server_transport;
   std::tie(client_transport, server_transport) =
       grpc_binder::end2end_testing::CreateClientServerBindersPairForTesting();
-  grpc_error_handle error = grpc_core::Server::FromC(server)->SetupTransport(
+  grpc_error_handle error = server->core_server->SetupTransport(
       server_transport, nullptr, args, nullptr);
   GPR_ASSERT(error == GRPC_ERROR_NONE);
   grpc_channel* channel =

--- a/test/cpp/microbenchmarks/fullstack_fixtures.h
+++ b/test/cpp/microbenchmarks/fullstack_fixtures.h
@@ -173,19 +173,19 @@ class EndpointPairFixture : public BaseFixture {
     /* add server endpoint to server_
      * */
     {
-      grpc_core::Server* core_server =
-          grpc_core::Server::FromC(server_->c_server());
-      const grpc_channel_args* server_args = core_server->channel_args();
+      const grpc_channel_args* server_args =
+          server_->c_server()->core_server->channel_args();
       server_transport_ = grpc_create_chttp2_transport(
           server_args, endpoints.server, false /* is_client */);
-      for (grpc_pollset* pollset : core_server->pollsets()) {
+      for (grpc_pollset* pollset :
+           server_->c_server()->core_server->pollsets()) {
         grpc_endpoint_add_to_pollset(endpoints.server, pollset);
       }
 
       GPR_ASSERT(GRPC_LOG_IF_ERROR(
           "SetupTransport",
-          core_server->SetupTransport(server_transport_, nullptr, server_args,
-                                      nullptr)));
+          server_->c_server()->core_server->SetupTransport(
+              server_transport_, nullptr, server_args, nullptr)));
       grpc_chttp2_transport_start_reading(server_transport_, nullptr, nullptr,
                                           nullptr);
     }

--- a/test/cpp/performance/writes_per_rpc_test.cc
+++ b/test/cpp/performance/writes_per_rpc_test.cc
@@ -71,18 +71,18 @@ class EndpointPairFixture {
 
     /* add server endpoint to server_ */
     {
-      grpc_core::Server* core_server =
-          grpc_core::Server::FromC(server_->c_server());
-      const grpc_channel_args* server_args = core_server->channel_args();
+      const grpc_channel_args* server_args =
+          server_->c_server()->core_server->channel_args();
       grpc_transport* transport = grpc_create_chttp2_transport(
           server_args, endpoints.server, false /* is_client */);
-      for (grpc_pollset* pollset : core_server->pollsets()) {
+      for (grpc_pollset* pollset :
+           server_->c_server()->core_server->pollsets()) {
         grpc_endpoint_add_to_pollset(endpoints.server, pollset);
       }
 
       GPR_ASSERT(GRPC_LOG_IF_ERROR(
-          "SetupTransport", core_server->SetupTransport(transport, nullptr,
-                                                        server_args, nullptr)));
+          "SetupTransport", server_->c_server()->core_server->SetupTransport(
+                                transport, nullptr, server_args, nullptr)));
       grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
     }
 


### PR DESCRIPTION
Reverts grpc/grpc#28112.

Causing internal breakage.  Will require a cherry-pick import.