### PR TITLE
Remove python2 from bazel docker images

### DIFF
--- a/templates/tools/dockerfile/oss_fuzz_base.include
+++ b/templates/tools/dockerfile/oss_fuzz_base.include
@@ -33,9 +33,3 @@ RUN apt-get update && apt-get install -y ${'\\'}
     python3-all-dev
 
 <%include file="./compile_python_36.include"/>
-
-# Python2's python.h still needs to be present in order for the bazel build
-# to work.
-# TODO(jtattermusch): remove once https://github.com/grpc/grpc/issues/28026
-# is fixed.
-RUN apt-get update && apt-get install -y python-all-dev python-setuptools

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -67,12 +67,6 @@ RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage
 
 
-# Python2's python.h still needs to be present in order for the bazel build
-# to work.
-# TODO(jtattermusch): remove once https://github.com/grpc/grpc/issues/28026
-# is fixed.
-RUN apt-get update && apt-get install -y python-all-dev python-setuptools
-
 #========================
 # Bazel installation
 

--- a/tools/dockerfile/test/binder_transport_apk/Dockerfile
+++ b/tools/dockerfile/test/binder_transport_apk/Dockerfile
@@ -67,12 +67,6 @@ RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage
 
 
-# Python2's python.h still needs to be present in order for the bazel build
-# to work.
-# TODO(jtattermusch): remove once https://github.com/grpc/grpc/issues/28026
-# is fixed.
-RUN apt-get update && apt-get install -y python-all-dev python-setuptools
-
 #========================
 # Bazel installation
 


### PR DESCRIPTION
https://github.com/grpc/grpc/issues/28026 has been closed, so this should work?