### PR TITLE
Add grpc-swift to language list

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ seeking contributions for all of these libraries:
 | WebJS                | [grpc-web](https://github.com/grpc/grpc-web)       |
 | Dart                 | [grpc-dart](https://github.com/grpc/grpc-dart)     |
 | .NET (pure C# impl.) | [grpc-dotnet](https://github.com/grpc/grpc-dotnet) |
+| Swift                | [grpc-swift](https://github.com/grpc/grpc-swift) |


### PR DESCRIPTION
Swift doesn't seem to be on this "front page" list, but development is vibrant and seems officially supported.

release notes: no

@veblush
