### PR TITLE
Run objc cfstream clients against 127.0.0.1

### DIFF
--- a/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
@@ -28,6 +28,7 @@
 #include <grpc/impl/codegen/sync.h>
 #include <grpc/support/sync.h>
 
+#include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/tcp_client.h"
@@ -86,9 +87,7 @@ static void must_fail(void* arg, grpc_error_handle error) {
 
   gpr_log(GPR_DEBUG, "test_succeeds");
 
-  memset(&resolved_addr, 0, sizeof(resolved_addr));
-  resolved_addr.len = sizeof(struct sockaddr_in);
-  addr->sin_family = AF_INET;
+  GPR_ASSERT(grpc_string_to_sockaddr(&resolved_addr, "127.0.0.1", 0) == GRPC_ERROR_NONE);
 
   /* create a phony server */
   svr_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -145,9 +144,7 @@ static void must_fail(void* arg, grpc_error_handle error) {
 
   gpr_log(GPR_DEBUG, "test_fails");
 
-  memset(&resolved_addr, 0, sizeof(resolved_addr));
-  resolved_addr.len = static_cast<socklen_t>(sizeof(struct sockaddr_in));
-  addr->sin_family = AF_INET;
+  GPR_ASSERT(grpc_string_to_sockaddr(&resolved_addr, "127.0.0.1", 0) == GRPC_ERROR_NONE);
 
   svr_fd = socket(AF_INET, SOCK_STREAM, 0);
   GPR_ASSERT(svr_fd >= 0);

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -28,6 +28,7 @@
 #include <grpc/impl/codegen/sync.h>
 #include <grpc/support/sync.h>
 
+#include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/tcp_client.h"
@@ -114,9 +115,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   gpr_log(GPR_DEBUG, "test_succeeds");
 
-  memset(&resolved_addr, 0, sizeof(resolved_addr));
-  resolved_addr.len = sizeof(struct sockaddr_in);
-  addr->sin_family = AF_INET;
+  GPR_ASSERT(grpc_string_to_sockaddr(&resolved_addr, "127.0.0.1", 0) == GRPC_ERROR_NONE);
 
   /* create a phony server */
   svr_fd = socket(AF_INET, SOCK_STREAM, 0);


### PR DESCRIPTION
According to my experiments, this should make the objc CFStream tests pass also on the new kokoro workers (macservice).
There seems to be some network setting differences that make cfstream clients connecting to 0.0.0.0 fail, but I'm not sure what it is.
AFAIK this change should have no effect on the usefulness of the tests.

See b/204280090
