### PR TITLE
remove deprecated distutils calls

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -201,8 +201,8 @@ def _get_python_lib(repository_ctx, python_bin, lib_path_key):
         "  python_paths = os.getenv('PYTHONPATH').split(':')\n" + "try:\n" +
         "  library_paths = site.getsitepackages()\n" +
         "except AttributeError:\n" +
-        " from distutils.sysconfig import get_python_lib\n" +
-        " library_paths = [get_python_lib()]\n" +
+        " from sysconfig import get_path\n" +
+        " library_paths = [get_path('purelib')]\n" +
         "all_paths = set(python_paths + library_paths)\n" + "paths = []\n" +
         "for path in all_paths:\n" + "  if os.path.isdir(path):\n" +
         "    paths.append(path)\n" + "if len(paths) >=1:\n" +
@@ -239,14 +239,13 @@ def _get_python_include(repository_ctx, python_bin):
             python_bin,
             "-c",
             "from __future__ import print_function;" +
-            "from distutils import sysconfig;" +
-            "print(sysconfig.get_python_inc())",
+            "import sysconfig;" +
+            "print(sysconfig.get_path('include'))",
         ],
         error_msg = "Problem getting python include path for {}.".format(python_bin),
         error_details = (
             "Is the Python binary path set up right? " + "(See ./configure or " +
-            python_bin + ".) " + "Is distutils installed? " +
-            _HEADERS_HELP
+            python_bin + ".) " + _HEADERS_HELP
         ),
     )
     include_path = result.stdout.splitlines()[0]


### PR DESCRIPTION
This PR removes deprecated distutils calls with the corresponding sysconfig calls. The following docs were used as a guide: https://docs.python.org/3/library/sysconfig.html

When utilizing this code in other projects, the following error shows up:
```
    INFO: Repository local_config_python instantiated at:
      /home/acxz/vcs/git/github/acxz/ray/WORKSPACE:9:19: in <toplevel>
      /home/acxz/vcs/git/github/acxz/ray/bazel/ray_deps_build_all.bzl:18:12: in ray_deps_build_all
      /home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/bazel/grpc_deps.bzl:447:21: in grpc_deps
      /home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/bazel/grpc_python_deps.bzl:58:21: in grpc_python_deps
    Repository rule python_configure defined at:
      /home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl:367:35: in <toplevel>
    ERROR: An error occurred during the fetch of repository 'local_config_python':
       Traceback (most recent call last):
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 349, column 35, in _python_autoconf_impl
    		_create_single_version_package(
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 306, column 45, in _create_single_version_package
    		python_include = _get_python_include(repository_ctx, python_bin)
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 236, column 22, in _get_python_include
    		result = _execute(
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 62, column 14, in _execute
    		_fail("\n".join([
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 35, column 9, in _fail
    		fail("%sPython Configuration Error:%s %s\n" % (red, no_color, msg))
    Error in fail: Python Configuration Error: Problem getting python include path for /usr/bin/python.
    <string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    <string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
    Is the Python binary path set up right? (See ./configure or /usr/bin/python.) Is distutils installed? Are Python headers installed? Try installing python-dev or python3-dev on Debian-based systems. Try python-devel or python3-devel on Redhat-based systems.
    ERROR: Error fetching repository: Traceback (most recent call last):
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 349, column 35, in _python_autoconf_impl
    		_create_single_version_package(
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 306, column 45, in _create_single_version_package
    		python_include = _get_python_include(repository_ctx, python_bin)
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 236, column 22, in _get_python_include
    		result = _execute(
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 62, column 14, in _execute
    		_fail("\n".join([
    	File "/home/acxz/.cache/bazel/_bazel_acxz/974634306b86eed169e075f9fa53453f/external/com_github_grpc_grpc/third_party/py/python_configure.bzl", line 35, column 9, in _fail
    		fail("%sPython Configuration Error:%s %s\n" % (red, no_color, msg))
    Error in fail: Python Configuration Error: Problem getting python include path for /usr/bin/python.
    <string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    <string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
    Is the Python binary path set up right? (See ./configure or /usr/bin/python.) Is distutils installed? Are Python headers installed? Try installing python-dev or python3-dev on Debian-based systems. Try python-devel or python3-devel on Redhat-based systems.
```
The error is most likely happening since both the deprecation warning and the path is seen as the output instead of just the output.

This PR fixes the issue by replacing the deprecation calls.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
