### PR TITLE
iOS ThirdPartyTest suite for libuv dns test

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -181,7 +181,7 @@ def grpc_deps():
     )
 
     native.bind(
-        name = "libuv",
+        name = "uv",
         actual = "@libuv//:libuv",
     )
 

--- a/src/objective-c/tests/ThirdPartyTests/Libuv/BUILD
+++ b/src/objective-c/tests/ThirdPartyTests/Libuv/BUILD
@@ -1,0 +1,48 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This is for the gRPC build system. This isn't intended to be used outsite of
+# the BUILD file for gRPC. It contains the mapping for the template system we
+# use to generate other platform's build system files.
+#
+# Please consider that there should be a high bar for additions and changes to
+# this file.
+# Each rule listed must be re-written for Google's internal build system, and
+# each change must be ported from one to the other.
+#
+
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
+
+ios_test_runner(
+    name = "ios_x86_64_sim_runner",
+    device_type = "iPhone 8",
+)
+
+objc_library(
+    name = "LibuvTestsLib",
+    testonly = True,
+    srcs = glob(["*.m"]),
+    deps = [
+        "//external:uv",
+    ],
+)
+
+ios_unit_test(
+    name = "LibuvTest",
+    minimum_os_version = "9.0",
+    runner = ":ios_x86_64_sim_runner",
+    deps = [":LibuvTestsLib"],
+)

--- a/src/objective-c/tests/ThirdPartyTests/Libuv/LibuvGetAddrInfoTests.m
+++ b/src/objective-c/tests/ThirdPartyTests/Libuv/LibuvGetAddrInfoTests.m
@@ -1,0 +1,142 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <stdlib.h>
+#import <uv.h>
+
+#define ASSERT(x) XCTAssertTrue(x)
+#define ASSERT_NULL(x) XCTAssertTrue(x == NULL)
+#define ASSERT_NOT_NULL(x) XCTAssertFalse(x == NULL)
+#define CONCURRENT_COUNT 10
+
+static const char* name = "localhost";
+
+static int getaddrinfo_cbs = 0;
+
+/* data used for running multiple calls concurrently */
+static uv_getaddrinfo_t* getaddrinfo_handle;
+static uv_getaddrinfo_t getaddrinfo_handles[CONCURRENT_COUNT];
+static int callback_counts[CONCURRENT_COUNT];
+static int fail_cb_called;
+
+static void getaddrinfo_fail_cb(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
+  ASSERT(fail_cb_called == 0);
+  ASSERT(status < 0);
+  ASSERT_NULL(res);
+  uv_freeaddrinfo(res); /* Should not crash. */
+  fail_cb_called++;
+}
+
+static void getaddrinfo_basic_cb(uv_getaddrinfo_t* handle, int status, struct addrinfo* res) {
+  ASSERT(handle == getaddrinfo_handle);
+  getaddrinfo_cbs++;
+  free(handle);
+  uv_freeaddrinfo(res);
+}
+
+static void getaddrinfo_cuncurrent_cb(uv_getaddrinfo_t* handle, int status, struct addrinfo* res) {
+  int i;
+  int* data = (int*)handle->data;
+
+  for (i = 0; i < CONCURRENT_COUNT; i++) {
+    if (&getaddrinfo_handles[i] == handle) {
+      ASSERT(i == *data);
+      callback_counts[i]++;
+      break;
+    }
+  }
+  ASSERT(i < CONCURRENT_COUNT);
+  free(data);
+  uv_freeaddrinfo(res);
+  getaddrinfo_cbs++;
+}
+
+@interface LibuvGetAddrInfoTests : XCTestCase
+
+@end
+
+@implementation LibuvGetAddrInfoTests
+
+- (void)testGetAddrInfoFail {
+  uv_getaddrinfo_t req;
+
+  ASSERT(UV_EINVAL ==
+         uv_getaddrinfo(uv_default_loop(), &req, (uv_getaddrinfo_cb)abort, NULL, NULL, NULL));
+
+  /* Use a FQDN by ending in a period */
+  ASSERT(0 == uv_getaddrinfo(uv_default_loop(), &req, getaddrinfo_fail_cb, "example.invalid.", NULL,
+                             NULL));
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT(fail_cb_called == 1);
+}
+
+- (void)testGetAddrInfoFailSync {
+  uv_getaddrinfo_t req;
+
+  /* Use a FQDN by ending in a period */
+  ASSERT(0 > uv_getaddrinfo(uv_default_loop(), &req, NULL, "example.invalid.", NULL, NULL));
+  uv_freeaddrinfo(req.addrinfo);
+}
+
+- (void)testGetAddrInfoBasic {
+  int r;
+  getaddrinfo_handle = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+
+  r = uv_getaddrinfo(uv_default_loop(), getaddrinfo_handle, &getaddrinfo_basic_cb, name, NULL,
+                     NULL);
+  ASSERT(r == 0);
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(getaddrinfo_cbs == 1);
+}
+
+- (void)testGetAddrInfoBasicSync {
+  uv_getaddrinfo_t req;
+
+  ASSERT(0 == uv_getaddrinfo(uv_default_loop(), &req, NULL, name, NULL, NULL));
+  uv_freeaddrinfo(req.addrinfo);
+}
+
+- (void)testGetAddrInfoConcurrent {
+  int i, r;
+  int* data;
+
+  for (i = 0; i < CONCURRENT_COUNT; i++) {
+    callback_counts[i] = 0;
+
+    data = (int*)malloc(sizeof(int));
+    ASSERT_NOT_NULL(data);
+    *data = i;
+    getaddrinfo_handles[i].data = data;
+
+    r = uv_getaddrinfo(uv_default_loop(), &getaddrinfo_handles[i], &getaddrinfo_cuncurrent_cb, name,
+                       NULL, NULL);
+    ASSERT(r == 0);
+  }
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  for (i = 0; i < CONCURRENT_COUNT; i++) {
+    ASSERT(callback_counts[i] == 1);
+  }
+}
+
+@end


### PR DESCRIPTION
Initial test suite setup for libuv dns test for iOS 

* ThirdPartyTest is bazel-only test that depends directly on gRPC c-core's libuv dependency. This allows to test directly against the same c-core dependency.  Existing Cocoapod libuv build will be migrated to this in the future. 
 
* LibuvGetAddrInfoTests.m closely mirroring [libuv/test-getaddrinfo.c](https://github.com/libuv/libuv/blob/v1.x/test/test-getaddrinfo.c).

* Copy in updated libuv bazel build patch from https://github.com/grpc/grpc/pull/27513

* Current list of apple platform archs are not exhaustively tested.  

Test Instructions 
* Run bazel test via command line 

```
bazel run //src/objective-c/tests/ThirdPartyTests/Libuv:LibuvTest 
```


cc @HannahShiSFB 

https://github.com/grpc/grpc-ios/issues/37