### PR TITLE
Run bloat_diff.py in a separate kokoro job

### DIFF
--- a/tools/internal_ci/linux/grpc_bloat_diff.sh
+++ b/tools/internal_ci/linux/grpc_bloat_diff.sh
@@ -13,18 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is invoked by Kokoro and runs a diff on the microbenchmarks
 set -ex
-
-# List of benchmarks that provide good signal for analyzing performance changes in pull requests
-BENCHMARKS_TO_RUN="bm_fullstack_unary_ping_pong bm_fullstack_streaming_ping_pong bm_fullstack_streaming_pump bm_closure bm_cq bm_call_create bm_chttp2_hpack bm_chttp2_transport bm_pollset"
 
 # Enter the gRPC repo root
 cd $(dirname $0)/../../..
 
-source tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/start_port_server.py
-tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/microbenchmarks/bm_diff/bm_main.py \
-  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" \
-  -b $BENCHMARKS_TO_RUN
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
+export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_bloat_diff_in_docker.sh
+# The check_on_pr.py needs access to the key to post status on github PRs,
+# so we mount the keystore dir to the docker container.
+export EXTRA_DOCKER_ARGS="-v ${KOKORO_KEYSTORE_DIR}:/kokoro_keystore -e KOKORO_KEYSTORE_DIR=/kokoro_keystore"
+exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_bloat_diff_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bloat_diff_in_docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Enter the gRPC repo root
+cd $(dirname $0)/../../..
+
+# some extra pip packages are needed for the check_on_pr.py script to work
+# TODO(jtattermusch): avoid needing to install these pip packages each time
+time python3 -m pip install --user -r tools/internal_ci/helper_scripts/requirements.linux_perf.txt
+
+tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/bloat/bloat_diff.py \
+  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"

--- a/tools/internal_ci/linux/pull_request/grpc_bloat_diff.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bloat_diff.cfg
@@ -1,0 +1,33 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_bloat_diff.sh"
+timeout_mins: 120
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "grpc_checks_private_key"
+    }
+  }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/tools/run_tests/dockerize/docker_propagate_env.list
+++ b/tools/run_tests/dockerize/docker_propagate_env.list
@@ -8,9 +8,13 @@ THIS_IS_REALLY_NEEDED="see https://github.com/docker/docker/issues/14203 for why
 # Kokoro sets environment variables for each build and we want them to be
 # available inside the test docker containers.
 KOKORO_BUILD_ID
+KOKORO_BUILD_INITIATOR
 KOKORO_BUILD_NUMBER
 KOKORO_BUILD_URL
+KOKORO_GIT_COMMIT
 KOKORO_JOB_NAME
+KOKORO_GITHUB_PULL_REQUEST_NUMBER
+KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH
 
 # Propagate ccache configuration to the docker containers.
 GRPC_BUILD_ENABLE_CCACHE


### PR DESCRIPTION
- currently it runs as part of grpc_microbenchmark_diff unnecessarily (making that job run even longer).
- also, there no reason for bloat_diff to run on performance workers (reserved for the microbenchmark diff).

Estimated speedup for the microbenchmark_diff job (that originally ran the bloat_diff) is ~10min.