### PR TITLE
Only apply "singleplatform" nuget suffix when actually needed

### DIFF
--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -91,7 +91,7 @@ class CSharpPackage:
         del inner_jobs  # arg unused as there is little opportunity for parallelizing
         environ = {
             'GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET':
-                os.getenv('GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET')
+                os.getenv('GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET', '')
         }
         if self.unity:
             return create_docker_jobspec(


### PR DESCRIPTION
Fixup for https://github.com/grpc/grpc/pull/27180.

if GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET is not set, the value inside the docker container gets set to `GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET=None`, which triggers generating the ".singleplatform" suffix even when it's not supposed to.

https://github.com/grpc/grpc/blob/27b6b45c329b7b4173f506c616d8119520f964fd/src/csharp/build_nuget.sh#L45
