### PR TITLE
A more reliable way of installing bazel on windows workers

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -41,7 +41,7 @@ then
 fi
 
 # IMPORTANT: if you update the version here, other parts of infrastructure might needs updating as well
-# (e.g. win RBE builds, sanity checks, bazel toolchains etc.)
+# (e.g. sanity checks, bazel toolchains etc.)
 VERSION=${OVERRIDE_BAZEL_VERSION:-4.2.1}
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
@@ -61,6 +61,9 @@ case $(uname -sm) in
     ;;
   "Darwin x86_64")
     suffix=darwin-x86_64
+    ;;
+  "MINGW"*)
+    suffix=windows-x86_64
     ;;
   *)
     echo "Unsupported architecture: $(uname -sm)" >&2

--- a/tools/bazel
+++ b/tools/bazel
@@ -62,8 +62,8 @@ case $(uname -sm) in
   "Darwin x86_64")
     suffix=darwin-x86_64
     ;;
-  "MINGW"*)
-    suffix=windows-x86_64
+  "MINGW"* | "MSYS_NT"*)
+    suffix=windows-x86_64.exe
     ;;
   *)
     echo "Unsupported architecture: $(uname -sm)" >&2

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -26,9 +26,12 @@ cd github/grpc
 
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
-@rem TODO(jtattermusch): make this generate less output
-@rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync
-choco install bazel -y --version 4.2.1 --limit-output || exit /b 1
+@rem Install bazel
+@rem Side effect of the tools/bazel script is that it downloads the correct version of bazel binary.
+mkdir C:\bazel
+bash -c "tools/bazel --version && cp tools/bazel-*.exe /c/bazel/bazel.exe"
+set PATH=C:\bazel;%PATH%
+bazel --version
 
 @rem Generate a random UUID and store in "bazel_invocation_ids" artifact file
 powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -37,7 +37,6 @@ bazel --version
 powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
-@rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
 bazel --bazelrc=tools/remote_build/windows.bazelrc --output_user_root=T:\_bazel_output test --invocation_id="%BAZEL_INVOCATION_ID%" %BAZEL_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat //test/...
 set BAZEL_EXITCODE=%errorlevel%
 


### PR DESCRIPTION
Make use of tools/bazel script that already knows the right bazel version (no need to keep file versions at sync) and tries downloading from both github and from a mirror.

Progress towards https://github.com/grpc/grpc/issues/26489
