### PR TITLE
[xDS GKE] use randomized local forwarding port for parallism

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -391,9 +391,11 @@ class KubernetesNamespace:
         local_port: Optional[int] = None,
         local_address: Optional[str] = None,
     ) -> PortForwarder:
-        return PortForwarder(self.api.context, self.name,
-                             f"pod/{pod.metadata.name}", remote_port,
-                             local_port, local_address)
+        pf = PortForwarder(self.api.context, self.name,
+                           f"pod/{pod.metadata.name}", remote_port, local_port,
+                           local_address)
+        pf.connect()
+        return pf
 
     @staticmethod
     def _pod_started(pod: V1Pod):

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -97,7 +97,9 @@ class PortForwarder:
         self.local_port, self.subprocess = self._establish_port_forwarding(
             local_port)
 
-    def _establish_port_forwarding(self, local_port: Optional[int] = None):
+    def _establish_port_forwarding(
+            self,
+            local_port: Optional[int] = None) -> Tuple[int, subprocess.Popen]:
         port_mapping = f"{local_port}:{self.remote_port}" if local_port else f":{self.remote_port}"
         cmd = [
             "kubectl", "--context", self.context, "--namespace", self.namespace,

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -79,9 +79,92 @@ class PortForwardingError(Exception):
     """Error forwarding port"""
 
 
+class PortForwarder:
+    PORT_FORWARD_LOCAL_ADDRESS: str = '127.0.0.1'
+
+    def __init__(self,
+                 context: str,
+                 namespace: str,
+                 destination: str,
+                 remote_port: int,
+                 local_port: Optional[int] = None,
+                 local_address: Optional[str] = None):
+        self.context = context
+        self.namespace = namespace
+        self.destination = destination
+        self.remote_port = remote_port
+        self.local_address = local_address or self.PORT_FORWARD_LOCAL_ADDRESS
+        self.local_port, self.subprocess = self._establish_port_forwarding(
+            local_port)
+
+    def _establish_port_forwarding(self, local_port: Optional[int] = None):
+        port_mapping = f"{local_port}:{self.remote_port}" if local_port else f":{self.remote_port}"
+        cmd = [
+            "kubectl", "--context", self.context, "--namespace", self.namespace,
+            "port-forward", "--address", self.local_address, self.destination,
+            port_mapping
+        ]
+        pf = subprocess.Popen(cmd,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT,
+                              universal_newlines=True)
+        # Wait for stdout line indicating successful start.
+        if local_port:
+            local_port_expected = (
+                f"Forwarding from {self.local_address}:{local_port}"
+                f" -> {self.remote_port}")
+        else:
+            local_port_re = re.compile(
+                f"Forwarding from {self.local_address}:([0-9]+) -> {self.remote_port}"
+            )
+        try:
+            while True:
+                time.sleep(0.05)
+                output = pf.stdout.readline().strip()
+                if not output:
+                    return_code = pf.poll()
+                    if return_code is not None:
+                        errors = [error for error in pf.stdout.readlines()]
+                        raise PortForwardingError(
+                            'Error forwarding port, kubectl return '
+                            f'code {return_code}, output {errors}')
+                    # If there is no output, and the subprocess is not exiting,
+                    # continue waiting for the log line.
+                    continue
+
+                # Validate output log
+                if local_port:
+                    if output != local_port_expected:
+                        raise PortForwardingError(
+                            f'Error forwarding port, unexpected output {output}'
+                        )
+                else:
+                    groups = local_port_re.search(output)
+                    if groups is None:
+                        raise PortForwardingError(
+                            f'Error forwarding port, unexpected output {output}'
+                        )
+                    local_port = int(groups[1])
+
+                logger.info(output)
+                break
+        except Exception:
+            self.port_forward_stop(pf)
+            raise
+
+        return local_port, pf
+
+    def close(self) -> None:
+        logger.info('Shutting down port forwarding, pid %s',
+                    self.subprocess.pid)
+        self.subprocess.kill()
+        stdout, _ = self.subprocess.communicate(timeout=5)
+        logger.info('Port forwarding stopped')
+        logger.debug('Port forwarding remaining stdout: %s', stdout)
+
+
 class KubernetesNamespace:
     NEG_STATUS_META = 'cloud.google.com/neg-status'
-    PORT_FORWARD_LOCAL_ADDRESS: str = '127.0.0.1'
     DELETE_GRACE_PERIOD_SEC: int = 5
     WAIT_SHORT_TIMEOUT_SEC: int = 60
     WAIT_SHORT_SLEEP_SEC: int = 1
@@ -303,72 +386,10 @@ class KubernetesNamespace:
         remote_port: int,
         local_port: Optional[int] = None,
         local_address: Optional[str] = None,
-    ) -> Tuple[int, subprocess.Popen]:
-        """Experimental"""
-        local_address = local_address or self.PORT_FORWARD_LOCAL_ADDRESS
-        port_mapping = f"{local_port}:{remote_port}" if local_port else f":{remote_port}"
-        cmd = [
-            "kubectl", "--context", self.api.context, "--namespace", self.name,
-            "port-forward", "--address", local_address,
-            f"pod/{pod.metadata.name}", port_mapping
-        ]
-        pf = subprocess.Popen(cmd,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT,
-                              universal_newlines=True)
-        # Wait for stdout line indicating successful start.
-        if local_port:
-            local_port_expected = (
-                f"Forwarding from {local_address}:{local_port}"
-                f" -> {remote_port}")
-        else:
-            local_port_re = re.compile(
-                f"Forwarding from {local_address}:([0-9]+) -> {remote_port}")
-        try:
-            while True:
-                time.sleep(0.05)
-                output = pf.stdout.readline().strip()
-                if not output:
-                    return_code = pf.poll()
-                    if return_code is not None:
-                        errors = [error for error in pf.stdout.readlines()]
-                        raise PortForwardingError(
-                            'Error forwarding port, kubectl return '
-                            f'code {return_code}, output {errors}')
-                    # If there is no output, and the subprocess is not exiting,
-                    # continue waiting for the log line.
-                    continue
-
-                # Validate output log
-                if local_port:
-                    if output != local_port_expected:
-                        raise PortForwardingError(
-                            f'Error forwarding port, unexpected output {output}'
-                        )
-                else:
-                    groups = local_port_re.search(output)
-                    if groups is None:
-                        raise PortForwardingError(
-                            f'Error forwarding port, unexpected output {output}'
-                        )
-                    local_port = int(groups[1])
-
-                logger.info(output)
-                break
-        except Exception:
-            self.port_forward_stop(pf)
-            raise
-
-        # TODO(sergiitk): return new PortForwarder object
-        return local_port, pf
-
-    @staticmethod
-    def port_forward_stop(pf):
-        logger.info('Shutting down port forwarding, pid %s', pf.pid)
-        pf.kill()
-        stdout, _stderr = pf.communicate(timeout=5)
-        logger.info('Port forwarding stopped')
-        logger.debug('Port forwarding remaining stdout: %s', stdout)
+    ) -> PortForwarder:
+        return PortForwarder(self.api.context, self.name,
+                             f"pod/{pod.metadata.name}", remote_port,
+                             local_port, local_address)
 
     @staticmethod
     def _pod_started(pod: V1Pod):

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -281,8 +281,7 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
         # Mutable state
         self.deployment: Optional[k8s.V1Deployment] = None
         self.service_account: Optional[k8s.V1ServiceAccount] = None
