### PR TITLE
Revert "use WorkSerializer for subchannel connectivity state notifications"

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -578,8 +578,7 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
           DEBUG_LOCATION);
     }
 
-    void OnConnectivityStateChange(grpc_connectivity_state state,
-                                   const absl::Status& status) override {
+    void OnConnectivityStateChange() override {
       if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
         gpr_log(GPR_INFO,
                 "chand=%p: connectivity change for subchannel wrapper %p "
@@ -588,9 +587,9 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
       }
       Ref().release();  // ref owned by lambda
       parent_->chand_->work_serializer_->Run(
-          [this, state, status]()
+          [this]()
               ABSL_EXCLUSIVE_LOCKS_REQUIRED(parent_->chand_->work_serializer_) {
-                ApplyUpdateInControlPlaneWorkSerializer(state, status);
+                ApplyUpdateInControlPlaneWorkSerializer();
                 Unref();
               },
           DEBUG_LOCATION);
@@ -613,20 +612,19 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
     grpc_connectivity_state last_seen_state() const { return last_seen_state_; }
 
    private:
-    void ApplyUpdateInControlPlaneWorkSerializer(grpc_connectivity_state state,
-                                                 const absl::Status& status)
+    void ApplyUpdateInControlPlaneWorkSerializer()
         ABSL_EXCLUSIVE_LOCKS_REQUIRED(parent_->chand_->work_serializer_) {
       if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
         gpr_log(GPR_INFO,
                 "chand=%p: processing connectivity change in work serializer "
-                "for subchannel wrapper %p subchannel %p watcher=%p: "
-                "state=%s status=%s",
+                "for subchannel wrapper %p subchannel %p "
+                "watcher=%p",
                 parent_->chand_, parent_.get(), parent_->subchannel_.get(),
-                watcher_.get(), ConnectivityStateName(state),
-                status.ToString().c_str());
+                watcher_.get());
       }
+      ConnectivityStateChange state_change = PopConnectivityStateChange();
       absl::optional<absl::Cord> keepalive_throttling =
-          status.GetPayload(kKeepaliveThrottlingKey);
+          state_change.status.GetPayload(kKeepaliveThrottlingKey);
       if (keepalive_throttling.has_value()) {
         int new_keepalive_time = -1;
         if (absl::SimpleAtoi(std::string(keepalive_throttling.value()),
@@ -654,8 +652,8 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
       // Ignore update if the parent WatcherWrapper has been replaced
       // since this callback was scheduled.
       if (watcher_ != nullptr) {
-        last_seen_state_ = state;
-        watcher_->OnConnectivityStateChange(state);
+        last_seen_state_ = state_change.state;
+        watcher_->OnConnectivityStateChange(state_change.state);
       }
     }
 

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -34,7 +34,6 @@
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/iomgr/timer.h"
-#include "src/core/lib/iomgr/work_serializer.h"
 #include "src/core/lib/transport/connectivity_state.h"
 #include "src/core/lib/transport/metadata.h"
 
@@ -146,13 +145,43 @@ class Subchannel : public DualRefCounted<Subchannel> {
   class ConnectivityStateWatcherInterface
       : public RefCounted<ConnectivityStateWatcherInterface> {
    public:
-    // Invoked whenever the subchannel's connectivity state changes.
-    // There will be only one invocation of this method on a given watcher
-    // instance at any given time.
-    virtual void OnConnectivityStateChange(grpc_connectivity_state state,
-                                           const absl::Status& status) = 0;
+    struct ConnectivityStateChange {
+      grpc_connectivity_state state;
+      absl::Status status;
+    };
+
+    ~ConnectivityStateWatcherInterface() override = default;
+
+    // Will be invoked whenever the subchannel's connectivity state
+    // changes.  There will be only one invocation of this method on a
+    // given watcher instance at any given time.
+    // Implementations should call PopConnectivityStateChange to get the next
+    // connectivity state change.
+    virtual void OnConnectivityStateChange() = 0;
 
     virtual grpc_pollset_set* interested_parties() = 0;
+
+    // Enqueues connectivity state change notifications.
+    // When the state changes to READY, connected_subchannel will
+    // contain a ref to the connected subchannel.  When it changes from
+    // READY to some other state, the implementation must release its
+    // ref to the connected subchannel.
+    // TODO(yashkt): This is currently needed to send the state updates in the
+    // right order when asynchronously notifying. This will no longer be
+    // necessary when we have access to EventManager.
+    void PushConnectivityStateChange(ConnectivityStateChange state_change);
+
+    // Dequeues connectivity state change notifications.
+    ConnectivityStateChange PopConnectivityStateChange();
+
+   private:
+    Mutex mu_;  // protects the queue
+    // Keeps track of the updates that the watcher instance must be notified of.
+    // TODO(yashkt): This is currently needed to send the state updates in the
+    // right order when asynchronously notifying. This will no longer be
+    // necessary when we have access to EventManager.
+    std::deque<ConnectivityStateChange> connectivity_state_queue_
+        ABSL_GUARDED_BY(&mu_);
   };
 
   // Creates a subchannel.
@@ -222,8 +251,6 @@ class Subchannel : public DualRefCounted<Subchannel> {
   // the subchannel's state.
   class ConnectivityStateWatcherList {
    public:
-    explicit ConnectivityStateWatcherList(Subchannel* subchannel)
-        : subchannel_(subchannel) {}
     ~ConnectivityStateWatcherList() { Clear(); }
 
     void AddWatcherLocked(
@@ -239,7 +266,6 @@ class Subchannel : public DualRefCounted<Subchannel> {
     bool empty() const { return watchers_.empty(); }
 
    private:
-    Subchannel* subchannel_;
     // TODO(roth): Once we can use C++-14 heterogeneous lookups, this can
     // be a set instead of a map.
     std::map<ConnectivityStateWatcherInterface*,
@@ -283,6 +309,8 @@ class Subchannel : public DualRefCounted<Subchannel> {
   };
 
   class ConnectedSubchannelStateWatcher;
+
+  class AsyncWatcherNotifierLocked;
 
   // Sets the subchannel's connectivity state to \a state.
   void SetConnectivityStateLocked(grpc_connectivity_state state,
@@ -332,8 +360,6 @@ class Subchannel : public DualRefCounted<Subchannel> {
   ConnectivityStateWatcherList watcher_list_ ABSL_GUARDED_BY(mu_);
   // The map of watchers with health check service names.
   HealthWatcherMap health_watcher_map_ ABSL_GUARDED_BY(mu_);
-  // Used for sending connectivity state notifications.
-  WorkSerializer work_serializer_;
 
   // Backoff state.
   BackOff backoff_ ABSL_GUARDED_BY(mu_);


### PR DESCRIPTION
Reverts grpc/grpc#28111

This is causing ASAN failures internally