### PR TITLE
Try to use configure-docker instead of gcloud docker

### DIFF
--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -207,7 +207,7 @@ def _generate_test_case_jobspecs(lang, runtime, release, suite_name):
 def _pull_image_for_lang(lang, image, release):
     """Pull an image for a given language form the image registry."""
     cmdline = [
-        'time gcloud docker -- pull %s && time docker run --rm=true %s /bin/true'
+        'gcloud auth configure-docker && time docker pull %s && time docker run --rm=true %s /bin/true'
         % (image, image)
     ]
     return jobset.JobSpec(cmdline=cmdline,


### PR DESCRIPTION
The interop tests are currently failing with this:

```
2021-11-30 08:27:46,391 WARNING: `gcloud docker` will not be supported for Docker client versions above 18.03.

As an alternative, use `gcloud auth configure-docker` to configure `docker` to
use `gcloud` as a credential helper, then use `docker` as you would for non-GCR
registries, e.g. `docker pull gcr.io/project-id/my-image`. Add
`--verbosity=error` to silence this warning: `gcloud docker
--verbosity=error -- pull gcr.io/project-id/my-image`.
```

~[Ad-hoc Run](https://fusion2.corp.google.com/invocations/4bbdb78d-cb5f-4133-9590-d8d51764f5ee/targets)~
[Another ad-hoc run](https://sponge2.corp.google.com/b230fab2-d281-4d94-837a-7503ed02f235)