### PR TITLE
Use ninja for all grpc_csharp_ext builds on windows

### DIFF
--- a/src/csharp/Grpc.Core/NativeDeps.Windows.csproj.include
+++ b/src/csharp/Grpc.Core/NativeDeps.Windows.csproj.include
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <Content Include="..\..\..\cmake\build\x64\$(NativeDependenciesConfiguration)\grpc_csharp_ext.dll">
+    <Content Include="..\..\..\cmake\build\grpc_csharp_ext.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>grpc_csharp_ext.x64.dll</Link>
       <Pack>false</Pack>

--- a/src/csharp/Grpc.Core/NativeDeps.csproj.include
+++ b/src/csharp/Grpc.Core/NativeDeps.csproj.include
@@ -1,16 +1,5 @@
 <!-- Ensures that native libraries are copied to the output directory for Exe targets -->
 <Project>
-
-  <PropertyGroup Condition=" '$(NativeDependenciesConfiguration)' == '' ">
-    <NativeDependenciesConfiguration Condition=" '$(Configuration)' == 'Debug' ">Debug</NativeDependenciesConfiguration>
-    <NativeDependenciesConfiguration Condition=" '$(Configuration)' == 'Release' ">Release</NativeDependenciesConfiguration>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(NativeDependenciesConfigurationUnix)' == '' ">
-    <NativeDependenciesConfigurationUnix Condition=" '$(Configuration)' == 'Debug' ">dbg</NativeDependenciesConfigurationUnix>
-    <NativeDependenciesConfigurationUnix Condition=" '$(Configuration)' == 'Release' ">opt</NativeDependenciesConfigurationUnix>
-  </PropertyGroup>
-
   <!-- Autodetect platform -->
   <PropertyGroup Condition=" '$(OS)' != 'Unix' ">
     <NativeDepsPlatform>Windows</NativeDepsPlatform>

--- a/tools/internal_ci/windows/grpc_build_artifacts.bat
+++ b/tools/internal_ci/windows/grpc_build_artifacts.bat
@@ -29,8 +29,7 @@ set PREPARE_BUILD_INSTALL_DEPS_CSHARP=true
 set PREPARE_BUILD_INSTALL_DEPS_PYTHON=true
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
-@rem TODO(jtattermusch): set --inner_jobs args
-python tools/run_tests/task_runner.py -f artifact windows %TASK_RUNNER_EXTRA_FILTERS% -j 4
+python tools/run_tests/task_runner.py -f artifact windows %TASK_RUNNER_EXTRA_FILTERS% -j 4 --inner_jobs 4
 set RUNTESTS_EXITCODE=%errorlevel%
 
 bash tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh

--- a/tools/internal_ci/windows/grpc_build_artifacts.bat
+++ b/tools/internal_ci/windows/grpc_build_artifacts.bat
@@ -29,6 +29,7 @@ set PREPARE_BUILD_INSTALL_DEPS_CSHARP=true
 set PREPARE_BUILD_INSTALL_DEPS_PYTHON=true
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
+@rem TODO(jtattermusch): set --inner_jobs args
 python tools/run_tests/task_runner.py -f artifact windows %TASK_RUNNER_EXTRA_FILTERS% -j 4
 set RUNTESTS_EXITCODE=%errorlevel%
 

--- a/tools/run_tests/artifacts/build_artifact_csharp.bat
+++ b/tools/run_tests/artifacts/build_artifact_csharp.bat
@@ -26,17 +26,17 @@ cd build
 mkdir %ARCHITECTURE%
 cd %ARCHITECTURE%
 
-@rem TODO(jtattermusch): is there a better way to force using MSVC?
-@rem select the MSVC compiler explicitly to avoid using gcc from mingw or cygwin
-@rem (both are on path)
-set "MSVC_COMPILER=C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/cl.exe"
-if "%ARCHITECTURE%" == "x64" (
-  set "MSVC_COMPILER=C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe"
-)
-
+@rem set cl.exe build environment to build with VS2015 tooling
+@rem this is required for Ninja build to work
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %ARCHITECTURE%
-cmake -G Ninja -DCMAKE_C_COMPILER="%MSVC_COMPILER%" -DCMAKE_CXX_COMPILER="%MSVC_COMPILER%" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON -DgRPC_BUILD_MSVC_MP_COUNT=4 ../../.. || goto :error
-cmake --build . --target grpc_csharp_ext
+@rem restore command echo
+echo on
+
+@rem Select MSVC compiler (cl.exe) explicitly to make sure we don't end up gcc from mingw or cygwin
+@rem (both are on path in kokoro win workers)
+cmake -G Ninja -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../../.. || goto :error
+
+ninja -j%GRPC_CSHARP_BUILD_EXT_COMPILER_JOBS% grpc_csharp_ext || goto :error
 cd ..\..\..
 
 mkdir -p %ARTIFACTS_OUT%

--- a/tools/run_tests/artifacts/build_artifact_csharp.bat
+++ b/tools/run_tests/artifacts/build_artifact_csharp.bat
@@ -26,6 +26,11 @@ cd build
 mkdir %ARCHITECTURE%
 cd %ARCHITECTURE%
 
