### PR TITLE
C# Remove msg class constraint

### DIFF
--- a/src/csharp/Grpc.Core.Api/AsyncStreamReaderExtensions.cs
+++ b/src/csharp/Grpc.Core.Api/AsyncStreamReaderExtensions.cs
@@ -37,7 +37,6 @@ namespace Grpc.Core
         /// to the next element; false if the reader has passed the end of the sequence.
         /// </returns>
         public static Task<bool> MoveNext<T>(this IAsyncStreamReader<T> streamReader)
-            where T : class
         {
             if (streamReader == null)
             {

--- a/src/csharp/Grpc.Core.Api/CallInvoker.cs
+++ b/src/csharp/Grpc.Core.Api/CallInvoker.cs
@@ -28,40 +28,30 @@ namespace Grpc.Core
         /// <summary>
         /// Invokes a simple remote call in a blocking fashion.
         /// </summary>
-        public abstract TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request)
-            where TRequest : class
-            where TResponse : class;
+        public abstract TResponse BlockingUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request);
 
         /// <summary>
         /// Invokes a simple remote call asynchronously.
         /// </summary>
-        public abstract AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request)
-            where TRequest : class
-            where TResponse : class;
+        public abstract AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request);
 
         /// <summary>
         /// Invokes a server streaming call asynchronously.
         /// In server streaming scenario, client sends on request and server responds with a stream of responses.
         /// </summary>
-        public abstract AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request)
-            where TRequest : class
-            where TResponse : class;
+        public abstract AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options, TRequest request);
 
         /// <summary>
         /// Invokes a client streaming call asynchronously.
         /// In client streaming scenario, client sends a stream of requests and server responds with a single response.
         /// </summary>
-        public abstract AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options)
-            where TRequest : class
-            where TResponse : class;
+        public abstract AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options);
 
         /// <summary>
         /// Invokes a duplex streaming call asynchronously.
         /// In duplex streaming scenario, client sends a stream of requests and server responds with a stream of responses.
         /// The response stream is completely independent and both side can be sending messages at the same time.
         /// </summary>
-        public abstract AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options)
-            where TRequest : class
-            where TResponse : class;
+        public abstract AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string? host, CallOptions options);
     }
 }

--- a/src/csharp/Grpc.Core.Api/ClientBase.cs
+++ b/src/csharp/Grpc.Core.Api/ClientBase.cs
@@ -162,8 +162,6 @@ namespace Grpc.Core
                 }
 
                 private ClientInterceptorContext<TRequest, TResponse> GetNewContext<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context)
-                    where TRequest : class
-                    where TResponse : class
                 {
                     var newHostAndCallOptions = interceptor(context.Method, context.Host, context.Options);
                     return new ClientInterceptorContext<TRequest, TResponse>(context.Method, newHostAndCallOptions.Host, newHostAndCallOptions.CallOptions);

--- a/src/csharp/Grpc.Core.Api/Interceptors/CallInvokerExtensions.cs
+++ b/src/csharp/Grpc.Core.Api/Interceptors/CallInvokerExtensions.cs
@@ -107,8 +107,6 @@ namespace Grpc.Core.Interceptors
             }
 
             private ClientInterceptorContext<TRequest, TResponse> GetNewContext<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context)
-                where TRequest : class
-                where TResponse : class
             {
                 var metadata = context.Options.Headers ?? new Metadata();
                 return new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, context.Options.WithHeaders(interceptor(metadata)));

--- a/src/csharp/Grpc.Core.Api/Interceptors/ClientInterceptorContext.cs
+++ b/src/csharp/Grpc.Core.Api/Interceptors/ClientInterceptorContext.cs
@@ -27,8 +27,6 @@ namespace Grpc.Core.Interceptors
     /// Carries along the context associated with intercepted invocations on the client side.
     /// </summary>
     public struct ClientInterceptorContext<TRequest, TResponse>
-        where TRequest : class
-        where TResponse : class
     {
         /// <summary>
         /// Creates a new instance of <see cref="Grpc.Core.Interceptors.ClientInterceptorContext{TRequest, TResponse}" />

--- a/src/csharp/Grpc.Core.Api/Interceptors/Interceptor.cs
+++ b/src/csharp/Grpc.Core.Api/Interceptors/Interceptor.cs
@@ -49,9 +49,7 @@ namespace Grpc.Core.Interceptors
         /// The interceptor can choose to return the return value of the
         /// continuation delegate or an arbitrary value as it sees fit.
         /// </returns>
-        public delegate TResponse BlockingUnaryCallContinuation<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context)
-            where TRequest : class
-            where TResponse : class;
+        public delegate TResponse BlockingUnaryCallContinuation<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context);
 
         /// <summary>
         /// Represents a continuation for intercepting simple asynchronous invocations.
@@ -75,9 +73,7 @@ namespace Grpc.Core.Interceptors
         /// The interceptor can choose to return the same object returned from
         /// the continuation delegate or an arbitrarily constructed instance as it sees fit.
         /// </returns>
-        public delegate AsyncUnaryCall<TResponse> AsyncUnaryCallContinuation<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context)
-            where TRequest : class
-            where TResponse : class;
+        public delegate AsyncUnaryCall<TResponse> AsyncUnaryCallContinuation<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context);
 
         /// <summary>
         /// Represents a continuation for intercepting asynchronous server-streaming invocations.
@@ -101,9 +97,7 @@ namespace Grpc.Core.Interceptors
         /// The interceptor can choose to return the same object returned from
         /// the continuation delegate or an arbitrarily constructed instance as it sees fit.
         /// </returns>
