### PR TITLE
Silence some MSVC warning in windows bazel build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,10 @@ if(MSVC)
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4987 /wd4774 /wd4819 /wd4996 /wd4619")
   # Silences thousands of trucation warnings
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4503")
+  # upb
+  set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4090 /wd4116")
+  # public_headers_must_be_c89.c
+  set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4311")
 endif()
 if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)

--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -56,7 +56,28 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wno-unused-function",
 ]
 
+# Warning suppression for MSVC on Windows.
+# The list of suppressed warnings should be kept in sync with the cmake build.
+GRPC_MSVC_DEFAULT_COPTS = [
+    "/wd4065",
+    "/wd4090",
+    "/wd4116",
+    "/wd4200",
+    "/wd4244",
+    "/wd4267",
+    "/wd4291",
+    "/wd4311",
+    "/wd4503",
+    "/wd4506",
+    "/wd4619",
+    "/wd4774",
+    "/wd4819",
+    "/wd4987",
+    "/wd4996",
+]
+
 GRPC_DEFAULT_COPTS = select({
     "//:use_strict_warning": GRPC_LLVM_WARNING_FLAGS,
+    "//:windows_msvc": GRPC_MSVC_DEFAULT_COPTS,
     "//conditions:default": [],
 })

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -299,6 +299,10 @@
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4987 /wd4774 /wd4819 /wd4996 /wd4619")
     # Silences thousands of trucation warnings
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4503")
+    # upb
+    set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4090 /wd4116")
+    # public_headers_must_be_c89.c
+    set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4311")
   endif()
   if (MINGW)
     add_definitions(-D_WIN32_WINNT=0x600)


### PR DESCRIPTION
Context b/210806277

Currently bazel build output on windows is flooded by MSVC warnings that are disabled when building with cmake.
Make bazel windows build disable the same warnings as cmake.

The most important warning to silence is C4503 which previously lead to kokoro job tool failures.

TODO: check that the options are actually being applied.