### PR TITLE
Enable ccache in more builds

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile.template
@@ -14,13 +14,15 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../csharp_deps.include"/>
   <%include file="../../csharp_dotnetcli_deps.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
+
   # Define the default command.
   CMD ["bash"]
   

--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile.template
@@ -14,13 +14,15 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../csharp_deps.include"/>
   <%include file="../../csharp_dotnetcli_deps.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
+
   # Define the default command.
   CMD ["bash"]
   

--- a/templates/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile.template
@@ -14,13 +14,15 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:jessie
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../cxx_deps.include"/>
-  <%include file="../../cmake_jessie_backports.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
+
   # Define the default command.
   CMD ["bash"]
   

--- a/templates/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile.template
@@ -20,3 +20,6 @@
   RUN ln -s $(which python3) /usr/bin/python
 
   <%include file="../../gcp_api_libraries.include"/>
+
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile.template
@@ -20,3 +20,6 @@
   RUN ln -s $(which python3) /usr/bin/python
 
   <%include file="../../gcp_api_libraries.include"/>
+
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile.template
@@ -14,12 +14,15 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../ruby_deps.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
+
   # Define the default command.
   CMD ["bash"]
   

--- a/templates/tools/dockerfile/test/csharp_debian11_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/csharp_debian11_x64/Dockerfile.template
@@ -14,13 +14,15 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../csharp_deps.include"/>
   <%include file="../../csharp_dotnetcli_deps.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
+
   # Define the default command.
   CMD ["bash"]
   

--- a/templates/tools/dockerfile/test/ruby_debian11_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/ruby_debian11_x64/Dockerfile.template
@@ -14,15 +14,14 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:buster
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../ruby_deps.include"/>
   <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
-
-  RUN python3 -m pip install virtualenv==16.7.9
 
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM debian:bullseye
+  FROM debian:11
 
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../cxx_deps.include"/>

--- a/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
@@ -1,1 +1,15 @@
 FROM larskanis/rake-compiler-dock-mri-arm64-darwin:1.1.0
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
@@ -1,15 +1,1 @@
 FROM larskanis/rake-compiler-dock-mri-arm64-darwin:1.1.0
-
-#=================
-# Install ccache
-
-# Install ccache from source since ccache 3.x packaged with most linux distributions
-# does not support Redis backend for caching.
-RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
-    && tar -zxf ccache.tar.gz \
-    && cd ccache-4.5.1 \
-    && mkdir build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
-    && make -j4 && make install \
-    && cd ../.. \
-    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
@@ -1,3 +1,17 @@
 FROM larskanis/rake-compiler-dock-mri-x64-mingw32:1.1.0
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
@@ -1,1 +1,15 @@
 FROM larskanis/rake-compiler-dock-mri-x86-linux:1.1.0
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
@@ -1,3 +1,17 @@
 FROM larskanis/rake-compiler-dock-mri-x86-mingw32:1.1.0
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
@@ -1,1 +1,15 @@
 FROM larskanis/rake-compiler-dock-mri-x86_64-darwin:1.1.0
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
@@ -1,15 +1,1 @@
 FROM larskanis/rake-compiler-dock-mri-x86_64-darwin:1.1.0
-
-#=================
-# Install ccache
-
-# Install ccache from source since ccache 3.x packaged with most linux distributions
-# does not support Redis backend for caching.
-RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
-    && tar -zxf ccache.tar.gz \
-    && cd ccache-4.5.1 \
-    && mkdir build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
-    && make -j4 && make install \
-    && cd ../.. \
-    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
@@ -1,1 +1,15 @@
 FROM larskanis/rake-compiler-dock-mri-x86_64-linux:1.1.0
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/tools/dockerfile/grpc_artifact_python_linux_armv7/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_linux_armv7/Dockerfile
@@ -31,3 +31,23 @@ RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.10.0" "3.10.0rc1" /
 
 ENV AUDITWHEEL_ARCH armv7l
 ENV AUDITWHEEL_PLAT linux_armv7l
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN unset CMAKE_TOOLCHAIN_FILE && unset AS AR CC CPP CXX LD \
+    && curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
+# The dockcross base of this image sets CC and CXX to absolute paths, which makes it impossible to redirect their invocations
+# to ccache via a symlink. Use relative paths instead.
+ENV CC ${CROSS_TRIPLE}-gcc
+ENV CXX ${CROSS_TRIPLE}-g++

--- a/tools/dockerfile/grpc_artifact_python_linux_armv7/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_linux_armv7/Dockerfile
@@ -50,3 +50,12 @@ RUN unset CMAKE_TOOLCHAIN_FILE && unset AS AR CC CPP CXX LD \
 # to ccache via a symlink. Use relative paths instead.
 ENV CC ${CROSS_TRIPLE}-gcc
 ENV CXX ${CROSS_TRIPLE}-g++