-        public delegate AsyncServerStreamingCall<TResponse> AsyncServerStreamingCallContinuation<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context)
-            where TRequest : class
-            where TResponse : class;
+        public delegate AsyncServerStreamingCall<TResponse> AsyncServerStreamingCallContinuation<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context);
 
         /// <summary>
         /// Represents a continuation for intercepting asynchronous client-streaming invocations.
@@ -126,9 +120,7 @@ namespace Grpc.Core.Interceptors
         /// The interceptor can choose to return the same object returned from
         /// the continuation delegate or an arbitrarily constructed instance as it sees fit.
         /// </returns>
-        public delegate AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCallContinuation<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context)
-            where TRequest : class
-            where TResponse : class;
+        public delegate AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCallContinuation<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context);
 
         /// <summary>
         /// Represents a continuation for intercepting asynchronous duplex invocations.
@@ -149,9 +141,7 @@ namespace Grpc.Core.Interceptors
         /// The interceptor can choose to return the same object returned from
         /// the continuation delegate or an arbitrarily constructed instance as it sees fit.
         /// </returns>
-        public delegate AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCallContinuation<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context)
-            where TRequest : class
-            where TResponse : class;
+        public delegate AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCallContinuation<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context);
 
         /// <summary>
         /// Intercepts a blocking invocation of a simple remote call.
@@ -174,8 +164,6 @@ namespace Grpc.Core.Interceptors
         /// value as it sees fit.
         /// </returns>
         public virtual TResponse BlockingUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, BlockingUnaryCallContinuation<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(request, context);
         }
@@ -202,8 +190,6 @@ namespace Grpc.Core.Interceptors
         /// own substitute as it sees fit.
         /// </returns>
         public virtual AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(request, context);
         }
@@ -230,8 +216,6 @@ namespace Grpc.Core.Interceptors
         /// own substitute as it sees fit.
         /// </returns>
         public virtual AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(request, context);
         }
@@ -257,8 +241,6 @@ namespace Grpc.Core.Interceptors
         /// own substitute as it sees fit.
         /// </returns>
         public virtual AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context, AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(context);
         }
@@ -284,8 +266,6 @@ namespace Grpc.Core.Interceptors
         /// own substitute as it sees fit.
         /// </returns>
         public virtual AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context, AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(context);
         }
@@ -313,8 +293,6 @@ namespace Grpc.Core.Interceptors
         /// or an arbitrary response value as it sees fit.
         /// </returns>
         public virtual Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(request, context);
         }
@@ -344,8 +322,6 @@ namespace Grpc.Core.Interceptors
         /// the continuation.
         /// </returns>
         public virtual Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context, ClientStreamingServerMethod<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(requestStream, context);
         }
@@ -370,8 +346,6 @@ namespace Grpc.Core.Interceptors
         /// when calling the continuation.
         /// </param>
         public virtual Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, ServerStreamingServerMethod<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(request, responseStream, context);
         }
@@ -396,8 +370,6 @@ namespace Grpc.Core.Interceptors
         /// when calling the continuation.
         /// </param>
         public virtual Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, DuplexStreamingServerMethod<TRequest, TResponse> continuation)
-            where TRequest : class
-            where TResponse : class
         {
             return continuation(requestStream, responseStream, context);
         }

--- a/src/csharp/Grpc.Core.Api/ServerMethods.cs
+++ b/src/csharp/Grpc.Core.Api/ServerMethods.cs
@@ -25,34 +25,26 @@ namespace Grpc.Core
     /// </summary>
     /// <typeparam name="TRequest">Request message type for this method.</typeparam>
     /// <typeparam name="TResponse">Response message type for this method.</typeparam>
-    public delegate Task<TResponse> UnaryServerMethod<TRequest, TResponse>(TRequest request, ServerCallContext context)
-        where TRequest : class
-        where TResponse : class;
+    public delegate Task<TResponse> UnaryServerMethod<TRequest, TResponse>(TRequest request, ServerCallContext context);
 
     /// <summary>
     /// Server-side handler for client streaming call.
     /// </summary>
     /// <typeparam name="TRequest">Request message type for this method.</typeparam>
     /// <typeparam name="TResponse">Response message type for this method.</typeparam>
-    public delegate Task<TResponse> ClientStreamingServerMethod<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context)
-        where TRequest : class
-        where TResponse : class;
+    public delegate Task<TResponse> ClientStreamingServerMethod<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context);
 
     /// <summary>
     /// Server-side handler for server streaming call.
     /// </summary>
     /// <typeparam name="TRequest">Request message type for this method.</typeparam>
     /// <typeparam name="TResponse">Response message type for this method.</typeparam>
-    public delegate Task ServerStreamingServerMethod<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context)
-        where TRequest : class
-        where TResponse : class;
+    public delegate Task ServerStreamingServerMethod<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context);
 
     /// <summary>
     /// Server-side handler for bidi streaming call.
     /// </summary>
     /// <typeparam name="TRequest">Request message type for this method.</typeparam>
     /// <typeparam name="TResponse">Response message type for this method.</typeparam>
-    public delegate Task DuplexStreamingServerMethod<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context)
-        where TRequest : class
-        where TResponse : class;
+    public delegate Task DuplexStreamingServerMethod<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context);
 }

--- a/src/csharp/Grpc.Core.Api/ServerServiceDefinition.cs
+++ b/src/csharp/Grpc.Core.Api/ServerServiceDefinition.cs
@@ -83,8 +83,6 @@ namespace Grpc.Core
             public Builder AddMethod<TRequest, TResponse>(
                 Method<TRequest, TResponse> method,
                 UnaryServerMethod<TRequest, TResponse> handler)
