### PR TITLE
Removed grpc_error_string usage

### DIFF
--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -319,7 +319,7 @@ class CallData<ChannelFilter, true> : public BaseCallData {
     metadata->Set(GrpcMessageMetadata(),
                   Slice::FromCopiedString(status_details));
     metadata->GetOrCreatePointer(GrpcStatusContext())
-        ->emplace_back(grpc_error_string(error));
+        ->emplace_back(grpc_error_std_string(error));
   }
 
   // Wakeup and poll the promise if appropriate.

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -445,6 +445,8 @@ static void internal_set_time(grpc_error_handle* err, grpc_error_times which,
   memcpy((*err)->arena + slot, &value, sizeof(value));
 }
 
+const char* grpc_error_string(grpc_error_handle err);
+
 static void internal_add_error(grpc_error_handle* err,
                                grpc_error_handle new_err) {
   grpc_linked_error new_last = {new_err, UINT8_MAX};

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -145,8 +145,6 @@ typedef enum {
   GRPC_ERROR_TIME_MAX,
 } grpc_error_times;
 
-// DEPRECATED: Use grpc_error_std_string instead
-const char* grpc_error_string(grpc_error_handle error);
 std::string grpc_error_std_string(grpc_error_handle error);
 
 // debug only toggles that allow for a sanity to check that ensures we will


### PR DESCRIPTION
Removed its usage from `promise_based_filter`.
Removed `grpc_error_string` from the header.