### PR TITLE
XdsClient: First steps toward a ResourceType abstraction

### DIFF
--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -97,6 +97,7 @@
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/socket_utils.h"
 #include "src/core/lib/slice/slice_utils.h"
+#include "src/core/lib/transport/error_utils.h"
 #include "src/core/lib/uri/uri_parser.h"
 
 namespace grpc_core {
@@ -827,6 +828,7 @@ const char* XdsApi::kEdsTypeUrl =
 
 namespace {
 
+// FIXME: most of these should go away!
 const char* kLdsV2TypeUrl = "envoy.api.v2.Listener";
 const char* kRdsV2TypeUrl = "envoy.api.v2.RouteConfiguration";
 const char* kCdsV2TypeUrl = "envoy.api.v2.Cluster";
@@ -853,6 +855,108 @@ bool IsEdsInternal(absl::string_view type_url, bool* /*is_v2*/ = nullptr) {
   return type_url == XdsApi::kEdsTypeUrl || type_url == kEdsV2TypeUrl;
 }
 
+absl::string_view TypeUrlExternalToInternal(bool use_v3,
+                                            const std::string& type_url) {
+  if (!use_v3) {
+    if (type_url == XdsApi::kLdsTypeUrl) {
+      return kLdsV2TypeUrl;
+    }
+    if (type_url == XdsApi::kRdsTypeUrl) {
+      return kRdsV2TypeUrl;
+    }
+    if (type_url == XdsApi::kCdsTypeUrl) {
+      return kCdsV2TypeUrl;
+    }
+    if (type_url == XdsApi::kEdsTypeUrl) {
+      return kEdsV2TypeUrl;
+    }
+  }
+  return type_url;
+}
+
+std::string TypeUrlInternalToExternal(absl::string_view type_url) {
+  if (type_url == kLdsV2TypeUrl) {
+    return XdsApi::kLdsTypeUrl;
+  } else if (type_url == kRdsV2TypeUrl) {
+    return XdsApi::kRdsTypeUrl;
+  } else if (type_url == kCdsV2TypeUrl) {
+    return XdsApi::kCdsTypeUrl;
+  } else if (type_url == kEdsV2TypeUrl) {
+    return XdsApi::kEdsTypeUrl;
+  }
+  return std::string(type_url);
+}
+
+struct EncodingContext {
+  XdsClient* client;  // Used only for logging. Unsafe for dereferencing.
+  TraceFlag* tracer;
+  upb_symtab* symtab;
+  upb_arena* arena;
+  bool use_v3;
+  const CertificateProviderStore::PluginDefinitionMap*
+      certificate_provider_definition_map;
+};
+
+class XdsResourceType {
+ public:
+  // A base type for resource data.
+  struct ResourceData {};
+
+  struct DecodeResult {
+    std::string name;
+    absl::StatusOr<std::unique_ptr<ResourceData>> resource;
+  };
+
+  virtual ~XdsResourceType() = default;
+
+  virtual absl::string_view type_url() const = 0;
+
+  virtual absl::string_view v2_type_url() const = 0;
+
+  virtual absl::StatusOr<DecodeResult> Decode(
+      const EncodingContext& context, absl::string_view serialized_resource,
+      bool is_v2) const = 0;
+
+  virtual std::string Encode(const ResourceData* resource) const = 0;
+
+  bool IsType(absl::string_view resource_type, bool* is_v2) const {
+    if (resource_type == type_url()) return true;
+    if (resource_type == v2_type_url()) {
+      if (is_v2 != nullptr) *is_v2 = true;
+      return true;
+    }
+    return false;
+  }
+};
+
+absl::StatusOr<XdsApi::ResourceName> ParseResourceNameInternal(
+    absl::string_view name, const XdsResourceType* type) {
+  // Old-style names use the empty string for authority.
+  // authority is prefixed with "old:" to indicate that it's an old-style name.
+  if (!absl::StartsWith(name, "xdstp:")) {
+    return XdsApi::ResourceName{"old:", std::string(name)};
+  }
+  // New style name.  Parse URI.
+  auto uri = URI::Parse(name);
+  if (!uri.ok()) return uri.status();
+  // Split the resource type off of the path to get the id.
+  std::pair<absl::string_view, absl::string_view> path_parts =
+      absl::StrSplit(uri->path(), absl::MaxSplits('/', 1));
+  if (!type->IsType(path_parts.first, nullptr)) {
+    return absl::InvalidArgumentError(
+        "xdstp URI path contains wrong resource type");
+  }
+  std::vector<std::pair<absl::string_view, absl::string_view>> query_parameters(
+      uri->query_parameter_map().begin(), uri->query_parameter_map().end());
+  std::sort(query_parameters.begin(), query_parameters.end());
+  return XdsApi::ResourceName{
+      absl::StrCat("xdstp:", uri->authority()),
+      absl::StrCat(
+          path_parts.second, (query_parameters.empty() ? "?" : ""),
+          absl::StrJoin(query_parameters, "&", absl::PairFormatter("=")))};
+}
+
+// FIXME: remove
 absl::StatusOr<XdsApi::ResourceName> ParseResourceNameInternal(
     absl::string_view name,
     std::function<bool(absl::string_view, bool*)> is_expected_type) {
@@ -972,16 +1076,6 @@ std::string XdsApi::ConstructFullResourceName(absl::string_view authority,
 }
 
 namespace {
-
-struct EncodingContext {
-  XdsClient* client;  // Used only for logging. Unsafe for dereferencing.
-  TraceFlag* tracer;
-  upb_symtab* symtab;
-  upb_arena* arena;
-  bool use_v3;
-  const CertificateProviderStore::PluginDefinitionMap*
-      certificate_provider_definition_map;
-};
 
 // Works for both std::string and absl::string_view.
 template <typename T>
@@ -1160,25 +1254,6 @@ grpc_slice SerializeDiscoveryRequest(
   char* output = envoy_service_discovery_v3_DiscoveryRequest_serialize(
       request, context.arena, &output_length);
   return grpc_slice_from_copied_buffer(output, output_length);
-}
-
-absl::string_view TypeUrlExternalToInternal(bool use_v3,
-                                            const std::string& type_url) {
-  if (!use_v3) {
-    if (type_url == XdsApi::kLdsTypeUrl) {
-      return kLdsV2TypeUrl;
-    }
-    if (type_url == XdsApi::kRdsTypeUrl) {
-      return kRdsV2TypeUrl;
-    }
-    if (type_url == XdsApi::kCdsTypeUrl) {
-      return kCdsV2TypeUrl;
-    }
-    if (type_url == XdsApi::kEdsTypeUrl) {
-      return kEdsV2TypeUrl;
-    }
-  }
-  return type_url;
 }
 
 }  // namespace
@@ -3473,104 +3548,209 @@ grpc_error_handle EdsResourceParse(
   return GRPC_ERROR_CREATE_FROM_VECTOR("errors parsing EDS resource", &errors);
 }
 
+class ListenerResourceType : public XdsResourceType {
+ public:
+  struct ListenerData : public ResourceData {
+    XdsApi::LdsUpdate resource;
+  };
+
+  absl::string_view type_url() const override { return XdsApi::kLdsTypeUrl; }
+  absl::string_view v2_type_url() const override { return kLdsV2TypeUrl; }
+
+  absl::StatusOr<DecodeResult> Decode(
+      const EncodingContext& context, absl::string_view serialized_resource,
+      bool is_v2) const override {
+    // Parse serialized proto.
+    auto* resource = envoy_config_listener_v3_Listener_parse(
+        serialized_resource.data(), serialized_resource.size(), context.arena);
+    if (resource == nullptr) {
+      return absl::InvalidArgumentError("Can't parse Listener resource.");
+    }
+    MaybeLogListener(context, resource);
+    // Validate resource.
+    DecodeResult result;
+    result.name =
+        UpbStringToStdString(envoy_config_listener_v3_Listener_name(resource));
+    auto listener_data = absl::make_unique<ListenerData>();
+    grpc_error_handle error =
+        LdsResourceParse(context, resource, is_v2, &listener_data->resource);
+    if (error != GRPC_ERROR_NONE) {
+      result.resource =
+          absl::InvalidArgumentError(grpc_error_std_string(error));
+      GRPC_ERROR_UNREF(error);
+    } else {
+      result.resource = std::move(listener_data);
+    }
+    return result;
+  }
+
+  std::string Encode(const ResourceData* resource) const override {
+// FIXME: implement
+    return "";
+  }
+};
+
+grpc_error_handle AdsResourceParse(
+    const EncodingContext& context, XdsResourceType* type,
+    size_t idx, const google_protobuf_Any* resource_any,
+    const std::map<absl::string_view /*authority*/,
+                   std::set<absl::string_view /*name*/>>&
+        subscribed_resource_names,
+    std::function<
+        grpc_error_handle(absl::string_view, XdsApi::ResourceName,
+                          std::unique_ptr<XdsResourceType::ResourceData>,
+                          std::string)>
+        add_result_func,
+    std::set<XdsApi::ResourceName>* resource_names_failed) {
+  // Check the type_url of the resource.
+  absl::string_view type_url = absl::StripPrefix(
+      UpbStringToAbsl(google_protobuf_Any_type_url(resource_any)),
+      "type.googleapis.com/");
+  bool is_v2 = false;
+  if (!type->IsType(type_url, &is_v2)) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("resource index ", idx, ": found resource type ",
+                     type_url, " in response for type ", type->type_url()));
+  }
+  // Parse the resource.
+  absl::string_view serialized_resource =
+      UpbStringToAbsl(google_protobuf_Any_value(resource_any));
+  absl::StatusOr<XdsResourceType::DecodeResult> result =
+      type->Decode(context, serialized_resource, is_v2);
+  if (!result.ok()) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "resource index ", idx, ": ", result.status().ToString()));
+  }
+  // Check the resource name.
+  auto resource_name = ParseResourceNameInternal(result->name, type);
+  if (!resource_name.ok()) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "resource index ", idx, ": Cannot parse xDS resource name \"",
+        result->name, "\""));
+  }
+  // Ignore unexpected names.
+  auto iter = subscribed_resource_names.find(resource_name->authority);
+  if (iter == subscribed_resource_names.end() ||
+      iter->second.find(resource_name->id) == iter->second.end()) {
+    return GRPC_ERROR_NONE;
+  }
+  // Check that resource was valid.
+  if (!result->resource.ok()) {
+    resource_names_failed->insert(*resource_name);
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "resource index ", idx, ": ", result->name, ": validation error: ",
+        result->resource.status().ToString()));
+  }
+  // Add result.
+  grpc_error_handle error = add_result_func(
+      result->name, *resource_name, std::move(*result->resource),
+      std::string(serialized_resource));
+  if (error != GRPC_ERROR_NONE) {
+    resource_names_failed->insert(*resource_name);
+    return grpc_error_add_child(
+        GRPC_ERROR_CREATE_FROM_CPP_STRING(
+            absl::StrCat("resource index ", idx, ": ", result->name,
+                         ": validation error")),
+        error);
+  }
+  return GRPC_ERROR_NONE;
+}
+
+template <typename UpdateMap, typename ResourceTypeData>
+grpc_error_handle AddResult(
+    UpdateMap* update_map, absl::string_view resource_name_string,
+    XdsApi::ResourceName resource_name,
+    std::unique_ptr<XdsResourceType::ResourceData> resource,
+    std::string serialized_resource) {
+  // Reject duplicate names.
+  if (update_map->find(resource_name) != update_map->end()) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("duplicate resource name \"", resource_name_string, "\""));
+  }
+  // Save result.
+  auto& resource_data = (*update_map)[resource_name];
+  ResourceTypeData* typed_resource =
+      static_cast<ResourceTypeData*>(resource.get());
+  resource_data.resource = std::move(typed_resource->resource);
+  resource_data.serialized_proto = std::move(serialized_resource);
+  return GRPC_ERROR_NONE;
+}
+
 template <typename ProtoParseFunction, typename ProtoResourceNameFunction,
           typename ResourceTypeSelectorFunction, typename ProtoLogFunction,
           typename ResourceParseFunction, typename UpdateMap>
