### PR TITLE
transport: add error attributes indicating stream network state

### DIFF
--- a/src/core/lib/gprpp/status_helper.cc
+++ b/src/core/lib/gprpp/status_helper.cc
@@ -83,6 +83,8 @@ const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
       return TYPE_URL(TYPE_INT_TAG "channel_connectivity_state");
     case StatusIntProperty::kLbPolicyDrop:
       return TYPE_URL(TYPE_INT_TAG "lb_policy_drop");
+    case StatusIntProperty::kStreamNetworkState:
+      return TYPE_URL(TYPE_INT_TAG "stream_network_state");
   }
   GPR_UNREACHABLE_CODE(return "unknown");
 }

--- a/src/core/lib/gprpp/status_helper.h
+++ b/src/core/lib/gprpp/status_helper.h
@@ -37,7 +37,6 @@ struct upb_arena;
 namespace grpc_core {
 
 /// This enum should have the same value of grpc_error_ints
-// TODO(veblush): Use camel-case names once migration to absl::Status is done.
 enum class StatusIntProperty {
   /// 'errno' from the operating system
   kErrorNo,
@@ -72,10 +71,11 @@ enum class StatusIntProperty {
   ChannelConnectivityState,
   /// LB policy drop
   kLbPolicyDrop,
+  /// stream network state
+  kStreamNetworkState,
 };
 
 /// This enum should have the same value of grpc_error_strs
-// TODO(veblush): Use camel-case names once migration to absl::Status is done.
 enum class StatusStrProperty {
   /// top-level textual description of this error
   kDescription,

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -252,6 +252,8 @@ static const char* error_int_name(grpc_error_ints key) {
       return "channel_connectivity_state";
     case GRPC_ERROR_INT_LB_POLICY_DROP:
       return "lb_policy_drop";
+    case GRPC_ERROR_INT_STREAM_NETWORK_STATE:
+      return "stream_network_state";
     case GRPC_ERROR_INT_MAX:
       GPR_UNREACHABLE_CODE(return "unknown");
   }

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -96,6 +96,9 @@ typedef enum {
   /// LB policy drop
   GRPC_ERROR_INT_LB_POLICY_DROP =
       static_cast<int>(grpc_core::StatusIntProperty::kLbPolicyDrop),
+  /// stream network state
+  GRPC_ERROR_INT_STREAM_NETWORK_STATE =
+      static_cast<int>(grpc_core::StatusIntProperty::kStreamNetworkState),
 
   /// Must always be last
   GRPC_ERROR_INT_MAX,

--- a/src/core/lib/transport/error_utils.h
+++ b/src/core/lib/transport/error_utils.h
@@ -27,6 +27,20 @@
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/transport/http2_errors.h"
 
+namespace grpc_core {
+
+enum class StreamNetworkState {
+  // Stream was never sent on the wire (e.g., because the transport became
+  // disconnected by the time the call got down to it).
+  kNotSentOnWire,
+  // Stream was sent on the wire but was not seen by the server application
+  // code (e.g., client sent data but then received a GOAWAY with a lower
+  // stream ID).
+  kNotSeenByServer,
+};
+
+}  // namespace grpc_core
+
 /// A utility function to get the status code and message to be returned
 /// to the application.  If not set in the top-level message, looks
 /// through child errors until it finds the first one with these attributes.


### PR DESCRIPTION
This will be used by the transparent retry code.