### PR TITLE
A more granular EventEngine conformance test suite

### DIFF
--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])
 
@@ -30,56 +30,6 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_library(
-    name = "event_engine_test_suite@timer",
-    testonly = True,
-    srcs = ["test_suite/timer_test.cc"],
-    language = "C++",
-    deps = [":event_engine_test_suite_base"],
-    # Ensure the linker doesn't throw away test cases.
-    alwayslink = 1,
-)
-
-grpc_cc_library(
-    name = "event_engine_test_suite@dns",
-    testonly = True,
-    srcs = ["test_suite/dns_test.cc"],
-    deps = [":event_engine_test_suite_base"],
-    # Ensure the linker doesn't throw away test cases.
-    alwayslink = 1,
-)
-
-grpc_cc_library(
-    name = "event_engine_test_suite@client",
-    testonly = True,
-    srcs = ["test_suite/client_test.cc"],
-    deps = [":event_engine_test_suite_base"],
-    # Ensure the linker doesn't throw away test cases.
-    alwayslink = 1,
-)
-
-grpc_cc_library(
-    name = "event_engine_test_suite@server",
-    testonly = True,
-    srcs = ["test_suite/server_test.cc"],
-    deps = [":event_engine_test_suite_base"],
-    # Ensure the linker doesn't throw away test cases.
-    alwayslink = 1,
-)
-
-grpc_cc_library(
-    name = "event_engine_test_suite",
-    testonly = 1,
-    deps = [
-        ":event_engine_test_suite@client",
-        ":event_engine_test_suite@dns",
-        ":event_engine_test_suite@server",
-        ":event_engine_test_suite@timer",
-    ],
-    # Ensure the linker doesn't throw away test cases.
-    alwayslink = 1,
-)
-
 grpc_cc_test(
     name = "smoke_test",
     srcs = ["smoke_test.cc"],
@@ -88,21 +38,4 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
-)
-
-# -- Internal targets --
-
-grpc_cc_library(
-    name = "event_engine_test_suite_base",
-    testonly = True,
-    srcs = ["test_suite/event_engine_test.cc"],
-    hdrs = ["test_suite/event_engine_test.h"],
-    external_deps = ["gtest"],
-    language = "C++",
-    deps = [
-        "//:grpc",
-        "//test/core/util:grpc_test_util",
-    ],
-    # Ensure the linker doesn't throw away test cases.
-    alwayslink = 1,
 )

--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -31,20 +31,50 @@ grpc_cc_test(
 )
 
 grpc_cc_library(
+    name = "event_engine_test_suite@timer",
+    testonly = True,
+    srcs = ["test_suite/timer_test.cc"],
+    language = "C++",
+    deps = [":event_engine_test_suite_base"],
+    # Ensure the linker doesn't throw away test cases.
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "event_engine_test_suite@dns",
+    testonly = True,
+    srcs = ["test_suite/dns_test.cc"],
+    deps = [":event_engine_test_suite_base"],
+    # Ensure the linker doesn't throw away test cases.
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "event_engine_test_suite@client",
+    testonly = True,
+    srcs = ["test_suite/client_test.cc"],
+    deps = [":event_engine_test_suite_base"],
+    # Ensure the linker doesn't throw away test cases.
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "event_engine_test_suite@server",
+    testonly = True,
+    srcs = ["test_suite/server_test.cc"],
+    deps = [":event_engine_test_suite_base"],
+    # Ensure the linker doesn't throw away test cases.
+    alwayslink = 1,
+)
+
+grpc_cc_library(
     name = "event_engine_test_suite",
     testonly = 1,
-    srcs = [
-        "test_suite/event_engine_test.cc",
-        "test_suite/timer_test.cc",
-    ],
-    hdrs = ["test_suite/event_engine_test.h"],
-    external_deps = [
-        "gtest",
-    ],
-    language = "C++",
     deps = [
-        "//:grpc",
-        "//test/core/util:grpc_test_util",
+        ":event_engine_test_suite@client",
+        ":event_engine_test_suite@dns",
+        ":event_engine_test_suite@server",
+        ":event_engine_test_suite@timer",
     ],
     # Ensure the linker doesn't throw away test cases.
     alwayslink = 1,
@@ -58,4 +88,21 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+)
+
+# -- Internal targets --
+
+grpc_cc_library(
+    name = "event_engine_test_suite_base",
+    testonly = True,
+    srcs = ["test_suite/event_engine_test.cc"],
+    hdrs = ["test_suite/event_engine_test.h"],
+    external_deps = ["gtest"],
+    language = "C++",
+    deps = [
+        "//:grpc",
+        "//test/core/util:grpc_test_util",
+    ],
+    # Ensure the linker doesn't throw away test cases.
+    alwayslink = 1,
 )

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -54,10 +54,10 @@ grpc_cc_library(
     name = "complete",
     testonly = 1,
     deps = [
-        ":event_engine_test_suite@client",
-        ":event_engine_test_suite@dns",
-        ":event_engine_test_suite@server",
-        ":event_engine_test_suite@timer",
+        ":client",
+        ":dns",
+        ":server",
+        ":timer",
     ],
     alwayslink = 1,
 )

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -1,0 +1,77 @@
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package")
+
+licenses(["notice"])
+
+grpc_package(name = "test/core/event_engine/test_suite")
+
+grpc_cc_library(
+    name = "timer",
+    testonly = True,
+    srcs = ["timer_test.cc"],
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "dns",
+    testonly = True,
+    srcs = ["dns_test.cc"],
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "client",
+    testonly = True,
+    srcs = ["client_test.cc"],
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "server",
+    testonly = True,
+    srcs = ["server_test.cc"],
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "complete",
+    testonly = 1,
+    deps = [
+        ":event_engine_test_suite@client",
+        ":event_engine_test_suite@dns",
+        ":event_engine_test_suite@server",
+        ":event_engine_test_suite@timer",
+    ],
+    alwayslink = 1,
+)
+
+# -- Internal targets --
+
+grpc_cc_library(
+    name = "conformance_test_base_lib",
+    testonly = True,
+    srcs = ["event_engine_test.cc"],
+    hdrs = ["event_engine_test.h"],
+    external_deps = ["gtest"],
+    deps = [
+        "//:grpc",
+        "//test/core/util:grpc_test_util",
+    ],
+)

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -18,10 +18,13 @@ licenses(["notice"])
 
 grpc_package(name = "test/core/event_engine/test_suite")
 