-grpc_error_handle AdsResponseParse(
+grpc_error_handle AdsResourceParse(
     const EncodingContext& context, ProtoParseFunction proto_parse_function,
     ProtoResourceNameFunction proto_resource_name_function,
     ResourceTypeSelectorFunction resource_type_selector_function,
     ProtoLogFunction proto_log_function,
     ResourceParseFunction resource_parse_function,
     const char* resource_type_string,
-    const envoy_service_discovery_v3_DiscoveryResponse* response,
+    size_t idx,
+    const google_protobuf_Any* resource_any,
     const std::map<absl::string_view /*authority*/,
                    std::set<absl::string_view /*name*/>>&
         subscribed_resource_names,
     UpdateMap* update_map,
     std::set<XdsApi::ResourceName>* resource_names_failed) {
-  std::vector<grpc_error_handle> errors;
-  // Get the resources from the response.
-  size_t size;
-  const google_protobuf_Any* const* resources =
-      envoy_service_discovery_v3_DiscoveryResponse_resources(response, &size);
-  for (size_t i = 0; i < size; ++i) {
-    // Check the type_url of the resource.
-    absl::string_view type_url = absl::StripPrefix(
-        UpbStringToAbsl(google_protobuf_Any_type_url(resources[i])),
-        "type.googleapis.com/");
-    bool is_v2 = false;
-    if (!resource_type_selector_function(type_url, &is_v2)) {
-      errors.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
-          absl::StrCat("resource index ", i, ": Resource is not ",
-                       resource_type_string, ".")));
-      continue;
-    }
-    // Parse the resource.
-    upb_strview serialized_resource = google_protobuf_Any_value(resources[i]);
-    auto* resource = proto_parse_function(
-        serialized_resource.data, serialized_resource.size, context.arena);
-    if (resource == nullptr) {
-      errors.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
-          absl::StrCat("resource index ", i, ": Can't parse ",
-                       resource_type_string, " resource.")));
-      continue;
-    }
-    proto_log_function(context, resource);
-    // Check the resource name.  Ignore unexpected names.
-    std::string resource_name =
-        UpbStringToStdString(proto_resource_name_function(resource));
-    auto resource_name_status = ParseResourceNameInternal(
-        resource_name, resource_type_selector_function);
-    if (!resource_name_status.ok()) {
-      errors.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
-          "Cannot parse xDS resource name \"", resource_name, "\"")));
-      continue;
-    }
-    auto iter = subscribed_resource_names.find(resource_name_status->authority);
-    if (iter == subscribed_resource_names.end() ||
-        iter->second.find(resource_name_status->id) == iter->second.end()) {
-      continue;
-    }
-    // Fail on duplicate resources.
-    if (update_map->find(*resource_name_status) != update_map->end()) {
-      errors.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
-          absl::StrCat("duplicate resource name \"", resource_name, "\"")));
-      resource_names_failed->insert(*resource_name_status);
-      continue;
-    }
-    // Validate resource.
-    decltype(UpdateMap::mapped_type::resource) update;
-    grpc_error_handle error =
-        resource_parse_function(context, resource, is_v2, &update);
-    if (error != GRPC_ERROR_NONE) {
-      errors.push_back(
-          grpc_error_add_child(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
-                                   resource_name, ": validation error")),
-                               error));
-      resource_names_failed->insert(*resource_name_status);
-    } else {
-      // Store result in update map, in both validated and serialized form.
-      auto& resource_data = (*update_map)[*resource_name_status];
-      resource_data.resource = std::move(update);
-      resource_data.serialized_proto =
-          UpbStringToStdString(serialized_resource);
-    }
+  // Check the type_url of the resource.
+  absl::string_view type_url = absl::StripPrefix(
+      UpbStringToAbsl(google_protobuf_Any_type_url(resource_any)),
+      "type.googleapis.com/");
+  bool is_v2 = false;
+  if (!resource_type_selector_function(type_url, &is_v2)) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("resource index ", idx, ": Resource is not ",
+                     resource_type_string, "."));
   }
