### PR TITLE
Add configuration for Grafana dashboard and Postgres replicator

### DIFF
--- a/tools/run_tests/performance/dashboard_config/cloudbuild.yaml
+++ b/tools/run_tests/performance/dashboard_config/cloudbuild.yaml
@@ -1,0 +1,36 @@
+steps:
+- name: 'ubuntu'
+  entrypoint: /bin/bash
+  args:
+    - -c
+    - |
+      apt-get update
+      apt-get install -y gettext-base git
+      pushd $_DASHBOARD_CONFIG_PATH
+      ./configure.sh
+  env:
+  - 'GCP_PROJECT_ID=$_GCP_PROJECT_ID'
+  - 'GCP_GRAFANA_SERVICE=$_GCP_GRAFANA_SERVICE'
+  - 'GCP_DATA_TRANSFER_SERVICE=$_GCP_DATA_TRANSFER_SERVICE'
+  - 'BQ_PROJECT_ID=$_BQ_PROJECT_ID'
+  - 'PG_USER=$_PG_USER'
+  - 'PG_DATABASE=$_PG_DATABASE'
+  - 'CLOUD_SQL_INSTANCE=$_CLOUD_SQL_INSTANCE'
+  secretEnv: ['GRAFANA_ADMIN_PASS', 'PG_PASS']
+
+# Deploy to App Engine
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: 'bash'
+  args:
+    - -c
+    - |
+      pushd $_DASHBOARD_CONFIG_PATH/$_DEPLOY_TARGET
+      gcloud config set app/cloud_build_timeout 1600 && gcloud app deploy
+  timeout: '1600s'
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/$PROJECT_ID/secrets/GRAFANA_ADMIN_PASS/versions/latest
+    env: GRAFANA_ADMIN_PASS
+  - versionName: projects/$PROJECT_ID/secrets/PG_PASS/versions/latest
+    env: PG_PASS

