### PR TITLE
Remove Python2 from python_configure.bzl

### DIFF
--- a/bazel/internal_python_rules.bzl
+++ b/bazel/internal_python_rules.bzl
@@ -23,7 +23,7 @@ def internal_py_grpc_test(name, **kwargs):
       **kwargs: Any additional arguments to add to the test.
     """
     native.py_test(
-        name = name + ".natvie",
+        name = name + ".native",
         python_version = "PY3",
         **kwargs
     )

--- a/bazel/internal_python_rules.bzl
+++ b/bazel/internal_python_rules.bzl
@@ -14,7 +14,6 @@
 """Python-related rules intended only for use internal to the repo."""
 
 load("//bazel:gevent_test.bzl", "py_grpc_gevent_test")
-load("//bazel:python_rules.bzl", "py2and3_test")
 
 def internal_py_grpc_test(name, **kwargs):
     """Runs a test under all supported environments.
@@ -23,7 +22,11 @@ def internal_py_grpc_test(name, **kwargs):
       name: The name of the test.
       **kwargs: Any additional arguments to add to the test.
     """
-    py2and3_test(name, **kwargs)
+    native.py_test(
+        name = name + ".natvie",
+        python_version = "PY3",
+        **kwargs
+    )
     py_grpc_gevent_test(name, **kwargs)
 
     suite_kwargs = {}
@@ -33,7 +36,7 @@ def internal_py_grpc_test(name, **kwargs):
     native.test_suite(
         name = name,
         tests = [
-            name + ".both_pythons",
+            name + ".native",
             name + ".gevent",
         ],
         **suite_kwargs

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -292,38 +292,3 @@ def py_grpc_library(
         strip_prefixes = strip_prefixes,
         **kwargs
     )
-
-# TODO(https://github.com/grpc/grpc/issues/27543): Remove once Python 2 is no longer supported.
-def py2and3_test(
-        name,
-        py_test = native.py_test,
-        **kwargs):
-    """Runs a Python test under both Python 2 and Python 3.
-
-    Args:
-      name: The name of the test.
-      py_test: The rule to use for each test.
-      **kwargs: Keyword arguments passed directly to the underlying py_test
-        rule.
-    """
-    if "python_version" in kwargs:
-        fail("Cannot specify 'python_version' in py2and3_test.")
-
-    names = [name + suffix for suffix in (".python2", ".python3")]
-    python_versions = ["PY2", "PY3"]
-    for case_name, python_version in zip(names, python_versions):
-        py_test(
-            name = case_name,
-            python_version = python_version,
-            **kwargs
-        )
-
-    suite_kwargs = {}
-    if "visibility" in kwargs:
-        suite_kwargs["visibility"] = kwargs["visibility"]
-
-    native.test_suite(
-        name = name + ".both_pythons",
-        tests = names,
-        **suite_kwargs
-    )

--- a/src/python/grpcio_tests/tests/unit/_cython/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/_cython/BUILD.bazel
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:python_rules.bzl", "py2and3_test")
-
 package(default_visibility = ["//visibility:public"])
 
 GRPCIO_TESTS_UNIT_CYTHON = [
@@ -37,7 +35,7 @@ py_library(
 )
 
 [
-    py2and3_test(
+    py_test(
         name = test_file_name[:-3],
         size = "small",
         srcs = [test_file_name],
@@ -46,6 +44,7 @@ py_library(
         ],
         imports = ["../../../"],
         main = test_file_name,
+        python_version = "PY3",
         deps = [
             ":common",
             ":test_utilities",

--- a/src/python/grpcio_tests/tests/unit/framework/foundation/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/framework/foundation/BUILD.bazel
@@ -1,5 +1,3 @@
-load("//bazel:python_rules.bzl", "py2and3_test")
-
 # Copyright 2021 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,11 +18,12 @@ py_library(
     srcs = ["stream_testing.py"],
 )
 
-py2and3_test(
+py_test(
     name = "logging_pool_test",
     size = "small",
     srcs = ["_logging_pool_test.py"],
     main = "_logging_pool_test.py",
+    python_version = "PY3",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
     ],

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -3,19 +3,17 @@
 
 `python_configure` depends on the following environment variables:
 
-  * `PYTHON2_BIN_PATH`: location of python binary.
-  * `PYTHON2_LIB_PATH`: Location of python libraries.
+  * `PYTHON3_BIN_PATH`: location of python binary.
+  * `PYTHON3_LIB_PATH`: Location of python libraries.
 """
 
 _BAZEL_SH = "BAZEL_SH"
-_PYTHON2_BIN_PATH = "PYTHON2_BIN_PATH"
-_PYTHON2_LIB_PATH = "PYTHON2_LIB_PATH"
 _PYTHON3_BIN_PATH = "PYTHON3_BIN_PATH"
 _PYTHON3_LIB_PATH = "PYTHON3_LIB_PATH"
 
 _HEADERS_HELP = (
-    "Are Python headers installed? Try installing python-dev or " +
-    "python3-dev on Debian-based systems. Try python-devel or python3-devel " +
+    "Are Python headers installed? Try installing " +
+    "python3-dev on Debian-based systems. Try python3-devel " +
     "on Redhat-based systems."
 )
 
@@ -346,14 +344,6 @@ def _python_autoconf_impl(repository_ctx):
     """Implementation of the python_autoconf repository rule."""
     _create_single_version_package(
         repository_ctx,
-        "_python2",
-        _PYTHON2_BIN_PATH,
-        "python2",
-        _PYTHON2_LIB_PATH,
-        True
-    )
-    _create_single_version_package(
-        repository_ctx,
         "_python3",
         _PYTHON3_BIN_PATH,
         "python3",
@@ -366,8 +356,6 @@ python_configure = repository_rule(
     implementation = _python_autoconf_impl,
     environ = [
         _BAZEL_SH,
-        _PYTHON2_BIN_PATH,
-        _PYTHON2_LIB_PATH,
         _PYTHON3_BIN_PATH,
         _PYTHON3_LIB_PATH,
     ],


### PR DESCRIPTION
As title.

Fixes #28026. Richard helped to offer some background about this issue. After discussion, we want to try remove the Python2-header-finding logic from our Bazel build.

This should unblock https://github.com/grpc/grpc/pull/28392.