### PR TITLE
Bump clang 12 to 13

### DIFF
--- a/templates/tools/dockerfile/test/cxx_clang_13_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_clang_13_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:12
+  FROM silkeh/clang:13
   
   RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
   <%include file="../../run_tests_python_deps.include"/>

--- a/tools/dockerfile/test/cxx_clang_13_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_clang_13_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:12
+FROM silkeh/clang:13
 
 RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
 #====================

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -474,8 +474,8 @@ class CLanguage(object):
             return ('alpine', [])
         elif compiler == 'clang4':
             return ('clang_4', self._clang_cmake_configure_extra_args())
-        elif compiler == 'clang12':
-            return ('clang_12', self._clang_cmake_configure_extra_args())
+        elif compiler == 'clang13':
+            return ('clang_13', self._clang_cmake_configure_extra_args())
         else:
             raise Exception('Compiler %s not supported.' % compiler)
 
@@ -1388,7 +1388,7 @@ argp.add_argument(
         'gcc11',
         'gcc_musl',
         'clang4',
-        'clang12',
+        'clang13',
         'python2.7',
         'python3.5',
         'python3.6',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -267,7 +267,7 @@ def _create_portability_test_jobs(extra_args=[],
     # portability C and C++ on x64
     for compiler in [
             'gcc4.9', 'gcc8.3', 'gcc8.3_openssl102', 'gcc11', 'gcc_musl',
-            'clang4', 'clang12'
+            'clang4', 'clang13'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],
                                     configs=['dbg'],


### PR DESCRIPTION
Since clang 13 was released in Oct 2021, let's bump the latest clang for the test from 12 to 13.