### PR TITLE
More run_microbenchmark.py cleanup

### DIFF
--- a/tools/profiling/microbenchmarks/bm2bq.py
+++ b/tools/profiling/microbenchmarks/bm2bq.py
@@ -27,6 +27,7 @@ import bm_json
 columns = []
 
 for row in json.loads(
+        # TODO(jtattermusch): make sure the dataset name is not hardcoded
         subprocess.check_output(
             ['bq', '--format=json', 'show',
              'microbenchmarks.microbenchmarks']))['schema']['fields']:
@@ -40,6 +41,8 @@ SANITIZE = {
     'timestamp': str,
 }
 
+# TODO(jtattermusch): add proper argparse argument, rather than trying
+# to emulate with manual argv inspection.
 if sys.argv[1] == '--schema':
     print(',\n'.join('%s:%s' % (k, t.upper()) for k, t in columns))
     sys.exit(0)

--- a/tools/profiling/microbenchmarks/bm_json.py
+++ b/tools/profiling/microbenchmarks/bm_json.py
@@ -210,6 +210,11 @@ def expand_json(js, js2=None):
         row.update(bm)
         row.update(parse_name(row['name']))
         row.update(labels)
+        # TODO(jtattermusch): add a comment explaining what's the point
+        # of merging values of some of the columns js2 into the row.
+        # Empirically, the js contains data from "counters" config
+        # and js2 contains data from the "opt" config, but the point of merging
+        # really deserves further explanation.
         if js2:
             for bm2 in js2['benchmarks']:
                 if bm['name'] == bm2['name'] and 'already_used' not in bm2:

--- a/tools/run_tests/run_microbenchmark.py
+++ b/tools/run_tests/run_microbenchmark.py
@@ -222,8 +222,6 @@ def collect_summary(bm_name, args):
     print(counters_summary)
 
     if args.bq_result_table:
-        # TODO(jtattermusch): currently there is no way to differentiate
-        # between the "counters" and "opt" data in bigquery.
         with open('%s.csv' % bm_name, 'w') as f:
             f.write(
                 subprocess.check_output([

--- a/tools/run_tests/run_microbenchmark.py
+++ b/tools/run_tests/run_microbenchmark.py
@@ -203,11 +203,27 @@ def run_summary(bm_name, cfg, base_json_name):
 
 
 def collect_summary(bm_name, args):
-    heading('Summary: %s [no counters]' % bm_name)
-    text(run_summary(bm_name, 'opt', bm_name))
-    heading('Summary: %s [with counters]' % bm_name)
-    text(run_summary(bm_name, 'counters', bm_name))
+    # no counters, run microbenchmark and add summary
+    # both to HTML report and to console.
+    nocounters_heading = 'Summary: %s [no counters]' % bm_name
+    nocounters_summary = run_summary(bm_name, 'opt', bm_name)
+    heading(nocounters_heading)
+    text(nocounters_summary)
+    print(nocounters_heading)
+    print(nocounters_summary)
+
+    # with counters, run microbenchmark and add summary
+    # both to HTML report and to console.
+    counter_heading = 'Summary: %s [with counters]' % bm_name
+    counters_summary = run_summary(bm_name, 'counters', bm_name)
+    heading(counter_heading)
+    text(counters_summary)
+    print(counters_heading)
+    print(counters_summary)
+
     if args.bq_result_table:
+        # TODO(jtattermusch): currently there is no way to differentiate
+        # between the "counters" and "opt" data in bigquery.
         with open('%s.csv' % bm_name, 'w') as f:
             f.write(
                 subprocess.check_output([

--- a/tools/run_tests/run_microbenchmark.py
+++ b/tools/run_tests/run_microbenchmark.py
@@ -214,9 +214,9 @@ def collect_summary(bm_name, args):
 
     # with counters, run microbenchmark and add summary
     # both to HTML report and to console.
-    counter_heading = 'Summary: %s [with counters]' % bm_name
+    counters_heading = 'Summary: %s [with counters]' % bm_name
     counters_summary = run_summary(bm_name, 'counters', bm_name)
-    heading(counter_heading)
+    heading(counters_heading)
     text(counters_summary)
     print(counters_heading)
     print(counters_summary)


### PR DESCRIPTION
- run_microbenchmark.py would really need some work, but for now I'm adding a few TODOs about things I noticed.
- print summaries to the console as well (currently the jobs output is empty and the HTML report it generates is quite hard to find - since unlike on Jenkins it's only available in job's artifacts.

