### PR TITLE
Bump the minimum gcc to 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ BUILD_WITH_SYSTEM_RE2 = _env_bool_value('GRPC_PYTHON_BUILD_SYSTEM_RE2', 'False')
 # without statically linking libstdc++ (which leads to a slight increase in the wheel size).
 # This option is useful when crosscompiling wheels for aarch64 where
 # it's difficult to ensure that the crosscompilation toolchain has a high-enough version
-# of GCC (we require >4.9) but still uses old-enough libstdc++ symbols.
+# of GCC (we require >=5.1) but still uses old-enough libstdc++ symbols.
 # TODO(jtattermusch): remove this workaround once issues with crosscompiler version are resolved.
 BUILD_WITH_STATIC_LIBSTDCXX = _env_bool_value(
     'GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX', 'False')

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -27,10 +27,10 @@ Therefore, gRPC supports several major build systems, which should satisfy most 
 
 | Operating System | Architectures | Versions | Support Level |
 |------------------|---------------|----------|---------------|
-| Linux - Debian, Ubuntu, CentOS | x86, x64      | clang 4+, GCC 4.9+     | Officially Supported |
+| Linux - Debian, Ubuntu, CentOS | x86, x64      | clang 4+, GCC 5.1+     | Officially Supported |
 | Windows 10+                    | x86, x64      | Visual Studio 2015+    | Officially Supported |
 | MacOS                          | x86, x64      | XCode 7.2+             | Officially Supported |
-| Linux - Others                 | x86, x64      | clang 4+, GCC 4.9+     | Best Effort          |
+| Linux - Others                 | x86, x64      | clang 4+, GCC 5.1+     | Best Effort          |
 | Linux                          | ARM           |                        | Best Effort          |
 | iOS                            |               |                        | Best Effort          |
 | Android                        |               |                        | Best Effort          |

--- a/templates/tools/dockerfile/test/cxx_gcc_5_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_gcc_5_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM gcc:4.9
+  FROM gcc:5
   
   RUN apt-get update && apt-get install -y curl git time wget zip && apt-get clean
   <%include file="../../run_tests_python_deps.include"/>

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -77,7 +77,7 @@ BUILD_WITH_CYTHON = _env_bool_value('GRPC_PYTHON_BUILD_WITH_CYTHON', 'False')
 # without statically linking libstdc++ (which leads to a slight increase in the wheel size).
 # This option is useful when crosscompiling wheels for aarch64 where
 # it's difficult to ensure that the crosscompilation toolchain has a high-enough version
-# of GCC (we require >4.9) but still uses old-enough libstdc++ symbols.
+# of GCC (we require >=5.1) but still uses old-enough libstdc++ symbols.
 # TODO(jtattermusch): remove this workaround once issues with crosscompiler version are resolved.
 BUILD_WITH_STATIC_LIBSTDCXX = _env_bool_value(
     'GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX', 'False')

--- a/tools/dockerfile/distribtest/python_dev_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_centos7_x64/Dockerfile
@@ -21,7 +21,7 @@ RUN yum install -y python3-pip
 RUN python3 -m pip install --upgrade pip==19.3.1
 RUN python3 -m pip install -U virtualenv
 
-# The default gcc of CentOS 7 is gcc 4.8 which is older than gcc 4.9,
+# The default gcc of CentOS 7 is gcc 4.8 which is older than gcc 5.1,
 # the minimum supported gcc version for gRPC Core so let's upgrade to
 # the oldest one that can build gRPC on Centos 7.
 RUN yum install -y centos-release-scl

--- a/tools/dockerfile/test/cxx_gcc_5_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_5_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcc:4.9
+FROM gcc:5
 
 RUN apt-get update && apt-get install -y curl git time wget zip && apt-get clean
 #====================

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -452,8 +452,8 @@ class CLanguage(object):
 
         if compiler == 'default' or compiler == 'cmake':
             return ('debian11', [])
-        elif compiler == 'gcc4.9':
-            return ('gcc_4.9', [])
+        elif compiler == 'gcc5':
+            return ('gcc_5', [])
         elif compiler == 'gcc10.2':
             return ('debian11', [])
         elif compiler == 'gcc10.2_openssl102':
@@ -1526,7 +1526,7 @@ argp.add_argument(
     '--compiler',
     choices=[
         'default',
-        'gcc4.9',
+        'gcc5',
         'gcc10.2',
         'gcc10.2_openssl102',
         'gcc11',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -266,7 +266,7 @@ def _create_portability_test_jobs(extra_args=[],
 
     # portability C and C++ on x64
     for compiler in [
-            'gcc4.9', 'gcc10.2_openssl102', 'gcc11', 'gcc_musl', 'clang4',
+            'gcc5', 'gcc10.2_openssl102', 'gcc11', 'gcc_musl', 'clang4',
             'clang13'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],


### PR DESCRIPTION
Debian 8 bundled with gcc 4.9 reached EOL in 2020 and the latest Abseil / googletest library also dropped the support to gcc 4.9 already so gRPC needs to / has to bump the gcc version to 5.1 in line with them.