### PR TITLE
Use more parallelism to windows portability tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,12 @@ set(gRPC_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries
 set(gRPC_INSTALL_INCLUDEDIR "include" CACHE STRING "Installation directory for headers")
 set(gRPC_INSTALL_CMAKEDIR "lib/cmake/${PACKAGE_NAME}" CACHE STRING "Installation directory for cmake config files")
 set(gRPC_INSTALL_SHAREDIR "share/grpc" CACHE STRING "Installation directory for root certificates")
+set(gRPC_BUILD_MSVC_MP_COUNT 0 CACHE INTERNAL "The maximum number of processes for MSVC /MP option")
 
 # Options
 option(gRPC_BUILD_TESTS "Build tests" OFF)
 option(gRPC_BUILD_CODEGEN "Build codegen" ON)
 option(gRPC_BUILD_CSHARP_EXT "Build C# extensions" ON)
-option(gRPC_BUILD_MSVC_MP "Enable build with multiple processes in Visual Studio" TRUE)
 option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
 
 set(gRPC_INSTALL_default ON)
@@ -221,7 +221,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 if(MSVC)
   include(cmake/msvc_static_runtime.cmake)
   add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
-  if (gRPC_BUILD_MSVC_MP)
+  # Set /MP option
+  if (gRPC_BUILD_MSVC_MP_COUNT GREATER 0)
+    set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /MP${gRPC_BUILD_MSVC_MP_COUNT}")
+  elseif (gRPC_BUILD_MSVC_MP_COUNT LESS 0)
     set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /MP")
   endif()
   # needed to compile protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(gRPC_INSTALL_SHAREDIR "share/grpc" CACHE STRING "Installation directory for 
 option(gRPC_BUILD_TESTS "Build tests" OFF)
 option(gRPC_BUILD_CODEGEN "Build codegen" ON)
 option(gRPC_BUILD_CSHARP_EXT "Build C# extensions" ON)
+option(gRPC_BUILD_MSVC_MP "Enable build with multiple processes in Visual Studio" TRUE)
 option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
 
 set(gRPC_INSTALL_default ON)
@@ -220,6 +221,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 if(MSVC)
   include(cmake/msvc_static_runtime.cmake)
   add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
+  if (gRPC_BUILD_MSVC_MP)
+    set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /MP")
+  endif()
   # needed to compile protobuf
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4065 /wd4506")
   # TODO(jtattermusch): revisit warnings that were silenced as part of upgrade to protobuf3.6.0

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -164,12 +164,12 @@
   set(gRPC_INSTALL_INCLUDEDIR "include" CACHE STRING "Installation directory for headers")
   set(gRPC_INSTALL_CMAKEDIR "lib/cmake/<%text>${PACKAGE_NAME}</%text>" CACHE STRING "Installation directory for cmake config files")
   set(gRPC_INSTALL_SHAREDIR "share/grpc" CACHE STRING "Installation directory for root certificates")
+  set(gRPC_BUILD_MSVC_MP_COUNT 0 CACHE INTERNAL "The maximum number of processes for MSVC /MP option")
 
   # Options
   option(gRPC_BUILD_TESTS "Build tests" OFF)
   option(gRPC_BUILD_CODEGEN "Build codegen" ON)
   option(gRPC_BUILD_CSHARP_EXT "Build C# extensions" ON)
-  option(gRPC_BUILD_MSVC_MP "Enable build with multiple processes in Visual Studio" TRUE)
   option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
 
   set(gRPC_INSTALL_default ON)
@@ -283,7 +283,10 @@
   if(MSVC)
     include(cmake/msvc_static_runtime.cmake)
     add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
-    if (gRPC_BUILD_MSVC_MP)
+    # Set /MP option
+    if (gRPC_BUILD_MSVC_MP_COUNT GREATER 0)
+      set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS} /MP${gRPC_BUILD_MSVC_MP_COUNT}</%text>")
+    elseif (gRPC_BUILD_MSVC_MP_COUNT LESS 0)
       set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /MP")
     endif()
     # needed to compile protobuf

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -169,6 +169,7 @@
   option(gRPC_BUILD_TESTS "Build tests" OFF)
   option(gRPC_BUILD_CODEGEN "Build codegen" ON)
   option(gRPC_BUILD_CSHARP_EXT "Build C# extensions" ON)
+  option(gRPC_BUILD_MSVC_MP "Enable build with multiple processes in Visual Studio" TRUE)
   option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
 
   set(gRPC_INSTALL_default ON)
@@ -282,6 +283,9 @@
   if(MSVC)
     include(cmake/msvc_static_runtime.cmake)
     add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
+    if (gRPC_BUILD_MSVC_MP)
+      set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /MP")
+    endif()
     # needed to compile protobuf
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4065 /wd4506")
     # TODO(jtattermusch): revisit warnings that were silenced as part of upgrade to protobuf3.6.0

--- a/tools/internal_ci/windows/grpc_portability.cfg
+++ b/tools/internal_ci/windows/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 1 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
+  value: "-f portability windows -j 1 --inner_jobs 16 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_portability.cfg
+++ b/tools/internal_ci/windows/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 1 --inner_jobs 16 --internal_ci --bq_result_table aggregate_results"
+  value: "-f portability windows -j 4 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_portability.cfg
+++ b/tools/internal_ci/windows/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 4 --internal_ci --bq_result_table aggregate_results"
+  value: "-f portability windows -j 4 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/windows/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 4 --internal_ci --build_only"
+  value: "-f portability windows -j 4 --inner_jobs 8 --internal_ci --build_only"
 }

--- a/tools/internal_ci/windows/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/windows/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows --inner_jobs 8 --internal_ci  --build_only"
+  value: "-f portability windows -j 4 --internal_ci --build_only"
 }

--- a/tools/internal_ci/windows/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/windows/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows --internal_ci  --build_only"
+  value: "-f portability windows --inner_jobs 8 --internal_ci  --build_only"
 }

--- a/tools/run_tests/helper_scripts/pre_build_cmake.bat
+++ b/tools/run_tests/helper_scripts/pre_build_cmake.bat
@@ -21,7 +21,7 @@ cd cmake
 mkdir build
 cd build
 
-cmake -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP=ON %* ../.. || goto :error
+cmake -DgRPC_BUILD_TESTS=ON %* ../.. || goto :error
 
 endlocal
 

--- a/tools/run_tests/helper_scripts/pre_build_cmake.bat
+++ b/tools/run_tests/helper_scripts/pre_build_cmake.bat
@@ -21,7 +21,7 @@ cd cmake
 mkdir build
 cd build
 
-cmake -DgRPC_BUILD_TESTS=ON %* ../.. || goto :error
+cmake -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP=ON %* ../.. || goto :error
 
 endlocal
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -424,8 +424,10 @@ class CLanguage(object):
 
     def pre_build_steps(self):
         if self.platform == 'windows':
-            return [['tools\\run_tests\\helper_scripts\\pre_build_cmake.bat'] +
-                    self._cmake_configure_extra_args]
+            return [[
+                'tools\\run_tests\\helper_scripts\\pre_build_cmake.bat',
+                '-DgRPC_BUILD_MSVC_MP_COUNT=%d' % args.jobs
+            ] + self._cmake_configure_extra_args]
         elif self._use_cmake:
             return [['tools/run_tests/helper_scripts/pre_build_cmake.sh'] +
                     self._cmake_configure_extra_args]


### PR DESCRIPTION
As Windows test machines get more cores, let's update actual tests to get more parallelism.