### PR TITLE
Patch GRPCCallOptions for missing property copy

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCallOptions.h
+++ b/src/objective-c/GRPCClient/GRPCCallOptions.h
@@ -120,6 +120,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(readonly) BOOL retryEnabled;
 
+/**
+ * Maximum interval in seconds between two consecutive retries.
+ * Internal-only property used for GTMSessionFetcher transport retry policy.
+ */
+@property(readonly) NSTimeInterval maxRetryInterval;
+
+/**
+ * Minimum interval in seconds between two consecutive retries.
+ * Internal-only property used for GTMSessionFetcher transport retry policy.
+ */
+@property(readonly) NSTimeInterval minRetryInterval;
+
+/**
+ * Multiplier used to increase the interval between retries.
+ * Internal-only property used for GTMSessionFetcher transport retry policy.
+ */
+@property(readonly) double retryFactor;
+
 // HTTP/2 keep-alive feature. The parameter \a keepaliveInterval specifies the interval between two
 // PING frames. The parameter \a keepaliveTimeout specifies the length of the period for which the
 // call should wait for PING ACK. If PING ACK is not received after this period, the call fails.
@@ -204,12 +222,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Hash for channel options.
  */
 @property(readonly) NSUInteger channelOptionsHash;
-
-// Parameters for GTMSessionFetcher transport retry policy. This is only for internal users.
-@property(atomic, assign) NSTimeInterval maxRetryInterval;
-@property(atomic, assign) NSTimeInterval minRetryInterval;
-@property(atomic, assign) NSUInteger retryCount;
-@property(atomic, assign) double retryFactor;
 
 @end
 
@@ -313,6 +325,24 @@ NS_ASSUME_NONNULL_BEGIN
  * https://github.com/grpc/proposal/blob/master/A6-client-retries.md
  */
 @property(readwrite) BOOL retryEnabled;
+
+/**
+ * Maximum interval in seconds between two consecutive retries. Pass 0 to use default.
+ * Internal-only property used for GTMSessionFetcher transport retry policy.
+ */
+@property(readwrite) NSTimeInterval maxRetryInterval;
+
+/**
+ * Minimum interval in seconds between two consecutive retries. Pass 0 to use default.
+ * Internal-only property used for GTMSessionFetcher transport retry policy.
+ */
+@property(readwrite) NSTimeInterval minRetryInterval;
+
+/**
+ * Multiplier used to increase the interval between retries. Pass 0 to use default.
+ * Internal-only property used for GTMSessionFetcher transport retry policy.
+ */
+@property(readwrite) double retryFactor;
 
 // HTTP/2 keep-alive feature. The parameter \a keepaliveInterval specifies the interval between two
 // PING frames. The parameter \a keepaliveTimeout specifies the length of the period for which the

--- a/src/objective-c/GRPCClient/GRPCCallOptions.m
+++ b/src/objective-c/GRPCClient/GRPCCallOptions.m
@@ -31,6 +31,11 @@ static NSString *const kDefaultUserAgentSuffix = nil;
 static const NSUInteger kDefaultResponseSizeLimit = 0;
 static const GRPCCompressionAlgorithm kDefaultCompressionAlgorithm = GRPCCompressNone;
 static const BOOL kDefaultRetryEnabled = YES;
+static const NSTimeInterval kDefaultMaxRetryInterval =
+    0;  // Use transport's default max retry interval
+static const NSTimeInterval kDefaultMinRetryInterval =
+    0;                                        // Use transport's default min retry interval
+static const double kDefaultRetryFactor = 0;  // Use transport's default retry factor
 static const NSTimeInterval kDefaultKeepaliveInterval = 0;
 static const NSTimeInterval kDefaultKeepaliveTimeout = 0;
 static const NSTimeInterval kDefaultConnectMinTimeout = 0;
@@ -74,6 +79,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
   NSUInteger _responseSizeLimit;
   GRPCCompressionAlgorithm _compressionAlgorithm;
   BOOL _retryEnabled;
