### PR TITLE
Fix C# single-job distribtests jobs when version has no suffix (on v1.44.x branch)

### DIFF
--- a/src/csharp/build_nuget.sh
+++ b/src/csharp/build_nuget.sh
@@ -51,7 +51,7 @@ then
   # add a suffix to the nuget's version
   # to avoid confusing the package with a full nuget package.
   # NOTE: adding the suffix must be done AFTER expand_dev_version.sh has run.
-  sed -ibak "s/<\/GrpcCsharpVersion>/.singleplatform<\/GrpcCsharpVersion>/" build/dependencies.props
+  sed -ibak "s/<\/GrpcCsharpVersion>/-singleplatform<\/GrpcCsharpVersion>/" build/dependencies.props
 fi
 
 dotnet restore Grpc.sln


### PR DESCRIPTION
Spotted on the release branch:
https://source.cloud.google.com/results/invocations/dc324217-4104-4606-8c03-b647d9cd5ec9/targets/github%2Fgrpc%2Fbuild_packages/tests

```
+ sed -ibak 's/<\/GrpcCsharpVersion>/.singleplatform<\/GrpcCsharpVersion>/' build/dependencies.props
+ dotnet restore Grpc.sln
  Determining projects to restore...
/usr/share/dotnet/sdk/6.0.100/NuGet.targets(130,5): error : '2.44.0.singleplatform' is not a valid version string. (Parameter 'value') [/var/local/git/grpc/src/csharp/Grpc.sln]
```

it only affects the singleplatform C# distribtest (and thus it doesn't affect the "full" multiplatform C# nuget and distribtest",
but it should be fixed anyway.
