### PR TITLE
Update cxx docker images

### DIFF
--- a/templates/tools/dockerfile/test/cxx_debian10_openssl102_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_debian10_openssl102_x64/Dockerfile.template
@@ -1,0 +1,40 @@
+%YAML 1.2
+--- |
+  # Copyright 2021 the gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM debian:10
+  
+  RUN apt-get --allow-releaseinfo-change update
+  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../python_deps.include"/>
+  <%include file="../../gcp_api_libraries.include"/>
+  <%include file="../../cxx_deps.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../run_tests_addons.include"/>
+
+  # Install openssl 1.0.2 from source
+  RUN apt-get update && apt-get install -y build-essential zlib1g-dev
+  RUN cd /tmp && ${"\\"}
+      wget --no-check-certificate https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && ${"\\"}
+      tar -xf openssl-1.0.2u.tar.gz && ${"\\"}
+      cd openssl-1.0.2u && ${"\\"}
+      ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && ${"\\"}
+      make -j 4 && ${"\\"}
+      make install && ${"\\"}
+      rm -rf /tmp/openssl-1.0.2u*
+  ENV OPENSSL_ROOT_DIR=/usr/local/ssl
+
+  # Define the default command.
+  CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_debian10_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_debian10_x64/Dockerfile.template
@@ -13,18 +13,16 @@
   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   # See the License for the specific language governing permissions and
   # limitations under the License.
-
-  <%include file="../../debian_8_header.include"/>
-
+  
+  FROM debian:10
+  
+  RUN apt-get --allow-releaseinfo-change update
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../cxx_deps.include"/>
-  <%include file="../../cmake_jessie_backports.include"/>
+  <%include file="../../cmake.include"/>
   <%include file="../../run_tests_addons.include"/>
-
-  # Install gcc-4.9 and other relevant items
-  RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
-
+  
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_debian9_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_debian9_x64/Dockerfile.template
@@ -1,6 +1,6 @@
 %YAML 1.2
 --- |
-  # Copyright 2015 gRPC authors.
+  # Copyright 2021 gRPC authors.
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
   # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM debian:9
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>
@@ -22,6 +22,6 @@
   <%include file="../../cxx_deps.include"/>
   <%include file="../../cmake.include"/>
   <%include file="../../run_tests_addons.include"/>
-  
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_debian9_x86/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_debian9_x86/Dockerfile.template
@@ -1,6 +1,6 @@
 %YAML 1.2
 --- |
-  # Copyright 2015 gRPC authors.
+  # Copyright 2021 gRPC authors.
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
   # you may not use this file except in compliance with the License.
@@ -14,18 +14,14 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM i386/debian:jessie
-  RUN sed -i '/deb http:\/\/http.debian.net\/debian jessie-updates main/d' /etc/apt/sources.list
+  FROM i386/debian:9
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../cxx_deps.include"/>
+  <%include file="../../cmake.include"/>
   <%include file="../../run_tests_addons.include"/>
-  <%include file="../../cmake_jessie_backports.include"/>
-
-  # Install gcc-4.9 and other relevant items
-  RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
 
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_gcc_4.9_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_gcc_4.9_x64/Dockerfile.template
@@ -1,6 +1,6 @@
 %YAML 1.2
 --- |
-  # Copyright 2021 the gRPC authors.
+  # Copyright 2021 gRPC authors.
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
   # you may not use this file except in compliance with the License.
@@ -14,26 +14,13 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM gcc:4.9
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../gcp_api_libraries.include"/>
-  <%include file="../../cxx_deps.include"/>
-  <%include file="../../cmake.include"/>
+  <%include file="../../cmake_jessie_backports.include"/>
   <%include file="../../run_tests_addons.include"/>
-
-  # Install openssl 1.0.2 from source
-  RUN apt-get update && apt-get install -y build-essential zlib1g-dev
-  RUN cd /tmp && ${"\\"}
-      wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && ${"\\"}
-      tar -xf openssl-1.0.2u.tar.gz && ${"\\"}
-      cd openssl-1.0.2u && ${"\\"}
-      ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && ${"\\"}
-      make -j 4 && ${"\\"}
-      make install && ${"\\"}
-      rm -rf /tmp/openssl-1.0.2u*
-  ENV OPENSSL_ROOT_DIR=/usr/local/ssl
-
+  
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/cxx_debian10_openssl102_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian10_openssl102_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2021 the gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM i386/debian:jessie
-RUN sed -i '/deb http:\/\/http.debian.net\/debian jessie-updates main/d' /etc/apt/sources.list
+FROM debian:10
 