+
+# For historical reasons, task_runner.py the script under docker container using "bash -l"
+# which loads /etc/profile on startup. dockcross/linux-armv7 is based on an image where
+# /etc/profile overwrites contents of PATH (for security reasons) when run as root.
+# That causes the crosscompiler binaries located under /usr/xcc/armv7-unknown-linux-gnueabi/bin
+# to be removed from PATH. Since in our builds we don't need the /etc/profile for anything, we can just
+# truncate it.
+# TODO(jtattermusch): Remove this hack when possible.
+RUN echo "# file contents removed to avoid resetting PATH set by the docker image" >/etc/profile

--- a/tools/dockerfile/grpc_artifact_python_linux_armv7/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_linux_armv7/Dockerfile
@@ -26,7 +26,6 @@ RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.6.13" "3.6.13" /opt
 RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.7.10" "3.7.10" /opt/python/cp37-cp37m
 RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.8.8" "3.8.8" /opt/python/cp38-cp38
 RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.9.2" "3.9.2" /opt/python/cp39-cp39
-RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.9.2" "3.9.2" /opt/python/cp39-cp39
 RUN /scripts/install_python_for_wheel_crosscompilation.sh "3.10.0" "3.10.0rc1" /opt/python/cp310-cp310
 
 ENV AUDITWHEEL_ARCH armv7l

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64/Dockerfile
@@ -25,9 +25,29 @@ RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython
 RUN /opt/python/cp39-cp39/bin/pip install --upgrade cython
 RUN /opt/python/cp310-cp310/bin/pip install --upgrade cython
 
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN unset CMAKE_TOOLCHAIN_FILE && unset AS AR CC CPP CXX LD \
+    && curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 # the dockcross docker image sets variables like CC, CXX etc.
 # to point to the crosscompilation toolchain, but doesn't set corresponding
 # variables for the "strip" and "objcopy" tools.
 # see https://github.com/dockcross/dockcross/blob/4349cb4999401cbf22a90f46f5052d29be240e50/manylinux2014-aarch64/Dockerfile.in#L23
 ENV STRIP=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-strip \
     OBJCOPY=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-objcopy
+
+# The dockcross base of this image sets CC and CXX to absolute paths, which makes it impossible to redirect their invocations
+# to ccache via a symlink. Use relative paths instead.
+ENV CC ${CROSS_TRIPLE}-gcc
+ENV CXX ${CROSS_TRIPLE}-g++

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -119,8 +119,23 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup
 
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
+
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -119,8 +119,23 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup
 
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
+
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -85,16 +85,28 @@ RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-clien
 RUN apt-get update && apt-get -y install libc++-dev clang && apt-get clean
 
 #=================
-# Use cmake 3.6 from jessie-backports
-# should only be used for images based on debian jessie.
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
 
-RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
-RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
 
 
 RUN mkdir /var/local/jenkins
+
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
@@ -67,3 +67,23 @@ RUN ln -s $(which python3) /usr/bin/python
 # These are needed for uploading test results to BigQuery (e.g. by tools/run_tests scripts)
 RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-client==1.12.8 oauth2client==4.1.0
 
+
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile
@@ -67,3 +67,24 @@ RUN ln -s $(which python3) /usr/bin/python
 # These are needed for uploading test results to BigQuery (e.g. by tools/run_tests scripts)
 RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-client==1.12.8 oauth2client==4.1.0
 
+
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -97,8 +97,29 @@ RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
 RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.5' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
+
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/csharp_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_debian11_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -119,8 +119,23 @@ RUN mkdir warmup \
     && cd .. \
     && rm -rf warmup
 
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
+
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/ruby_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_debian11_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:buster
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -103,11 +103,23 @@ RUN /bin/bash -l -c "gem install bundler --no-document -v 1.9"
 
 RUN apt-get update && apt-get install -y cmake && apt-get clean
 
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
 
-
-RUN python3 -m pip install virtualenv==16.7.9
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:bullseye
+FROM debian:11
 
 #=================
 # Basic C core dependencies

--- a/tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
+++ b/tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
@@ -45,6 +45,8 @@ then
       # python artifacts: dockcross crosscompilers
       "aarch64-unknown-linux-gnueabi-gcc"
       "aarch64-unknown-linux-gnueabi-g++"
+      "armv7-unknown-linux-gnueabi-gcc"
+      "armv7-unknown-linux-gnueabi-g++"
     )
     CCACHE_BINARY_PATH="$(command -v ccache)"
     TEMP_CCACHE_BINDIR="$(mktemp -d)"