-                    where TRequest : class
-                    where TResponse : class
             {
                 duplicateDetector.Add(method.FullName, null);
                 addMethodActions.Add((serviceBinder) => serviceBinder.AddMethod(method, handler));
@@ -102,8 +100,6 @@ namespace Grpc.Core
             public Builder AddMethod<TRequest, TResponse>(
                 Method<TRequest, TResponse> method,
                 ClientStreamingServerMethod<TRequest, TResponse> handler)
-                    where TRequest : class
-                    where TResponse : class
             {
                 duplicateDetector.Add(method.FullName, null);
                 addMethodActions.Add((serviceBinder) => serviceBinder.AddMethod(method, handler));
@@ -121,8 +117,6 @@ namespace Grpc.Core
             public Builder AddMethod<TRequest, TResponse>(
                 Method<TRequest, TResponse> method,
                 ServerStreamingServerMethod<TRequest, TResponse> handler)
-                    where TRequest : class
-                    where TResponse : class
             {
                 duplicateDetector.Add(method.FullName, null);
                 addMethodActions.Add((serviceBinder) => serviceBinder.AddMethod(method, handler));
@@ -140,8 +134,6 @@ namespace Grpc.Core
             public Builder AddMethod<TRequest, TResponse>(
                 Method<TRequest, TResponse> method,
                 DuplexStreamingServerMethod<TRequest, TResponse> handler)
-                    where TRequest : class
-                    where TResponse : class
             {
                 duplicateDetector.Add(method.FullName, null);
                 addMethodActions.Add((serviceBinder) => serviceBinder.AddMethod(method, handler));

--- a/src/csharp/Grpc.Core.Api/ServiceBinderBase.cs
+++ b/src/csharp/Grpc.Core.Api/ServiceBinderBase.cs
@@ -41,8 +41,6 @@ namespace Grpc.Core
         public virtual void AddMethod<TRequest, TResponse>(
             Method<TRequest, TResponse> method,
             UnaryServerMethod<TRequest, TResponse> handler)
-                where TRequest : class
-                where TResponse : class
         {
             throw new NotImplementedException();
         }
@@ -57,8 +55,6 @@ namespace Grpc.Core
         public virtual void AddMethod<TRequest, TResponse>(
             Method<TRequest, TResponse> method,
             ClientStreamingServerMethod<TRequest, TResponse> handler)
-                where TRequest : class
-                where TResponse : class
         {
             throw new NotImplementedException();
         }
@@ -73,8 +69,6 @@ namespace Grpc.Core
         public virtual void AddMethod<TRequest, TResponse>(
             Method<TRequest, TResponse> method,
             ServerStreamingServerMethod<TRequest, TResponse> handler)
-                where TRequest : class
-                where TResponse : class
         {
             throw new NotImplementedException();
         }
@@ -89,8 +83,6 @@ namespace Grpc.Core
         public virtual void AddMethod<TRequest, TResponse>(
             Method<TRequest, TResponse> method,
             DuplexStreamingServerMethod<TRequest, TResponse> handler)
-                where TRequest : class
-                where TResponse : class
         {
             throw new NotImplementedException();
         }

--- a/src/csharp/Grpc.Core.Tests/ClientServerTestValueType.cs
+++ b/src/csharp/Grpc.Core.Tests/ClientServerTestValueType.cs
@@ -1,0 +1,408 @@
+#region Copyright notice and license
+
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Profiling;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    public class ClientServerTestValueType // inspired from ClientServerTest
+    {
+        const string Host = "127.0.0.1";
+
+        MockServiceHelperWrappedString helper;
+        Server server;
+        Channel channel;
+
+        [SetUp]
+        public void Init()
+        {
+            helper = new MockServiceHelperWrappedString(Host);
+            server = helper.GetServer();
+            server.Start();
+            channel = helper.GetChannel();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            channel.ShutdownAsync().Wait();
+            server.ShutdownAsync().Wait();
+        }
+
+        [Test]
+        public async Task UnaryCall()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                return Task.FromResult(request);
+            });
+
+            Assert.AreEqual("ABC", Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "ABC"));
+
+            Assert.AreEqual("ABC", await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "ABC"));
+
+            Assert.AreEqual("ABC", await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "ABC").ConfigureAwait(false));
+        }
+
+        [Test]
+        public void UnaryCall_ServerHandlerThrows()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                throw new Exception("This was thrown on purpose by a test");
+            });
+                
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unknown, ex.Status.StatusCode); 
+
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unknown, ex2.Status.StatusCode);
+        }
+
+        [Test]
+        public void UnaryCall_ServerHandlerThrowsRpcException()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                throw new RpcException(new Status(StatusCode.Unauthenticated, ""));
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex.Status.StatusCode);
+            Assert.AreEqual(0, ex.Trailers.Count);
+
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex2.Status.StatusCode);
+            Assert.AreEqual(0, ex.Trailers.Count);
+        }
+
+        [Test]
+        public void UnaryCall_ServerHandlerThrowsRpcExceptionWithTrailers()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                var trailers = new Metadata { {"xyz", "xyz-value"} };
+                throw new RpcException(new Status(StatusCode.Unauthenticated, ""), trailers);
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex.Status.StatusCode);
+            Assert.AreEqual(1, ex.Trailers.Count);
+            Assert.AreEqual("xyz", ex.Trailers[0].Key);
+            Assert.AreEqual("xyz-value", ex.Trailers[0].Value);
+
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex2.Status.StatusCode);
+            Assert.AreEqual(1, ex2.Trailers.Count);
+            Assert.AreEqual("xyz", ex2.Trailers[0].Key);
+            Assert.AreEqual("xyz-value", ex2.Trailers[0].Value);
+        }
+
+        [Test]
+        public void UnaryCall_ServerHandlerSetsStatus()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                context.Status = new Status(StatusCode.Unauthenticated, "");
+                return Task.FromResult<WrappedString>("");
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex.Status.StatusCode);
+            Assert.AreEqual(0, ex.Trailers.Count);
+
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex2.Status.StatusCode);
+            Assert.AreEqual(0, ex2.Trailers.Count);
+        }
+
+        [Test]
+        public void UnaryCall_StatusDebugErrorStringNotTransmittedFromServer()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                context.Status = new Status(StatusCode.Unauthenticated, "", new CoreErrorDetailException("this DebugErrorString value should not be transmitted to the client"));
+                return Task.FromResult<WrappedString>("");
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex.Status.StatusCode);
+            StringAssert.Contains("Error received from peer", ex.Status.DebugException.Message, "Is \"Error received from peer\" still a valid substring to search for in the client-generated error message from C-core?");
+            Assert.AreEqual(0, ex.Trailers.Count);
+
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex2.Status.StatusCode);
+            StringAssert.Contains("Error received from peer", ex2.Status.DebugException.Message, "Is \"Error received from peer\" still a valid substring to search for in the client-generated error message from C-core?");
+            Assert.AreEqual(0, ex2.Trailers.Count);
+        }
+
+        [Test]
+        public void UnaryCall_ServerHandlerSetsStatusAndTrailers()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                context.Status = new Status(StatusCode.Unauthenticated, "");
+                context.ResponseTrailers.Add("xyz", "xyz-value");
+                return Task.FromResult<WrappedString>("");
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex.Status.StatusCode);
+            Assert.AreEqual(1, ex.Trailers.Count);
+            Assert.AreEqual("xyz", ex.Trailers[0].Key);
+            Assert.AreEqual("xyz-value", ex.Trailers[0].Value);
+
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex2.Status.StatusCode);
+            Assert.AreEqual(1, ex2.Trailers.Count);
+            Assert.AreEqual("xyz", ex2.Trailers[0].Key);
+            Assert.AreEqual("xyz-value", ex2.Trailers[0].Value);
+        }
+
+        [Test]
+        public async Task ClientStreamingCall()
+        {
+            helper.ClientStreamingHandler = new ClientStreamingServerMethod<WrappedString, WrappedString>(async (requestStream, context) =>
+            {
+                string result = "";
+                await requestStream.ForEachAsync((request) =>
+                {
+                    result += request;
+                    return TaskUtils.CompletedTask;
+                });
+                await Task.Delay(100);
+                return result;
+            });
+
+            {
+                var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall());
+                await call.RequestStream.WriteAllAsync(new WrappedString[] { "A", "B", "C" });
+                Assert.AreEqual("ABC", await call);
+                Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+                Assert.IsNotNull(call.GetTrailers());
+            }
+
+            {
+                var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall());
+                await call.RequestStream.WriteAllAsync(new WrappedString[] { "A", "B", "C" });
+                Assert.AreEqual("ABC", await call.ConfigureAwait(false));
+                Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+                Assert.IsNotNull(call.GetTrailers());
+            }
+        }
+
+        [Test]
+        public async Task ServerStreamingCall()
+        {
+            helper.ServerStreamingHandler = new ServerStreamingServerMethod<WrappedString, WrappedString>(async (request, responseStream, context) =>
+            {
+                await responseStream.WriteAllAsync(request.Value.Split(new []{' '}).Select(x => new WrappedString(x)));
+                context.ResponseTrailers.Add("xyz", "");
+            });
+
+            var call = Calls.AsyncServerStreamingCall(helper.CreateServerStreamingCall(), "A B C");
+            CollectionAssert.AreEqual(new string[] { "A", "B", "C" }, await call.ResponseStream.ToListAsync());
+
+            Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+            Assert.AreEqual("xyz", call.GetTrailers()[0].Key);
+        }
+
+        [Test]
+        public async Task ServerStreamingCall_EndOfStreamIsIdempotent()
+        {
+            helper.ServerStreamingHandler = new ServerStreamingServerMethod<WrappedString, WrappedString>((request, responseStream, context) => TaskUtils.CompletedTask);
+
+            var call = Calls.AsyncServerStreamingCall(helper.CreateServerStreamingCall(), "");
+
+            Assert.IsFalse(await call.ResponseStream.MoveNext());
+            Assert.IsFalse(await call.ResponseStream.MoveNext());
+        }
+
+        [Test]
+        public void ServerStreamingCall_ErrorCanBeAwaitedTwice()
+        {
+            helper.ServerStreamingHandler = new ServerStreamingServerMethod<WrappedString, WrappedString>((request, responseStream, context) =>
+            {
+                context.Status = new Status(StatusCode.InvalidArgument, "");
+                return TaskUtils.CompletedTask;
+            });
+
+            var call = Calls.AsyncServerStreamingCall(helper.CreateServerStreamingCall(), "");
+
+            var ex = Assert.ThrowsAsync<RpcException>(async () => await call.ResponseStream.MoveNext());
+            Assert.AreEqual(StatusCode.InvalidArgument, ex.Status.StatusCode);
+
+            // attempting MoveNext again should result in throwing the same exception.
+            var ex2 = Assert.ThrowsAsync<RpcException>(async () => await call.ResponseStream.MoveNext());
+            Assert.AreEqual(StatusCode.InvalidArgument, ex2.Status.StatusCode);
+        }
+
+        [Test]
+        public void ServerStreamingCall_TrailersFromMultipleSourcesGetConcatenated()
+        {
+            helper.ServerStreamingHandler = new ServerStreamingServerMethod<WrappedString, WrappedString>((request, responseStream, context) =>
+            {
+                context.ResponseTrailers.Add("xyz", "xyz-value");
+                throw new RpcException(new Status(StatusCode.InvalidArgument, ""), new Metadata { {"abc", "abc-value"} });
+            });
+
+            var call = Calls.AsyncServerStreamingCall(helper.CreateServerStreamingCall(), "");
+
+            var ex = Assert.ThrowsAsync<RpcException>(async () => await call.ResponseStream.MoveNext());
+            Assert.AreEqual(StatusCode.InvalidArgument, ex.Status.StatusCode);
+            Assert.AreEqual(2, call.GetTrailers().Count);
+            Assert.AreEqual(2, ex.Trailers.Count);
+            Assert.AreEqual("xyz", ex.Trailers[0].Key);
+            Assert.AreEqual("xyz-value", ex.Trailers[0].Value);
+            Assert.AreEqual("abc", ex.Trailers[1].Key);
+            Assert.AreEqual("abc-value", ex.Trailers[1].Value);
+        }
+
+        [Test]
+        public async Task DuplexStreamingCall()
+        {
+            helper.DuplexStreamingHandler = new DuplexStreamingServerMethod<WrappedString, WrappedString>(async (requestStream, responseStream, context) =>
+            {
+                while (await requestStream.MoveNext())
+                {
+                    await responseStream.WriteAsync(requestStream.Current);
+                }
+                context.ResponseTrailers.Add("xyz", "xyz-value");
+            });
+
+            var call = Calls.AsyncDuplexStreamingCall(helper.CreateDuplexStreamingCall());
+            await call.RequestStream.WriteAllAsync(new WrappedString[] { "A", "B", "C" });
+            CollectionAssert.AreEqual(new string[] { "A", "B", "C" }, await call.ResponseStream.ToListAsync());
+
+            Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+            Assert.AreEqual("xyz-value", call.GetTrailers()[0].Value);
+        }
+
+        [Test]
+        public async Task AsyncUnaryCall_EchoMetadata()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                foreach (Metadata.Entry metadataEntry in context.RequestHeaders)
+                {
+                    if (metadataEntry.Key != "user-agent")
+                    {
+                        context.ResponseTrailers.Add(metadataEntry);
+                    }
+                }
+                return Task.FromResult<WrappedString>("");
+            });
+
+            var headers = new Metadata
+            {
+                { "ascii-header", "abcdefg" },
+                { "binary-header-bin", new byte[] { 1, 2, 3, 0, 0xff } }
+            };
+            var call = Calls.AsyncUnaryCall(helper.CreateUnaryCall(new CallOptions(headers: headers)), "ABC");
+            await call;
+
+            Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
+
+            var trailers = call.GetTrailers();
+            Assert.AreEqual(2, trailers.Count);
+            Assert.AreEqual(headers[0].Key, trailers[0].Key);
+            Assert.AreEqual(headers[0].Value, trailers[0].Value);
+
+            Assert.AreEqual(headers[1].Key, trailers[1].Key);
+            CollectionAssert.AreEqual(headers[1].ValueBytes, trailers[1].ValueBytes);
+        }
+
+        [Test]
+        public void UnknownMethodHandler()
+        {
+            var nonexistentMethod = new Method<WrappedString, WrappedString>(
+                MethodType.Unary,
+                MockServiceHelper.ServiceName,
+                "NonExistentMethod",
+                MockServiceHelperWrappedString.Marshaller,
+                MockServiceHelperWrappedString.Marshaller);
+
+            var callDetails = new CallInvocationDetails<WrappedString, WrappedString>(channel, nonexistentMethod, new CallOptions());
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(callDetails, "abc"));
+            Assert.AreEqual(StatusCode.Unimplemented, ex.Status.StatusCode);
+        }
+
+        [Test]
+        public void StatusDetailIsUtf8()
+        {
+            // some japanese and chinese characters
+            var nonAsciiString = "\u30a1\u30a2\u30a3 \u62b5\u6297\u662f\u5f92\u52b3\u7684";
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                context.Status = new Status(StatusCode.Unknown, nonAsciiString);
+                return Task.FromResult<WrappedString>("");
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+            Assert.AreEqual(StatusCode.Unknown, ex.Status.StatusCode);
+            Assert.AreEqual(nonAsciiString, ex.Status.Detail);
+        }
+
+        [Test]
+        public void ServerCallContext_PeerInfoPresent()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                return Task.FromResult<WrappedString>(context.Peer);
+            });
+
+            string peer = Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc");
+            Assert.IsTrue(peer.Contains(Host));
+        }
+
+        [Test]
+        public void ServerCallContext_HostAndMethodPresent()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                Assert.IsTrue(context.Host.Contains(Host));
+                Assert.AreEqual("/tests.Test/Unary", context.Method);
+                return Task.FromResult<WrappedString>("PASS");
+            });
+            Assert.AreEqual("PASS", (string)Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+        }
+
+        [Test]
+        public void ServerCallContext_AuthContextNotPopulated()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<WrappedString, WrappedString>((request, context) =>
+            {
+                Assert.IsFalse(context.AuthContext.IsPeerAuthenticated);
+                Assert.AreEqual(0, context.AuthContext.Properties.Count());
+                return Task.FromResult<WrappedString>("PASS");
+            });
+            Assert.AreEqual("PASS", (string)Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
+        }
+    }
+}

