### PR TITLE
grpc_xds_k8s_lb_python interop: Increase timeout

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.cfg
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh"
-timeout_mins: 90
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
Recent runs got close to 90 minutes.
<img width="959" alt="image" src="https://user-images.githubusercontent.com/672669/154562472-39e11a52-a546-4ed8-bf68-b1d84e713b28.png">

 We added more tests to this [recently](https://github.com/grpc/grpc/pull/28745), makes sense to bump the timeout.
