### PR TITLE
Added iproute2 to grpc_flaky_network_in_docker.sh

### DIFF
--- a/tools/internal_ci/linux/grpc_flaky_network_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_flaky_network_in_docker.sh
@@ -26,6 +26,6 @@ ${name}')
 cd /var/local/git/grpc/test/cpp/end2end
 
 # iptables is used to drop traffic between client and server
-apt-get install -y iptables
+apt-get install -y iptables iproute2
 
 bazel test --test_output=all --test_timeout=1200 :flaky_network_test --test_env=GRPC_TRACE=http --test_env=GRPC_VERBOSITY=DEBUG


### PR DESCRIPTION
To fix `ip: not found` error ([log](https://source.cloud.google.com/results/invocations/bb3ad4db-d2a4-482b-9d44-16da7856a975/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_flaky_network/log)) introduced by https://github.com/grpc/grpc/pull/28768
