### PR TITLE
Chttp2IncomingByteStream basic shutdown test to illustrate required error ref-counting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -815,6 +815,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx channelz_registry_test)
   add_dependencies(buildtests_cxx channelz_service_test)
   add_dependencies(buildtests_cxx channelz_test)
+  add_dependencies(buildtests_cxx chttp2_byte_stream_test)
   add_dependencies(buildtests_cxx chunked_vector_test)
   add_dependencies(buildtests_cxx cli_call_test)
   add_dependencies(buildtests_cxx client_authority_filter_test)
@@ -8956,6 +8957,41 @@ target_link_libraries(channelz_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++
+  grpc_test_util
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(chttp2_byte_stream_test
+  test/core/transport/chttp2/chttp2_byte_stream_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+target_include_directories(chttp2_byte_stream_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(chttp2_byte_stream_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5102,6 +5102,16 @@ targets:
   deps:
   - grpc++
   - grpc_test_util
+- name: chttp2_byte_stream_test
+  gtest: true
+  build: test
+  language: c++
+  headers: []
+  src:
+  - test/core/transport/chttp2/chttp2_byte_stream_test.cc
+  deps:
+  - grpc_test_util
+  uses_polling: false
 - name: chunked_vector_test
   gtest: true
   build: test

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -83,6 +83,21 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "chttp2_byte_stream_test",
+    srcs = ["chttp2_byte_stream_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    language = "C++",
+    uses_polling = False,
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "flow_control_test",
     size = "large",
     srcs = ["flow_control_test.cc"],

--- a/test/core/transport/chttp2/chttp2_byte_stream_test.cc
+++ b/test/core/transport/chttp2/chttp2_byte_stream_test.cc
@@ -68,7 +68,12 @@ TEST(Chttp2ByteStream, ShutdownTest) {
   // ref is not taken here, the subsequent unref will lead to a double free.
   chttp2_byte_stream->Shutdown(GRPC_ERROR_REF(shutdown_error));
   exec_ctx.Flush();
-  GRPC_ERROR_UNREF(shutdown_error);
+
+  EXPECT_EQ(s->read_closed_error, shutdown_error);
+  EXPECT_EQ(s->write_closed_error, shutdown_error);
+  ASSERT_TRUE(s->read_closed);
+  ASSERT_TRUE(s->write_closed);
+
   // Clean up.
   chttp2_byte_stream->Orphan();
   grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
@@ -77,6 +82,8 @@ TEST(Chttp2ByteStream, ShutdownTest) {
   gpr_free(s);
   grpc_transport_destroy(t);
   exec_ctx.Flush();
+
+  GRPC_ERROR_UNREF(shutdown_error);
 }
 
 }  // namespace

--- a/test/core/transport/chttp2/chttp2_byte_stream_test.cc
+++ b/test/core/transport/chttp2/chttp2_byte_stream_test.cc
@@ -1,0 +1,94 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <grpc/grpc.h>
+
+#include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/slice/slice_internal.h"
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
+#include "src/core/ext/transport/chttp2/transport/internal.h"
+#include "src/core/lib/config/core_configuration.h"
+#include "src/core/lib/transport/transport.h"
+#include "test/core/util/mock_endpoint.h"
+#include "test/core/util/test_config.h"
+
+namespace grpc_core {
+namespace testing {
+namespace {
+
+void discard_write(grpc_slice /*slice*/) {}
+
+/**
+ * Tests the error ref-counting when Chttp2 stream is shutdown with a
+ * non-special error.
+ */
+TEST(Chttp2ByteStream, ShutdownTest) {
+  ExecCtx exec_ctx;
+  grpc_stream_refcount ref;
+  GRPC_STREAM_REF_INIT(&ref, 1, nullptr, nullptr, "phony ref");
+  grpc_endpoint* mock_endpoint = grpc_mock_endpoint_create(discard_write);
+  const grpc_channel_args* args = CoreConfiguration::Get()
+                                      .channel_args_preconditioning()
+                                      .PreconditionChannelArgs(nullptr);
+  grpc_transport* t = grpc_create_chttp2_transport(args, mock_endpoint, true);
+  grpc_chttp2_transport_start_reading(t, nullptr, nullptr, nullptr);
+  grpc_channel_args_destroy(args);
+  grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(
+      gpr_malloc(grpc_transport_stream_size(t)));
+  s->id = 1;
+  s->byte_stream_error = GRPC_ERROR_NONE;
+  grpc_transport_init_stream(reinterpret_cast<grpc_transport*>(t),
+                             reinterpret_cast<grpc_stream*>(s), &ref, nullptr,
+                             nullptr);
+
+  // Create a Chttp2 stream and immediately shut it down
+  grpc_core::Chttp2IncomingByteStream* chttp2_byte_stream =
+      new grpc_core::Chttp2IncomingByteStream(
+          reinterpret_cast<grpc_chttp2_transport*>(t), s, 1000, 0);
+
+  grpc_error_handle shutdown_error =
+      GRPC_ERROR_CREATE_FROM_STATIC_STRING("shutdown error");
+  // Chttp2ByteStream->Shutdown must be called with a ref of the non-special
+  // error. The Shutdown method implementation will unref this error. If the
+  // ref is not taken here, the subsequent unref will lead to a double free.
+  chttp2_byte_stream->Shutdown(GRPC_ERROR_REF(shutdown_error));
+  exec_ctx.Flush();
+  GRPC_ERROR_UNREF(shutdown_error);
+  // Clean up.
+  chttp2_byte_stream->Orphan();
+  grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
+                                reinterpret_cast<grpc_stream*>(s), nullptr);
+  exec_ctx.Flush();
+  gpr_free(s);
+  grpc_transport_destroy(t);
+  exec_ctx.Flush();
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
+  int ret = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return ret;
+}
+

--- a/test/core/transport/chttp2/chttp2_byte_stream_test.cc
+++ b/test/core/transport/chttp2/chttp2_byte_stream_test.cc
@@ -16,13 +16,13 @@
 
 #include <grpc/grpc.h>
 
+#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
+#include "src/core/ext/transport/chttp2/transport/internal.h"
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/slice/slice_internal.h"
-#include "src/core/lib/channel/channel_args.h"
-#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
-#include "src/core/ext/transport/chttp2/transport/internal.h"
-#include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/transport/transport.h"
 #include "test/core/util/mock_endpoint.h"
 #include "test/core/util/test_config.h"
@@ -91,4 +91,3 @@ int main(int argc, char** argv) {
   grpc_shutdown();
   return ret;
 }
-

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3538,6 +3538,30 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "chttp2_byte_stream_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": false
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "chunked_vector_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
This PR creates a test which shows the error ref-counting semantics required before invoking Chttp2IncomingByteStream::Shutdown. This is in reference to b/216625346 which was due to a misuse of error ref-counting.

@donnadionne
