### PR TITLE
Fix invocation of respawn scripts on windows

### DIFF
--- a/tools/internal_ci/helper_scripts/move_src_tree_and_respawn_itself.bat
+++ b/tools/internal_ci/helper_scripts/move_src_tree_and_respawn_itself.bat
@@ -20,10 +20,18 @@
 @rem Since batch scripts don't support the "source" unix command,
 @rem invoking this script is a bit trickier than on unix.
 @rem This script should be invoked from the CI script like this:
+@rem Note that honoring the pattern (including e.g. EnableDelayedExpansion)
+@rem is critical for correctly propagating the exitcode.
+@rem TODO(jtattermusch): find a way to simplify the invocation of the respawn script.
+@rem
+@rem setlocal EnableDelayedExpansion
 @rem IF "%cd%"=="T:\src" (
 @rem   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-@rem   exit /b %errorlevel%
+@rem   echo respawn script has finished with exitcode !errorlevel!
+@rem   exit /b !errorlevel!
 @rem )
+@rem endlocal
+
 
 @echo off
 

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -14,10 +14,13 @@
 
 @rem Avoid slow finalization after the script has exited.
 @rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
 IF "%cd%"=="T:\src" (
   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-  exit /b %errorlevel%
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
 )
+endlocal
 
 @rem TODO(jtattermusch): make this generate less output
 @rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync

--- a/tools/internal_ci/windows/grpc_build_artifacts.bat
+++ b/tools/internal_ci/windows/grpc_build_artifacts.bat
@@ -14,10 +14,13 @@
 
 @rem Avoid slow finalization after the script has exited.
 @rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
 IF "%cd%"=="T:\src" (
   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-  exit /b %errorlevel%
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
 )
+endlocal
 
 @rem Boringssl build no longer supports yasm
 choco uninstall yasm -y --limit-output

--- a/tools/internal_ci/windows/grpc_build_packages.bat
+++ b/tools/internal_ci/windows/grpc_build_packages.bat
@@ -14,10 +14,13 @@
 
 @rem Avoid slow finalization after the script has exited.
 @rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
 IF "%cd%"=="T:\src" (
   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-  exit /b %errorlevel%
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
 )
+endlocal
 
 @rem enter repo root
 cd /d %~dp0\..\..\..

--- a/tools/internal_ci/windows/grpc_distribtests.bat
+++ b/tools/internal_ci/windows/grpc_distribtests.bat
@@ -14,10 +14,13 @@
 
 @rem Avoid slow finalization after the script has exited.
 @rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
 IF "%cd%"=="T:\src" (
   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-  exit /b %errorlevel%
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
 )
+endlocal
 
 @rem enter repo root
 cd /d %~dp0\..\..\..

--- a/tools/internal_ci/windows/grpc_distribtests_standalone.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_standalone.bat
@@ -14,10 +14,13 @@
 
 @rem Avoid slow finalization after the script has exited.
 @rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
 IF "%cd%"=="T:\src" (
   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-  exit /b %errorlevel%
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
 )
+endlocal
 
 @rem enter repo root
 cd /d %~dp0\..\..\..

--- a/tools/internal_ci/windows/grpc_run_tests_matrix.bat
+++ b/tools/internal_ci/windows/grpc_run_tests_matrix.bat
@@ -14,10 +14,13 @@
 
 @rem Avoid slow finalization after the script has exited.
 @rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
 IF "%cd%"=="T:\src" (
   call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
-  exit /b %errorlevel%
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
 )
+endlocal
 
 @rem enter repo root
 cd /d %~dp0\..\..\..


### PR DESCRIPTION
See b/210817756

@veblush

The issue was introduced by https://github.com/grpc/grpc/pull/28259 and the windows builds have been incorrectly reporting the exitcode (which is interpreted as green/red status of the kokoro build) since then.

The fix is needed because batch scripts are a bad joke and evaluation of variable inside and IF statement behaves completely counterintuitively.
