### PR TITLE
Remove openssl extern c wrapping

### DIFF
--- a/src/core/tsi/ssl/key_logging/ssl_key_logging.h
+++ b/src/core/tsi/ssl/key_logging/ssl_key_logging.h
@@ -20,15 +20,13 @@
 #include <iostream>
 #include <map>
 
+#include <openssl/ssl.h>
+
+#include "absl/base/thread_annotations.h"
+
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
 #include <grpc/support/sync.h>
-
-extern "C" {
-#include <openssl/ssl.h>
-}
-
-#include "absl/base/thread_annotations.h"
 
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/ref_counted.h"


### PR DESCRIPTION
Extra follow up clean up from https://github.com/grpc/grpc/pull/28360 

https://github.com/grpc/grpc-ios/issues/47