### PR TITLE
Upgrade base-builder to the latest for blaze build

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -54,6 +54,9 @@ GRPC_LLVM_WARNING_FLAGS = [
     # Exceptions but will be removed
     "-Wno-deprecated-declarations",
     "-Wno-unused-function",
+    # googletest 1.11 or later is needed to have this warning
+    # https://github.com/google/googletest/commit/1b3eb6ef34620c1203263d76ec169ef0853789cc
+    "-Wno-deprecated-copy",
 ]
 
 GRPC_DEFAULT_COPTS = select({

--- a/templates/tools/dockerfile/oss_fuzz_base.include
+++ b/templates/tools/dockerfile/oss_fuzz_base.include
@@ -1,8 +1,8 @@
 # Pinned version of the base image is used to avoid regressions caused
 # by rebuilding of this docker image. To see available versions, you can run
 # "gcloud container images list-tags gcr.io/oss-fuzz-base/base-builder"
-# Image(c7f1523ebd92) is built on Jul 29, 2021
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c06569143373be019c92f1e6df18a1e048f37
+# Image(5eceb81f5759) is built on Jan 31, 2022
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:5eceb81f57599d63ca7c9a70c8968b23b128119699626ca749017019eb0b523f
 
 # -------------------------- WARNING --------------------------------------
 # If you are making changes to this file, consider changing
@@ -10,26 +10,12 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c065691
 # accordingly.
 # -------------------------------------------------------------------------
 
-# Install basic packages and Bazel dependencies.
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties
-RUN add-apt-repository ppa:webupd8team/java
+# Install basic packages
 RUN apt-get update && apt-get -y install ${'\\'}
   autoconf ${'\\'}
   build-essential ${'\\'}
   curl ${'\\'}
-  wget ${'\\'}
   libtool ${'\\'}
   make ${'\\'}
-  openjdk-8-jdk ${'\\'}
-  vim
-
-#====================
-# Python dependencies
-
-# Install dependencies
-# TODO(jtattermusch): This installs python3.5. Is it even needed
-# when we install python3.6 in the next step?
-RUN apt-get update && apt-get install -y ${'\\'}
-    python3-all-dev
-
-<%include file="./compile_python_36.include"/>
+  vim ${'\\'}
+  wget

--- a/templates/tools/dockerfile/test/binder_transport_apk/Dockerfile.template
+++ b/templates/tools/dockerfile/test/binder_transport_apk/Dockerfile.template
@@ -18,6 +18,10 @@
   <%include file="../../bazel.include"/>
 
   #========================
+  # Java
+  RUN apt-get install -y openjdk-8-jdk
+
+  #========================
   # Android SDK/NDK installation
   ENV SDK_ROOT=/opt/android-sdk
   RUN mkdir -p $SDK_ROOT

--- a/test/core/end2end/inproc_callback_test.cc
+++ b/test/core/end2end/inproc_callback_test.cc
@@ -296,7 +296,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
-static void simple_request_body(grpc_end2end_test_config config,
+static void simple_request_body(grpc_end2end_test_config /* config */,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
   grpc_call* s;
@@ -431,11 +431,6 @@ static void simple_request_body(grpc_end2end_test_config config,
 
   grpc_call_unref(c);
   grpc_call_unref(s);
-
-  int expected_calls = 1;
-  if (config.feature_mask & FEATURE_MASK_SUPPORTS_REQUEST_PROXYING) {
-    expected_calls *= 2;
-  }
 }
 
 static void test_invoke_simple_request(grpc_end2end_test_config config) {

--- a/test/cpp/naming/resolver_component_tests_runner_invoker.cc
+++ b/test/cpp/naming/resolver_component_tests_runner_invoker.cc
@@ -87,7 +87,6 @@ void InvokeResolverComponentTestsRunner(
   gpr_mu_init(&test_driver_mu);
   gpr_cv test_driver_cv;
   gpr_cv_init(&test_driver_cv);
-  int test_driver_done = 0;
   int status = test_driver->Join();
   if (WIFEXITED(status)) {
     if (WEXITSTATUS(status)) {
@@ -108,7 +107,6 @@ void InvokeResolverComponentTestsRunner(
     abort();
   }
   gpr_mu_lock(&test_driver_mu);
-  test_driver_done = 1;
   gpr_cv_signal(&test_driver_cv);
   gpr_mu_unlock(&test_driver_mu);
   delete test_driver;

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -15,8 +15,8 @@
 # Pinned version of the base image is used to avoid regressions caused
 # by rebuilding of this docker image. To see available versions, you can run
 # "gcloud container images list-tags gcr.io/oss-fuzz-base/base-builder"
-# Image(c7f1523ebd92) is built on Jul 29, 2021
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c06569143373be019c92f1e6df18a1e048f37
+# Image(5eceb81f5759) is built on Jan 31, 2022
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:5eceb81f57599d63ca7c9a70c8968b23b128119699626ca749017019eb0b523f
 
 # -------------------------- WARNING --------------------------------------
 # If you are making changes to this file, consider changing
@@ -24,49 +24,15 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c065691
 # accordingly.
 # -------------------------------------------------------------------------
 
-# Install basic packages and Bazel dependencies.
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties
-RUN add-apt-repository ppa:webupd8team/java
+# Install basic packages
 RUN apt-get update && apt-get -y install \
   autoconf \
   build-essential \
   curl \
-  wget \
   libtool \
   make \
-  openjdk-8-jdk \
-  vim
-
-#====================
-# Python dependencies
-
-# Install dependencies
-# TODO(jtattermusch): This installs python3.5. Is it even needed
-# when we install python3.6 in the next step?
-RUN apt-get update && apt-get install -y \
-    python3-all-dev
-
-#=================
-# Compile CPython 3.6.9 from source
-
-RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev && apt-get clean
-RUN apt-get update && apt-get install -y jq build-essential libffi-dev && apt-get clean
-
-RUN cd /tmp && \
-    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
-    tar xzvf Python-3.6.9.tgz && \
-    cd Python-3.6.9 && \
-    ./configure && \
-    make -j4 && \
-    make install
-
-RUN cd /tmp && \
-    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
-    md5sum -c checksum.md5
-
-RUN python3.6 -m ensurepip && \
-    python3.6 -m pip install coverage
-
+  vim \
+  wget
 
 #========================
 # Bazel installation

--- a/tools/dockerfile/test/binder_transport_apk/Dockerfile
+++ b/tools/dockerfile/test/binder_transport_apk/Dockerfile
@@ -15,8 +15,8 @@
 # Pinned version of the base image is used to avoid regressions caused
 # by rebuilding of this docker image. To see available versions, you can run
 # "gcloud container images list-tags gcr.io/oss-fuzz-base/base-builder"
-# Image(c7f1523ebd92) is built on Jul 29, 2021
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c06569143373be019c92f1e6df18a1e048f37
+# Image(5eceb81f5759) is built on Jan 31, 2022
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:5eceb81f57599d63ca7c9a70c8968b23b128119699626ca749017019eb0b523f
 
 # -------------------------- WARNING --------------------------------------
 # If you are making changes to this file, consider changing
@@ -24,49 +24,15 @@ FROM gcr.io/oss-fuzz-base/base-builder@sha256:c7f1523ebd9234b9ff57e5240f8c065691
 # accordingly.
 # -------------------------------------------------------------------------
 
-# Install basic packages and Bazel dependencies.
-RUN apt-get update && apt-get install -y software-properties-common python-software-properties
-RUN add-apt-repository ppa:webupd8team/java
+# Install basic packages
 RUN apt-get update && apt-get -y install \
   autoconf \
   build-essential \
   curl \
-  wget \
   libtool \
   make \
-  openjdk-8-jdk \
-  vim
-
-#====================
-# Python dependencies
-
-# Install dependencies
-# TODO(jtattermusch): This installs python3.5. Is it even needed
-# when we install python3.6 in the next step?
-RUN apt-get update && apt-get install -y \
-    python3-all-dev
-
-#=================
-# Compile CPython 3.6.9 from source
-
-RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev && apt-get clean
-RUN apt-get update && apt-get install -y jq build-essential libffi-dev && apt-get clean
-
-RUN cd /tmp && \
-    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
-    tar xzvf Python-3.6.9.tgz && \
-    cd Python-3.6.9 && \
-    ./configure && \
-    make -j4 && \
-    make install
-
-RUN cd /tmp && \
-    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
-    md5sum -c checksum.md5
-
-RUN python3.6 -m ensurepip && \
-    python3.6 -m pip install coverage
-
+  vim \
+  wget
 
 #========================
 # Bazel installation
@@ -82,6 +48,10 @@ RUN wget "https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/b
   bash ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
   rm bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
+
+#========================
+# Java
+RUN apt-get install -y openjdk-8-jdk
 
 #========================
 # Android SDK/NDK installation


### PR DESCRIPTION
This is to get the latest clang (14) for Linux Bazel build docker image (unintentionally binder_transport_apk is affected as well). In addition to the upgrade; two things are done

- No more Python 3.6 installation (which doesn't seem to be needed anymore)
- Use `openjdk-8-jdk` ubuntu package instead of `ppa:webupd8team/java` which was deprecated
- Added `-Wno-deprecated-copy` for `use_strict_warning=true` build to silence a new clang warning coming from `googletest`.
