### PR TITLE
Fix for a racy WorkSerializer shutdown

### DIFF
--- a/src/core/lib/iomgr/work_serializer.cc
+++ b/src/core/lib/iomgr/work_serializer.cc
@@ -121,7 +121,7 @@ void WorkSerializer::WorkSerializerImpl::Orphan() {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_work_serializer_trace)) {
     gpr_log(GPR_INFO, "WorkSerializer::Orphan() %p", this);
   }
-  uint64_t prev_ref_pair =
+  const uint64_t prev_ref_pair =
       refs_.fetch_sub(MakeRefPair(0, 1), std::memory_order_acq_rel);
   if (GetOwners(prev_ref_pair) == 0 && GetSize(prev_ref_pair) == 1) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_work_serializer_trace)) {

--- a/test/core/iomgr/work_serializer_test.cc
+++ b/test/core/iomgr/work_serializer_test.cc
@@ -223,7 +223,7 @@ TEST(WorkSerializerTest, WorkSerializerDestructionRaceMultipleThreads) {
   std::vector<std::thread> threads;
   threads.reserve(50);
   for (int i = 0; i < 50; ++i) {
-    threads.emplace_back([lock, &barrier]() {
+    threads.emplace_back([lock, &barrier]() mutable {
       barrier.Block();
       lock->Run([lock]() mutable { lock.reset(); }, DEBUG_LOCATION);
     });

--- a/test/core/iomgr/work_serializer_test.cc
+++ b/test/core/iomgr/work_serializer_test.cc
@@ -19,10 +19,12 @@
 #include "src/core/lib/iomgr/work_serializer.h"
 
 #include <memory>
+#include <thread>
 
 #include <gtest/gtest.h>
 
 #include "absl/memory/memory.h"
+#include "absl/synchronization/notification.h"
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
@@ -30,6 +32,7 @@
 
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/thd.h"
+#include "src/core/lib/iomgr/executor.h"
 #include "test/core/util/test_config.h"
 
 namespace {
@@ -187,6 +190,27 @@ TEST(WorkSerializerTest, ExecuteManyMixedRunScheduleAndDrain) {
       schedule_threads.push_back(
           absl::make_unique<TestThreadScheduleAndDrain>(&lock));
     }
+  }
+}
+
+// Tests that work serializers allow destruction from the last callback
+TEST(WorkSerializerTest, CallbackDestroysWorkSerializer) {
+  auto lock = std::make_shared<grpc_core::WorkSerializer>();
+  lock->Run([&]() { lock.reset(); }, DEBUG_LOCATION);
+}
+
+// Tests additional racy conditions when the last callback triggers work
+// serializer destruction.
+TEST(WorkSerializerTest, WorkSerializerDestructionRace) {
+  for (int i = 0; i < 1000; ++i) {
+    auto lock = std::make_shared<grpc_core::WorkSerializer>();
+    absl::Notification notification;
+    std::thread t1([&]() {
+      notification.WaitForNotification();
+      lock.reset();
+    });
+    lock->Run([&]() { notification.Notify(); }, DEBUG_LOCATION);
+    t1.join();
   }
 }
 


### PR DESCRIPTION
Fixes b/217470353

The way WorkSerializer is used inside gRPC Core, it is usually destroyed by a callback that's scheduled on the same work serializer. Note that there are a few layers of indirection here, where gRPC Core creates a shared WorkSerializer object so that it can pass it around to various subsystems. Additionally, WorkSerializer itself creates an Orphanable object to WorkSerializerImpl to allow the last callback to destroy this object safely.

This race was caused by an unhandled condition where the WorkSerializerImpl object could be orphaned between the time the last callback was executed and the queue size decremented https://github.com/grpc/grpc/blob/63398540b65c775de36f1e7e370c1800aca6637d/src/core/lib/iomgr/work_serializer.cc#L162 and the point where we make sure the queue has been drained https://github.com/grpc/grpc/blob/63398540b65c775de36f1e7e370c1800aca6637d/src/core/lib/iomgr/work_serializer.cc#L177.

In such cases, we end up hitting the assert at https://source.corp.google.com/piper///depot/google3/third_party/grpc/src/core/lib/iomgr/work_serializer.cc;rcl=424645002;l=127