+  NSTimeInterval _maxRetryInterval;
+  NSTimeInterval _minRetryInterval;
+  double _retryFactor;
   NSTimeInterval _keepaliveInterval;
   NSTimeInterval _keepaliveTimeout;
   NSTimeInterval _connectMinTimeout;
@@ -103,6 +111,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
 @synthesize responseSizeLimit = _responseSizeLimit;
 @synthesize compressionAlgorithm = _compressionAlgorithm;
 @synthesize retryEnabled = _retryEnabled;
+@synthesize maxRetryInterval = _maxRetryInterval;
+@synthesize minRetryInterval = _minRetryInterval;
+@synthesize retryFactor = _retryFactor;
 @synthesize keepaliveInterval = _keepaliveInterval;
 @synthesize keepaliveTimeout = _keepaliveTimeout;
 @synthesize connectMinTimeout = _connectMinTimeout;
@@ -132,6 +143,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
                      responseSizeLimit:kDefaultResponseSizeLimit
                   compressionAlgorithm:kDefaultCompressionAlgorithm
                           retryEnabled:kDefaultRetryEnabled
+                      maxRetryInterval:kDefaultMaxRetryInterval
+                      minRetryInterval:kDefaultMinRetryInterval
+                           retryFactor:kDefaultRetryFactor
                      keepaliveInterval:kDefaultKeepaliveInterval
                       keepaliveTimeout:kDefaultKeepaliveTimeout
                      connectMinTimeout:kDefaultConnectMinTimeout
@@ -161,6 +175,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
                       responseSizeLimit:(NSUInteger)responseSizeLimit
                    compressionAlgorithm:(GRPCCompressionAlgorithm)compressionAlgorithm
                            retryEnabled:(BOOL)retryEnabled
+                       maxRetryInterval:(NSTimeInterval)maxRetryInterval
+                       minRetryInterval:(NSTimeInterval)minRetryInterval
+                            retryFactor:(double)retryFactor
                       keepaliveInterval:(NSTimeInterval)keepaliveInterval
                        keepaliveTimeout:(NSTimeInterval)keepaliveTimeout
                       connectMinTimeout:(NSTimeInterval)connectMinTimeout
@@ -192,6 +209,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
     _responseSizeLimit = responseSizeLimit;
     _compressionAlgorithm = compressionAlgorithm;
     _retryEnabled = retryEnabled;
+    _maxRetryInterval = maxRetryInterval;
+    _minRetryInterval = minRetryInterval;
+    _retryFactor = retryFactor;
     _keepaliveInterval = keepaliveInterval < 0 ? 0 : keepaliveInterval;
     _keepaliveTimeout = keepaliveTimeout < 0 ? 0 : keepaliveTimeout;
     _connectMinTimeout = connectMinTimeout < 0 ? 0 : connectMinTimeout;
@@ -228,6 +248,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
                                                   responseSizeLimit:_responseSizeLimit
                                                compressionAlgorithm:_compressionAlgorithm
                                                        retryEnabled:_retryEnabled
+                                                   maxRetryInterval:_maxRetryInterval
+                                                   minRetryInterval:_minRetryInterval
+                                                        retryFactor:_retryFactor
                                                   keepaliveInterval:_keepaliveInterval
                                                    keepaliveTimeout:_keepaliveTimeout
                                                   connectMinTimeout:_connectMinTimeout
@@ -261,6 +284,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
             responseSizeLimit:_responseSizeLimit
          compressionAlgorithm:_compressionAlgorithm
                  retryEnabled:_retryEnabled
+             maxRetryInterval:_maxRetryInterval
+             minRetryInterval:_minRetryInterval
+                  retryFactor:_retryFactor
             keepaliveInterval:_keepaliveInterval
              keepaliveTimeout:_keepaliveTimeout
             connectMinTimeout:_connectMinTimeout
@@ -287,6 +313,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
   if (!(callOptions.responseSizeLimit == _responseSizeLimit)) return NO;
   if (!(callOptions.compressionAlgorithm == _compressionAlgorithm)) return NO;
   if (!(callOptions.retryEnabled == _retryEnabled)) return NO;