--- a/src/csharp/Grpc.Core.Tests/ClientServerTestValueType.cs
+++ b/src/csharp/Grpc.Core.Tests/ClientServerTestValueType.cs
@@ -62,11 +62,11 @@ namespace Grpc.Core.Tests
                 return Task.FromResult(request);
             });
 
-            Assert.AreEqual("ABC", Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "ABC"));
+            Assert.AreEqual("ABC", (string)Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "ABC"));
 
-            Assert.AreEqual("ABC", await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "ABC"));
+            Assert.AreEqual("ABC", (string)await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "ABC"));
 
-            Assert.AreEqual("ABC", await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "ABC").ConfigureAwait(false));
+            Assert.AreEqual("ABC", (string)await Calls.AsyncUnaryCall(helper.CreateUnaryCall(), "ABC").ConfigureAwait(false));
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace Grpc.Core.Tests
             {
                 var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall());
                 await call.RequestStream.WriteAllAsync(new WrappedString[] { "A", "B", "C" });
-                Assert.AreEqual("ABC", await call);
+                Assert.AreEqual("ABC", (string)await call);
                 Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
                 Assert.IsNotNull(call.GetTrailers());
             }
@@ -210,7 +210,7 @@ namespace Grpc.Core.Tests
             {
                 var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall());
                 await call.RequestStream.WriteAllAsync(new WrappedString[] { "A", "B", "C" });
