### PR TITLE
Stop building the universal-darwin ruby gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,8 +30,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
   ext.cross_platform = [
     'x86-mingw32', 'x64-mingw32',
     'x86_64-linux', 'x86-linux',
-    'x86_64-darwin', 'arm64-darwin',
-    'universal-darwin'
+    'x86_64-darwin', 'arm64-darwin'
   ]
   ext.cross_compiling do |spec|
     spec.files = %w( etc/roots.pem grpc_c.32.ruby grpc_c.64.ruby )


### PR DESCRIPTION
So that the arm-specific gem can be more easily picked up on arm platforms

Followup to https://github.com/grpc/grpc/issues/28085
