### PR TITLE
More cleanup of docker run machinery.

### DIFF
--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -51,6 +51,8 @@ else
 fi
 
 # Git root as seen by the docker instance
+# TODO(jtattermusch): rename to a more descriptive directory name
+# currently that's nontrivial because the name is hardcoded in many places.
 EXTERNAL_GIT_ROOT=/var/local/jenkins/grpc
 
 # temporary directory that will be mounted to the docker container
@@ -78,7 +80,6 @@ docker run \
   -v "${git_root}:${EXTERNAL_GIT_ROOT}" \
   -v "${TEMP_REPORT_DIR}:/var/local/report_dir" \
   -v "${TEMP_OUTPUT_DIR}:/var/local/output_dir" \
-  -w /var/local/git/grpc \
   "${DOCKER_IMAGE_NAME}" \
   bash -l "/var/local/jenkins/grpc/${DOCKER_RUN_SCRIPT}" || DOCKER_EXIT_CODE=$?
 

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2015 gRPC authors.
+# Copyright 2016 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -18,9 +18,6 @@
 
 set -e
 
-# TODO(jtattermusch): added in https://github.com/grpc/grpc/pull/17303, should be removed.
-export CONFIG=${config:-opt}
-
 if [ "$RELATIVE_COPY_PATH" == "" ]
 then
   mkdir -p /var/local/git

--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2015 gRPC authors.
+# Copyright 2016 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -18,25 +18,24 @@
 
 set -e
 
-if [ "$RELATIVE_COPY_PATH" == "" ]
+if [ "${RELATIVE_COPY_PATH}" == "" ]
 then
   mkdir -p /var/local/git
-  git clone "$EXTERNAL_GIT_ROOT" /var/local/git/grpc
+  git clone "${EXTERNAL_GIT_ROOT}" /var/local/git/grpc
   # clone gRPC submodules, use data from locally cloned submodules where possible
   # TODO: figure out a way to eliminate this following shellcheck suppressions
   # shellcheck disable=SC2016,SC1004
   (cd "${EXTERNAL_GIT_ROOT}" && git submodule foreach 'git clone ${EXTERNAL_GIT_ROOT}/${name} /var/local/git/grpc/${name}')
   (cd /var/local/git/grpc && git submodule init)
 else
-  mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
-  cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH"/* "/var/local/git/grpc/$RELATIVE_COPY_PATH"
+  mkdir -p "/var/local/git/grpc/${RELATIVE_COPY_PATH}"
+  cp -r "${EXTERNAL_GIT_ROOT}/${RELATIVE_COPY_PATH}"/* "/var/local/git/grpc/${RELATIVE_COPY_PATH}"
 fi
+
+cd /var/local/git/grpc
 
 # ensure the "reports" directory exists
 mkdir -p reports
-
-# TODO(jtattermusch): is this necessary?
-cd /var/local/git/grpc
 
 exit_code=0
 ${DOCKER_RUN_SCRIPT_COMMAND} || exit_code=$?

--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -35,9 +35,6 @@ fi
 # ensure the "reports" directory exists
 mkdir -p reports
 
-# TODO(jtattermusch): this is garbage, remove it.
-$POST_GIT_STEP
-
 # TODO(jtattermusch): is this necessary?
 cd /var/local/git/grpc
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1586,9 +1586,6 @@ if args.use_docker:
     env['DOCKERFILE_DIR'] = dockerfile_dir
     env['DOCKER_RUN_SCRIPT'] = 'tools/run_tests/dockerize/docker_run.sh'
     env['DOCKER_RUN_SCRIPT_COMMAND'] = run_tests_cmd
-    # TODO(jtattermusch): is the XML_REPORT env variable any useful?
-    if args.xml_report:
-        env['XML_REPORT'] = args.xml_report
 
     retcode = subprocess.call(
         'tools/run_tests/dockerize/build_and_run_docker.sh',


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/28704 (which got reverted, but was reintroduced by https://github.com/grpc/grpc/pull/28748).

See commit history for individual cleanup items.