-                Assert.AreEqual("ABC", await call.ConfigureAwait(false));
+                Assert.AreEqual("ABC", (string)await call.ConfigureAwait(false));
                 Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
                 Assert.IsNotNull(call.GetTrailers());
             }
@@ -226,7 +226,7 @@ namespace Grpc.Core.Tests
             });
 
             var call = Calls.AsyncServerStreamingCall(helper.CreateServerStreamingCall(), "A B C");
-            CollectionAssert.AreEqual(new string[] { "A", "B", "C" }, await call.ResponseStream.ToListAsync());
+            CollectionAssert.AreEqual(new string[] { "A", "B", "C" }, (await call.ResponseStream.ToListAsync()).ConvertAll(x => x.Value));
 
             Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
             Assert.AreEqual("xyz", call.GetTrailers()[0].Key);
@@ -297,7 +297,7 @@ namespace Grpc.Core.Tests
 
             var call = Calls.AsyncDuplexStreamingCall(helper.CreateDuplexStreamingCall());
             await call.RequestStream.WriteAllAsync(new WrappedString[] { "A", "B", "C" });
-            CollectionAssert.AreEqual(new string[] { "A", "B", "C" }, await call.ResponseStream.ToListAsync());
+            CollectionAssert.AreEqual(new string[] { "A", "B", "C" }, (await call.ResponseStream.ToListAsync()).ConvertAll(x => x.Value));
 
             Assert.AreEqual(StatusCode.OK, call.GetStatus().StatusCode);
             Assert.AreEqual("xyz-value", call.GetTrailers()[0].Value);

