### PR TITLE
add support for windows py detection

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -206,7 +206,7 @@ def _get_python_lib(repository_ctx, python_bin, lib_path_key):
         "    paths.append(path)\n" + "if len(paths) >=1:\n" +
         "  print(paths[0])\n" + "END"
     )
-    cmd = "%s - %s" % (python_bin, print_lib)
+    cmd = '"%s" - %s' % (python_bin, print_lib)
     result = repository_ctx.execute([_get_bash_bin(repository_ctx), "-c", cmd])
     return result.stdout.strip("\n")
 


### PR DESCRIPTION
`python` is found but the path is still incorrect on windows, this PR adds the proper quotes to find the path on windows.

Here is the error this PR solves: https://buildkite.com/ray-project/ray-builders-pr/builds/24659#d293616f-225d-41f9-8de2-03780f12b13f/2386-2416

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