-        self.port_forwarder = None
-        self.local_forwarding_port: Optional[int] = None
+        self.port_forwarder: Optional[k8s.PortForwarder] = None
 
     # TODO(sergiitk): make rpc UnaryCall enum or get it from proto
     def run(self,
@@ -352,10 +351,10 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
         if self.debug_use_port_forwarding:
             logger.info('LOCAL DEV MODE: Enabling port forwarding to %s:%s',
                         pod_ip, self.stats_port)
-            self.local_forwarding_port, self.port_forwarder = self.k8s_namespace.port_forward_pod(
+            self.port_forwarder = self.k8s_namespace.port_forward_pod(
                 pod, remote_port=self.stats_port)
-            rpc_port = self.local_forwarding_port
-            rpc_host = self.k8s_namespace.PORT_FORWARD_LOCAL_ADDRESS
+            rpc_port = self.port_forwarder.local_port
+            rpc_host = self.port_forwarder.local_address
 
         return XdsTestClient(ip=pod_ip,
                              rpc_port=rpc_port,
@@ -364,7 +363,7 @@ class KubernetesClientRunner(base_runner.KubernetesBaseRunner):
 
     def cleanup(self, *, force=False, force_namespace=False):
         if self.port_forwarder:
-            self.k8s_namespace.port_forward_stop(self.port_forwarder)
+            self.port_forwarder.close()
             self.port_forwarder = None
         if self.deployment or force:
             self._delete_deployment(self.deployment_name)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -322,7 +322,6 @@ class KubernetesServerRunner(base_runner.KubernetesBaseRunner):
 
             pod_ip = pod.status.pod_ip
             rpc_host = None
-            rpc_port = test_port
             # Experimental, for local debugging.
             local_port = maintenance_port
             if self.debug_use_port_forwarding:

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -43,9 +43,6 @@ UrlMapType = Any
 HostRule = Any
 PathMatcher = Any
 
-_BackendHTTP2 = gcp.compute.ComputeV1.BackendServiceProtocol.HTTP2
-_COMPUTE_V1_URL_PREFIX = 'https://www.googleapis.com/compute/v1'
-
 
 class _UrlMapChangeAggregator:
     """Where all the urlMap change happens."""


### PR DESCRIPTION
While implementing parallel run with Bazel in https://github.com/grpc/grpc/pull/27170, I found we have one mutual exclusive resource -- the local forwarding port. This technically won't impact CI, since they use direct connection, but it's always nice to be able to develop locally.

Tested with the CSDS test case. See test run log: https://gist.github.com/lidizheng/d839200a7d8781cb0c4420f8d922006a