### PR TITLE
Allow --qps_server_target_override to replace the original server

### DIFF
--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -483,6 +483,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     // overriding the qps server target only makes since if there is <= 1
     // servers
     GPR_ASSERT(num_servers <= 1);
+    client_config.clear_server_targets();
     client_config.add_server_targets(qps_server_target_override);
   }
   client_config.set_median_latency_collection_interval_millis(


### PR DESCRIPTION
targets.

This commit makes sure that the client's server target is only
from the --qps_server_target_override, any prior server targets
are cleared away.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
