### PR TITLE
[OBJC] Don't add unnecessary prefixes to service class names

### DIFF
--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -40,7 +40,8 @@ inline bool AsciiIsUpper(char c) { return c >= 'A' && c <= 'Z'; }
 
 inline ::std::string ServiceClassName(const ServiceDescriptor* service) {
   const FileDescriptor* file = service->file();
-  ::std::string prefix = google::protobuf::compiler::objectivec::FileClassPrefix(file);
+  ::std::string prefix =
+      google::protobuf::compiler::objectivec::FileClassPrefix(file);
   ::std::string class_name = service->name();
   // We add the prefix in the cases where the string is missing a prefix.
   // We define "missing a prefix" as where 'input':


### PR DESCRIPTION
This is the same semantics as the Objective-C protoc.

This prevents cases where you have an RPC named `FOOOpener` and a objc class prefix of `FOO` becoming `FOOFOOOpener`.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
