### PR TITLE
Merge the 3 repeating Python binary compilations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,24 +6,23 @@ libs
 objs
 
 # Python items
-cython_debug/
-python_build/
-yapf_virtual_environment/
-python_pylint_venv/
 .coverage*
 .eggs
-htmlcov/
-dist/
+.pytype
 *.egg
-py27_gevent/
-py27_native/
-py3[0-9]_gevent/
-py3[0-9]_native/
+*.egg-info
 a.out
+cython_debug/
+dist/
+htmlcov/
+py3*/
+python_build/
+python_pylint_venv/
+src/python/grpcio_*/=*
+src/python/grpcio_*/build/
 src/python/grpcio_*/LICENSE
 src/python/grpcio_status/grpc_status/google/rpc/status.proto
-.pytype
-*.egg-info
+yapf_virtual_environment/
 
 # Node installation output
 node_modules

--- a/src/python/grpcio/grpc/_grpcio_metadata.py
+++ b/src/python/grpcio/grpc/_grpcio_metadata.py
@@ -1,17 +1,1 @@
-# Copyright 2017 gRPC authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio/grpc/_grpcio_metadata.py.template`!!!
-
 __version__ = """1.44.0.dev0"""

--- a/src/python/grpcio/grpc/_grpcio_metadata.py
+++ b/src/python/grpcio/grpc/_grpcio_metadata.py
@@ -1,1 +1,17 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio/grpc/_grpcio_metadata.py.template`!!!
+
 __version__ = """1.44.0.dev0"""

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -176,16 +176,13 @@ pip_install_dir() {
   cd "$PWD"
 }
 
-case "$VENV" in
-  *py36_gevent*)
+# Install gevent
+if [[ "$VENV" == "py36" ]]; then
   # TODO(https://github.com/grpc/grpc/issues/15411) unpin this
   pip_install gevent==1.3.b1
-  ;;
-  *gevent*)
+else
   pip_install -U gevent
-  ;;
-esac
-
+fi
 
 pip_install --upgrade cython
 pip_install --upgrade six protobuf

--- a/tools/run_tests/helper_scripts/run_python.sh
+++ b/tools/run_tests/helper_scripts/run_python.sh
@@ -27,4 +27,3 @@ $PYTHON "$ROOT/src/python/grpcio_tests/setup.py" "$2"
 mkdir -p "$ROOT/reports"
 rm -rf "$ROOT/reports/python-coverage"
 (mv -T "$ROOT/htmlcov" "$ROOT/reports/python-coverage") || true
-

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -645,7 +645,8 @@ class PythonLanguage(object):
                     timeout_seconds=8 * 60,
                     environ=dict(GRPC_PYTHON_TESTRUNNER_FILTER=str(test_case),
                                  **environment),
-                    shortname=f'{python_config.name}.{io_platform}.{test_case}',
+                    shortname='%s.%s.%s' %
+                    (python_config.name, io_platform, test_case),
                 ) for test_case in test_cases for python_config in self.pythons
             ])
         return jobs

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -178,22 +178,18 @@ _PythonConfigVars = collections.namedtuple('_ConfigVars', [
     'venv_relative_python',
     'toolchain',
     'runner',
-    'test_name',
-    'iomgr_platform',
 ])
 
 
 def _python_config_generator(name, major, minor, bits, config_vars):
-    name += '_' + config_vars.iomgr_platform
-    return PythonConfig(
-        name, config_vars.shell + config_vars.builder +
-        config_vars.builder_prefix_arguments +
-        [_python_pattern_function(major=major, minor=minor, bits=bits)] +
-        [name] + config_vars.venv_relative_python + config_vars.toolchain,
-        config_vars.shell + config_vars.runner + [
-            os.path.join(name, config_vars.venv_relative_python[0]),
-            config_vars.test_name
-        ])
+    build = (config_vars.shell + config_vars.builder +
+             config_vars.builder_prefix_arguments +
+             [_python_pattern_function(major=major, minor=minor, bits=bits)] +
+             [name] + config_vars.venv_relative_python + config_vars.toolchain)
+    run = (config_vars.shell + config_vars.runner + [
+        os.path.join(name, config_vars.venv_relative_python[0]),
+    ])
+    return PythonConfig(name, build, run)
 
 
 def _pypy_config_generator(name, major, config_vars):
@@ -616,8 +612,9 @@ class PythonLanguage(object):
         ],
         'asyncio': ['src/python/grpcio_tests/tests_aio/tests.json'],
     }
-    _TEST_FOLDER = {
-        'native': 'test',
+
+    _TEST_COMMAND = {
+        'native': 'test_lite',
         'gevent': 'test_gevent',
         'asyncio': 'test_aio',
     }
@@ -629,28 +626,29 @@ class PythonLanguage(object):
 
     def test_specs(self):
         # load list of known test suites
-        tests_json = []
-        for tests_json_file_name in self._TEST_SPECS_FILE[
-                self.args.iomgr_platform]:
-            with open(tests_json_file_name) as tests_json_file:
-                tests_json.extend(json.load(tests_json_file))
-        environment = dict(_FORCE_ENVIRON_FOR_WRAPPERS)
-        # TODO(https://github.com/grpc/grpc/issues/21401) Fork handlers is not
-        # designed for non-native IO manager. It has a side-effect that
-        # overrides threading settings in C-Core.
-        if args.iomgr_platform != 'native':
-            environment['GRPC_ENABLE_FORK_SUPPORT'] = '0'
-        return [
-            self.config.job_spec(
-                config.run,
-                timeout_seconds=8 * 60,
-                environ=dict(GRPC_PYTHON_TESTRUNNER_FILTER=str(suite_name),
-                             **environment),
-                shortname='%s.%s.%s' %
-                (config.name, self._TEST_FOLDER[self.args.iomgr_platform],
-                 suite_name),
-            ) for suite_name in tests_json for config in self.pythons
-        ]
+        jobs = []
+        for io_platform in self._TEST_SPECS_FILE:
+            test_cases = []
+            for tests_json_file_name in self._TEST_SPECS_FILE[io_platform]:
+                with open(tests_json_file_name) as tests_json_file:
+                    test_cases.extend(json.load(tests_json_file))
+
+            environment = dict(_FORCE_ENVIRON_FOR_WRAPPERS)
+            # TODO(https://github.com/grpc/grpc/issues/21401) Fork handlers is not
+            # designed for non-native IO manager. It has a side-effect that
+            # overrides threading settings in C-Core.
+            if io_platform != 'native':
+                environment['GRPC_ENABLE_FORK_SUPPORT'] = '0'
+            jobs.extend([
+                self.config.job_spec(
+                    python_config.run + [self._TEST_COMMAND[io_platform]],
+                    timeout_seconds=8 * 60,
+                    environ=dict(GRPC_PYTHON_TESTRUNNER_FILTER=str(test_case),
+                                 **environment),
+                    shortname=f'{python_config.name}.{io_platform}.{test_case}',
+                ) for test_case in test_cases for python_config in self.pythons
+            ])
+        return jobs
 
     def pre_build_steps(self):
         return []
@@ -688,6 +686,11 @@ class PythonLanguage(object):
 
     def _get_pythons(self, args):
         """Get python runtimes to test with, based on current platform, architecture, compiler etc."""
+        if args.iomgr_platform != 'native':
+            raise ValueError(
+                'Python builds no longer differentiate IO Manager platforms, please use "native"'
+            )
+
         if args.arch == 'x86':
             bits = '32'
         else:
@@ -712,25 +715,13 @@ class PythonLanguage(object):
             venv_relative_python = ['bin/python']
             toolchain = ['unix']
 
-        # Selects the corresponding testing mode.
-        # See src/python/grpcio_tests/commands.py for implementation details.
-        if args.iomgr_platform == 'native':
-            test_command = 'test_lite'
-        elif args.iomgr_platform == 'gevent':
-            test_command = 'test_gevent'
-        elif args.iomgr_platform == 'asyncio':
-            test_command = 'test_aio'
-        else:
-            raise ValueError('Unsupported IO Manager platform: %s' %
-                             args.iomgr_platform)
         runner = [
             os.path.abspath('tools/run_tests/helper_scripts/run_python.sh')
         ]
 
         config_vars = _PythonConfigVars(shell, builder,
                                         builder_prefix_arguments,
-                                        venv_relative_python, toolchain, runner,
-                                        test_command, args.iomgr_platform)
+                                        venv_relative_python, toolchain, runner)
         python36_config = _python_config_generator(name='py36',
                                                    major='3',
                                                    minor='6',
@@ -751,6 +742,11 @@ class PythonLanguage(object):
                                                    minor='9',
                                                    bits=bits,
                                                    config_vars=config_vars)
+        python310_config = _python_config_generator(name='py310',
+                                                    major='3',
+                                                    minor='10',
+                                                    bits=bits,
+                                                    config_vars=config_vars)
         pypy27_config = _pypy_config_generator(name='pypy',
                                                major='2',
                                                config_vars=config_vars)
@@ -758,34 +754,19 @@ class PythonLanguage(object):
                                                major='3',
                                                config_vars=config_vars)
 
-        if args.iomgr_platform in ('asyncio', 'gevent'):
-            if args.compiler not in ('default', 'python3.6', 'python3.7',
-                                     'python3.8', 'python3.9'):
-                raise Exception(
-                    'Compiler %s not supported with IO Manager platform: %s' %
-                    (args.compiler, args.iomgr_platform))
-
         if args.compiler == 'default':
             if os.name == 'nt':
-                if args.iomgr_platform == 'gevent':
-                    # TODO(https://github.com/grpc/grpc/issues/23784) allow
-                    # gevent to run on later version once issue solved.
-                    return (python36_config,)
-                else:
-                    return (python38_config,)
+                return (python38_config,)
+            elif os.uname()[0] == 'Darwin':
+                # NOTE(rbellevi): Testing takes significantly longer on
+                # MacOS, so we restrict the number of interpreter versions
+                # tested.
+                return (python38_config,)
             else:
-                if args.iomgr_platform in ('asyncio', 'gevent'):
-                    return (python36_config, python38_config)
-                elif os.uname()[0] == 'Darwin':
-                    # NOTE(rbellevi): Testing takes significantly longer on
-                    # MacOS, so we restrict the number of interpreter versions
-                    # tested.
-                    return (python38_config,)
-                else:
-                    return (
-                        python37_config,
-                        python38_config,
-                    )
+                return (
+                    python36_config,
+                    python38_config,
+                )
         elif args.compiler == 'python3.6':
             return (python36_config,)
         elif args.compiler == 'python3.7':
@@ -794,6 +775,8 @@ class PythonLanguage(object):
             return (python38_config,)
         elif args.compiler == 'python3.9':
             return (python39_config,)
+        elif args.compiler == 'python3.10':
+            return (python310_config,)
         elif args.compiler == 'pypy':
             return (pypy27_config,)
         elif args.compiler == 'pypy3':
@@ -805,6 +788,8 @@ class PythonLanguage(object):
                 python36_config,
                 python37_config,
                 python38_config,
+                python39_config,
+                python310_config,
             )
         else:
             raise Exception('Compiler %s not supported.' % args.compiler)

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -223,7 +223,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
     test_jobs += _generate_jobs(languages=['python'],
                                 configs=['opt'],
                                 platforms=['linux', 'macos', 'windows'],
-                                iomgr_platforms=['native', 'gevent', 'asyncio'],
+                                iomgr_platforms=['native'],
                                 labels=['basictests', 'multilang'],
                                 extra_args=extra_args +
                                 ['--report_multi_target'],


### PR DESCRIPTION
This PR affects "Basic Tests Python" on Linux/Windows/macOS. We used to re-compile Python binaries for different IO platforms (native/gevent/asyncio). But they are actually the exact same build. In recent effort of improving grpc/grpc's presubmit tests efficiency, @jtattermusch has brought this problem up.

This PR merges the build stage of different IO platforms. Test coverage should be the same.
This PR also adds Python3.10 support to run_tests.py.

---

TIL that the parallelism in test running was not achieved by the customized test runners, but run_tests.py itself. run_tests.py encapsulates every single test into a job, then handle the scheduling. Each test case will be run as a different process. (We did work hard to implement an OSS Blaze back then.

---

Optimized Time Cost for "Basic Tests Python":
- [Linux](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_basictests_python): 30 minutes -> [17](https://source.cloud.google.com/results/invocations/34852fd3-208a-4017-b366-3112252d06d7/targets) minutes
- [macOS](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_basictests_python): 30 or 60 minutes -> [14](https://source.cloud.google.com/results/invocations/e408a4fb-5ed2-4d8d-a8cf-3a57ea67af24/targets) minutes (we have 2 types of macOS worker)
- [Windows](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Fwindows%2Fgrpc_basictests_python): 80 minutes -> [38](https://source.cloud.google.com/results/invocations/f4913dce-60e5-4592-a8dd-cad4df7eb076/targets) minutes