### PR TITLE
Revert "Cleanup run docker machinery in run_tests.py, task_runner.py and elsewhere"

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -34,6 +34,7 @@ def create_docker_jobspec(name,
                           verbose_success=False):
     """Creates jobspec for a task running under docker."""
     environ = environ.copy()
+    environ['RUN_COMMAND'] = shell_command
     environ['ARTIFACTS_OUT'] = 'artifacts/%s' % name
 
     docker_args = []
@@ -42,7 +43,6 @@ def create_docker_jobspec(name,
     docker_env = {
         'DOCKERFILE_DIR': dockerfile_dir,
         'DOCKER_RUN_SCRIPT': 'tools/run_tests/dockerize/docker_run.sh',
-        'DOCKER_RUN_SCRIPT_COMMAND': shell_command,
         'OUTPUT_DIR': 'artifacts'
     }
     if extra_docker_args is not None:

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -31,6 +31,7 @@ def create_docker_jobspec(name,
                           timeout_seconds=30 * 60):
     """Creates jobspec for a task running under docker."""
     environ = environ.copy()
+    environ['RUN_COMMAND'] = shell_command
     # the entire repo will be cloned if copy_rel_path is not set.
     if copy_rel_path:
         environ['RELATIVE_COPY_PATH'] = copy_rel_path
@@ -40,8 +41,7 @@ def create_docker_jobspec(name,
         docker_args += ['-e', '%s=%s' % (k, v)]
     docker_env = {
         'DOCKERFILE_DIR': dockerfile_dir,
-        'DOCKER_RUN_SCRIPT': 'tools/run_tests/dockerize/docker_run.sh',
-        'DOCKER_RUN_SCRIPT_COMMAND': shell_command,
+        'DOCKER_RUN_SCRIPT': 'tools/run_tests/dockerize/docker_run.sh'
     }
     jobspec = jobset.JobSpec(
         cmdline=['tools/run_tests/dockerize/build_and_run_docker.sh'] +

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -29,6 +29,7 @@ def create_docker_jobspec(name,
                           timeout_retries=0):
     """Creates jobspec for a task running under docker."""
     environ = environ.copy()
+    environ['RUN_COMMAND'] = shell_command
 
     docker_args = []
     for k, v in list(environ.items()):
@@ -36,7 +37,6 @@ def create_docker_jobspec(name,
     docker_env = {
         'DOCKERFILE_DIR': dockerfile_dir,
         'DOCKER_RUN_SCRIPT': 'tools/run_tests/dockerize/docker_run.sh',
-        'DOCKER_RUN_SCRIPT_COMMAND': shell_command,
         'OUTPUT_DIR': 'artifacts'
     }
     jobspec = jobset.JobSpec(

--- a/tools/run_tests/dockerize/build_docker_and_run_tests.sh
+++ b/tools/run_tests/dockerize/build_docker_and_run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 gRPC authors.
+# Copyright 2015 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Builds docker image and runs a command under it.
-# You should never need to call this script on your own.
+# This script is invoked by run_tests.py to accommodate "test under docker"
+# scenario. You should never need to call this script on your own.
 
 # shellcheck disable=SC2103
 
@@ -27,9 +27,7 @@ cd -
 # Inputs
 # DOCKERFILE_DIR - Directory in which Dockerfile file is located.
 # DOCKER_RUN_SCRIPT - Script to run under docker (relative to grpc repo root)
-# OUTPUT_DIR - Directory that will be copied from inside docker after finishing.
 # DOCKERHUB_ORGANIZATION - If set, pull a prebuilt image from given dockerhub org.
-# $@ - Extra args to pass to docker run
 
 # Use image name based on Dockerfile location checksum
 DOCKER_IMAGE_NAME=$(basename "$DOCKERFILE_DIR"):$(sha1sum "$DOCKERFILE_DIR/Dockerfile" | cut -f1 -d\ )
@@ -51,38 +49,48 @@ else
 fi
 
 # Choose random name for docker container
-CONTAINER_NAME="build_and_run_docker_$(uuidgen)"
+CONTAINER_NAME="run_tests_$(uuidgen)"
 
-# Run command inside docker
-# TODO: use a proper array instead of $EXTRA_DOCKER_ARGS
-# shellcheck disable=SC2086
+# Git root as seen by the docker instance
+docker_instance_git_root=/var/local/jenkins/grpc
+
+# Run tests inside docker
+DOCKER_EXIT_CODE=0
+# TODO: silence complaint about $DOCKER_TTY_ARGS expansion in some other way
+# shellcheck disable=SC2086,SC2154
 docker run \
-  "$@" \
   --cap-add SYS_PTRACE \
-  -e EXTERNAL_GIT_ROOT="/var/local/jenkins/grpc" \
+  -e "RUN_TESTS_COMMAND=$RUN_TESTS_COMMAND" \
+  -e "config=$config" \
+  -e "arch=$arch" \
+  -e THIS_IS_REALLY_NEEDED='see https://github.com/docker/docker/issues/14203 for why docker is awful' \
+  -e HOST_GIT_ROOT="$git_root" \
+  -e LOCAL_GIT_ROOT=$docker_instance_git_root \
   --env-file "tools/run_tests/dockerize/docker_propagate_env.list" \
-  -v "$git_root:/var/local/jenkins/grpc:ro" \
+  $DOCKER_TTY_ARGS \
+  --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+  -v ~/.config/gcloud:/root/.config/gcloud \
+  -v "$git_root:$docker_instance_git_root" \
+  -v /tmp/npm-cache:/tmp/npm-cache \
   -w /var/local/git/grpc \
   --name="$CONTAINER_NAME" \
-  $DOCKER_TTY_ARGS \
-  $EXTRA_DOCKER_ARGS \
   "$DOCKER_IMAGE_NAME" \
-  /bin/bash -l "/var/local/jenkins/grpc/$DOCKER_RUN_SCRIPT" || FAILED="true"
+  bash -l "/var/local/jenkins/grpc/$DOCKER_RUN_SCRIPT" || DOCKER_EXIT_CODE=$?
 
-# Copy output artifacts
-if [ "$OUTPUT_DIR" != "" ]
+# use unique name for reports.zip to prevent clash between concurrent
+# run_tests.py runs 
+TEMP_REPORTS_ZIP=$(mktemp)
+docker cp "$CONTAINER_NAME:/var/local/git/grpc/reports.zip" "${TEMP_REPORTS_ZIP}" || true
+if [ "${GRPC_TEST_REPORT_BASE_DIR}" != "" ]
 then
-  # Create the artifact directory in advance to avoid a race in "docker cp" if tasks
-  # that were running in parallel finish at the same time.
-  # see https://github.com/grpc/grpc/issues/16155
-  mkdir -p "$git_root/$OUTPUT_DIR"
-  docker cp "$CONTAINER_NAME:/var/local/git/grpc/$OUTPUT_DIR" "$git_root" || FAILED="true"
+  REPORTS_DEST_DIR="${GRPC_TEST_REPORT_BASE_DIR}"
+else
+  REPORTS_DEST_DIR="${git_root}"
 fi
+unzip -o "${TEMP_REPORTS_ZIP}" -d "${REPORTS_DEST_DIR}" || true
+rm -f "${TEMP_REPORTS_ZIP}"
 
 # remove the container, possibly killing it first
 docker rm -f "$CONTAINER_NAME" || true
 
-if [ "$FAILED" != "" ]
-then
-  exit 1
-fi
+exit $DOCKER_EXIT_CODE

--- a/tools/run_tests/dockerize/docker_run_tests.sh
+++ b/tools/run_tests/dockerize/docker_run_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script is invoked by build_docker_and_run_tests.sh inside a docker
+# container. You should never need to call this script on your own.
+
+set -e
+
+export CONFIG=${config:-opt}
+export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+export PATH=$PATH:/usr/bin/llvm-symbolizer
+
+mkdir -p /var/local/git
+git clone /var/local/jenkins/grpc /var/local/git/grpc
+# clone gRPC submodules, use data from locally cloned submodules where possible
+# TODO: figure out a way to eliminate this shellcheck suppression:
+# shellcheck disable=SC2016
+(cd /var/local/jenkins/grpc/ && git submodule foreach 'git clone /var/local/jenkins/grpc/${name} /var/local/git/grpc/${name}')
+(cd /var/local/git/grpc/ && git submodule init)
+
+mkdir -p reports
+
+$POST_GIT_STEP
+
+exit_code=0
+
+$RUN_TESTS_COMMAND || exit_code=$?
+
+# The easiest way to copy all the reports files from inside of
+# the docker container is to zip them and then copy the zip.
+zip -r reports.zip reports
+find . -name report.xml -print0 | xargs -0 -r zip reports.zip
+find . -name sponge_log.xml -print0 | xargs -0 -r zip reports.zip
+find . -name 'report_*.xml' -print0 | xargs -0 -r zip reports.zip
+
+if [ -x "$(command -v ccache)" ]
+then
+  ccache --show-stats || true
+fi
+
+exit $exit_code

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -181,7 +181,7 @@ def _check_arch(arch, supported_archs):
 
 def _is_use_docker_child():
     """Returns True if running running as a --use_docker child."""
-    return True if os.getenv('DOCKER_RUN_SCRIPT_COMMAND') else False
+    return True if os.getenv('RUN_TESTS_COMMAND') else False
 
 
 _PythonConfigVars = collections.namedtuple('_ConfigVars', [
@@ -1583,15 +1583,14 @@ if args.use_docker:
         child_argv[1:])
 
     env = os.environ.copy()
+    env['RUN_TESTS_COMMAND'] = run_tests_cmd
     env['DOCKERFILE_DIR'] = dockerfile_dir
-    env['DOCKER_RUN_SCRIPT'] = 'tools/run_tests/dockerize/docker_run.sh'
-    env['DOCKER_RUN_SCRIPT_COMMAND'] = run_tests_cmd
-    # TODO(jtattermusch): is the XML_REPORT env variable any useful?
+    env['DOCKER_RUN_SCRIPT'] = 'tools/run_tests/dockerize/docker_run_tests.sh'
     if args.xml_report:
         env['XML_REPORT'] = args.xml_report
 
     retcode = subprocess.call(
-        'tools/run_tests/dockerize/build_and_run_docker.sh',
+        'tools/run_tests/dockerize/build_docker_and_run_tests.sh',
         shell=True,
         env=env)
     _print_debug_info_epilogue(dockerfile_dir=dockerfile_dir)


### PR DESCRIPTION
Reverts grpc/grpc#28704
It breaks prod:grpc/core/master/linux/grpc_distribtests_python