### PR TITLE
Make Activity more of an interface

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1296,6 +1296,7 @@ grpc_cc_library(
         "context",
         "gpr_base",
         "gpr_codegen",
+        "orphanable",
         "poll",
         "promise_factory",
         "promise_status",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7399,52 +7399,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(activity_test
-  src/core/ext/upb-generated/google/protobuf/any.upb.c
-  src/core/ext/upb-generated/google/rpc/status.upb.c
-  src/core/lib/gpr/alloc.cc
-  src/core/lib/gpr/atm.cc
-  src/core/lib/gpr/cpu_iphone.cc
-  src/core/lib/gpr/cpu_linux.cc
-  src/core/lib/gpr/cpu_posix.cc
-  src/core/lib/gpr/cpu_windows.cc
-  src/core/lib/gpr/env_linux.cc
-  src/core/lib/gpr/env_posix.cc
-  src/core/lib/gpr/env_windows.cc
-  src/core/lib/gpr/log.cc
-  src/core/lib/gpr/log_android.cc
-  src/core/lib/gpr/log_linux.cc
-  src/core/lib/gpr/log_posix.cc
-  src/core/lib/gpr/log_windows.cc
-  src/core/lib/gpr/murmur_hash.cc
-  src/core/lib/gpr/string.cc
-  src/core/lib/gpr/string_posix.cc
-  src/core/lib/gpr/string_util_windows.cc
-  src/core/lib/gpr/string_windows.cc
-  src/core/lib/gpr/sync.cc
-  src/core/lib/gpr/sync_abseil.cc
-  src/core/lib/gpr/sync_posix.cc
-  src/core/lib/gpr/sync_windows.cc
-  src/core/lib/gpr/time.cc
-  src/core/lib/gpr/time_posix.cc
-  src/core/lib/gpr/time_precise.cc
-  src/core/lib/gpr/time_windows.cc
-  src/core/lib/gpr/tmpfile_msys.cc
-  src/core/lib/gpr/tmpfile_posix.cc
-  src/core/lib/gpr/tmpfile_windows.cc
-  src/core/lib/gpr/wrap_memcpy.cc
-  src/core/lib/gprpp/examine_stack.cc
-  src/core/lib/gprpp/fork.cc
-  src/core/lib/gprpp/global_config_env.cc
-  src/core/lib/gprpp/host_port.cc
-  src/core/lib/gprpp/mpscq.cc
-  src/core/lib/gprpp/stat_posix.cc
-  src/core/lib/gprpp/stat_windows.cc
-  src/core/lib/gprpp/status_helper.cc
-  src/core/lib/gprpp/thd_posix.cc
-  src/core/lib/gprpp/thd_windows.cc
-  src/core/lib/gprpp/time_util.cc
-  src/core/lib/profiling/basic_timers.cc
-  src/core/lib/profiling/stap_timers.cc
+  src/core/lib/debug/trace.cc
   src/core/lib/promise/activity.cc
   test/core/promise/activity_test.cc
   third_party/googletest/googletest/src/gtest-all.cc
@@ -7473,21 +7428,10 @@ target_include_directories(activity_test
 target_link_libraries(activity_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::base
-  absl::core_headers
   absl::flat_hash_set
-  absl::memory
-  absl::random_random
-  absl::status
   absl::statusor
-  absl::cord
-  absl::str_format
-  absl::strings
-  absl::synchronization
-  absl::time
-  absl::optional
   absl::variant
-  upb
+  gpr
 )
 
 
@@ -12466,52 +12410,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(latch_test
-  src/core/ext/upb-generated/google/protobuf/any.upb.c
-  src/core/ext/upb-generated/google/rpc/status.upb.c
-  src/core/lib/gpr/alloc.cc
-  src/core/lib/gpr/atm.cc
-  src/core/lib/gpr/cpu_iphone.cc
-  src/core/lib/gpr/cpu_linux.cc
-  src/core/lib/gpr/cpu_posix.cc
-  src/core/lib/gpr/cpu_windows.cc
-  src/core/lib/gpr/env_linux.cc
-  src/core/lib/gpr/env_posix.cc
-  src/core/lib/gpr/env_windows.cc
-  src/core/lib/gpr/log.cc
-  src/core/lib/gpr/log_android.cc
-  src/core/lib/gpr/log_linux.cc
-  src/core/lib/gpr/log_posix.cc
-  src/core/lib/gpr/log_windows.cc
-  src/core/lib/gpr/murmur_hash.cc
-  src/core/lib/gpr/string.cc
-  src/core/lib/gpr/string_posix.cc
-  src/core/lib/gpr/string_util_windows.cc
-  src/core/lib/gpr/string_windows.cc
-  src/core/lib/gpr/sync.cc
-  src/core/lib/gpr/sync_abseil.cc
-  src/core/lib/gpr/sync_posix.cc
-  src/core/lib/gpr/sync_windows.cc
-  src/core/lib/gpr/time.cc
-  src/core/lib/gpr/time_posix.cc
-  src/core/lib/gpr/time_precise.cc
-  src/core/lib/gpr/time_windows.cc
-  src/core/lib/gpr/tmpfile_msys.cc
-  src/core/lib/gpr/tmpfile_posix.cc
-  src/core/lib/gpr/tmpfile_windows.cc
-  src/core/lib/gpr/wrap_memcpy.cc
-  src/core/lib/gprpp/examine_stack.cc
-  src/core/lib/gprpp/fork.cc
-  src/core/lib/gprpp/global_config_env.cc
-  src/core/lib/gprpp/host_port.cc
-  src/core/lib/gprpp/mpscq.cc
-  src/core/lib/gprpp/stat_posix.cc
-  src/core/lib/gprpp/stat_windows.cc
-  src/core/lib/gprpp/status_helper.cc
-  src/core/lib/gprpp/thd_posix.cc
-  src/core/lib/gprpp/thd_windows.cc
-  src/core/lib/gprpp/time_util.cc
-  src/core/lib/profiling/basic_timers.cc
-  src/core/lib/profiling/stap_timers.cc
+  src/core/lib/debug/trace.cc
   src/core/lib/promise/activity.cc
   test/core/promise/latch_test.cc
   third_party/googletest/googletest/src/gtest-all.cc
@@ -12540,20 +12439,9 @@ target_include_directories(latch_test
 target_link_libraries(latch_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::base
-  absl::core_headers
-  absl::memory
-  absl::random_random
-  absl::status
   absl::statusor
-  absl::cord
-  absl::str_format
-  absl::strings
-  absl::synchronization
-  absl::time
-  absl::optional
   absl::variant
-  upb
+  gpr
 )
 
 
@@ -13127,52 +13015,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(observable_test
-  src/core/ext/upb-generated/google/protobuf/any.upb.c
-  src/core/ext/upb-generated/google/rpc/status.upb.c
-  src/core/lib/gpr/alloc.cc
-  src/core/lib/gpr/atm.cc
-  src/core/lib/gpr/cpu_iphone.cc
-  src/core/lib/gpr/cpu_linux.cc
-  src/core/lib/gpr/cpu_posix.cc
-  src/core/lib/gpr/cpu_windows.cc
-  src/core/lib/gpr/env_linux.cc
-  src/core/lib/gpr/env_posix.cc
-  src/core/lib/gpr/env_windows.cc
-  src/core/lib/gpr/log.cc
-  src/core/lib/gpr/log_android.cc
-  src/core/lib/gpr/log_linux.cc
-  src/core/lib/gpr/log_posix.cc
-  src/core/lib/gpr/log_windows.cc
-  src/core/lib/gpr/murmur_hash.cc
-  src/core/lib/gpr/string.cc
-  src/core/lib/gpr/string_posix.cc
-  src/core/lib/gpr/string_util_windows.cc
-  src/core/lib/gpr/string_windows.cc
-  src/core/lib/gpr/sync.cc
-  src/core/lib/gpr/sync_abseil.cc
-  src/core/lib/gpr/sync_posix.cc
-  src/core/lib/gpr/sync_windows.cc
-  src/core/lib/gpr/time.cc
-  src/core/lib/gpr/time_posix.cc
-  src/core/lib/gpr/time_precise.cc
-  src/core/lib/gpr/time_windows.cc
-  src/core/lib/gpr/tmpfile_msys.cc
-  src/core/lib/gpr/tmpfile_posix.cc
-  src/core/lib/gpr/tmpfile_windows.cc
-  src/core/lib/gpr/wrap_memcpy.cc
-  src/core/lib/gprpp/examine_stack.cc
-  src/core/lib/gprpp/fork.cc
-  src/core/lib/gprpp/global_config_env.cc
-  src/core/lib/gprpp/host_port.cc
-  src/core/lib/gprpp/mpscq.cc
-  src/core/lib/gprpp/stat_posix.cc
-  src/core/lib/gprpp/stat_windows.cc
-  src/core/lib/gprpp/status_helper.cc
-  src/core/lib/gprpp/thd_posix.cc
-  src/core/lib/gprpp/thd_windows.cc
-  src/core/lib/gprpp/time_util.cc
-  src/core/lib/profiling/basic_timers.cc
-  src/core/lib/profiling/stap_timers.cc
+  src/core/lib/debug/trace.cc
   src/core/lib/promise/activity.cc
   test/core/promise/observable_test.cc
   third_party/googletest/googletest/src/gtest-all.cc
@@ -13201,21 +13044,10 @@ target_include_directories(observable_test
 target_link_libraries(observable_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::base
-  absl::core_headers
   absl::flat_hash_set
-  absl::memory
-  absl::random_random
-  absl::status
   absl::statusor
-  absl::cord
-  absl::str_format
-  absl::strings
-  absl::synchronization
-  absl::time
-  absl::optional
   absl::variant
-  upb
+  gpr
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4402,38 +4402,12 @@ targets:
   build: test
   language: c++
   headers:
-  - src/core/ext/upb-generated/google/protobuf/any.upb.h
-  - src/core/ext/upb-generated/google/rpc/status.upb.h
-  - src/core/lib/gpr/alloc.h
-  - src/core/lib/gpr/env.h
-  - src/core/lib/gpr/murmur_hash.h
-  - src/core/lib/gpr/spinlock.h
-  - src/core/lib/gpr/string.h
-  - src/core/lib/gpr/string_windows.h
-  - src/core/lib/gpr/time_precise.h
-  - src/core/lib/gpr/tls.h
-  - src/core/lib/gpr/tmpfile.h
-  - src/core/lib/gpr/useful.h
+  - src/core/lib/debug/trace.h
   - src/core/lib/gprpp/atomic_utils.h
   - src/core/lib/gprpp/bitset.h
-  - src/core/lib/gprpp/construct_destruct.h
-  - src/core/lib/gprpp/debug_location.h
-  - src/core/lib/gprpp/examine_stack.h
-  - src/core/lib/gprpp/fork.h
-  - src/core/lib/gprpp/global_config.h
-  - src/core/lib/gprpp/global_config_custom.h
-  - src/core/lib/gprpp/global_config_env.h
-  - src/core/lib/gprpp/global_config_generic.h
-  - src/core/lib/gprpp/host_port.h
-  - src/core/lib/gprpp/manual_constructor.h
-  - src/core/lib/gprpp/memory.h
-  - src/core/lib/gprpp/mpscq.h
-  - src/core/lib/gprpp/stat.h
-  - src/core/lib/gprpp/status_helper.h
-  - src/core/lib/gprpp/sync.h
-  - src/core/lib/gprpp/thd.h
-  - src/core/lib/gprpp/time_util.h
-  - src/core/lib/profiling/timers.h
+  - src/core/lib/gprpp/orphanable.h
+  - src/core/lib/gprpp/ref_counted.h
+  - src/core/lib/gprpp/ref_counted_ptr.h
   - src/core/lib/promise/activity.h
   - src/core/lib/promise/context.h
   - src/core/lib/promise/detail/basic_join.h
@@ -4449,70 +4423,14 @@ targets:
   - src/core/lib/promise/wait_set.h
   - test/core/promise/test_wakeup_schedulers.h
   src:
-  - src/core/ext/upb-generated/google/protobuf/any.upb.c
-  - src/core/ext/upb-generated/google/rpc/status.upb.c
-  - src/core/lib/gpr/alloc.cc
-  - src/core/lib/gpr/atm.cc
-  - src/core/lib/gpr/cpu_iphone.cc
-  - src/core/lib/gpr/cpu_linux.cc
-  - src/core/lib/gpr/cpu_posix.cc
-  - src/core/lib/gpr/cpu_windows.cc
-  - src/core/lib/gpr/env_linux.cc
-  - src/core/lib/gpr/env_posix.cc
-  - src/core/lib/gpr/env_windows.cc
-  - src/core/lib/gpr/log.cc
-  - src/core/lib/gpr/log_android.cc
-  - src/core/lib/gpr/log_linux.cc
-  - src/core/lib/gpr/log_posix.cc
-  - src/core/lib/gpr/log_windows.cc
-  - src/core/lib/gpr/murmur_hash.cc
-  - src/core/lib/gpr/string.cc
-  - src/core/lib/gpr/string_posix.cc
-  - src/core/lib/gpr/string_util_windows.cc
-  - src/core/lib/gpr/string_windows.cc
-  - src/core/lib/gpr/sync.cc
-  - src/core/lib/gpr/sync_abseil.cc
-  - src/core/lib/gpr/sync_posix.cc
-  - src/core/lib/gpr/sync_windows.cc
-  - src/core/lib/gpr/time.cc
-  - src/core/lib/gpr/time_posix.cc
-  - src/core/lib/gpr/time_precise.cc
-  - src/core/lib/gpr/time_windows.cc
-  - src/core/lib/gpr/tmpfile_msys.cc
-  - src/core/lib/gpr/tmpfile_posix.cc
-  - src/core/lib/gpr/tmpfile_windows.cc
-  - src/core/lib/gpr/wrap_memcpy.cc
-  - src/core/lib/gprpp/examine_stack.cc
-  - src/core/lib/gprpp/fork.cc
-  - src/core/lib/gprpp/global_config_env.cc
-  - src/core/lib/gprpp/host_port.cc
-  - src/core/lib/gprpp/mpscq.cc
-  - src/core/lib/gprpp/stat_posix.cc
-  - src/core/lib/gprpp/stat_windows.cc
-  - src/core/lib/gprpp/status_helper.cc
-  - src/core/lib/gprpp/thd_posix.cc
-  - src/core/lib/gprpp/thd_windows.cc
-  - src/core/lib/gprpp/time_util.cc
-  - src/core/lib/profiling/basic_timers.cc
-  - src/core/lib/profiling/stap_timers.cc
+  - src/core/lib/debug/trace.cc
   - src/core/lib/promise/activity.cc
   - test/core/promise/activity_test.cc
   deps:
-  - absl/base:base
-  - absl/base:core_headers
   - absl/container:flat_hash_set
-  - absl/memory:memory
-  - absl/random:random
-  - absl/status:status
   - absl/status:statusor
-  - absl/strings:cord
-  - absl/strings:str_format
-  - absl/strings:strings
-  - absl/synchronization:synchronization
-  - absl/time:time
-  - absl/types:optional
   - absl/types:variant
-  - upb
+  - gpr
   uses_polling: false
 - name: address_sorting_test
   gtest: true
@@ -5768,6 +5686,7 @@ targets:
   headers:
   - src/core/lib/debug/trace.h
   - src/core/lib/gprpp/atomic_utils.h
+  - src/core/lib/gprpp/orphanable.h
   - src/core/lib/gprpp/ref_counted.h
   - src/core/lib/gprpp/ref_counted_ptr.h
   - src/core/lib/iomgr/closure.h
@@ -6560,38 +6479,12 @@ targets:
   build: test
   language: c++
   headers:
-  - src/core/ext/upb-generated/google/protobuf/any.upb.h
-  - src/core/ext/upb-generated/google/rpc/status.upb.h
-  - src/core/lib/gpr/alloc.h
-  - src/core/lib/gpr/env.h
-  - src/core/lib/gpr/murmur_hash.h
-  - src/core/lib/gpr/spinlock.h
-  - src/core/lib/gpr/string.h
-  - src/core/lib/gpr/string_windows.h
-  - src/core/lib/gpr/time_precise.h
-  - src/core/lib/gpr/tls.h
-  - src/core/lib/gpr/tmpfile.h
-  - src/core/lib/gpr/useful.h
+  - src/core/lib/debug/trace.h
   - src/core/lib/gprpp/atomic_utils.h
   - src/core/lib/gprpp/bitset.h
-  - src/core/lib/gprpp/construct_destruct.h
-  - src/core/lib/gprpp/debug_location.h
-  - src/core/lib/gprpp/examine_stack.h
-  - src/core/lib/gprpp/fork.h
-  - src/core/lib/gprpp/global_config.h
-  - src/core/lib/gprpp/global_config_custom.h
-  - src/core/lib/gprpp/global_config_env.h
-  - src/core/lib/gprpp/global_config_generic.h
-  - src/core/lib/gprpp/host_port.h
-  - src/core/lib/gprpp/manual_constructor.h
-  - src/core/lib/gprpp/memory.h
-  - src/core/lib/gprpp/mpscq.h
-  - src/core/lib/gprpp/stat.h
-  - src/core/lib/gprpp/status_helper.h
-  - src/core/lib/gprpp/sync.h
-  - src/core/lib/gprpp/thd.h
-  - src/core/lib/gprpp/time_util.h
-  - src/core/lib/profiling/timers.h
+  - src/core/lib/gprpp/orphanable.h
+  - src/core/lib/gprpp/ref_counted.h
+  - src/core/lib/gprpp/ref_counted_ptr.h
   - src/core/lib/promise/activity.h
   - src/core/lib/promise/context.h
   - src/core/lib/promise/detail/basic_join.h
@@ -6607,69 +6500,13 @@ targets:
   - src/core/lib/promise/seq.h
   - test/core/promise/test_wakeup_schedulers.h
   src:
-  - src/core/ext/upb-generated/google/protobuf/any.upb.c
-  - src/core/ext/upb-generated/google/rpc/status.upb.c
-  - src/core/lib/gpr/alloc.cc
-  - src/core/lib/gpr/atm.cc
-  - src/core/lib/gpr/cpu_iphone.cc
-  - src/core/lib/gpr/cpu_linux.cc
-  - src/core/lib/gpr/cpu_posix.cc
-  - src/core/lib/gpr/cpu_windows.cc
-  - src/core/lib/gpr/env_linux.cc
-  - src/core/lib/gpr/env_posix.cc
-  - src/core/lib/gpr/env_windows.cc
-  - src/core/lib/gpr/log.cc
-  - src/core/lib/gpr/log_android.cc
-  - src/core/lib/gpr/log_linux.cc
-  - src/core/lib/gpr/log_posix.cc
-  - src/core/lib/gpr/log_windows.cc
-  - src/core/lib/gpr/murmur_hash.cc
-  - src/core/lib/gpr/string.cc
-  - src/core/lib/gpr/string_posix.cc
-  - src/core/lib/gpr/string_util_windows.cc
-  - src/core/lib/gpr/string_windows.cc
-  - src/core/lib/gpr/sync.cc
-  - src/core/lib/gpr/sync_abseil.cc
-  - src/core/lib/gpr/sync_posix.cc
-  - src/core/lib/gpr/sync_windows.cc
-  - src/core/lib/gpr/time.cc
-  - src/core/lib/gpr/time_posix.cc
-  - src/core/lib/gpr/time_precise.cc
-  - src/core/lib/gpr/time_windows.cc
-  - src/core/lib/gpr/tmpfile_msys.cc
-  - src/core/lib/gpr/tmpfile_posix.cc
-  - src/core/lib/gpr/tmpfile_windows.cc
-  - src/core/lib/gpr/wrap_memcpy.cc
-  - src/core/lib/gprpp/examine_stack.cc
-  - src/core/lib/gprpp/fork.cc
-  - src/core/lib/gprpp/global_config_env.cc
-  - src/core/lib/gprpp/host_port.cc
-  - src/core/lib/gprpp/mpscq.cc
-  - src/core/lib/gprpp/stat_posix.cc
-  - src/core/lib/gprpp/stat_windows.cc
-  - src/core/lib/gprpp/status_helper.cc
-  - src/core/lib/gprpp/thd_posix.cc
-  - src/core/lib/gprpp/thd_windows.cc
-  - src/core/lib/gprpp/time_util.cc
-  - src/core/lib/profiling/basic_timers.cc
-  - src/core/lib/profiling/stap_timers.cc
+  - src/core/lib/debug/trace.cc
   - src/core/lib/promise/activity.cc
   - test/core/promise/latch_test.cc
   deps:
-  - absl/base:base
-  - absl/base:core_headers
-  - absl/memory:memory
-  - absl/random:random
-  - absl/status:status
   - absl/status:statusor
-  - absl/strings:cord
-  - absl/strings:str_format
-  - absl/strings:strings
-  - absl/synchronization:synchronization
-  - absl/time:time
-  - absl/types:optional
   - absl/types:variant
-  - upb
+  - gpr
   uses_polling: false
 - name: lb_get_cpu_stats_test
   gtest: true
@@ -6892,37 +6729,11 @@ targets:
   build: test
   language: c++
   headers:
-  - src/core/ext/upb-generated/google/protobuf/any.upb.h
-  - src/core/ext/upb-generated/google/rpc/status.upb.h
-  - src/core/lib/gpr/alloc.h
-  - src/core/lib/gpr/env.h
-  - src/core/lib/gpr/murmur_hash.h
-  - src/core/lib/gpr/spinlock.h
-  - src/core/lib/gpr/string.h
-  - src/core/lib/gpr/string_windows.h
-  - src/core/lib/gpr/time_precise.h
-  - src/core/lib/gpr/tls.h
-  - src/core/lib/gpr/tmpfile.h
-  - src/core/lib/gpr/useful.h
+  - src/core/lib/debug/trace.h
   - src/core/lib/gprpp/atomic_utils.h
-  - src/core/lib/gprpp/construct_destruct.h
-  - src/core/lib/gprpp/debug_location.h
-  - src/core/lib/gprpp/examine_stack.h
-  - src/core/lib/gprpp/fork.h
-  - src/core/lib/gprpp/global_config.h
-  - src/core/lib/gprpp/global_config_custom.h
-  - src/core/lib/gprpp/global_config_env.h
-  - src/core/lib/gprpp/global_config_generic.h
-  - src/core/lib/gprpp/host_port.h
-  - src/core/lib/gprpp/manual_constructor.h
-  - src/core/lib/gprpp/memory.h
-  - src/core/lib/gprpp/mpscq.h
-  - src/core/lib/gprpp/stat.h
-  - src/core/lib/gprpp/status_helper.h
-  - src/core/lib/gprpp/sync.h
-  - src/core/lib/gprpp/thd.h
-  - src/core/lib/gprpp/time_util.h
-  - src/core/lib/profiling/timers.h
+  - src/core/lib/gprpp/orphanable.h
+  - src/core/lib/gprpp/ref_counted.h
+  - src/core/lib/gprpp/ref_counted_ptr.h
   - src/core/lib/promise/activity.h
   - src/core/lib/promise/context.h
   - src/core/lib/promise/detail/basic_seq.h
@@ -6937,70 +6748,14 @@ targets:
   - src/core/lib/promise/wait_set.h
   - test/core/promise/test_wakeup_schedulers.h
   src:
-  - src/core/ext/upb-generated/google/protobuf/any.upb.c
-  - src/core/ext/upb-generated/google/rpc/status.upb.c
-  - src/core/lib/gpr/alloc.cc
-  - src/core/lib/gpr/atm.cc
-  - src/core/lib/gpr/cpu_iphone.cc
-  - src/core/lib/gpr/cpu_linux.cc
-  - src/core/lib/gpr/cpu_posix.cc
-  - src/core/lib/gpr/cpu_windows.cc
-  - src/core/lib/gpr/env_linux.cc
-  - src/core/lib/gpr/env_posix.cc
-  - src/core/lib/gpr/env_windows.cc
-  - src/core/lib/gpr/log.cc
-  - src/core/lib/gpr/log_android.cc
-  - src/core/lib/gpr/log_linux.cc
-  - src/core/lib/gpr/log_posix.cc
-  - src/core/lib/gpr/log_windows.cc
-  - src/core/lib/gpr/murmur_hash.cc
-  - src/core/lib/gpr/string.cc
-  - src/core/lib/gpr/string_posix.cc
-  - src/core/lib/gpr/string_util_windows.cc
-  - src/core/lib/gpr/string_windows.cc
-  - src/core/lib/gpr/sync.cc
-  - src/core/lib/gpr/sync_abseil.cc
-  - src/core/lib/gpr/sync_posix.cc
-  - src/core/lib/gpr/sync_windows.cc
-  - src/core/lib/gpr/time.cc
-  - src/core/lib/gpr/time_posix.cc
-  - src/core/lib/gpr/time_precise.cc
-  - src/core/lib/gpr/time_windows.cc
-  - src/core/lib/gpr/tmpfile_msys.cc
-  - src/core/lib/gpr/tmpfile_posix.cc
-  - src/core/lib/gpr/tmpfile_windows.cc
-  - src/core/lib/gpr/wrap_memcpy.cc
-  - src/core/lib/gprpp/examine_stack.cc
-  - src/core/lib/gprpp/fork.cc
-  - src/core/lib/gprpp/global_config_env.cc
-  - src/core/lib/gprpp/host_port.cc
-  - src/core/lib/gprpp/mpscq.cc
-  - src/core/lib/gprpp/stat_posix.cc
-  - src/core/lib/gprpp/stat_windows.cc
-  - src/core/lib/gprpp/status_helper.cc
-  - src/core/lib/gprpp/thd_posix.cc
-  - src/core/lib/gprpp/thd_windows.cc
-  - src/core/lib/gprpp/time_util.cc
-  - src/core/lib/profiling/basic_timers.cc
-  - src/core/lib/profiling/stap_timers.cc
+  - src/core/lib/debug/trace.cc
   - src/core/lib/promise/activity.cc
   - test/core/promise/observable_test.cc
   deps:
-  - absl/base:base
-  - absl/base:core_headers
   - absl/container:flat_hash_set
-  - absl/memory:memory
-  - absl/random:random
-  - absl/status:status
   - absl/status:statusor
-  - absl/strings:cord
-  - absl/strings:str_format
-  - absl/strings:strings
-  - absl/synchronization:synchronization
-  - absl/time:time
-  - absl/types:optional
   - absl/types:variant
-  - upb
+  - gpr
   uses_polling: false
 - name: orphanable_test
   gtest: true

--- a/src/core/lib/promise/activity.cc
+++ b/src/core/lib/promise/activity.cc
@@ -28,14 +28,16 @@ namespace grpc_core {
 GPR_THREAD_LOCAL(Activity*) Activity::g_current_activity_{nullptr};
 Waker::Unwakeable Waker::unwakeable_;
 
+namespace promise_detail {
+
 ///////////////////////////////////////////////////////////////////////////////
 // HELPER TYPES
 
 // Weak handle to an Activity.
 // Handle can persist while Activity goes away.
-class Activity::Handle final : public Wakeable {
+class FreestandingActivity::Handle final : public Wakeable {
  public:
-  explicit Handle(Activity* activity) : activity_(activity) {}
+  explicit Handle(FreestandingActivity* activity) : activity_(activity) {}
 
   // Ref the Handle (not the activity).
   void Ref() { refs_.fetch_add(1, std::memory_order_relaxed); }
@@ -57,7 +59,7 @@ class Activity::Handle final : public Wakeable {
     // against DropActivity, so we need to only increase activities refcount if
     // it is non-zero.
     if (activity_ && activity_->RefIfNonzero()) {
-      Activity* activity = activity_;
+      FreestandingActivity* activity = activity_;
       mu_.Unlock();
       // Activity still exists and we have a reference: wake it up, which will
       // drop the ref.
@@ -85,15 +87,15 @@ class Activity::Handle final : public Wakeable {
   // activity.
   std::atomic<size_t> refs_{2};
   Mutex mu_ ABSL_ACQUIRED_AFTER(activity_->mu_);
-  Activity* activity_ ABSL_GUARDED_BY(mu_);
+  FreestandingActivity* activity_ ABSL_GUARDED_BY(mu_);
 };
 
 ///////////////////////////////////////////////////////////////////////////////
 // ACTIVITY IMPLEMENTATION
 
-bool Activity::RefIfNonzero() { return IncrementIfNonzero(&refs_); }
+bool FreestandingActivity::RefIfNonzero() { return IncrementIfNonzero(&refs_); }
 
-Activity::Handle* Activity::RefHandle() {
+FreestandingActivity::Handle* FreestandingActivity::RefHandle() {
   if (handle_ == nullptr) {
     // No handle created yet - construct it and return it.
     handle_ = new Handle(this);
@@ -105,11 +107,15 @@ Activity::Handle* Activity::RefHandle() {
   }
 }
 
-void Activity::DropHandle() {
+void FreestandingActivity::DropHandle() {
   handle_->DropActivity();
   handle_ = nullptr;
 }
 
-Waker Activity::MakeNonOwningWaker() { return Waker(RefHandle()); }
+Waker FreestandingActivity::MakeNonOwningWaker() {
+  mu_.AssertHeld();
+  return Waker(RefHandle());
+}
 
+}  // namespace promise_detail
 }  // namespace grpc_core

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -37,6 +37,7 @@
 
 #include "src/core/lib/gpr/tls.h"
 #include "src/core/lib/gprpp/construct_destruct.h"
+#include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/promise/context.h"
 #include "src/core/lib/promise/detail/promise_factory.h"
@@ -110,18 +111,10 @@ class Waker {
 // Activity execution may be cancelled by simply deleting the activity. In such
 // a case, if execution had not already finished, the done callback would be
 // called with absl::CancelledError().
-class Activity : private Wakeable {
+class Activity : public Orphanable {
  public:
   // Cancel execution of the underlying promise.
-  virtual void Cancel() ABSL_LOCKS_EXCLUDED(mu_) = 0;
-
-  // Destroy the Activity - used for the type alias ActivityPtr.
-  struct Deleter {
-    void operator()(Activity* activity) {
-      activity->Cancel();
-      activity->Unref();
-    }
-  };
+  virtual void Cancel() = 0;
 
   // Fetch the size of the implementation of this activity.
   virtual size_t Size() = 0;
@@ -133,11 +126,8 @@ class Activity : private Wakeable {
   // an Activity to repoll.
   void ForceWakeup() { MakeOwningWaker().Wakeup(); }
 
-  // Wakeup the current threads activity - will force a subsequent poll after
-  // the one that's running.
-  static void WakeupCurrent() {
-    current()->SetActionDuringRun(ActionDuringRun::kWakeup);
-  }
+  // Force the current activity to immediately repoll if it doesn't complete.
+  virtual void ForceImmediateRepoll() = 0;
 
   // Return the current activity.
   // Additionally:
@@ -146,58 +136,23 @@ class Activity : private Wakeable {
   //   locked
   // - back up that assertation with a runtime check in debug builds (it's
   //   prohibitively expensive in non-debug builds)
-  static Activity* current() ABSL_ASSERT_EXCLUSIVE_LOCK(current()->mu_) {
-#ifndef NDEBUG
-    GPR_ASSERT(g_current_activity_);
-    if (g_current_activity_ != nullptr) {
-      g_current_activity_->mu_.AssertHeld();
-    }
-#endif
-    return g_current_activity_;
-  }
+  static Activity* current() { return g_current_activity_; }
 
   // Produce an activity-owning Waker. The produced waker will keep the activity
   // alive until it's awoken or dropped.
-  Waker MakeOwningWaker() {
-    Ref();
-    return Waker(this);
-  }
+  virtual Waker MakeOwningWaker() = 0;
 
   // Produce a non-owning Waker. The waker will own a small heap allocated weak
   // pointer to this activity. This is more suitable for wakeups that may not be
   // delivered until long after the activity should be destroyed.
-  Waker MakeNonOwningWaker() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  virtual Waker MakeNonOwningWaker() = 0;
 
  protected:
-  // Action received during a run, in priority order.
-  // If more than one action is received during a run, we use max() to resolve
-  // which one to report (so Cancel overrides Wakeup).
-  enum class ActionDuringRun : uint8_t {
-    kNone,    // No action occured during run.
-    kWakeup,  // A wakeup occured during run.
-    kCancel,  // Cancel was called during run.
-  };
-
-  inline virtual ~Activity() {
-    if (handle_) {
-      DropHandle();
-    }
-  }
-
-  // All promise execution occurs under this mutex.
-  Mutex mu_;
-
   // Check if this activity is the current activity executing on the current
   // thread.
   bool is_current() const { return this == g_current_activity_; }
   // Check if there is an activity executing on the current thread.
   static bool have_current() { return g_current_activity_ != nullptr; }
-  // Check if we got an internal wakeup since the last time this function was
-  // called.
-  ActionDuringRun GotActionDuringRun() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-    return absl::exchange(action_during_run_, ActionDuringRun::kNone);
-  }
-
   // Set the current activity at construction, clean it up at destruction.
   class ScopedActivity {
    public:
@@ -210,58 +165,14 @@ class Activity : private Wakeable {
     ScopedActivity& operator=(const ScopedActivity&) = delete;
   };
 
-  // Implementors of Wakeable::Wakeup should call this after the wakeup has
-  // completed.
-  void WakeupComplete() { Unref(); }
-
-  // Mark the current activity as being cancelled (so we can actually cancel it
-  // after polling).
-  void CancelCurrent() {
-    current()->SetActionDuringRun(ActionDuringRun::kCancel);
-  }
-
  private:
-  class Handle;
-
-  void Ref() { refs_.fetch_add(1, std::memory_order_relaxed); }
-  void Unref() {
-    if (1 == refs_.fetch_sub(1, std::memory_order_acq_rel)) {
-      delete this;
-    }
-  }
-
-  // Return a Handle instance with a ref so that it can be stored waiting for
-  // some wakeup.
-  Handle* RefHandle() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  // If our refcount is non-zero, ref and return true.
-  // Otherwise, return false.
-  bool RefIfNonzero();
-  // Drop the (proved existing) wait handle.
-  void DropHandle() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  // Set the action that occured during this run.
-  // We use max to combine actions so that cancellation overrides wakeups.
-  void SetActionDuringRun(ActionDuringRun action)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-    action_during_run_ = std::max(action_during_run_, action);
-  }
-
-  // Current refcount.
-  std::atomic<uint32_t> refs_{1};
-  // If wakeup is called during Promise polling, we set this to Wakeup and
-  // repoll. If cancel is called during Promise polling, we set this to Cancel
-  // and cancel at the end of polling.
-  ActionDuringRun action_during_run_ ABSL_GUARDED_BY(mu_) =
-      ActionDuringRun::kNone;
-  // Handle for long waits. Allows a very small weak pointer type object to
-  // queue for wakeups while Activity may be deleted earlier.
-  Handle* handle_ ABSL_GUARDED_BY(mu_) = nullptr;
   // Set during RunLoop to the Activity that's executing.
   // Being set implies that mu_ is held.
   static GPR_THREAD_LOCAL(Activity*) g_current_activity_;
 };
 
 // Owned pointer to one Activity.
-using ActivityPtr = std::unique_ptr<Activity, Activity::Deleter>;
+using ActivityPtr = OrphanablePtr<Activity>;
 
 namespace promise_detail {
 
@@ -320,6 +231,96 @@ class ActivityContexts : public ContextHolder<Contexts>... {
   };
 };
 
+// A free standing activity: an activity that owns its own synchronization and
+// memory.
+// The alternative is an activity that's somehow tied into another system, for
+// instance the type seen in promise_based_filter.h as we're transitioning from
+// the old filter stack to the new system.
+class FreestandingActivity : public Activity, private Wakeable {
+ public:
+  Waker MakeOwningWaker() final {
+    Ref();
+    return Waker(this);
+  }
+  Waker MakeNonOwningWaker() final;
+
+  void Orphan() final {
+    Cancel();
+    Unref();
+  }
+
+  void ForceImmediateRepoll() final {
+    mu_.AssertHeld();
+    SetActionDuringRun(ActionDuringRun::kWakeup);
+  }
+
+ protected:
+  // Action received during a run, in priority order.
+  // If more than one action is received during a run, we use max() to resolve
+  // which one to report (so Cancel overrides Wakeup).
+  enum class ActionDuringRun : uint8_t {
+    kNone,    // No action occured during run.
+    kWakeup,  // A wakeup occured during run.
+    kCancel,  // Cancel was called during run.
+  };
+
+  inline ~FreestandingActivity() override {
+    if (handle_) {
+      DropHandle();
+    }
+  }
+
+  // All promise execution occurs under this mutex.
+  Mutex mu_;
+
+  // Check if we got an internal wakeup since the last time this function was
+  // called.
+  ActionDuringRun GotActionDuringRun() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    return absl::exchange(action_during_run_, ActionDuringRun::kNone);
+  }
+
+  // Implementors of Wakeable::Wakeup should call this after the wakeup has
+  // completed.
+  void WakeupComplete() { Unref(); }
+
+  // Set the action that occured during this run.
+  // We use max to combine actions so that cancellation overrides wakeups.
+  void SetActionDuringRun(ActionDuringRun action)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    action_during_run_ = std::max(action_during_run_, action);
+  }
+
+ private:
+  class Handle;
+
+  void Ref() { refs_.fetch_add(1, std::memory_order_relaxed); }
+  void Unref() {
+    if (1 == refs_.fetch_sub(1, std::memory_order_acq_rel)) {
+      delete this;
+    }
+  }
+
+  // Return a Handle instance with a ref so that it can be stored waiting for
+  // some wakeup.
+  Handle* RefHandle() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  // If our refcount is non-zero, ref and return true.
+  // Otherwise, return false.
+  bool RefIfNonzero();
+  // Drop the (proved existing) wait handle.
+  void DropHandle() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  // Current refcount.
+  std::atomic<uint32_t> refs_{1};
+  // If wakeup is called during Promise polling, we set this to Wakeup and
+  // repoll. If cancel is called during Promise polling, we set this to Cancel
+  // and cancel at the end of polling.
+  ActionDuringRun action_during_run_ ABSL_GUARDED_BY(mu_) =
+      ActionDuringRun::kNone;
+  // Handle for long waits. Allows a very small weak pointer type object to
+  // queue for wakeups while Activity may be deleted earlier.
+  Handle* handle_ ABSL_GUARDED_BY(mu_) = nullptr;
+};
+
 // Implementation details for an Activity of an arbitrary type of promise.
 // There should exist a static function:
 // struct WakeupScheduler {
@@ -332,7 +333,7 @@ class ActivityContexts : public ContextHolder<Contexts>... {
 // invoked, and that a given activity will not be concurrently scheduled again
 // until its RunScheduledWakeup() has been invoked.
 template <class F, class WakeupScheduler, class OnDone, typename... Contexts>
-class PromiseActivity final : public Activity,
+class PromiseActivity final : public FreestandingActivity,
                               private ActivityContexts<Contexts...> {
  public:
   using Factory = PromiseFactory<void, F>;
@@ -340,7 +341,7 @@ class PromiseActivity final : public Activity,
 
   PromiseActivity(F promise_factory, WakeupScheduler wakeup_scheduler,
                   OnDone on_done, Contexts&&... contexts)
-      : Activity(),
+      : FreestandingActivity(),
         ActivityContexts<Contexts...>(std::forward<Contexts>(contexts)...),
         wakeup_scheduler_(std::move(wakeup_scheduler)),
         on_done_(std::move(on_done)) {
@@ -368,7 +369,8 @@ class PromiseActivity final : public Activity,
 
   void Cancel() final {
     if (Activity::is_current()) {
-      CancelCurrent();
+      mu_.AssertHeld();
+      SetActionDuringRun(ActionDuringRun::kCancel);
       return;
     }
     bool was_done;
@@ -402,7 +404,8 @@ class PromiseActivity final : public Activity,
     // If there is an active activity, but hey it's us, flag that and we'll loop
     // in RunLoop (that's calling from above here!).
     if (Activity::is_current()) {
-      WakeupCurrent();
+      mu_.AssertHeld();
+      SetActionDuringRun(ActionDuringRun::kWakeup);
       WakeupComplete();
       return;
     }

--- a/src/core/lib/promise/intra_activity_waiter.h
+++ b/src/core/lib/promise/intra_activity_waiter.h
@@ -36,7 +36,7 @@ class IntraActivityWaiter {
   void Wake() {
     if (waiting_) {
       waiting_ = false;
-      Activity::WakeupCurrent();
+      Activity::current()->ForceImmediateRepoll();
     }
   }
 

--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -135,7 +135,7 @@ Poll<RefCountedPtr<ReclaimerQueue::Handle>> ReclaimerQueue::PollNext() {
   if (!empty) {
     // If we don't, but the queue is probably not empty, schedule an immediate
     // repoll.
-    Activity::WakeupCurrent();
+    Activity::current()->ForceImmediateRepoll();
   } else {
     // Otherwise, schedule a wakeup for whenever something is pushed.
     state_->waker = Activity::current()->MakeNonOwningWaker();


### PR DESCRIPTION
Move mutex and wakeup logic into a new class between `PromiseActivity<>`
and `Activity` (so that the sharing can persist), but make `Activity` closer
to a pure interface, so that whilst we migrate code we can implement
better fakes without forcing allocation.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
