### PR TITLE
Fix google-c2p-experimental issue

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -1058,7 +1058,8 @@ class XdsClusterResolverLbFactory : public LoadBalancingPolicyFactory {
     GPR_ASSERT(uri.ok() && !uri->path().empty());
     absl::string_view server_name = absl::StripPrefix(uri->path(), "/");
     // Determine if it's an xds URI.
-    bool is_xds_uri = uri->scheme() == "xds" || uri->scheme() == "google-c2p";
+    bool is_xds_uri =
+        uri->scheme() == "xds" || uri->scheme() == "google-c2p-experimental";
     // Get XdsClient.
     RefCountedPtr<XdsClient> xds_client =
         XdsClient::GetFromChannelArgs(*args.args);


### PR DESCRIPTION
This fixes the directpath/td connection issue that gRPC 1.43.0 has. Initially https://github.com/grpc/grpc/pull/28274 was about to be backported but it ended up with conflicts. Instead, having a one-line fix would solve the problem.