### PR TITLE
Fix deprecated inheritance of std::iterator

### DIFF
--- a/include/grpcpp/impl/codegen/security/auth_context.h
+++ b/include/grpcpp/impl/codegen/security/auth_context.h
@@ -36,9 +36,14 @@ class SecureAuthContext;
 
 typedef std::pair<string_ref, string_ref> AuthProperty;
 
-class AuthPropertyIterator
-    : public std::iterator<std::input_iterator_tag, const AuthProperty> {
+class AuthPropertyIterator {
  public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = const AuthProperty;
+  using pointer = void;
+  using reference = void;
+  using difference_type = std::ptrdiff_t;
+
   ~AuthPropertyIterator();
   AuthPropertyIterator& operator++();
   AuthPropertyIterator operator++(int);


### PR DESCRIPTION
Fix of "-Wdeprecated-declarations" (seen with clang 13) in the way it was suggested by #25125.
The approach has been slightly adapted to be more like protocolbuffers/protobuf#8741 - mainly by using "using" instead of "typedef".

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
