### PR TITLE
Fix #28147

### DIFF
--- a/src/core/ext/xds/xds_common_types.h
+++ b/src/core/ext/xds/xds_common_types.h
@@ -36,7 +36,7 @@ struct Duration {
   int64_t seconds = 0;
   int32_t nanos = 0;
 
-  Duration() = default;
+  Duration() : seconds(0), nanos(0) {}
 
   bool operator==(const Duration& other) const {
     return seconds == other.seconds && nanos == other.nanos;

--- a/src/core/ext/xds/xds_common_types.h
+++ b/src/core/ext/xds/xds_common_types.h
@@ -33,8 +33,8 @@
 namespace grpc_core {
 
 struct Duration {
-  int64_t seconds = 0;
-  int32_t nanos = 0;
+  int64_t seconds;
+  int32_t nanos;
 
   Duration() : seconds(0), nanos(0) {}
 


### PR DESCRIPTION
According to my test and https://stackoverflow.com/questions/53408962/try-to-understand-compiler-error-message-default-member-initializer-required-be , `Duration() = default;` can not solve #28147

@drfloob
