### PR TITLE
add secure hello world example

### DIFF
--- a/examples/cpp/helloworld/BUILD
+++ b/examples/cpp/helloworld/BUILD
@@ -55,6 +55,16 @@ cc_binary(
 )
 
 cc_binary(
+    name = "greeter_secure_client",
+    srcs = ["greeter_secure_client.cc"],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "//:grpc++",
+        "//examples/protos:helloworld_cc_grpc",
+    ],
+)
+
+cc_binary(
     name = "xds_greeter_client",
     srcs = ["xds_greeter_client.cc"],
     defines = ["BAZEL_BUILD"],
@@ -94,6 +104,16 @@ cc_binary(
     deps = [
         "//:grpc++",
         "//:grpc++_reflection",
+        "//examples/protos:helloworld_cc_grpc",
+    ],
+)
+
+cc_binary(
+    name = "greeter_secure_server",
+    srcs = ["greeter_secure_server.cc"],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "//:grpc++",
         "//examples/protos:helloworld_cc_grpc",
     ],
 )

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -58,8 +58,9 @@ target_link_libraries(hw_grpc_proto
 
 # Targets greeter_[async_](client|server)
 foreach(_target
-  greeter_client greeter_server 
-  greeter_callback_client greeter_callback_server 
+  greeter_client greeter_server
+  greeter_secure_client greeter_secure_server
+  greeter_callback_client greeter_callback_server
   greeter_async_client greeter_async_client2 greeter_async_server)
   add_executable(${_target} "${_target}.cc")
   target_link_libraries(${_target}

--- a/examples/cpp/helloworld/Makefile
+++ b/examples/cpp/helloworld/Makefile
@@ -38,7 +38,7 @@ PROTOS_PATH = ../../protos
 
 vpath %.proto $(PROTOS_PATH)
 
-all: system-check greeter_client greeter_server greeter_async_client greeter_async_client2 greeter_async_server greeter_callback_client greeter_callback_server 
+all: system-check greeter_client greeter_server greeter_async_client greeter_async_client2 greeter_async_server greeter_callback_client greeter_callback_server greeter_secure_client greeter_secure_server
 
 greeter_client: helloworld.pb.o helloworld.grpc.pb.o greeter_client.o
 	$(CXX) $^ $(LDFLAGS) -o $@
@@ -59,6 +59,12 @@ greeter_callback_client: helloworld.pb.o helloworld.grpc.pb.o greeter_callback_c
 	$(CXX) $^ $(LDFLAGS) -o $@
 
 greeter_callback_server: helloworld.pb.o helloworld.grpc.pb.o greeter_callback_server.o
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+greeter_secure_client: helloworld.pb.o helloworld.grpc.pb.o greeter_secure_client.o
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+greeter_secure_server: helloworld.pb.o helloworld.grpc.pb.o greeter_secure_server.o
 	$(CXX) $^ $(LDFLAGS) -o $@
 
 .PRECIOUS: %.grpc.pb.cc

--- a/examples/cpp/helloworld/gen-certs.sh
+++ b/examples/cpp/helloworld/gen-certs.sh
@@ -1,0 +1,36 @@
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+# Generate valid CA
+openssl genrsa -passout pass:1234 -des3 -out ca.key 4096
+openssl req -passin pass:1234 -new -x509 -days 365 -key ca.key -out ca.crt -subj  "/C=SP/ST=Spain/L=Valdepenias/O=Test/OU=Test/CN=Root CA"
+
+# Generate valid Server Key/Cert
+openssl genrsa -passout pass:1234 -des3 -out server.key 4096
+openssl req -passin pass:1234 -new -key server.key -out server.csr -subj  "/C=SP/ST=Spain/L=Valdepenias/O=Test/OU=Server/CN=localhost"
+openssl x509 -req -passin pass:1234 -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out server.crt
+
+# Remove passphrase from the Server Key
+openssl rsa -passin pass:1234 -in server.key -out server.key
+
+# Generate valid Client Key/Cert
+openssl genrsa -passout pass:1234 -des3 -out client.key 4096
+openssl req -passin pass:1234 -new -key client.key -out client.csr -subj  "/C=SP/ST=Spain/L=Valdepenias/O=Test/OU=Client/CN=localhost"
+openssl x509 -passin pass:1234 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt
+
+# Remove passphrase from Client Key
+openssl rsa -passin pass:1234 -in client.key -out client.key
+

--- a/examples/cpp/helloworld/greeter_secure_client.cc
+++ b/examples/cpp/helloworld/greeter_secure_client.cc
@@ -1,0 +1,99 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "helloworld.grpc.pb.h"
+
+#include <grpc++/grpc++.h>
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+class GreeterClient {
+ public:
+  GreeterClient(const std::string& cert, const std::string& key,
+                const std::string& root, const std::string& server) {
+    grpc::SslCredentialsOptions opts = {root, key, cert};
+
+    stub_ = Greeter::NewStub(
+        grpc::CreateChannel(server, grpc::SslCredentials(opts)));
+  }
+
+  std::string SayHello(const std::string& user) {
+    HelloRequest request;
+    request.set_name(user);
+
+    HelloReply reply;
+
+    ClientContext context;
+
+    Status status = stub_->SayHello(&context, request, &reply);
+
+    if (status.ok()) {
+      return reply.message();
+    } else {
+      std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+      return "RPC failed";
+    }
+  }
+
+ private:
+  std::unique_ptr<Greeter::Stub> stub_;
+};
+
+void read(const std::string& filename, std::string& data) {
+  std::ifstream file(filename.c_str(), std::ios::in);
+
+  if (file.is_open()) {
+    std::stringstream ss;
+    ss << file.rdbuf();
+
+    file.close();
+
+    data = ss.str();
+  }
+
+  return;
+}
+
+int main(int argc, char** argv) {
+  std::string cert;
+  std::string key;
+  std::string root;
+  std::string server{"localhost:50051"};
+
+  read("client.crt", cert);
+  read("client.key", key);
+  read("ca.crt", root);
+
+  GreeterClient greeter(cert, key, root, server);
+
+  std::string user("world");
+  std::string reply = greeter.SayHello(user);
+
+  std::cout << "Greeter received: " << reply << std::endl;
+
+  return 0;
+}

--- a/examples/cpp/helloworld/greeter_secure_server.cc
+++ b/examples/cpp/helloworld/greeter_secure_server.cc
@@ -1,0 +1,97 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "helloworld.grpc.pb.h"
+
+#include <grpc++/grpc++.h>
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+class GreeterServiceImpl final : public Greeter::Service {
+  Status SayHello(ServerContext* context, const HelloRequest* request,
+                  HelloReply* reply) override {
+    std::string prefix("Hello ");
+
+    reply->set_message(prefix + request->name());
+
+    return Status::OK;
+  }
+};
+
+void read(const std::string& filename, std::string& data) {
+  std::ifstream file(filename.c_str(), std::ios::in);
+
+  if (file.is_open()) {
+    std::stringstream ss;
+    ss << file.rdbuf();
+
+    file.close();
+
+    data = ss.str();
+  }
+
+  return;
+}
+
+void runServer() {
+  /**
+   * [!] Be carefull here using one cert with the CN != localhost. [!]
+   **/
+  std::string server_address("localhost:50051");
+
+  std::string key;
+  std::string cert;
+  std::string root;
+
+  read("server.crt", cert);
+  read("server.key", key);
+  read("ca.crt", root);
+
+  ServerBuilder builder;
+
+  grpc::SslServerCredentialsOptions::PemKeyCertPair keycert = {key, cert};
+
+  grpc::SslServerCredentialsOptions sslOps;
+  sslOps.pem_root_certs = root;
+  sslOps.pem_key_cert_pairs.push_back(keycert);
+
+  builder.AddListeningPort(server_address, grpc::SslServerCredentials(sslOps));
+
+  GreeterServiceImpl service;
+  builder.RegisterService(&service);
+
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  server->Wait();
+}
+
+int main(int argc, char** argv) {
+  runServer();
+
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

Add a secure example to clarify how to use TLS with gRPC.

Most from https://github.com/grpc/grpc/issues/9593#issuecomment-277946137.
