### PR TITLE
Fix some clang-tidy issue (fix-forward)

### DIFF
--- a/src/core/ext/xds/xds_routing.cc
+++ b/src/core/ext/xds/xds_routing.cc
@@ -70,7 +70,7 @@ bool DomainMatch(MatchType match_type, absl::string_view domain_pattern_in,
 
 MatchType DomainPatternMatchType(absl::string_view domain_pattern) {
   if (domain_pattern.empty()) return INVALID_MATCH;
-  if (domain_pattern.find('*') == std::string::npos) return EXACT_MATCH;
+  if (!absl::StrContains(domain_pattern, '*')) return EXACT_MATCH;
   if (domain_pattern == "*") return UNIVERSE_MATCH;
   if (domain_pattern[0] == '*') return SUFFIX_MATCH;
   if (domain_pattern[domain_pattern.size() - 1] == '*') return PREFIX_MATCH;

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -233,7 +233,7 @@ static bool IsSpiffeId(absl::string_view uri) {
     return false;
   }
   std::vector<absl::string_view> splits = absl::StrSplit(uri, '/');
-  if (splits.size() < 4 || splits[3] == "") {
+  if (splits.size() < 4 || splits[3].empty()) {
     gpr_log(GPR_INFO, "Invalid SPIFFE ID: workload id is empty.");
     return false;
   }


### PR DESCRIPTION
Fix forward of #28679

Previously it happened to break the test but I suspect it was caused by wrong merge so I'm trying to lang it as it was again.