--- a/tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
+++ b/tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
@@ -20,12 +20,43 @@ if [ "${GRPC_BUILD_ENABLE_CCACHE}" != "" ]
 then
   if [ -x "$(command -v ccache)" ]
   then
+    SUPPORTED_COMPILERS=(
+      # common compiler binaries
+      "gcc"
+      "g++"
+      "clang"
+      "clang++"
+      "cc"
+      "c++"
+      # ruby artifacts: rake-compiler-dock crosscompilers
+      # TODO(jtattermusch): ensure that the list of ruby crosscompilers stays up to date.
+      "x86_64-redhat-linux-gcc"
+      "x86_64-redhat-linux-g++"
+      "i686-redhat-linux-gcc"
+      "i686-redhat-linux-g++"
+      "x86_64-w64-mingw32-gcc"
+      "x86_64-w64-mingw32-g++"
+      "i686-w64-mingw32-gcc"
+      "i686-w64-mingw32-g++"
+      "x86_64-apple-darwin-clang"
+      "x86_64-apple-darwin-clang++"
+      "aarch64-apple-darwin-clang"
+      "aarch64-apple-darwin-clang++"
+      # python artifacts: dockcross crosscompilers
+    )
+    CCACHE_BINARY_PATH="$(command -v ccache)"
     TEMP_CCACHE_BINDIR="$(mktemp -d)"
-    # TODO: symlinks for crosscompilers...
-    for compiler in "gcc" "g++" "clang" "clang++" "cc" "c++"
+
+    for compiler in "${SUPPORTED_COMPILERS[@]}"
     do
-      ln -s "$(which ccache)" "${TEMP_CCACHE_BINDIR}/${compiler}"
+      # create a symlink pointing to ccache if compiler binary exists
+      if [ -x "$(command -v $compiler)" ]
+      then
+        ln -s "${CCACHE_BINARY_PATH}" "${TEMP_CCACHE_BINDIR}/${compiler}"
+        echo "Creating symlink $compiler pointing to ${CCACHE_BINARY_PATH}"
+      fi
     done
+    echo "Adding ${TEMP_CCACHE_BINDIR} to PATH"
     export PATH="${TEMP_CCACHE_BINDIR}:$PATH"
   fi
 fi

--- a/tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
+++ b/tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
@@ -43,6 +43,8 @@ then
       "aarch64-apple-darwin-clang"
       "aarch64-apple-darwin-clang++"
       # python artifacts: dockcross crosscompilers
+      "aarch64-unknown-linux-gnueabi-gcc"
+      "aarch64-unknown-linux-gnueabi-g++"
     )
     CCACHE_BINARY_PATH="$(command -v ccache)"
     TEMP_CCACHE_BINDIR="$(mktemp -d)"

--- a/tools/internal_ci/linux/grpc_run_interop_tests.sh
+++ b/tools/internal_ci/linux/grpc_run_interop_tests.sh
@@ -26,4 +26,7 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 source tools/internal_ci/helper_scripts/prepare_build_interop_rc
 
+# configure ccache
+source tools/internal_ci/helper_scripts/prepare_ccache_rc
+
 tools/run_tests/run_interop_tests.py $RUN_TESTS_FLAGS

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -96,13 +96,13 @@ class CSharpPackage:
         if self.unity:
             return create_docker_jobspec(
                 self.name,
-                'tools/dockerfile/test/csharp_buster_x64',
+                'tools/dockerfile/test/csharp_debian11_x64',
                 'src/csharp/build_unitypackage.sh',
                 environ=environ)
         else:
             return create_docker_jobspec(
                 self.name,
-                'tools/dockerfile/test/csharp_buster_x64',
+                'tools/dockerfile/test/csharp_debian11_x64',
                 'src/csharp/build_nuget.sh',
                 environ=environ)
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -861,7 +861,7 @@ class RubyLanguage(object):
         return 'Makefile'
 
     def dockerfile_dir(self):
-        return 'tools/dockerfile/test/ruby_buster_%s' % _docker_arch_suffix(
+        return 'tools/dockerfile/test/ruby_debian11_%s' % _docker_arch_suffix(
             self.args.arch)
 
     def __str__(self):
@@ -888,7 +888,7 @@ class CSharpLanguage(object):
             _check_arch(self.args.arch, ['default'])
             self._cmake_arch_option = 'x64'
         else:
-            self._docker_distro = 'buster'
+            self._docker_distro = 'debian11'
 
     def test_specs(self):
         with open('src/csharp/tests.json') as f:


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/28661.

-use ccache for more builds
- upgrade many docker containers to debian11 (since that's the current stable) and add cccache 4.x to them
- enable using ccache in ruby's rake-compiler-dock images (which requires patching Rakefile to propagate the ccache related settings to the inner docker container run by rake-compiler-dock.