### PR TITLE
Leak static table

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -226,8 +226,8 @@ GPR_ATTRIBUTE_NOINLINE HPackTable::Memento MakeMemento(size_t i) {
 }  // namespace
 
 const HPackTable::StaticMementos& HPackTable::GetStaticMementos() {
-  static const StaticMementos static_mementos;
-  return static_mementos;
+  static const StaticMementos* const static_mementos = new StaticMementos();
+  return *static_mementos;
 }
 
 HPackTable::StaticMementos::StaticMementos() {


### PR DESCRIPTION
Work around a bug whereby we may crash if a particular order of static destruction is chosen.
By simply not freeing memory, we prevent ourselves from caring about such details.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