--- a/src/csharp/Grpc.Core.Tests/MockServiceHelper.cs
+++ b/src/csharp/Grpc.Core.Tests/MockServiceHelper.cs
@@ -52,6 +52,8 @@ namespace Grpc.Core.Tests
         public static readonly Marshaller<WrappedString> Marshaller = new Marshaller<WrappedString>(
             (WrappedString s) => System.Text.Encoding.UTF8.GetBytes(s.Value),
             (byte[] a) => System.Text.Encoding.UTF8.GetString(a));
+
+        public override WrappedString DefaultValue => "";
     }
 
     public readonly struct WrappedString // allows us to test value-typed marshellers using existing tests which expect string-like semantics

--- a/src/csharp/Grpc.Core/Calls.cs
+++ b/src/csharp/Grpc.Core/Calls.cs
@@ -39,8 +39,6 @@ namespace Grpc.Core
         /// <typeparam name="TRequest">Type of request message.</typeparam>
         /// <typeparam name="TResponse">The of response message.</typeparam>
         public static TResponse BlockingUnaryCall<TRequest, TResponse>(CallInvocationDetails<TRequest, TResponse> call, TRequest req)
-            where TRequest : class
-            where TResponse : class
         {
             var asyncCall = new AsyncCall<TRequest, TResponse>(call);
             return asyncCall.UnaryCall(req);
@@ -55,8 +53,6 @@ namespace Grpc.Core
         /// <typeparam name="TRequest">Type of request message.</typeparam>
         /// <typeparam name="TResponse">The of response message.</typeparam>
         public static AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(CallInvocationDetails<TRequest, TResponse> call, TRequest req)
-            where TRequest : class
-            where TResponse : class
         {
             var asyncCall = new AsyncCall<TRequest, TResponse>(call);
             var asyncResult = asyncCall.UnaryCallAsync(req);
@@ -76,8 +72,6 @@ namespace Grpc.Core
         /// <typeparam name="TRequest">Type of request message.</typeparam>
         /// <typeparam name="TResponse">The of response messages.</typeparam>
         public static AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(CallInvocationDetails<TRequest, TResponse> call, TRequest req)
-            where TRequest : class
-            where TResponse : class
         {
             var asyncCall = new AsyncCall<TRequest, TResponse>(call);
             asyncCall.StartServerStreamingCall(req);
@@ -97,8 +91,6 @@ namespace Grpc.Core
         /// <typeparam name="TRequest">Type of request messages.</typeparam>
         /// <typeparam name="TResponse">The of response message.</typeparam>
         public static AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(CallInvocationDetails<TRequest, TResponse> call)
-            where TRequest : class
-            where TResponse : class
         {
             var asyncCall = new AsyncCall<TRequest, TResponse>(call);
             var resultTask = asyncCall.ClientStreamingCallAsync();
@@ -119,8 +111,6 @@ namespace Grpc.Core
         /// <typeparam name="TRequest">Type of request messages.</typeparam>
         /// <typeparam name="TResponse">Type of responsemessages.</typeparam>
         public static AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(CallInvocationDetails<TRequest, TResponse> call)
-            where TRequest : class
-            where TResponse : class
         {
             var asyncCall = new AsyncCall<TRequest, TResponse>(call);
             asyncCall.StartDuplexStreamingCall();

--- a/src/csharp/Grpc.Core/DefaultCallInvoker.cs
+++ b/src/csharp/Grpc.Core/DefaultCallInvoker.cs
@@ -89,8 +89,6 @@ namespace Grpc.Core
 
         /// <summary>Creates call invocation details for given method.</summary>
         protected virtual CallInvocationDetails<TRequest, TResponse> CreateCall<TRequest, TResponse>(Method<TRequest, TResponse> method, string host, CallOptions options)
-                where TRequest : class
-                where TResponse : class
         {
             return new CallInvocationDetails<TRequest, TResponse>(channel, method, host, options);
         }

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -306,7 +306,7 @@ namespace Grpc.Core.Internal
         /// <summary>
         /// Receives a streaming response. Only one pending read action is allowed at any given time.
         /// </summary>
-        public Task<TResponse> ReadMessageAsync()
+        public Task<Maybe<TResponse>> ReadMessageAsync()
         {
             return ReadMessageInternalAsync();
         }
@@ -558,7 +558,7 @@ namespace Grpc.Core.Internal
             // success will be always set to true.
 
             TaskCompletionSource<object> delayedStreamingWriteTcs = null;
-            TResponse msg = default(TResponse);
+            var msg = Maybe<TResponse>.Empty;
             var deserializeException = TryDeserialize(receivedMessageReader, out msg);
 
             bool releasedResources;
@@ -600,7 +600,7 @@ namespace Grpc.Core.Internal
                 return;
             }
 
-            unaryResponseTcs.SetResult(msg);
+            unaryResponseTcs.SetResult(msg.Value);
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/AsyncCallServer.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallServer.cs
@@ -86,7 +86,7 @@ namespace Grpc.Core.Internal
         /// <summary>
         /// Receives a streaming request. Only one pending read action is allowed at any given time.
         /// </summary>
-        public Task<TRequest> ReadMessageAsync()
+        public Task<Maybe<TRequest>> ReadMessageAsync()
         {
             return ReadMessageInternalAsync();
         }
@@ -218,8 +218,8 @@ namespace Grpc.Core.Internal
                     // if there's no pending read, readingDone=true will dispose now.
                     // if there is a pending read, we will dispose once that read finishes.
                     readingDone = true;
-                    streamingReadTcs = new TaskCompletionSource<TRequest>();
-                    streamingReadTcs.SetResult(default(TRequest));
+                    streamingReadTcs = new TaskCompletionSource<Maybe<TRequest>>();
+                    streamingReadTcs.SetResult(Maybe<TRequest>.Empty);
                 }
                 releasedResources = ReleaseResourcesIfPossible();
             }

--- a/src/csharp/Grpc.Core/Internal/ClientResponseStream.cs
+++ b/src/csharp/Grpc.Core/Internal/ClientResponseStream.cs
@@ -24,11 +24,9 @@ using System.Threading.Tasks;
 namespace Grpc.Core.Internal
 {
     internal class ClientResponseStream<TRequest, TResponse> : IAsyncStreamReader<TResponse>
-        where TRequest : class
-        where TResponse : class
     {
         readonly AsyncCall<TRequest, TResponse> call;
-        TResponse current;
+        Maybe<TResponse> current;
 
         public ClientResponseStream(AsyncCall<TRequest, TResponse> call)
         {
@@ -39,11 +37,11 @@ namespace Grpc.Core.Internal
         {
             get
             {
-                if (current == null)
+                if (!current.HasValue)
                 {
                     throw new InvalidOperationException("No current element is available.");
                 }
-                return current;
+                return current.Value;
             }
         }
 
@@ -54,7 +52,7 @@ namespace Grpc.Core.Internal
                 var result = await call.ReadMessageAsync().ConfigureAwait(false);
                 this.current = result;
 
-                if (result == null)
+                if (!result.HasValue)
                 {
                     await call.StreamingResponseCallFinishedTask.ConfigureAwait(false);
                     return false;

--- a/src/csharp/Grpc.Core/Internal/Maybe.cs
+++ b/src/csharp/Grpc.Core/Internal/Maybe.cs
@@ -1,0 +1,34 @@
+#region Copyright notice and license
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace Grpc.Core.Internal
+{
+    // mainly for use with Task<T> replies when receiving results
+
+    // this is basically (bool HasValue, T Value), but without the need to ref System.ValueTuple;
+    // alternatively you could think of it as Nullable<T> but for any T (not just T : struct)
+    internal readonly struct Maybe<T>
+    {
+        public bool HasValue { get; }
+        public T Value { get; }
+        public Maybe(T value)
+        {
+            HasValue = true;
+            Value = value;
+        }
+        public static Maybe<T> Empty => default;
+    }
+}

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -34,8 +34,6 @@ namespace Grpc.Core.Internal
     }
 
     internal class UnaryServerCallHandler<TRequest, TResponse> : IServerCallHandler
-        where TRequest : class
-        where TResponse : class
     {
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<UnaryServerCallHandler<TRequest, TResponse>>();
 
@@ -93,8 +91,6 @@ namespace Grpc.Core.Internal
     }
 
     internal class ServerStreamingServerCallHandler<TRequest, TResponse> : IServerCallHandler
-        where TRequest : class
-        where TResponse : class
     {
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
 
@@ -151,8 +147,6 @@ namespace Grpc.Core.Internal
     }
 
     internal class ClientStreamingServerCallHandler<TRequest, TResponse> : IServerCallHandler
-        where TRequest : class
-        where TResponse : class
     {
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
 
@@ -209,8 +203,6 @@ namespace Grpc.Core.Internal
     }
 
     internal class DuplexStreamingServerCallHandler<TRequest, TResponse> : IServerCallHandler
-        where TRequest : class
-        where TResponse : class
     {
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
 

--- a/src/csharp/Grpc.Core/Internal/ServerCalls.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCalls.cs
@@ -26,29 +26,21 @@ namespace Grpc.Core.Internal
     internal static class ServerCalls
     {
         public static IServerCallHandler UnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
         {
             return new UnaryServerCallHandler<TRequest, TResponse>(method, handler);
         }
 
         public static IServerCallHandler ClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
         {
             return new ClientStreamingServerCallHandler<TRequest, TResponse>(method, handler);
         }
 
         public static IServerCallHandler ServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
         {
             return new ServerStreamingServerCallHandler<TRequest, TResponse>(method, handler);
         }
 
         public static IServerCallHandler DuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
         {
             return new DuplexStreamingServerCallHandler<TRequest, TResponse>(method, handler);
         }

--- a/src/csharp/Grpc.Core/Internal/ServerRequestStream.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerRequestStream.cs
@@ -24,11 +24,9 @@ using System.Threading.Tasks;
 namespace Grpc.Core.Internal
 {
     internal class ServerRequestStream<TRequest, TResponse> : IAsyncStreamReader<TRequest>
-        where TRequest : class
-        where TResponse : class
     {
         readonly AsyncCallServer<TRequest, TResponse> call;
-        TRequest current;
+        Maybe<TRequest> current;
 
         public ServerRequestStream(AsyncCallServer<TRequest, TResponse> call)
         {
@@ -39,11 +37,11 @@ namespace Grpc.Core.Internal
         {
             get
             {
-                if (current == null)
+                if (!current.HasValue)
                 {
                     throw new InvalidOperationException("No current element is available.");
                 }
-                return current;
+                return current.Value;
             }
         }
 
@@ -53,7 +51,7 @@ namespace Grpc.Core.Internal
             {
                 var result = await call.ReadMessageAsync().ConfigureAwait(false);
                 this.current = result;
-                return result != null;
+                return result.HasValue;
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/ServerResponseStream.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerResponseStream.cs
@@ -24,8 +24,6 @@ namespace Grpc.Core.Internal
     /// Writes responses asynchronously to an underlying AsyncCallServer object.
     /// </summary>
     internal class ServerResponseStream<TRequest, TResponse> : IServerStreamWriter<TResponse>, IServerResponseStream
-        where TRequest : class
-        where TResponse : class
     {
         readonly AsyncCallServer<TRequest, TResponse> call;
         WriteOptions writeOptions;

--- a/src/csharp/Grpc.Core/Utils/AsyncStreamExtensions.cs
+++ b/src/csharp/Grpc.Core/Utils/AsyncStreamExtensions.cs
@@ -31,7 +31,6 @@ namespace Grpc.Core.Utils
         /// Reads the entire stream and executes an async action for each element.
         /// </summary>
         public static async Task ForEachAsync<T>(this IAsyncStreamReader<T> streamReader, Func<T, Task> asyncAction)
-            where T : class
         {
             while (await streamReader.MoveNext().ConfigureAwait(false))
             {
@@ -43,7 +42,6 @@ namespace Grpc.Core.Utils
         /// Reads the entire stream and creates a list containing all the elements read.
         /// </summary>
         public static async Task<List<T>> ToListAsync<T>(this IAsyncStreamReader<T> streamReader)
-            where T : class
         {
             var result = new List<T>();
             while (await streamReader.MoveNext().ConfigureAwait(false))
@@ -58,7 +56,6 @@ namespace Grpc.Core.Utils
         /// Completes the stream afterwards unless close = false.
         /// </summary>
         public static async Task WriteAllAsync<T>(this IClientStreamWriter<T> streamWriter, IEnumerable<T> elements, bool complete = true)
-            where T : class
         {
             foreach (var element in elements)
             {
@@ -74,7 +71,6 @@ namespace Grpc.Core.Utils
         /// Writes all elements from given enumerable to the stream.
         /// </summary>
         public static async Task WriteAllAsync<T>(this IServerStreamWriter<T> streamWriter, IEnumerable<T> elements)
-            where T : class
         {
             foreach (var element in elements)
             {


### PR DESCRIPTION
Fixes #22605 "remove the class constraint on `TRequest` / `TResponse`"

See discussion in ^^^ for more context

Main implementation is to switch from `null` tests to an internal `Maybe<T>` which is basically `(bool HasValue, T Value)`, testing on `.HasValue`

Existing client-server mock tests have been duplicated into `ClientServerTestValueType` and used to validate, using a `struct WrappedString` (so that the existing string logic in the old tests can be reused)

/cc @jtattermusch 