### PR TITLE
run_tests.py cleanup and simplification

### DIFF
--- a/tools/run_tests/helper_scripts/build_csharp.bat
+++ b/tools/run_tests/helper_scripts/build_csharp.bat
@@ -14,7 +14,19 @@
 
 setlocal
 
-cd /d %~dp0\..\..\..\src\csharp
+cd /d %~dp0\..\..\..
+
+mkdir cmake
+cd cmake
+mkdir build
+cd build
+mkdir %ARCHITECTURE%
+cd %ARCHITECTURE%
+
+cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON  -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% ../../.. || goto :error
+cmake --build . --target grpc_csharp_ext --config %MSBUILD_CONFIG% || goto :error
+
+cd ..\..\..\src\csharp
 
 dotnet build --configuration %MSBUILD_CONFIG% Grpc.sln || goto :error
 

--- a/tools/run_tests/helper_scripts/build_csharp.sh
+++ b/tools/run_tests/helper_scripts/build_csharp.sh
@@ -17,6 +17,14 @@ set -ex
 
 cd "$(dirname "$0")/../../../src/csharp"
 
+mkdir -p cmake/build
+pushd cmake/build
+
+cmake -DgRPC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE="${MSBUILD_CONFIG}" -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../..
+make -j"${GRPC_RUN_TESTS_JOBS}" grpc_csharp_ext
+
+popd
+
 if [ "$CONFIG" == "gcov" ]
 then
   # overriding NativeDependenciesConfigurationUnix makes C# project pick up the gcov flavor of grpc_csharp_ext

--- a/tools/run_tests/helper_scripts/build_csharp.sh
+++ b/tools/run_tests/helper_scripts/build_csharp.sh
@@ -15,7 +15,7 @@
 
 set -ex
 
-cd "$(dirname "$0")/../../../src/csharp"
+cd "$(dirname "$0")/../../.."
 
 mkdir -p cmake/build
 pushd cmake/build
@@ -24,6 +24,7 @@ cmake -DgRPC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE="${MSBUILD_CONFIG}" -DgRPC_XDS_U
 make -j"${GRPC_RUN_TESTS_JOBS}" grpc_csharp_ext
 
 popd
+pushd src/csharp
 
 if [ "$CONFIG" == "gcov" ]
 then

--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -1,4 +1,4 @@
-@rem Copyright 2017 gRPC authors.
+@rem Copyright 2022 The gRPC Authors
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");
 @rem you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@ mkdir build
 cd build
 
 cmake -DgRPC_BUILD_TESTS=ON %* ../.. || goto :error
+
+@rem GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
+cmake --build . --target buildtests_%GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX% --config %MSBUILD_CONFIG% || goto :error
 
 endlocal
 

--- a/tools/run_tests/helper_scripts/build_cxx.sh
+++ b/tools/run_tests/helper_scripts/build_cxx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2015 gRPC authors.
+# Copyright 2022 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,3 +22,6 @@ cd cmake/build
 
 # MSBUILD_CONFIG's values are suitable for cmake as well
 cmake -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE="${MSBUILD_CONFIG}" "$@" ../..
+
+# GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
+make -j"${GRPC_RUN_TESTS_JOBS}" "buildtests_${GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX}" "tools_${GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX}" "check_epollexclusive"

--- a/tools/run_tests/helper_scripts/build_php.sh
+++ b/tools/run_tests/helper_scripts/build_php.sh
@@ -20,7 +20,10 @@ CONFIG=${CONFIG:-opt}
 # change to grpc repo root
 cd "$(dirname "$0")/../../.."
 
-root=$(pwd)
+# build C core first
+make -j"${GRPC_RUN_TESTS_JOBS}" EMBED_OPENSSL=true EMBED_ZLIB=true static_c shared_c
+
+repo_root="$(pwd)"
 export GRPC_LIB_SUBDIR=libs/$CONFIG
 export CFLAGS="-Wno-parentheses-equality"
 
@@ -30,8 +33,8 @@ cd src/php
 cd ext/grpc
 phpize
 if [ "$CONFIG" != "gcov" ] ; then
