### PR TITLE
Backport "Don't gem install rake-compiler on macos setup scripts (#28415)" to 1.42.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,7 @@ task 'gem:native' do
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
         "build should be running on ruby 2.5."
     end
-    system "rake cross native gem RUBY_CC_VERSION=#{ruby_cc_versions} V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    system "bundle exec rake cross native gem RUBY_CC_VERSION=#{ruby_cc_versions} V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     Rake::Task['dlls'].execute
     ['x86-mingw32', 'x64-mingw32'].each do |plat|

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -68,7 +68,8 @@ mkdir -p "$(dirname $RUBY_3_0_0_TAR)"
 curl -L "https://ftp.ruby-lang.org/pub/ruby/3.0/$(basename $RUBY_3_0_0_TAR)" -o "$RUBY_3_0_0_TAR"
 ccache -c
 ruby --version | grep 'ruby 3.0.0'
-rake -f "$CROSS_RUBY" cross-ruby VERSION=3.0.0 HOST=x86_64-darwin11 MAKE="$MAKE" SOURCE="$RUBY_3_0_0_TAR"
+tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+bundle exec rake -f "$CROSS_RUBY" cross-ruby VERSION=3.0.0 HOST=x86_64-darwin11 MAKE="$MAKE" SOURCE="$RUBY_3_0_0_TAR"
 echo "installed ruby 3.0.0 build targets"
 # Install ruby 2.7.0 for rake-compiler
 set +x
@@ -77,7 +78,8 @@ rvm use 2.7.0
 set -x
 ruby --version | grep 'ruby 2.7.0'
 ccache -c
-rake -f "$CROSS_RUBY" cross-ruby VERSION=2.7.0 HOST=x86_64-darwin11 MAKE="$MAKE"
+tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+bundle exec rake -f "$CROSS_RUBY" cross-ruby VERSION=2.7.0 HOST=x86_64-darwin11 MAKE="$MAKE"
 echo "installed ruby 2.7.0 build targets"
 # Install ruby 2.4-2.6 for rake-compiler
 set +x
@@ -87,7 +89,8 @@ set -x
 ruby --version | grep 'ruby 2.5.0'
 for v in 2.6.0 2.5.0 2.4.0 ; do
   ccache -c
-  rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
+  tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+  bundle exec rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
   echo "installed ruby $v build targets"
 done
 

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
@@ -30,4 +30,4 @@ cd /var/local/git/grpc
 rvm --default use ruby-2.5
 
 # build Ruby interop client and server
-(cd src/ruby && gem install bundler -v 1.17.3 && bundle && rake compile)
+(cd src/ruby && gem install bundler -v 1.17.3 && bundle && bundle exec rake compile)

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -80,7 +80,6 @@ then
   for RUBY_VERSION in 2.5.0 2.7.0 3.0.0; do
     echo "Installing ruby-${RUBY_VERSION}"
     time rvm install "ruby-${RUBY_VERSION}"
-    time gem install rake-compiler --no-document
   done;
   echo "Setting default ruby version."
   rvm use 2.5.0 --default

--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -59,7 +59,7 @@ touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
     --grpc_python_out=${TOOLS_DIR} \
     ${HEALTH_PROTO_SOURCE_DIR}/health.proto
 
-(cd src/ruby && bundle && rake compile)
+(cd src/ruby && bundle && bundle exec rake compile)
 
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
   tools/run_tests/run_xds_tests.py \

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -32,11 +32,11 @@ python3.7 -m pip install -U cython setuptools==44.1.1 wheel --user
 python3.8 -m pip install -U cython setuptools==44.1.1 wheel --user
 python3.9 -m pip install -U cython setuptools==44.1.1 wheel --user
 
-# needed to build ruby artifacts
-time bash tools/distrib/build_ruby_environment_macos.sh
-
 gem install rubygems-update
 update_rubygems
+
+# needed to build ruby artifacts
+time bash tools/distrib/build_ruby_environment_macos.sh
 
 tools/run_tests/task_runner.py -f artifact macos || FAILED="true"
 

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -51,7 +51,7 @@ tools/run_tests/helper_scripts/bundle_install_wrapper.sh
 set -ex
 
 export DOCKERHUB_ORGANIZATION=grpctesting
-rake gem:native
+bundle exec rake gem:native
 
 if [ "$SYSTEM" == "Darwin" ] ; then
   # TODO: consider rewriting this to pass shellcheck

--- a/tools/run_tests/helper_scripts/build_ruby.sh
+++ b/tools/run_tests/helper_scripts/build_ruby.sh
@@ -28,7 +28,7 @@ fi
 cd "$(dirname "$0")/../../.."
 
 rm -rf ./tmp
-rake compile
+bundle exec rake compile
 
 # build grpc_ruby_plugin
 mkdir -p cmake/build


### PR DESCRIPTION
backports https://github.com/grpc/grpc/pull/28415