### PR TITLE
Fix bugprone-stringview-nullptr

### DIFF
--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -80,7 +80,7 @@ absl::Status TrySplitHostPort(absl::string_view name,
   }
   if (port->empty()) {
     // TODO(murgatroid99): add tests for this case
-    if (default_port == nullptr) {
+    if (default_port.empty()) {
       return absl::UnknownError(absl::StrFormat("no port in name '%s'", name));
     }
     *port = std::string(default_port);

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -121,7 +121,7 @@ NativeDNSResolver::ResolveNameBlocking(absl::string_view name,
     goto done;
   }
   if (port.empty()) {
-    if (default_port == nullptr) {
+    if (default_port.empty()) {
       err = grpc_error_set_str(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("no port in name"),
           GRPC_ERROR_STR_TARGET_ADDRESS, name);


### PR DESCRIPTION
From internal cl/423891334

LSC: Apply bugprone-stringview-nullptr across google3 to remove undefined behavior

Callsites matched by the bugprone-stringview-nullptr check are calling the single-parameter `const char*` constructor of `string_view`. This constructor uses C-string semantics, meaning it does not support the null case. Passing null results in undefined behavior.

More information: http://go/Bugprone-Stringview-Nullptr-LSC