### PR TITLE
Revert "XdsClient: remove resource-type-specific methods from XdsClient API"

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc
@@ -30,7 +30,6 @@
 #include "src/core/ext/filters/client_channel/lb_policy_registry.h"
 #include "src/core/ext/xds/xds_client.h"
 #include "src/core/ext/xds/xds_client_stats.h"
-#include "src/core/ext/xds/xds_endpoint.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/env.h"
 #include "src/core/lib/gpr/string.h"

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -39,7 +39,6 @@
 #include "src/core/ext/xds/xds_channel_args.h"
 #include "src/core/ext/xds/xds_client.h"
 #include "src/core/ext/xds/xds_client_stats.h"
-#include "src/core/ext/xds/xds_endpoint.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/orphanable.h"
@@ -166,7 +165,7 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
     bool disable_reresolution() override { return true; }
 
    private:
-    class EndpointWatcher : public XdsEndpointResourceType::WatcherInterface {
+    class EndpointWatcher : public XdsClient::EndpointWatcherInterface {
      public:
       explicit EndpointWatcher(
           RefCountedPtr<EdsDiscoveryMechanism> discovery_mechanism)
@@ -415,8 +414,8 @@ void XdsClusterResolverLb::EdsDiscoveryMechanism::Start() {
   auto watcher = MakeRefCounted<EndpointWatcher>(
       Ref(DEBUG_LOCATION, "EdsDiscoveryMechanism"));
   watcher_ = watcher.get();
-  XdsEndpointResourceType::StartWatch(parent()->xds_client_.get(),
-                                      GetEdsResourceName(), std::move(watcher));
+  parent()->xds_client_->WatchEndpointData(GetEdsResourceName(),
+                                           std::move(watcher));
 }
 
 void XdsClusterResolverLb::EdsDiscoveryMechanism::Orphan() {
@@ -426,8 +425,8 @@ void XdsClusterResolverLb::EdsDiscoveryMechanism::Orphan() {
             ":%p cancelling xds watch for %s",
             parent(), index(), this, std::string(GetEdsResourceName()).c_str());
   }
-  XdsEndpointResourceType::CancelWatch(parent()->xds_client_.get(),
-                                       GetEdsResourceName(), watcher_);
+  parent()->xds_client_->CancelEndpointDataWatch(GetEdsResourceName(),
+                                                 watcher_);
   Unref();
 }
 

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -37,10 +37,7 @@
 #include "src/core/ext/xds/xds_bootstrap.h"
 #include "src/core/ext/xds/xds_channel_args.h"
 #include "src/core/ext/xds/xds_client_stats.h"
-#include "src/core/ext/xds/xds_cluster.h"
-#include "src/core/ext/xds/xds_endpoint.h"
 #include "src/core/ext/xds/xds_http_filters.h"
-#include "src/core/ext/xds/xds_listener.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/backoff/backoff.h"
 #include "src/core/lib/channel/channel_args.h"
@@ -78,6 +75,11 @@ Mutex* g_mu = nullptr;
 const grpc_channel_args* g_channel_args ABSL_GUARDED_BY(*g_mu) = nullptr;
 XdsClient* g_xds_client ABSL_GUARDED_BY(*g_mu) = nullptr;
 char* g_fallback_bootstrap_config ABSL_GUARDED_BY(*g_mu) = nullptr;
+
+const char* kLdsTypeUrl = "envoy.config.listener.v3.Listener";
+const char* kRdsTypeUrl = "envoy.config.route.v3.RouteConfiguration";
+const char* kCdsTypeUrl = "envoy.config.cluster.v3.Cluster";
+const char* kEdsTypeUrl = "envoy.config.endpoint.v3.ClusterLoadAssignment";
 
 }  // namespace
 
@@ -1922,6 +1924,66 @@ void XdsClient::CancelResourceWatch(const XdsResourceType* type,
   }
 }
 
