### PR TITLE
Faster finalization of "grpc_build_artifacts" job

### DIFF
--- a/tools/internal_ci/linux/grpc_build_artifacts.sh
+++ b/tools/internal_ci/linux/grpc_build_artifacts.sh
@@ -26,4 +26,11 @@ set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
 set -ex
 
-tools/run_tests/task_runner.py -f artifact linux -j 12
+tools/run_tests/task_runner.py -f artifact linux -j 12 || FAILED="true"
+
+tools/internal_ci/helper_scripts/delete_nonartifacts.sh || true
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi


### PR DESCRIPTION
When kokoro finished the job, it does rsync of the entire workspace back to an agent, before selecting the actual artifact files.
So if our build ends up with a very large workspace, rsyncing the workspace can take a lot of time.
We already use the delete_nonartifacts.sh trick in multiple places. (also see b/74837748)

I didn't realize previously that it was also important for the grpc_build_artifacts job.
(I think what's making the workspace large is the intermediate files from ruby artifact build, other artifacts get build in a docker container, which doesn't leave intermediate files)


Excerpt from the end of the grpc_build_artifacts log (it takes ~8mins to finalize the job)
```
[21:52:07] Collecting build artifacts from build VM
[22:00:42] Kokoro builder finished
```
```
[01:47:05] Collecting build artifacts from build VM
[01:55:42] Kokoro builder finished
```


