### PR TITLE
Remove python2 from third_party/py/BUILD.tpl

### DIFF
--- a/third_party/py/BUILD.tpl
+++ b/third_party/py/BUILD.tpl
@@ -9,11 +9,6 @@ config_setting(
 )
 
 config_setting(
-    name="python2",
-    flag_values = {"@rules_python//python:python_version": "PY2"}
-)
-
-config_setting(
     name="python3",
     flag_values = {"@rules_python//python:python_version": "PY3"}
 )
@@ -21,7 +16,6 @@ config_setting(
 cc_library(
     name = "python_lib",
     deps = select({
-        ":python2": ["//_python2:_python2_lib"],
         ":python3": ["//_python3:_python3_lib"],
         "//conditions:default": ["not-existing.lib"],
     })
@@ -30,7 +24,6 @@ cc_library(
 cc_library(
     name = "python_headers",
     deps = select({
-        ":python2": ["//_python2:_python2_headers"],
         ":python3": ["//_python3:_python3_headers"],
         "//conditions:default": ["not-existing.headers"],
     })

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -372,8 +372,7 @@ python_configure = repository_rule(
 )
 """Detects and configures the local Python.
 
-It is expected that the system have both a working Python 2 and python 3
-installation
+It expects the system have a working Python 3 installation.
 
 Add the following to your WORKSPACE FILE:
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/28447

Previous attempt https://github.com/grpc/grpc/pull/28406.

Python2 is included by a template generated BUILD file. Technically, it's hidden for Python3 build path, but there is still a random chance that Bazel tries Python2 before Python3.