-  ./configure --enable-grpc="$root" --enable-tests
+  ./configure --enable-grpc="${repo_root}" --enable-tests
 else
-  ./configure --enable-grpc="$root" --enable-coverage --enable-tests
+  ./configure --enable-grpc="${repo_root}" --enable-coverage --enable-tests
 fi
-make
+make -j"${GRPC_RUN_TESTS_JOBS}"

--- a/tools/run_tests/helper_scripts/pre_build_csharp.bat
+++ b/tools/run_tests/helper_scripts/pre_build_csharp.bat
@@ -16,21 +16,10 @@
 
 setlocal
 
-set ARCHITECTURE=%1
-
 @rem enter repo root
 cd /d %~dp0\..\..\..
 
-mkdir cmake
-cd cmake
-mkdir build
-cd build
-mkdir %ARCHITECTURE%
-cd %ARCHITECTURE%
-
-cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON  -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON -DgRPC_BUILD_MSVC_MP_COUNT=4 ../../.. || goto :error
-
-cd ..\..\..\src\csharp
+cd src\csharp
 
 dotnet restore Grpc.sln || goto :error
 

--- a/tools/run_tests/helper_scripts/pre_build_csharp.sh
+++ b/tools/run_tests/helper_scripts/pre_build_csharp.sh
@@ -18,11 +18,6 @@ set -ex
 # cd to repository root
 cd "$(dirname "$0")/../../.."
 
-mkdir -p cmake/build
-cd cmake/build
-
-cmake -DgRPC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE="${MSBUILD_CONFIG}" -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../..
-
-cd ../../src/csharp
+cd src/csharp
 
 dotnet restore Grpc.sln

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -240,8 +240,8 @@ def _pypy_pattern_function(major):
 
 class CLanguage(object):
 
-    def __init__(self, make_target, test_lang):
-        self.make_target = make_target
+    def __init__(self, lang_suffix, test_lang):
+        self.lang_suffix = lang_suffix
         self.platform = platform_string()
         self.test_lang = test_lang
 
@@ -435,7 +435,7 @@ class CLanguage(object):
 
     def build_steps_environ(self):
         """Extra environment variables set for pre_build_steps and build_steps jobs."""
-        return {'GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX': self.make_target}
+        return {'GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX': self.lang_suffix}
 
     def post_tests_steps(self):
         if self.platform == 'windows':
@@ -485,7 +485,7 @@ class CLanguage(object):
             self._docker_distro, _docker_arch_suffix(self.args.arch))
 
     def __str__(self):
