### PR TITLE
Fix the setuptools distutils overriding issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """A setup module for the GRPC Python package."""
 
-# setuptools need to be imported before distutils. Otherwise it might lead to
-# undesirable behaviors or errors.
+# NOTE(https://github.com/grpc/grpc/issues/24028): allow setuptools to monkey
+# patch distutils
 import setuptools  # isort:skip
 
 # Monkey Patch the unix compiler to accept ASM

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -15,6 +15,10 @@
 
 from __future__ import print_function
 
+# NOTE(https://github.com/grpc/grpc/issues/24028): allow setuptools to monkey
+# patch distutils
+import setuptools  # isort:skip
+
 import distutils
 import glob
 import os
@@ -27,7 +31,6 @@ import sys
 import sysconfig
 import traceback
 
-import setuptools
 from setuptools.command import build_ext
 from setuptools.command import build_py
 from setuptools.command import easy_install

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -13,18 +13,13 @@
 # limitations under the License.
 """Provides distutils command classes for the GRPC Python setup process."""
 
-from __future__ import print_function
-
 # NOTE(https://github.com/grpc/grpc/issues/24028): allow setuptools to monkey
 # patch distutils
 import setuptools  # isort:skip
 
-import distutils
 import glob
 import os
 import os.path
-import platform
-import re
 import shutil
 import subprocess
 import sys
@@ -33,9 +28,6 @@ import traceback
 
 from setuptools.command import build_ext
 from setuptools.command import build_py
-from setuptools.command import easy_install
-from setuptools.command import install
-from setuptools.command import test
 import support
 
 PYTHON_STEM = os.path.dirname(os.path.abspath(__file__))

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -162,7 +162,7 @@ pip_install() {
 
 # Pin setuptools to < 60.0.0 to restore the distutil installation, see:
 # https://github.com/pypa/setuptools/pull/2896
-export SETUPTOOLS_USE_DISTUTILS=local
+export SETUPTOOLS_USE_DISTUTILS=stdlib
 pip_install --upgrade pip==21.3.1
 pip_install --upgrade setuptools==59.7.0
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -155,6 +155,9 @@ fi
 # TLS version to run `pip install`.
 curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
 
+pip_install --upgrade setuptools==60.0.2
+pip_install --upgrade pip==21.3.1
+
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
 # Python gets confused when parsing paths.
 pip_install_dir() {
@@ -185,8 +188,6 @@ case "$VENV" in
 esac
 
 
-pip_install --upgrade setuptools==44.1.1
-pip_install --upgrade pip==19.3.1
 pip_install --upgrade cython
 pip_install --upgrade six protobuf
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -150,13 +150,22 @@ else
   VENV_PYTHON=$(script_realpath "$VENV/$VENV_RELATIVE_PYTHON")
 fi
 
+
+# On library/version/platforms combo that do not have a binary
+# published, we may end up building a dependency from source. In that
+# case, several of our build environment variables may disrupt the
+# third-party build process. This function pipes through only the
+# minimal environment necessary.
+pip_install() {
+  /usr/bin/env -i PATH="$PATH" "$VENV_PYTHON" -m pip install "$@"
+}
+
 # See https://github.com/grpc/grpc/issues/14815 for more context. We cannot rely
 # on pip to upgrade itself because if pip is too old, it may not have the required
 # TLS version to run `pip install`.
 export SETUPTOOLS_USE_DISTUTILS=local
 pip_install --upgrade pip==21.3.1
 # curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
-
 pip_install --upgrade setuptools==59.7.0
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
@@ -167,15 +176,6 @@ pip_install_dir() {
   ($VENV_PYTHON setup.py build_ext -c "$TOOLCHAIN" || true)
   $VENV_PYTHON -m pip install --no-deps .
   cd "$PWD"
-}
-
-# On library/version/platforms combo that do not have a binary
-# published, we may end up building a dependency from source. In that
-# case, several of our build environment variables may disrupt the
-# third-party build process. This function pipes through only the
-# minimal environment necessary.
-pip_install() {
-  /usr/bin/env -i PATH="$PATH" "$VENV_PYTHON" -m pip install "$@"
 }
 
 case "$VENV" in

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -164,7 +164,7 @@ pip_install() {
 # https://github.com/pypa/setuptools/pull/2896
 export SETUPTOOLS_USE_DISTUTILS=stdlib
 pip_install --upgrade pip==21.3.1
-pip_install --upgrade setuptools==59.7.0
+pip_install --upgrade setuptools==59.6.0
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
 # Python gets confused when parsing paths.

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -153,7 +153,7 @@ fi
 # See https://github.com/grpc/grpc/issues/14815 for more context. We cannot rely
 # on pip to upgrade itself because if pip is too old, it may not have the required
 # TLS version to run `pip install`.
-curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | $VENV_PYTHON
+curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
 # Python gets confused when parsing paths.

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -153,6 +153,7 @@ fi
 # See https://github.com/grpc/grpc/issues/14815 for more context. We cannot rely
 # on pip to upgrade itself because if pip is too old, it may not have the required
 # TLS version to run `pip install`.
+export SETUPTOOLS_USE_DISTUTILS=local
 pip_install --upgrade pip==21.3.1
 # curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -160,12 +160,10 @@ pip_install() {
   /usr/bin/env -i PATH="$PATH" "$VENV_PYTHON" -m pip install "$@"
 }
 
-# See https://github.com/grpc/grpc/issues/14815 for more context. We cannot rely
-# on pip to upgrade itself because if pip is too old, it may not have the required
-# TLS version to run `pip install`.
+# Pin setuptools to < 60.0.0 to restore the distutil installation, see:
+# https://github.com/pypa/setuptools/pull/2896
 export SETUPTOOLS_USE_DISTUTILS=local
 pip_install --upgrade pip==21.3.1
-# curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
 pip_install --upgrade setuptools==59.7.0
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -153,10 +153,10 @@ fi
 # See https://github.com/grpc/grpc/issues/14815 for more context. We cannot rely
 # on pip to upgrade itself because if pip is too old, it may not have the required
 # TLS version to run `pip install`.
-curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
-
-pip_install --upgrade setuptools==60.0.2
 pip_install --upgrade pip==21.3.1
+# curl https://bootstrap.pypa.io/pip/get-pip.py | $VENV_PYTHON
+
+pip_install --upgrade setuptools==59.7.0
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
 # Python gets confused when parsing paths.


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/28391 b/211485805

The latest `setuptools` (>= 60.0.0) tries to replace `distutils`:
- https://github.com/pypa/setuptools/issues/417#issuecomment-392298401
- https://github.com/pypa/setuptools/pull/2896

The main reason is ` we don't have many folks contributing to distutils any more`, so they re-implemented it inside `setuptools`.

Unfortunately, the default overriding behavior breaks under several environment, including our Kokoro job. Well, they have released 5 times in that 24 hours, but the issue still persists. Technically, we should work to embrace the new `distutils`, but let's upgrade after the CIs are green again

We sort of prepared for this failure but it still got us. Our repo tried to pin `pip` and `setuptools` before building wheels, in this case, `setuptools` is bundled with `pip`, causing the CI job to fail at the `pip` installation step.

---


For "Distribution Tests Python Linux" failure:

This PR didn't fix the __wrap_memcpy issue, I posted another fix at https://github.com/grpc/grpc/pull/28397. Related b/211487922 https://github.com/grpc/grpc/issues/24028.

The gcc-regression-on-memcpy: https://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html