### PR TITLE
Build protoc windows artifacts with ninja

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -385,8 +385,8 @@ class ProtocArtifact:
                     timeout_seconds=60 * 60,
                     use_workspace=True)
         else:
-            generator = 'Visual Studio 14 2015 Win64' if self.arch == 'x64' else 'Visual Studio 14 2015'
-            environ['generator'] = generator
+            vs_tools_architecture = self.arch  # architecture selector passed to vcvarsall.bat
+            environ['ARCHITECTURE'] = vs_tools_architecture
             return create_jobspec(
                 self.name,
                 ['tools\\run_tests\\artifacts\\build_artifact_protoc.bat'],

--- a/tools/run_tests/artifacts/build_artifact_protoc.bat
+++ b/tools/run_tests/artifacts/build_artifact_protoc.bat
@@ -22,13 +22,26 @@ cd cmake
 mkdir build
 cd build
 
-cmake -G "%generator%" -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON -DgRPC_BUILD_MSVC_MP_COUNT=4 ../.. || goto :error
-cmake --build . --target protoc --config Release || goto :error
-cmake --build . --target plugins --config Release || goto :error
+@rem Use externally provided env to determine build parallelism, otherwise use default.
+if "%GRPC_PROTOC_BUILD_COMPILER_JOBS%"=="" (
+  set GRPC_PROTOC_BUILD_COMPILER_JOBS=2
+)
+
+@rem set cl.exe build environment to build with VS2015 tooling
+@rem this is required for Ninja build to work
+call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %ARCHITECTURE%
+@rem restore command echo
+echo on
+
+@rem Select MSVC compiler (cl.exe) explicitly to make sure we don't end up gcc from mingw or cygwin
+@rem (both are on path in kokoro win workers)
+cmake -G Ninja -DCMAKE_C_COMPILER="cl.exe" -DCMAKE_CXX_COMPILER="cl.exe" -DCMAKE_BUILD_TYPE=Release -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON ../../.. || goto :error
+
+ninja -j%GRPC_PROTOC_BUILD_COMPILER_JOBS% protoc plugins || goto :error
 cd ..\..
 
-xcopy /Y cmake\build\third_party\protobuf\Release\protoc.exe %ARTIFACTS_OUT%\ || goto :error
-xcopy /Y cmake\build\Release\*_plugin.exe %ARTIFACTS_OUT%\ || goto :error
+xcopy /Y cmake\build\third_party\protobuf\protoc.exe %ARTIFACTS_OUT%\ || goto :error
+xcopy /Y cmake\build\*_plugin.exe %ARTIFACTS_OUT%\ || goto :error
 
 goto :EOF
 


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/28841/ 

Switch windows protoc artifact build to ninja (for faster build and to be able to enable ccache in the future).