### PR TITLE
Upgrade PHP docker images to debian11

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
@@ -14,10 +14,12 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:stretch
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../php7_deps.include"/>
-  <%include file="../../run_tests_addons.include"/>
   <%include file="../../php_common_deps.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
+  <%include file="../../run_tests_addons.include"/>

--- a/templates/tools/dockerfile/test/php73_zts_debian11_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php73_zts_debian11_x64/Dockerfile.template
@@ -14,12 +14,33 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:stretch
+  # debian 11 = "bullseye"
+  FROM php:7.3-zts-bullseye
   
-  <%include file="../../apt_get_basic.include"/>
+  RUN apt-get update && apt-get install -y ${'\\'}
+    autoconf automake build-essential git libtool curl ${'\\'}
+    zlib1g-dev ${'\\'}
+    && apt-get clean
+
+  # install php pthreads from source
+  # TODO(jtattermusch): is this really needed?
+  # See https://github.com/grpc/grpc/pull/23056
+  WORKDIR /tmp
+  RUN git clone https://github.com/krakjoe/pthreads
+  RUN cd pthreads && ${'\\'}
+    phpize && ${'\\'}
+    ./configure && ${'\\'}
+    make && ${'\\'}
+    make install
+
   <%include file="../../run_tests_python_deps.include"/>
-  <%include file="../../php7_deps.include"/>
-  <%include file="../../php_valgrind.include"/>
+  <%include file="../../php_common_deps.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
+
+  # Seems required by XDS interop tests.
+  RUN python3 -m pip install virtualenv==16.7.9
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/php7_debian11_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php7_debian11_x64/Dockerfile.template
@@ -14,29 +14,14 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM php:7.3-zts-stretch
+  FROM debian:11
   
-  RUN apt-get update && apt-get install -y ${'\\'}
-    autoconf automake build-essential git libtool curl ${'\\'}
-    zlib1g-dev ${'\\'}
-    && apt-get clean
-
-  # install php pthreads from source
-  # TODO(jtattermusch): is this really needed?
-  # See https://github.com/grpc/grpc/pull/23056
-  WORKDIR /tmp
-  RUN git clone https://github.com/krakjoe/pthreads
-  RUN cd pthreads && ${'\\'}
-    phpize && ${'\\'}
-    ./configure && ${'\\'}
-    make && ${'\\'}
-    make install
-
+  <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
-  <%include file="../../php_common_deps.include"/>
+  <%include file="../../php7_deps.include"/>
+  <%include file="../../php_valgrind.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
-
-  RUN python3 -m pip install virtualenv==16.7.9
-
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -107,10 +107,30 @@ RUN cd /var/local/git/php-src \
   && make -j$(nproc) \
   && make install
 
-
-RUN mkdir /var/local/jenkins
-
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
+
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
+
+RUN mkdir /var/local/jenkins
 

--- a/tools/dockerfile/test/php73_zts_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/php73_zts_debian11_x64/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:7.3-zts-stretch
+# debian 11 = "bullseye"
+FROM php:7.3-zts-bullseye
 
 RUN apt-get update && apt-get install -y \
   autoconf automake build-essential git libtool curl \
@@ -59,10 +60,31 @@ RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-clien
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
 
 
+# Seems required by XDS interop tests.
 RUN python3 -m pip install virtualenv==16.7.9
 
 # Define the default command.

--- a/tools/dockerfile/test/php7_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_debian11_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -112,6 +112,26 @@ RUN cd /var/local/git/php-src \
 
  RUN apt-get update && apt-get install -y \
     valgrind
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
+
 
 RUN mkdir /var/local/jenkins
 

--- a/tools/internal_ci/linux/grpc_xds_php.sh
+++ b/tools/internal_ci/linux/grpc_xds_php.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/php73_zts_stretch_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/php73_zts_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_xds_v3_php.sh
+++ b/tools/internal_ci/linux/grpc_xds_v3_php.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/php73_zts_stretch_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/php73_zts_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_v3_php_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -315,7 +315,7 @@ class PHPArtifact:
         if self.platform == 'linux':
             return create_docker_jobspec(
                 self.name,
-                'tools/dockerfile/test/php73_zts_stretch_{}'.format(self.arch),
+                'tools/dockerfile/test/php73_zts_debian11_{}'.format(self.arch),
                 'tools/run_tests/artifacts/build_artifact_php.sh')
         else:
             return create_jobspec(

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -588,7 +588,7 @@ class Php7Language(object):
         return 'Makefile'
 
     def dockerfile_dir(self):
-        return 'tools/dockerfile/test/php7_stretch_%s' % _docker_arch_suffix(
+        return 'tools/dockerfile/test/php7_debian11_%s' % _docker_arch_suffix(
             self.args.arch)
 
     def __str__(self):


### PR DESCRIPTION
- debian11 is the current stable
- similar upgrade has happened for other languages
- install ccache into the docker images to allow speeding up the build (but don't activate ccache for builds yet).
