### PR TITLE
Remove the explicit IO platform setting

### DIFF
--- a/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
@@ -29,9 +29,7 @@ cd grpc
 git submodule update --init
 
 # build and test python (currently we only test with python3.6, but that's ok since our aarch64 testing resources are limited)
-tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform native -t -x run_tests/python_linux_opt_native/sponge_log.xml --report_suite_name python_linux_opt_native --report_multi_target || FAILED=true
-tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform asyncio -t -x run_tests/python_linux_opt_asyncio/sponge_log.xml --report_suite_name python_linux_opt_asyncio --report_multi_target || FAILED=true
-tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt --iomgr_platform gevent -t -x run_tests/python_linux_opt_gevent/sponge_log.xml --report_suite_name python_linux_opt_gevent --report_multi_target || FAILED=true
+tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt -t -x run_tests/python_linux_opt_native/sponge_log.xml --report_suite_name python_linux_opt_native --report_multi_target || FAILED=true
 
 if [ "$FAILED" != "" ]
 then


### PR DESCRIPTION
Found by @jtattermusch. There is still a CI script explicitly asking for different Python builds with different IO platforms. This PR removes this setup in the script, since Python builds in run_tests.py no longer differentiated by IO platforms.

[prod:grpc/core/master/linux/aws/grpc_aws_basictests_python](https://fusion2.corp.google.com/invocations/f9faef70-7571-4f21-ba5b-d1ef415cb1ae)