### PR TITLE
[WIP][EXPERIMENTAL] Eventengine end2end test setup alternative (using sh_test)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2355,6 +2355,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_library(grpc_test_util
+  test/core/event_engine/factory.cc
   test/core/util/build.cc
   test/core/util/cmdline.cc
   test/core/util/fuzzer_util.cc
@@ -2424,6 +2425,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_library(grpc_test_util_unsecure
+  test/core/event_engine/factory.cc
   test/core/util/build.cc
   test/core/util/cmdline.cc
   test/core/util/fuzzer_util.cc
@@ -16848,6 +16850,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.grpc.pb.cc
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.pb.h
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.grpc.pb.h
+    test/core/event_engine/factory.cc
     test/core/util/build.cc
     test/core/util/cmdline.cc
     test/core/util/fuzzer_util.cc

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -1755,6 +1755,7 @@ libs:
   language: c
   public_headers: []
   headers:
+  - test/core/event_engine/factory.h
   - test/core/util/build.h
   - test/core/util/cmdline.h
   - test/core/util/evaluate_args_test_util.h
@@ -1778,6 +1779,7 @@ libs:
   - test/core/util/tls_utils.h
   - test/core/util/tracer_util.h
   src:
+  - test/core/event_engine/factory.cc
   - test/core/util/build.cc
   - test/core/util/cmdline.cc
   - test/core/util/fuzzer_util.cc
@@ -1810,6 +1812,7 @@ libs:
   language: c
   public_headers: []
   headers:
+  - test/core/event_engine/factory.h
   - test/core/util/build.h
   - test/core/util/cmdline.h
   - test/core/util/evaluate_args_test_util.h
@@ -1832,6 +1835,7 @@ libs:
   - test/core/util/test_tcp_server.h
   - test/core/util/tracer_util.h
   src:
+  - test/core/event_engine/factory.cc
   - test/core/util/build.cc
   - test/core/util/cmdline.cc
   - test/core/util/fuzzer_util.cc
@@ -8502,6 +8506,7 @@ targets:
   build: test
   language: c++
   headers:
+  - test/core/event_engine/factory.h
   - test/core/util/build.h
   - test/core/util/cmdline.h
   - test/core/util/evaluate_args_test_util.h
@@ -8527,6 +8532,7 @@ targets:
   - src/proto/grpc/testing/echo.proto
   - src/proto/grpc/testing/echo_messages.proto
   - src/proto/grpc/testing/simple_messages.proto
+  - test/core/event_engine/factory.cc
   - test/core/util/build.cc
   - test/core/util/cmdline.cc
   - test/core/util/fuzzer_util.cc

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -2522,6 +2522,8 @@ Pod::Spec.new do |s|
                       'test/core/end2end/tests/trailing_metadata.cc',
                       'test/core/end2end/tests/write_buffering.cc',
                       'test/core/end2end/tests/write_buffering_at_end.cc',
+                      'test/core/event_engine/factory.cc',
+                      'test/core/event_engine/factory.h',
                       'test/core/util/build.cc',
                       'test/core/util/build.h',
                       'test/core/util/cmdline.cc',

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -1165,6 +1165,7 @@
         'grpc',
       ],
       'sources': [
+        'test/core/event_engine/factory.cc',
         'test/core/util/build.cc',
         'test/core/util/cmdline.cc',
         'test/core/util/fuzzer_util.cc',
@@ -1199,6 +1200,7 @@
         'grpc_unsecure',
       ],
       'sources': [
+        'test/core/event_engine/factory.cc',
         'test/core/util/build.cc',
         'test/core/util/cmdline.cc',
         'test/core/util/fuzzer_util.cc',

--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -16,7 +16,10 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_p
 
 licenses(["notice"])
 
-grpc_package(name = "test/core/event_engine")
+grpc_package(
+    name = "test/core/event_engine",
+    visibility = "tests",
+)
 
 grpc_cc_test(
     name = "endpoint_config_test",
@@ -58,4 +61,12 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+)
+
+grpc_cc_library(
+    name = "event_engine_test_factory",
+    srcs = ["factory.cc"],
+    hdrs = ["factory.h"],
+    deps = ["//:event_engine_base"],
+    language = "C++",
 )

--- a/test/core/event_engine/factory.cc
+++ b/test/core/event_engine/factory.cc
@@ -1,0 +1,45 @@
+// Copyright 2022 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <grpc/support/port_platform.h>
+
+#include "test/core/event_engine/factory.h"
+
+#include "src/core/lib/event_engine/event_engine_factory.h"
+#include "src/core/lib/gpr/string.h"
+
+GPR_GLOBAL_CONFIG_DEFINE_STRING(
+    testonly_grpc_eventengine_strategy, "default",
+    "Declares which EventEngine to use with gRPC tests.")
+
+namespace grpc_event_engine {
+namespace experimental {
+
+void InitTestEventEngineFactory() {
+  grpc_core::UniquePtr<char> engine_name =
+      GPR_GLOBAL_CONFIG_GET(testonly_grpc_eventengine_strategy);
+  if (strlen(engine_name.get()) == 0 ||
+      gpr_stricmp("default", engine_name.get()) == 0) {
+    // Set the default EventEngine factory
+    // TODO(hork): SetDefaultEventEngineFactory(LibuvEventEngineFactory)
+    gpr_log(GPR_DEBUG, "Libuv EventEngine initialized.");
+  } else {
+    gpr_log(GPR_ERROR,
+            "Invalid EventEngine '%s'. See doc/environment_variables.md",
+            engine_name.get());
+    GPR_ASSERT(false);
+  }
+}
+
+}  // namespace experimental
+}  // namespace grpc_event_engine

--- a/test/core/event_engine/factory.h
+++ b/test/core/event_engine/factory.h
@@ -1,0 +1,35 @@
+// Copyright 2022 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <grpc/support/port_platform.h>
+
+#ifndef GRPC_CORE_LIB_EVENT_ENGINE_INIT_H
+#define GRPC_CORE_LIB_EVENT_ENGINE_INIT_H
+
+#include <grpc/event_engine/event_engine.h>
+
+#include "src/core/lib/gprpp/global_config.h"
+
+GPR_GLOBAL_CONFIG_DECLARE_STRING(testonly_grpc_eventengine_strategy);
+
+namespace grpc_event_engine {
+namespace experimental {
+
+// Sets different EventEngine factories based on the
+// TESTONLY_GRPC_EVENTENGINE_STRATEGY environment variable.
+void InitTestEventEngineFactory();
+
+}  // namespace experimental
+}  // namespace grpc_event_engine
+
+#endif  // GRPC_CORE_LIB_EVENT_ENGINE_INIT_H

--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -87,6 +87,7 @@ grpc_cc_library(
         "//:gpr",
         "//:grpc_base",
         "//:grpc_common",
+        "//test/core/event_engine:event_engine_test_factory",
     ],
 )
 

--- a/test/core/util/run_with_poller.sh
+++ b/test/core/util/run_with_poller.sh
@@ -14,6 +14,4 @@
 # limitations under the License.
 
 set -ex
-export GRPC_POLL_STRATEGY=$1
-shift
 "$@"

--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -33,6 +33,7 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
+#include "test/core/event_engine/factory.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/examine_stack.h"
@@ -92,9 +93,10 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms) {
 
 void grpc_test_init(int /*argc*/, char** argv) {
   grpc_core::testing::InitializeStackTracer(argv[0]);
+  gpr_log_verbosity_init();
+  grpc_event_engine::experimental::InitTestEventEngineFactory();
   absl::FailureSignalHandlerOptions options;
   absl::InstallFailureSignalHandler(options);
-  gpr_log_verbosity_init();
   gpr_log(GPR_DEBUG,
           "test slowdown factor: sanitizer=%" PRId64 ", fixture=%" PRId64
           ", poller=%" PRId64 ", total=%" PRId64,


### PR DESCRIPTION
Forked from https://github.com/grpc/grpc/pull/28667 in case the RBE oddities continue to be troublesome. Better to have a working solution than a perfect one.

Known EventEngines can be exercised in tests using the environment variable `TESTONLY_GRPC_EVENTENGINE_STRATEGY=<name>`. This variable is only used in `grpc_test_init`, and does not affect production gRPC code. The gRPC build system automatically generates all permutations of tests x engines for relevant tests.