+COMMON_HEADERS = ["event_engine_test.h"]
+
 grpc_cc_library(
     name = "timer",
     testonly = True,
     srcs = ["timer_test.cc"],
+    hdrs = COMMON_HEADERS,
     deps = [":conformance_test_base_lib"],
     alwayslink = 1,
 )
@@ -30,6 +33,7 @@ grpc_cc_library(
     name = "dns",
     testonly = True,
     srcs = ["dns_test.cc"],
+    hdrs = COMMON_HEADERS,
     deps = [":conformance_test_base_lib"],
     alwayslink = 1,
 )
@@ -38,6 +42,7 @@ grpc_cc_library(
     name = "client",
     testonly = True,
     srcs = ["client_test.cc"],
+    hdrs = COMMON_HEADERS,
     deps = [":conformance_test_base_lib"],
     alwayslink = 1,
 )
@@ -46,6 +51,7 @@ grpc_cc_library(
     name = "server",
     testonly = True,
     srcs = ["server_test.cc"],
+    hdrs = COMMON_HEADERS,
     deps = [":conformance_test_base_lib"],
     alwayslink = 1,
 )
@@ -53,6 +59,7 @@ grpc_cc_library(
 grpc_cc_library(
     name = "complete",
     testonly = 1,
+    hdrs = COMMON_HEADERS,
     deps = [
         ":client",
         ":dns",
@@ -68,7 +75,7 @@ grpc_cc_library(
     name = "conformance_test_base_lib",
     testonly = True,
     srcs = ["event_engine_test.cc"],
-    hdrs = ["event_engine_test.h"],
+    hdrs = COMMON_HEADERS,
     external_deps = ["gtest"],
     deps = [
         "//:grpc",

--- a/test/core/event_engine/test_suite/README.md
+++ b/test/core/event_engine/test_suite/README.md
@@ -10,9 +10,8 @@ Your custom test target will look something like:
 grpc_cc_test(
     name = "my_custom_event_engine_test",
     srcs = ["my_custom_event_engine_test.cc"],
-    language = "C++",
     uses_polling = False,
-    deps = [//test/core/event_engine/test_suite:complete],
+    deps = ["//test/core/event_engine/test_suite:complete"],
 )
 ```
 

--- a/test/core/event_engine/test_suite/README.md
+++ b/test/core/event_engine/test_suite/README.md
@@ -1,14 +1,29 @@
 A reusable test suite for EventEngine implementations.
 
-To exercise a custom EventEngine, simply link against `:event_engine_test_suite`
-and provide a testing `main` function that sets a custom EventEngine factory:
+To exercise a custom EventEngine, create a new bazel test target that links
+against the `//test/core/event_engine/test_suite:complete` library, and provide
+a testing `main` function that sets a custom EventEngine factory.
+
+Your custom test target will look something like:
+
+```
+grpc_cc_test(
+    name = "my_custom_event_engine_test",
+    srcs = ["my_custom_event_engine_test.cc"],
+    language = "C++",
+    uses_polling = False,
+    deps = [//test/core/event_engine/test_suite:complete],
+)
+```
+
+And the main function will be similar to:
 
 ```
 #include "path/to/my_custom_event_engine.h"
 #include "src/core/event_engine/test_suite/event_engine_test.h"
 
 int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleTest(&argc, argv);
   SetEventEngineFactory(
       []() { return absl::make_unique<MyCustomEventEngine>(); });
   auto result = RUN_ALL_TESTS();
@@ -16,20 +31,10 @@ int main(int argc, char** argv) {
 }
 ```
 
-And add a target to the `BUILD` file:
+Alternatively, if you only want to exercise a subset of the conformance tests,
+you could depend on any subset of the following:
 
-```
-grpc_cc_test(
-    name = "my_custom_event_engine_test",
-    srcs = ["test_suite/my_custom_event_engine_test.cc"],
-    external_deps = [
-        "gtest",
-    ],
-    language = "C++",
-    uses_polling = False,
-    deps = [
-        ":event_engine_test_suite",
-        "//:grpc",
-    ],
-)
-```
+* `//test/core/event_engine/test_suite:timer`
+* `//test/core/event_engine/test_suite:dns`
+* `//test/core/event_engine/test_suite:client`
+* `//test/core/event_engine/test_suite:server`

--- a/test/core/event_engine/test_suite/client_test.cc
+++ b/test/core/event_engine/test_suite/client_test.cc
@@ -29,4 +29,5 @@
 
 class EventEngineClientTest : public EventEngineTest {};
 
+// TODO(hork): establish meaningful tests
 TEST_F(EventEngineClientTest, TODO) {}

--- a/test/core/event_engine/test_suite/client_test.cc
+++ b/test/core/event_engine/test_suite/client_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <random>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "absl/functional/bind_front.h"
+#include "absl/time/time.h"
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gprpp/sync.h"
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+class EventEngineClientTest : public EventEngineTest {};
+
+TEST_F(EventEngineClientTest, TODO) {}

--- a/test/core/event_engine/test_suite/client_test.cc
+++ b/test/core/event_engine/test_suite/client_test.cc
@@ -12,19 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <random>
-#include <thread>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include "absl/functional/bind_front.h"
-#include "absl/time/time.h"
-
-#include <grpc/event_engine/event_engine.h>
-#include <grpc/support/log.h>
-
-#include "src/core/lib/gprpp/sync.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineClientTest : public EventEngineTest {};

--- a/test/core/event_engine/test_suite/dns_test.cc
+++ b/test/core/event_engine/test_suite/dns_test.cc
@@ -12,19 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <random>
-#include <thread>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include "absl/functional/bind_front.h"
-#include "absl/time/time.h"
-
-#include <grpc/event_engine/event_engine.h>
-#include <grpc/support/log.h>
-
-#include "src/core/lib/gprpp/sync.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineDNSTest : public EventEngineTest {};

--- a/test/core/event_engine/test_suite/dns_test.cc
+++ b/test/core/event_engine/test_suite/dns_test.cc
@@ -29,4 +29,5 @@
 
 class EventEngineDNSTest : public EventEngineTest {};
 
+// TODO(hork): establish meaningful tests
 TEST_F(EventEngineDNSTest, TODO) {}

--- a/test/core/event_engine/test_suite/dns_test.cc
+++ b/test/core/event_engine/test_suite/dns_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <random>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "absl/functional/bind_front.h"
+#include "absl/time/time.h"
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gprpp/sync.h"
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+class EventEngineDNSTest : public EventEngineTest {};
+
+TEST_F(EventEngineDNSTest, TODO) {}

--- a/test/core/event_engine/test_suite/server_test.cc
+++ b/test/core/event_engine/test_suite/server_test.cc
@@ -12,19 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <random>
-#include <thread>
-
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
-#include "absl/functional/bind_front.h"
-#include "absl/time/time.h"
-
-#include <grpc/event_engine/event_engine.h>
-#include <grpc/support/log.h>
-
-#include "src/core/lib/gprpp/sync.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineServerTest : public EventEngineTest {};

--- a/test/core/event_engine/test_suite/server_test.cc
+++ b/test/core/event_engine/test_suite/server_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <random>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "absl/functional/bind_front.h"
+#include "absl/time/time.h"
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gprpp/sync.h"
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+class EventEngineServerTest : public EventEngineTest {};
+
+TEST_F(EventEngineServerTest, TODO) {}

--- a/test/core/event_engine/test_suite/server_test.cc
+++ b/test/core/event_engine/test_suite/server_test.cc
@@ -29,4 +29,5 @@
 
 class EventEngineServerTest : public EventEngineTest {};
 
+// TODO(hork): establish meaningful tests
 TEST_F(EventEngineServerTest, TODO) {}


### PR DESCRIPTION
This allows EventEngine implementers to select which subset of the conformance test suite they wish to exercise with their implementation. This was a request from the fuchsia team, and it may be useful for partial implementations that will be composed into a complete EventEngine solution.

Requires a cherry-pick

CC @tamird 