### PR TITLE
Add locks to synchronize access to shared variable in flow control test to prevent data race

### DIFF
--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -69,6 +69,7 @@ class TransportTargetWindowSizeMocker
   // Alternates the initial window size targets. Computes a low values if it was
   // previously high, or a high value if it was previously low.
   void AlternateTargetInitialWindowSizes() {
+    absl::MutexLock lock(&mu_);
     alternating_initial_window_sizes_ = true;
   }
 
@@ -81,9 +82,9 @@ class TransportTargetWindowSizeMocker
   }
 
  private:
-  bool alternating_initial_window_sizes_ = false;
-  double window_size_ = kLargeInitialWindowSize;
   absl::Mutex mu_;
+  bool alternating_initial_window_sizes_ ABSL_GUARDED_BY(mu_) = false;
+  double window_size_ ABSL_GUARDED_BY(mu_) = kLargeInitialWindowSize;
 };
 
 TransportTargetWindowSizeMocker* g_target_initial_window_size_mocker;

--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -29,6 +29,8 @@
 
 #include <gmock/gmock.h>
 
+#include "third_party/absl/synchronization/mutex.h"
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>
@@ -44,7 +46,6 @@
 #include "test/core/end2end/cq_verifier.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
-#include "third_party/absl/synchronization/mutex.h"
 
 namespace {
 

--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -29,8 +29,6 @@
 
 #include <gmock/gmock.h>
 
-#include "third_party/absl/synchronization/mutex.h"
-
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>


### PR DESCRIPTION

Prevents tsan failures reported in internal bug b/199572141

@nicolasnoble