+RUN apt-get --allow-releaseinfo-change update
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -73,21 +73,27 @@ RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 o
 # C++ dependencies
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
 
 RUN mkdir /var/local/jenkins
 
-#=================
-# Use cmake 3.6 from jessie-backports
-# should only be used for images based on debian jessie.
 
-RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
-RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
-
-
-# Install gcc-4.9 and other relevant items
-RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
+# Install openssl 1.0.2 from source
+RUN apt-get update && apt-get install -y build-essential zlib1g-dev
+RUN cd /tmp && \
+    wget --no-check-certificate https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && \
+    tar -xf openssl-1.0.2u.tar.gz && \
+    cd openssl-1.0.2u && \
+    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
+    make -j 4 && \
+    make install && \
+    rm -rf /tmp/openssl-1.0.2u*
+ENV OPENSSL_ROOT_DIR=/usr/local/ssl
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_debian10_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian10_x64/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:8
+FROM debian:10
 
-
+RUN apt-get --allow-releaseinfo-change update
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -74,20 +74,14 @@ RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 o
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
 #=================
-# Use cmake 3.6 from jessie-backports
-# should only be used for images based on debian jessie.
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
 
-RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
-RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
+RUN apt-get update && apt-get install -y cmake && apt-get clean
 
 
 RUN mkdir /var/local/jenkins
 
-
-# Install gcc-4.9 and other relevant items
-RUN apt-get update && apt-get -y install gcc gcc-multilib g++ g++-multilib && apt-get clean
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_debian9_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian9_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2021 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:9
 
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \

--- a/tools/dockerfile/test/cxx_debian9_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian9_x86/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 the gRPC authors.
+# Copyright 2021 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM i386/debian:9
 
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
@@ -81,18 +81,6 @@ RUN apt-get update && apt-get install -y cmake && apt-get clean
 
 RUN mkdir /var/local/jenkins
 
-
-# Install openssl 1.0.2 from source
-RUN apt-get update && apt-get install -y build-essential zlib1g-dev
-RUN cd /tmp && \
-    wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && \
-    tar -xf openssl-1.0.2u.tar.gz && \
-    cd openssl-1.0.2u && \
-    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
-    make -j 4 && \
-    make install && \
-    rm -rf /tmp/openssl-1.0.2u*
-ENV OPENSSL_ROOT_DIR=/usr/local/ssl
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_gcc_4.9_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_4.9_x64/Dockerfile
@@ -1,0 +1,85 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcc:4.9
+
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  gcc \
+  gcc-multilib \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#================
+# Build profiling
+RUN apt-get update && apt-get install -y time && apt-get clean
+
+#====================
+# Python dependencies
+
+# Install dependencies
+
+RUN apt-get update && apt-get install -y \
+    python-all-dev \
+    python3-all-dev \
+    python-setuptools
+
+# Install Python packages from PyPI
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
+RUN pip install --upgrade pip==19.3.1
+RUN pip install virtualenv==16.7.9
+RUN pip install futures==3.1.1 enum34==1.1.10 protobuf==3.5.2.post1 six==1.16.0 twisted==19.10.0
+
+# Google Cloud platform API libraries
+RUN pip install --upgrade google-auth==1.24.0 google-api-python-client==1.12.8 oauth2client==4.1.0
+
+#=================
+# Use cmake 3.6 from jessie-backports
+# should only be used for images based on debian jessie.
+
+RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
+
+
+RUN mkdir /var/local/jenkins
+
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -460,14 +460,16 @@ class CLanguage(object):
             # so we only allow the non-specific choices.
             _check_compiler(compiler, ['default', 'cmake'])
 
-        if compiler == 'gcc4.9' or compiler == 'default' or compiler == 'cmake':
-            return ('jessie', [])
+        if compiler == 'default' or compiler == 'cmake':
+            return ('debian9', [])
+        elif compiler == 'gcc4.9':
+            return ('gcc_4.9', [])
         elif compiler == 'gcc5.3':
             return ('ubuntu1604', [])
         elif compiler == 'gcc8.3':
-            return ('buster', [])
+            return ('debian10', [])
         elif compiler == 'gcc8.3_openssl102':
-            return ('buster_openssl102', [
+            return ('debian10_openssl102', [
                 "-DgRPC_SSL_PROVIDER=package",
             ])
         elif compiler == 'gcc11':


### PR DESCRIPTION
Updated cxx docker images to
 - Use Debian 9 (stretch) instead of Debian 8 for c++ default tests, which will fix the one of CI test failures (with at-head Abseil) Abseil test doesn't pass with 32bits Debian 8.
 - Having a explicit docker for gcc 4.9 instead of using Debian 8 image to run the test with gcc 4.9