+void XdsClient::WatchListenerData(
+    absl::string_view listener_name,
+    RefCountedPtr<ListenerWatcherInterface> watcher) {
+  WatchResource(XdsResourceTypeRegistry::GetOrCreate()->GetType(kLdsTypeUrl),
+                listener_name, std::move(watcher));
+}
+
+void XdsClient::CancelListenerDataWatch(absl::string_view listener_name,
+                                        ListenerWatcherInterface* watcher,
+                                        bool delay_unsubscription) {
+  CancelResourceWatch(
+      XdsResourceTypeRegistry::GetOrCreate()->GetType(kLdsTypeUrl),
+      listener_name, watcher, delay_unsubscription);
+}
+
+void XdsClient::WatchRouteConfigData(
+    absl::string_view route_config_name,
+    RefCountedPtr<RouteConfigWatcherInterface> watcher) {
+  WatchResource(XdsResourceTypeRegistry::GetOrCreate()->GetType(kRdsTypeUrl),
+                route_config_name, std::move(watcher));
+}
+
+void XdsClient::CancelRouteConfigDataWatch(absl::string_view route_config_name,
+                                           RouteConfigWatcherInterface* watcher,
+                                           bool delay_unsubscription) {
+  CancelResourceWatch(
+      XdsResourceTypeRegistry::GetOrCreate()->GetType(kRdsTypeUrl),
+      route_config_name, watcher, delay_unsubscription);
+}
+
+void XdsClient::WatchClusterData(
+    absl::string_view cluster_name,
+    RefCountedPtr<ClusterWatcherInterface> watcher) {
+  WatchResource(XdsResourceTypeRegistry::GetOrCreate()->GetType(kCdsTypeUrl),
+                cluster_name, std::move(watcher));
+}
+
+void XdsClient::CancelClusterDataWatch(absl::string_view cluster_name,
+                                       ClusterWatcherInterface* watcher,
+                                       bool delay_unsubscription) {
+  CancelResourceWatch(
+      XdsResourceTypeRegistry::GetOrCreate()->GetType(kCdsTypeUrl),
+      cluster_name, watcher, delay_unsubscription);
+}
+
+void XdsClient::WatchEndpointData(
+    absl::string_view eds_service_name,
+    RefCountedPtr<EndpointWatcherInterface> watcher) {
+  WatchResource(XdsResourceTypeRegistry::GetOrCreate()->GetType(kEdsTypeUrl),
+                eds_service_name, std::move(watcher));
+}
+
+void XdsClient::CancelEndpointDataWatch(absl::string_view eds_service_name,
+                                        EndpointWatcherInterface* watcher,
+                                        bool delay_unsubscription) {
+  CancelResourceWatch(
+      XdsResourceTypeRegistry::GetOrCreate()->GetType(kEdsTypeUrl),
+      eds_service_name, watcher, delay_unsubscription);
+}
+
 absl::StatusOr<XdsClient::XdsResourceName> XdsClient::ParseXdsResourceName(
     absl::string_view name, const XdsResourceType* type) {
   // Old-style names use the empty string for authority.
@@ -1988,8 +2050,9 @@ RefCountedPtr<XdsClusterDropStats> XdsClient::AddClusterDropStats(
         it->first.second /*eds_service_name*/);
     load_report_state.drop_stats = cluster_drop_stats.get();
   }
-  auto resource_name =
-      ParseXdsResourceName(cluster_name, XdsClusterResourceType::Get());
+  auto resource_name = ParseXdsResourceName(
+      cluster_name,
+      XdsResourceTypeRegistry::GetOrCreate()->GetType(kCdsTypeUrl));
   GPR_ASSERT(resource_name.ok());
   auto a = authority_state_map_.find(resource_name->authority);
   if (a != authority_state_map_.end()) {
@@ -2051,8 +2114,9 @@ RefCountedPtr<XdsClusterLocalityStats> XdsClient::AddClusterLocalityStats(
         std::move(locality));
     locality_state.locality_stats = cluster_locality_stats.get();
   }