-  return GRPC_ERROR_CREATE_FROM_VECTOR("errors parsing ADS response", &errors);
-}
-
-std::string TypeUrlInternalToExternal(absl::string_view type_url) {
-  if (type_url == kLdsV2TypeUrl) {
-    return XdsApi::kLdsTypeUrl;
-  } else if (type_url == kRdsV2TypeUrl) {
-    return XdsApi::kRdsTypeUrl;
-  } else if (type_url == kCdsV2TypeUrl) {
-    return XdsApi::kCdsTypeUrl;
-  } else if (type_url == kEdsV2TypeUrl) {
-    return XdsApi::kEdsTypeUrl;
+  // Parse the resource.
+  upb_strview serialized_resource = google_protobuf_Any_value(resource_any);
+  auto* resource = proto_parse_function(
+      serialized_resource.data, serialized_resource.size, context.arena);
+  if (resource == nullptr) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("resource index ", idx, ": Can't parse ",
+                     resource_type_string, " resource."));
   }
-  return std::string(type_url);
+  proto_log_function(context, resource);
+  // Check the resource name.  Ignore unexpected names.
+  std::string resource_name =
+      UpbStringToStdString(proto_resource_name_function(resource));
+  auto resource_name_status = ParseResourceNameInternal(
+      resource_name, resource_type_selector_function);
+  if (!resource_name_status.ok()) {
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        "Cannot parse xDS resource name \"", resource_name, "\""));
+  }
+  auto iter = subscribed_resource_names.find(resource_name_status->authority);
+  if (iter == subscribed_resource_names.end() ||
+      iter->second.find(resource_name_status->id) == iter->second.end()) {
+    return GRPC_ERROR_NONE;
+  }
+  // Fail on duplicate resources.
+  if (update_map->find(*resource_name_status) != update_map->end()) {
+    resource_names_failed->insert(*resource_name_status);
+    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        absl::StrCat("duplicate resource name \"", resource_name, "\""));
+  }
+  // Validate resource.
+  decltype(UpdateMap::mapped_type::resource) update;
+  grpc_error_handle error =
+      resource_parse_function(context, resource, is_v2, &update);
+  if (error != GRPC_ERROR_NONE) {
+    resource_names_failed->insert(*resource_name_status);
+    return grpc_error_add_child(
+        GRPC_ERROR_CREATE_FROM_CPP_STRING(
+            absl::StrCat(resource_name, ": validation error")),
+        error);
+  } else {
+    // Store result in update map, in both validated and serialized form.
+    auto& resource_data = (*update_map)[*resource_name_status];
+    resource_data.resource = std::move(update);
+    resource_data.serialized_proto =
+        UpbStringToStdString(serialized_resource);
+  }
+  return GRPC_ERROR_NONE;
 }
 
 upb_strview LdsResourceName(
@@ -3639,35 +3819,62 @@ XdsApi::AdsParseResult XdsApi::ParseAdsResponse(
       envoy_service_discovery_v3_DiscoveryResponse_version_info(response));
   result.nonce = UpbStringToStdString(
       envoy_service_discovery_v3_DiscoveryResponse_nonce(response));
-  // Parse the response according to the resource type.
-  // TODO(roth): When we have time, consider defining an interface for the
-  // methods of each resource type, so that we don't have to pass
-  // individual functions into each call to AdsResponseParse().
-  if (IsLds(result.type_url)) {
-    result.parse_error = AdsResponseParse(
-        context, envoy_config_listener_v3_Listener_parse, LdsResourceName,
-        IsLdsInternal, MaybeLogListener, LdsResourceParse, "LDS", response,
-        subscribed_listener_names, &result.lds_update_map,
-        &result.resource_names_failed);
-  } else if (IsRds(result.type_url)) {
-    result.parse_error = AdsResponseParse(
-        context, envoy_config_route_v3_RouteConfiguration_parse,
-        RdsResourceName, IsRdsInternal, MaybeLogRouteConfiguration,
-        RouteConfigParse, "RDS", response, subscribed_route_config_names,
-        &result.rds_update_map, &result.resource_names_failed);
-  } else if (IsCds(result.type_url)) {
-    result.parse_error = AdsResponseParse(
-        context, envoy_config_cluster_v3_Cluster_parse, CdsResourceName,
-        IsCdsInternal, MaybeLogCluster, CdsResourceParse, "CDS", response,
-        subscribed_cluster_names, &result.cds_update_map,
-        &result.resource_names_failed);
-  } else if (IsEds(result.type_url)) {
-    result.parse_error = AdsResponseParse(
-        context, envoy_config_endpoint_v3_ClusterLoadAssignment_parse,
-        EdsResourceName, IsEdsInternal, MaybeLogClusterLoadAssignment,
-        EdsResourceParse, "EDS", response, subscribed_eds_service_names,
-        &result.eds_update_map, &result.resource_names_failed);
+  // Get the resources from the response.
+  std::vector<grpc_error_handle> errors;
+  size_t size;
+  const google_protobuf_Any* const* resources =
+      envoy_service_discovery_v3_DiscoveryResponse_resources(response, &size);
+  for (size_t i = 0; i < size; ++i) {
+    // Parse the response according to the resource type.
+    // TODO(roth): When we have time, consider defining an interface for the
+    // methods of each resource type, so that we don't have to pass
+    // individual functions into each call to AdsResourceParse().
+    grpc_error_handle parse_error = GRPC_ERROR_NONE;
+    if (IsLds(result.type_url)) {
+#if 1
+      ListenerResourceType resource_type;
+      auto& update_map = result.lds_update_map;
+      parse_error = AdsResourceParse(
+          context, &resource_type, i, resources[i], subscribed_listener_names,
+          [&update_map](absl::string_view resource_name_string,
+                        XdsApi::ResourceName resource_name,
+                        std::unique_ptr<XdsResourceType::ResourceData> resource,
+                        std::string serialized_resource) {
+            return AddResult<LdsUpdateMap, ListenerResourceType::ListenerData>(
+                &update_map, resource_name_string, std::move(resource_name),
+                std::move(resource), std::move(serialized_resource));
+          },
+          &result.resource_names_failed);
+#else
+      parse_error = AdsResourceParse(
+          context, envoy_config_listener_v3_Listener_parse, LdsResourceName,
+          IsLdsInternal, MaybeLogListener, LdsResourceParse, "LDS", i,
+          resources[i], subscribed_listener_names, &result.lds_update_map,
+          &result.resource_names_failed);
+#endif
+    } else if (IsRds(result.type_url)) {
+      parse_error = AdsResourceParse(
+          context, envoy_config_route_v3_RouteConfiguration_parse,
+          RdsResourceName, IsRdsInternal, MaybeLogRouteConfiguration,
+          RouteConfigParse, "RDS", i, resources[i], subscribed_route_config_names,
+          &result.rds_update_map, &result.resource_names_failed);
+    } else if (IsCds(result.type_url)) {
+      parse_error = AdsResourceParse(
+          context, envoy_config_cluster_v3_Cluster_parse, CdsResourceName,
+          IsCdsInternal, MaybeLogCluster, CdsResourceParse, "CDS", i,
+          resources[i], subscribed_cluster_names, &result.cds_update_map,
+          &result.resource_names_failed);
+    } else if (IsEds(result.type_url)) {
+      parse_error = AdsResourceParse(
+          context, envoy_config_endpoint_v3_ClusterLoadAssignment_parse,
+          EdsResourceName, IsEdsInternal, MaybeLogClusterLoadAssignment,
+          EdsResourceParse, "EDS", i, resources[i], subscribed_eds_service_names,
+          &result.eds_update_map, &result.resource_names_failed);
+    }
+    if (parse_error != GRPC_ERROR_NONE) errors.push_back(parse_error);
   }
+  result.parse_error =
+      GRPC_ERROR_CREATE_FROM_VECTOR("errors parsing ADS response", &errors);
   return result;
 }
 

--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -3551,7 +3551,7 @@ class ListenerResourceType : public XdsResourceType {
     } else {
       result.resource = std::move(listener_data);
     }
-    return result;
+    return std::move(result);
   }
 };
 
@@ -3588,7 +3588,7 @@ class RouteConfigResourceType : public XdsResourceType {
     } else {
       result.resource = std::move(route_config_data);
     }
-    return result;
+    return std::move(result);
   }
 };
 
@@ -3625,7 +3625,7 @@ class ClusterResourceType : public XdsResourceType {
     } else {
       result.resource = std::move(cluster_data);
     }
-    return result;
+    return std::move(result);
   }
 };
 
@@ -3662,7 +3662,7 @@ class EndpointResourceType : public XdsResourceType {
     } else {
       result.resource = std::move(endpoint_data);
     }
-    return result;
+    return std::move(result);
   }
 };
 


### PR DESCRIPTION
This is just moving some code around without any functional changes.  It is the first step toward moving all resource-type-specific logic into its own class, with the ultimate goal being to change the XdsClient API to be resource-type-agnostic.  This work will be spread across a number of PRs.