### PR TITLE
fix api_listener parsing logic

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
@@ -155,7 +155,7 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
   run_alpha_test subsetting_test || (( failed_tests++ ))
-  test_suites=("change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "affinity_test")
+  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test" "affinity_test")
   for test in "${test_suites[@]}"; do
     run_test $test || (( failed_tests++ ))
   done

--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
@@ -148,7 +148,7 @@ main() {
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
-  test_suites=("change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
+  test_suites=("api_listener_test" "change_backend_service_test" "failover_test" "remove_neg_test" "round_robin_test")
   for test in "${test_suites[@]}"; do
     run_test $test || (( failed_tests++ ))
   done

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -222,12 +222,14 @@ class ComputeV1(gcp.api.GcpProjectApiResource):
         self,
         name: str,
         url_map: GcpResource,
+        validate_for_proxyless: bool = True,
     ) -> GcpResource:
-        return self._insert_resource(self.api.targetGrpcProxies(), {
-            'name': name,
-            'url_map': url_map.url,
-            'validate_for_proxyless': True,
-        })
+        return self._insert_resource(
+            self.api.targetGrpcProxies(), {
+                'name': name,
+                'url_map': url_map.url,
+                'validate_for_proxyless': validate_for_proxyless,
+            })
 
     def delete_target_grpc_proxy(self, name):
         self._delete_resource(self.api.targetGrpcProxies(), 'targetGrpcProxy',
@@ -247,13 +249,13 @@ class ComputeV1(gcp.api.GcpProjectApiResource):
         self._delete_resource(self.api.targetHttpProxies(), 'targetHttpProxy',
                               name)
 
-    def create_forwarding_rule(
-        self,
-        name: str,
-        src_port: int,
-        target_proxy: GcpResource,
-        network_url: str,
-    ) -> GcpResource:
+    def create_forwarding_rule(self,
+                               name: str,
+                               src_port: int,
+                               target_proxy: GcpResource,
+                               network_url: str,
+                               *,
+                               ip_address: str = '0.0.0.0') -> GcpResource:
         return self._insert_resource(
             self.api.globalForwardingRules(),
             {
@@ -261,7 +263,7 @@ class ComputeV1(gcp.api.GcpProjectApiResource):
                 'loadBalancingScheme':
                     'INTERNAL_SELF_MANAGED',  # Traffic Director
                 'portRange': src_port,
-                'IPAddress': '0.0.0.0',
+                'IPAddress': ip_address,
                 'network': network_url,
                 'target': target_proxy.url,
             })

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -56,9 +56,12 @@ class TrafficDirectorManager:
     AFFINITY_BACKEND_SERVICE_NAME = "backend-service-affinity"
     HEALTH_CHECK_NAME = "health-check"
     URL_MAP_NAME = "url-map"
+    ALTERNATIVE_URL_MAP_NAME = "url-map-alt"
     URL_MAP_PATH_MATCHER_NAME = "path-matcher"
     TARGET_PROXY_NAME = "target-proxy"
+    ALTERNATIVE_TARGET_PROXY_NAME = "target-proxy-alt"
     FORWARDING_RULE_NAME = "forwarding-rule"
+    ALTERNATIVE_FORWARDING_RULE_NAME = "forwarding-rule-alt"
     FIREWALL_RULE_NAME = "allow-health-checks"
 
     def __init__(
@@ -88,11 +91,14 @@ class TrafficDirectorManager:
         # TODO(sergiitk): remove this flag once backend service resource loaded
         self.backend_service_protocol: Optional[BackendServiceProtocol] = None
         self.url_map: Optional[GcpResource] = None
+        self.alternative_url_map: Optional[GcpResource] = None
         self.firewall_rule: Optional[GcpResource] = None
         self.target_proxy: Optional[GcpResource] = None
         # TODO(sergiitk): remove this flag once target proxy resource loaded
         self.target_proxy_is_http: bool = False
+        self.alternative_target_proxy: Optional[GcpResource] = None
         self.forwarding_rule: Optional[GcpResource] = None
+        self.alternative_forwarding_rule: Optional[GcpResource] = None
         self.backends: Set[ZonalGcpResource] = set()
         self.alternative_backend_service: Optional[GcpResource] = None
         # TODO(sergiitk): remove this flag once backend service resource loaded
@@ -136,9 +142,12 @@ class TrafficDirectorManager:
     def cleanup(self, *, force=False):
         # Cleanup in the reverse order of creation
         self.delete_forwarding_rule(force=force)
+        self.delete_alternative_forwarding_rule(force=force)
         self.delete_target_http_proxy(force=force)
         self.delete_target_grpc_proxy(force=force)
+        self.delete_alternative_target_grpc_proxy(force=force)
         self.delete_url_map(force=force)
+        self.delete_alternative_url_map(force=force)
         self.delete_backend_service(force=force)
         self.delete_alternative_backend_service(force=force)
         self.delete_affinity_backend_service(force=force)
@@ -399,11 +408,7 @@ class TrafficDirectorManager:
             }],
         }
 
-    def create_url_map(
-        self,
-        src_host: str,
-        src_port: int,
-    ) -> GcpResource:
+    def create_url_map(self, src_host: str, src_port: int) -> GcpResource:
         src_address = f'{src_host}:{src_port}'
         name = self.make_resource_name(self.URL_MAP_NAME)
         matcher_name = self.make_resource_name(self.URL_MAP_PATH_MATCHER_NAME)
@@ -441,6 +446,35 @@ class TrafficDirectorManager:
         else:
             return
         logger.info('Deleting URL Map "%s"', name)
+        self.compute.delete_url_map(name)
+        self.url_map = None
+
+    def create_alternative_url_map(
+            self,
+            src_host: str,
+            src_port: int,
+            backend_service: Optional[GcpResource] = None) -> GcpResource:
+        name = self.make_resource_name(self.ALTERNATIVE_URL_MAP_NAME)
+        src_address = f'{src_host}:{src_port}'
+        matcher_name = self.make_resource_name(self.URL_MAP_PATH_MATCHER_NAME)
+        if backend_service is None:
+            backend_service = self.alternative_backend_service
+        logger.info('Creating alternative URL map "%s": %s -> %s', name,
+                    src_address, backend_service.name)
+        resource = self.compute.create_url_map_with_content(
+            self._generate_url_map_body(name, matcher_name, [src_address],
+                                        backend_service))
+        self.alternative_url_map = resource
+        return resource
+
+    def delete_alternative_url_map(self, force=False):
+        if force:
+            name = self.make_resource_name(self.ALTERNATIVE_URL_MAP_NAME)
+        elif self.alternative_url_map:
+            name = self.alternative_url_map.name
+        else:
+            return
+        logger.info('Deleting alternative URL Map "%s"', name)
         self.compute.delete_url_map(name)
         self.url_map = None
 
@@ -485,6 +519,28 @@ class TrafficDirectorManager:
         self.target_proxy = None
         self.target_proxy_is_http = False
 
+    def create_alternative_target_proxy(self):
+        name = self.make_resource_name(self.ALTERNATIVE_TARGET_PROXY_NAME)
+        if self.backend_service_protocol is BackendServiceProtocol.GRPC:
+            logger.info(
+                'Creating alternative target GRPC proxy "%s" to URL map %s',
+                name, self.alternative_url_map.name)
+            self.alternative_target_proxy = self.compute.create_target_grpc_proxy(
+                name, self.alternative_url_map, False)
+        else:
+            raise TypeError('Unexpected backend service protocol')
+
+    def delete_alternative_target_grpc_proxy(self, force=False):
+        if force:
+            name = self.make_resource_name(self.ALTERNATIVE_TARGET_PROXY_NAME)
+        elif self.alternative_target_proxy:
+            name = self.alternative_target_proxy.name
+        else:
+            return
+        logger.info('Deleting alternative Target GRPC proxy "%s"', name)
+        self.compute.delete_target_grpc_proxy(name)
+        self.alternative_target_proxy = None
+
     def find_unused_forwarding_rule_port(
             self,
             *,
@@ -520,6 +576,36 @@ class TrafficDirectorManager:
         logger.info('Deleting Forwarding rule "%s"', name)
         self.compute.delete_forwarding_rule(name)
         self.forwarding_rule = None
+
+    def create_alternative_forwarding_rule(self,
+                                           src_port: int,
+                                           ip_address='0.0.0.0'):
+        name = self.make_resource_name(self.ALTERNATIVE_FORWARDING_RULE_NAME)
+        src_port = int(src_port)
+        logging.info(
+            'Creating alternative forwarding rule "%s" in network "%s": %s:%s -> %s',
+            name, self.network, ip_address, src_port,
+            self.alternative_target_proxy.url)
+        resource = self.compute.create_forwarding_rule(
+            name,
+            src_port,
+            self.alternative_target_proxy,
+            self.network_url,
+            ip_address=ip_address)
+        self.alternative_forwarding_rule = resource
+        return resource
+
+    def delete_alternative_forwarding_rule(self, force=False):
+        if force:
+            name = self.make_resource_name(
+                self.ALTERNATIVE_FORWARDING_RULE_NAME)
+        elif self.alternative_forwarding_rule:
+            name = self.alternative_forwarding_rule.name
+        else:
+            return
+        logger.info('Deleting alternative Forwarding rule "%s"', name)
+        self.compute.delete_forwarding_rule(name)
+        self.alternative_forwarding_rule = None
 
     def create_firewall_rule(self, allowed_ports: List[str]):
         name = self.make_resource_name(self.FIREWALL_RULE_NAME)

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -27,6 +27,7 @@ import grpc
 
 from framework import xds_flags
 from framework import xds_k8s_flags
+from framework import xds_url_map_testcase
 from framework.helpers import retryers
 import framework.helpers.rand
 from framework.infrastructure import gcp
@@ -36,7 +37,6 @@ from framework.rpc import grpc_channelz
 from framework.rpc import grpc_testing
 from framework.test_app import client_app
 from framework.test_app import server_app
-from framework import xds_url_map_testcase
 
 logger = logging.getLogger(__name__)
 _FORCE_CLEANUP = flags.DEFINE_bool(

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -85,6 +85,7 @@ class DumpedXdsConfig(dict):
         self.json_config = xds_json
         self.lds = None
         self.rds = None
+        self.rds_version = None
         self.cds = []
         self.eds = []
         self.endpoints = []
@@ -96,6 +97,8 @@ class DumpedXdsConfig(dict):
                 elif 'routeConfig' in xds_config:
                     self.rds = xds_config['routeConfig']['dynamicRouteConfigs'][
                         0]['routeConfig']
+                    self.rds_version = xds_config['routeConfig'][
+                        'dynamicRouteConfigs'][0]['versionInfo']
                 elif 'clusterConfig' in xds_config:
                     for cluster in xds_config['clusterConfig'][
                             'dynamicActiveClusters']:
@@ -114,6 +117,7 @@ class DumpedXdsConfig(dict):
                 elif re.search(r'\.RouteConfiguration$',
                                generic_xds_config['typeUrl']):
                     self.rds = generic_xds_config["xdsConfig"]
+                    self.rds_version = generic_xds_config["versionInfo"]
                 elif re.search(r'\.Cluster$', generic_xds_config['typeUrl']):
                     self.cds.append(generic_xds_config["xdsConfig"])
                 elif re.search(r'\.ClusterLoadAssignment$',

--- a/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
@@ -1,0 +1,102 @@
+# Copyright 2021 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from absl import flags
+from absl.testing import absltest
+
+from framework import xds_k8s_testcase
+
+logger = logging.getLogger(__name__)
+flags.adopt_module_key_flags(xds_k8s_testcase)
+
+# Type aliases
+_XdsTestServer = xds_k8s_testcase.XdsTestServer
+_XdsTestClient = xds_k8s_testcase.XdsTestClient
+
+_TD_CONFIG_RETRY_WAIT_SEC = 2
+
+
+class ApiListenerTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
+
+    def test_api_listener(self) -> None:
+        with self.subTest('00_create_health_check'):
+            self.td.create_health_check()
+
+        with self.subTest('01_create_backend_services'):
+            self.td.create_backend_service()
+
+        with self.subTest('02_create_default_url_map'):
+            self.td.create_url_map(self.server_xds_host, self.server_xds_port)
+
+        with self.subTest('03_create_default_target_proxy'):
+            self.td.create_target_proxy()
+
+        with self.subTest('04_create_default_forwarding_rule'):
+            self.td.create_forwarding_rule(self.server_xds_port)
+
+        with self.subTest('05_start_test_server'):
+            test_server: _XdsTestServer = self.startTestServers()[0]
+
+        with self.subTest('06_add_server_backends_to_backend_services'):
+            self.setupServerBackends()
+
+        with self.subTest('07_start_test_client'):
+            test_client: _XdsTestClient = self.startTestClient(test_server)
+
+        with self.subTest('08_test_client_xds_config_exists'):
+            self.assertXdsConfigExists(test_client)
+
+        with self.subTest('09_test_server_received_rpcs'):
+            self.assertSuccessfulRpcs(test_client)
+
+        with self.subTest('10_create_alternate_url_map'):
+            self.td.create_alternative_url_map(self.server_xds_host,
+                                               self.server_xds_port,
+                                               self.td.backend_service)
+
+        # Create alternate target proxy pointing to alternate url_map with the same
+        # host name in host rule. The port is fixed because they point to the same backend service.
+        # Therefore we have to choose a non-`0.0.0.0` ip because ip:port needs to be unique.
+        # We also have to set validate_for_proxyless=false because requires `0.0.0.0` ip.
+        # See https://github.com/grpc/grpc-java/issues/8009
+        with self.subTest('11_create_alternate_target_proxy'):
+            self.td.create_alternative_target_proxy()
+
+        # Create a second suite of map+tp+fr with the same host name in host rule.
+        # We set fr ip_address to be different from `0.0.0.0` and then set
+        # validate_for_proxyless=false because ip:port needs to be unique.
+        with self.subTest('12_create_alternate_forwarding_rule'):
+            self.td.create_alternative_forwarding_rule(self.server_xds_port,
+                                                       ip_address='10.10.10.10')
+
+        with self.subTest('13_test_server_received_rpcs_with_two_url_maps'):
+            self.assertSuccessfulRpcs(test_client)
+            previous_route_config_version = self.getRouteConfigVersion(
+                test_client)
+
+        with self.subTest('14_delete_one_url_map_target_proxy_forwarding_rule'):
+            self.td.delete_forwarding_rule()
+            self.td.delete_target_grpc_proxy()
+            self.td.delete_url_map()
+
+        with self.subTest('15_test_server_continues_to_receive_rpcs'):
+            self.assertRouteConfigUpdateTrafficHandoff(
+                test_client, previous_route_config_version,
+                _TD_CONFIG_RETRY_WAIT_SEC,
+                xds_k8s_testcase._TD_CONFIG_MAX_WAIT_SEC)
+
+
+if __name__ == '__main__':
+    absltest.main(failfast=True)

--- a/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
@@ -17,6 +17,8 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_k8s_testcase
+from google.protobuf import json_format
+from framework.xds_url_map_testcase import DumpedXdsConfig
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)
@@ -83,8 +85,12 @@ class ApiListenerTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
         with self.subTest('13_test_server_received_rpcs_with_two_url_maps'):
             self.assertSuccessfulRpcs(test_client)
-            previous_route_config_version = self.getRouteConfigVersion(
-                test_client)
+            config = test_client.csds.fetch_client_status(
+                log_level=logging.INFO)
+            logger.info('received client config from CSDS, dump config: %s',
+                        config)
+            previous_route_config_version = DumpedXdsConfig(
+                json_format.MessageToDict(config)).rds_version
 
         with self.subTest('14_delete_one_url_map_target_proxy_forwarding_rule'):
             self.td.delete_forwarding_rule()

--- a/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
@@ -15,9 +15,9 @@ import logging
 
 from absl import flags
 from absl.testing import absltest
+from google.protobuf import json_format
 
 from framework import xds_k8s_testcase
-from google.protobuf import json_format
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)


### PR DESCRIPTION
Revert Revert "cont. Add api listener test for k8s" in https://github.com/grpc/grpc/pull/28719

fix b/216278078

Indeed the parsing logic does not work for RDS response in CI.
RDS responses are in different format between local run and CI.
successful [kokoro build](https://fusion2.corp.google.com/invocations/3330f9d0-d166-49b7-aeaf-36b8ee8de8b9/log) after fix