### PR TITLE
Add an env var to override make parallelism in ruby build

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -73,9 +73,12 @@ unless windows
   nproc_override = ENV['GRPC_RUBY_BUILD_PROCS']
   unless nproc_override.nil? or nproc_override.size == 0
     nproc = nproc_override
+    puts "Overriding make parallelism to #{nproc}"
   end
   make = bsd ? 'gmake' : 'make'
-  system("#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q=")
+  cmd = "#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q="
+  puts "Building grpc native library: #{cmd}"
+  system(cmd)
   exit 1 unless $? == 0
 end
 

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -70,6 +70,10 @@ unless windows
   puts 'Building internal gRPC into ' + grpc_lib_dir
   nproc = 4
   nproc = Etc.nprocessors * 2 if Etc.respond_to? :nprocessors
+  nproc_override = ENV['GRPC_RUBY_BUILD_PROCS']
+  unless nproc_override.nil? or nproc_override.size == 0
+    nproc = nproc_override
+  end
   make = bsd ? 'gmake' : 'make'
   system("#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q=")
   exit 1 unless $? == 0

--- a/templates/src/ruby/ext/grpc/extconf.rb.template
+++ b/templates/src/ruby/ext/grpc/extconf.rb.template
@@ -75,9 +75,12 @@
     nproc_override = ENV['GRPC_RUBY_BUILD_PROCS']
     unless nproc_override.nil? or nproc_override.size == 0
       nproc = nproc_override
+      puts "Overriding make parallelism to #{nproc}"
     end
     make = bsd ? 'gmake' : 'make'
-    system("#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q=")
+    cmd = "#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q="
+    puts "Building grpc native library: #{cmd}"
+    system(cmd)
     exit 1 unless $? == 0
   end
   

--- a/templates/src/ruby/ext/grpc/extconf.rb.template
+++ b/templates/src/ruby/ext/grpc/extconf.rb.template
@@ -72,6 +72,10 @@
     puts 'Building internal gRPC into ' + grpc_lib_dir
     nproc = 4
     nproc = Etc.nprocessors * 2 if Etc.respond_to? :nprocessors
+    nproc_override = ENV['GRPC_RUBY_BUILD_PROCS']
+    unless nproc_override.nil? or nproc_override.size == 0
+      nproc = nproc_override
+    end
     make = bsd ? 'gmake' : 'make'
     system("#{make} -j#{nproc} -C #{grpc_root} #{grpc_lib_dir}/libgrpc.a CONFIG=#{grpc_config} Q=")
     exit 1 unless $? == 0


### PR DESCRIPTION
To fix https://github.com/grpc/grpc/issues/28244