--- a/tools/run_tests/performance/dashboard_config/configure.sh
+++ b/tools/run_tests/performance/dashboard_config/configure.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -ex
+
+# check_env checks that all required environment variables are set
+check_env () {
+  env_vars=("$@")
+  missing_var=0
+  for var in "${env_vars[@]}"; do
+    if [ -z "${!var}" ]; then
+      echo "${var} not set"
+      missing_var=1
+    fi
+  done
+  return $missing_var
+}
+
+# substitute_env_in_files injects environment variables to files passed as
+# arguments
+substitute_env_in_files () {
+  files=("$@")
+  for file in "${files[@]}"; do
+    tmp=$(mktemp)
+    echo "Making substitutions in ${file}"
+    cp --attributes-only --preserve ${file} ${tmp}
+    cat ${file} | envsubst > $tmp && mv $tmp $file
+  done
+}
+
+# Check required environment variables
+check_env GCP_PROJECT_ID GCP_GRAFANA_SERVICE GCP_DATA_TRANSFER_SERVICE BQ_PROJECT_ID PG_USER PG_PASS PG_DATABASE GRAFANA_ADMIN_PASS CLOUD_SQL_INSTANCE || exit 1
+
+# Configure postgres replicator
+git clone --depth 1 https://github.com/grpc/test-infra
+mkdir postgres_replicator
+mv test-infra postgres_replicator
+cp postgres_replicator_config/* postgres_replicator
+
+# Configure grafana
+mkdir grafana
+cp -r grafana_config/* grafana
+
+# Substitute environment variables
+substitute_env_in_files \
+  "./grafana/app.yaml" \
+  "./postgres_replicator/app.yaml" \
+  "./postgres_replicator/replicator_config.yaml"

--- a/tools/run_tests/performance/dashboard_config/configure.sh
+++ b/tools/run_tests/performance/dashboard_config/configure.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -ex
 
@@ -22,8 +35,8 @@ substitute_env_in_files () {
   for file in "${files[@]}"; do
     tmp=$(mktemp)
     echo "Making substitutions in ${file}"
-    cp --attributes-only --preserve ${file} ${tmp}
-    cat ${file} | envsubst > $tmp && mv $tmp $file
+    cp --attributes-only --preserve "${file}" "${tmp}"
+    envsubst < "${file}" > "$tmp" && mv "$tmp" "$file"
   done
 }
 

--- a/tools/run_tests/performance/dashboard_config/grafana_config/Dockerfile
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/Dockerfile
@@ -1,0 +1,9 @@
+# DO NOT UPGRADE!
+# Grafana 7.5.5 is the last Apache-2.0 licensed version.
+# New versions are licensed under the AGPL, which is forbidden at Google.
+FROM grafana/grafana:7.5.5
+WORKDIR /app
+COPY provisioning /etc/grafana/provisioning
+COPY dashboards /var/lib/grafana/dashboards
+COPY grafana.ini /etc/grafana/grafana.ini
+EXPOSE 8080

--- a/tools/run_tests/performance/dashboard_config/grafana_config/Dockerfile
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # DO NOT UPGRADE!
 # Grafana 7.5.5 is the last Apache-2.0 licensed version.
 # New versions are licensed under the AGPL, which is forbidden at Google.

--- a/tools/run_tests/performance/dashboard_config/grafana_config/app.yaml
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/app.yaml
@@ -1,0 +1,20 @@
+runtime: custom
+env: flexible
+service: ${GCP_GRAFANA_SERVICE}
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 2
+resources:
+  cpu: 1
+  memory_gb: 1
+beta_settings:
+  cloud_sql_instances: ${CLOUD_SQL_INSTANCE}=tcp:5432
+liveness_check:
+  path: "/"
+readiness_check:
+  path: "/"
+env_variables:
+  PG_USER: ${PG_USER}
+  PG_PASS: ${PG_PASS}
+  PG_DATABASE: ${PG_DATABASE}
+  GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASS}

--- a/tools/run_tests/performance/dashboard_config/grafana_config/dashboards/home.json
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/dashboards/home.json
@@ -1,0 +1,4068 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Postgres",
+      "description": "Language comparison of unary ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone). Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_sync_unary_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_sync_to_async_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C#"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "palette-classic"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_unary_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "µs"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "hide": false,
+          "metricColumn": "none",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  (metadata->>'created')::timestamp AS time,\n  (scenario->>'name') AS metric,\n  MAX(CAST(summary->>'latency50' AS DOUBLE PRECISION) / 1000) as latency_us\nFROM\n ci_master_results_8core\nWHERE\n $__timeFilter(metadata->>'created') AND\n scenario->>'name' IN (\n   'java_protobuf_unary_ping_pong_secure',\n   'ruby_protobuf_unary_ping_pong',\n   'node_to_node_protobuf_async_unary_ping_pong_secure',\n   'node_purejs_to_node_protobuf_async_unary_ping_pong_secure',\n   'csharp_protobuf_sync_to_async_unary_ping_pong',\n   'cpp_protobuf_sync_unary_ping_pong_secure',\n   'go_protobuf_sync_unary_ping_pong_secure',\n   'python_protobuf_sync_unary_ping_pong',\n   'netperf_tcp_rr'\n )\n \n GROUP BY\n     time, metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "servercpuusage"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "metadata->>'created'",
+          "timeColumnType": "float8",
+          "where": [
+            {
+              "name": "$__unixEpochFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure ping pong median latency - Language comparison (in microsec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Language comparison of unary ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone) when running language-specific clients against a C++ server. Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_to_cpp_protobuf_sync_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_to_cpp_protobuf_sync_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_sync_unary_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_to_cpp_protobuf_sync_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C#"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "μs"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(CAST(summary->>'latency50' AS DOUBLE PRECISION) / 1000) as latency_us\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n    'csharp_to_cpp_protobuf_sync_unary_ping_pong',\n    'ruby_to_cpp_protobuf_sync_unary_ping_pong',\n    'cpp_protobuf_sync_unary_ping_pong_secure',\n    'python_to_cpp_protobuf_sync_unary_ping_pong',\n    'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_ping_pong',\n    'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_ping_pong',\n    'netperf_tcp_rr'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure ping pong median latency - Language-specific clients against C++ server (in microsec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Language comparison of streaming ping pong between two GKE nodes in the same cluster (each node resides on a separate VM, both VMs are located in the same compute zone) when running language-specific clients against a C++ server. Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C#"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP 7 (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_ping_pong"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "μs"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_ping_pong_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(CAST(summary->>'latency50' AS DOUBLE PRECISION) / 1000) as latency_us\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n    'cpp_protobuf_async_streaming_ping_pong_secure',\n    'csharp_protobuf_async_streaming_ping_pong',\n    'ruby_protobuf_sync_streaming_ping_pong',\n    'node_to_node_protobuf_async_streaming_ping_pong_secure',\n    'node_purejs_to_node_protobuf_async_streaming_ping_pong_secure',\n    'java_protobuf_async_streaming_ping_pong_secure',\n    'go_protobuf_sync_streaming_ping_pong_secure',\n    'python_protobuf_sync_streaming_ping_pong',\n    'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_ping_pong',\n    'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_ping_pong',\n    'netperf_tcp_rr'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure ping pong median latency (in microsec)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate 32core VM, both VMs are located in the same compute zone). Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "QPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 27
+      },
+      "id": 26,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MIN(ROUND(CAST(summary->>'qps' AS DOUBLE PRECISION))) as throughput_qps\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_qps_unconstrained_secure',\n     'java_protobuf_async_unary_qps_unconstrained_secure',\n     'csharp_protobuf_async_unary_qps_unconstrained',\n     'node_protobuf_unary_qps_unconstrained',\n     'ruby_protobuf_sync_unary_qps_unconstrained',\n     'python_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'go_protobuf_sync_unary_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure throughput QPS (8 core client to 8 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Server CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 27
+      },
+      "id": 13,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'serverSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'serverUserTime' AS DOUBLE PRECISION))) / 100 as server_cpu\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_qps_unconstrained_secure',\n     'java_protobuf_async_unary_qps_unconstrained_secure',\n     'csharp_protobuf_async_unary_qps_unconstrained',\n     'node_protobuf_unary_qps_unconstrained',\n     'ruby_protobuf_sync_unary_qps_unconstrained',\n     'python_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'go_protobuf_sync_unary_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure server CPU (8 core client to 8 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Client CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 27
+      },
+      "id": 14,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'clientSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'clientUserTime' AS DOUBLE PRECISION)) / 100) as client_cpu\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_qps_unconstrained_secure',\n     'java_protobuf_async_unary_qps_unconstrained_secure',\n     'csharp_protobuf_async_unary_qps_unconstrained',\n     'node_protobuf_unary_qps_unconstrained',\n     'ruby_protobuf_sync_unary_qps_unconstrained',\n     'python_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'go_protobuf_sync_unary_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure client CPU (8 core client to 8 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Throughput as streaming ping-pong operations per second between two GKE nodes in the same cluster (each node resides on a separate 8core VM, both VMs are located in the same compute zone). Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "QPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "id": 6,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MIN(ROUND(CAST(summary->>'qps' AS DOUBLE PRECISION))) as throughput_qps\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_streaming_qps_unconstrained_secure',\n     'java_protobuf_async_streaming_qps_unconstrained_secure',\n     'csharp_protobuf_async_streaming_qps_unconstrained',\n     'node_protobuf_streaming_qps_unconstrained',\n     'ruby_protobuf_sync_streaming_qps_unconstrained',\n     'python_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'go_protobuf_sync_streaming_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure throughput QPS (8 core client to 8 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Server CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "id": 19,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'serverSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'serverUserTime' AS DOUBLE PRECISION))) / 100 as server_cpu\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_streaming_qps_unconstrained_secure',\n     'java_protobuf_async_streaming_qps_unconstrained_secure',\n     'csharp_protobuf_async_streaming_qps_unconstrained',\n     'node_protobuf_streaming_qps_unconstrained',\n     'ruby_protobuf_sync_streaming_qps_unconstrained',\n     'python_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'go_protobuf_sync_streaming_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure server CPU (8 core client to 8 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Client CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 36
+      },
+      "id": 20,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'clientSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'clientUserTime' AS DOUBLE PRECISION)) / 100) as client_cpu\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_streaming_qps_unconstrained_secure',\n     'java_protobuf_async_streaming_qps_unconstrained_secure',\n     'csharp_protobuf_async_streaming_qps_unconstrained',\n     'node_protobuf_streaming_qps_unconstrained',\n     'ruby_protobuf_sync_streaming_qps_unconstrained',\n     'python_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'go_protobuf_sync_streaming_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure client CPU (8 core client to 8 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate 32core VM, both VMs are located in the same compute zone). Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "QPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 15,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MIN(ROUND(CAST(summary->>'qps' AS DOUBLE PRECISION))) as throughput_qps\nFROM ci_master_results_32core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_qps_unconstrained_secure',\n     'java_protobuf_async_unary_qps_unconstrained_secure',\n     'csharp_protobuf_async_unary_qps_unconstrained',\n     'node_protobuf_unary_qps_unconstrained',\n     'ruby_protobuf_sync_unary_qps_unconstrained',\n     'python_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'go_protobuf_sync_unary_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure throughput QPS (32 core client to 32 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Server CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 21,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'serverSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'serverUserTime' AS DOUBLE PRECISION))) / 100 as server_cpu\nFROM ci_master_results_32core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_qps_unconstrained_secure',\n     'java_protobuf_async_unary_qps_unconstrained_secure',\n     'csharp_protobuf_async_unary_qps_unconstrained',\n     'node_protobuf_unary_qps_unconstrained',\n     'ruby_protobuf_sync_unary_qps_unconstrained',\n     'python_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'go_protobuf_sync_unary_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure server CPU (32 core client to 32 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Client CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 17,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'clientSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'clientUserTime' AS DOUBLE PRECISION)) / 100) as client_cpu\nFROM ci_master_results_32core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_qps_unconstrained_secure',\n     'java_protobuf_async_unary_qps_unconstrained_secure',\n     'csharp_protobuf_async_unary_qps_unconstrained',\n     'node_protobuf_unary_qps_unconstrained',\n     'ruby_protobuf_sync_unary_qps_unconstrained',\n     'python_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained',\n     'go_protobuf_sync_unary_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure client CPU (32 core client to 32 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Throughput as streaming ping-pong operations per second between two GKE nodes in the same cluster (each node resides on a separate 32core VM, both VMs are located in the same compute zone). Secure connection is used.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "QPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 22,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MIN(ROUND(CAST(summary->>'qps' AS DOUBLE PRECISION))) as throughput_qps\nFROM ci_master_results_32core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_streaming_qps_unconstrained_secure',\n     'java_protobuf_async_streaming_qps_unconstrained_secure',\n     'csharp_protobuf_async_streaming_qps_unconstrained',\n     'node_protobuf_streaming_qps_unconstrained',\n     'ruby_protobuf_sync_streaming_qps_unconstrained',\n     'python_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'go_protobuf_sync_streaming_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure throughput QPS (32 core client to 32 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Server CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 23,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'serverSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'serverUserTime' AS DOUBLE PRECISION))) / 100 as server_cpu\nFROM ci_master_results_32core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_streaming_qps_unconstrained_secure',\n     'java_protobuf_async_streaming_qps_unconstrained_secure',\n     'csharp_protobuf_async_streaming_qps_unconstrained',\n     'node_protobuf_streaming_qps_unconstrained',\n     'ruby_protobuf_sync_streaming_qps_unconstrained',\n     'python_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'go_protobuf_sync_streaming_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure server CPU (32 core client to 32 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Client CPU",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_streaming_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_streaming_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "id": 24,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MAX(ROUND(CAST(summary->>'clientSystemTime' AS DOUBLE PRECISION) + CAST(summary->>'clientUserTime' AS DOUBLE PRECISION)) / 100) as client_cpu\nFROM ci_master_results_32core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_streaming_qps_unconstrained_secure',\n     'java_protobuf_async_streaming_qps_unconstrained_secure',\n     'csharp_protobuf_async_streaming_qps_unconstrained',\n     'node_protobuf_streaming_qps_unconstrained',\n     'ruby_protobuf_sync_streaming_qps_unconstrained',\n     'python_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_c_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'php7_protobuf_php_extension_to_cpp_protobuf_sync_streaming_qps_unconstrained',\n     'go_protobuf_sync_streaming_qps_unconstrained_secure'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Streaming secure client CPU (32 core client to 32 core server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Postgres",
+      "description": "Throughput as number of unary RPCs per second between two GKE nodes in the same cluster (each node resides on a separate VM, but both VMs are located in the same compute zone). Secure connection is used. Both request & response are 1MB large.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "QPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "python_protobuf_sync_unary_ping_pong_1MB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Python"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ruby_protobuf_unary_ping_pong_1MB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Ruby"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_php_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf php)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "php7_protobuf_c_extension_to_cpp_protobuf_sync_unary_qps_unconstrained"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "PHP Sync (protobuf c)"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cpp_protobuf_async_unary_ping_pong_secure_1MB"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "C++"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "go_protobuf_sync_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Go"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#67cfde",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "java_protobuf_async_unary_qps_unconstrained_secure"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Java"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "csharp_protobuf_async_unary_ping_pong_1MB"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "C#"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 25,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right"
+        },
+        "tooltipOptions": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "7.5.5",
+      "targets": [
+        {
+          "format": "time_series",
+          "group": [],
+          "metricColumn": "scenario",
+          "queryType": "randomWalk",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    (metadata->>'created')::timestamp AS \"time\",\n    scenario->>'name' as metric,\n    MIN(ROUND(CAST(summary->>'qps' AS DOUBLE PRECISION))) as throughput_qps\nFROM ci_master_results_8core\nWHERE\n  $__timeFilter(metadata->>'created') AND\n  scenario->>'name' IN (\n     'cpp_protobuf_async_unary_ping_pong_secure_1MB',\n     'csharp_protobuf_async_unary_ping_pong_1MB',\n     'python_protobuf_sync_unary_ping_pong_1MB',\n     'ruby_protobuf_unary_ping_pong_1MB',\n     'node_protobuf_unary_ping_pong_1MB'\n  )\n\nGROUP BY\n  \"time\", metric;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "ci_master_results_8core",
+          "timeColumn": "date",
+          "timeColumnType": "timestamptz",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unary secure throughput QPS (8 core client to 8 core server)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-14d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "gRPC Performance Multi-language on GKE (@upstream/master)",
+  "uid": "18sWlbd7z",
+  "version": 3
+}

--- a/tools/run_tests/performance/dashboard_config/grafana_config/grafana.ini
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/grafana.ini
@@ -1,0 +1,22 @@
+[server]
+http_port = 8080
+
+[users]
+allow_sign_up = false
+allow_org_create = false
+default_theme = dark
+
+[security]
+admin_user = admin
+
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Viewer
+
+[auth.basic]
+enabled = false
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/home.json
+

--- a/tools/run_tests/performance/dashboard_config/grafana_config/provisioning/dashboards/default_provider_config.yaml
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/provisioning/dashboards/default_provider_config.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+- name: default
+  orgId: 1
+  folder: ''
+  folderUid: ''
+  type: file
+  disableDeletion: true
+  updateIntervalSeconds: 30
+  allowUIUpdates: true
+  options:
+    path: /var/lib/grafana/dashboards
+    foldersFromFilesStructure: true

--- a/tools/run_tests/performance/dashboard_config/grafana_config/provisioning/datasources/postgres_config.yaml
+++ b/tools/run_tests/performance/dashboard_config/grafana_config/provisioning/datasources/postgres_config.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Postgres
+    type: postgres
+    url: 172.17.0.1:5432
+    database: ${PG_DATABASE}
+    user: ${PG_USER}
+    secureJsonData:
+      password: ${PG_PASS}
+    jsonData:
+      sslmode: 'disable' # disable/require/verify-ca/verify-full
+      maxOpenConns: 0 # Grafana v5.4+
+      maxIdleConns: 2 # Grafana v5.4+
+      connMaxLifetime: 14400 # Grafana v5.4+
+      postgresVersion: 1200 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
+      timescaledb: false

--- a/tools/run_tests/performance/dashboard_config/postgres_replicator_config/Dockerfile
+++ b/tools/run_tests/performance/dashboard_config/postgres_replicator_config/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # syntax=docker/dockerfile:1
 
 FROM golang:1.16-alpine

--- a/tools/run_tests/performance/dashboard_config/postgres_replicator_config/Dockerfile
+++ b/tools/run_tests/performance/dashboard_config/postgres_replicator_config/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.16-alpine
+WORKDIR /app
+
+# Copy config
+COPY replicator_config.yaml ./
+COPY test-infra ./test-infra
+
+RUN cd test-infra \
+    && go mod download \
+    && go build -o /postgres_replicator cmd/postgres_replicator/main.go
+RUN rm -rf test-infra
+
+
+EXPOSE 8080
+CMD [ "/postgres_replicator", "-c", "replicator_config.yaml" ]

--- a/tools/run_tests/performance/dashboard_config/postgres_replicator_config/app.yaml
+++ b/tools/run_tests/performance/dashboard_config/postgres_replicator_config/app.yaml
@@ -1,0 +1,17 @@
+runtime: custom
+env: flexible
+service: ${GCP_DATA_TRANSFER_SERVICE}
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 1
+resources:
+  cpu: 1
+  memory_gb: 1
+beta_settings:
+  cloud_sql_instances: ${CLOUD_SQL_INSTANCE}=tcp:5432
+liveness_check:
+  path: "/"
+readiness_check:
+  path: "/"
+env_variables:
+  PG_PASS: ${PG_PASS}

--- a/tools/run_tests/performance/dashboard_config/postgres_replicator_config/replicator_config.yaml
+++ b/tools/run_tests/performance/dashboard_config/postgres_replicator_config/replicator_config.yaml
@@ -1,0 +1,18 @@
+bigQuery:
+  projectID: ${BQ_PROJECT_ID}
+
+postgres:
+  dbHost: 172.17.0.1
+  dbPort: 5432
+  dbUser: ${PG_USER}
+  dbPass:
+  dbName: ${PG_DATABASE}
+
+transfer:
+  datasets:
+  - name: e2e_benchmarks
+    tables:
+      - name: ci_master_results_8core
+        dateField: metadata.created
+      - name: ci_master_results_32core
+        dateField: metadata.created


### PR DESCRIPTION
The code here will configure the Postgres replicator from test-infra (PR https://github.com/grpc/test-infra/pull/244) and a Grafana instance. Secrets are pulled from the GCP secret manager and passed to the container as environment variables.