### PR TITLE
Pin rake-compiler at 1.1.1 to fix ruby breakages on CI (backport to v1.43.x)

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -40,7 +40,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
-  s.add_development_dependency 'rake-compiler',      '~> 1.1'
+  # rake-compiler 1.1.2 and 1.1.3 are broken, see b/209603283
+  s.add_development_dependency 'rake-compiler',      '1.1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -42,7 +42,8 @@
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'
     s.add_development_dependency 'rake',               '~> 13.0'
-    s.add_development_dependency 'rake-compiler',      '~> 1.1'
+    # rake-compiler 1.1.2 and 1.1.3 are broken, see b/209603283
+    s.add_development_dependency 'rake-compiler',      '1.1.1'
     s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'


### PR DESCRIPTION
Backports #28320.
