### PR TITLE
Build macos_arm64 binaries for grpc-tools

### DIFF
--- a/src/ruby/tools/README.md
+++ b/src/ruby/tools/README.md
@@ -10,3 +10,4 @@ Before this package is published, the following directories should be filled wit
  - `bin/x86_64-macos`
  - `bin/x86-windows`
  - `bin/x86_64-windows`
+ - `bin/arm64-macos`

--- a/src/ruby/tools/platform_check.rb
+++ b/src/ruby/tools/platform_check.rb
@@ -29,12 +29,9 @@ module PLATFORM
   end
 
   def PLATFORM.architecture
-    host_cpu = RbConfig::CONFIG['host_cpu']
-
-    # When we're on arm in macOS, we can rely on Rosetta and use the x86_64 binary
-    return 'x86_64' if RbConfig::CONFIG['host_os'] =~ /darwin/ && host_cpu =~ /arm/
-
-    case host_cpu
+    case RbConfig::CONFIG['host_cpu']
+      when /arm/
+        'arm64'
       when /x86_64/
         'x86_64'
       else

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -52,12 +52,6 @@ tools/run_tests/helper_scripts/bundle_install_wrapper.sh
 export DOCKERHUB_ORGANIZATION=grpctesting
 bundle exec rake "gem:native[${GEM_PLATFORM}]"
 
-if [ "$SYSTEM" == "Darwin" ] ; then
-  # TODO: consider rewriting this to pass shellcheck
-  # shellcheck disable=SC2046,SC2010
-  rm $(ls pkg/*.gem | grep -v darwin)
-fi
-
 mkdir -p "${ARTIFACTS_OUT}"
 
 cp pkg/*.gem "${ARTIFACTS_OUT}"/

--- a/tools/run_tests/artifacts/build_package_ruby.sh
+++ b/tools/run_tests/artifacts/build_package_ruby.sh
@@ -33,7 +33,7 @@ cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/ruby_native_gem_*/* artifacts/ || t
 # that have been built by the the artifact build phase previously.
 well_known_protos=( any api compiler/plugin descriptor duration empty field_mask source_context struct timestamp type wrappers )
 
-for arch in {x86,x64}; do
+for arch in {x86,x64,arm64}; do
   case $arch in
     x64)
       ruby_arch=x86_64
@@ -45,6 +45,16 @@ for arch in {x86,x64}; do
   for plat in {windows,linux,macos}; do
     # skip non-existent macos x86 protoc artifact
     if [[ "${plat}_${arch}" == "macos_x86" ]]
+    then
+      continue
+    fi
+    # skip non-existent windows arm64 protoc artifact
+    if [[ "${plat}_${arch}" == "windows_arm64" ]]
+    then
+      continue
+    fi
+    # skip non-existent linux arm64 protoc artifact
+    if [[ "${plat}_${arch}" == "linux_arm64" ]]
     then
       continue
     fi


### PR DESCRIPTION

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@apolcyn 

Resolves [#28512](https://github.com/grpc/grpc/issues/28512).

Build the `protoc` and `grpc_ruby_plugin` binaries for arm64 on macOS (the new _Apple Silicon_ M1's), and use them in the `grpc-tools` scripts (`grpc_tools_ruby_protoc` and `grpc_tools_ruby_protoc_plugin`).

This issue was _partially_ addressed before, please see the linked github issue for more details.