### PR TITLE
Fix dyld errors on macos

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -11,6 +11,10 @@ build:opt --copt=-Wframe-larger-than=16384
 build:dbg --compilation_mode=dbg
 build:dbg --copt=-Werror=return-stack-address
 
+# Dynamic link cause issues like: `dyld: malformed mach-o: load commands size (59272) > 32768`
+# https://github.com/bazelbuild/bazel/issues/9190
+build:macos --dynamic_mode=off
+
 build:windows_opt --compilation_mode=opt
 build:windows_dbg --compilation_mode=dbg
 
@@ -39,10 +43,6 @@ build:fuzzer_asan --linkopt=-fsanitize=fuzzer,address
 build:fuzzer_asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 build:fuzzer_asan --action_env=LSAN_OPTIONS=suppressions=test/core/util/lsan_suppressions.txt:report_objects=1
 
-# Dynamic link cause issues like: `dyld: malformed mach-o: load commands size (59272) > 32768`
-# https://github.com/bazelbuild/bazel/issues/9190
-build:macos --dynamic_mode=off
-
 # We have a separate ASAN config for Mac OS to workaround a couple of bugs:
 # 1. https://github.com/bazelbuild/bazel/issues/6932
 #    _FORTIFY_SOURCE=1 is enabled by default on Mac OS, which breaks ASAN.
@@ -61,6 +61,7 @@ build:asan_macos --copt=-fno-omit-frame-pointer
 build:asan_macos --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:asan_macos --linkopt=-fsanitize=address
 build:asan_macos --action_env=ASAN_OPTIONS=detect_leaks=0
+build:asan_macos --dynamic_mode=off
 
 build:msan --strip=never
 build:msan --copt=-fsanitize=memory
@@ -82,6 +83,16 @@ build:tsan --linkopt=-fsanitize=thread
 # https://github.com/google/sanitizers/issues/953
 build:tsan --test_env=TSAN_OPTIONS=report_atomic_races=0
 build:tsan --action_env=TSAN_OPTIONS=suppressions=test/core/util/tsan_suppressions.txt:halt_on_error=1:second_deadlock_stack=1
+
+build:tsan_macos --strip=never
+build:tsan_macos --copt=-fsanitize=thread
+build:tsan_macos --copt=-fno-omit-frame-pointer
+build:tsan_macos --copt=-DGPR_NO_DIRECT_SYSCALLS
+build:tsan_macos --copt=-DGRPC_TSAN
+build:tsan_macos --linkopt=-fsanitize=thread
+build:tsan_macos --test_env=TSAN_OPTIONS=report_atomic_races=0
+build:tsan_macos --action_env=TSAN_OPTIONS=suppressions=test/core/util/tsan_suppressions.txt:halt_on_error=1:second_deadlock_stack=1
+build:tsan_macos --dynamic_mode=off
 
 build:ubsan --strip=never
 build:ubsan --copt=-fsanitize=undefined

--- a/tools/internal_ci/macos/grpc_cfstream.cfg
+++ b/tools/internal_ci/macos/grpc_cfstream.cfg
@@ -16,4 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh"
-
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "--config=macos"
+}


### PR DESCRIPTION
Fixed internal b/215700567 about having errors like

```
dyld: malformed mach-o: load commands size (38680) > 32768
```