### PR TITLE
Explicitly use python3 virtualenv in Ruby and PHP xDS interop setup scripts

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -23,8 +23,9 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 
+python3 -m pip install virtualenv
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV" -p python3
+python3 -m virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio-tools google-api-python-client google-auth-httplib2 oauth2client xds-protos

--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -23,8 +23,9 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 ${name}')
 cd /var/local/git/grpc
 
+python3 -m pip install virtualenv
 VIRTUAL_ENV=$(mktemp -d)
-virtualenv "$VIRTUAL_ENV" -p python3
+python3 -m virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
 "$PYTHON" -m pip install --upgrade grpcio-tools google-api-python-client google-auth-httplib2 oauth2client xds-protos


### PR DESCRIPTION
Very similar to https://github.com/grpc/grpc/pull/26953

[Ruby Manual run](https://sponge2.corp.google.com/fc814cf2-9a72-4c73-bb97-cec13f5f488b)
[PHP Manual Run](https://sponge2.corp.google.com/932fc9f6-61de-423b-ac09-518e0e207e54)