### PR TITLE
[objc]podfile cleanup and add core test to script to run

### DIFF
--- a/src/objective-c/tests/CoreTests/CoreTests.xcodeproj/project.pbxproj
+++ b/src/objective-c/tests/CoreTests/CoreTests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -216,7 +216,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -269,7 +269,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -293,7 +293,7 @@
 					"\"${PODS_ROOT}/Headers/Public/abseil\"",
 					"\"${PODS_ROOT}/Headers/Public/gRPC-Core\"",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -323,7 +323,7 @@
 					"\"${PODS_ROOT}/Headers/Public/abseil\"",
 					"\"${PODS_ROOT}/Headers/Public/gRPC-Core\"",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/src/objective-c/tests/CoreTests/Podfile
+++ b/src/objective-c/tests/CoreTests/Podfile
@@ -5,6 +5,7 @@ install! 'cocoapods', :deterministic_uuids => false
 GRPC_LOCAL_SRC = '../../../..'
 
 def grpc_deps
+  pod 'BoringSSL-GRPC', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c"
   pod 'gRPC-Core', :path => GRPC_LOCAL_SRC
   pod 'gRPC-Core/Tests', :path => GRPC_LOCAL_SRC
 end
@@ -12,14 +13,4 @@ end
 target 'CoreTests' do
   platform :ios, '9.0'
   grpc_deps
-end
-
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    if target.name == "CoreTests"
-      target.build_configurations.each do |config|
-        config.build_settings['USER_HEADER_SEARCH_PATHS'] = "$(inherited) $(PODS_ROOT)/../#{GRPC_LOCAL_SRC}"
-      end
-    end
-  end
 end

--- a/src/objective-c/tests/CoreTests/build_and_run_tests.sh
+++ b/src/objective-c/tests/CoreTests/build_and_run_tests.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Don't run this script standalone. Instead, run from the repository root:
+# ./tools/run_tests/run_tests.py -l c++
+
+set -ev
+
+cd "$(dirname "$0")"
+
+echo "TIME:  $(date)"
+
+./build_tests.sh | ./verbose_time.sh
+
+echo "TIME:  $(date)"
+
+set -o pipefail
+
+XCODEBUILD_FILTER='(^CompileC |^Ld |^ *[^ ]*clang |^ *cd |^ *export |^Libtool |^ *[^ ]*libtool |^CpHeader |^ *builtin-copy )'
+
+xcodebuild \
+    -workspace CoreTests.xcworkspace \
+    -scheme CoreTests \
+    -destination name="iPhone 8" \
+    test \
+    | ./verbose_time.sh \
+    | grep -E -v "$XCODEBUILD_FILTER" \
+    | grep -E -v '^$' -

--- a/src/objective-c/tests/CoreTests/build_tests.sh
+++ b/src/objective-c/tests/CoreTests/build_tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Don't run this script standalone. Instead, run from the repository root:
+# ./tools/run_tests/run_tests.py -l objc
+
+set -e
+
+# CocoaPods requires the terminal to be using UTF-8 encoding.
+export LANG=en_US.UTF-8
+
+cd "$(dirname "$0")"
+
+hash pod 2>/dev/null || { echo >&2 "Cocoapods needs to be installed."; exit 1; }
+hash xcodebuild 2>/dev/null || {
+    echo >&2 "XCode command-line tools need to be installed."
+    exit 1
+}
+
+# clean the directory
+rm -rf Pods
+rm -rf Tests.xcworkspace
+rm -f Podfile.lock
+rm -rf RemoteTestClientCpp/src
+
+echo "TIME:  $(date)"
+pod install
+
+# ios-cpp-test-cronet flakes sometimes because of missing files in Protobuf-C++,
+# add some log to help find out the root cause.
+# TODO(yulinliang): Delete it after solving the issue.
+if [ -d "./Pods/Headers/Public/Protobuf-C++/google/protobuf" ]
+then
+    echo "Protobuf-C++/google/protobuf/ has been imported."
+    number_of_files=$(find Pods/Headers/Public/Protobuf-C++/google/protobuf -name "*.h" | wc -l)
+    echo "The number of header files in Pods/Headers/Public/Protobuf-C++/google/protobuf/ is $number_of_files"
+else
+    echo "Error: Protobuf-C++/google/protobuf/ hasn't been imported."
+fi

--- a/src/objective-c/tests/CoreTests/verbose_time.sh
+++ b/src/objective-c/tests/CoreTests/verbose_time.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+while IFS= read -r line; do
+  echo "$(date) - $line"
+done

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1083,6 +1083,13 @@ class ObjCLanguage(object):
                 shortname='ios-test-cfstream-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
+        out.append(
+            self.config.job_spec(
+                ['src/objective-c/tests/CoreTests/build_and_run_tests.sh'],
+                timeout_seconds=60 * 60,
+                shortname='ios-test-core-tests',
+                cpu_cost=1e6,
+                environ=_FORCE_ENVIRON_FOR_WRAPPERS))
         # TODO: replace with run_one_test_bazel.sh when Bazel-Xcode is stable
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],


### PR DESCRIPTION
Splitting #27740 to 2 PRs to locate the problem, since some CI test failed after #27740 merged. 

check if this is causing grpc_basictests_objc_ios timeout

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@dennycd 