### PR TITLE
C# macos single-job distribtest

### DIFF
--- a/src/csharp/build_nuget.sh
+++ b/src/csharp/build_nuget.sh
@@ -57,9 +57,10 @@ fi
 dotnet restore Grpc.sln
 
 # To be able to build the Grpc.Core project, we also need to put grpc_csharp_ext to where Grpc.Core.csproj
-# expects it.
+# expects it. Since this script can be run on either linux or mac we copy multiple variants of grpc_csharp_ext.
 mkdir -p ../../cmake/build
 cp nativelibs/csharp_ext_linux_x64/libgrpc_csharp_ext.so ../../cmake/build
+cp nativelibs/csharp_ext_macos_x64/libgrpc_csharp_ext.dylib ../../cmake/build
 
 dotnet pack --configuration Release Grpc.Core.Api --output ../../artifacts
 dotnet pack --configuration Release Grpc.Core --output ../../artifacts

--- a/tools/internal_ci/macos/grpc_distribtests_csharp.cfg
+++ b/tools/internal_ci/macos/grpc_distribtests_csharp.cfg
@@ -1,0 +1,27 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_distribtests_csharp.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+timeout_mins: 240
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}

--- a/tools/internal_ci/macos/grpc_distribtests_csharp.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_csharp.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# avoid slow finalization after the script has exited.
+source $(dirname $0)/../../../tools/internal_ci/helper_scripts/move_src_tree_and_respawn_itself_rc
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+export PREPARE_BUILD_INSTALL_DEPS_CSHARP=true
+source tools/internal_ci/helper_scripts/prepare_build_macos_rc
+
+# Build all C# macos artifacts
+tools/run_tests/task_runner.py -f artifact macos csharp ${TASK_RUNNER_EXTRA_FILTERS} -j 2 --inner_jobs 4 -x build_artifacts_csharp/sponge_log.xml || FAILED="true"
+
+# Build all protoc macos artifacts
+tools/run_tests/task_runner.py -f artifact macos protoc ${TASK_RUNNER_EXTRA_FILTERS} -j 2 --inner_jobs 4 -x build_artifacts_protoc/sponge_log.xml || FAILED="true"
+
+# the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
+rm -rf input_artifacts
+mkdir -p input_artifacts
+cp -r artifacts/* input_artifacts/ || true
+
+# This step builds the nuget packages from input_artifacts
+# Set env variable option to build single platform version of the nugets.
+# (this is required as we only have the macos artifacts at hand)
+GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET=1 tools/run_tests/task_runner.py -f package macos csharp nuget -j 2 -x build_packages/sponge_log.xml || FAILED="true"
+
+# the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
+# in addition to that, preserve the contents of "artifacts" directory since we want kokoro
+# to upload its contents as job output artifacts
+rm -rf input_artifacts
+mkdir -p input_artifacts
+cp -r artifacts/* input_artifacts/ || true
+
+# Run all C# macos distribtests
+# We run the distribtests even if some of the artifacts have failed to build, since that gives
+# a better signal about which distribtest are affected by the currently broken artifact builds.
+tools/run_tests/task_runner.py -f distribtest macos csharp ${TASK_RUNNER_EXTRA_FILTERS} -j 4 -x distribtests/sponge_log.xml || FAILED="true"
+
+tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi

--- a/tools/internal_ci/macos/pull_request/grpc_distribtests_csharp.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_distribtests_csharp.cfg
@@ -1,0 +1,32 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_distribtests_csharp.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+timeout_mins: 240
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}
+
+env_vars {
+  key: "TASK_RUNNER_EXTRA_FILTERS"
+  value: "presubmit"
+}

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -74,14 +74,15 @@ def create_jobspec(name,
 class CSharpPackage:
     """Builds C# packages."""
 
-    def __init__(self, unity=False):
+    def __init__(self, platform, unity=False):
+        self.platform = platform
         self.unity = unity
-        self.labels = ['package', 'csharp', 'linux']
+        self.labels = ['package', 'csharp', self.platform]
         if unity:
-            self.name = 'csharp_package_unity_linux'
+            self.name = 'csharp_package_unity_%s' % self.platform
             self.labels += ['unity']
         else:
-            self.name = 'csharp_package_nuget_linux'
+            self.name = 'csharp_package_nuget_%s' % self.platform
             self.labels += ['nuget']
 
     def pre_build_jobspecs(self):
@@ -93,18 +94,22 @@ class CSharpPackage:
             'GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET':
                 os.getenv('GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET', '')
         }
-        if self.unity:
+
+        build_script = 'src/csharp/build_unitypackage.sh' if self.unity else 'src/csharp/build_nuget.sh'
+
+        if self.platform == 'linux':
             return create_docker_jobspec(
                 self.name,
                 'tools/dockerfile/test/csharp_debian11_x64',
-                'src/csharp/build_unitypackage.sh',
+                build_script,
                 environ=environ)
         else:
-            return create_docker_jobspec(
-                self.name,
-                'tools/dockerfile/test/csharp_debian11_x64',
-                'src/csharp/build_nuget.sh',
-                environ=environ)
+            repo_root = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                     '..', '..', '..')
+            environ['EXTERNAL_GIT_ROOT'] = repo_root
+            return create_jobspec(self.name, [build_script],
+                                  environ=environ,
+                                  shell=True)
 
     def __str__(self):
         return self.name
@@ -169,8 +174,9 @@ class PHPPackage:
 def targets():
     """Gets list of supported targets"""
     return [
-        CSharpPackage(),
-        CSharpPackage(unity=True),
+        CSharpPackage('linux'),
+        CSharpPackage('linux', unity=True),
+        CSharpPackage('macos'),
         RubyPackage(),
         PythonPackage(),
         PHPPackage()


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc/pull/27180 for linux, introduce a single-job C# distribtest for macos.