### PR TITLE
TSI: free the fixture in destruct() instead of in tsi_test_fixture_destroy()

### DIFF
--- a/test/core/tsi/fake_transport_security_test.cc
+++ b/test/core/tsi/fake_transport_security_test.cc
@@ -64,7 +64,7 @@ static void fake_test_check_handshaker_peers(tsi_test_fixture* fixture) {
   validate_handshaker_peers(fixture->server_result);
 }
 
-static void fake_test_destruct(tsi_test_fixture* /*fixture*/) {}
+static void fake_test_destruct(tsi_test_fixture* fixture) { gpr_free(fixture); }
 
 static const struct tsi_test_fixture_vtable vtable = {
     fake_test_setup_handshakers, fake_test_check_handshaker_peers,

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -415,6 +415,7 @@ static void ssl_test_destruct(tsi_test_fixture* fixture) {
       ssl_fixture->server_handshaker_factory);
   tsi_ssl_client_handshaker_factory_unref(
       ssl_fixture->client_handshaker_factory);
+  gpr_free(ssl_fixture);
 }
 
 static const struct tsi_test_fixture_vtable vtable = {

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -628,10 +628,9 @@ void tsi_test_fixture_destroy(tsi_test_fixture* fixture) {
   tsi_test_channel_destroy(fixture->channel);
   GPR_ASSERT(fixture->vtable != nullptr);
   GPR_ASSERT(fixture->vtable->destruct != nullptr);
-  fixture->vtable->destruct(fixture);
   gpr_mu_destroy(&fixture->mu);
   gpr_cv_destroy(&fixture->cv);
-  gpr_free(fixture);
+  fixture->vtable->destruct(fixture);
 }
 
 tsi_test_frame_protector_fixture* tsi_test_frame_protector_fixture_create() {


### PR DESCRIPTION
The test framework is not responsible for allocating the fixture object, so it should also not be responsible for destroying it.  That should be delegated to the vtable destruct() method.

This should fix the problem you were seeing in #26287.