### PR TITLE
Increase number of threads in stress test

### DIFF
--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -43,7 +43,7 @@
 using grpc::testing::EchoRequest;
 using grpc::testing::EchoResponse;
 
-const int kNumThreads = 100;  // Number of threads
+const int kNumThreads = 300;  // Number of threads
 const int kNumAsyncSendThreads = 2;
 const int kNumAsyncReceiveThreads = 50;
 const int kNumAsyncServerThreads = 50;


### PR DESCRIPTION
In some configurations 100 threads is not enough to cause exhaustion failing tests.

Increase number of threads to ensure resource exhaustion




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
