### PR TITLE
Public APIs need ExecCtx

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -298,6 +298,7 @@ static void add_init_error(grpc_error_handle* composite,
 }
 
 void* grpc_call_arena_alloc(grpc_call* call, size_t size) {
+  grpc_core::ExecCtx exec_ctx;
   return call->arena->Alloc(size);
 }
 


### PR DESCRIPTION
Fix for b/215751335 - note that Alloc might cause resource quota starvation and consequently need to wakeup the resource reclaimer - which involves queuing a thing on an exec ctx.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
