### PR TITLE
RefCountedPtr: Explicit constructor

### DIFF
--- a/src/core/ext/filters/client_channel/dynamic_filters.cc
+++ b/src/core/ext/filters/client_channel/dynamic_filters.cc
@@ -184,7 +184,7 @@ RefCountedPtr<DynamicFilters::Call> DynamicFilters::CreateCall(
                            channel_stack_->call_stack_size;
   Call* call = static_cast<Call*>(args.arena->Alloc(allocation_size));
   new (call) Call(std::move(args), error);
-  return call;
+  return RefCountedPtr<DynamicFilters::Call>(call);
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/xds/xds_bootstrap.cc
+++ b/src/core/ext/xds/xds_bootstrap.cc
@@ -59,11 +59,14 @@ RefCountedPtr<grpc_channel_credentials>
 XdsChannelCredsRegistry::MakeChannelCreds(const std::string& creds_type,
                                           const Json& /*config*/) {
   if (creds_type == "google_default") {
-    return grpc_google_default_credentials_create(nullptr);
+    return RefCountedPtr<grpc_channel_credentials>(
+        grpc_google_default_credentials_create(nullptr));
   } else if (creds_type == "insecure") {
-    return grpc_insecure_credentials_create();
+    return RefCountedPtr<grpc_channel_credentials>(
+        grpc_insecure_credentials_create());
   } else if (creds_type == "fake") {
-    return grpc_fake_transport_security_credentials_create();
+    return RefCountedPtr<grpc_channel_credentials>(
+        grpc_fake_transport_security_credentials_create());
   }
   return nullptr;
 }

--- a/src/core/lib/gprpp/ref_counted_ptr.h
+++ b/src/core/lib/gprpp/ref_counted_ptr.h
@@ -190,8 +190,7 @@ class WeakRefCountedPtr {
 
   // If value is non-null, we take ownership of a ref to it.
   template <typename Y>
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  WeakRefCountedPtr(Y* value) {
+  explicit WeakRefCountedPtr(Y* value) {
     value_ = value;
   }
 

--- a/src/core/lib/gprpp/ref_counted_ptr.h
+++ b/src/core/lib/gprpp/ref_counted_ptr.h
@@ -40,8 +40,7 @@ class RefCountedPtr {
 
   // If value is non-null, we take ownership of a ref to it.
   template <typename Y>
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  RefCountedPtr(Y* value) : value_(value) {}
+  explicit RefCountedPtr(Y* value) : value_(value) {}
 
   // Move ctors.
   RefCountedPtr(RefCountedPtr&& other) noexcept {


### PR DESCRIPTION
Rationale: An implicit construction of RefCountedPtr can cause cause refcounting bugs.

For example -
```
class A : public RefCounted<A> {
public:
  class B {
  public:
    explicit B(RefCountedPtr<A> parent) : parent_(std::move(parent)) {}
  private:
    RefCountedPtr<A> parent_;
  }

  void func() {
    //...
    B b(this); // !! Refcounting bug!!
    //...
  }
}

```