### PR TITLE
Freeze benchmarks reference to test-infra repo.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -66,10 +66,12 @@ go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 
 # Fetch test-infra repository and build all tools.
-# Note: Submodules are not required for tools build.
 pushd ..
 git clone --depth 1 https://github.com/grpc/test-infra.git
 cd test-infra
+# Freeze test-infra repo to account for incompatible change.
+# See https://github.com/grpc/test-infra/pull/267.
+git checkout ce3352fe5d07f13c908748e61610914f87cd4af1
 git log -1 --oneline
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -63,11 +63,13 @@ TEST_INFRA_GOVERSION=go1.17.1
 go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 
-# Fetch test-infra repository and build all tools.
 # Note: Submodules are not required for tools build.
 pushd ..
 git clone --depth 1 https://github.com/grpc/test-infra.git
 cd test-infra
+# Freeze test-infra repo to account for incompatible change.
+# See https://github.com/grpc/test-infra/pull/267.
+git checkout ce3352fe5d07f13c908748e61610914f87cd4af1
 git log -1 --oneline
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd


### PR DESCRIPTION
Freezing reference to account for incompatible change in https://github.com/grpc/test-infra/pull/267.

Will unfreeze once loadtest templates are updated.
