### PR TITLE
Removed grpc_error_handle from cython

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -726,10 +726,3 @@ cdef extern from "grpc/grpc_security_constants.h":
   ctypedef enum grpc_local_connect_type:
     UDS
     LOCAL_TCP
-
-
-cdef extern from "src/core/lib/iomgr/error.h":
-  ctypedef grpc_error* grpc_error_handle
-  grpc_error_handle GRPC_ERROR_CANCELLED
-  struct grpc_error:
-    pass


### PR DESCRIPTION
Removed unnecessary `grpc_error_handle` type mapping in gRPC cython.