### PR TITLE
PHP: update examples

### DIFF
--- a/examples/php/echo/README.md
+++ b/examples/php/echo/README.md
@@ -12,7 +12,7 @@ For all the following examples, we use a simple gRPC server, written in Node.
 ```sh
 $ git clone https://github.com/grpc/grpc-web
 $ cd grpc-web
-$ docker-compose build common node-server
+$ docker-compose build prereqs node-server
 $ docker run -d -p 9090:9090 --name node-server grpcweb/node-server
 ```
 

--- a/examples/php/echo/apache.Dockerfile
+++ b/examples/php/echo/apache.Dockerfile
@@ -25,9 +25,10 @@ RUN apt-get -qq update && apt-get -qq install -y git
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=grpc-base /github/grpc/cmake/build/third_party/protobuf/protoc \
+  /usr/local/bin/protoc
 
-COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin \
+COPY --from=grpc-base /github/grpc/cmake/build/grpc_php_plugin \
   /usr/local/bin/protoc-gen-grpc
 
 COPY --from=grpc-base \

--- a/examples/php/echo/base.Dockerfile
+++ b/examples/php/echo/base.Dockerfile
@@ -15,26 +15,20 @@
 FROM php:7.2-stretch
 
 RUN apt-get -qq update && apt-get -qq install -y \
-  autoconf automake curl git libtool \
+  autoconf automake cmake curl git libtool \
   pkg-config unzip zlib1g-dev
 
 ARG MAKEFLAGS=-j8
 
 
-WORKDIR /tmp
-
-RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/\
-protoc-3.8.0-linux-x86_64.zip -o /tmp/protoc.zip && \
-  unzip -qq protoc.zip && \
-  cp /tmp/bin/protoc /usr/local/bin/protoc
-
-
 WORKDIR /github/grpc
 
 RUN git clone https://github.com/grpc/grpc . && \
-  git submodule update --init && \
-  cd third_party/protobuf && git submodule update --init
+  git submodule update --init --recursive
 
-RUN make grpc_php_plugin
+WORKDIR /github/grpc/cmake/build
+
+RUN cmake ../.. && \
+  make protoc grpc_php_plugin
 
 RUN pecl install grpc

--- a/examples/php/echo/cli.Dockerfile
+++ b/examples/php/echo/cli.Dockerfile
@@ -25,9 +25,10 @@ RUN apt-get -qq update && apt-get -qq install -y git
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=grpc-base /github/grpc/cmake/build/third_party/protobuf/protoc \
+  /usr/local/bin/protoc
 
-COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin \
+COPY --from=grpc-base /github/grpc/cmake/build/grpc_php_plugin \
   /usr/local/bin/protoc-gen-grpc
 
 COPY --from=grpc-base \

--- a/examples/php/echo/fpm.Dockerfile
+++ b/examples/php/echo/fpm.Dockerfile
@@ -25,9 +25,10 @@ RUN apt-get -qq update && apt-get -qq install -y git
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=grpc-base /github/grpc/cmake/build/third_party/protobuf/protoc \
+  /usr/local/bin/protoc
 
-COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin \
+COPY --from=grpc-base /github/grpc/cmake/build/grpc_php_plugin \
   /usr/local/bin/protoc-gen-grpc
 
 COPY --from=grpc-base \

--- a/templates/examples/php/echo/base.Dockerfile.template
+++ b/templates/examples/php/echo/base.Dockerfile.template
@@ -17,26 +17,20 @@
   FROM php:${settings.php_version.php_current_version()}-${settings.php_version.php_debian_version()}
 
   RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
-    autoconf automake curl git libtool ${'\\'}
+    autoconf automake cmake curl git libtool ${'\\'}
     pkg-config unzip zlib1g-dev
 
   ARG MAKEFLAGS=-j8
 
 
-  WORKDIR /tmp
-
-  RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/${'\\'}
-  protoc-3.8.0-linux-x86_64.zip -o /tmp/protoc.zip && ${'\\'}
-    unzip -qq protoc.zip && ${'\\'}
-    cp /tmp/bin/protoc /usr/local/bin/protoc
-
-
   WORKDIR /github/grpc
 
   RUN git clone https://github.com/grpc/grpc . && ${'\\'}
-    git submodule update --init && ${'\\'}
-    cd third_party/protobuf && git submodule update --init
+    git submodule update --init --recursive
 
-  RUN make grpc_php_plugin
+  WORKDIR /github/grpc/cmake/build
+
+  RUN cmake ../.. && ${'\\'}
+    make protoc grpc_php_plugin
 
   RUN pecl install grpc

--- a/templates/examples/php/echo/copy_from_grpc_base.include
+++ b/templates/examples/php/echo/copy_from_grpc_base.include
@@ -1,8 +1,9 @@
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=grpc-base /github/grpc/cmake/build/third_party/protobuf/protoc ${'\\'}
+  /usr/local/bin/protoc
 
-COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin ${'\\'}
+COPY --from=grpc-base /github/grpc/cmake/build/grpc_php_plugin ${'\\'}
   /usr/local/bin/protoc-gen-grpc
 
 COPY --from=grpc-base ${'\\'}


### PR DESCRIPTION
The PHP examples under the `examples/php/echo` directory had been heavily outdated.

- should update to use `cmake` to build `grpc_php_plugin`
- can remove an extra download of `protoc`
- the build command for the `node-server` was a little outdated