### PR TITLE
[App Net] Switch Router to Mesh and Add unique string to Scope

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
@@ -69,7 +69,7 @@ def main(argv):
         gcp_service_account=gcp_service_account,
         xds_server_uri=xds_flags.XDS_SERVER_URI.value,
         network=xds_flags.NETWORK.value,
-        config_scope=xds_flags.ROUTER_SCOPE.value,
+        config_scope=xds_flags.CONFIG_SCOPE.value,
         stats_port=xds_flags.CLIENT_PORT.value,
         reuse_namespace=_REUSE_NAMESPACE.value)
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/network_services.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/network_services.py
@@ -55,7 +55,7 @@ class EndpointPolicy:
 
 
 @dataclasses.dataclass(frozen=True)
-class Router:
+class Mesh:
 
     name: str
     url: str
@@ -65,7 +65,7 @@ class Router:
     routes: Optional[List[str]]
 
     @classmethod
-    def from_response(cls, name: str, d: Dict[str, Any]) -> 'Router':
+    def from_response(cls, name: str, d: Dict[str, Any]) -> 'Mesh':
         return cls(
             name=name,
             url=d["name"],
@@ -169,7 +169,7 @@ class GrpcRoute:
     url: str
     hostnames: Tuple[str]
     rules: Tuple['RouteRule']
-    routers: Optional[Tuple[str]]
+    meshes: Optional[Tuple[str]]
 
     @classmethod
     def from_response(cls, name: str, d: Dict[str, Any]) -> 'RouteRule':
@@ -178,7 +178,7 @@ class GrpcRoute:
             url=d["name"],
             hostnames=tuple(d["hostnames"]),
             rules=tuple(d["rules"]),
-            routers=None if d.get("routers") is None else tuple(d["routers"]),
+            meshes=None if d.get("meshes") is None else tuple(d["meshes"]),
         )
 
 
