### PR TITLE
Fix tautological unsigned comparison

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -47,6 +47,8 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wthread-safety-beta",
     "-Wunused-comparison",
     "-Wvla",
+    # -Wextra compatibility between gcc and clang
+    "-Wtype-limits",
     # A list of disabled flags coming from internal build system
     "-Wno-string-concatenation",
     # Exceptions but will be removed

--- a/src/core/ext/filters/fault_injection/service_config_parser.cc
+++ b/src/core/ext/filters/fault_injection/service_config_parser.cc
@@ -122,6 +122,9 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
       }
     }
     // Parse max_faults
+    static_assert(
+        std::is_unsigned<decltype(fault_injection_policy.max_faults)>::value,
+        "maxFaults should be unsigned");
     ParseJsonObjectField(json_object, "maxFaults",
                          &fault_injection_policy.max_faults, &sub_error_list,
                          false);

--- a/src/core/ext/filters/fault_injection/service_config_parser.cc
+++ b/src/core/ext/filters/fault_injection/service_config_parser.cc
@@ -122,14 +122,9 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
       }
     }
     // Parse max_faults
-    if (ParseJsonObjectField(json_object, "maxFaults",
-                             &fault_injection_policy.max_faults,
-                             &sub_error_list, false)) {
-      if (fault_injection_policy.max_faults < 0) {
-        sub_error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "field:maxFaults error:should be zero or positive"));
-      }
-    }
+    ParseJsonObjectField(json_object, "maxFaults",
+                         &fault_injection_policy.max_faults, &sub_error_list,
+                         false);
     if (!sub_error_list.empty()) {
       error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
           absl::StrCat("failed to parse faultInjectionPolicy index ", i),


### PR DESCRIPTION
This also enables the -Wtype-limits warning, which is included in GCC's
-Wextra, but not in Clang's -Wextra.