-        return self.make_target
+        return self.lang_suffix
 
 
 # This tests Node on grpc/grpc-node and will become the standard for Node testing

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -421,7 +421,7 @@ class CLanguage(object):
         if self.platform == 'windows':
             return [[
                 'tools\\run_tests\\helper_scripts\\build_cxx.bat',
-                '-DgRPC_BUILD_MSVC_MP_COUNT=%d' % args.jobs
+                '-DgRPC_BUILD_MSVC_MP_COUNT=%d' % self.args.jobs
             ] + self._cmake_configure_extra_args]
         else:
             return [['tools/run_tests/helper_scripts/build_cxx.sh'] +

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1300,7 +1300,7 @@ def _calculate_num_runs_failures(list_of_results):
 
 
 def _has_epollexclusive():
-    binary = 'bins/%s/check_epollexclusive' % args.config
+    binary = 'cmake/build/check_epollexclusive'
     if not os.path.exists(binary):
         return False
     try:

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -965,7 +965,10 @@ class CSharpLanguage(object):
 
     def build_steps_environ(self):
         """Extra environment variables set for pre_build_steps and build_steps jobs."""
-        return {'ARCHITECTURE': self._cmake_arch_option}
+        if self.platform == 'windows':
+            return {'ARCHITECTURE': self._cmake_arch_option}
+        else:
+            return {}
 
     def post_tests_steps(self):
         if self.platform == 'windows':

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -566,7 +566,6 @@ class Php7Language(object):
         self.config = config
         self.args = args
         _check_compiler(self.args.compiler, ['default'])
-        self._make_options = ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true']
 
     def test_specs(self):
         return [
@@ -578,10 +577,10 @@ class Php7Language(object):
         return []
 
     def make_targets(self):
-        return ['static_c', 'shared_c']
+        return []
 
     def make_options(self):
-        return self._make_options
+        return []
 
     def build_steps(self):
         return [['tools/run_tests/helper_scripts/build_php.sh']]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -414,12 +414,6 @@ class CLanguage(object):
                     print('\nWARNING: binary not found, skipping', binary)
         return sorted(out)
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def pre_build_steps(self):
         return []
 
@@ -442,9 +436,6 @@ class CLanguage(object):
             return []
         else:
             return [['tools/run_tests/helper_scripts/post_tests_c.sh']]
-
-    def makefile_name(self):
-        return 'cmake/build/Makefile'
 
     def _clang_cmake_configure_extra_args(self, version_suffix=''):
         return [
@@ -533,12 +524,6 @@ class RemoteNodeLanguage(object):
     def pre_build_steps(self):
         return []
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         return []
 
@@ -548,9 +533,6 @@ class RemoteNodeLanguage(object):
 
     def post_tests_steps(self):
         return []
-
-    def makefile_name(self):
-        return 'Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/node_jessie_%s' % _docker_arch_suffix(
@@ -576,12 +558,6 @@ class Php7Language(object):
     def pre_build_steps(self):
         return []
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         return [['tools/run_tests/helper_scripts/build_php.sh']]
 
@@ -591,9 +567,6 @@ class Php7Language(object):
 
     def post_tests_steps(self):
         return [['tools/run_tests/helper_scripts/post_tests_php.sh']]
-
-    def makefile_name(self):
-        return 'Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/php7_debian11_%s' % _docker_arch_suffix(
@@ -666,12 +639,6 @@ class PythonLanguage(object):
     def pre_build_steps(self):
         return []
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         return [config.build for config in self.pythons]
 
@@ -684,9 +651,6 @@ class PythonLanguage(object):
             return []
         else:
             return [['tools/run_tests/helper_scripts/post_tests_python.sh']]
-
-    def makefile_name(self):
-        return 'Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/python_%s_%s' % (
@@ -857,12 +821,6 @@ class RubyLanguage(object):
     def pre_build_steps(self):
         return [['tools/run_tests/helper_scripts/pre_build_ruby.sh']]
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         return [['tools/run_tests/helper_scripts/build_ruby.sh']]
 
@@ -872,9 +830,6 @@ class RubyLanguage(object):
 
     def post_tests_steps(self):
         return [['tools/run_tests/helper_scripts/post_tests_ruby.sh']]
-
-    def makefile_name(self):
-        return 'Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/ruby_debian11_%s' % _docker_arch_suffix(
@@ -951,12 +906,6 @@ class CSharpLanguage(object):
         else:
             return [['tools/run_tests/helper_scripts/pre_build_csharp.sh']]
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         if self.platform == 'windows':
             return [['tools\\run_tests\\helper_scripts\\build_csharp.bat']]
@@ -975,10 +924,6 @@ class CSharpLanguage(object):
             return [['tools\\run_tests\\helper_scripts\\post_tests_csharp.bat']]
         else:
             return [['tools/run_tests/helper_scripts/post_tests_csharp.sh']]
-
-    def makefile_name(self):
-        # value does not matter as build_csharp script takes care of the build.
-        return 'cmake/build/Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/csharp_%s_%s' % (
@@ -1142,12 +1087,6 @@ class ObjCLanguage(object):
     def pre_build_steps(self):
         return []
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         return []
 
@@ -1157,9 +1096,6 @@ class ObjCLanguage(object):
 
     def post_tests_steps(self):
         return []
-
-    def makefile_name(self):
-        return 'Makefile'
 
     def dockerfile_dir(self):
         return None
@@ -1198,12 +1134,6 @@ class Sanity(object):
     def pre_build_steps(self):
         return []
 
-    def make_targets(self):
-        return []
-
-    def make_options(self):
-        return []
-
     def build_steps(self):
         return []
 
@@ -1213,9 +1143,6 @@ class Sanity(object):
 
     def post_tests_steps(self):
         return []
-
-    def makefile_name(self):
-        return 'Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/sanity'
@@ -1563,21 +1490,11 @@ languages = set(_LANGUAGES[l] for l in args.language)
 for l in languages:
     l.configure(run_config, args)
 
-language_make_options = []
-if any(language.make_options() for language in languages):
-    if not 'gcov' in args.config and len(languages) != 1:
-        print(
-            'languages with custom make options cannot be built simultaneously with other languages'
-        )
-        sys.exit(1)
-    else:
-        # Combining make options is not clean and just happens to work. It allows C & C++ to build
-        # together, and is only used under gcov. All other configs should build languages individually.
-        language_make_options = list(
-            set([
-                make_option for lang in languages
-                for make_option in lang.make_options()
-            ]))
+if len(languages) != 1:
+    print(
+        'Building multiple languages simultaneously is not supported!'
+    )
+    sys.exit(1)
 
 if args.use_docker:
     if not args.travis:
@@ -1620,50 +1537,8 @@ if args.use_docker:
 
 _check_arch_option(args.arch)
 
-
-def make_jobspec(cfg, targets, makefile='Makefile'):
-    if platform_string() == 'windows':
-        return [
-            jobset.JobSpec([
-                'cmake', '--build', '.', '--target',
-                '%s' % target, '--config', _MSBUILD_CONFIG[cfg]
-            ],
-                           cwd=os.path.dirname(makefile),
-                           timeout_seconds=None) for target in targets
-        ]
-    else:
-        if targets and makefile.startswith('cmake/build/'):
-            # With cmake, we've passed all the build configuration in the pre-build step already
-            return [
-                jobset.JobSpec(
-                    [os.getenv('MAKE', 'make'), '-j',
-                     '%d' % args.jobs] + targets,
-                    cwd='cmake/build',
-                    timeout_seconds=None)
-            ]
-        if targets:
-            return [
-                jobset.JobSpec(
-                    [
-                        os.getenv('MAKE', 'make'), '-f', makefile, '-j',
-                        '%d' % args.jobs,
-                        'EXTRA_DEFINES=GRPC_TEST_SLOWDOWN_MACHINE_FACTOR=%f' %
-                        args.slowdown,
-                        'CONFIG=%s' % cfg, 'Q='
-                    ] + language_make_options +
-                    ([] if not args.travis else ['JENKINS_BUILD=1']) + targets,
-                    timeout_seconds=None)
-            ]
-        else:
-            return []
-
-
-make_targets = {}
-for l in languages:
-    makefile = l.makefile_name()
-    make_targets[makefile] = make_targets.get(makefile, set()).union(
-        set(l.make_targets()))
-
+# collect pre-build steps (which get retried if they fail, e.g. to avoid
+# flakes on downloading dependencies etc.)
 build_steps = list(
     set(
         jobset.JobSpec(cmdline,
@@ -1673,11 +1548,8 @@ build_steps = list(
                        flake_retries=2)
         for l in languages
         for cmdline in l.pre_build_steps()))
-if make_targets:
-    make_commands = itertools.chain.from_iterable(
-        make_jobspec(build_config, list(targets), makefile)
-        for (makefile, targets) in make_targets.items())
-    build_steps.extend(set(make_commands))
+
+# collect build steps
 build_steps.extend(
     set(
         jobset.JobSpec(cmdline,
@@ -1687,6 +1559,7 @@ build_steps.extend(
         for l in languages
         for cmdline in l.build_steps()))
 
+# collect post test steps
 post_tests_steps = list(
     set(
         jobset.JobSpec(cmdline,

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -948,15 +948,12 @@ class CSharpLanguage(object):
 
     def pre_build_steps(self):
         if self.platform == 'windows':
-            return [[
-                'tools\\run_tests\\helper_scripts\\pre_build_csharp.bat',
-                self._cmake_arch_option
-            ]]
+            return [['tools\\run_tests\\helper_scripts\\pre_build_csharp.bat']]
         else:
             return [['tools/run_tests/helper_scripts/pre_build_csharp.sh']]
 
     def make_targets(self):
-        return ['grpc_csharp_ext']
+        return []
 
     def make_options(self):
         return []
@@ -969,7 +966,7 @@ class CSharpLanguage(object):
 
     def build_steps_environ(self):
         """Extra environment variables set for pre_build_steps and build_steps jobs."""
-        return {}
+        return {'ARCHITECTURE': self._cmake_arch_option}
 
     def post_tests_steps(self):
         if self.platform == 'windows':
@@ -978,12 +975,8 @@ class CSharpLanguage(object):
             return [['tools/run_tests/helper_scripts/post_tests_csharp.sh']]
 
     def makefile_name(self):
-        if self.platform == 'windows':
-            return 'cmake/build/%s/Makefile' % self._cmake_arch_option
-        else:
-            # no need to set x86 specific flags as run_tests.py
-            # currently forbids x86 C# builds on both Linux and MacOS.
-            return 'cmake/build/Makefile'
+        # value does not matter as build_csharp script takes care of the build.
+        return 'cmake/build/Makefile'
 
     def dockerfile_dir(self):
         return 'tools/dockerfile/test/csharp_%s_%s' % (

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1455,6 +1455,7 @@ def _build_and_run(check_cancelled,
 
     return out
 
+
 # parse command line
 argp = argparse.ArgumentParser(description='Run grpc tests.')
 argp.add_argument('-c',
@@ -1680,9 +1681,7 @@ for l in languages:
     l.configure(run_config, args)
 
 if len(languages) != 1:
-    print(
-        'Building multiple languages simultaneously is not supported!'
-    )
+    print('Building multiple languages simultaneously is not supported!')
     sys.exit(1)
 
 # If --use_docker was used, respawn the run_tests.py script under a docker container

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1524,9 +1524,6 @@ if args.use_docker:
     env['DOCKERFILE_DIR'] = dockerfile_dir
     env['DOCKER_RUN_SCRIPT'] = 'tools/run_tests/dockerize/docker_run.sh'
     env['DOCKER_RUN_SCRIPT_COMMAND'] = run_tests_cmd
-    # TODO(jtattermusch): is the XML_REPORT env variable any useful?
-    if args.xml_report:
-        env['XML_REPORT'] = args.xml_report
 
     retcode = subprocess.call(
         'tools/run_tests/dockerize/build_and_run_docker.sh',

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -249,7 +249,6 @@ class CLanguage(object):
         self.config = config
         self.args = args
         self._make_options = []
-        self._use_cmake = True
         if self.platform == 'windows':
             _check_compiler(self.args.compiler, [
                 'default', 'cmake', 'cmake_vs2015', 'cmake_vs2017',
@@ -286,7 +285,7 @@ class CLanguage(object):
         out = []
         binaries = get_c_tests(self.args.travis, self.test_lang)
         for target in binaries:
-            if self._use_cmake and target.get('boringssl', False):
+            if target.get('boringssl', False):
                 # cmake doesn't build boringssl tests
                 continue
             auto_timeout_scaling = target.get('auto_timeout_scaling', True)
@@ -327,11 +326,8 @@ class CLanguage(object):
                     binary = 'cmake/build/%s/%s.exe' % (_MSBUILD_CONFIG[
                         self.config.build_config], target['name'])
                 else:
-                    if self._use_cmake:
-                        binary = 'cmake/build/%s' % target['name']
-                    else:
-                        binary = 'bins/%s/%s' % (self.config.build_config,
-                                                 target['name'])
+                    binary = 'cmake/build/%s' % target['name']
+
                 cpu_cost = target['cpu_cost']
                 if cpu_cost == 'capacity':
                     cpu_cost = multiprocessing.cpu_count()
@@ -437,11 +433,9 @@ class CLanguage(object):
                 'tools\\run_tests\\helper_scripts\\pre_build_cmake.bat',
                 '-DgRPC_BUILD_MSVC_MP_COUNT=%d' % args.jobs
             ] + self._cmake_configure_extra_args]
-        elif self._use_cmake:
+        else:
             return [['tools/run_tests/helper_scripts/pre_build_cmake.sh'] +
                     self._cmake_configure_extra_args]
-        else:
-            return []
 
     def build_steps(self):
         return []
@@ -453,10 +447,7 @@ class CLanguage(object):
             return [['tools/run_tests/helper_scripts/post_tests_c.sh']]
 
     def makefile_name(self):
-        if self._use_cmake:
-            return 'cmake/build/Makefile'
-        else:
-            return 'Makefile'
+        return 'cmake/build/Makefile'
 
     def _clang_cmake_configure_extra_args(self, version_suffix=''):
         return [

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1570,15 +1570,6 @@ argp.add_argument('--measure_cpu_costs',
                   action='store_const',
                   const=True,
                   help='Measure the cpu costs of tests')
-argp.add_argument(
-    '--update_submodules',
-    default=[],
-    nargs='*',
-    help=
-    'Update some submodules before building. If any are updated, also run generate_projects. '
-    +
-    'Submodules are specified as SUBMODULE_NAME:BRANCH; if BRANCH is omitted, master is assumed.'
-)
 argp.add_argument('-a', '--antagonists', default=0, type=int)
 argp.add_argument('-x',
                   '--xml_report',
@@ -1637,36 +1628,6 @@ elif args.force_use_pollers:
     _POLLING_STRATEGIES[platform_string()] = args.force_use_pollers.split(',')
 
 jobset.measure_cpu_costs = args.measure_cpu_costs
-
-# update submodules if necessary
-need_to_regenerate_projects = False
-for spec in args.update_submodules:
-    spec = spec.split(':', 1)
-    if len(spec) == 1:
-        submodule = spec[0]
-        branch = 'master'
-    elif len(spec) == 2:
-        submodule = spec[0]
-        branch = spec[1]
-    cwd = 'third_party/%s' % submodule
-
-    def git(cmd, cwd=cwd):
-        print('in %s: git %s' % (cwd, cmd))
-        run_shell_command('git %s' % cmd, cwd=cwd)
-
-    git('fetch')
-    git('checkout %s' % branch)
-    git('pull origin %s' % branch)
-    if os.path.exists('src/%s/gen_build_yaml.py' % submodule):
-        need_to_regenerate_projects = True
-if need_to_regenerate_projects:
-    if jobset.platform_string() == 'linux':
-        run_shell_command('tools/buildgen/generate_projects.sh')
-    else:
-        print(
-            'WARNING: may need to regenerate projects, but since we are not on')
-        print(
-            '         Linux this step is being skipped. Compilation MAY fail.')
 
 # grab config
 run_config = _CONFIGS[args.config]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1483,6 +1483,7 @@ if need_to_regenerate_projects:
 run_config = _CONFIGS[args.config]
 build_config = run_config.build_config
 
+# TODO(jtattermusch): is this setting applied/being used?
 if args.travis:
     _FORCE_ENVIRON_FOR_WRAPPERS = {'GRPC_TRACE': 'api'}
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1199,7 +1199,7 @@ class Sanity(object):
         return []
 
     def make_targets(self):
-        return ['run_dep_checks']
+        return []
 
     def make_options(self):
         return []


### PR DESCRIPTION
- get rid of the "Makefile" support in run_tests.py (as makefile has been deprecated quite a while ago). Instead, each of the languages has a "build_LANG" script that takes care of building given language (e.g. run cmake configure, then run make and then build the wrapper). This leads to quite a bit of simplification and makes the process of building each language more transparent.
- reorganize run_tests.py so that the body of "main" function is towards end of the file and not scattered across the entire file.
- get rid of some unused features 
- propagate some useful env variables (such as GRPC_RUN_TESTS_JOBS which has the value of `-j` argument) into the build environment. This allows language specific builds to benefit from parallelism wherever possible.
- some minor fixes

This cleanup is a prerequisite for future improvements & speedup in windows builds (adding support for ninja). It also make the run_tests.py logic less specialized (most "build" steps are now basically invoking a build script with the right args).

The commit history has individual improvements (each can be reviewed separately).