### PR TITLE
Always define GPR_SUPPORT_BINDER_TRANSPORT on Android

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -134,9 +134,7 @@
 #if __ANDROID_API__ < 21
 #error "Requires Android API v21 and above"
 #endif
-#if (__ANDROID_API__) >= 23
 #define GPR_SUPPORT_BINDER_TRANSPORT 1
-#endif
 // TODO(apolcyn): re-evaluate support for c-ares
 // on android after upgrading our c-ares dependency.
 // See https://github.com/grpc/grpc/issues/18038.


### PR DESCRIPTION
We previously have this restriction because some code does not compile
with older NDK version. Now the binder transport implementation loads
the library and resolves symbols at runtime so we don't need the
compile time restriction anymore (and in some case it is overly
restrictive)

Later we might consider remove the GPR_SUPPORT_BINDER_TRANSPORT symbol
and simply use GPR_ANDROID, once we become sure that binder transport
will always be available on Android at compile time.

