### PR TITLE
Improve TTY output of run_tests.py  and other scripts

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -126,12 +126,13 @@ def message(tag, msg, explanatory_text=None, do_newline=False):
         return
     message.old_tag = tag
     message.old_msg = msg
+    if explanatory_text:
+        if isinstance(explanatory_text, bytes):
+            explanatory_text = explanatory_text.decode('utf8', errors='replace')
     while True:
         try:
             if platform_string() == 'windows' or not sys.stdout.isatty():
                 if explanatory_text:
-                    if isinstance(explanatory_text, bytes):
-                        explanatory_text = explanatory_text.decode('utf8')
                     logging.info(explanatory_text)
                 logging.info('%s: %s', tag, msg)
             else:
@@ -359,7 +360,7 @@ class Job(object):
                 if measure_cpu_costs:
                     m = re.search(
                         r'real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)',
-                        (stdout()).decode("utf8", errors="replace"))
+                        (stdout()).decode('utf8', errors='replace'))
                     real = float(m.group(1))
                     user = float(m.group(2))
                     sys = float(m.group(3))


### PR DESCRIPTION
Followup for changes in https://github.com/grpc/grpc/pull/27135.

The issue is that when run_tests.py is run locally (on linux in a terminal), the job outputs are printed in a mangled binary form (e.g. with "\n" instead of newlines), which makes them unreadable.

Repro:
in a linux terminal, run some tests that will fail  (e.g. `tools/run_tests/run_tests.py -l sanity` without --use_docker, some of which will likely fail).