### PR TITLE
Added workaround for gcc 6.3.0

### DIFF
--- a/test/core/address_utils/sockaddr_utils_test.cc
+++ b/test/core/address_utils/sockaddr_utils_test.cc
@@ -182,16 +182,18 @@ TEST(SockAddrUtilsTest, SockAddrToString) {
             "[2001:db8::1%25101]:12345");
   EXPECT_EQ(grpc_sockaddr_to_uri(&input6), "ipv6:[2001:db8::1%25101]:12345");
 
-  input6 = MakeAddr6(kMapped, sizeof(kMapped));
-  EXPECT_EQ(grpc_sockaddr_to_string(&input6, false),
+  grpc_resolved_address input6x = MakeAddr6(kMapped, sizeof(kMapped));
+  EXPECT_EQ(grpc_sockaddr_to_string(&input6x, false),
             "[::ffff:192.0.2.1]:12345");
-  EXPECT_EQ(grpc_sockaddr_to_string(&input6, true), "192.0.2.1:12345");
-  EXPECT_EQ(grpc_sockaddr_to_uri(&input6), "ipv4:192.0.2.1:12345");
+  EXPECT_EQ(grpc_sockaddr_to_string(&input6x, true), "192.0.2.1:12345");
+  EXPECT_EQ(grpc_sockaddr_to_uri(&input6x), "ipv4:192.0.2.1:12345");
 
-  input6 = MakeAddr6(kNotQuiteMapped, sizeof(kNotQuiteMapped));
-  EXPECT_EQ(grpc_sockaddr_to_string(&input6, false), "[::fffe:c000:263]:12345");
-  EXPECT_EQ(grpc_sockaddr_to_string(&input6, true), "[::fffe:c000:263]:12345");
-  EXPECT_EQ(grpc_sockaddr_to_uri(&input6), "ipv6:[::fffe:c000:263]:12345");
+  grpc_resolved_address input6y =
+      MakeAddr6(kNotQuiteMapped, sizeof(kNotQuiteMapped));
+  EXPECT_EQ(grpc_sockaddr_to_string(&input6y, false),
+            "[::fffe:c000:263]:12345");
+  EXPECT_EQ(grpc_sockaddr_to_string(&input6y, true), "[::fffe:c000:263]:12345");
+  EXPECT_EQ(grpc_sockaddr_to_uri(&input6y), "ipv6:[::fffe:c000:263]:12345");
 
   grpc_resolved_address phony;
   memset(&phony, 0, sizeof(phony));


### PR DESCRIPTION
It seems that gcc 6.3.0 which is installed on Debian 9 has an issue with the existing SockAddrUtils when running release build. Its output is

```
[ RUN      ] SockAddrUtilsTest.SockAddrToString
/var/local/git/grpc/test/core/address_utils/sockaddr_utils_test.cc:187: Failure
Expected equality of these values:
  grpc_sockaddr_to_string(&input6, false)
    Which is: "[::ffff:192.0.2.1]:0"
  "[::ffff:192.0.2.1]:12345"
/var/local/git/grpc/test/core/address_utils/sockaddr_utils_test.cc:188: Failure
Expected equality of these values:
  grpc_sockaddr_to_string(&input6, true)
    Which is: "192.0.2.1:0"
  "192.0.2.1:12345"
/var/local/git/grpc/test/core/address_utils/sockaddr_utils_test.cc:189: Failure
Expected equality of these values:
  grpc_sockaddr_to_uri(&input6)
    Which is: "ipv4:192.0.2.1:0"
  "ipv4:192.0.2.1:12345"
/var/local/git/grpc/test/core/address_utils/sockaddr_utils_test.cc:192: Failure
Expected equality of these values:
  grpc_sockaddr_to_string(&input6, false)
    Which is: "[::fffe:c000:263]:0"
  "[::fffe:c000:263]:12345"
/var/local/git/grpc/test/core/address_utils/sockaddr_utils_test.cc:193: Failure
Expected equality of these values:
  grpc_sockaddr_to_string(&input6, true)
    Which is: "[::fffe:c000:263]:0"
  "[::fffe:c000:263]:12345"
/var/local/git/grpc/test/core/address_utils/sockaddr_utils_test.cc:194: Failure
Expected equality of these values:
  grpc_sockaddr_to_uri(&input6)
    Which is: "ipv6:[::fffe:c000:263]:0"
  "ipv6:[::fffe:c000:263]:12345"
[  FAILED  ] SockAddrUtilsTest.SockAddrToString (1 ms)
```

This looks suspicious and it's most likely a compiler optimization bug which happens with gcc 6.3.0. So I came up with workaround code to avoid this issue since we need to run our tests on Debian 9 with a built-in gcc anyway.