@@ -247,27 +247,27 @@ class NetworkServicesV1Alpha1(NetworkServicesV1Beta1):
     """
 
     GRPC_ROUTES = 'grpcRoutes'
-    ROUTERS = 'routers'
+    MESHES = 'meshes'
 
     @property
     def api_version(self) -> str:
         return 'v1alpha1'
 
-    def create_router(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(collection=self._api_locations.routers(),
+    def create_mesh(self, name: str, body: dict) -> GcpResource:
+        return self._create_resource(collection=self._api_locations.meshes(),
                                      body=body,
-                                     routerId=name)
+                                     meshId=name)
 
-    def get_router(self, name: str) -> Router:
-        full_name = self.resource_full_name(name, self.ROUTERS)
-        result = self._get_resource(collection=self._api_locations.routers(),
+    def get_mesh(self, name: str) -> Mesh:
+        full_name = self.resource_full_name(name, self.MESHES)
+        result = self._get_resource(collection=self._api_locations.meshes(),
                                     full_name=full_name)
-        return Router.from_response(name, result)
+        return Mesh.from_response(name, result)
 
-    def delete_router(self, name: str) -> bool:
-        return self._delete_resource(collection=self._api_locations.routers(),
+    def delete_mesh(self, name: str) -> bool:
+        return self._delete_resource(collection=self._api_locations.meshes(),
                                      full_name=self.resource_full_name(
-                                         name, self.ROUTERS))
+                                         name, self.MESHES))
 
     def create_grpc_route(self, name: str, body: dict) -> GcpResource:
         return self._create_resource(

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -547,7 +547,7 @@ class TrafficDirectorManager:
 class TrafficDirectorAppNetManager(TrafficDirectorManager):
 
     GRPC_ROUTE_NAME = "grpc-route"
-    ROUTER_NAME = "router"
+    MESH_NAME = "mesh"
 
     netsvc: _NetworkServicesV1Alpha1
 
@@ -574,37 +574,37 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
 
         # Managed resources
         self.grpc_route: Optional[_NetworkServicesV1Alpha1.GrpcRoute] = None
-        self.router: Optional[_NetworkServicesV1Alpha1.Router] = None
+        self.mesh: Optional[_NetworkServicesV1Alpha1.Mesh] = None
 
-    def create_router(self) -> GcpResource:
-        name = self.make_resource_name(self.ROUTER_NAME)
-        logger.info("Creating Router %s", name)
+    def create_mesh(self) -> GcpResource:
+        name = self.make_resource_name(self.MESH_NAME)
+        logger.info("Creating Mesh %s", name)
         body = {
             "type": "PROXYLESS_GRPC",
             "scope": self.config_scope,
         }
-        resource = self.netsvc.create_router(name, body)
-        self.router = self.netsvc.get_router(name)
-        logger.debug("Loaded Router: %s", self.router)
+        resource = self.netsvc.create_mesh(name, body)
+        self.mesh = self.netsvc.get_mesh(name)
+        logger.debug("Loaded Mesh: %s", self.mesh)
         return resource
 
-    def delete_router(self, force=False):
+    def delete_mesh(self, force=False):
         if force:
-            name = self.make_resource_name(self.ROUTER_NAME)
-        elif self.router:
-            name = self.router.name
+            name = self.make_resource_name(self.MESH_NAME)
+        elif self.mesh:
+            name = self.mesh.name
         else:
             return
-        logger.info('Deleting Router %s', name)
-        self.netsvc.delete_router(name)
-        self.router = None
+        logger.info('Deleting Mesh %s', name)
+        self.netsvc.delete_mesh(name)
+        self.mesh = None
 
     def create_grpc_route(self, src_host: str, src_port: int) -> GcpResource:
         host = f'{src_host}:{src_port}'
         service_name = self.netsvc.resource_full_name(self.backend_service.name,
                                                       "backendServices")
         body = {
-            "routers": [self.router.url],
+            "meshes": [self.mesh.url],
             "hostnames":
                 host,
             "rules": [{
@@ -643,7 +643,7 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
 
     def cleanup(self, *, force=False):
         self.delete_grpc_route(force=force)
-        self.delete_router(force=force)
+        self.delete_mesh(force=force)
         super().cleanup(force=force)
 
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -36,10 +36,10 @@ RESOURCE_SUFFIX = flags.DEFINE_string(
 NETWORK = flags.DEFINE_string("network",
                               default="default",
                               help="GCP Network ID")
-ROUTER_SCOPE = flags.DEFINE_string(
+CONFIG_SCOPE = flags.DEFINE_string(
     "config_scope",
     default=None,
-    help="Scope specified in router if using AppNet APIs")
+    help="Scope specified in mesh if using AppNet APIs")
 COMPUTE_API_VERSION = flags.DEFINE_string(
     "compute_api_version",
     default='v1',

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -87,7 +87,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         # GCP
         cls.project: str = xds_flags.PROJECT.value
         cls.network: str = xds_flags.NETWORK.value
-        cls.config_scope: str = xds_flags.ROUTER_SCOPE.value
+        cls.config_scope: str = xds_flags.ROUTER_SCOPE.value + framework.helpers.rand.random_resource_suffix()
         cls.gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value
         cls.td_bootstrap_image = xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value
         cls.xds_server_uri = xds_flags.XDS_SERVER_URI.value
@@ -453,7 +453,6 @@ class AppNetXdsKubernetesTestCase(RegularXdsKubernetesTestCase):
     td: TrafficDirectorAppNetManager
 
     def initTrafficDirectorManager(self) -> TrafficDirectorAppNetManager:
-        config_scope = self.config_scope + framework.helpers.rand.random_resource_suffix()
         return TrafficDirectorAppNetManager(
             self.gcp_api_manager,
             project=self.project,

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -78,6 +78,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
     server_runner: KubernetesServerRunner
     server_xds_port: int
     td: TrafficDirectorManager
+    config_scope: str
 
     @classmethod
     def setUpClass(cls):
@@ -137,6 +138,9 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         logger.info('Test run resource prefix: %s, suffix: %s',
                     self.resource_prefix, self.resource_suffix)
 
+        self.config_scope = self.td.make_resource_name(
+            xds_flags.CONFIG_SCOPE.value)
+
         # TD Manager
         self.td = self.initTrafficDirectorManager()
 
@@ -164,9 +168,6 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
             #  but we should find a better approach.
             self.server_xds_port = self.td.find_unused_forwarding_rule_port()
             logger.info('Found unused xds port: %s', self.server_xds_port)
-
-        self.config_scope: str = self.td.make_resource_name(
-            xds_flags.CONFIG_SCOPE.value)
 
     @abc.abstractmethod
     def initTrafficDirectorManager(self) -> TrafficDirectorManager:

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -453,6 +453,7 @@ class AppNetXdsKubernetesTestCase(RegularXdsKubernetesTestCase):
     td: TrafficDirectorAppNetManager
 
     def initTrafficDirectorManager(self) -> TrafficDirectorAppNetManager:
+        config_scope = self.config_scope + framework.helpers.rand.random_resource_suffix()
         return TrafficDirectorAppNetManager(
             self.gcp_api_manager,
             project=self.project,

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -138,7 +138,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         logger.info('Test run resource prefix: %s, suffix: %s',
                     self.resource_prefix, self.resource_suffix)
 
-        self.config_scope = xds_flags.CONFIG_SCOPE.value + framework.helpers.rand.random_resource_suffix(
+        self.config_scope = xds_flags.CONFIG_SCOPE.value + "-" + framework.helpers.rand.random_resource_suffix(
         )
 
         # TD Manager

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -87,7 +87,8 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         # GCP
         cls.project: str = xds_flags.PROJECT.value
         cls.network: str = xds_flags.NETWORK.value
-        cls.config_scope: str = xds_flags.CONFIG_SCOPE.value + framework.helpers.rand.random_resource_suffix()
+        cls.config_scope: str = xds_flags.CONFIG_SCOPE.value + framework.helpers.rand.random_resource_suffix(
+        )
         cls.gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value
         cls.td_bootstrap_image = xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value
         cls.xds_server_uri = xds_flags.XDS_SERVER_URI.value

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -138,8 +138,8 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         logger.info('Test run resource prefix: %s, suffix: %s',
                     self.resource_prefix, self.resource_suffix)
 
-        self.config_scope = self.td.make_resource_name(
-            xds_flags.CONFIG_SCOPE.value)
+        self.config_scope = xds_flags.CONFIG_SCOPE.value + framework.helpers.rand.random_resource_suffix(
+        )
 
         # TD Manager
         self.td = self.initTrafficDirectorManager()

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -87,8 +87,6 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         # GCP
         cls.project: str = xds_flags.PROJECT.value
         cls.network: str = xds_flags.NETWORK.value
-        cls.config_scope: str = xds_flags.CONFIG_SCOPE.value + framework.helpers.rand.random_resource_suffix(
-        )
         cls.gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value
         cls.td_bootstrap_image = xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value
         cls.xds_server_uri = xds_flags.XDS_SERVER_URI.value
@@ -166,6 +164,9 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
             #  but we should find a better approach.
             self.server_xds_port = self.td.find_unused_forwarding_rule_port()
             logger.info('Found unused xds port: %s', self.server_xds_port)
+
+        self.config_scope: str = self.td.make_resource_name(
+            xds_flags.CONFIG_SCOPE.value)
 
     @abc.abstractmethod
     def initTrafficDirectorManager(self) -> TrafficDirectorManager:

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -87,7 +87,7 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         # GCP
         cls.project: str = xds_flags.PROJECT.value
         cls.network: str = xds_flags.NETWORK.value
-        cls.config_scope: str = xds_flags.ROUTER_SCOPE.value + framework.helpers.rand.random_resource_suffix()
+        cls.config_scope: str = xds_flags.CONFIG_SCOPE.value + framework.helpers.rand.random_resource_suffix()
         cls.gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value
         cls.td_bootstrap_image = xds_k8s_flags.TD_BOOTSTRAP_IMAGE.value
         cls.xds_server_uri = xds_flags.XDS_SERVER_URI.value

--- a/tools/run_tests/xds_k8s_test_driver/tests/app_net_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/app_net_test.py
@@ -34,8 +34,8 @@ class AppNetTest(xds_k8s_testcase.AppNetXdsKubernetesTestCase):
         with self.subTest('1_create_backend_service'):
             self.td.create_backend_service()
 
-        with self.subTest('2_create_router'):
-            self.td.create_router()
+        with self.subTest('2_create_mesh'):
+            self.td.create_mesh()
 
         with self.subTest('3_create_grpc_route'):
             self.td.create_grpc_route(self.server_xds_host,


### PR DESCRIPTION
A rename from `Router` to `Mesh` has occurred, so I'm doing a straightforward swap.

Additionally, I've found that using a single static `scope` value makes concurrent test runs impossible. This fixes that.

[Manual run.](https://fusion2.corp.google.com/ci/guitar/projects/network_staging_us-west1-pj1-proxyless-grpc-app-net/workflows/%2F%2Fcloud%2Fcluster%2Ftesting%2Fguitar%2Fnetwork:network_staging_us-west1-pj1-proxyless-grpc-app-net/activity/58d4a362-6778-3ecf-817f-0a2cf43b723e:0/overview)

I will trigger runs of the other k8s interop tests once I have LGTM.

- [grpc/core/master/linux/psm-security](https://fusion2.corp.google.com/invocations/50cdfd7f-ac9d-4596-9fb5-35fd4db38d40)
- [grpc/core/master/linux/grpc_xds_k8s_lb](https://fusion2.corp.google.com/invocations/34e1c0f1-a6de-4145-8ed6-fb0c144e32ba)
- [grpc/core/master/linux/grpc_xds_url_map](https://fusion2.corp.google.com/invocations/aeb60547-7190-4314-b53e-bee053fe2373)