### PR TITLE
Fix build & test errors when `GRPC_ERROR_IS_ABSEIL_STATUS` enabled.

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -691,8 +691,7 @@ static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
         hr->qtype, hr->host, hr->is_balancer, ares_strerror(status));
     GRPC_CARES_TRACE_LOG("request:%p on_hostbyname_done_locked: %s", r,
                          error_msg.c_str());
-    grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error_msg));
+    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(error_msg);
     r->error = grpc_error_add_child(error, r->error);
   }
   destroy_hostbyname_request_locked(hr);
@@ -739,8 +738,7 @@ static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
         ares_strerror(status));
     GRPC_CARES_TRACE_LOG("request:%p on_srv_query_done_locked: %s", r,
                          error_msg.c_str());
-    grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error_msg));
+    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(error_msg);
     r->error = grpc_error_add_child(error, r->error);
   }
   delete q;
@@ -802,7 +800,7 @@ fail:
                       q->name(), ares_strerror(status));
   GRPC_CARES_TRACE_LOG("request:%p on_txt_done_locked %s", r,
                        error_msg.c_str());
-  error = GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error_msg));
+  error = GRPC_ERROR_CREATE_FROM_CPP_STRING(error_msg);
   r->error = grpc_error_add_child(error, r->error);
 }
 

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -947,7 +947,7 @@ grpc_error_handle Chttp2ServerAddPort(Server* server, const char* addr,
     }
     return GRPC_ERROR_NONE;
   }();  // lambda end
-  for (grpc_error_handle error : error_list) {
+  for (const grpc_error_handle& error : error_list) {
     GRPC_ERROR_UNREF(error);
   }
   grpc_channel_args_destroy(args);

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -1199,9 +1199,9 @@ bool XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked() {
           result.type_url.c_str(), result.version.c_str(), state.nonce.c_str(),
           error.c_str());
       GRPC_ERROR_UNREF(state.error);
-      state.error = grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_CPP_STRING(std::move(error)),
-          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
+      state.error = grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(error),
+                                       GRPC_ERROR_INT_GRPC_STATUS,
+                                       GRPC_STATUS_UNAVAILABLE);
     }
     // Delete resources not seen in update if needed.
     if (result.type->AllResourcesRequiredInSotW()) {

--- a/src/core/lib/gprpp/debug_location.h
+++ b/src/core/lib/gprpp/debug_location.h
@@ -42,6 +42,8 @@ class DebugLocation {
 #else
 class DebugLocation {
  public:
+  DebugLocation() {}
+  DebugLocation(const char* /* file */, int /* line */) {}
   const char* file() const { return nullptr; }
   int line() const { return -1; }
 };

--- a/src/core/lib/iomgr/ev_apple.cc
+++ b/src/core/lib/iomgr/ev_apple.cc
@@ -313,7 +313,7 @@ static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
   GrpcApplePollset* apple_pollset =
       reinterpret_cast<GrpcApplePollset*>(pollset);
   apple_pollset->is_shutdown = true;
-  pollset_kick(pollset, GRPC_POLLSET_KICK_BROADCAST);
+  (void)pollset_kick(pollset, GRPC_POLLSET_KICK_BROADCAST);
 
   // If there is any worker blocked, shutdown will be done asynchronously.
   if (apple_pollset->workers.empty()) {

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -262,9 +262,9 @@ TEST(XdsBootstrapTest, MissingChannelCreds) {
   Json json = Json::Parse(json_str, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
   XdsBootstrap bootstrap(std::move(json), &error);
-  EXPECT_THAT(grpc_error_std_string(error),
-              ::testing::ContainsRegex(
-                  "\"field:channel_creds error:does not exist.\""));
+  EXPECT_THAT(
+      grpc_error_std_string(error),
+      ::testing::ContainsRegex("field:channel_creds error:does not exist."));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -335,7 +335,7 @@ TEST(XdsBootstrapTest, XdsServerMissingServerUri) {
       ::testing::ContainsRegex("errors parsing \"xds_servers\" array.*"
                                "errors parsing index 0.*"
                                "errors parsing xds server.*"
-                               "\"field:server_uri error:does not exist.\","));
+                               "field:server_uri error:does not exist."));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -358,8 +358,8 @@ TEST(XdsBootstrapTest, XdsServerUriAndCredsWrongTypes) {
                   "errors parsing \"xds_servers\" array.*"
                   "errors parsing index 0.*"
                   "errors parsing xds server.*"
-                  "\"field:server_uri error:type should be STRING.*"
-                  "\"field:channel_creds error:type should be ARRAY\""));
+                  "field:server_uri error:type should be STRING.*"
+                  "field:channel_creds error:type should be ARRAY"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -389,8 +389,8 @@ TEST(XdsBootstrapTest, ChannelCredsFieldsWrongTypes) {
                                "errors parsing xds server.*"
                                "errors parsing \"channel_creds\" array.*"
                                "errors parsing index 0.*"
-                               "\"field:type error:type should be STRING.*"
-                               "\"field:config error:type should be OBJECT\""));
+                               "field:type error:type should be STRING.*"
+                               "field:config error:type should be OBJECT"));
   GRPC_ERROR_UNREF(error);
 }
 
@@ -555,7 +555,7 @@ TEST(XdsBootstrapTest, AuthorityXdsServerInvalidResourceTemplate) {
   EXPECT_THAT(grpc_error_std_string(error),
               ::testing::ContainsRegex(
                   "errors parsing \"authorities\".*"
-                  "errors parsing authority xds.example.com\".*"
+                  "errors parsing authority xds.example.com.*"
                   "field must begin with \"xdstp://xds.example.com/\""));
   GRPC_ERROR_UNREF(error);
   gpr_unsetenv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
@@ -587,11 +587,11 @@ TEST(XdsBootstrapTest, AuthorityXdsServerMissingServerUri) {
   EXPECT_THAT(
       grpc_error_std_string(error),
       ::testing::ContainsRegex("errors parsing \"authorities\".*"
-                               "errors parsing authority xds.example.com\".*"
+                               "errors parsing authority xds.example.com.*"
                                "errors parsing \"xds_servers\" array.*"
                                "errors parsing index 0.*"
                                "errors parsing xds server.*"
-                               "\"field:server_uri error:does not exist.\","));
+                               "field:server_uri error:does not exist."));
   GRPC_ERROR_UNREF(error);
   gpr_unsetenv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
 }


### PR DESCRIPTION
From https://github.com/grpc/grpc/pull/27376, followings updates are made to address those errors.

- Changed the expected string of errors a bit in `xds_bootstrap_test` because `grpc_error` and `absl::Status` have slightly different string representations.
- Fixed the clang-tidy issue mainly around `std::move`.
- Added a new ctor to `DebugLocation` for the non-debug build so that manually created `DebugLocation` with given `file` and `line` can be built regardless of build config.