### PR TITLE
Fix xds_end2end_test dyld

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -252,7 +252,7 @@ def ios_cc_test(
             deps = ios_test_deps,
         )
 
-def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = [], exec_properties = {}, shard_count = None, flaky = None, copts = []):
+def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = [], exec_properties = {}, shard_count = None, flaky = None, copts = [], linkstatic = None):
     """A cc_test target for use in the gRPC repo.
 
     Args:
@@ -274,6 +274,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         shard_count: The number of shards for this test.
         flaky: Whether this test is flaky.
         copts: Add these to the compiler invocation.
+        linkstatic: link the binary in static mode
     """
     copts = copts + if_mac(["-DGRPC_CFSTREAM"])
     if language.upper() == "C":
@@ -294,6 +295,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         "exec_properties": exec_properties,
         "shard_count": shard_count,
         "flaky": flaky,
+        "linkstatic": linkstatic,
     }
     if uses_polling:
         # the vanilla version of the test should run on platforms that only

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -64,6 +64,7 @@ grpc_cc_test(
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
+    linkstatic = True,  # Fixes dyld error on MacOS
     shard_count = 50,
     tags = [
         "no_test_ios",


### PR DESCRIPTION
`xds_end2end_test` started to have dyld error on MacOS recently with some PRs which potentially add more dependencies. ([log](https://source.cloud.google.com/results/invocations/7ce2d359-01ad-49b7-8d6c-4b1d8a8938f5/targets))

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //test/cpp/end2end/xds:xds_end2end_test
-----------------------------------------------------------------------------
dyld: malformed mach-o: load commands size (33104) > 32768
```

This is because it uses dynamic-link for test targets and it ends up consuming all 32K limit on MacOS. Simple solution here is using static linking (from internal b/139542874 and b/169956587) so let's change this particular test to use it.