+@rem Use externally provided env to determine build parallelism, otherwise use default.
+if "%GRPC_CSHARP_BUILD_EXT_COMPILER_JOBS%"=="" (
+  set GRPC_CSHARP_BUILD_EXT_COMPILER_JOBS=2
+)
+
 @rem set cl.exe build environment to build with VS2015 tooling
 @rem this is required for Ninja build to work
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %ARCHITECTURE%

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -32,7 +32,10 @@ set GRPC_PYTHON_BUILD_WITH_CYTHON=1
 
 @rem Allow build_ext to build C/C++ files in parallel
 @rem by enabling a monkeypatch. It speeds up the build a lot.
-set GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=4
+@rem Use externally provided GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS value if set.
+if "%GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS%"=="" (
+  set GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=4
+)
 
 mkdir -p %ARTIFACTS_OUT%
 set ARTIFACT_DIR=%cd%\%ARTIFACTS_OUT%

--- a/tools/run_tests/helper_scripts/build_csharp.bat
+++ b/tools/run_tests/helper_scripts/build_csharp.bat
@@ -20,8 +20,6 @@ mkdir cmake
 cd cmake
 mkdir build
 cd build
-mkdir %ARCHITECTURE%
-cd %ARCHITECTURE%
 
 @rem use setlocal/endlocal to prevent the C++ build env variables from polluting the environment for "dotnet build"
 setlocal
@@ -34,13 +32,13 @@ echo on
 
 @rem Select MSVC compiler (cl.exe) explicitly to make sure we don't end up gcc from mingw or cygwin
 @rem (both are on path in kokoro win workers)
-cmake -G Ninja -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=%MSBUILD_CONFIG% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../../.. || goto :error
+cmake -G Ninja -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=%MSBUILD_CONFIG% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../.. || goto :error
 
 ninja -j%GRPC_RUN_TESTS_JOBS% grpc_csharp_ext || goto :error
 
 endlocal
 
-cd ..\..\..\src\csharp
+cd ..\..\src\csharp
 
 dotnet build --configuration %MSBUILD_CONFIG% Grpc.sln || goto :error
 

--- a/tools/run_tests/helper_scripts/build_csharp.bat
+++ b/tools/run_tests/helper_scripts/build_csharp.bat
@@ -23,6 +23,9 @@ cd build
 mkdir %ARCHITECTURE%
 cd %ARCHITECTURE%
 
+@rem use setlocal/endlocal to prevent the C++ build env variables from polluting the environment for "dotnet build"
+setlocal
+
 @rem set cl.exe build environment to build with VS2015 tooling
 @rem this is required for Ninja build to work
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %ARCHITECTURE%
@@ -34,6 +37,8 @@ echo on
 cmake -G Ninja -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=%MSBUILD_CONFIG% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../../.. || goto :error
 
 ninja -j%GRPC_RUN_TESTS_JOBS% grpc_csharp_ext || goto :error
+
+endlocal
 
 cd ..\..\..\src\csharp
 

--- a/tools/run_tests/helper_scripts/build_csharp.bat
+++ b/tools/run_tests/helper_scripts/build_csharp.bat
@@ -23,8 +23,17 @@ cd build
 mkdir %ARCHITECTURE%
 cd %ARCHITECTURE%
 
-cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON  -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% ../../.. || goto :error
-cmake --build . --target grpc_csharp_ext --config %MSBUILD_CONFIG% || goto :error
+@rem set cl.exe build environment to build with VS2015 tooling
+@rem this is required for Ninja build to work
+call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %ARCHITECTURE%
+@rem restore command echo
+echo on
+
+@rem Select MSVC compiler (cl.exe) explicitly to make sure we don't end up gcc from mingw or cygwin
+@rem (both are on path in kokoro win workers)
+cmake -G Ninja -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=%MSBUILD_CONFIG% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_XDS_USER_AGENT_IS_CSHARP=ON ../../.. || goto :error
+
+ninja -j%GRPC_RUN_TESTS_JOBS% grpc_csharp_ext || goto :error
 
 cd ..\..\..\src\csharp
 

--- a/tools/run_tests/helper_scripts/build_csharp.sh
+++ b/tools/run_tests/helper_scripts/build_csharp.sh
@@ -26,10 +26,4 @@ make -j"${GRPC_RUN_TESTS_JOBS}" grpc_csharp_ext
 popd
 pushd src/csharp
 
-if [ "$CONFIG" == "gcov" ]
-then
-  # overriding NativeDependenciesConfigurationUnix makes C# project pick up the gcov flavor of grpc_csharp_ext
-  dotnet build --configuration "$MSBUILD_CONFIG" /p:NativeDependenciesConfigurationUnix=gcov Grpc.sln
-else
-  dotnet build --configuration "$MSBUILD_CONFIG" Grpc.sln
-fi
+dotnet build --configuration "$MSBUILD_CONFIG" Grpc.sln


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/28833

C# artifact build already uses ninja, this switches to C# basictest on windows to ninja build as well (with the hope of getting a boost in compilation speed).