### PR TITLE
Removed warning options for PHP build

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -18,7 +18,7 @@ if test "$PHP_GRPC" != "no"; then
 
   LIBS="-lpthread $LIBS"
 
-  CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11 -g -O2"
+  CFLAGS="-std=c11 -g -O2"
   CXXFLAGS="-std=c++11 -fno-exceptions -fno-rtti -g -O2"
   GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
   PHP_REQUIRE_CXX()

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -20,7 +20,7 @@
 
     LIBS="-lpthread $LIBS"
 
-    CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11 -g -O2"
+    CFLAGS="-std=c11 -g -O2"
     CXXFLAGS="-std=c++11 -fno-exceptions -fno-rtti -g -O2"
     GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
     PHP_REQUIRE_CXX()


### PR DESCRIPTION
The recent attempt to upgrade upb to the latest (https://github.com/grpc/grpc/pull/28685) ran into a couple of errors and one of them came from `grpc_distribtests_php` ([log](https://source.cloud.google.com/results/invocations/f3422200-9b5b-4566-88e0-8ec024e264f3/targets/grpc%2Fcore%2Fpull_request%2Flinux%2Fgrpc_distribtests_php/log)) and its error was;

```
In file included from /tmp/pear/temp/grpc/third_party/upb/upb/decode.c:38:0:
/tmp/pear/temp/grpc/third_party/upb/upb/decode.c: In function 'decode_isdonefallback':
/tmp/pear/temp/grpc/third_party/upb/upb/port_def.inc:162:31: error: 'status' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define UPB_LONGJMP(buf, val) longjmp(buf, val)
                               ^~~~~~~
/tmp/pear/temp/grpc/third_party/upb/upb/decode.c:309:7: note: 'status' was declared here
   int status;
       ^~~~~~
```

This warning doesn't look to be correct and it might be related to the existing gcc [bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635). Moreover it doesn't seem to make sense to have a strict warning in building PHP artifacts. We've already been doing a stricter warning test with a regular bazel C++ build so we already cover them. I think it does more harm than good so let's remove this option from PHP build.