### PR TITLE
silence C4503 warning on MSVC (in cmake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,8 @@ if(MSVC)
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4267")
   # TODO(jtattermusch): needed to build boringssl with VS2017, revisit later
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4987 /wd4774 /wd4819 /wd4996 /wd4619")
+  # Silences thousands of trucation warnings
+  set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4503")
 endif()
 if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -297,6 +297,8 @@
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4267")
     # TODO(jtattermusch): needed to build boringssl with VS2017, revisit later
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4987 /wd4774 /wd4819 /wd4996 /wd4619")
+    # Silences thousands of trucation warnings
+    set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4503")
   endif()
   if (MINGW)
     add_definitions(-D_WIN32_WINNT=0x600)


### PR DESCRIPTION
see b/210806277

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=msvc-170#:~:text=name%20was%20truncated-,Remarks,name%20lengths%20of%20identifiers%20used.

(at least for cmake for now)