### PR TITLE
pin rake compiler to 1.1.1

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
-  s.add_development_dependency 'rake-compiler',      '~> 1.1'
+  s.add_development_dependency 'rake-compiler',      '== 1.1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
-  s.add_development_dependency 'rake-compiler',      '== 1.1.1'
+  s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -42,7 +42,7 @@
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'
     s.add_development_dependency 'rake',               '~> 13.0'
-    s.add_development_dependency 'rake-compiler',      '== 1.1.1'
+    s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
     s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -42,7 +42,7 @@
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'
     s.add_development_dependency 'rake',               '~> 13.0'
-    s.add_development_dependency 'rake-compiler',      '~> 1.1'
+    s.add_development_dependency 'rake-compiler',      '== 1.1.1'
     s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'


### PR DESCRIPTION
ruby builds are in CBF recently

Looks like this is needed due to upstream issue:  https://github.com/rake-compiler/rake-compiler/issues/194

b/209603283