### PR TITLE
speedup C# basictests: only build C# once for coreclr and mono tests

### DIFF
--- a/tools/internal_ci/linux/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux csharp --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux csharp --inner_jobs 4 -j 2 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux csharp --inner_jobs 4 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux csharp --inner_jobs 4 -j 1 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux csharp --inner_jobs 4 -j 2 --internal_ci --max_time=3600"
+  value: "-f basictests linux csharp --inner_jobs 4 -j 1 --internal_ci --max_time=3600"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux csharp --inner_jobs 16 -j 2 --internal_ci --max_time=3600"
+  value: "-f basictests linux csharp --inner_jobs 4 -j 2 --internal_ci --max_time=3600"
 }

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -201,20 +201,10 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         inner_jobs=inner_jobs,
         timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
-    # C# tests on .NET desktop/mono
+    # C# tests (both on .NET desktop/mono and .NET core)
     test_jobs += _generate_jobs(languages=['csharp'],
                                 configs=['dbg', 'opt'],
                                 platforms=['linux', 'macos', 'windows'],
-                                labels=['basictests', 'multilang'],
-                                extra_args=extra_args +
-                                ['--report_multi_target'],
-                                inner_jobs=inner_jobs)
-    # C# tests on .NET core
-    test_jobs += _generate_jobs(languages=['csharp'],
-                                configs=['dbg', 'opt'],
-                                platforms=['linux', 'macos', 'windows'],
-                                arch='default',
-                                compiler='coreclr',
                                 labels=['basictests', 'multilang'],
                                 extra_args=extra_args +
                                 ['--report_multi_target'],


### PR DESCRIPTION
Currently C# is being built from scratch twice  for {coreclr, mono} tests, even though the build process is identical (its just test invocation that changes).
Speed up C# basictests for linux, windows and macos by using the same grpc_csharp_ext build for both coreclr and mono tests.