+  if (!(callOptions.maxRetryInterval == _maxRetryInterval)) return NO;
+  if (!(callOptions.minRetryInterval == _minRetryInterval)) return NO;
+  if (!(callOptions.retryFactor == _retryFactor)) return NO;
   if (!(callOptions.keepaliveInterval == _keepaliveInterval)) return NO;
   if (!(callOptions.keepaliveTimeout == _keepaliveTimeout)) return NO;
   if (!(callOptions.connectMinTimeout == _connectMinTimeout)) return NO;
@@ -348,6 +377,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
 @dynamic responseSizeLimit;
 @dynamic compressionAlgorithm;
 @dynamic retryEnabled;
+@dynamic maxRetryInterval;
+@dynamic minRetryInterval;
+@dynamic retryFactor;
 @dynamic keepaliveInterval;
 @dynamic keepaliveTimeout;
 @dynamic connectMinTimeout;
@@ -377,6 +409,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
                      responseSizeLimit:kDefaultResponseSizeLimit
                   compressionAlgorithm:kDefaultCompressionAlgorithm
                           retryEnabled:kDefaultRetryEnabled
+                      maxRetryInterval:kDefaultMaxRetryInterval
+                      minRetryInterval:kDefaultMinRetryInterval
+                           retryFactor:kDefaultRetryFactor
                      keepaliveInterval:kDefaultKeepaliveInterval
                       keepaliveTimeout:kDefaultKeepaliveTimeout
                      connectMinTimeout:kDefaultConnectMinTimeout
@@ -408,6 +443,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
                                                   responseSizeLimit:_responseSizeLimit
                                                compressionAlgorithm:_compressionAlgorithm
                                                        retryEnabled:_retryEnabled
+                                                   maxRetryInterval:_maxRetryInterval
+                                                   minRetryInterval:_minRetryInterval
+                                                        retryFactor:_retryFactor
                                                   keepaliveInterval:_keepaliveInterval
                                                    keepaliveTimeout:_keepaliveTimeout
                                                   connectMinTimeout:_connectMinTimeout
@@ -440,6 +478,9 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
             responseSizeLimit:_responseSizeLimit
          compressionAlgorithm:_compressionAlgorithm
                  retryEnabled:_retryEnabled
+             maxRetryInterval:_maxRetryInterval
+             minRetryInterval:_minRetryInterval
+                  retryFactor:_retryFactor
             keepaliveInterval:_keepaliveInterval
              keepaliveTimeout:_keepaliveTimeout
             connectMinTimeout:_connectMinTimeout
@@ -508,6 +549,18 @@ static BOOL areObjectsEqual(id obj1, id obj2) {
 
 - (void)setRetryEnabled:(BOOL)retryEnabled {
   _retryEnabled = retryEnabled;
+}
+
+- (void)setMaxRetryInterval:(NSTimeInterval)maxRetryInterval {
+  _maxRetryInterval = maxRetryInterval;
+}
+
+- (void)setMinRetryInterval:(NSTimeInterval)minRetryInterval {
+  _minRetryInterval = minRetryInterval;
+}
+
+- (void)setRetryFactor:(double)retryFactor {
+  _retryFactor = retryFactor;
 }
 
 - (void)setKeepaliveInterval:(NSTimeInterval)keepaliveInterval {

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -145,6 +145,11 @@ grpc_objc_testing_library(
 )
 
 grpc_objc_testing_library(
+    name = "GRPCBasicUnitTests-lib",
+    srcs = ["UnitTests/GRPCCallOptionsTests.m"],
+)
+
+grpc_objc_testing_library(
     name = "APIv2Tests-lib",
     srcs = ["UnitTests/APIv2Tests.m"],
 )
@@ -180,6 +185,7 @@ ios_unit_test(
         ":APIv2Tests-lib",
         ":ChannelPoolTest-lib",
         ":ChannelTests-lib",
+        ":GRPCBasicUnitTests-lib",
         ":GRPCClientTests-lib",
         ":NSErrorUnitTests-lib",
         ":RxLibraryUnitTests-lib",

--- a/src/objective-c/tests/Tests.xcodeproj/project.pbxproj
+++ b/src/objective-c/tests/Tests.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		5EA4770522736AC4000F72FC /* TestCertificates.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 63E240CF1B6C63DC005F3B0E /* TestCertificates.bundle */; };
 		5ECFED8623030DCC00626501 /* TestCertificates.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 63E240CF1B6C63DC005F3B0E /* TestCertificates.bundle */; };
 		65EB19E418B39A8374D407BB /* libPods-CronetTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B1511C20E16A8422B58D61A /* libPods-CronetTests.a */; };
