### PR TITLE
Add python3 to list of acceptable pythons in python wrapper

### DIFF
--- a/test/core/http/test_server.py
+++ b/test/core/http/test_server.py
@@ -27,7 +27,7 @@ _PEM = os.path.abspath(
 _KEY = os.path.abspath(
     os.path.join(os.path.dirname(sys.argv[0]), '../../..',
                  'src/core/tsi/test_creds/server1.key'))
-print _PEM
+print(_PEM)
 open(_PEM).close()
 
 argp = argparse.ArgumentParser(description='Server for httpcli_test')
@@ -35,7 +35,7 @@ argp.add_argument('-p', '--port', default=10080, type=int)
 argp.add_argument('-s', '--ssl', default=False, action='store_true')
 args = argp.parse_args()
 
-print 'server running on port %d' % args.port
+print('server running on port %d' % args.port)
 
 
 class Handler(BaseHTTPServer.BaseHTTPRequestHandler):

--- a/test/core/http/test_server.py
+++ b/test/core/http/test_server.py
@@ -16,10 +16,12 @@
 
 import argparse
 import os
+import six
 import ssl
 import sys
 
-import BaseHTTPServer
+from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
+from six.moves.BaseHTTPServer import HTTPServer
 
 _PEM = os.path.abspath(
     os.path.join(os.path.dirname(sys.argv[0]), '../../..',
@@ -38,7 +40,7 @@ args = argp.parse_args()
 print('server running on port %d' % args.port)
 
 
-class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+class Handler(BaseHTTPRequestHandler):
 
     def good(self):
         self.send_response(200)
@@ -57,7 +59,7 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.good()
 
 
-httpd = BaseHTTPServer.HTTPServer(('localhost', args.port), Handler)
+httpd = HTTPServer(('localhost', args.port), Handler)
 if args.ssl:
     httpd.socket = ssl.wrap_socket(httpd.socket,
                                    certfile=_PEM,

--- a/tools/distrib/python_wrapper.sh
+++ b/tools/distrib/python_wrapper.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-for p in python2.7 python2.6 python2 python not_found ; do 
+for p in python3 python2.7 python2.6 python2 python not_found ; do
 
   python=$(which $p || echo not_found)
 


### PR DESCRIPTION
This is an attempt to fix fix httpcli portability tests which have been failing continuously since what appears to be https://github.com/grpc/grpc/pull/28010/files, with example log: https://source.cloud.google.com/results/invocations/34f2174c-5660-4f37-9414-a7b0b75c43e1/targets/github%2Fgrpc%2Frun_tests%2Fc_linux_dbg_native_x64_gcc11/tests

b/209014236