### PR TITLE
Adding a user supplied callback to MemoryAllocator API to be invoked at slice destruction

### DIFF
--- a/include/grpc/event_engine/memory_allocator.h
+++ b/include/grpc/event_engine/memory_allocator.h
@@ -151,8 +151,8 @@ class MemoryAllocator {
   /// any relevant control structures also.
   grpc_slice MakeSlice(MemoryRequest request);
 
-  // Similar to previous function but also invokes a user supplied destroy
-  // function at destruction.
+  /// Similar to above function but also invokes a user supplied destroy
+  /// function at destruction.
   grpc_slice MakeSlice(MemoryRequest request, void* arg,
                        void (*on_destroy)(void*));
 

--- a/include/grpc/event_engine/memory_allocator.h
+++ b/include/grpc/event_engine/memory_allocator.h
@@ -151,6 +151,11 @@ class MemoryAllocator {
   /// any relevant control structures also.
   grpc_slice MakeSlice(MemoryRequest request);
 
+  // Similar to previous function but also invokes a user supplied destroy
+  // function at destruction.
+  grpc_slice MakeSlice(MemoryRequest request, void* arg,
+                       void (*on_destroy)(void*));
+
   /// A C++ allocator for containers of T.
   template <typename T>
   class Container {


### PR DESCRIPTION
This makes it convenient for event engine implementations to trigger invocation of code at slice destruction.

@drfloob 
