### PR TITLE
Revert "[BinderTransport] Allow finding Java class using custom class finder"

### DIFF
--- a/include/grpcpp/create_channel_binder.h
+++ b/include/grpcpp/create_channel_binder.h
@@ -78,15 +78,6 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
 /// Returns true when the initialization is successful.
 bool InitializeBinderChannelJavaClass(void* jni_env_void);
 
-/// EXPERIMENTAL Alternative version of `InitializeBinderChannelJavaClass(void*
-/// jni_env_void)`. This version used a user-specified function to find the
-/// required internal Java class. When a class is found, the `class_finder`
-/// function should return a local reference to the class (jclass type). The
-/// returned jclass will then be used to create global reference for gRPC to use
-/// it later. After that, gRPC will DeleteLocalRef the returned local reference.
-bool InitializeBinderChannelJavaClass(
-    void* jni_env_void, std::function<void*(std::string)> class_finder);
-
 }  // namespace experimental
 }  // namespace grpc
 

--- a/src/core/ext/transport/binder/client/channel_create.cc
+++ b/src/core/ext/transport/binder/client/channel_create.cc
@@ -50,7 +50,6 @@
 #include "src/core/ext/transport/binder/wire_format/binder.h"
 #include "src/core/ext/transport/binder/wire_format/binder_android.h"
 #include "src/core/lib/channel/channel_args.h"
-#include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/surface/channel.h"
 #include "src/core/lib/transport/transport.h"
 #include "src/cpp/client/create_channel_internal.h"
@@ -123,12 +122,6 @@ bool InitializeBinderChannelJavaClass(void* jni_env_void) {
              static_cast<JNIEnv*>(jni_env_void)) != nullptr;
 }
 
-bool InitializeBinderChannelJavaClass(
-    void* jni_env_void, std::function<void*(std::string)> class_finder) {
-  return grpc_binder::FindNativeConnectionHelper(
-             static_cast<JNIEnv*>(jni_env_void), class_finder) != nullptr;
-}
-
 }  // namespace experimental
 }  // namespace grpc
 
@@ -161,16 +154,6 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
 }
 
 bool InitializeBinderChannelJavaClass(void* jni_env_void) {
-  gpr_log(GPR_ERROR,
-          "This APK is compiled with Android API level = %d, which is not "
-          "supported. See port_platform.h for supported versions.",
-          __ANDROID_API__);
-  GPR_ASSERT(0);
-  return {};
-}
-
-bool InitializeBinderChannelJavaClass(
-    void* jni_env_void, std::function<void*(std::string)> class_finder) {
   gpr_log(GPR_ERROR,
           "This APK is compiled with Android API level = %d, which is not "
           "supported. See port_platform.h for supported versions.",

--- a/src/core/ext/transport/binder/client/jni_utils.cc
+++ b/src/core/ext/transport/binder/client/jni_utils.cc
@@ -25,20 +25,12 @@
 namespace grpc_binder {
 
 jclass FindNativeConnectionHelper(JNIEnv* env) {
-  return FindNativeConnectionHelper(
-      env, [env](std::string cl) { return env->FindClass(cl.c_str()); });
-}
-
-jclass FindNativeConnectionHelper(
-    JNIEnv* env, std::function<void*(std::string)> class_finder) {
-  auto do_find = [env, class_finder]() {
-    jclass cl = static_cast<jclass>(
-        class_finder("io/grpc/binder/cpp/NativeConnectionHelper"));
+  auto do_find = [env]() {
+    jclass cl = env->FindClass("io/grpc/binder/cpp/NativeConnectionHelper");
     if (cl == nullptr) {
       return cl;
     }
     jclass global_cl = static_cast<jclass>(env->NewGlobalRef(cl));
-    env->DeleteLocalRef(cl);
     GPR_ASSERT(global_cl != nullptr);
     return global_cl;
   };

--- a/src/core/ext/transport/binder/client/jni_utils.h
+++ b/src/core/ext/transport/binder/client/jni_utils.h
@@ -31,9 +31,6 @@ namespace grpc_binder {
 // JNI_OnLoad) so subsequent BinderTransport code can find Java class
 jclass FindNativeConnectionHelper(JNIEnv* env);
 
-jclass FindNativeConnectionHelper(
-    JNIEnv* env, std::function<void*(std::string)> class_finder);
-
 // Calls Java method NativeConnectionHelper.tryEstablishConnection
 void TryEstablishConnection(JNIEnv* env, jobject application,
                             absl::string_view pkg, absl::string_view cls,


### PR DESCRIPTION
Reverts grpc/grpc#28348 - causes master/linux/grpc_android build failure: https://source.cloud.google.com/results/invocations/fee97c1d-e941-4660-b360-7142d6f6c0d8/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_android/log

```
In file included from /tmpfs/src/github/grpc/src/core/ext/transport/binder/client/jni_utils.cc:17:
  ../../../../../../../../../src/core/ext/transport/binder/client/jni_utils.h:35:23: error: no type named 'function' in namespace 'std'
      JNIEnv* env, std::function<void*(std::string)> class_finder);
                   ~~~~~^
  ../../../../../../../../../src/core/ext/transport/binder/client/jni_utils.h:35:31: error: expected ')'
      JNIEnv* env, std::function<void*(std::string)> class_finder);
                                ^
  ../../../../../../../../../src/core/ext/transport/binder/client/jni_utils.h:34:34: note: to match this '('
  jclass FindNativeConnectionHelper(
                                   ^
  /tmpfs/src/github/grpc/src/core/ext/transport/binder/client/jni_utils.cc:28:10: error: no matching function for call to 'FindNativeConnectionHelper'
    return FindNativeConnectionHelper(
           ^~~~~~~~~~~~~~~~~~~~~~~~~~
  /tmpfs/src/github/grpc/src/core/ext/transport/binder/client/jni_utils.cc:27:8: note: candidate function not viable: requires single argument 'env', but 2 arguments were provided
  jclass FindNativeConnectionHelper(JNIEnv* env) {
```