+		74E1354127A0D22B009FC4F3 /* GRPCCallOptionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 74E1354027A0D22A009FC4F3 /* GRPCCallOptionsTests.m */; };
 		903163C7FE885838580AEC7A /* libPods-InteropTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D457AD9797664CFA191C3280 /* libPods-InteropTests.a */; };
 		953CD2942A3A6D6CE695BE87 /* libPods-MacTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 276873A05AC5479B60DF6079 /* libPods-MacTests.a */; };
 		9BF9672E0D0BF5B42D4F2B72 /* libPods-PerfTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D6F190224A515F9A4D09E4CF /* libPods-PerfTests.a */; };
@@ -158,6 +159,7 @@
 		6793C9D019CB268C5BB491A2 /* Pods-CoreCronetEnd2EndTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreCronetEnd2EndTests.test.xcconfig"; path = "Pods/Target Support Files/Pods-CoreCronetEnd2EndTests/Pods-CoreCronetEnd2EndTests.test.xcconfig"; sourceTree = "<group>"; };
 		680439AC2BC8761EDD54A1EA /* Pods-InteropTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteropTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-InteropTests/Pods-InteropTests.debug.xcconfig"; sourceTree = "<group>"; };
 		73D2DF07027835BA0FB0B1C0 /* Pods-InteropTestsCallOptions.cronet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteropTestsCallOptions.cronet.xcconfig"; path = "Pods/Target Support Files/Pods-InteropTestsCallOptions/Pods-InteropTestsCallOptions.cronet.xcconfig"; sourceTree = "<group>"; };
+		74E1354027A0D22A009FC4F3 /* GRPCCallOptionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GRPCCallOptionsTests.m; sourceTree = "<group>"; };
 		781089FAE980F51F88A3BE0B /* Pods-RxLibraryUnitTests.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxLibraryUnitTests.test.xcconfig"; path = "Pods/Target Support Files/Pods-RxLibraryUnitTests/Pods-RxLibraryUnitTests.test.xcconfig"; sourceTree = "<group>"; };
 		79C68EFFCB5533475D810B79 /* Pods-RxLibraryUnitTests.cronet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxLibraryUnitTests.cronet.xcconfig"; path = "Pods/Target Support Files/Pods-RxLibraryUnitTests/Pods-RxLibraryUnitTests.cronet.xcconfig"; sourceTree = "<group>"; };
 		7A2E97E3F469CC2A758D77DE /* Pods-InteropTestsLocalSSL.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InteropTestsLocalSSL.release.xcconfig"; path = "Pods/Target Support Files/Pods-InteropTestsLocalSSL/Pods-InteropTestsLocalSSL.release.xcconfig"; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 		5E0282E7215AA697007AC99D /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				74E1354027A0D22A009FC4F3 /* GRPCCallOptionsTests.m */,
 				5E9F1C58232302E200837469 /* TransportTests.m */,
 				5E9F1C322321AB1700837469 /* TransportRegistryTests.m */,
 				5E7F488A22778B5D006656AD /* RxLibraryUnitTests.m */,
@@ -1035,6 +1038,7 @@
 				5E0282E9215AA697007AC99D /* NSErrorUnitTests.m in Sources */,
 				5E7F4880227782C1006656AD /* APIv2Tests.m in Sources */,
 				5E7F487D22778256006656AD /* ChannelPoolTest.m in Sources */,
