### PR TITLE
Pin google-auth to 2.3.3

### DIFF
--- a/tools/run_tests/helper_scripts/run_python.sh
+++ b/tools/run_tests/helper_scripts/run_python.sh
@@ -22,6 +22,7 @@ PYTHON=$(realpath "${1:-py36/bin/python}")
 
 ROOT=$(pwd)
 
+$PYTHON -m pip install google-auth==2.3.3
 $PYTHON "$ROOT/src/python/grpcio_tests/setup.py" "$2"
 
 mkdir -p "$ROOT/reports"


### PR DESCRIPTION
[The 2.4.0 release of google-auth seems to have introduced breakage](https://github.com/googleapis/google-auth-library-python/issues/952). Until this is resolved, pinning back should resolve our issue.