### PR TITLE
Pin rake-compiler at 1.1.1 to fix ruby breakages on CI

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -40,7 +40,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
-  s.add_development_dependency 'rake-compiler',      '~> 1.1'
+  # rake-compiler 1.1.2 and 1.1.3 are broken, see b/209603283
+  s.add_development_dependency 'rake-compiler',      '1.1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
   # rake-compiler 1.1.2 and 1.1.3 are broken, see b/209603283
-  s.add_development_dependency 'rake-compiler',      '1.1.1'
+  s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -42,7 +42,8 @@
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'
     s.add_development_dependency 'rake',               '~> 13.0'
-    s.add_development_dependency 'rake-compiler',      '~> 1.1'
+    # rake-compiler 1.1.2 and 1.1.3 are broken, see b/209603283
+    s.add_development_dependency 'rake-compiler',      '1.1.1'
     s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'


### PR DESCRIPTION
These rake-compiler versions published on Dec 7 have probably caused b/209603283 (and 1.1.3 has fixed things partially, but not fully).
```
1.1.3 - December 07, 2021 (37.5 KB)
1.1.2 - December 07, 2021 (37.5 KB)
```

Example failure:
https://source.cloud.google.com/results/invocations/02d5523f-14f8-444e-98ba-8b90e3a1cabe (with rake-compiler 1.1.3)