### PR TITLE
Revert "Update to rbac policy struct and end2end authz test."

### DIFF
--- a/src/core/lib/security/authorization/matchers.h
+++ b/src/core/lib/security/authorization/matchers.h
@@ -153,13 +153,13 @@ class PortAuthorizationMatcher : public AuthorizationMatcher {
 // or DNS SAN in that order, otherwise uses subject field.
 class AuthenticatedAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit AuthenticatedAuthorizationMatcher(absl::optional<StringMatcher> auth)
+  explicit AuthenticatedAuthorizationMatcher(StringMatcher auth)
       : matcher_(std::move(auth)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
  private:
-  const absl::optional<StringMatcher> matcher_;
+  const StringMatcher matcher_;
 };
 
 // Perform a match against the request server from the client's connection

--- a/src/core/lib/security/authorization/rbac_policy.cc
+++ b/src/core/lib/security/authorization/rbac_policy.cc
@@ -278,7 +278,7 @@ Rbac::Principal Rbac::Principal::MakeAnyPrincipal() {
 }
 
 Rbac::Principal Rbac::Principal::MakeAuthenticatedPrincipal(
-    absl::optional<StringMatcher> string_matcher) {
+    StringMatcher string_matcher) {
   Principal principal;
   principal.type = Principal::RuleType::kPrincipalName;
   principal.string_matcher = std::move(string_matcher);
@@ -398,7 +398,7 @@ std::string Rbac::Principal::ToString() const {
     case RuleType::kAny:
       return "any";
     case RuleType::kPrincipalName:
-      return absl::StrFormat("principal_name=%s", string_matcher->ToString());
+      return absl::StrFormat("principal_name=%s", string_matcher.ToString());
     case RuleType::kSourceIp:
       return absl::StrFormat("source_ip=%s", ip.ToString());
     case RuleType::kDirectRemoteIp:
@@ -408,7 +408,7 @@ std::string Rbac::Principal::ToString() const {
     case RuleType::kHeader:
       return absl::StrFormat("header=%s", header_matcher.ToString());
     case RuleType::kPath:
-      return absl::StrFormat("path=%s", string_matcher->ToString());
+      return absl::StrFormat("path=%s", string_matcher.ToString());
     case RuleType::kMetadata:
       return absl::StrFormat("%smetadata", invert ? "invert " : "");
     default:

--- a/src/core/lib/security/authorization/rbac_policy.h
+++ b/src/core/lib/security/authorization/rbac_policy.h
@@ -113,8 +113,7 @@ struct Rbac {
         std::vector<std::unique_ptr<Principal>> principals);
     static Principal MakeNotPrincipal(Principal principal);
     static Principal MakeAnyPrincipal();
-    static Principal MakeAuthenticatedPrincipal(
-        absl::optional<StringMatcher> string_matcher);
+    static Principal MakeAuthenticatedPrincipal(StringMatcher string_matcher);
     static Principal MakeSourceIpPrincipal(CidrRange ip);
     static Principal MakeDirectRemoteIpPrincipal(CidrRange ip);
     static Principal MakeRemoteIpPrincipal(CidrRange ip);
@@ -132,7 +131,7 @@ struct Rbac {
 
     RuleType type = RuleType::kAnd;
     HeaderMatcher header_matcher;
-    absl::optional<StringMatcher> string_matcher;
+    StringMatcher string_matcher;
     CidrRange ip;
     // For type kAnd/kOr/kNot. For kNot type, the vector will have only one
     // element.

--- a/test/core/security/authorization_matchers_test.cc
+++ b/test/core/security/authorization_matchers_test.cc
@@ -456,7 +456,11 @@ TEST_F(AuthorizationMatchersTest,
   args_.AddPropertyToAuthContext(GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
                                  GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   EvaluateArgs args = args_.MakeEvaluateArgs();
-  AuthenticatedAuthorizationMatcher matcher(/*auth=*/absl::nullopt);
+  AuthenticatedAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"",
+                            /*case_sensitive=*/false)
+          .value());
   EXPECT_TRUE(matcher.Matches(args));
 }
 

--- a/test/core/security/rbac_translator_test.cc
+++ b/test/core/security/rbac_translator_test.cc
@@ -24,12 +24,10 @@ namespace {
 MATCHER_P3(EqualsPrincipalName, expected_matcher_type, expected_matcher_value,
            is_regex, "") {
   return arg->type == Rbac::Principal::RuleType::kPrincipalName &&
-                 arg->string_matcher.value().type() == expected_matcher_type &&
-                 is_regex
-             ? arg->string_matcher.value().regex_matcher()->pattern() ==
+                 arg->string_matcher.type() == expected_matcher_type && is_regex
+             ? arg->string_matcher.regex_matcher()->pattern() ==
                    expected_matcher_value
-             : arg->string_matcher.value().string_matcher() ==
-                   expected_matcher_value;
+             : arg->string_matcher.string_matcher() == expected_matcher_value;
 }
 
 MATCHER_P3(EqualsPath, expected_matcher_type, expected_matcher_value, is_regex,

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -855,13 +855,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "sdk_authz_end2end_test",
     srcs = ["sdk_authz_end2end_test.cc"],
-    data = [
-        "//src/core/tsi/test_creds:ca.pem",
-        "//src/core/tsi/test_creds:client.key",
-        "//src/core/tsi/test_creds:client.pem",
-        "//src/core/tsi/test_creds:server1.key",
-        "//src/core/tsi/test_creds:server1.pem",
-    ],
     external_deps = [
         "gtest",
     ],


### PR DESCRIPTION
Reverts grpc/grpc#27074

Looks like it broke the `grpc/core/master/macos/grpc_bazel_cpp_ios_tests` kokoro job on master:
https://source.cloud.google.com/results/invocations/6dec90a4-7bce-4d99-86a3-e98ea7fafc06/log

```
FAIL: //test/cpp/end2end:sdk_authz_end2end_test_on_ios (see /Volumes/BuildData/tmpfs/tmp/bazel/execroot/com_github_grpc_grpc/bazel-out/darwin-fastbuild/testlogs/test/cpp/end2end/sdk_authz_end2end_test_on_ios/test.log)
INFO: From Testing //test/cpp/end2end:sdk_authz_end2end_test_on_ios:
==================== Test output for //test/cpp/end2end:sdk_authz_end2end_test_on_ios:
2022-01-12 23:32:50,093 Will consider the test as test type logic_test to run.
2022-01-12 23:32:50,563 Creating a new simulator:
Name: New-iPhone 11 Pro Max-13.3
OS: iOS 13.3
Type: iPhone 11 Pro Max
2022-01-12 23:32:50,763 Created new simulator CBDF3AF5-38B1-4082-85B4-B9F338FC6CDD.
Test Suite 'All tests' started at 2022-01-12 15:32:51.034
Test Suite 'sdk_authz_end2end_test_on_ios.xctest' started at 2022-01-12 15:32:51.034
Test Suite 'GTMGoogleTestRunner' started at 2022-01-12 15:32:51.034
Test Suite 'SdkAuthzEnd2EndTest' started at 2022-01-12 15:32:51.034
Test Case '-[GTMGoogleTestRunner SdkAuthzEnd2EndTest::StaticInitAllowsRpcRequestNoMatchInDenyMatchInAllow]' started.
E0112 15:32:51.068633000 4603672000 sdk_authz_end2end_test.cc:50]      load_file: {"created":"@1642030371.068608000","description":"Failed to load file","file":"src/core/lib/iomgr/load_file.cc","file_line":72,"filename":"src/core/tsi/test_creds/ca.pem","referenced_errors":[{"created":"@1642030371.068606000","description":"No such file or directory","errno":2,"file":"src/core/lib/iomgr/load_file.cc","file_line":45,"os_error":"No such file or directory","syscall":"fopen"}]}
E0112 15:32:51.068732000 4603672000 sdk_authz_end2end_test.cc:50]      assertion failed: GRPC_LOG_IF_ERROR("load_file", grpc_load_file(file_path, 0, &slice))
Child process terminated with signal 6: Abort trap
2022-01-12 23:32:51,070 Deleting simulator CBDF3AF5-38B1-4082-85B4-B9F338FC6CDD asynchronously.
2022-01-12 23:32:51,074 Done.
================================================================================
Target //test/cpp/end2end:sdk_authz_end2end_test_on_ios up-to-date:
  bazel-bin/test/cpp/end2end/sdk_authz_end2end_test_on_ios
  bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-e637a0adc749/bin/test/cpp/end2end/sdk_authz_end2end_test_on_ios.zip
INFO: Elapsed time: 12.650s, Critical Path: 10.90s
INFO: 60 processes: 18 internal, 41 darwin-sandbox, 1 local.
INFO: Build completed, 1 test FAILED, 60 total actions
//test/cpp/end2end:sdk_authz_end2end_test_on_ios                         FAILED in 1.7s
    ERROR   .test/cpp/end2end/sdk_authz_end2end_test_on_ios (0.0s)
```