### PR TITLE
Filter zero length slices passed to grpc passthru endpoint

### DIFF
--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-4563554393260032
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-4563554393260032
@@ -1,0 +1,46 @@
+actions {
+  create_server {
+  }
+}
+actions {
+  create_channel {
+    target: "unix::::::::::::::::::::::::::;:::::;:::::::::::::>:::::::::::::::::::::::9:::::\026I:::::::c::,:::\332\261::::::::::::::::"
+    channel_actions {
+      add_n_bytes_writable: 18446744073709551607
+      add_n_bytes_readable: 18446744073709551607
+    }
+  }
+}
+actions {
+  create_call {
+    propagation_mask: 6881280
+    method {
+      value: "/foo"
+    }
+    timeout: 1953002608
+  }
+}
+actions {
+  queue_batch {
+    operations {
+      send_initial_metadata {
+      }
+    }
+    operations {
+      send_message {
+        message {
+          intern: true
+        }
+        message {
+          value: "Bh\007-600"
+          intern: true
+        }
+      }
+    }
+  }
+}
+actions {
+  advance_time: 6881280
+}
+actions {
+}

--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -274,11 +274,14 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
                                       grpc_slice_copy(slices->slices[i]));
       }
     }
-    if (m->pending_write_op.slices->count) {
+    if (m->pending_write_op.slices->count > 0) {
       m->pending_write_op.is_armed = true;
       m->pending_write_op.cb = cb;
       m->pending_write_op.ep = ep;
       do_pending_write_op_locked(m, GRPC_ERROR_NONE);
+    } else {
+      // There is nothing to write. Schedule callback to be run right away.
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
     }
   }
   gpr_mu_unlock(&m->parent->mu);


### PR DESCRIPTION

grpc passthru endpoint changes to filter out 0 length slices that may be passed to endpoint write method.

@nicolasnoble