-  auto resource_name =
-      ParseXdsResourceName(cluster_name, XdsClusterResourceType::Get());
+  auto resource_name = ParseXdsResourceName(
+      cluster_name,
+      XdsResourceTypeRegistry::GetOrCreate()->GetType(kCdsTypeUrl));
   GPR_ASSERT(resource_name.ok());
   auto a = authority_state_map_.find(resource_name->authority);
   if (a != authority_state_map_.end()) {
@@ -2221,9 +2285,23 @@ std::string XdsClient::DumpClientConfigBinary() {
 // accessors for global state
 //
 
+namespace {
+
+void InitResourceTypeRegistry() {
+  auto* registry = XdsResourceTypeRegistry::GetOrCreate();
+  registry->RegisterType(absl::make_unique<XdsListenerResourceType>());
+  registry->RegisterType(absl::make_unique<XdsRouteConfigResourceType>());
+  registry->RegisterType(absl::make_unique<XdsClusterResourceType>());
+  registry->RegisterType(absl::make_unique<XdsEndpointResourceType>());
+}
+
+}  // namespace
+
 void XdsClientGlobalInit() {
   g_mu = new Mutex;
   XdsHttpFilterRegistry::Init();
+  static gpr_once once = GPR_ONCE_INIT;
+  gpr_once_init(&once, InitResourceTypeRegistry);
 }
 
 // TODO(roth): Find a better way to clear the fallback config that does

--- a/src/core/ext/xds/xds_cluster.h
+++ b/src/core/ext/xds/xds_cluster.h
@@ -27,7 +27,6 @@
 #include "envoy/extensions/clusters/aggregate/v3/cluster.upbdefs.h"
 #include "envoy/extensions/transport_sockets/tls/v3/tls.upbdefs.h"
 
-#include "src/core/ext/xds/xds_client.h"
 #include "src/core/ext/xds/xds_common_types.h"
 #include "src/core/ext/xds/xds_resource_type.h"
 
@@ -88,43 +87,11 @@ class XdsClusterResourceType : public XdsResourceType {
     XdsClusterResource resource;
   };
 
-  class WatcherInterface : public XdsClient::ResourceWatcherInterface {
-   public:
-    virtual void OnClusterChanged(XdsClusterResource cluster_data) = 0;
-
-   private:
-    void OnResourceChanged(
-        const XdsResourceType::ResourceData* resource) override {
-      OnClusterChanged(
-          static_cast<const XdsClusterResourceType::ClusterData*>(resource)
-              ->resource);
-    }
-  };
-
-  static const XdsClusterResourceType* Get() {
-    static const XdsClusterResourceType* g_instance =
-        new XdsClusterResourceType();
-    return g_instance;
-  }
-
   absl::string_view type_url() const override {
     return "envoy.config.cluster.v3.Cluster";
   }
   absl::string_view v2_type_url() const override {
     return "envoy.api.v2.Cluster";
-  }
-
-  static void StartWatch(XdsClient* xds_client, absl::string_view resource_name,
-                         RefCountedPtr<WatcherInterface> watcher) {
-    xds_client->WatchResource(Get(), resource_name, std::move(watcher));
-  }
-
-  static void CancelWatch(XdsClient* xds_client,
-                          absl::string_view resource_name,
-                          WatcherInterface* watcher,
-                          bool delay_unsubscription = false) {
-    xds_client->CancelResourceWatch(Get(), resource_name, watcher,
-                                    delay_unsubscription);
   }
 
   absl::StatusOr<DecodeResult> Decode(const XdsEncodingContext& context,
@@ -152,11 +119,6 @@ class XdsClusterResourceType : public XdsResourceType {
     envoy_extensions_clusters_aggregate_v3_ClusterConfig_getmsgdef(symtab);
     envoy_extensions_transport_sockets_tls_v3_UpstreamTlsContext_getmsgdef(
         symtab);
-  }
-
- private:
-  XdsClusterResourceType() {
-    XdsResourceTypeRegistry::GetOrCreate()->RegisterType(this);
   }
 };
 

--- a/src/core/ext/xds/xds_endpoint.h
+++ b/src/core/ext/xds/xds_endpoint.h
@@ -27,7 +27,6 @@
 #include "envoy/config/endpoint/v3/endpoint.upbdefs.h"
 
 #include "src/core/ext/filters/client_channel/server_address.h"
-#include "src/core/ext/xds/xds_client.h"
 #include "src/core/ext/xds/xds_client_stats.h"
 #include "src/core/ext/xds/xds_resource_type.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
@@ -117,43 +116,11 @@ class XdsEndpointResourceType : public XdsResourceType {
     XdsEndpointResource resource;
   };
 
-  class WatcherInterface : public XdsClient::ResourceWatcherInterface {
-   public:
-    virtual void OnEndpointChanged(XdsEndpointResource update) = 0;
-
-   private:
-    void OnResourceChanged(
-        const XdsResourceType::ResourceData* resource) override {
-      OnEndpointChanged(
-          static_cast<const XdsEndpointResourceType::EndpointData*>(resource)
-              ->resource);
-    }
-  };
-
-  static const XdsEndpointResourceType* Get() {
-    static const XdsEndpointResourceType* g_instance =
-        new XdsEndpointResourceType();
-    return g_instance;
-  }
-
   absl::string_view type_url() const override {
     return "envoy.config.endpoint.v3.ClusterLoadAssignment";
   }
   absl::string_view v2_type_url() const override {
     return "envoy.api.v2.ClusterLoadAssignment";
-  }
-
-  static void StartWatch(XdsClient* xds_client, absl::string_view resource_name,
-                         RefCountedPtr<WatcherInterface> watcher) {
-    xds_client->WatchResource(Get(), resource_name, std::move(watcher));
-  }
-
-  static void CancelWatch(XdsClient* xds_client,
-                          absl::string_view resource_name,
-                          WatcherInterface* watcher,
-                          bool delay_unsubscription = false) {
-    xds_client->CancelResourceWatch(Get(), resource_name, watcher,
-                                    delay_unsubscription);
   }
 
   absl::StatusOr<DecodeResult> Decode(const XdsEncodingContext& context,
@@ -176,11 +143,6 @@ class XdsEndpointResourceType : public XdsResourceType {
 
   void InitUpbSymtab(upb_symtab* symtab) const override {
     envoy_config_endpoint_v3_ClusterLoadAssignment_getmsgdef(symtab);
-  }
-
- private:
-  XdsEndpointResourceType() {
-    XdsResourceTypeRegistry::GetOrCreate()->RegisterType(this);
   }
 };
 

--- a/src/core/ext/xds/xds_listener.h
+++ b/src/core/ext/xds/xds_listener.h
@@ -30,7 +30,6 @@
 #include "envoy/config/listener/v3/listener.upbdefs.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.upbdefs.h"
 
-#include "src/core/ext/xds/xds_client.h"
 #include "src/core/ext/xds/xds_common_types.h"
 #include "src/core/ext/xds/xds_http_filters.h"
 #include "src/core/ext/xds/xds_route_config.h"
@@ -196,43 +195,11 @@ class XdsListenerResourceType : public XdsResourceType {
     XdsListenerResource resource;
   };
 
-  class WatcherInterface : public XdsClient::ResourceWatcherInterface {
-   public:
-    virtual void OnListenerChanged(XdsListenerResource listener) = 0;
-
-   private:
-    void OnResourceChanged(
-        const XdsResourceType::ResourceData* resource) override {
-      OnListenerChanged(
-          static_cast<const XdsListenerResourceType::ListenerData*>(resource)
-              ->resource);
-    }
-  };
-
-  static const XdsListenerResourceType* Get() {
-    static const XdsListenerResourceType* g_instance =
-        new XdsListenerResourceType();
-    return g_instance;
-  }
-
   absl::string_view type_url() const override {
     return "envoy.config.listener.v3.Listener";
   }
   absl::string_view v2_type_url() const override {
     return "envoy.api.v2.Listener";
-  }
-
-  static void StartWatch(XdsClient* xds_client, absl::string_view resource_name,
-                         RefCountedPtr<WatcherInterface> watcher) {
-    xds_client->WatchResource(Get(), resource_name, std::move(watcher));
-  }
-
-  static void CancelWatch(XdsClient* xds_client,
-                          absl::string_view resource_name,
-                          WatcherInterface* watcher,
-                          bool delay_unsubscription = false) {
-    xds_client->CancelResourceWatch(Get(), resource_name, watcher,
-                                    delay_unsubscription);
   }
 
   absl::StatusOr<DecodeResult> Decode(const XdsEncodingContext& context,
@@ -260,11 +227,6 @@ class XdsListenerResourceType : public XdsResourceType {
     envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_getmsgdef(
         symtab);
     XdsHttpFilterRegistry::PopulateSymtab(symtab);
-  }
-
- private:
-  XdsListenerResourceType() {
-    XdsResourceTypeRegistry::GetOrCreate()->RegisterType(this);
   }
 };
 

--- a/src/core/ext/xds/xds_resource_type.cc
+++ b/src/core/ext/xds/xds_resource_type.cc
@@ -45,26 +45,26 @@ XdsResourceTypeRegistry* XdsResourceTypeRegistry::GetOrCreate() {
 const XdsResourceType* XdsResourceTypeRegistry::GetType(
     absl::string_view resource_type) {
   auto it = resource_types_.find(resource_type);
-  if (it != resource_types_.end()) return it->second;
+  if (it != resource_types_.end()) return it->second.get();
   auto it2 = v2_resource_types_.find(resource_type);
   if (it2 != v2_resource_types_.end()) return it2->second;
   return nullptr;
 }
 
 void XdsResourceTypeRegistry::RegisterType(
-    const XdsResourceType* resource_type) {
+    std::unique_ptr<XdsResourceType> resource_type) {
   GPR_ASSERT(resource_types_.find(resource_type->type_url()) ==
              resource_types_.end());
   GPR_ASSERT(v2_resource_types_.find(resource_type->v2_type_url()) ==
              v2_resource_types_.end());
-  v2_resource_types_.emplace(resource_type->v2_type_url(), resource_type);
-  resource_types_.emplace(resource_type->type_url(), resource_type);
+  v2_resource_types_.emplace(resource_type->v2_type_url(), resource_type.get());
+  resource_types_.emplace(resource_type->type_url(), std::move(resource_type));
 }
 
 void XdsResourceTypeRegistry::ForEach(
     std::function<void(const XdsResourceType*)> func) {
   for (const auto& p : resource_types_) {
-    func(p.second);
+    func(p.second.get());
   }
 }
 

--- a/src/core/ext/xds/xds_resource_type.h
+++ b/src/core/ext/xds/xds_resource_type.h
@@ -105,15 +105,16 @@ class XdsResourceTypeRegistry {
 
   // Registers a resource type.
   // All types must be registered before they can be used in the XdsClient.
-  void RegisterType(const XdsResourceType* resource_type);
+  void RegisterType(std::unique_ptr<XdsResourceType> resource_type);
 
   // Calls func for each resource type.
   void ForEach(std::function<void(const XdsResourceType*)> func);
 
  private:
-  std::map<absl::string_view /*resource_type*/, const XdsResourceType*>
+  std::map<absl::string_view /*resource_type*/,
+           std::unique_ptr<XdsResourceType>>
       resource_types_;
-  std::map<absl::string_view /*v2_resource_type*/, const XdsResourceType*>
+  std::map<absl::string_view /*v2_resource_type*/, XdsResourceType*>
       v2_resource_types_;
 };
 

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -64,7 +64,6 @@
 #include "src/core/ext/xds/xds_api.h"
 #include "src/core/ext/xds/xds_channel_args.h"
 #include "src/core/ext/xds/xds_client.h"
-#include "src/core/ext/xds/xds_listener.h"
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/env.h"


### PR DESCRIPTION
Reverts grpc/grpc#28231 due to internal TSAN failure.