### PR TITLE
Fix fetching CXX variable in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cxx = os.environ.get('CXX', 'c++')
+    cxx = shlex.split(os.environ.get('CXX', 'c++'))[0]
     cpp_test = subprocess.Popen([cxx, '-x', 'c++', '-std=c++11', '-'],
                                 stdin=PIPE,
                                 stdout=PIPE,

--- a/setup.py
+++ b/setup.py
@@ -200,8 +200,8 @@ def check_linker_need_libatomic():
     """Test if linker on system needs libatomic."""
     code_test = (b'#include <atomic>\n' +
                  b'int main() { return std::atomic<int64_t>{}; }')
-    cxx = shlex.split(os.environ.get('CXX', 'c++'))[0]
-    cpp_test = subprocess.Popen([cxx, '-x', 'c++', '-std=c++11', '-'],
+    cxx = shlex.split(os.environ.get('CXX', 'c++'))
+    cpp_test = subprocess.Popen(cxx + ['-x', 'c++', '-std=c++11', '-'],
                                 stdin=PIPE,
                                 stdout=PIPE,
                                 stderr=PIPE)


### PR DESCRIPTION
While building the *Python* package for a *poky*-based custom distribution I have stumbled upon an issue caused by the mechanism of subprocess invocation.

`setup.py` in `check_linker_need_libatomic` function verifies whether inclusion of `atomic` library is necessary. It is done by invoking a C++ compiler in a subprocess and the compiler's name is read from `CXX` environmental variable. In a *bitbake* managed build context this variable holds not only compiler's executable but various compiler flags as well, in my case the contents of this variable are:
```
arm-poky-linux-gnueabi-g++ -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a7 -fstack-protector-strong -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wdate-time --sysroot=<redacted>/build/tmp/work/cortexa7t2hf-neon-poky-linux-gnueabi/grpcio/1.43.0-r0/recipe-sysroot
```

Proposed solution of the issue is to split the contents of the variable and take only the first element of the resulting list. Possibly it would be better to preserve all the flags though I don't think it is necessary as we only need to know whether `-latomic` switch is required (I don't think the outcome depends on CPU model, instruction set or floating-point ABI).

This PR resolves #25362

