### PR TITLE
Ruby: Undefine unused native types allocators

### DIFF
--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -801,6 +801,8 @@ static void Init_grpc_connectivity_states() {
 
 void Init_grpc_channel() {
   grpc_rb_cChannelArgs = rb_define_class("TmpChannelArgs", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cChannelArgs);
+
   grpc_rb_cChannel =
       rb_define_class_under(grpc_rb_mGrpcCore, "Channel", rb_cObject);
 

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -111,6 +111,8 @@ typedef struct channel_convert_params {
 static VALUE grpc_rb_hash_convert_to_channel_args0(VALUE as_value) {
   ID id_size = rb_intern("size");
   VALUE grpc_rb_cChannelArgs = rb_define_class("TmpChannelArgs", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cChannelArgs);
+
   channel_convert_params* params = (channel_convert_params*)as_value;
   size_t num_args = 0;
 

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -198,6 +198,8 @@ static void Init_grpc_time_consts() {
       rb_define_module_under(grpc_rb_mGrpcCore, "TimeConsts");
   grpc_rb_cTimeVal =
       rb_define_class_under(grpc_rb_mGrpcCore, "TimeSpec", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cTimeVal);
+
   zero_realtime = gpr_time_0(GPR_CLOCK_REALTIME);
   inf_future_realtime = gpr_inf_future(GPR_CLOCK_REALTIME);
   inf_past_realtime = gpr_inf_past(GPR_CLOCK_REALTIME);


### PR DESCRIPTION
T_DATA object must either define an allocator or undefine the
default one.

See: https://bugs.ruby-lang.org/issues/18007

This currently cause a warning on ruby-head.

cc @apolcyn @flavorjones 