### PR TITLE
Fixing absolute path issues for test credential files used by tls key export test

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -881,6 +881,13 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server0.key",
         "//src/core/tsi/test_creds:server0.pem",
     ],
+    args = [
+        "--ca_cert=$(location //src/core/tsi/test_creds:ca.pem)",
+        "--client_private_key=$(location //src/core/tsi/test_creds:client.key)",
+        "--server_private_key=$(location //src/core/tsi/test_creds:server0.key)",
+        "--client_cert=$(location //src/core/tsi/test_creds:client.pem)",
+        "--server_cert=$(location //src/core/tsi/test_creds:server0.pem)",
+    ],
     external_deps = [
         "gtest",
     ],

--- a/test/cpp/end2end/tls_key_export_test.cc
+++ b/test/cpp/end2end/tls_key_export_test.cc
@@ -32,8 +32,8 @@
 #include "src/core/lib/gpr/tmpfile.h"
 #include "src/cpp/client/secure_credentials.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
-#include "test/core/util/test_config.h"
 #include "test/core/util/cmdline.h"
+#include "test/core/util/test_config.h"
 #include "test/core/util/tls_utils.h"
 
 extern "C" {
@@ -45,13 +45,13 @@ extern "C" {
 #endif
 
 namespace {
-  constexpr int kNumRequestsPerChannel = 5;
-  const char* kCACertPath = nullptr;
-  const char* kServerKeyPath = nullptr;
-  const char* kServerCertPath = nullptr;
-  const char* kClientKeyPath = nullptr;
-  const char* kClientCertPath = nullptr;
-}
+constexpr int kNumRequestsPerChannel = 5;
+const char* kCACertPath = nullptr;
+const char* kServerKeyPath = nullptr;
+const char* kServerCertPath = nullptr;
+const char* kClientKeyPath = nullptr;
+const char* kClientCertPath = nullptr;
+}  // namespace
 
 using ::grpc::experimental::FileWatcherCertificateProvider;
 using ::grpc::experimental::TlsChannelCredentialsOptions;
@@ -342,8 +342,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
 
   gpr_cmdline* cl = gpr_cmdline_create("tls key export test");
-  gpr_cmdline_add_string(cl, "ca_cert", "Path to CA certificate",
-                         &kCACertPath);
+  gpr_cmdline_add_string(cl, "ca_cert", "Path to CA certificate", &kCACertPath);
   gpr_cmdline_add_string(cl, "client_private_key", "Path to Client Private key",
                          &kClientKeyPath);
   gpr_cmdline_add_string(cl, "server_private_key", "Path to Server Private key",


### PR DESCRIPTION

Due to muddled paths for test credentials, grpc/core/master/macos/grpc_bazel_cpp_ios_tests is broken. This change should fix it.

@markdroth 
