### PR TITLE
xds_end2end_test: Set skip cancelled check

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -8308,9 +8308,10 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
       context.set_wait_for_ready(true);
       context.set_deadline(grpc_timeout_milliseconds_to_deadline(2000));
       EchoRequest request;
-      // Skipping the cancelled check on the server since the server's graceful
-      // shutdown isn't as per spec and the check isn't necessary for what we
-      // want to test here anyway. https://github.com/grpc/grpc/issues/24237
+      // TODO(yashykt): Skipping the cancelled check on the server since the
+      // server's graceful shutdown isn't as per spec and the check isn't
+      // necessary for what we want to test here anyway.
+      // https://github.com/grpc/grpc/issues/24237
       request.mutable_param()->set_skip_cancelled_check(true);
       request.set_message(kRequestMessage);
       EchoResponse response;

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -8308,6 +8308,10 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
       context.set_wait_for_ready(true);
       context.set_deadline(grpc_timeout_milliseconds_to_deadline(2000));
       EchoRequest request;
+      // Skipping the cancelled check on the server since the server's graceful
+      // shutdown isn't as per spec and the check isn't necessary for what we
+      // want to test here anyway. https://github.com/grpc/grpc/issues/24237
+      request.mutable_param()->set_skip_cancelled_check(true);
       request.set_message(kRequestMessage);
       EchoResponse response;
       Status status = stub->Echo(&context, request, &response);


### PR DESCRIPTION
Removes the flakiness from some of the server side tests.
