### PR TITLE
Replace C2P resolver env var with experimental scheme suffix

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -362,20 +362,15 @@ class GoogleCloud2ProdResolverFactory : public ResolverFactory {
     return MakeOrphanable<GoogleCloud2ProdResolver>(std::move(args));
   }
 
-  const char* scheme() const override { return "google-c2p"; }
+  // TODO(roth): Remove experimental suffix once this code is proven stable.
+  const char* scheme() const override { return "google-c2p-experimental"; }
 };
 
 }  // namespace
 
 void GoogleCloud2ProdResolverInit() {
-  // TODO(roth): Remove env var protection once this code is proven stable.
-  UniquePtr<char> value(gpr_getenv("GRPC_EXPERIMENTAL_GOOGLE_C2P_RESOLVER"));
-  bool parsed_value;
-  bool parse_succeeded = gpr_parse_bool_value(value.get(), &parsed_value);
-  if (parse_succeeded && parsed_value) {
-    ResolverRegistry::Builder::RegisterResolverFactory(
-        absl::make_unique<GoogleCloud2ProdResolverFactory>());
-  }
+  ResolverRegistry::Builder::RegisterResolverFactory(
+      absl::make_unique<GoogleCloud2ProdResolverFactory>());
 }
 
 void GoogleCloud2ProdResolverShutdown() {}


### PR DESCRIPTION
To make it easier to opt into the c2p resolver from library code