### PR TITLE
Add back pip virtualenv back to ruby image for XDS tests

### DIFF
--- a/templates/tools/dockerfile/test/ruby_debian11_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/ruby_debian11_x64/Dockerfile.template
@@ -23,5 +23,8 @@
   <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
 
+  # Seems required by XDS interop tests.
+  RUN python3 -m pip install virtualenv==16.7.9
+
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/ruby_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_debian11_x64/Dockerfile
@@ -121,5 +121,8 @@ RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/downloa
 RUN mkdir /var/local/jenkins
 
 
+# Seems required by XDS interop tests.
+RUN python3 -m pip install virtualenv==16.7.9
+
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Removed here:
https://github.com/grpc/grpc/pull/28665/files#diff-fcb175551b36e6ec998eaf6a45849783f7784d7dbf20dafcea8967f039d49310L25

But might still be needed (same mistake was made here before: https://github.com/grpc/grpc/pull/28263/files#diff-1eea8c6189b253471cee6f183e91f9781995d6402154d6501451c1ac4550dfbeR25).