### PR TITLE
Upgrade clang to 13 for clang-format, clang-tidy, and sanity

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,8 @@
 # Once those issues are clear, these checks can be enabled later.
 #
 # - bugprone-branch-clone
+# - bugprone-easily-swappable-parameters,
+# - bugprone-implicit-widening-of-multiplication-result
 # - bugprone-infinite-loop
 # - bugprone-narrowing-conversions
 # - bugprone-not-null-terminated-result
@@ -42,6 +44,7 @@
 # - modernize-use-equals-delete
 # - modernize-use-using
 # - performance-no-automatic-move
+# - performance-no-int-to-ptr
 # - performance-unnecessary-copy-initialization
 # - performance-unnecessary-value-param
 # - readability-else-after-return
@@ -53,6 +56,8 @@ Checks: '-*,
   -abseil-no-namespace,
   bugprone-*,
   -bugprone-branch-clone,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-infinite-loop,
   -bugprone-narrowing-conversions,
   -bugprone-not-null-terminated-result,
@@ -67,6 +72,7 @@ Checks: '-*,
   -google-upgrade-googletest-case,
   performance-*,
   -performance-no-automatic-move,
+  -performance-no-int-to-ptr,
   -performance-unnecessary-copy-initialization,
   -performance-unnecessary-value-param,
   clang-diagnostic-deprecated-register,

--- a/src/core/lib/promise/detail/basic_seq.h
+++ b/src/core/lib/promise/detail/basic_seq.h
@@ -162,9 +162,9 @@ absl::enable_if_t<I <= J, SeqState<Traits, I, Fs...>*> GetSeqState(
 }
 
 template <template <typename> class Traits, char I, typename... Fs, typename T>
-auto CallNext(SeqState<Traits, I, Fs...>* state, T&& arg) -> decltype(
-    SeqState<Traits, I, Fs...>::Types::PromiseResultTraits::CallFactory(
-        &state->next_factory, std::forward<T>(arg))) {
+auto CallNext(SeqState<Traits, I, Fs...>* state, T&& arg)
+    -> decltype(SeqState<Traits, I, Fs...>::Types::PromiseResultTraits::
+                    CallFactory(&state->next_factory, std::forward<T>(arg))) {
   return SeqState<Traits, I, Fs...>::Types::PromiseResultTraits::CallFactory(
       &state->next_factory, std::forward<T>(arg));
 }

--- a/src/core/lib/promise/for_each.h
+++ b/src/core/lib/promise/for_each.h
@@ -58,8 +58,8 @@ template <typename Reader, typename Action>
 class ForEach {
  private:
   using ReaderNext = decltype(std::declval<Reader>().Next());
-  using ReaderResult = typename PollTraits<decltype(
-      std::declval<ReaderNext>()())>::Type::value_type;
+  using ReaderResult = typename PollTraits<
+      decltype(std::declval<ReaderNext>()())>::Type::value_type;
   using ActionFactory = promise_detail::PromiseFactory<ReaderResult, Action>;
   using ActionPromise = typename ActionFactory::Promise;
 

--- a/src/core/lib/promise/observable.h
+++ b/src/core/lib/promise/observable.h
@@ -172,8 +172,8 @@ class ObservableNext {
 template <typename T, typename F>
 class ObservableWatch final : private WatchCommitter {
  private:
-  using Promise = PromiseLike<decltype(
-      std::declval<F>()(std::declval<T>(), std::declval<WatchCommitter*>()))>;
+  using Promise = PromiseLike<decltype(std::declval<F>()(
+      std::declval<T>(), std::declval<WatchCommitter*>()))>;
   using Result = typename Promise::Result;
 
  public:

--- a/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
@@ -14,11 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM debian:11
-
-  # Install clang-format
-  RUN apt-get update && apt-get install -y clang-format-11
-  ENV CLANG_FORMAT=clang-format-11
+  FROM silkeh/clang:13
 
   ADD clang_format_all_the_things.sh /
   

--- a/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
@@ -14,11 +14,13 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:11
+  FROM silkeh/clang:13
   
-  # Install clang-tidy 11
-  RUN apt-get update && apt-get install -y clang-tidy-11 jq git
-  ENV CLANG_TIDY=clang-tidy-11
+  # Install prerequisites for the clang-tidy script
+  RUN apt-get update && apt-get install -y python3 jq git && apt-get clean
+
+  # otherwise clang-tidy will report missing <gtest/gtest.h> header
+  RUN apt-get update && apt-get install -y libgtest-dev && apt-get clean
 
   ADD clang_tidy_all_the_things.sh /
   

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM debian:11
+  FROM silkeh/clang:13
 
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../cxx_deps.include"/>
@@ -52,10 +52,8 @@
   # Upgrade Python's YAML library
   RUN python3 -m pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
 
-  # Install clang, clang-format, and clang-tidy
-  RUN apt-get update && apt-get install -y clang clang-format-11 clang-tidy-11 jq
-  ENV CLANG_FORMAT=clang-format-11
-  ENV CLANG_TIDY=clang-tidy-11
+  # Install prerequisites for the clang-tidy script
+  RUN apt-get update && apt-get install -y jq git
 
   <%include file="../../bazel.include"/>
   <%include file="../../buildifier.include"/>

--- a/tools/dockerfile/grpc_clang_format/Dockerfile
+++ b/tools/dockerfile/grpc_clang_format/Dockerfile
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:11
-
-# Install clang-format
-RUN apt-get update && apt-get install -y clang-format-11
-ENV CLANG_FORMAT=clang-format-11
+FROM silkeh/clang:13
 
 ADD clang_format_all_the_things.sh /
 

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:11
+FROM silkeh/clang:13
 
-# Install clang-tidy 11
-RUN apt-get update && apt-get install -y clang-tidy-11 jq git
-ENV CLANG_TIDY=clang-tidy-11
+# Install prerequisites for the clang-tidy script
+RUN apt-get update && apt-get install -y python3 jq git && apt-get clean
+
+# otherwise clang-tidy will report missing <gtest/gtest.h> header
+RUN apt-get update && apt-get install -y libgtest-dev && apt-get clean
 
 ADD clang_tidy_all_the_things.sh /
 

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:11
+FROM silkeh/clang:13
 
 #=================
 # Basic C core dependencies
@@ -98,10 +98,8 @@ RUN python3 -m pip install simplejson mako virtualenv==16.7.9 lxml six
 # Upgrade Python's YAML library
 RUN python3 -m pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
 
-# Install clang, clang-format, and clang-tidy
-RUN apt-get update && apt-get install -y clang clang-format-11 clang-tidy-11 jq
-ENV CLANG_FORMAT=clang-format-11
-ENV CLANG_TIDY=clang-tidy-11
+# Install prerequisites for the clang-tidy script
+RUN apt-get update && apt-get install -y jq git
 
 #========================
 # Bazel installation


### PR DESCRIPTION
In line with the recent rollout of clang-13 on workstation.