### PR TITLE
allow running instances of DepFileUtilTest in parallel

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/DepFileUtilTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/DepFileUtilTest.cs
@@ -146,20 +146,17 @@ obj\Release x64\net45\/FooGrpc.cs: C:/usr/include/google/protobuf/wrappers.proto
             Assert.Zero(deps.Length);
         }
 
-        // NB in our tests files are put into the temp directory but all have
-        // different names. Avoid adding files with the same directory path and
-        // name, or add reasonable handling for it if required. Tests are run in
-        // parallel and will collide otherwise.
         private string[] ReadDependencyInputFromFileData(string fileData, string protoName)
         {
-            string tempPath = Path.GetTempPath();
-            string tempfile = DepFileUtil.GetDepFilenameForProto(tempPath, protoName);
+            string randomTempDir = Path.GetTempPath() + '/' + Path.GetRandomFileName();
+            Directory.CreateDirectory(randomTempDir);
+            string tempfile = DepFileUtil.GetDepFilenameForProto(randomTempDir, protoName);
             try
             {
                 File.WriteAllText(tempfile, fileData);
                 var mockEng = new Moq.Mock<IBuildEngine>();
                 var log = new TaskLoggingHelper(mockEng.Object, "x");
-                return DepFileUtil.ReadDependencyInputs(tempPath, protoName, log);
+                return DepFileUtil.ReadDependencyInputs(randomTempDir, protoName, log);
             }
             finally
             {


### PR DESCRIPTION
Fixes b/215223023

The test is failing because after merging https://github.com/grpc/grpc/pull/28587, there can now be multiple instances of DepFileUtilTest running in parallel.