### PR TITLE
Add test for c-ares resolver error message propogation

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -354,7 +354,7 @@ void AresDnsResolver::OnResolvedLocked(grpc_error_handle error) {
     GRPC_CARES_TRACE_LOG("resolver:%p dns resolution failed: %s", this,
                          grpc_error_std_string(error).c_str());
     std::string error_message =
-        absl::StrCat("DNS resolution failed for service: ", name_to_resolve_);
+        absl::StrCat("DNS resolution failed for ", name_to_resolve_);
     result_handler_->ReturnError(grpc_error_set_int(
         GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(error_message.c_str(),
                                                          &error, 1),

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -279,13 +279,14 @@ void TestCancelDuringActiveQuery(
   int fake_dns_port = grpc_pick_unused_port_or_die();
   grpc::testing::FakeNonResponsiveDNSServer fake_dns_server(fake_dns_port);
   // Create a call that will try to use the fake DNS server
-  std::string client_target = absl::StrFormat(
-      "dns://[::1]:%d/dont-care-since-wont-be-resolved.test.com:1234",
-      fake_dns_port);
+  std::string name = "dont-care-since-wont-be-resolved.test.com:1234";
+  std::string client_target =
+      absl::StrFormat("dns://[::1]:%d/%s", fake_dns_port, name);
   gpr_log(GPR_DEBUG, "TestCancelActiveDNSQuery. query timeout setting: %d",
           query_timeout_setting);
   grpc_channel_args* client_args = nullptr;
   grpc_status_code expected_status_code = GRPC_STATUS_OK;
+  std::string expected_error_message_substring;
   gpr_timespec rpc_deadline;
   if (query_timeout_setting == NONE) {
     // The RPC deadline should go off well before the DNS resolution
@@ -298,6 +299,8 @@ void TestCancelDuringActiveQuery(
     // The DNS resolution timeout should fire well before the
     // RPC's deadline expires.
     expected_status_code = GRPC_STATUS_UNAVAILABLE;
+    expected_error_message_substring =
+        absl::StrCat("DNS resolution failed for ", name);
     grpc_arg arg;
     arg.type = GRPC_ARG_INTEGER;
     arg.key = const_cast<char*>(GRPC_ARG_DNS_ARES_QUERY_TIMEOUT_MS);
@@ -374,6 +377,8 @@ void TestCancelDuringActiveQuery(
   CQ_EXPECT_COMPLETION(cqv, Tag(1), 1);
   cq_verify(cqv);
   EXPECT_EQ(status, expected_status_code);
+  EXPECT_THAT(std::string(error_string),
+              testing::HasSubstr(expected_error_message_substring));
   // Teardown
   grpc_channel_args_destroy(client_args);
   grpc_slice_unref(details);


### PR DESCRIPTION
Seems useful considering changes around this code in https://github.com/grpc/grpc/pull/28091