### PR TITLE
Disable EventEngine smoke tests for ease of import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -979,7 +979,6 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx settings_timeout_test)
   add_dependencies(buildtests_cxx shutdown_test)
   add_dependencies(buildtests_cxx simple_request_bad_client_test)
-  add_dependencies(buildtests_cxx smoke_test)
   add_dependencies(buildtests_cxx sockaddr_utils_test)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_cxx stack_tracer_test)
@@ -15168,41 +15167,6 @@ target_include_directories(simple_request_bad_client_test
 )
 
 target_link_libraries(simple_request_bad_client_test
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-)
-
-
-endif()
-if(gRPC_BUILD_TESTS)
-
-add_executable(smoke_test
-  test/core/event_engine/smoke_test.cc
-  third_party/googletest/googletest/src/gtest-all.cc
-  third_party/googletest/googlemock/src/gmock-all.cc
-)
-
-target_include_directories(smoke_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-    third_party/googletest/googletest/include
-    third_party/googletest/googletest
-    third_party/googletest/googlemock/include
-    third_party/googletest/googlemock
-    ${_gRPC_PROTO_GENS_DIR}
-)
-
-target_link_libraries(smoke_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -7750,15 +7750,6 @@ targets:
   - test/core/end2end/cq_verifier.cc
   deps:
   - grpc_test_util
-- name: smoke_test
-  gtest: true
-  build: test
-  language: c++
-  headers: []
-  src:
-  - test/core/event_engine/smoke_test.cc
-  deps:
-  - grpc_test_util
 - name: sockaddr_utils_test
   gtest: true
   build: test

--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -50,12 +50,13 @@ grpc_cc_library(
     alwayslink = 1,
 )
 
-grpc_cc_test(
-    name = "smoke_test",
-    srcs = ["smoke_test.cc"],
-    external_deps = ["gtest"],
-    deps = [
-        "//:grpc",
-        "//test/core/util:grpc_test_util",
-    ],
-)
+# TODO(hork): re-enable after #28721 is imported
+# grpc_cc_test(
+#     name = "smoke_test",
+#     srcs = ["smoke_test.cc"],
+#     external_deps = ["gtest"],
+#     deps = [
+#         "//:grpc",
+#         "//test/core/util:grpc_test_util",
+#     ],
+# )

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -6490,30 +6490,6 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
-    "name": "smoke_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": true,
-    "language": "c++",
     "name": "sockaddr_utils_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
This avoids having to do a cherry-pick import, and is harmless since
there are no dependencies yet on the EventEngine. This test will be
re-enabled shortly after both the import and related changes are
finished.

CC @tamird 