### PR TITLE
Avoid sync_test timeouts on arm64

### DIFF
--- a/test/core/gpr/sync_test.cc
+++ b/test/core/gpr/sync_test.cc
@@ -240,7 +240,7 @@ static void mark_thread_done(struct test* m) {
    */
 static void test(const char* name, void (*body)(void* m),
                  void (*extra)(void* m), int timeout_s, int incr_step) {
-  int64_t iterations = 256;
+  int64_t iterations = 8;
   struct test* m;
   gpr_timespec start = gpr_now(GPR_CLOCK_REALTIME);
   gpr_timespec time_taken;


### PR DESCRIPTION
See b/204865607. 

It looks like the "queue" part of the test is unusually slow on ARM64.

`queue: 256 512 1024 2048 4096 8192 16384 32768 done` takes 13.64 sec on x64
https://source.cloud.google.com/results/invocations/c7ce2a1f-b64e-415e-a142-3f0c036ca0c1/targets;query=sync_test/%2F%2Ftest%2Fcore%2Fgpr:sync_test/log

`but queue: 256 done` (which is a small subset of the above) takes 267.241315011 sec on arm64 (Graviton2)

Upon futher inspection, the problem seems to be the producers that run `queue_try_append`
https://github.com/grpc/grpc/blob/55b365f287fda218e1e05b1b83a89f8473d1900d/test/core/gpr/sync_test.cc#L377,
which makes it hard for the consumer to obtain a lock to consume elements added by the producer (the consumer eventually obtains the lock, but it takes a lot of time to do it, so the test progresses very slowly).
If only "queue_append" is used, the test is as fast as on x64.
I guess this boils down to mutexes being less fair on arm64 (Graviton2) than on x64?


The tentative fix is to reduce the number of iterations, to make sure the slowly proceeding test can still finish within a reasonable timeframe.

tested with `tools/bazel test --config opt //test/core/gpr:sync_test --runs_per_test 100`

```
Executing tests from //test/core/gpr:sync_test
-----------------------------------------------------------------------------
mutex: 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 2097152 done 1.773408363 s
mutex try: 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 done 1.006153190 s
cv: 8 16 32 64 128 256 512 1024 2048 4096 done 1.587238012 s
timedcv: 8 16 32 64 128 256 512 done 1.080519063 s
queue: 8 16 done 20.700857133 s
stats_counter: 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 2097152 4194304 done 1.841731760 s
refcount by 1: 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 2097152 done 1.372278996 s
refcount by 3: 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 done 1.085255970 s
timedevent: 8 16 32 64 128 256 512 done 1.078835677 s
```

