### PR TITLE
Remove unnecessary gflags related comments in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,6 @@ endif
 # Also set PROTOBUF_CONFIG_OPTS to indicate cross-compilation to protobuf (e.g.,
 #  PROTOBUF_CONFIG_OPTS="--host=arm-linux --with-protoc=/usr/local/bin/protoc" )
 # Set HAS_PKG_CONFIG=false
-# To build tests, go to third_party/gflags and follow its ccmake instructions
 # Make sure that you enable building shared libraries and set your prefix to
 # something useful like /usr/local/cross
 # You will also need to set GRPC_CROSS_LDOPTS and GRPC_CROSS_AROPTS to hold

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -290,7 +290,6 @@
   # Also set PROTOBUF_CONFIG_OPTS to indicate cross-compilation to protobuf (e.g.,
   #  PROTOBUF_CONFIG_OPTS="--host=arm-linux --with-protoc=/usr/local/bin/protoc" )
   # Set HAS_PKG_CONFIG=false
-  # To build tests, go to third_party/gflags and follow its ccmake instructions
   # Make sure that you enable building shared libraries and set your prefix to
   # something useful like /usr/local/cross
   # You will also need to set GRPC_CROSS_LDOPTS and GRPC_CROSS_AROPTS to hold


### PR DESCRIPTION
Are gflags related comments still necessary? For me they may lead to confusion as grpc has moved to abseil flags.

Signed-off-by: chengzrz <czrzrichard@gmail.com>




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
