### PR TITLE
xds-k8s: Fix ModuleNotFoundError: No module named 'packaging'

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/requirements.txt
+++ b/tools/run_tests/xds_k8s_test_driver/requirements.txt
@@ -14,6 +14,7 @@ kubernetes~=12.0
 retrying~=1.3
 six~=1.13
 tenacity~=6.2
+packaging~=21.3
 Pygments~=2.9
 protobuf~=3.14
 xds-protos~=0.0.8


### PR DESCRIPTION
`packaging` was explicitly used in xds_url_map_testcase.py,
but wasn't added to the requirements.txt.
It (unintentionally) worked before because `packaging` is
a transitive dependency of `google-api-python-client@1.12.8`
via `google-api-core@1.31.5`.

With `google-api-python-client` upgraded to `1.12.10`, it's not
the case anymore.

cc @lidizheng @gnossen 

