### PR TITLE
Revert "pin rake compiler to 1.1.1"

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
-  s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
+  s.add_development_dependency 'rake-compiler',      '~> 1.1'
   s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -42,7 +42,7 @@
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'
     s.add_development_dependency 'rake',               '~> 13.0'
-    s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
+    s.add_development_dependency 'rake-compiler',      '~> 1.1'
     s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'


### PR DESCRIPTION
This reverts commit 4d3c9630eaa9fb69ee8203e3994cd44a2d45381d.

rake-compiler 1.1.7 was released several days ago, so let's see if things are working now