### PR TITLE
resolvers: fix resolvers to return channel args even when reporting an error

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -373,6 +373,7 @@ void AresDnsResolver::OnResolvedLocked(grpc_error_handle error) {
     Result result;
     result.addresses = status;
     result.service_config = status;
+    result.args = grpc_channel_args_copy(channel_args_);
     result_handler_->ReportResult(std::move(result));
     // Set retry timer.
     // InvalidateNow to avoid getting stuck re-initializing this timer

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -199,6 +199,7 @@ void NativeDnsResolver::OnResolvedLocked(grpc_error_handle error) {
     Result result;
     result.addresses = absl::UnavailableError(absl::StrCat(
         "DNS resolution failed for ", name_to_resolve_, ": ", error_message));
+    result.args = grpc_channel_args_copy(channel_args_);
     result_handler_->ReportResult(std::move(result));
     // Set up for retry.
     // InvalidateNow to avoid getting stuck re-initializing this timer

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -147,6 +147,7 @@ void FakeResolver::MaybeSendResultLocked() {
     Result result;
     result.addresses = absl::UnavailableError("Resolver transient failure");
     result.service_config = result.addresses.status();
+    result.args = grpc_channel_args_copy(channel_args_);
     result_handler_->ReportResult(std::move(result));
     return_failure_ = false;
   } else if (has_next_result_) {


### PR DESCRIPTION
This fixes a potential problem introduced in #28091.