+				74E1354127A0D22B009FC4F3 /* GRPCCallOptionsTests.m in Sources */,
 				5E9F1C59232302E200837469 /* TransportTests.m in Sources */,
 				5E9F1C332321AB1700837469 /* TransportRegistryTests.m in Sources */,
 				5E7F488722778AEA006656AD /* GRPCClientTests.m in Sources */,

--- a/src/objective-c/tests/UnitTests/GRPCCallOptionsTests.m
+++ b/src/objective-c/tests/UnitTests/GRPCCallOptionsTests.m
@@ -1,0 +1,161 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <GRPCClient/GRPCCallOptions.h>
+
+static NSString *const kGRPCCallOptionsTestServerAuthority = @"dummy";
+static NSTimeInterval kGRPCCallOptionsTestTimeout = 11;
+static BOOL kGRPCCallOptionsTestFlowControl = YES;
+static NSString *const kGRPCCallOptionsTestOAuth2Token = @"token";
+static NSString *const kGRPCCallOptionsTestUserAgentPrefix = @"test_prefix";
+static NSString *const kGRPCCallOptionsTestUserAgentSuffix = @"test_suffix";
+static NSUInteger kGRPCCallOptionsTestResponseSizeLimit = 81;
+static GRPCCompressionAlgorithm kGRPCCallOptionsTestCompressionAlgorithm = GRPCCompressDeflate;
+static BOOL kGRPCCallOptionsTestRetryEnabled = YES;
+static NSTimeInterval kGRPCCallOptionsTestMaxRetryInterval = 101;
+static NSTimeInterval kGRPCCallOptionsTestMinRetryInterval = 23;
+static double kGRPCCallOptionsTestRetryFactor = 2.12;
+static NSTimeInterval kGRPCCallOptionsTestKeepAliveTimeout = 120;
+static NSTimeInterval kGRPCCallOptionsTestKeepAliveInterval = 60;
+static NSTimeInterval kGRPCCallOptionsTestConnectMaxBackoff = 180;
+static NSTimeInterval kGRPCCallOptionsTestConnectMinTimeout = 210;
+static NSTimeInterval kGRPCCallOptionsTestConnectInitialBackoff = 12;
+static NSString *const kGRPCCallOptionsTestPEMPrivateKey = @"dummy_key";
+static NSString *const kGRPCCallOptionsTestPEMRootCertificates = @"dummy_cert";
+static NSString *const kGRPCCallOptionsTestPEMCertificateChain = @"dummy_chain";
+static GRPCTransportType kGRPCCallOptionsTestTransportType = GRPCTransportTypeChttp2BoringSSL;
+static GRPCTransportID kGRPCCallOptionsTestTransportID = "dummy_transport";
+static NSString *const kGRPCCallOptionsTestHostNameOverride = @"localhost";
+static NSString *const kGRPCCallOptionsTestChannelPoolDomain = @"dummy_domain";
+static NSUInteger kGRPCCallOptionsTestChannelID = 111;
+
+@interface GRPCCallOptionsTests : XCTestCase
+
+@end
+
+@implementation GRPCCallOptionsTests
+
+/** Verify a valid immutable copy can be created from GRPCCallOptions. */
+- (void)testCreateImmutableCopyFromImmutable {
+  GRPCCallOptions *opt = [[GRPCCallOptions alloc] init];
+  GRPCCallOptions *subject = [opt copy];
+  XCTAssertTrue([subject isKindOfClass:[GRPCCallOptions class]]);
+}
+
+/** Verify a valid mutable copy can be created from GRPCCallOptions. */
+- (void)testCreateMutableCopyFromImmutable {
+  GRPCCallOptions *opt = [[GRPCCallOptions alloc] init];
+  GRPCMutableCallOptions *subject = [opt mutableCopy];
+  XCTAssertTrue([subject isKindOfClass:[GRPCMutableCallOptions class]]);
+}
+
+/** Verify a valid mutable copy can be created from GRPCMutableCallOptions. */
+- (void)testCreateMutableCopyFromMutable {
+  GRPCMutableCallOptions *opt = [[GRPCMutableCallOptions alloc] init];
+  GRPCMutableCallOptions *subject = [opt mutableCopy];
+  XCTAssertTrue([subject isKindOfClass:[GRPCMutableCallOptions class]]);
+}
+
+/** Verify a valid immutable copy can be created from GRPCMutableCallOptions. */
+- (void)testCreateImmutableCopyFromMutable {
+  GRPCMutableCallOptions *mutableOpt = [[GRPCMutableCallOptions alloc] init];
+  GRPCCallOptions *subject = [mutableOpt copy];
+  XCTAssertTrue([subject isKindOfClass:[GRPCCallOptions class]]);
+}
+
+/** Verify property values are copied when copy from mutable options. */
+- (void)testCopyFromMutableCallOptions {
+  GRPCMutableCallOptions *mutableOpt = [self testMutableCallOptions];
+  XCTAssertTrue([self isEqualToTestCallOptions:[mutableOpt copy]]);
+  XCTAssertTrue([self isEqualToTestCallOptions:[mutableOpt mutableCopy]]);
+}
+
+/** Verify property values are copied when copy from immutable options */
+- (void)testCopyFromImmutableCallOptions {
+  GRPCCallOptions *opt = [[self testMutableCallOptions] copy];
+  XCTAssertTrue([self isEqualToTestCallOptions:[opt copy]]);
+  XCTAssertTrue([self isEqualToTestCallOptions:[opt mutableCopy]]);
+}
+
+#pragma mark - Private
+
+- (GRPCMutableCallOptions *)testMutableCallOptions {
+  GRPCMutableCallOptions *mutableOpt = [[GRPCMutableCallOptions alloc] init];
+  mutableOpt.serverAuthority = kGRPCCallOptionsTestServerAuthority;
+  mutableOpt.timeout = kGRPCCallOptionsTestTimeout;
+  mutableOpt.flowControlEnabled = kGRPCCallOptionsTestFlowControl;
+  mutableOpt.oauth2AccessToken = kGRPCCallOptionsTestOAuth2Token;
+  mutableOpt.initialMetadata = @{@"key" : @"value"};
+  mutableOpt.userAgentPrefix = kGRPCCallOptionsTestUserAgentPrefix;
+  mutableOpt.userAgentSuffix = kGRPCCallOptionsTestUserAgentSuffix;
+  mutableOpt.responseSizeLimit = kGRPCCallOptionsTestResponseSizeLimit;
+  mutableOpt.compressionAlgorithm = kGRPCCallOptionsTestCompressionAlgorithm;
+  mutableOpt.retryEnabled = kGRPCCallOptionsTestRetryEnabled;
+  mutableOpt.maxRetryInterval = kGRPCCallOptionsTestMaxRetryInterval;
+  mutableOpt.minRetryInterval = kGRPCCallOptionsTestMinRetryInterval;
+  mutableOpt.retryFactor = kGRPCCallOptionsTestRetryFactor;
+  mutableOpt.keepaliveTimeout = kGRPCCallOptionsTestKeepAliveTimeout;
+  mutableOpt.keepaliveInterval = kGRPCCallOptionsTestKeepAliveInterval;
+  mutableOpt.connectMaxBackoff = kGRPCCallOptionsTestConnectMaxBackoff;
+  mutableOpt.connectMinTimeout = kGRPCCallOptionsTestConnectMinTimeout;
+  mutableOpt.connectInitialBackoff = kGRPCCallOptionsTestConnectInitialBackoff;
+  mutableOpt.additionalChannelArgs = @{@"extra_key" : @"extra_value"};
+  mutableOpt.PEMPrivateKey = kGRPCCallOptionsTestPEMPrivateKey;
+  mutableOpt.PEMRootCertificates = kGRPCCallOptionsTestPEMRootCertificates;
+  mutableOpt.PEMCertificateChain = kGRPCCallOptionsTestPEMCertificateChain;
+  mutableOpt.transportType = kGRPCCallOptionsTestTransportType;
+  mutableOpt.transport = kGRPCCallOptionsTestTransportID;
+  mutableOpt.hostNameOverride = kGRPCCallOptionsTestHostNameOverride;
+  mutableOpt.channelPoolDomain = kGRPCCallOptionsTestChannelPoolDomain;
+  mutableOpt.channelID = kGRPCCallOptionsTestChannelID;
+  return mutableOpt;
+}
+
+- (BOOL)isEqualToTestCallOptions:(GRPCCallOptions *)callOpt {
+  return [callOpt.serverAuthority isEqualToString:kGRPCCallOptionsTestServerAuthority] &&
+         callOpt.timeout == kGRPCCallOptionsTestTimeout &&
+         callOpt.flowControlEnabled == kGRPCCallOptionsTestFlowControl &&
+         [callOpt.oauth2AccessToken isEqualToString:kGRPCCallOptionsTestOAuth2Token] &&
+         [callOpt.initialMetadata isEqualToDictionary:@{@"key" : @"value"}] &&
+         [callOpt.userAgentPrefix isEqualToString:kGRPCCallOptionsTestUserAgentPrefix] &&
+         [callOpt.userAgentSuffix isEqualToString:kGRPCCallOptionsTestUserAgentSuffix] &&
+         callOpt.responseSizeLimit == kGRPCCallOptionsTestResponseSizeLimit &&
+         callOpt.compressionAlgorithm == kGRPCCallOptionsTestCompressionAlgorithm &&
+         callOpt.retryEnabled == kGRPCCallOptionsTestRetryEnabled &&
+         callOpt.maxRetryInterval == kGRPCCallOptionsTestMaxRetryInterval &&
+         callOpt.minRetryInterval == kGRPCCallOptionsTestMinRetryInterval &&
+         callOpt.retryFactor == kGRPCCallOptionsTestRetryFactor &&
+         callOpt.keepaliveTimeout == kGRPCCallOptionsTestKeepAliveTimeout &&
+         callOpt.keepaliveInterval == kGRPCCallOptionsTestKeepAliveInterval &&
+         callOpt.connectMaxBackoff == kGRPCCallOptionsTestConnectMaxBackoff &&
+         callOpt.connectMinTimeout == kGRPCCallOptionsTestConnectMinTimeout &&
+         callOpt.connectInitialBackoff == kGRPCCallOptionsTestConnectInitialBackoff &&
+         [callOpt.additionalChannelArgs isEqualToDictionary:@{@"extra_key" : @"extra_value"}] &&
+         [callOpt.PEMPrivateKey isEqualToString:kGRPCCallOptionsTestPEMPrivateKey] &&
+         [callOpt.PEMCertificateChain isEqualToString:kGRPCCallOptionsTestPEMCertificateChain] &&
+         [callOpt.PEMRootCertificates isEqualToString:kGRPCCallOptionsTestPEMRootCertificates] &&
+         callOpt.transportType == kGRPCCallOptionsTestTransportType &&
+         callOpt.transport == kGRPCCallOptionsTestTransportID &&
+         [callOpt.hostNameOverride isEqualToString:kGRPCCallOptionsTestHostNameOverride] &&
+         [callOpt.channelPoolDomain isEqualToString:kGRPCCallOptionsTestChannelPoolDomain] &&
+         callOpt.channelID == kGRPCCallOptionsTestChannelID;
+}
+
+@end


### PR DESCRIPTION
**Change Summary** 
* Added missing copy logic for maxRetryInterval, minRetryInterval, retryFactor for both immutable & mutable clone
* Removed retryCount which is not a valid retry parameters and not currently in use
* Marked retry prop as readonly for GRPCCallOptions and move mutability to GRPCMutableCallOptions instead

**Test & Verification**
* Added GRPCCallOptionsTests test suite to ensure copy operation correctness

**API Change Notes** 
* The above retry parameters were marked google internal only, not affecting OSS clients 
* For g3, will run internal checks to ensure no API breakage. 



Closing https://github.com/grpc/grpc-ios/issues/49