### PR TITLE
Store ExecCtx before work serializer in AresDnsResolver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -197,6 +197,8 @@ void AresClientChannelDNSResolver::OnNextResolution(void* arg,
   AresClientChannelDNSResolver* r =
       static_cast<AresClientChannelDNSResolver*>(arg);
   (void)GRPC_ERROR_REF(error);  // ref owned by lambda
+  grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
+  grpc_core::ExecCtx exec_ctx;
   r->work_serializer_->Run([r, error]() { r->OnNextResolutionLocked(error); },
                            DEBUG_LOCATION);
 }


### PR DESCRIPTION
I think https://github.com/grpc/grpc/pull/27883 caused b/212501393 - the work serializer is not running in the core thread and needs its own ExecCtx. This might also be needed in other places where work serializer is used; I'm not sure why we haven't run into these issues before, where segfaults are caused by ExecCtx not sticking around long enough for the callbacks to complete.