### PR TITLE
Make Static Data Provider Capable of Handling Cert Updates

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -803,18 +803,52 @@ GRPCAPI void grpc_tls_identity_pairs_destroy(grpc_tls_identity_pairs* pairs);
 /**
  * EXPERIMENTAL API - Subject to change
  *
- * Creates a grpc_tls_certificate_provider that will load credential data from
- * static string during initialization. This provider will always return the
- * same cert data for all cert names.
- * root_certificate and pem_key_cert_pairs can be nullptr, indicating the
- * corresponding credential data is not needed.
- * This function will make a copy of |root_certificate|.
- * The ownership of |pem_key_cert_pairs| is transferred.
+ * Creates a grpc_tls_certificate_provider that loads credentials which will be
+ * used in TLS handshakes. The credentials can be updated via
+ * gprc_tls_certificate_provider_data_watcher_set_root_cert() and
+ * gprc_tls_certificate_provider_data_watcher_set_key_cert_pairs().
+ * The update is thread-safe.
  */
 GRPCAPI grpc_tls_certificate_provider*
-grpc_tls_certificate_provider_static_data_create(
-    const char* root_certificate, grpc_tls_identity_pairs* pem_key_cert_pairs);
+grpc_tls_certificate_provider_data_watcher_create();
 
+/*
+ * EXPERIMENTAL API - Subject to change
+ *
+ * Sets the root certificate to |root_certificate|.
+ * - This function will make a copy of |root_certificate|.
+ * - |root_certificate| can be nullptr. In that case, the changes for the root
+ *   certificates shouldn't be watched.
+ * - If the certificate is invalid, a non-OK status will be returned, in which
+ *   case |error_details| will be set, and the caller is responsible for calling
+ *   gpr_free() on it.
+ * - |provider| must be created from
+ *   grpc_tls_certificate_provider_data_watcher_create(), otherwise the result
+ *   is undefined.
+ */
+GRPCAPI grpc_status_code
+grpc_tls_certificate_provider_data_watcher_set_root_cert(
+    grpc_tls_certificate_provider* provider, const char* root_certificate,
+    char** error_details);
+
+/*
+ * EXPERIMENTAL API - Subject to change
+ *
+ * Sets the identity key-cert pairs to |pem_key_cert_pairs|.
+ * - The ownership of |pem_key_cert_pairs| is transferred.
+ * - |pem_key_cert_pairs| can be nullptr. In that case, the changes for the
+ *   identity pairs shouldn't be watched.
+ * - If the certificate is invalid, a non-OK status will be returned, in which
+ *   case |error_details| will be set, and the caller is responsible for calling
+ *   gpr_free() on it.
+ * - |provider| must be created from
+ *   grpc_tls_certificate_provider_data_watcher_create(), otherwise the result
+ *   is undefined.
+ */
+GRPCAPI grpc_status_code
+grpc_tls_certificate_provider_data_watcher_set_key_cert_pairs(
+    grpc_tls_certificate_provider* provider,
+    grpc_tls_identity_pairs* pem_key_cert_pairs, char** error_details);
 /**
  * EXPERIMENTAL API - Subject to change
  *

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -30,30 +30,36 @@
 
 namespace grpc_core {
 
-StaticDataCertificateProvider::StaticDataCertificateProvider(
-    std::string root_certificate, PemKeyCertPairList pem_key_cert_pairs)
-    : distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()),
-      root_certificate_(std::move(root_certificate)),
-      pem_key_cert_pairs_(std::move(pem_key_cert_pairs)) {
+CertificateProviderWatcherNotifier::CertificateProviderWatcherNotifier(DataWatcherCertificateProvider* provider) : distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()), provider_(provider) {
   distributor_->SetWatchStatusCallback([this](std::string cert_name,
                                               bool root_being_watched,
                                               bool identity_being_watched) {
-    MutexLock lock(&mu_);
+    GPR_ASSERT(provider_ != nullptr);
     absl::optional<std::string> root_certificate;
     absl::optional<PemKeyCertPairList> pem_key_cert_pairs;
-    StaticDataCertificateProvider::WatcherInfo& info = watcher_info_[cert_name];
-    if (!info.root_being_watched && root_being_watched &&
-        !root_certificate_.empty()) {
-      root_certificate = root_certificate_;
+    CertificateProviderWatcherNotifier::WatcherInfo* info = nullptr;
+    {
+      MutexLock lock(&mu_);
+      info = &watcher_info_[cert_name];
     }
-    info.root_being_watched = root_being_watched;
-    if (!info.identity_being_watched && identity_being_watched &&
-        !pem_key_cert_pairs_.empty()) {
-      pem_key_cert_pairs = pem_key_cert_pairs_;
+    std::string root_certs_being_cached = provider_->root_certificate();
+    if (!info->root_being_watched && root_being_watched &&
+        !root_certs_being_cached.empty()) {
+      root_certificate = root_certs_being_cached;
     }
-    info.identity_being_watched = identity_being_watched;
-    if (!info.root_being_watched && !info.identity_being_watched) {
-      watcher_info_.erase(cert_name);
+    info->root_being_watched = root_being_watched;
+    PemKeyCertPairList identity_certs_being_cached = provider_->pem_key_cert_pairs();
+    if (!info->identity_being_watched && identity_being_watched &&
+        !identity_certs_being_cached.empty()) {
+      GPR_ASSERT(provider_ != nullptr);
+      pem_key_cert_pairs = identity_certs_being_cached;
+    }
+    info->identity_being_watched = identity_being_watched;
+    if (!info->root_being_watched && !info->identity_being_watched) {
+      {
+        MutexLock lock(&mu_);
+        watcher_info_.erase(cert_name);
+      }
     }
     const bool root_has_update = root_certificate.has_value();
     const bool identity_has_update = pem_key_cert_pairs.has_value();
@@ -79,10 +85,111 @@ StaticDataCertificateProvider::StaticDataCertificateProvider(
   });
 }
 
-StaticDataCertificateProvider::~StaticDataCertificateProvider() {
+void CertificateProviderWatcherNotifier::SetRootCertificate(std::string root_certificate) {
+  MutexLock lock(&mu_);
+  ExecCtx exec_ctx;
+  grpc_error_handle root_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      "Unable to get latest root certificates.");
+  for (const auto& p : watcher_info_) {
+    const std::string& cert_name = p.first;
+    const WatcherInfo& info = p.second;
+    absl::optional<std::string> root_to_report;
+    if (info.root_being_watched) {
+      root_to_report = root_certificate;
+    }
+    if (root_to_report.has_value() && !root_to_report.value().empty()) {
+      distributor_->SetKeyMaterials(cert_name, std::move(root_to_report),
+                                    absl::nullopt);
+    }
+    if (info.root_being_watched && root_certificate.empty()) {
+      distributor_->SetErrorForCert(cert_name, GRPC_ERROR_REF(root_cert_error),
+                                    absl::nullopt);
+    }
+  }
+  GRPC_ERROR_UNREF(root_cert_error);
+}
+
+void CertificateProviderWatcherNotifier::SetKeyCertificatePairs(PemKeyCertPairList pem_key_cert_pairs) {
+  MutexLock lock(&mu_);
+  ExecCtx exec_ctx;
+  grpc_error_handle identity_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      "Unable to get latest identity certificates.");
+  for (const auto& p : watcher_info_) {
+    const std::string& cert_name = p.first;
+    const WatcherInfo& info = p.second;
+    absl::optional<grpc_core::PemKeyCertPairList> identity_to_report;
+    if (info.identity_being_watched) {
+      identity_to_report = pem_key_cert_pairs;
+    }
+    if (identity_to_report.has_value() && !identity_to_report.value().empty()) {
+      distributor_->SetKeyMaterials(cert_name, absl::nullopt,
+                                    std::move(identity_to_report));
+    }
+    if (info.identity_being_watched && pem_key_cert_pairs.empty()) {
+      distributor_->SetErrorForCert(cert_name, absl::nullopt,
+                                    GRPC_ERROR_REF(identity_cert_error));
+    }
+  }
+  GRPC_ERROR_UNREF(identity_cert_error);
+}
+
+CertificateProviderWatcherNotifier::~CertificateProviderWatcherNotifier() {
   // Reset distributor's callback to make sure the callback won't be invoked
   // again after this object(provider) is destroyed.
   distributor_->SetWatchStatusCallback(nullptr);
+}
+
+/*void CertificateProviderWatcherNotifier::SetRootCertificateAndKeyCertificatePairs(
+      std::string root_certificate, PemKeyCertPairList pem_key_cert_pairs);*/
+
+DataWatcherCertificateProvider::DataWatcherCertificateProvider() : distributor_notifier_(MakeRefCounted<CertificateProviderWatcherNotifier>(this)) {
+
+}
+
+absl::Status DataWatcherCertificateProvider::SetRootCertificate(
+    std::string root_certificate) {
+  MutexLock lock(&mu_);
+  if (root_certificate_ == root_certificate) {
+    gpr_log(GPR_INFO, "The root certs have not changed.");
+    return absl::OkStatus();
+  }
+  root_certificate_ = root_certificate;
+  distributor_notifier_->SetRootCertificate(std::move(root_certificate));
+  return absl::OkStatus();
+}
+
+absl::Status DataWatcherCertificateProvider::SetKeyCertificatePairs(
+    PemKeyCertPairList pem_key_cert_pairs) {
+  MutexLock lock(&mu_);
+  if (pem_key_cert_pairs == pem_key_cert_pairs_) {
+    gpr_log(GPR_INFO, "The key-cert pair list has not changed.");
+    return absl::OkStatus();
+  }
+  absl::StatusOr<bool> match_result =
+      PrivateKeyAndCertificateMatch(pem_key_cert_pairs);
+  if (!match_result.ok()) {
+    gpr_log(GPR_ERROR, "The key-cert match check failed: %s",
+            std::string(match_result.status().message()).c_str());
+    return match_result.status();
+  }
+  if (!(*match_result)) {
+    std::string error_message = "the key-cert pair list contains invalid pair(s)";
+    gpr_log(GPR_ERROR, "The key-cert match check failed: %s", error_message.c_str());
+    return absl::InvalidArgumentError(error_message);
+  }
+  pem_key_cert_pairs_ = pem_key_cert_pairs;
+  distributor_notifier_->SetKeyCertificatePairs(std::move(pem_key_cert_pairs));
+  return absl::OkStatus();
+}
+
+std::string DataWatcherCertificateProvider::root_certificate() {
+  MutexLock lock(&mu_);
+  return root_certificate_;
+}
+
+PemKeyCertPairList DataWatcherCertificateProvider::pem_key_cert_pairs() {
+  MutexLock lock(&mu_);
+  return pem_key_cert_pairs_;
 }
 
 namespace {
@@ -413,25 +520,71 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
   return result;
 }
 
+absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
+    const PemKeyCertPairList& pair_list) {
+  for (size_t i = 0; i < pair_list.size(); ++i) {
+    absl::StatusOr<bool> matched_or = PrivateKeyAndCertificateMatch(
+        pair_list[i].private_key(), pair_list[i].cert_chain());
+    if (!(matched_or.ok() && *matched_or)) {
+      return matched_or;
+    }
+  }
+  return true;
+}
+
 }  // namespace grpc_core
 
 /** -- Wrapper APIs declared in grpc_security.h -- **/
 
-grpc_tls_certificate_provider* grpc_tls_certificate_provider_static_data_create(
-    const char* root_certificate, grpc_tls_identity_pairs* pem_key_cert_pairs) {
-  GPR_ASSERT(root_certificate != nullptr || pem_key_cert_pairs != nullptr);
-  grpc_core::ExecCtx exec_ctx;
-  grpc_core::PemKeyCertPairList identity_pairs_core;
+namespace {
+
+grpc_core::PemKeyCertPairList ConvertToCoreObject(
+    grpc_tls_identity_pairs* pem_key_cert_pairs) {
+  grpc_core::PemKeyCertPairList identity_pairs_core = {};
   if (pem_key_cert_pairs != nullptr) {
     identity_pairs_core = std::move(pem_key_cert_pairs->pem_key_cert_pairs);
     delete pem_key_cert_pairs;
   }
-  std::string root_cert_core;
-  if (root_certificate != nullptr) {
-    root_cert_core = root_certificate;
+  return identity_pairs_core;
+}
+
+std::string ConvertToCoreObject(const char* root_certificate) {
+  return root_certificate == nullptr ? "" : root_certificate;
+}
+
+}  // namespace
+
+grpc_tls_certificate_provider* grpc_tls_certificate_provider_data_watcher_create() {
+  grpc_core::ExecCtx exec_ctx;
+  return new grpc_core::DataWatcherCertificateProvider();
+}
+
+grpc_status_code grpc_tls_certificate_provider_data_watcher_set_root_cert(
+    grpc_tls_certificate_provider* provider, const char* root_certificate,
+    char** error_details) {
+  GPR_ASSERT(provider != nullptr && root_certificate != nullptr);
+  grpc_core::DataWatcherCertificateProvider* data_provider =
+      dynamic_cast<grpc_core::DataWatcherCertificateProvider*>(provider);
+  absl::Status status =
+      data_provider->SetRootCertificate(ConvertToCoreObject(root_certificate));
+  if (!status.ok()) {
+    *error_details = gpr_strdup(std::string(status.message()).c_str());
   }
-  return new grpc_core::StaticDataCertificateProvider(
-      std::move(root_cert_core), std::move(identity_pairs_core));
+  return static_cast<grpc_status_code>(status.code());
+}
+
+grpc_status_code grpc_tls_certificate_provider_data_watcher_set_key_cert_pairs(
+    grpc_tls_certificate_provider* provider,
+    grpc_tls_identity_pairs* pem_key_cert_pairs, char** error_details) {
+  GPR_ASSERT(provider != nullptr && pem_key_cert_pairs != nullptr);
+  grpc_core::DataWatcherCertificateProvider* data_provider =
+      dynamic_cast<grpc_core::DataWatcherCertificateProvider*>(provider);
+  absl::Status status = data_provider->SetKeyCertificatePairs(
+      ConvertToCoreObject(pem_key_cert_pairs));
+  if (!status.ok()) {
+    *error_details = gpr_strdup(std::string(status.message()).c_str());
+  }
+  return static_cast<grpc_status_code>(status.code());
 }
 
 grpc_tls_certificate_provider*

--- a/test/core/end2end/fixtures/h2_tls.cc
+++ b/test/core/end2end/fixtures/h2_tls.cc
@@ -22,6 +22,7 @@
 #include "absl/container/inlined_vector.h"
 
 #include <grpc/grpc_security.h>
+#include <grpc/status.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -109,13 +110,15 @@ static void SetCertificateProvider(
       grpc_tls_identity_pairs* client_pairs = grpc_tls_identity_pairs_create();
       grpc_tls_identity_pairs_add_pair(client_pairs, private_key.c_str(),
                                        identity_cert.c_str());
-      ffd->client_provider = grpc_tls_certificate_provider_static_data_create(
-          root_cert.c_str(), client_pairs);
+      ffd->client_provider = grpc_tls_certificate_provider_data_watcher_create();
+      GPR_ASSERT(grpc_tls_certificate_provider_data_watcher_set_root_cert(ffd->client_provider, root_cert.c_str(), nullptr) == GRPC_STATUS_OK);
+      GPR_ASSERT(grpc_tls_certificate_provider_data_watcher_set_key_cert_pairs(ffd->client_provider, client_pairs, nullptr) == GRPC_STATUS_OK);
       grpc_tls_identity_pairs* server_pairs = grpc_tls_identity_pairs_create();
       grpc_tls_identity_pairs_add_pair(server_pairs, private_key.c_str(),
                                        identity_cert.c_str());
-      ffd->server_provider = grpc_tls_certificate_provider_static_data_create(
-          root_cert.c_str(), server_pairs);
+      ffd->server_provider = grpc_tls_certificate_provider_data_watcher_create();
+      GPR_ASSERT(grpc_tls_certificate_provider_data_watcher_set_root_cert(ffd->server_provider, root_cert.c_str(), nullptr) == GRPC_STATUS_OK);
+      GPR_ASSERT(grpc_tls_certificate_provider_data_watcher_set_key_cert_pairs(ffd->server_provider, server_pairs, nullptr) == GRPC_STATUS_OK);
       grpc_slice_unref(root_slice);
       grpc_slice_unref(cert_slice);
       grpc_slice_unref(key_slice);

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -205,9 +205,10 @@ class GrpcTlsCertificateProviderTest : public ::testing::Test {
   Mutex mu_;
 };
 
-TEST_F(GrpcTlsCertificateProviderTest, StaticDataCertificateProviderCreation) {
-  StaticDataCertificateProvider provider(
-      root_cert_, MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+TEST_F(GrpcTlsCertificateProviderTest, DataWatcherCertificateProviderCreationSucceeds) {
+  DataWatcherCertificateProvider provider;
+  ASSERT_TRUE(provider.SetRootCertificate(root_cert_).ok());
+  ASSERT_TRUE(provider.SetKeyCertificatePairs(MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str())).ok());
   // Watcher watching both root and identity certs.
   WatcherState* watcher_state_1 =
       MakeWatcher(provider.distributor(), kCertName, kCertName);
@@ -230,6 +231,86 @@ TEST_F(GrpcTlsCertificateProviderTest, StaticDataCertificateProviderCreation) {
       ::testing::ElementsAre(CredentialInfo(
           "", MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()))));
   CancelWatch(watcher_state_3);
+}
+
+TEST_F(GrpcTlsCertificateProviderTest,
+       DataWatcherCertificateProviderCreationFailsOnInvalidIdentityCerts) {
+  DataWatcherCertificateProvider provider;
+  ASSERT_TRUE(provider.SetRootCertificate(root_cert_).ok());
+  EXPECT_FALSE(provider.SetKeyCertificatePairs(MakeCertKeyPairs(private_key_2_.c_str(),
+                                   (cert_chain_ + cert_chain_2_).c_str())).ok());
+  WatcherState* watcher_state_1 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  EXPECT_THAT(watcher_state_1->GetErrorQueue(),
+              ::testing::ElementsAre(ErrorInfo("", kIdentityError)));
+  EXPECT_THAT(watcher_state_1->GetCredentialQueue(),
+              ::testing::ElementsAre(CredentialInfo(root_cert_, {})));
+  CancelWatch(watcher_state_1);
+}
+
+TEST_F(GrpcTlsCertificateProviderTest,
+       DataWatcherCertificateProviderSetRootCertificateSucceeds) {
+  DataWatcherCertificateProvider provider;
+  ASSERT_TRUE(provider.SetRootCertificate(root_cert_).ok());
+  WatcherState* watcher_state_1 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  EXPECT_THAT(watcher_state_1->GetCredentialQueue(),
+              ::testing::ElementsAre(CredentialInfo(root_cert_, {})));
+  CancelWatch(watcher_state_1);
+  absl::Status status = provider.SetRootCertificate(root_cert_2_);
+  WatcherState* watcher_state_2 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  EXPECT_THAT(watcher_state_2->GetCredentialQueue(),
+              ::testing::ElementsAre(CredentialInfo(root_cert_2_, {})));
+  EXPECT_TRUE(status.ok());
+  CancelWatch(watcher_state_2);
+}
+
+TEST_F(GrpcTlsCertificateProviderTest,
+       DataWatcherCertificateProviderSetKeyCertificatePairSucceeds) {
+  auto pem_key_cert_pair_list = MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str());
+  DataWatcherCertificateProvider provider;
+  ASSERT_TRUE(provider.SetKeyCertificatePairs(pem_key_cert_pair_list).ok());
+  WatcherState* watcher_state_1 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  EXPECT_THAT(
+      watcher_state_1->GetCredentialQueue(),
+      ::testing::ElementsAre(CredentialInfo("", pem_key_cert_pair_list)));
+  CancelWatch(watcher_state_1);
+  pem_key_cert_pair_list =
+      MakeCertKeyPairs(private_key_2_.c_str(), cert_chain_2_.c_str());
+  absl::Status status = provider.SetKeyCertificatePairs(pem_key_cert_pair_list);
+  WatcherState* watcher_state_2 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  EXPECT_THAT(
+      watcher_state_2->GetCredentialQueue(),
+      ::testing::ElementsAre(CredentialInfo("", pem_key_cert_pair_list)));
+  EXPECT_TRUE(status.ok());
+  CancelWatch(watcher_state_2);
+}
+
+TEST_F(GrpcTlsCertificateProviderTest,
+       DataWatcherCertificateProviderSetKeyCertificatePairFailsOnInvalidPairs) {
+  auto pem_key_cert_pair_list = MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str());
+  DataWatcherCertificateProvider provider;
+  ASSERT_TRUE(provider.SetRootCertificate(root_cert_).ok());
+  ASSERT_TRUE(provider.SetKeyCertificatePairs(pem_key_cert_pair_list).ok());
+  WatcherState* watcher_state_1 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  EXPECT_THAT(watcher_state_1->GetCredentialQueue(),
+              ::testing::ElementsAre(
+                  CredentialInfo(root_cert_, pem_key_cert_pair_list)));
+  CancelWatch(watcher_state_1);
+  WatcherState* watcher_state_2 =
+      MakeWatcher(provider.distributor(), kCertName, kCertName);
+  absl::Status status = provider.SetKeyCertificatePairs(
+      MakeCertKeyPairs(private_key_.c_str(), cert_chain_2_.c_str()));
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(), "the key-cert pair list contains invalid pair(s)");
+  EXPECT_THAT(watcher_state_2->GetCredentialQueue(),
+              ::testing::ElementsAre(
+                  CredentialInfo(root_cert_, pem_key_cert_pair_list)));
+  CancelWatch(watcher_state_2);
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
@@ -490,7 +571,14 @@ TEST_F(GrpcTlsCertificateProviderTest,
   CancelWatch(watcher_state_1);
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {
+TEST_F(GrpcTlsCertificateProviderTest, KeyCertMatchSucceeds) {
+  absl::StatusOr<bool> matched_result = PrivateKeyAndCertificateMatch(
+      private_key_2_, /*cert_chain=*/cert_chain_2_ + cert_chain_);
+  ASSERT_TRUE(matched_result.ok());
+  EXPECT_TRUE(*matched_result);
+}
+
+TEST_F(GrpcTlsCertificateProviderTest, KeyCertMatchFailsOnEmptyPrivateKey) {
   absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(/*private_key=*/"", cert_chain_);
   EXPECT_FALSE(status.ok());
@@ -498,7 +586,7 @@ TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {
   EXPECT_EQ(status.status().message(), "Private key string is empty.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyCertificate) {
+TEST_F(GrpcTlsCertificateProviderTest, KeyCertMatchFailsOnEmptyCertificate) {
   absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, /*cert_chain=*/"");
   EXPECT_FALSE(status.ok());
@@ -506,7 +594,7 @@ TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyCertificate) {
   EXPECT_EQ(status.status().message(), "Certificate string is empty.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidCertFormat) {
+TEST_F(GrpcTlsCertificateProviderTest, KeyCertMatchFailsOnInvalidCertFormat) {
   absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, "invalid_certificate");
   EXPECT_FALSE(status.ok());
@@ -516,7 +604,7 @@ TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidCertFormat) {
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
-       FailedKeyCertMatchOnInvalidPrivateKeyFormat) {
+       KeyCertMatchFailsOnInvalidPrivateKeyFormat) {
   absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch("invalid_private_key", cert_chain_2_);
   EXPECT_EQ(status.status().code(), absl::StatusCode::kInvalidArgument);
@@ -524,17 +612,10 @@ TEST_F(GrpcTlsCertificateProviderTest,
             "Conversion from PEM string to EVP_PKEY failed.");
 }
 
-TEST_F(GrpcTlsCertificateProviderTest, SuccessfulKeyCertMatch) {
-  absl::StatusOr<bool> status =
-      PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_2_);
-  EXPECT_TRUE(status.ok());
-  EXPECT_TRUE(*status);
-}
-
-TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnInvalidPair) {
+TEST_F(GrpcTlsCertificateProviderTest, KeyCertMatchFailsOnInvalidPair) {
   absl::StatusOr<bool> status =
       PrivateKeyAndCertificateMatch(private_key_2_, cert_chain_);
-  EXPECT_TRUE(status.ok());
+  ASSERT_TRUE(status.ok());
   EXPECT_FALSE(*status);
 }
 

--- a/test/core/security/grpc_tls_credentials_options_test.cc
+++ b/test/core/security/grpc_tls_credentials_options_test.cc
@@ -87,10 +87,14 @@ TEST_F(GrpcTlsCredentialsOptionsTest, ClientOptionsOnDefaultRootCerts) {
 //
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ClientOptionsWithStaticDataProviderOnBothCerts) {
+       ClientOptionsWithDataWatcherProviderOnBothCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      root_cert_, MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider->SetRootCertificate(root_cert_).ok());
+  ASSERT_TRUE(provider
+                  ->SetKeyCertificatePairs(MakeCertKeyPairs(
+                      private_key_.c_str(), cert_chain_.c_str()))
+                  .ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_root_cert(true);
   options->set_watch_identity_pair(true);
@@ -109,10 +113,10 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ClientOptionsWithStaticDataProviderOnRootCerts) {
+       ClientOptionsWithDataWatcherProviderOnRootCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      root_cert_, PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider->SetRootCertificate(root_cert_).ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_root_cert(true);
   auto credentials = MakeRefCounted<TlsCredentials>(options);
@@ -130,10 +134,13 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ClientOptionsWithStaticDataProviderOnNotProvidedCerts) {
+       ClientOptionsWithDataWatcherProviderOnNotProvidedCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      "", MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider
+                  ->SetKeyCertificatePairs(MakeCertKeyPairs(
+                      private_key_.c_str(), cert_chain_.c_str()))
+                  .ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_root_cert(true);
   auto credentials = MakeRefCounted<TlsCredentials>(options);
@@ -149,10 +156,13 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ClientOptionsWithDefaultRootAndStaticDataProviderOnIdentityCerts) {
+       ClientOptionsWithDefaultRootAndDataWatcherProviderOnIdentityCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      "", MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider
+                  ->SetKeyCertificatePairs(MakeCertKeyPairs(
+                      private_key_.c_str(), cert_chain_.c_str()))
+                  .ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsCredentials>(options);
@@ -168,10 +178,14 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ServerOptionsWithStaticDataProviderOnBothCerts) {
+       ServerOptionsWithDataWatcherProviderOnBothCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      root_cert_, MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider->SetRootCertificate(root_cert_).ok());
+  ASSERT_TRUE(provider
+                  ->SetKeyCertificatePairs(MakeCertKeyPairs(
+                      private_key_.c_str(), cert_chain_.c_str()))
+                  .ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_root_cert(true);
   options->set_watch_identity_pair(true);
@@ -189,10 +203,13 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ServerOptionsWithStaticDataProviderOnIdentityCerts) {
+       ServerOptionsWithDataWatcherProviderOnIdentityCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      "", MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider
+                  ->SetKeyCertificatePairs(MakeCertKeyPairs(
+                      private_key_.c_str(), cert_chain_.c_str()))
+                  .ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
@@ -208,10 +225,10 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
 }
 
 TEST_F(GrpcTlsCredentialsOptionsTest,
-       ServerOptionsWithStaticDataProviderOnNotProvidedCerts) {
+       ServerOptionsWithDataWatcherProviderOnNotProvidedCerts) {
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      root_cert_, PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider->SetRootCertificate(root_cert_).ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
@@ -518,8 +535,8 @@ TEST_F(GrpcTlsCredentialsOptionsTest, ServerOptionsWithExternalVerifier) {
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
   options->set_certificate_verifier(core_external_verifier.Ref());
   // On server side we have to set the provider providing identity certs.
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      root_cert_, PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider->SetRootCertificate(root_cert_).ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsServerCredentials>(options);
@@ -558,8 +575,8 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
   options->set_certificate_verifier(hostname_certificate_verifier_.Ref());
   // On server side we have to set the provider providing identity certs.
-  auto provider = MakeRefCounted<StaticDataCertificateProvider>(
-      root_cert_, PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
+  ASSERT_TRUE(provider->SetRootCertificate(root_cert_).ok());
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsServerCredentials>(options);

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -951,8 +951,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_credentials_options>();
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
   options->set_certificate_verifier(core_external_verifier.Ref());
-  auto provider =
-      MakeRefCounted<StaticDataCertificateProvider>("", PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsServerCredentials>(options);
@@ -981,8 +980,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_credentials_options>();
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
   options->set_certificate_verifier(core_external_verifier.Ref());
-  auto provider =
-      MakeRefCounted<StaticDataCertificateProvider>("", PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsServerCredentials>(options);
@@ -1015,8 +1013,7 @@ TEST_F(TlsSecurityConnectorTest,
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
   options->set_certificate_verifier(core_external_verifier->Ref());
-  auto provider =
-      MakeRefCounted<StaticDataCertificateProvider>("", PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsServerCredentials>(options);
@@ -1047,8 +1044,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_credentials_options>();
   options->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
   options->set_certificate_verifier(core_external_verifier->Ref());
-  auto provider =
-      MakeRefCounted<StaticDataCertificateProvider>("", PemKeyCertPairList());
+  auto provider = MakeRefCounted<DataWatcherCertificateProvider>();
   options->set_certificate_provider(std::move(provider));
   options->set_watch_identity_pair(true);
   auto credentials = MakeRefCounted<TlsServerCredentials>(options);


### PR DESCRIPTION
This intends to replace https://github.com/grpc/grpc/pull/26663.
It does the following things:
1. expose two new APIs for `StaticDataCertificateProvider` that can update the root certs as well as the key-cert pair list being used
2. rename `StaticCertificateProvider` to `DataWatcherCertificateProvider` since it is not "static" anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/28411)
<!-- Reviewable:end -->
