### PR TITLE
HTTP2: Add GrpcNetworkStreamState metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -990,6 +990,7 @@ if(gRPC_BUILD_TESTS)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_cxx streaming_throughput_test)
   endif()
+  add_dependencies(buildtests_cxx streams_not_seen_test)
   add_dependencies(buildtests_cxx string_ref_test)
   add_dependencies(buildtests_cxx table_test)
   add_dependencies(buildtests_cxx test_core_slice_slice_test)
@@ -15379,6 +15380,42 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
 
 endif()
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(streams_not_seen_test
+  test/core/end2end/cq_verifier.cc
+  test/core/transport/chttp2/streams_not_seen_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(streams_not_seen_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(streams_not_seen_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
+)
+
+
 endif()
 if(gRPC_BUILD_TESTS)
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -7682,6 +7682,17 @@ targets:
   - linux
   - posix
   - mac
+- name: streams_not_seen_test
+  gtest: true
+  build: test
+  language: c++
+  headers:
+  - test/core/end2end/cq_verifier.h
+  src:
+  - test/core/end2end/cq_verifier.cc
+  - test/core/transport/chttp2/streams_not_seen_test.cc
+  deps:
+  - grpc_test_util
 - name: string_ref_test
   gtest: true
   build: test

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -173,6 +173,7 @@ namespace {
 TestOnlyGlobalHttp2TransportInitCallback test_only_init_callback = nullptr;
 TestOnlyGlobalHttp2TransportDestructCallback test_only_destruct_callback =
     nullptr;
+bool test_only_disable_transient_failure_state_notification = false;
 }  // namespace
 
 void TestOnlySetGlobalHttp2TransportInitCallback(
@@ -183,6 +184,11 @@ void TestOnlySetGlobalHttp2TransportInitCallback(
 void TestOnlySetGlobalHttp2TransportDestructCallback(
     TestOnlyGlobalHttp2TransportDestructCallback callback) {
   test_only_destruct_callback = callback;
+}
+
+void TestOnlyGlobalHttp2TransportDisableTransientFailureStateNotification(
+    bool disable) {
+  test_only_disable_transient_failure_state_notification = disable;
 }
 
 }  // namespace grpc_core
@@ -1043,6 +1049,19 @@ static void queue_setting_update(grpc_chttp2_transport* t,
   }
 }
 
+// Cancel out streams that haven't yet started if we have received a GOAWAY
+static void cancel_unstarted_streams(grpc_chttp2_transport* t,
+                                     grpc_error_handle error) {
+  grpc_chttp2_stream* s;
+  while (grpc_chttp2_list_pop_waiting_for_concurrency(t, &s)) {
+    s->trailing_metadata_buffer.Set(
+        grpc_core::GrpcStreamNetworkState(),
+        grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+    grpc_chttp2_cancel_stream(t, s, GRPC_ERROR_REF(error));
+  }
+  GRPC_ERROR_UNREF(error);
+}
+
 void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
                                      uint32_t goaway_error,
                                      uint32_t last_stream_id,
@@ -1068,6 +1087,22 @@ void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
     gpr_log(GPR_INFO, "%s: Got goaway [%d] err=%s", t->peer_string.c_str(),
             goaway_error, grpc_error_std_string(t->goaway_error).c_str());
   }
+  cancel_unstarted_streams(t, GRPC_ERROR_REF(t->goaway_error));
+  // Cancel all unseen streams
+  grpc_chttp2_stream_map_for_each(
+      &t->stream_map,
+      [](void* user_data, uint32_t /* key */, void* stream) {
+        uint32_t last_stream_id = *(static_cast<uint32_t*>(user_data));
+        grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(stream);
+        if (s->id > last_stream_id) {
+          s->trailing_metadata_buffer.Set(
+              grpc_core::GrpcStreamNetworkState(),
+              grpc_core::GrpcStreamNetworkState::kNotSeenByServer);
+          grpc_chttp2_cancel_stream(s->t, s,
+                                    GRPC_ERROR_REF(s->t->goaway_error));
+        }
+      },
+      &last_stream_id);
   absl::Status status = grpc_error_to_absl_status(t->goaway_error);
   // When a client receives a GOAWAY with error code ENHANCE_YOUR_CALM and debug
   // data equal to "too_many_pings", it should log the occurrence at a log level
@@ -1092,21 +1127,18 @@ void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
   }
   // lie: use transient failure from the transport to indicate goaway has been
   // received.
-  connectivity_state_set(t, GRPC_CHANNEL_TRANSIENT_FAILURE, status,
-                         "got_goaway");
+  if (!grpc_core::test_only_disable_transient_failure_state_notification) {
+    connectivity_state_set(t, GRPC_CHANNEL_TRANSIENT_FAILURE, status,
+                           "got_goaway");
+  }
 }
 
 static void maybe_start_some_streams(grpc_chttp2_transport* t) {
   grpc_chttp2_stream* s;
-  // cancel out streams that haven't yet started if we have received a GOAWAY
+  // maybe cancel out streams that haven't yet started if we have received a
+  // GOAWAY
   if (t->goaway_error != GRPC_ERROR_NONE) {
-    while (grpc_chttp2_list_pop_waiting_for_concurrency(t, &s)) {
-      grpc_chttp2_cancel_stream(
-          t, s,
-          grpc_error_set_int(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING("GOAWAY received"),
-              GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));
-    }
+    cancel_unstarted_streams(t, GRPC_ERROR_REF(t->goaway_error));
     return;
   }
   // start streams where we have free grpc_chttp2_stream ids and free
@@ -1141,6 +1173,9 @@ static void maybe_start_some_streams(grpc_chttp2_transport* t) {
   // cancel out streams that will never be started
   if (t->next_stream_id >= MAX_CLIENT_STREAM_ID) {
     while (grpc_chttp2_list_pop_waiting_for_concurrency(t, &s)) {
+      s->trailing_metadata_buffer.Set(
+          grpc_core::GrpcStreamNetworkState(),
+          grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
       grpc_chttp2_cancel_stream(
           t, s,
           grpc_error_set_int(
@@ -1408,6 +1443,9 @@ static void perform_stream_op_locked(void* stream_op,
           grpc_chttp2_list_add_waiting_for_concurrency(t, s);
           maybe_start_some_streams(t);
         } else {
+          s->trailing_metadata_buffer.Set(
+              grpc_core::GrpcStreamNetworkState(),
+              grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
           grpc_chttp2_cancel_stream(
               t, s,
               grpc_error_set_int(
@@ -2310,6 +2348,7 @@ static void end_all_the_calls(grpc_chttp2_transport* t,
     error = grpc_error_set_int(error, GRPC_ERROR_INT_GRPC_STATUS,
                                GRPC_STATUS_UNAVAILABLE);
   }
+  cancel_unstarted_streams(t, GRPC_ERROR_REF(error));
   cancel_stream_cb_args args = {error, t};
   grpc_chttp2_stream_map_for_each(&t->stream_map, cancel_stream_cb, &args);
   GRPC_ERROR_UNREF(error);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.h
@@ -60,6 +60,14 @@ void TestOnlySetGlobalHttp2TransportInitCallback(
 
 void TestOnlySetGlobalHttp2TransportDestructCallback(
     TestOnlyGlobalHttp2TransportDestructCallback callback);
+
+// If \a disable is true, the HTTP2 transport will not update the connectivity
+// state tracker to TRANSIENT_FAILURE when a goaway is received. This prevents
+// the watchers (eg. client_channel) from noticing the GOAWAY, thereby allowing
+// us to test the racy behavior when a call is sent down the stack around the
+// same time that a GOAWAY is received.
+void TestOnlyGlobalHttp2TransportDisableTransientFailureStateNotification(
+    bool disable);
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_CHTTP2_TRANSPORT_H */

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -85,7 +85,7 @@ absl::Status grpc_wsa_error(const grpc_core::DebugLocation& location, int err,
                             const char* call_name) {
   char* utf8_message = gpr_format_message(err);
   absl::Status s =
-      StatusCreate(absl::StatusCode::kUnknown, "WSA Error", location, {});
+      StatusCreate(absl::StatusCode::kUnavailable, "WSA Error", location, {});
   StatusSetInt(&s, grpc_core::StatusIntProperty::kWsaError, err);
   StatusSetStr(&s, grpc_core::StatusStrProperty::kOsError, utf8_message);
   StatusSetStr(&s, grpc_core::StatusStrProperty::kSyscall, call_name);
@@ -960,15 +960,17 @@ grpc_error_handle grpc_os_error(const char* file, int line, int err,
 grpc_error_handle grpc_wsa_error(const char* file, int line, int err,
                                  const char* call_name) {
   char* utf8_message = gpr_format_message(err);
-  grpc_error_handle error = grpc_error_set_str(
+  grpc_error_handle error = grpc_error_set_int(
       grpc_error_set_str(
-          grpc_error_set_int(
-              grpc_error_create(file, line,
-                                grpc_slice_from_static_string("OS Error"), NULL,
-                                0),
-              GRPC_ERROR_INT_WSA_ERROR, err),
-          GRPC_ERROR_STR_OS_ERROR, utf8_message),
-      GRPC_ERROR_STR_SYSCALL, call_name);
+          grpc_error_set_str(
+              grpc_error_set_int(
+                  grpc_error_create(file, line,
+                                    grpc_slice_from_static_string("OS Error"),
+                                    NULL, 0),
+                  GRPC_ERROR_INT_WSA_ERROR, err),
+              GRPC_ERROR_STR_OS_ERROR, utf8_message),
+          GRPC_ERROR_STR_SYSCALL, call_name),
+      GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
   gpr_free(utf8_message);
   return error;
 }

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -219,10 +219,12 @@ static void on_read(void* tcpp, grpc_error_handle error) {
           gpr_log(GPR_INFO, "TCP:%p unref read_slice", tcp);
         }
         grpc_slice_buffer_reset_and_unref_internal(tcp->read_slices);
-        error = tcp->shutting_down
-                    ? GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                          "TCP stream shutting down", &tcp->shutdown_error, 1)
-                    : GRPC_ERROR_CREATE_FROM_STATIC_STRING("End of TCP stream");
+        error = grpc_error_set_int(
+            tcp->shutting_down
+                ? GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                      "TCP stream shutting down", &tcp->shutdown_error, 1)
+                : GRPC_ERROR_CREATE_FROM_STATIC_STRING("End of TCP stream"),
+            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
       }
     }
   }
@@ -252,8 +254,10 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
   if (tcp->shutting_down) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-            "TCP socket is shutting down", &tcp->shutdown_error, 1));
+        grpc_error_set_int(
+            GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                "TCP socket is shutting down", &tcp->shutdown_error, 1),
+            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));
     return;
   }
 
@@ -366,8 +370,10 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   if (tcp->shutting_down) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-            "TCP socket is shutting down", &tcp->shutdown_error, 1));
+        grpc_error_set_int(
+            GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                "TCP socket is shutting down", &tcp->shutdown_error, 1),
+            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE));
     return;
   }
 

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -148,6 +148,19 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "streams_not_seen_test",
+    srcs = ["streams_not_seen_test.cc"],
+    external_deps = ["gtest"],
+    language = "C++",
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//test/core/end2end:cq_verifier",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "settings_timeout_test",
     srcs = ["settings_timeout_test.cc"],
     external_deps = [

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -147,7 +147,7 @@ absl::optional<GrpcStreamNetworkState::ValueType>
 
 class StreamsNotSeenTest : public ::testing::Test {
  protected:
-  StreamsNotSeenTest(bool server_allows_streams = true)
+  explicit StreamsNotSeenTest(bool server_allows_streams = true)
       : server_allows_streams_(server_allows_streams) {
     // Reset the filter state
     TrailingMetadataRecordingFilter::reset_stream_network_state();
@@ -189,7 +189,7 @@ class StreamsNotSeenTest : public ::testing::Test {
     connect_notification_.WaitForNotificationWithTimeout(absl::Seconds(1));
   }
 
-  ~StreamsNotSeenTest() {
+  ~StreamsNotSeenTest() override {
     cq_verifier_destroy(cqv_);
     grpc_completion_queue_shutdown(cq_);
     grpc_event ev;

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -93,7 +93,7 @@ class TrailingMetadataRecordingFilter {
     }
 
    private:
-    explicit CallData(const grpc_call_element_args* args) {
+    explicit CallData(const grpc_call_element_args* /*args*/) {
       GRPC_CLOSURE_INIT(&recv_trailing_metadata_ready_,
                         RecvTrailingMetadataReady, this, nullptr);
     }
@@ -102,9 +102,9 @@ class TrailingMetadataRecordingFilter {
       auto* calld = static_cast<CallData*>(arg);
       stream_network_state_ =
           calld->recv_trailing_metadata_->get(GrpcStreamNetworkState());
-      grpc_core::Closure::Run(DEBUG_LOCATION,
-                              calld->original_recv_trailing_metadata_ready_,
-                              GRPC_ERROR_REF(error));
+      Closure::Run(DEBUG_LOCATION,
+                   calld->original_recv_trailing_metadata_ready_,
+                   GRPC_ERROR_REF(error));
     }
 
     grpc_metadata_batch* recv_trailing_metadata_ = nullptr;
@@ -293,7 +293,7 @@ class StreamsNotSeenTest : public ::testing::Test {
     if (error == GRPC_ERROR_NONE) {
       {
         absl::MutexLock lock(&self->mu_);
-        for (int i = 0; i < self->read_buffer_.count; ++i) {
+        for (size_t i = 0; i < self->read_buffer_.count; ++i) {
           absl::StrAppend(&self->read_bytes_,
                           StringViewFromSlice(self->read_buffer_.slices[i]));
         }
@@ -399,11 +399,10 @@ TEST_F(StreamsNotSeenTest, StartStreamBeforeGoaway) {
   cq_verify(cqv_);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
-  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                  .has_value());
-  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                .value(),
-            grpc_core::GrpcStreamNetworkState::kNotSeenByServer);
+  ASSERT_TRUE(
+      TrailingMetadataRecordingFilter::stream_network_state().has_value());
+  EXPECT_EQ(TrailingMetadataRecordingFilter::stream_network_state().value(),
+            GrpcStreamNetworkState::kNotSeenByServer);
   grpc_slice_unref(details);
   gpr_free(const_cast<char*>(error_string));
   grpc_metadata_array_destroy(&initial_metadata_recv);
@@ -467,11 +466,10 @@ TEST_F(StreamsNotSeenTest, StartStreamAfterGoaway) {
   cq_verify(cqv_);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
-  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                  .has_value());
-  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                .value(),
-            grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+  ASSERT_TRUE(
+      TrailingMetadataRecordingFilter::stream_network_state().has_value());
+  EXPECT_EQ(TrailingMetadataRecordingFilter::stream_network_state().value(),
+            GrpcStreamNetworkState::kNotSentOnWire);
   grpc_slice_unref(details);
   gpr_free(const_cast<char*>(error_string));
   grpc_metadata_array_destroy(&initial_metadata_recv);
@@ -545,11 +543,10 @@ TEST_F(ZeroConcurrencyTest, StartStreamBeforeGoaway) {
   cq_verify(cqv_);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
-  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                  .has_value());
-  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                .value(),
-            grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+  ASSERT_TRUE(
+      TrailingMetadataRecordingFilter::stream_network_state().has_value());
+  EXPECT_EQ(TrailingMetadataRecordingFilter::stream_network_state().value(),
+            GrpcStreamNetworkState::kNotSentOnWire);
   grpc_slice_unref(details);
   gpr_free(const_cast<char*>(error_string));
   grpc_metadata_array_destroy(&initial_metadata_recv);
@@ -611,11 +608,10 @@ TEST_F(ZeroConcurrencyTest, TransportDestroyed) {
   cq_verify(cqv_);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
-  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                  .has_value());
-  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
-                .value(),
-            grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+  ASSERT_TRUE(
+      TrailingMetadataRecordingFilter::stream_network_state().has_value());
+  EXPECT_EQ(TrailingMetadataRecordingFilter::stream_network_state().value(),
+            GrpcStreamNetworkState::kNotSentOnWire);
   grpc_slice_unref(details);
   gpr_free(const_cast<char*>(error_string));
   grpc_metadata_array_destroy(&initial_metadata_recv);

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -637,20 +637,16 @@ int main(int argc, char** argv) {
         auto register_stage = [builder](grpc_channel_stack_type type,
                                         const grpc_channel_filter* filter) {
           builder->channel_init()->RegisterStage(
-              type, INT_MAX, [filter](grpc_channel_stack_builder* builder) {
+              type, INT_MAX, [filter](grpc_core::ChannelStackBuilder* builder) {
                 // Want to add the filter as close to the end as possible, to
                 // make sure that all of the filters work well together.
                 // However, we can't add it at the very end, because the
                 // connected channel filter must be the last one.  So we add it
                 // right before the last one.
-                grpc_channel_stack_builder_iterator* it =
-                    grpc_channel_stack_builder_create_iterator_at_last(builder);
-                GPR_ASSERT(grpc_channel_stack_builder_move_prev(it));
-                const bool retval =
-                    grpc_channel_stack_builder_add_filter_before(
-                        it, filter, nullptr, nullptr);
-                grpc_channel_stack_builder_iterator_destroy(it);
-                return retval;
+                auto it = builder->mutable_stack()->end();
+                --it;
+                builder->mutable_stack()->insert(it, {filter, nullptr});
+                return true;
               });
         };
         register_stage(

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -1,0 +1,672 @@
+//
+//
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <grpc/support/port_platform.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <thread>
+
+#include <gmock/gmock.h>
+
+#include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
+
+#include <grpc/grpc.h>
+
+#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
+#include "src/core/ext/transport/chttp2/transport/frame_goaway.h"
+#include "src/core/lib/channel/channel_stack_builder.h"
+#include "src/core/lib/config/core_configuration.h"
+#include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/slice/slice.h"
+#include "src/core/lib/surface/channel.h"
+#include "test/core/end2end/cq_verifier.h"
+#include "test/core/util/memory_counters.h"
+#include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
+#include "test/core/util/test_tcp_server.h"
+
+namespace grpc_core {
+namespace {
+
+void* Tag(intptr_t t) { return reinterpret_cast<void*>(t); }
+
+// A filter that fails all batches with send ops.
+class TrailingMetadataRecordingFilter {
+ public:
+  static grpc_channel_filter kFilterVtable;
+
+  static absl::optional<GrpcStreamNetworkState::ValueType>
+  stream_network_state() {
+    return stream_network_state_;
+  }
+
+  static void reset_stream_network_state() {
+    stream_network_state_ = absl::nullopt;
+  }
+
+ private:
+  class CallData {
+   public:
+    static grpc_error_handle Init(grpc_call_element* elem,
+                                  const grpc_call_element_args* args) {
+      new (elem->call_data) CallData(args);
+      return GRPC_ERROR_NONE;
+    }
+
+    static void Destroy(grpc_call_element* elem,
+                        const grpc_call_final_info* /*final_info*/,
+                        grpc_closure* /*ignored*/) {
+      auto* calld = static_cast<CallData*>(elem->call_data);
+      calld->~CallData();
+    }
+
+    static void StartTransportStreamOpBatch(
+        grpc_call_element* elem, grpc_transport_stream_op_batch* batch) {
+      auto* calld = static_cast<CallData*>(elem->call_data);
+      if (batch->recv_trailing_metadata) {
+        calld->recv_trailing_metadata_ =
+            batch->payload->recv_trailing_metadata.recv_trailing_metadata;
+        calld->original_recv_trailing_metadata_ready_ =
+            batch->payload->recv_trailing_metadata.recv_trailing_metadata_ready;
+        batch->payload->recv_trailing_metadata.recv_trailing_metadata_ready =
+            &calld->recv_trailing_metadata_ready_;
+      }
+      grpc_call_next_op(elem, batch);
+    }
+
+   private:
+    explicit CallData(const grpc_call_element_args* args) {
+      GRPC_CLOSURE_INIT(&recv_trailing_metadata_ready_,
+                        RecvTrailingMetadataReady, this, nullptr);
+    }
+
+    static void RecvTrailingMetadataReady(void* arg, grpc_error_handle error) {
+      auto* calld = static_cast<CallData*>(arg);
+      stream_network_state_ =
+          calld->recv_trailing_metadata_->get(GrpcStreamNetworkState());
+      grpc_core::Closure::Run(DEBUG_LOCATION,
+                              calld->original_recv_trailing_metadata_ready_,
+                              GRPC_ERROR_REF(error));
+    }
+
+    grpc_metadata_batch* recv_trailing_metadata_ = nullptr;
+    grpc_closure recv_trailing_metadata_ready_;
+    grpc_closure* original_recv_trailing_metadata_ready_ = nullptr;
+  };
+
+  static grpc_error_handle Init(grpc_channel_element* elem,
+                                grpc_channel_element_args* /*args*/) {
+    new (elem->channel_data) TrailingMetadataRecordingFilter();
+    return GRPC_ERROR_NONE;
+  }
+
+  static void Destroy(grpc_channel_element* elem) {
+    auto* chand =
+        static_cast<TrailingMetadataRecordingFilter*>(elem->channel_data);
+    chand->~TrailingMetadataRecordingFilter();
+  }
+
+  static absl::optional<GrpcStreamNetworkState::ValueType>
+      stream_network_state_;
+};
+
+grpc_channel_filter TrailingMetadataRecordingFilter::kFilterVtable = {
+    CallData::StartTransportStreamOpBatch,
+    nullptr,
+    grpc_channel_next_op,
+    sizeof(CallData),
+    CallData::Init,
+    grpc_call_stack_ignore_set_pollset_or_pollset_set,
+    CallData::Destroy,
+    sizeof(TrailingMetadataRecordingFilter),
+    Init,
+    Destroy,
+    grpc_channel_next_get_info,
+    "TrailingMetadataRecordingFilter",
+};
+absl::optional<GrpcStreamNetworkState::ValueType>
+    TrailingMetadataRecordingFilter::stream_network_state_;
+
+class StreamsNotSeenTest : public ::testing::Test {
+ protected:
+  StreamsNotSeenTest(bool server_allows_streams = true)
+      : server_allows_streams_(server_allows_streams) {
+    // Reset the filter state
+    TrailingMetadataRecordingFilter::reset_stream_network_state();
+    grpc_slice_buffer_init(&read_buffer_);
+    GRPC_CLOSURE_INIT(&on_read_done_, OnReadDone, this, nullptr);
+    // Start the test tcp server
+    port_ = grpc_pick_unused_port_or_die();
+    test_tcp_server_init(&server_, OnConnect, this);
+    test_tcp_server_start(&server_, port_);
+    // Start polling on the test tcp server
+    server_poll_thread_ = absl::make_unique<std::thread>([this]() {
+      while (!shutdown_) {
+        test_tcp_server_poll(&server_, 10);
+      }
+    });
+    // Create the channel
+    cq_ = grpc_completion_queue_create_for_next(nullptr);
+    cqv_ = cq_verifier_create(cq_);
+    grpc_arg client_args[] = {
+        grpc_channel_arg_integer_create(
+            const_cast<char*>(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA), 0),
+        grpc_channel_arg_integer_create(
+            const_cast<char*>(GRPC_ARG_HTTP2_BDP_PROBE), 0)};
+    grpc_channel_args client_channel_args = {GPR_ARRAY_SIZE(client_args),
+                                             client_args};
+    channel_ =
+        grpc_insecure_channel_create(JoinHostPort("127.0.0.1", port_).c_str(),
+                                     &client_channel_args, nullptr);
+    // Wait for the channel to connect
+    grpc_connectivity_state state = grpc_channel_check_connectivity_state(
+        channel_, /*try_to_connect=*/true);
+    while (state != GRPC_CHANNEL_READY) {
+      grpc_channel_watch_connectivity_state(
+          channel_, state, grpc_timeout_seconds_to_deadline(5), cq_, Tag(1));
+      CQ_EXPECT_COMPLETION(cqv_, Tag(1), true);
+      cq_verify(cqv_);
+      state = grpc_channel_check_connectivity_state(channel_, false);
+    }
+    connect_notification_.WaitForNotificationWithTimeout(absl::Seconds(1));
+  }
+
+  ~StreamsNotSeenTest() {
+    cq_verifier_destroy(cqv_);
+    grpc_completion_queue_shutdown(cq_);
+    grpc_event ev;
+    do {
+      ev = grpc_completion_queue_next(cq_, grpc_timeout_seconds_to_deadline(1),
+                                      nullptr);
+    } while (ev.type != GRPC_QUEUE_SHUTDOWN);
+    grpc_completion_queue_destroy(cq_);
+    grpc_channel_destroy(channel_);
+    grpc_endpoint_shutdown(
+        tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+    read_end_notification_.WaitForNotificationWithTimeout(absl::Seconds(5));
+    grpc_endpoint_destroy(tcp_);
+    shutdown_ = true;
+    server_poll_thread_->join();
+    test_tcp_server_destroy(&server_);
+    ExecCtx::Get()->Flush();
+  }
+
+  static void OnConnect(void* arg, grpc_endpoint* tcp,
+                        grpc_pollset* /* accepting_pollset */,
+                        grpc_tcp_server_acceptor* acceptor) {
+    gpr_free(acceptor);
+    StreamsNotSeenTest* self = static_cast<StreamsNotSeenTest*>(arg);
+    self->tcp_ = tcp;
+    grpc_endpoint_add_to_pollset(tcp, self->server_.pollset[0]);
+    grpc_endpoint_read(tcp, &self->read_buffer_, &self->on_read_done_, false);
+    // Send settings frame from server
+    if (self->server_allows_streams_) {
+      constexpr char kHttp2SettingsFrame[] =
+          "\x00\x00\x00\x04\x00\x00\x00\x00\x00";
+      self->Write(absl::string_view(kHttp2SettingsFrame,
+                                    sizeof(kHttp2SettingsFrame) - 1));
+    } else {
+      // Create a settings frame with a max concurrent stream setting of 0
+      constexpr char kHttp2SettingsFrame[] =
+          "\x00\x00\x06\x04\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00";
+      self->Write(absl::string_view(kHttp2SettingsFrame,
+                                    sizeof(kHttp2SettingsFrame) - 1));
+    }
+    self->connect_notification_.Notify();
+  }
+
+  void Write(absl::string_view bytes) {
+    grpc_slice slice =
+        StaticSlice::FromStaticBuffer(bytes.data(), bytes.size()).TakeCSlice();
+    grpc_slice_buffer buffer;
+    grpc_slice_buffer_init(&buffer);
+    grpc_slice_buffer_add(&buffer, slice);
+    WriteBuffer(&buffer);
+    grpc_slice_buffer_destroy(&buffer);
+  }
+
+  void SendPing() {
+    // Send and recv ping ack
+    const char ping_bytes[] =
+        "\x00\x00\x08\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    const char ping_ack_bytes[] =
+        "\x00\x00\x08\x06\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    Write(absl::string_view(ping_bytes, sizeof(ping_bytes) - 1));
+    std::atomic<bool> done{false};
+    std::thread cq_driver([&]() {
+      while (!done) {
+        grpc_event ev = grpc_completion_queue_next(
+            cq_, grpc_timeout_milliseconds_to_deadline(10), nullptr);
+        GPR_ASSERT(ev.type == GRPC_QUEUE_TIMEOUT);
+      }
+    });
+    WaitForReadBytes(
+        absl::string_view(ping_ack_bytes, sizeof(ping_ack_bytes) - 1));
+    done = true;
+    cq_driver.join();
+  }
+
+  void SendGoaway(uint32_t last_stream_id) {
+    grpc_slice_buffer buffer;
+    grpc_slice_buffer_init(&buffer);
+    grpc_chttp2_goaway_append(last_stream_id, 0, grpc_empty_slice(), &buffer);
+    WriteBuffer(&buffer);
+    grpc_slice_buffer_destroy(&buffer);
+  }
+
+  void WriteBuffer(grpc_slice_buffer* buffer) {
+    absl::Notification on_write_done_notification_;
+    GRPC_CLOSURE_INIT(&on_write_done_, OnWriteDone,
+                      &on_write_done_notification_, nullptr);
+    grpc_endpoint_write(tcp_, buffer, &on_write_done_, nullptr);
+    on_write_done_notification_.WaitForNotificationWithTimeout(
+        absl::Seconds(5));
+  }
+
+  static void OnWriteDone(void* arg, grpc_error_handle error) {
+    GPR_ASSERT(error == GRPC_ERROR_NONE);
+    absl::Notification* on_write_done_notification_ =
+        static_cast<absl::Notification*>(arg);
+    on_write_done_notification_->Notify();
+  }
+
+  static void OnReadDone(void* arg, grpc_error_handle error) {
+    StreamsNotSeenTest* self = static_cast<StreamsNotSeenTest*>(arg);
+    if (error == GRPC_ERROR_NONE) {
+      {
+        absl::MutexLock lock(&self->mu_);
+        for (int i = 0; i < self->read_buffer_.count; ++i) {
+          absl::StrAppend(&self->read_bytes_,
+                          StringViewFromSlice(self->read_buffer_.slices[i]));
+        }
+        self->read_cv_.SignalAll();
+      }
+      grpc_slice_buffer_reset_and_unref(&self->read_buffer_);
+      grpc_endpoint_read(self->tcp_, &self->read_buffer_, &self->on_read_done_,
+                         false);
+    } else {
+      grpc_slice_buffer_destroy(&self->read_buffer_);
+      self->read_end_notification_.Notify();
+    }
+  }
+
+  // Waits for \a bytes to show up in read_bytes_
+  void WaitForReadBytes(absl::string_view bytes) {
+    absl::MutexLock lock(&mu_);
+    while (!absl::StrContains(read_bytes_, bytes)) {
+      read_cv_.WaitWithTimeout(&mu_, absl::Seconds(5));
+    }
+  }
+
+  // Flag to check whether the server's MAX_CONCURRENT_STREAM setting is
+  // non-zero or not.
+  bool server_allows_streams_;
+  int port_;
+  test_tcp_server server_;
+  std::unique_ptr<std::thread> server_poll_thread_;
+  grpc_endpoint* tcp_ = nullptr;
+  absl::Notification connect_notification_;
+  grpc_slice_buffer read_buffer_;
+  grpc_closure on_write_done_;
+  grpc_closure on_read_done_;
+  absl::Notification read_end_notification_;
+  std::string read_bytes_ ABSL_GUARDED_BY(mu_);
+  grpc_channel* channel_ = nullptr;
+  grpc_completion_queue* cq_ = nullptr;
+  cq_verifier* cqv_ = nullptr;
+  absl::Mutex mu_;
+  absl::CondVar read_cv_;
+  std::atomic<bool> shutdown_{false};
+};
+
+// Client's HTTP2 transport starts a new stream, sends the request on the wire,
+// but receives a GOAWAY with a stream ID of 0, meaning that the request was
+// unseen by the server.The test verifies that the HTTP2 transport adds
+// GrpcNetworkStreamState with a value of kNotSeenByServer to the trailing
+// metadata.
+TEST_F(StreamsNotSeenTest, StartStreamBeforeGoaway) {
+  grpc_call* c =
+      grpc_channel_create_call(channel_, nullptr, GRPC_PROPAGATE_DEFAULTS, cq_,
+                               grpc_slice_from_static_string("/foo"), nullptr,
+                               grpc_timeout_seconds_to_deadline(1), nullptr);
+  GPR_ASSERT(c);
+  grpc_metadata_array initial_metadata_recv;
+  grpc_metadata_array trailing_metadata_recv;
+  grpc_metadata_array_init(&initial_metadata_recv);
+  grpc_metadata_array_init(&trailing_metadata_recv);
+  grpc_op* op;
+  grpc_op ops[6];
+  grpc_status_code status;
+  const char* error_string;
+  grpc_call_error error;
+  grpc_slice details;
+  // Send the request
+  memset(ops, 0, sizeof(ops));
+  op = ops;
+  op->op = GRPC_OP_SEND_INITIAL_METADATA;
+  op->data.send_initial_metadata.count = 0;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
+                                nullptr);
+  CQ_EXPECT_COMPLETION(cqv_, Tag(101), 1);
+  cq_verify(cqv_);
+  // Send a goaway from server signalling that the request was unseen by the
+  // server.
+  SendGoaway(0);
+  memset(ops, 0, sizeof(ops));
+  op = ops;
+  op->op = GRPC_OP_RECV_INITIAL_METADATA;
+  op->data.recv_initial_metadata.recv_initial_metadata = &initial_metadata_recv;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_STATUS_ON_CLIENT;
+  op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv;
+  op->data.recv_status_on_client.status = &status;
+  op->data.recv_status_on_client.status_details = &details;
+  op->data.recv_status_on_client.error_string = &error_string;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(102),
+                                nullptr);
+  GPR_ASSERT(GRPC_CALL_OK == error);
+  CQ_EXPECT_COMPLETION(cqv_, Tag(102), 1);
+  cq_verify(cqv_);
+  // Verify status and metadata
+  EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
+  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                  .has_value());
+  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                .value(),
+            grpc_core::GrpcStreamNetworkState::kNotSeenByServer);
+  grpc_slice_unref(details);
+  gpr_free(const_cast<char*>(error_string));
+  grpc_metadata_array_destroy(&initial_metadata_recv);
+  grpc_metadata_array_destroy(&trailing_metadata_recv);
+  grpc_call_unref(c);
+  ExecCtx::Get()->Flush();
+}
+
+// Client's HTTP2 transport tries to send an RPC after having received a GOAWAY
+// frame. The test verifies that the HTTP2 transport adds GrpcNetworkStreamState
+// with a value of kNotSentOnWire to the trailing metadata.
+TEST_F(StreamsNotSeenTest, StartStreamAfterGoaway) {
+  // Send Goaway from the server
+  SendGoaway(0);
+  // Send a ping to make sure that the goaway was received.
+  SendPing();
+  // Try sending an RPC
+  grpc_call* c =
+      grpc_channel_create_call(channel_, nullptr, GRPC_PROPAGATE_DEFAULTS, cq_,
+                               grpc_slice_from_static_string("/foo"), nullptr,
+                               grpc_timeout_seconds_to_deadline(1), nullptr);
+  GPR_ASSERT(c);
+  grpc_metadata_array initial_metadata_recv;
+  grpc_metadata_array trailing_metadata_recv;
+  grpc_metadata_array_init(&initial_metadata_recv);
+  grpc_metadata_array_init(&trailing_metadata_recv);
+  grpc_op* op;
+  grpc_op ops[6];
+  grpc_status_code status;
+  const char* error_string;
+  grpc_call_error error;
+  grpc_slice details;
+  memset(ops, 0, sizeof(ops));
+  op = ops;
+  op->op = GRPC_OP_SEND_INITIAL_METADATA;
+  op->data.send_initial_metadata.count = 0;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_INITIAL_METADATA;
+  op->data.recv_initial_metadata.recv_initial_metadata = &initial_metadata_recv;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_STATUS_ON_CLIENT;
+  op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv;
+  op->data.recv_status_on_client.status = &status;
+  op->data.recv_status_on_client.status_details = &details;
+  op->data.recv_status_on_client.error_string = &error_string;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
+                                nullptr);
+  GPR_ASSERT(GRPC_CALL_OK == error);
+  CQ_EXPECT_COMPLETION(cqv_, Tag(101), 1);
+  cq_verify(cqv_);
+  // Verify status and metadata
+  EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
+  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                  .has_value());
+  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                .value(),
+            grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+  grpc_slice_unref(details);
+  gpr_free(const_cast<char*>(error_string));
+  grpc_metadata_array_destroy(&initial_metadata_recv);
+  grpc_metadata_array_destroy(&trailing_metadata_recv);
+  grpc_call_unref(c);
+  ExecCtx::Get()->Flush();
+}
+
+// These tests have the server sending a SETTINGS_FRAME with a max concurrent
+// streams settings of 0 which denies the client the chance to start a stream.
+// Note that in the future, these tests might become outdated if the
+// client_channel learns about the max concurrent streams setting.
+class ZeroConcurrencyTest : public StreamsNotSeenTest {
+ protected:
+  ZeroConcurrencyTest() : StreamsNotSeenTest(/*server_allows_streams=*/false) {}
+};
+
+// Client's HTTP2 transport receives a RPC request, but it cannot start the RPC
+// because of the max concurrent streams setting. A goaway frame is then
+// received which should result in the RPC getting cancelled with
+// kNotSentOnWire.
+TEST_F(ZeroConcurrencyTest, StartStreamBeforeGoaway) {
+  grpc_call* c =
+      grpc_channel_create_call(channel_, nullptr, GRPC_PROPAGATE_DEFAULTS, cq_,
+                               grpc_slice_from_static_string("/foo"), nullptr,
+                               grpc_timeout_seconds_to_deadline(5), nullptr);
+  GPR_ASSERT(c);
+  grpc_metadata_array initial_metadata_recv;
+  grpc_metadata_array trailing_metadata_recv;
+  grpc_metadata_array_init(&initial_metadata_recv);
+  grpc_metadata_array_init(&trailing_metadata_recv);
+  grpc_op* op;
+  grpc_op ops[6];
+  grpc_status_code status;
+  const char* error_string;
+  grpc_call_error error;
+  grpc_slice details;
+  // Send the request
+  memset(ops, 0, sizeof(ops));
+  op = ops;
+  op->op = GRPC_OP_SEND_INITIAL_METADATA;
+  op->data.send_initial_metadata.count = 0;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_INITIAL_METADATA;
+  op->data.recv_initial_metadata.recv_initial_metadata = &initial_metadata_recv;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_STATUS_ON_CLIENT;
+  op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv;
+  op->data.recv_status_on_client.status = &status;
+  op->data.recv_status_on_client.status_details = &details;
+  op->data.recv_status_on_client.error_string = &error_string;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
+                                nullptr);
+  // This test assumes that nothing would pause the RPC before its received by
+  // the transport. If that no longer holds true, we might need to drive the cq
+  // for some time to make sure that the RPC reaches the HTTP2 layer.
+  SendGoaway(0);
+  GPR_ASSERT(GRPC_CALL_OK == error);
+  CQ_EXPECT_COMPLETION(cqv_, Tag(101), 1);
+  cq_verify(cqv_);
+  // Verify status and metadata
+  EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
+  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                  .has_value());
+  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                .value(),
+            grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+  grpc_slice_unref(details);
+  gpr_free(const_cast<char*>(error_string));
+  grpc_metadata_array_destroy(&initial_metadata_recv);
+  grpc_metadata_array_destroy(&trailing_metadata_recv);
+  grpc_call_unref(c);
+  ExecCtx::Get()->Flush();
+}
+
+// Client's HTTP2 transport receives a RPC request, but it cannot start the RPC
+// because of the max concurrent streams setting. Server then shuts its endpoint
+// which should result in the RPC getting cancelled with kNotSentOnWire.
+TEST_F(ZeroConcurrencyTest, TransportDestroyed) {
+  grpc_call* c =
+      grpc_channel_create_call(channel_, nullptr, GRPC_PROPAGATE_DEFAULTS, cq_,
+                               grpc_slice_from_static_string("/foo"), nullptr,
+                               grpc_timeout_seconds_to_deadline(5), nullptr);
+  GPR_ASSERT(c);
+  grpc_metadata_array initial_metadata_recv;
+  grpc_metadata_array trailing_metadata_recv;
+  grpc_metadata_array_init(&initial_metadata_recv);
+  grpc_metadata_array_init(&trailing_metadata_recv);
+  grpc_op* op;
+  grpc_op ops[6];
+  grpc_status_code status;
+  const char* error_string;
+  grpc_call_error error;
+  grpc_slice details;
+  // Send the request
+  memset(ops, 0, sizeof(ops));
+  op = ops;
+  op->op = GRPC_OP_SEND_INITIAL_METADATA;
+  op->data.send_initial_metadata.count = 0;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_INITIAL_METADATA;
+  op->data.recv_initial_metadata.recv_initial_metadata = &initial_metadata_recv;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_STATUS_ON_CLIENT;
+  op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv;
+  op->data.recv_status_on_client.status = &status;
+  op->data.recv_status_on_client.status_details = &details;
+  op->data.recv_status_on_client.error_string = &error_string;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
+                                nullptr);
+  grpc_endpoint_shutdown(
+      tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown"));
+  GPR_ASSERT(GRPC_CALL_OK == error);
+  CQ_EXPECT_COMPLETION(cqv_, Tag(101), 1);
+  cq_verify(cqv_);
+  // Verify status and metadata
+  EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
+  ASSERT_TRUE(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                  .has_value());
+  EXPECT_EQ(grpc_core::TrailingMetadataRecordingFilter::stream_network_state()
+                .value(),
+            grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+  grpc_slice_unref(details);
+  gpr_free(const_cast<char*>(error_string));
+  grpc_metadata_array_destroy(&initial_metadata_recv);
+  grpc_metadata_array_destroy(&trailing_metadata_recv);
+  grpc_call_unref(c);
+  ExecCtx::Get()->Flush();
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc::testing::TestEnvironment env(argc, argv);
+  int result;
+  grpc_core::CoreConfiguration::RunWithSpecialConfiguration(
+      [](grpc_core::CoreConfiguration::Builder* builder) {
+        grpc_core::BuildCoreConfiguration(builder);
+        auto register_stage = [builder](grpc_channel_stack_type type,
+                                        const grpc_channel_filter* filter) {
+          builder->channel_init()->RegisterStage(
+              type, INT_MAX, [filter](grpc_channel_stack_builder* builder) {
+                // Want to add the filter as close to the end as possible, to
+                // make sure that all of the filters work well together.
+                // However, we can't add it at the very end, because the
+                // connected channel filter must be the last one.  So we add it
+                // right before the last one.
+                grpc_channel_stack_builder_iterator* it =
+                    grpc_channel_stack_builder_create_iterator_at_last(builder);
+                GPR_ASSERT(grpc_channel_stack_builder_move_prev(it));
+                const bool retval =
+                    grpc_channel_stack_builder_add_filter_before(
+                        it, filter, nullptr, nullptr);
+                grpc_channel_stack_builder_iterator_destroy(it);
+                return retval;
+              });
+        };
+        register_stage(
+            GRPC_CLIENT_SUBCHANNEL,
+            &grpc_core::TrailingMetadataRecordingFilter::kFilterVtable);
+      },
+      [&] {
+        grpc_core::
+            TestOnlyGlobalHttp2TransportDisableTransientFailureStateNotification(
+                true);
+        grpc_init();
+        {
+          grpc_core::ExecCtx exec_ctx;
+          result = RUN_ALL_TESTS();
+        }
+        grpc_shutdown();
+      });
+  return result;
+}

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -6678,6 +6678,30 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "streams_not_seen_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "string_ref_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
HTTP2: Add GrpcNetworkStreamState metadata for calls that are not sent on wire and for those that are not seen by server
