### PR TITLE
Reintroduce: Avoid fully qualifying namespaces (and add check)

### DIFF
--- a/include/grpcpp/alarm.h
+++ b/include/grpcpp/alarm.h
@@ -32,7 +32,7 @@
 
 namespace grpc {
 
-class Alarm : private ::grpc::GrpcLibraryCodegen {
+class Alarm : private grpc::GrpcLibraryCodegen {
  public:
   /// Create an unset completion queue alarm
   Alarm();
@@ -48,8 +48,8 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   /// internal::GrpcLibraryInitializer instance would need to be introduced
   /// here. \endinternal.
   template <typename T>
-  Alarm(::grpc::CompletionQueue* cq, const T& deadline, void* tag) : Alarm() {
-    SetInternal(cq, ::grpc::TimePoint<T>(deadline).raw_time(), tag);
+  Alarm(grpc::CompletionQueue* cq, const T& deadline, void* tag) : Alarm() {
+    SetInternal(cq, grpc::TimePoint<T>(deadline).raw_time(), tag);
   }
 
   /// Trigger an alarm instance on completion queue \a cq at the specified time.
@@ -61,8 +61,8 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   // setting an immediate deadline. Such usage allows synchronizing an external
   // event with an application's \a grpc::CompletionQueue::Next loop.
   template <typename T>
-  void Set(::grpc::CompletionQueue* cq, const T& deadline, void* tag) {
-    SetInternal(cq, ::grpc::TimePoint<T>(deadline).raw_time(), tag);
+  void Set(grpc::CompletionQueue* cq, const T& deadline, void* tag) {
+    SetInternal(cq, grpc::TimePoint<T>(deadline).raw_time(), tag);
   }
 
   /// Alarms aren't copyable.
@@ -86,15 +86,14 @@ class Alarm : private ::grpc::GrpcLibraryCodegen {
   /// (false)
   template <typename T>
   void Set(const T& deadline, std::function<void(bool)> f) {
-    SetInternal(::grpc::TimePoint<T>(deadline).raw_time(), std::move(f));
+    SetInternal(grpc::TimePoint<T>(deadline).raw_time(), std::move(f));
   }
 
  private:
-  void SetInternal(::grpc::CompletionQueue* cq, gpr_timespec deadline,
-                   void* tag);
+  void SetInternal(grpc::CompletionQueue* cq, gpr_timespec deadline, void* tag);
   void SetInternal(gpr_timespec deadline, std::function<void(bool)> f);
 
-  ::grpc::internal::CompletionQueueTag* alarm_;
+  grpc::internal::CompletionQueueTag* alarm_;
 };
 
 }  // namespace grpc

--- a/include/grpcpp/channel.h
+++ b/include/grpcpp/channel.h
@@ -117,7 +117,7 @@ class Channel final : public grpc::ChannelInterface,
   std::atomic<CompletionQueue*> callback_cq_{nullptr};
 
   std::vector<
-      std::unique_ptr<::grpc::experimental::ClientInterceptorFactoryInterface>>
+      std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
       interceptor_creators_;
 };
 

--- a/include/grpcpp/channel.h
+++ b/include/grpcpp/channel.h
@@ -51,10 +51,10 @@ void ChannelResetConnectionBackoff(Channel* channel);
 }  // namespace experimental
 
 /// Channels represent a connection to an endpoint. Created by \a CreateChannel.
-class Channel final : public ::grpc::ChannelInterface,
-                      public ::grpc::internal::CallHook,
+class Channel final : public grpc::ChannelInterface,
+                      public grpc::internal::CallHook,
                       public std::enable_shared_from_this<Channel>,
-                      private ::grpc::GrpcLibraryCodegen {
+                      private grpc::GrpcLibraryCodegen {
  public:
   ~Channel() override;
 
@@ -71,38 +71,38 @@ class Channel final : public ::grpc::ChannelInterface,
 
  private:
   template <class InputMessage, class OutputMessage>
-  friend class ::grpc::internal::BlockingUnaryCallImpl;
-  friend class ::grpc::testing::ChannelTestPeer;
+  friend class grpc::internal::BlockingUnaryCallImpl;
+  friend class grpc::testing::ChannelTestPeer;
   friend void experimental::ChannelResetConnectionBackoff(Channel* channel);
   friend std::shared_ptr<Channel> grpc::CreateChannelInternal(
       const std::string& host, grpc_channel* c_channel,
       std::vector<std::unique_ptr<
-          ::grpc::experimental::ClientInterceptorFactoryInterface>>
+          grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators);
-  friend class ::grpc::internal::InterceptedChannel;
+  friend class grpc::internal::InterceptedChannel;
   Channel(const std::string& host, grpc_channel* c_channel,
           std::vector<std::unique_ptr<
-              ::grpc::experimental::ClientInterceptorFactoryInterface>>
+              grpc::experimental::ClientInterceptorFactoryInterface>>
               interceptor_creators);
 
-  ::grpc::internal::Call CreateCall(const ::grpc::internal::RpcMethod& method,
-                                    ::grpc::ClientContext* context,
-                                    ::grpc::CompletionQueue* cq) override;
-  void PerformOpsOnCall(::grpc::internal::CallOpSetInterface* ops,
-                        ::grpc::internal::Call* call) override;
+  grpc::internal::Call CreateCall(const grpc::internal::RpcMethod& method,
+                                  grpc::ClientContext* context,
+                                  grpc::CompletionQueue* cq) override;
+  void PerformOpsOnCall(grpc::internal::CallOpSetInterface* ops,
+                        grpc::internal::Call* call) override;
   void* RegisterMethod(const char* method) override;
 
   void NotifyOnStateChangeImpl(grpc_connectivity_state last_observed,
-                               gpr_timespec deadline,
-                               ::grpc::CompletionQueue* cq, void* tag) override;
+                               gpr_timespec deadline, grpc::CompletionQueue* cq,
+                               void* tag) override;
   bool WaitForStateChangeImpl(grpc_connectivity_state last_observed,
                               gpr_timespec deadline) override;
 
-  ::grpc::CompletionQueue* CallbackCQ() override;
+  grpc::CompletionQueue* CallbackCQ() override;
 
-  ::grpc::internal::Call CreateCallInternal(
-      const ::grpc::internal::RpcMethod& method, ::grpc::ClientContext* context,
-      ::grpc::CompletionQueue* cq, size_t interceptor_pos) override;
+  grpc::internal::Call CreateCallInternal(
+      const grpc::internal::RpcMethod& method, grpc::ClientContext* context,
+      grpc::CompletionQueue* cq, size_t interceptor_pos) override;
 
   const std::string host_;
   grpc_channel* const c_channel_;  // owned

--- a/include/grpcpp/ext/proto_server_reflection_plugin.h
+++ b/include/grpcpp/ext/proto_server_reflection_plugin.h
@@ -28,7 +28,7 @@ class ServerInitializer;
 
 namespace reflection {
 
-class ProtoServerReflectionPlugin : public ::grpc::ServerBuilderPlugin {
+class ProtoServerReflectionPlugin : public grpc::ServerBuilderPlugin {
  public:
   ProtoServerReflectionPlugin();
   ::std::string name() override;

--- a/include/grpcpp/ext/server_load_reporting.h
+++ b/include/grpcpp/ext/server_load_reporting.h
@@ -38,7 +38,7 @@ class LoadReportingServiceServerBuilderOption
     : public grpc::ServerBuilderOption {
  public:
   void UpdateArguments(grpc::ChannelArguments* args) override;
-  void UpdatePlugins(std::vector<std::unique_ptr<::grpc::ServerBuilderPlugin>>*
+  void UpdatePlugins(std::vector<std::unique_ptr<grpc::ServerBuilderPlugin>>*
                          plugins) override;
 };
 

--- a/include/grpcpp/ext/server_load_reporting.h
+++ b/include/grpcpp/ext/server_load_reporting.h
@@ -37,7 +37,7 @@ namespace experimental {
 class LoadReportingServiceServerBuilderOption
     : public grpc::ServerBuilderOption {
  public:
-  void UpdateArguments(::grpc::ChannelArguments* args) override;
+  void UpdateArguments(grpc::ChannelArguments* args) override;
   void UpdatePlugins(std::vector<std::unique_ptr<::grpc::ServerBuilderPlugin>>*
                          plugins) override;
 };

--- a/include/grpcpp/generic/generic_stub.h
+++ b/include/grpcpp/generic/generic_stub.h
@@ -53,7 +53,7 @@ class TemplatedGenericStub final {
   /// succeeded (i.e. the call won't proceed if the return value is nullptr).
   std::unique_ptr<ClientAsyncReaderWriter<RequestType, ResponseType>>
   PrepareCall(ClientContext* context, const std::string& method,
-              ::grpc::CompletionQueue* cq) {
+              grpc::CompletionQueue* cq) {
     return CallInternal(channel_.get(), context, method, /*options=*/{}, cq,
                         false, nullptr);
   }
@@ -64,7 +64,7 @@ class TemplatedGenericStub final {
   /// succeeded (i.e. the call won't proceed if the return value is nullptr).
   std::unique_ptr<ClientAsyncResponseReader<ResponseType>> PrepareUnaryCall(
       ClientContext* context, const std::string& method,
-      const RequestType& request, ::grpc::CompletionQueue* cq) {
+      const RequestType& request, grpc::CompletionQueue* cq) {
     return std::unique_ptr<ClientAsyncResponseReader<ResponseType>>(
         internal::ClientAsyncResponseReaderHelper::Create<ResponseType>(
             channel_.get(), cq,
@@ -82,7 +82,7 @@ class TemplatedGenericStub final {
   /// succeeded (i.e. the call won't proceed if the return value is nullptr).
   std::unique_ptr<ClientAsyncReaderWriter<RequestType, ResponseType>> Call(
       ClientContext* context, const std::string& method,
-      ::grpc::CompletionQueue* cq, void* tag) {
+      grpc::CompletionQueue* cq, void* tag) {
     return CallInternal(channel_.get(), context, method, /*options=*/{}, cq,
                         true, tag);
   }
@@ -157,7 +157,7 @@ class TemplatedGenericStub final {
   std::unique_ptr<ClientAsyncReaderWriter<RequestType, ResponseType>>
   CallInternal(grpc::ChannelInterface* channel, ClientContext* context,
                const std::string& method, StubOptions options,
-               ::grpc::CompletionQueue* cq, bool start, void* tag) {
+               grpc::CompletionQueue* cq, bool start, void* tag) {
     return std::unique_ptr<ClientAsyncReaderWriter<RequestType, ResponseType>>(
         internal::ClientAsyncReaderWriterFactory<RequestType, ResponseType>::
             Create(channel, cq,

--- a/include/grpcpp/impl/codegen/async_generic_service.h
+++ b/include/grpcpp/impl/codegen/async_generic_service.h
@@ -73,8 +73,8 @@ class AsyncGenericService final {
 
   void RequestCall(GenericServerContext* ctx,
                    GenericServerAsyncReaderWriter* reader_writer,
-                   ::grpc::CompletionQueue* call_cq,
-                   ::grpc::ServerCompletionQueue* notification_cq, void* tag);
+                   grpc::CompletionQueue* call_cq,
+                   grpc::ServerCompletionQueue* notification_cq, void* tag);
 
  private:
   friend class grpc::Server;
@@ -92,7 +92,7 @@ class GenericCallbackServerContext final : public grpc::CallbackServerContext {
   const std::string& host() const { return host_; }
 
  private:
-  friend class ::grpc::Server;
+  friend class grpc::Server;
 
   std::string method_;
   std::string host_;
@@ -124,7 +124,7 @@ class CallbackGenericService {
 
   internal::CallbackBidiHandler<ByteBuffer, ByteBuffer>* Handler() {
     return new internal::CallbackBidiHandler<ByteBuffer, ByteBuffer>(
-        [this](::grpc::CallbackServerContext* ctx) {
+        [this](grpc::CallbackServerContext* ctx) {
           return CreateReactor(static_cast<GenericCallbackServerContext*>(ctx));
         });
   }

--- a/include/grpcpp/impl/codegen/async_stream.h
+++ b/include/grpcpp/impl/codegen/async_stream.h
@@ -75,7 +75,7 @@ class ClientAsyncStreamingInterface {
   ///
   /// \param[in] tag Tag identifying this request.
   /// \param[out] status To be updated with the operation status.
-  virtual void Finish(::grpc::Status* status, void* tag) = 0;
+  virtual void Finish(grpc::Status* status, void* tag) = 0;
 };
 
 /// An interface that yields a sequence of messages of type \a R.
@@ -135,7 +135,7 @@ class AsyncWriterInterface {
   /// \param[in] msg The message to be written.
   /// \param[in] options The WriteOptions to be used to write this message.
   /// \param[in] tag The tag identifying the operation.
-  virtual void Write(const W& msg, ::grpc::WriteOptions options, void* tag) = 0;
+  virtual void Write(const W& msg, grpc::WriteOptions options, void* tag) = 0;
 
   /// Request the writing of \a msg and coalesce it with the writing
   /// of trailing metadata, using WriteOptions \a options with
@@ -155,7 +155,7 @@ class AsyncWriterInterface {
   /// \param[in] msg The message to be written.
   /// \param[in] options The WriteOptions to be used to write this message.
   /// \param[in] tag The tag identifying the operation.
-  void WriteLast(const W& msg, ::grpc::WriteOptions options, void* tag) {
+  void WriteLast(const W& msg, grpc::WriteOptions options, void* tag) {
     Write(msg, options.set_last_message(), tag);
   }
 };
@@ -179,13 +179,13 @@ class ClientAsyncReaderFactory {
   /// Note that \a context will be used to fill in custom initial metadata
   /// used to send to the server when starting the call.
   template <class W>
-  static ClientAsyncReader<R>* Create(::grpc::ChannelInterface* channel,
-                                      ::grpc::CompletionQueue* cq,
-                                      const ::grpc::internal::RpcMethod& method,
-                                      ::grpc::ClientContext* context,
+  static ClientAsyncReader<R>* Create(grpc::ChannelInterface* channel,
+                                      grpc::CompletionQueue* cq,
+                                      const grpc::internal::RpcMethod& method,
+                                      grpc::ClientContext* context,
                                       const W& request, bool start, void* tag) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
-    return new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+    grpc::internal::Call call = channel->CreateCall(method, context, cq);
+    return new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncReader<R>)))
         ClientAsyncReader<R>(call, context, request, start, tag);
   }
@@ -248,7 +248,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   /// Side effect:
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata received from the server.
-  void Finish(::grpc::Status* status, void* tag) override {
+  void Finish(grpc::Status* status, void* tag) override {
     GPR_CODEGEN_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
@@ -261,7 +261,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
  private:
   friend class internal::ClientAsyncReaderFactory<R>;
   template <class W>
-  ClientAsyncReader(::grpc::internal::Call call, ::grpc::ClientContext* context,
+  ClientAsyncReader(grpc::internal::Call call, grpc::ClientContext* context,
                     const W& request, bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     // TODO(ctiller): don't assert
@@ -281,20 +281,20 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
     call_.PerformOps(&init_ops_);
   }
 
-  ::grpc::ClientContext* context_;
-  ::grpc::internal::Call call_;
+  grpc::ClientContext* context_;
+  grpc::internal::Call call_;
   bool started_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpClientSendClose>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpClientSendClose>
       init_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
       meta_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                              ::grpc::internal::CallOpRecvMessage<R>>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                            grpc::internal::CallOpRecvMessage<R>>
       read_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                              ::grpc::internal::CallOpClientRecvStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                            grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
 };
 
@@ -327,13 +327,13 @@ class ClientAsyncWriterFactory {
   /// message from the server upon a successful call to the \a Finish
   /// method of this instance.
   template <class R>
-  static ClientAsyncWriter<W>* Create(::grpc::ChannelInterface* channel,
-                                      ::grpc::CompletionQueue* cq,
-                                      const ::grpc::internal::RpcMethod& method,
-                                      ::grpc::ClientContext* context,
-                                      R* response, bool start, void* tag) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
-    return new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+  static ClientAsyncWriter<W>* Create(grpc::ChannelInterface* channel,
+                                      grpc::CompletionQueue* cq,
+                                      const grpc::internal::RpcMethod& method,
+                                      grpc::ClientContext* context, R* response,
+                                      bool start, void* tag) {
+    grpc::internal::Call call = channel->CreateCall(method, context, cq);
+    return new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncWriter<W>)))
         ClientAsyncWriter<W>(call, context, response, start, tag);
   }
@@ -388,7 +388,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
     call_.PerformOps(&write_ops_);
   }
 
-  void Write(const W& msg, ::grpc::WriteOptions options, void* tag) override {
+  void Write(const W& msg, grpc::WriteOptions options, void* tag) override {
     GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
@@ -414,7 +414,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   ///     possible initial and trailing metadata received from the server.
   ///   - attempts to fill in the \a response parameter passed to this class's
   ///     constructor with the server's response message.
-  void Finish(::grpc::Status* status, void* tag) override {
+  void Finish(grpc::Status* status, void* tag) override {
     GPR_CODEGEN_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
@@ -427,7 +427,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
  private:
   friend class internal::ClientAsyncWriterFactory<W>;
   template <class R>
-  ClientAsyncWriter(::grpc::internal::Call call, ::grpc::ClientContext* context,
+  ClientAsyncWriter(grpc::internal::Call call, grpc::ClientContext* context,
                     R* response, bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     finish_ops_.RecvMessage(response);
@@ -450,18 +450,18 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
     }
   }
 
-  ::grpc::ClientContext* context_;
-  ::grpc::internal::Call call_;
+  grpc::ClientContext* context_;
+  grpc::internal::Call call_;
   bool started_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
       meta_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpClientSendClose>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpClientSendClose>
       write_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                              ::grpc::internal::CallOpGenericRecvMessage,
-                              ::grpc::internal::CallOpClientRecvStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                            grpc::internal::CallOpGenericRecvMessage,
+                            grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
 };
 
@@ -493,12 +493,12 @@ class ClientAsyncReaderWriterFactory {
   /// Note that \a context will be used to fill in custom initial metadata
   /// used to send to the server when starting the call.
   static ClientAsyncReaderWriter<W, R>* Create(
-      ::grpc::ChannelInterface* channel, ::grpc::CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ::grpc::ClientContext* context,
+      grpc::ChannelInterface* channel, grpc::CompletionQueue* cq,
+      const grpc::internal::RpcMethod& method, grpc::ClientContext* context,
       bool start, void* tag) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
+    grpc::internal::Call call = channel->CreateCall(method, context, cq);
 
-    return new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+    return new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncReaderWriter<W, R>)))
         ClientAsyncReaderWriter<W, R>(call, context, start, tag);
   }
@@ -565,7 +565,7 @@ class ClientAsyncReaderWriter final
     call_.PerformOps(&write_ops_);
   }
 
-  void Write(const W& msg, ::grpc::WriteOptions options, void* tag) override {
+  void Write(const W& msg, grpc::WriteOptions options, void* tag) override {
     GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
@@ -588,7 +588,7 @@ class ClientAsyncReaderWriter final
   /// Side effect
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
-  void Finish(::grpc::Status* status, void* tag) override {
+  void Finish(grpc::Status* status, void* tag) override {
     GPR_CODEGEN_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
@@ -600,8 +600,8 @@ class ClientAsyncReaderWriter final
 
  private:
   friend class internal::ClientAsyncReaderWriterFactory<W, R>;
-  ClientAsyncReaderWriter(::grpc::internal::Call call,
-                          ::grpc::ClientContext* context, bool start, void* tag)
+  ClientAsyncReaderWriter(grpc::internal::Call call,
+                          grpc::ClientContext* context, bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     if (start) {
       StartCallInternal(tag);
@@ -621,26 +621,26 @@ class ClientAsyncReaderWriter final
     }
   }
 
-  ::grpc::ClientContext* context_;
-  ::grpc::internal::Call call_;
+  grpc::ClientContext* context_;
+  grpc::internal::Call call_;
   bool started_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
       meta_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                              ::grpc::internal::CallOpRecvMessage<R>>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                            grpc::internal::CallOpRecvMessage<R>>
       read_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpClientSendClose>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpClientSendClose>
       write_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                              ::grpc::internal::CallOpClientRecvStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                            grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
 };
 
 template <class W, class R>
 class ServerAsyncReaderInterface
-    : public ::grpc::internal::ServerAsyncStreamingInterface,
+    : public grpc::internal::ServerAsyncStreamingInterface,
       public internal::AsyncReaderInterface<R> {
  public:
   /// Indicate that the stream is to be finished with a certain status code
@@ -665,8 +665,7 @@ class ServerAsyncReaderInterface
   /// \param[in] tag Tag identifying this request.
   /// \param[in] status To be sent to the client as the result of this call.
   /// \param[in] msg To be sent to the client as the response for this call.
-  virtual void Finish(const W& msg, const ::grpc::Status& status,
-                      void* tag) = 0;
+  virtual void Finish(const W& msg, const grpc::Status& status, void* tag) = 0;
 
   /// Indicate that the stream is to be finished with a certain
   /// non-OK status code.
@@ -689,7 +688,7 @@ class ServerAsyncReaderInterface
   /// \param[in] tag Tag identifying this request.
   /// \param[in] status To be sent to the client as the result of this call.
   ///     - Note: \a status must have a non-OK code.
-  virtual void FinishWithError(const ::grpc::Status& status, void* tag) = 0;
+  virtual void FinishWithError(const grpc::Status& status, void* tag) = 0;
 };
 
 /// Async server-side API for doing client-streaming RPCs,
@@ -698,7 +697,7 @@ class ServerAsyncReaderInterface
 template <class W, class R>
 class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
  public:
-  explicit ServerAsyncReader(::grpc::ServerContext* ctx)
+  explicit ServerAsyncReader(grpc::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -736,7 +735,7 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
   ///
   /// gRPC doesn't take ownership or a reference to \a msg and \a status, so it
   /// is safe to deallocate once Finish returns.
-  void Finish(const W& msg, const ::grpc::Status& status, void* tag) override {
+  void Finish(const W& msg, const grpc::Status& status, void* tag) override {
     finish_ops_.set_output_tag(tag);
     if (!ctx_->sent_initial_metadata_) {
       finish_ops_.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -765,7 +764,7 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
   ///
   /// gRPC doesn't take ownership or a reference to \a status, so it is safe to
   /// to deallocate once FinishWithError returns.
-  void FinishWithError(const ::grpc::Status& status, void* tag) override {
+  void FinishWithError(const grpc::Status& status, void* tag) override {
     GPR_CODEGEN_ASSERT(!status.ok());
     finish_ops_.set_output_tag(tag);
     if (!ctx_->sent_initial_metadata_) {
@@ -781,22 +780,22 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
   }
 
  private:
-  void BindCall(::grpc::internal::Call* call) override { call_ = *call; }
+  void BindCall(grpc::internal::Call* call) override { call_ = *call; }
 
-  ::grpc::internal::Call call_;
-  ::grpc::ServerContext* ctx_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::Call call_;
+  grpc::ServerContext* ctx_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpServerSendStatus>
       finish_ops_;
 };
 
 template <class W>
 class ServerAsyncWriterInterface
-    : public ::grpc::internal::ServerAsyncStreamingInterface,
+    : public grpc::internal::ServerAsyncStreamingInterface,
       public internal::AsyncWriterInterface<W> {
  public:
   /// Indicate that the stream is to be finished with a certain status code.
@@ -820,7 +819,7 @@ class ServerAsyncWriterInterface
   ///
   /// \param[in] tag Tag identifying this request.
   /// \param[in] status To be sent to the client as the result of this call.
-  virtual void Finish(const ::grpc::Status& status, void* tag) = 0;
+  virtual void Finish(const grpc::Status& status, void* tag) = 0;
 
   /// Request the writing of \a msg and coalesce it with trailing metadata which
   /// contains \a status, using WriteOptions options with
@@ -836,8 +835,8 @@ class ServerAsyncWriterInterface
   /// \param[in] options The WriteOptions to be used to write this message.
   /// \param[in] status The Status that server returns to client.
   /// \param[in] tag The tag identifying the operation.
-  virtual void WriteAndFinish(const W& msg, ::grpc::WriteOptions options,
-                              const ::grpc::Status& status, void* tag) = 0;
+  virtual void WriteAndFinish(const W& msg, grpc::WriteOptions options,
+                              const grpc::Status& status, void* tag) = 0;
 };
 
 /// Async server-side API for doing server streaming RPCs,
@@ -845,7 +844,7 @@ class ServerAsyncWriterInterface
 template <class W>
 class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
  public:
-  explicit ServerAsyncWriter(::grpc::ServerContext* ctx)
+  explicit ServerAsyncWriter(grpc::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -876,7 +875,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
     call_.PerformOps(&write_ops_);
   }
 
-  void Write(const W& msg, ::grpc::WriteOptions options, void* tag) override {
+  void Write(const W& msg, grpc::WriteOptions options, void* tag) override {
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
       options.set_buffer_hint();
@@ -898,8 +897,8 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
   ///
   /// gRPC doesn't take ownership or a reference to \a msg and \a status, so it
   /// is safe to deallocate once WriteAndFinish returns.
-  void WriteAndFinish(const W& msg, ::grpc::WriteOptions options,
-                      const ::grpc::Status& status, void* tag) override {
+  void WriteAndFinish(const W& msg, grpc::WriteOptions options,
+                      const grpc::Status& status, void* tag) override {
     write_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&write_ops_);
     options.set_buffer_hint();
@@ -919,7 +918,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
   ///
   /// gRPC doesn't take ownership or a reference to \a status, so it is safe to
   /// to deallocate once Finish returns.
-  void Finish(const ::grpc::Status& status, void* tag) override {
+  void Finish(const grpc::Status& status, void* tag) override {
     finish_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&finish_ops_);
     finish_ops_.ServerSendStatus(&ctx_->trailing_metadata_, status);
@@ -927,7 +926,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
   }
 
  private:
-  void BindCall(::grpc::internal::Call* call) override { call_ = *call; }
+  void BindCall(grpc::internal::Call* call) override { call_ = *call; }
 
   template <class T>
   void EnsureInitialMetadataSent(T* ops) {
@@ -941,23 +940,23 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
     }
   }
 
-  ::grpc::internal::Call call_;
-  ::grpc::ServerContext* ctx_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::Call call_;
+  grpc::ServerContext* ctx_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpServerSendStatus>
       write_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpServerSendStatus>
       finish_ops_;
 };
 
 /// Server-side interface for asynchronous bi-directional streaming.
 template <class W, class R>
 class ServerAsyncReaderWriterInterface
-    : public ::grpc::internal::ServerAsyncStreamingInterface,
+    : public grpc::internal::ServerAsyncStreamingInterface,
       public internal::AsyncWriterInterface<W>,
       public internal::AsyncReaderInterface<R> {
  public:
@@ -983,7 +982,7 @@ class ServerAsyncReaderWriterInterface
   ///
   /// \param[in] tag Tag identifying this request.
   /// \param[in] status To be sent to the client as the result of this call.
-  virtual void Finish(const ::grpc::Status& status, void* tag) = 0;
+  virtual void Finish(const grpc::Status& status, void* tag) = 0;
 
   /// Request the writing of \a msg and coalesce it with trailing metadata which
   /// contains \a status, using WriteOptions options with
@@ -999,8 +998,8 @@ class ServerAsyncReaderWriterInterface
   /// \param[in] options The WriteOptions to be used to write this message.
   /// \param[in] status The Status that server returns to client.
   /// \param[in] tag The tag identifying the operation.
-  virtual void WriteAndFinish(const W& msg, ::grpc::WriteOptions options,
-                              const ::grpc::Status& status, void* tag) = 0;
+  virtual void WriteAndFinish(const W& msg, grpc::WriteOptions options,
+                              const grpc::Status& status, void* tag) = 0;
 };
 
 /// Async server-side API for doing bidirectional streaming RPCs,
@@ -1011,7 +1010,7 @@ template <class W, class R>
 class ServerAsyncReaderWriter final
     : public ServerAsyncReaderWriterInterface<W, R> {
  public:
-  explicit ServerAsyncReaderWriter(::grpc::ServerContext* ctx)
+  explicit ServerAsyncReaderWriter(grpc::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -1048,7 +1047,7 @@ class ServerAsyncReaderWriter final
     call_.PerformOps(&write_ops_);
   }
 
-  void Write(const W& msg, ::grpc::WriteOptions options, void* tag) override {
+  void Write(const W& msg, grpc::WriteOptions options, void* tag) override {
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
       options.set_buffer_hint();
@@ -1069,8 +1068,8 @@ class ServerAsyncReaderWriter final
   //
   /// gRPC doesn't take ownership or a reference to \a msg and \a status, so it
   /// is safe to deallocate once WriteAndFinish returns.
-  void WriteAndFinish(const W& msg, ::grpc::WriteOptions options,
-                      const ::grpc::Status& status, void* tag) override {
+  void WriteAndFinish(const W& msg, grpc::WriteOptions options,
+                      const grpc::Status& status, void* tag) override {
     write_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&write_ops_);
     options.set_buffer_hint();
@@ -1090,7 +1089,7 @@ class ServerAsyncReaderWriter final
   //
   /// gRPC doesn't take ownership or a reference to \a status, so it is safe to
   /// to deallocate once Finish returns.
-  void Finish(const ::grpc::Status& status, void* tag) override {
+  void Finish(const grpc::Status& status, void* tag) override {
     finish_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&finish_ops_);
 
@@ -1099,9 +1098,9 @@ class ServerAsyncReaderWriter final
   }
 
  private:
-  friend class ::grpc::Server;
+  friend class grpc::Server;
 
-  void BindCall(::grpc::internal::Call* call) override { call_ = *call; }
+  void BindCall(grpc::internal::Call* call) override { call_ = *call; }
 
   template <class T>
   void EnsureInitialMetadataSent(T* ops) {
@@ -1115,17 +1114,17 @@ class ServerAsyncReaderWriter final
     }
   }
 
-  ::grpc::internal::Call call_;
-  ::grpc::ServerContext* ctx_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::Call call_;
+  grpc::ServerContext* ctx_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpServerSendStatus>
       write_ops_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpServerSendStatus>
       finish_ops_;
 };
 

--- a/include/grpcpp/impl/codegen/async_stream.h
+++ b/include/grpcpp/impl/codegen/async_stream.h
@@ -284,16 +284,16 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   grpc::ClientContext* context_;
   grpc::internal::Call call_;
   bool started_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpClientSendClose>
       init_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata>
       meta_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                             grpc::internal::CallOpRecvMessage<R>>
       read_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                             grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
 };
@@ -453,13 +453,13 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   grpc::ClientContext* context_;
   grpc::internal::Call call_;
   bool started_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata>
       meta_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpClientSendClose>
       write_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                             grpc::internal::CallOpGenericRecvMessage,
                             grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
@@ -624,16 +624,16 @@ class ClientAsyncReaderWriter final
   grpc::ClientContext* context_;
   grpc::internal::Call call_;
   bool started_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata>
       meta_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                             grpc::internal::CallOpRecvMessage<R>>
       read_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpClientSendClose>
       write_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                             grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
 };
@@ -784,10 +784,10 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
 
   grpc::internal::Call call_;
   grpc::ServerContext* ctx_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<R>> read_ops_;
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpServerSendStatus>
       finish_ops_;
@@ -942,13 +942,13 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
 
   grpc::internal::Call call_;
   grpc::ServerContext* ctx_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpServerSendStatus>
       write_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpServerSendStatus>
       finish_ops_;
 };
@@ -1116,14 +1116,14 @@ class ServerAsyncReaderWriter final
 
   grpc::internal::Call call_;
   grpc::ServerContext* ctx_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<R>> read_ops_;
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpServerSendStatus>
       write_ops_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpServerSendStatus>
       finish_ops_;
 };

--- a/include/grpcpp/impl/codegen/async_unary_call.h
+++ b/include/grpcpp/impl/codegen/async_unary_call.h
@@ -70,7 +70,7 @@ class ClientAsyncResponseReaderInterface {
   /// \param[in] tag Tag identifying this request.
   /// \param[out] status To be updated with the operation status.
   /// \param[out] msg To be filled in with the server's response message.
-  virtual void Finish(R* msg, ::grpc::Status* status, void* tag) = 0;
+  virtual void Finish(R* msg, grpc::Status* status, void* tag) = 0;
 };
 
 namespace internal {
@@ -91,12 +91,12 @@ class ClientAsyncResponseReaderHelper {
   /// extraneous parameter just to provide the needed type information.
   template <class R, class W, class BaseR = R, class BaseW = W>
   static ClientAsyncResponseReader<R>* Create(
-      ::grpc::ChannelInterface* channel, ::grpc::CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ::grpc::ClientContext* context,
+      grpc::ChannelInterface* channel, grpc::CompletionQueue* cq,
+      const grpc::internal::RpcMethod& method, grpc::ClientContext* context,
       const W& request) /* __attribute__((noinline)) */ {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
+    grpc::internal::Call call = channel->CreateCall(method, context, cq);
     ClientAsyncResponseReader<R>* result =
-        new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+        new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
             call.call(), sizeof(ClientAsyncResponseReader<R>)))
             ClientAsyncResponseReader<R>(call, context);
     SetupRequest<BaseR, BaseW>(
@@ -111,7 +111,7 @@ class ClientAsyncResponseReaderHelper {
   template <class R, class W>
   static void SetupRequest(
       grpc_call* call,
-      ::grpc::internal::CallOpSendInitialMetadata** single_buf_ptr,
+      grpc::internal::CallOpSendInitialMetadata** single_buf_ptr,
       std::function<void(ClientContext*, internal::Call*,
                          internal::CallOpSendInitialMetadata*, void*)>*
           read_initial_metadata,
@@ -121,14 +121,14 @@ class ClientAsyncResponseReaderHelper {
                internal::CallOpSetInterface**, void*, Status*, void*)>* finish,
       const W& request) {
     using SingleBufType =
-        ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                    ::grpc::internal::CallOpSendMessage,
-                                    ::grpc::internal::CallOpClientSendClose,
-                                    ::grpc::internal::CallOpRecvInitialMetadata,
-                                    ::grpc::internal::CallOpRecvMessage<R>,
-                                    ::grpc::internal::CallOpClientRecvStatus>;
+        grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                                  grpc::internal::CallOpSendMessage,
+                                  grpc::internal::CallOpClientSendClose,
+                                  grpc::internal::CallOpRecvInitialMetadata,
+                                  grpc::internal::CallOpRecvMessage<R>,
+                                  grpc::internal::CallOpClientRecvStatus>;
     SingleBufType* single_buf =
-        new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+        new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
             call, sizeof(SingleBufType))) SingleBufType;
     *single_buf_ptr = single_buf;
     // TODO(ctiller): don't assert
@@ -162,11 +162,11 @@ class ClientAsyncResponseReaderHelper {
                  internal::CallOpSetInterface** finish_buf_ptr, void* msg,
                  Status* status, void* tag) {
       if (initial_metadata_read) {
-        using FinishBufType = ::grpc::internal::CallOpSet<
-            ::grpc::internal::CallOpRecvMessage<R>,
-            ::grpc::internal::CallOpClientRecvStatus>;
+        using FinishBufType =
+            grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<R>,
+                                      grpc::internal::CallOpClientRecvStatus>;
         FinishBufType* finish_buf =
-            new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+            new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
                 call->call(), sizeof(FinishBufType))) FinishBufType;
         *finish_buf_ptr = finish_buf;
         finish_buf->set_output_tag(tag);
@@ -186,9 +186,8 @@ class ClientAsyncResponseReaderHelper {
     };
   }
 
-  static void StartCall(
-      ::grpc::ClientContext* context,
-      ::grpc::internal::CallOpSendInitialMetadata* single_buf) {
+  static void StartCall(grpc::ClientContext* context,
+                        grpc::internal::CallOpSendInitialMetadata* single_buf) {
     single_buf->SendInitialMetadata(&context->send_initial_metadata_,
                                     context->initial_metadata_flags());
   }
@@ -201,8 +200,8 @@ class ClientAsyncResponseReaderFactory {
  public:
   template <class W>
   static ClientAsyncResponseReader<R>* Create(
-      ::grpc::ChannelInterface* channel, ::grpc::CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ::grpc::ClientContext* context,
+      grpc::ChannelInterface* channel, grpc::CompletionQueue* cq,
+      const grpc::internal::RpcMethod& method, grpc::ClientContext* context,
       const W& request, bool start) {
     auto* result = ClientAsyncResponseReaderHelper::Create<R>(
         channel, cq, method, context, request);
@@ -257,7 +256,7 @@ class ClientAsyncResponseReader final
   /// Side effect:
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
-  void Finish(R* msg, ::grpc::Status* status, void* tag) override {
+  void Finish(R* msg, grpc::Status* status, void* tag) override {
     GPR_CODEGEN_DEBUG_ASSERT(started_);
     finish_(context_, &call_, initial_metadata_read_, single_buf_, &finish_buf_,
             static_cast<void*>(msg), status, tag);
@@ -265,13 +264,13 @@ class ClientAsyncResponseReader final
 
  private:
   friend class internal::ClientAsyncResponseReaderHelper;
-  ::grpc::ClientContext* const context_;
-  ::grpc::internal::Call call_;
+  grpc::ClientContext* const context_;
+  grpc::internal::Call call_;
   bool started_ = false;
   bool initial_metadata_read_ = false;
 
-  ClientAsyncResponseReader(::grpc::internal::Call call,
-                            ::grpc::ClientContext* context)
+  ClientAsyncResponseReader(grpc::internal::Call call,
+                            grpc::ClientContext* context)
       : context_(context), call_(call) {}
 
   // disable operator new
@@ -294,9 +293,9 @@ class ClientAsyncResponseReader final
 /// response message sent to the client is of type \a W.
 template <class W>
 class ServerAsyncResponseWriter final
-    : public ::grpc::internal::ServerAsyncStreamingInterface {
+    : public grpc::internal::ServerAsyncStreamingInterface {
  public:
-  explicit ServerAsyncResponseWriter(::grpc::ServerContext* ctx)
+  explicit ServerAsyncResponseWriter(grpc::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -338,7 +337,7 @@ class ServerAsyncResponseWriter final
   /// gRPC doesn't take ownership or a reference to msg and status, so it is
   /// safe to deallocate them once the Finish operation is complete (i.e. a
   /// result arrives in the completion queue).
-  void Finish(const W& msg, const ::grpc::Status& status, void* tag) {
+  void Finish(const W& msg, const grpc::Status& status, void* tag) {
     finish_buf_.set_output_tag(tag);
     finish_buf_.set_core_cq_tag(&finish_buf_);
     if (!ctx_->sent_initial_metadata_) {
@@ -375,7 +374,7 @@ class ServerAsyncResponseWriter final
   /// gRPC doesn't take ownership or a reference to status, so it is safe to
   /// deallocate them once the Finish operation is complete (i.e. a result
   /// arrives in the completion queue).
-  void FinishWithError(const ::grpc::Status& status, void* tag) {
+  void FinishWithError(const grpc::Status& status, void* tag) {
     GPR_CODEGEN_ASSERT(!status.ok());
     finish_buf_.set_output_tag(tag);
     if (!ctx_->sent_initial_metadata_) {
@@ -391,15 +390,15 @@ class ServerAsyncResponseWriter final
   }
 
  private:
-  void BindCall(::grpc::internal::Call* call) override { call_ = *call; }
+  void BindCall(grpc::internal::Call* call) override { call_ = *call; }
 
-  ::grpc::internal::Call call_;
-  ::grpc::ServerContext* ctx_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::Call call_;
+  grpc::ServerContext* ctx_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_buf_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpServerSendStatus>
       finish_buf_;
 };
 

--- a/include/grpcpp/impl/codegen/async_unary_call.h
+++ b/include/grpcpp/impl/codegen/async_unary_call.h
@@ -121,7 +121,7 @@ class ClientAsyncResponseReaderHelper {
                internal::CallOpSetInterface**, void*, Status*, void*)>* finish,
       const W& request) {
     using SingleBufType =
-        grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+        grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                                   grpc::internal::CallOpSendMessage,
                                   grpc::internal::CallOpClientSendClose,
                                   grpc::internal::CallOpRecvInitialMetadata,
@@ -394,9 +394,9 @@ class ServerAsyncResponseWriter final
 
   grpc::internal::Call call_;
   grpc::ServerContext* ctx_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
       meta_buf_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpServerSendStatus>
       finish_buf_;
@@ -406,12 +406,12 @@ class ServerAsyncResponseWriter final
 
 namespace std {
 template <class R>
-class default_delete<::grpc::ClientAsyncResponseReader<R>> {
+class default_delete<grpc::ClientAsyncResponseReader<R>> {
  public:
   void operator()(void* /*p*/) {}
 };
 template <class R>
-class default_delete<::grpc::ClientAsyncResponseReaderInterface<R>> {
+class default_delete<grpc::ClientAsyncResponseReaderInterface<R>> {
  public:
   void operator()(void* /*p*/) {}
 };

--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -45,7 +45,7 @@ template <class RequestType>
 void* UnaryDeserializeHelper(grpc_byte_buffer*, grpc::Status*, RequestType*);
 template <class ServiceType, class RequestType, class ResponseType>
 class ServerStreamingHandler;
-template <::grpc::StatusCode code>
+template <grpc::StatusCode code>
 class ErrorMethodHandler;
 class CallOpSendMessage;
 template <class R>

--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -42,7 +42,7 @@ class CallbackUnaryHandler;
 template <class RequestType, class ResponseType>
 class CallbackServerStreamingHandler;
 template <class RequestType>
-void* UnaryDeserializeHelper(grpc_byte_buffer*, ::grpc::Status*, RequestType*);
+void* UnaryDeserializeHelper(grpc_byte_buffer*, grpc::Status*, RequestType*);
 template <class ServiceType, class RequestType, class ResponseType>
 class ServerStreamingHandler;
 template <::grpc::StatusCode code>
@@ -172,7 +172,7 @@ class ByteBuffer final {
   friend class internal::CallOpGenericRecvMessage;
   template <class RequestType>
   friend void* internal::UnaryDeserializeHelper(grpc_byte_buffer*,
-                                                ::grpc::Status*, RequestType*);
+                                                grpc::Status*, RequestType*);
   template <class ServiceType, class RequestType, class ResponseType>
   friend class internal::ServerStreamingHandler;
   template <class RequestType, class ResponseType>

--- a/include/grpcpp/impl/codegen/call.h
+++ b/include/grpcpp/impl/codegen/call.h
@@ -42,13 +42,13 @@ class Call final {
         call_(nullptr),
         max_receive_message_size_(-1) {}
   /** call is owned by the caller */
-  Call(grpc_call* call, CallHook* call_hook, ::grpc::CompletionQueue* cq)
+  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq)
       : call_hook_(call_hook),
         cq_(cq),
         call_(call),
         max_receive_message_size_(-1) {}
 
-  Call(grpc_call* call, CallHook* call_hook, ::grpc::CompletionQueue* cq,
+  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq,
        experimental::ClientRpcInfo* rpc_info)
       : call_hook_(call_hook),
         cq_(cq),
@@ -56,7 +56,7 @@ class Call final {
         max_receive_message_size_(-1),
         client_rpc_info_(rpc_info) {}
 
-  Call(grpc_call* call, CallHook* call_hook, ::grpc::CompletionQueue* cq,
+  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq,
        int max_receive_message_size, experimental::ServerRpcInfo* rpc_info)
       : call_hook_(call_hook),
         cq_(cq),
@@ -69,7 +69,7 @@ class Call final {
   }
 
   grpc_call* call() const { return call_; }
-  ::grpc::CompletionQueue* cq() const { return cq_; }
+  grpc::CompletionQueue* cq() const { return cq_; }
 
   int max_receive_message_size() const { return max_receive_message_size_; }
 
@@ -83,7 +83,7 @@ class Call final {
 
  private:
   CallHook* call_hook_;
-  ::grpc::CompletionQueue* cq_;
+  grpc::CompletionQueue* cq_;
   grpc_call* call_;
   int max_receive_message_size_;
   experimental::ClientRpcInfo* client_rpc_info_ = nullptr;

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -729,7 +729,7 @@ class CallOpRecvInitialMetadata {
  public:
   CallOpRecvInitialMetadata() : metadata_map_(nullptr) {}
 
-  void RecvInitialMetadata(::grpc::ClientContext* context) {
+  void RecvInitialMetadata(grpc::ClientContext* context) {
     context->initial_metadata_received_ = true;
     metadata_map_ = &context->recv_initial_metadata_;
   }
@@ -778,7 +778,7 @@ class CallOpClientRecvStatus {
   CallOpClientRecvStatus()
       : recv_status_(nullptr), debug_error_string_(nullptr) {}
 
-  void ClientRecvStatus(::grpc::ClientContext* context, Status* status) {
+  void ClientRecvStatus(grpc::ClientContext* context, Status* status) {
     client_context_ = context;
     metadata_map_ = &client_context_->trailing_metadata_;
     recv_status_ = status;
@@ -845,7 +845,7 @@ class CallOpClientRecvStatus {
 
  private:
   bool hijacked_ = false;
-  ::grpc::ClientContext* client_context_;
+  grpc::ClientContext* client_context_;
   MetadataMap* metadata_map_;
   Status* recv_status_;
   const char* debug_error_string_;

--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -81,7 +81,7 @@ class ChannelInterface {
   /// deadline expires. \a GetState needs to called to get the current state.
   template <typename T>
   void NotifyOnStateChange(grpc_connectivity_state last_observed, T deadline,
-                           ::grpc::CompletionQueue* cq, void* tag) {
+                           grpc::CompletionQueue* cq, void* tag) {
     TimePoint<T> deadline_tp(deadline);
     NotifyOnStateChangeImpl(last_observed, deadline_tp.raw_time(), cq, tag);
   }
@@ -106,41 +106,41 @@ class ChannelInterface {
 
  private:
   template <class R>
-  friend class ::grpc::ClientReader;
+  friend class grpc::ClientReader;
   template <class W>
-  friend class ::grpc::ClientWriter;
+  friend class grpc::ClientWriter;
   template <class W, class R>
-  friend class ::grpc::ClientReaderWriter;
+  friend class grpc::ClientReaderWriter;
   template <class R>
-  friend class ::grpc::internal::ClientAsyncReaderFactory;
+  friend class grpc::internal::ClientAsyncReaderFactory;
   template <class W>
-  friend class ::grpc::internal::ClientAsyncWriterFactory;
+  friend class grpc::internal::ClientAsyncWriterFactory;
   template <class W, class R>
-  friend class ::grpc::internal::ClientAsyncReaderWriterFactory;
-  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
+  friend class grpc::internal::ClientAsyncReaderWriterFactory;
+  friend class grpc::internal::ClientAsyncResponseReaderHelper;
   template <class W, class R>
-  friend class ::grpc::internal::ClientCallbackReaderWriterFactory;
+  friend class grpc::internal::ClientCallbackReaderWriterFactory;
   template <class R>
-  friend class ::grpc::internal::ClientCallbackReaderFactory;
+  friend class grpc::internal::ClientCallbackReaderFactory;
   template <class W>
-  friend class ::grpc::internal::ClientCallbackWriterFactory;
-  friend class ::grpc::internal::ClientCallbackUnaryFactory;
+  friend class grpc::internal::ClientCallbackWriterFactory;
+  friend class grpc::internal::ClientCallbackUnaryFactory;
   template <class InputMessage, class OutputMessage>
-  friend class ::grpc::internal::BlockingUnaryCallImpl;
+  friend class grpc::internal::BlockingUnaryCallImpl;
   template <class InputMessage, class OutputMessage>
-  friend class ::grpc::internal::CallbackUnaryCallImpl;
-  friend class ::grpc::internal::RpcMethod;
-  friend class ::grpc::experimental::DelegatingChannel;
-  friend class ::grpc::internal::InterceptedChannel;
+  friend class grpc::internal::CallbackUnaryCallImpl;
+  friend class grpc::internal::RpcMethod;
+  friend class grpc::experimental::DelegatingChannel;
+  friend class grpc::internal::InterceptedChannel;
   virtual internal::Call CreateCall(const internal::RpcMethod& method,
-                                    ::grpc::ClientContext* context,
-                                    ::grpc::CompletionQueue* cq) = 0;
+                                    grpc::ClientContext* context,
+                                    grpc::CompletionQueue* cq) = 0;
   virtual void PerformOpsOnCall(internal::CallOpSetInterface* ops,
                                 internal::Call* call) = 0;
   virtual void* RegisterMethod(const char* method) = 0;
   virtual void NotifyOnStateChangeImpl(grpc_connectivity_state last_observed,
                                        gpr_timespec deadline,
-                                       ::grpc::CompletionQueue* cq,
+                                       grpc::CompletionQueue* cq,
                                        void* tag) = 0;
   virtual bool WaitForStateChangeImpl(grpc_connectivity_state last_observed,
                                       gpr_timespec deadline) = 0;
@@ -153,8 +153,8 @@ class ChannelInterface {
   // method and adding a new pure method to an interface would be a breaking
   // change (even though this is private and non-API)
   virtual internal::Call CreateCallInternal(
-      const internal::RpcMethod& /*method*/, ::grpc::ClientContext* /*context*/,
-      ::grpc::CompletionQueue* /*cq*/, size_t /*interceptor_pos*/) {
+      const internal::RpcMethod& /*method*/, grpc::ClientContext* /*context*/,
+      grpc::CompletionQueue* /*cq*/, size_t /*interceptor_pos*/) {
     return internal::Call();
   }
 
@@ -165,7 +165,7 @@ class ChannelInterface {
   // Returns nullptr (rather than being pure) since this is a post-1.0 method
   // and adding a new pure method to an interface would be a breaking change
   // (even though this is private and non-API)
-  virtual ::grpc::CompletionQueue* CallbackCQ() { return nullptr; }
+  virtual grpc::CompletionQueue* CallbackCQ() { return nullptr; }
 };
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -430,38 +430,38 @@ class ClientContext {
   ClientContext(const ClientContext&);
   ClientContext& operator=(const ClientContext&);
 
-  friend class ::grpc::testing::InteropClientContextInspector;
-  friend class ::grpc::testing::ClientContextTestPeer;
-  friend class ::grpc::internal::CallOpClientRecvStatus;
-  friend class ::grpc::internal::CallOpRecvInitialMetadata;
-  friend class ::grpc::Channel;
+  friend class grpc::testing::InteropClientContextInspector;
+  friend class grpc::testing::ClientContextTestPeer;
+  friend class grpc::internal::CallOpClientRecvStatus;
+  friend class grpc::internal::CallOpRecvInitialMetadata;
+  friend class grpc::Channel;
   template <class R>
-  friend class ::grpc::ClientReader;
+  friend class grpc::ClientReader;
   template <class W>
-  friend class ::grpc::ClientWriter;
+  friend class grpc::ClientWriter;
   template <class W, class R>
-  friend class ::grpc::ClientReaderWriter;
+  friend class grpc::ClientReaderWriter;
   template <class R>
-  friend class ::grpc::ClientAsyncReader;
+  friend class grpc::ClientAsyncReader;
   template <class W>
-  friend class ::grpc::ClientAsyncWriter;
+  friend class grpc::ClientAsyncWriter;
   template <class W, class R>
-  friend class ::grpc::ClientAsyncReaderWriter;
+  friend class grpc::ClientAsyncReaderWriter;
   template <class R>
-  friend class ::grpc::ClientAsyncResponseReader;
-  friend class ::grpc::internal::ClientAsyncResponseReaderHelper;
+  friend class grpc::ClientAsyncResponseReader;
+  friend class grpc::internal::ClientAsyncResponseReaderHelper;
   template <class InputMessage, class OutputMessage>
-  friend class ::grpc::internal::BlockingUnaryCallImpl;
+  friend class grpc::internal::BlockingUnaryCallImpl;
   template <class InputMessage, class OutputMessage>
-  friend class ::grpc::internal::CallbackUnaryCallImpl;
+  friend class grpc::internal::CallbackUnaryCallImpl;
   template <class Request, class Response>
-  friend class ::grpc::internal::ClientCallbackReaderWriterImpl;
+  friend class grpc::internal::ClientCallbackReaderWriterImpl;
   template <class Response>
-  friend class ::grpc::internal::ClientCallbackReaderImpl;
+  friend class grpc::internal::ClientCallbackReaderImpl;
   template <class Request>
-  friend class ::grpc::internal::ClientCallbackWriterImpl;
-  friend class ::grpc::internal::ClientCallbackUnaryImpl;
-  friend class ::grpc::internal::ClientContextAccessor;
+  friend class grpc::internal::ClientCallbackWriterImpl;
+  friend class grpc::internal::ClientCallbackUnaryImpl;
+  friend class grpc::internal::ClientContextAccessor;
 
   // Used by friend class CallOpClientRecvStatus
   void set_debug_error_string(const std::string& debug_error_string) {

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -470,7 +470,7 @@ class ClientContext {
 
   grpc_call* call() const { return call_; }
   void set_call(grpc_call* call,
-                const std::shared_ptr<::grpc::Channel>& channel);
+                const std::shared_ptr<grpc::Channel>& channel);
 
   grpc::experimental::ClientRpcInfo* set_client_rpc_info(
       const char* method, const char* suffix_for_stats,
@@ -507,7 +507,7 @@ class ClientContext {
   bool wait_for_ready_explicitly_set_;
   bool idempotent_;
   bool cacheable_;
-  std::shared_ptr<::grpc::Channel> channel_;
+  std::shared_ptr<grpc::Channel> channel_;
   grpc::internal::Mutex mu_;
   grpc_call* call_;
   bool call_canceled_;

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -469,8 +469,7 @@ class ClientContext {
   }
 
   grpc_call* call() const { return call_; }
-  void set_call(grpc_call* call,
-                const std::shared_ptr<grpc::Channel>& channel);
+  void set_call(grpc_call* call, const std::shared_ptr<grpc::Channel>& channel);
 
   grpc::experimental::ClientRpcInfo* set_client_rpc_info(
       const char* method, const char* suffix_for_stats,

--- a/include/grpcpp/impl/codegen/client_unary_call.h
+++ b/include/grpcpp/impl/codegen/client_unary_call.h
@@ -60,10 +60,10 @@ class BlockingUnaryCallImpl {
   BlockingUnaryCallImpl(ChannelInterface* channel, const RpcMethod& method,
                         grpc::ClientContext* context,
                         const InputMessage& request, OutputMessage* result) {
-    ::grpc::CompletionQueue cq(grpc_completion_queue_attributes{
+    grpc::CompletionQueue cq(grpc_completion_queue_attributes{
         GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
         nullptr});  // Pluckable completion queue
-    ::grpc::internal::Call call(channel->CreateCall(method, context, &cq));
+    grpc::internal::Call call(channel->CreateCall(method, context, &cq));
     CallOpSet<CallOpSendInitialMetadata, CallOpSendMessage,
               CallOpRecvInitialMetadata, CallOpRecvMessage<OutputMessage>,
               CallOpClientSendClose, CallOpClientRecvStatus>

--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -64,8 +64,8 @@ class ServerReaderWriterBody;
 
 template <class ResponseType>
 void UnaryRunHandlerHelper(
-    const ::grpc::internal::MethodHandler::HandlerParameter&, ResponseType*,
-    ::grpc::Status&);
+    const grpc::internal::MethodHandler::HandlerParameter&, ResponseType*,
+    grpc::Status&);
 template <class ServiceType, class RequestType, class ResponseType,
           class BaseRequestType, class BaseResponseType>
 class RpcMethodHandler;
@@ -101,7 +101,7 @@ extern CoreCodegenInterface* g_core_codegen_interface;
 /// src/core/lib/surface/completion_queue.h).
 /// See \ref doc/cpp/perf_notes.md for notes on best practices for high
 /// performance servers.
-class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
+class CompletionQueue : private grpc::GrpcLibraryCodegen {
  public:
   /// Default constructor. Implicitly creates a \a grpc_completion_queue
   /// instance.
@@ -117,7 +117,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
 
   /// Destructor. Destroys the owned wrapped completion queue / instance.
   ~CompletionQueue() override {
-    ::grpc::g_core_codegen_interface->grpc_completion_queue_destroy(cq_);
+    grpc::g_core_codegen_interface->grpc_completion_queue_destroy(cq_);
   }
 
   /// Tri-state return for AsyncNext: SHUTDOWN, GOT_EVENT, TIMEOUT.
@@ -183,7 +183,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
     //             false.
     // GOT_EVENT - we actually got an event, return true.
     return (AsyncNextInternal(tag, ok,
-                              ::grpc::g_core_codegen_interface->gpr_inf_future(
+                              grpc::g_core_codegen_interface->gpr_inf_future(
                                   GPR_CLOCK_REALTIME)) == GOT_EVENT);
   }
 
@@ -200,7 +200,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// \return The type of event read.
   template <typename T>
   NextStatus AsyncNext(void** tag, bool* ok, const T& deadline) {
-    ::grpc::TimePoint<T> deadline_tp(deadline);
+    grpc::TimePoint<T> deadline_tp(deadline);
     return AsyncNextInternal(tag, ok, deadline_tp.raw_time());
   }
 
@@ -251,8 +251,8 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
  protected:
   /// Private constructor of CompletionQueue only visible to friend classes
   explicit CompletionQueue(const grpc_completion_queue_attributes& attributes) {
-    cq_ = ::grpc::g_core_codegen_interface->grpc_completion_queue_create(
-        ::grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
+    cq_ = grpc::g_core_codegen_interface->grpc_completion_queue_create(
+        grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
             &attributes),
         &attributes, nullptr);
     InitialAvalanching();  // reserve this for the future shutdown
@@ -261,46 +261,46 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
  private:
   // Friends for access to server registration lists that enable checking and
   // logging on shutdown
-  friend class ::grpc::ServerBuilder;
-  friend class ::grpc::Server;
+  friend class grpc::ServerBuilder;
+  friend class grpc::Server;
 
   // Friend synchronous wrappers so that they can access Pluck(), which is
   // a semi-private API geared towards the synchronous implementation.
   template <class R>
-  friend class ::grpc::ClientReader;
+  friend class grpc::ClientReader;
   template <class W>
-  friend class ::grpc::ClientWriter;
+  friend class grpc::ClientWriter;
   template <class W, class R>
-  friend class ::grpc::ClientReaderWriter;
+  friend class grpc::ClientReaderWriter;
   template <class R>
-  friend class ::grpc::ServerReader;
+  friend class grpc::ServerReader;
   template <class W>
-  friend class ::grpc::ServerWriter;
+  friend class grpc::ServerWriter;
   template <class W, class R>
-  friend class ::grpc::internal::ServerReaderWriterBody;
+  friend class grpc::internal::ServerReaderWriterBody;
   template <class ResponseType>
-  friend void ::grpc::internal::UnaryRunHandlerHelper(
-      const ::grpc::internal::MethodHandler::HandlerParameter&, ResponseType*,
-      ::grpc::Status&);
+  friend void grpc::internal::UnaryRunHandlerHelper(
+      const grpc::internal::MethodHandler::HandlerParameter&, ResponseType*,
+      grpc::Status&);
   template <class ServiceType, class RequestType, class ResponseType>
-  friend class ::grpc::internal::ClientStreamingHandler;
+  friend class grpc::internal::ClientStreamingHandler;
   template <class ServiceType, class RequestType, class ResponseType>
-  friend class ::grpc::internal::ServerStreamingHandler;
+  friend class grpc::internal::ServerStreamingHandler;
   template <class Streamer, bool WriteNeeded>
-  friend class ::grpc::internal::TemplatedBidiStreamingHandler;
+  friend class grpc::internal::TemplatedBidiStreamingHandler;
   template <::grpc::StatusCode code>
-  friend class ::grpc::internal::ErrorMethodHandler;
-  friend class ::grpc::ServerContextBase;
-  friend class ::grpc::ServerInterface;
+  friend class grpc::internal::ErrorMethodHandler;
+  friend class grpc::ServerContextBase;
+  friend class grpc::ServerInterface;
   template <class InputMessage, class OutputMessage>
-  friend class ::grpc::internal::BlockingUnaryCallImpl;
+  friend class grpc::internal::BlockingUnaryCallImpl;
 
   // Friends that need access to constructor for callback CQ
-  friend class ::grpc::Channel;
+  friend class grpc::Channel;
 
   // For access to Register/CompleteAvalanching
   template <class Op1, class Op2, class Op3, class Op4, class Op5, class Op6>
-  friend class ::grpc::internal::CallOpSet;
+  friend class grpc::internal::CallOpSet;
 
   /// EXPERIMENTAL
   /// Creates a Thread Local cache to store the first event
@@ -321,11 +321,11 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
 
   /// Wraps \a grpc_completion_queue_pluck.
   /// \warning Must not be mixed with calls to \a Next.
-  bool Pluck(::grpc::internal::CompletionQueueTag* tag) {
+  bool Pluck(grpc::internal::CompletionQueueTag* tag) {
     auto deadline =
-        ::grpc::g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_REALTIME);
+        grpc::g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_REALTIME);
     while (true) {
-      auto ev = ::grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
+      auto ev = grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
           cq_, tag, deadline, nullptr);
       bool ok = ev.success != 0;
       void* ignored = tag;
@@ -344,10 +344,10 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   /// implementation to simple call the other TryPluck function with a zero
   /// timeout. i.e:
   ///      TryPluck(tag, gpr_time_0(GPR_CLOCK_REALTIME))
-  void TryPluck(::grpc::internal::CompletionQueueTag* tag) {
+  void TryPluck(grpc::internal::CompletionQueueTag* tag) {
     auto deadline =
-        ::grpc::g_core_codegen_interface->gpr_time_0(GPR_CLOCK_REALTIME);
-    auto ev = ::grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
+        grpc::g_core_codegen_interface->gpr_time_0(GPR_CLOCK_REALTIME);
+    auto ev = grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
         cq_, tag, deadline, nullptr);
     if (ev.type == GRPC_QUEUE_TIMEOUT) return;
     bool ok = ev.success != 0;
@@ -361,9 +361,9 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   ///
   /// This exects tag->FinalizeResult (if called) to return 'false' i.e expects
   /// that the tag is internal not something that is returned to the user.
-  void TryPluck(::grpc::internal::CompletionQueueTag* tag,
+  void TryPluck(grpc::internal::CompletionQueueTag* tag,
                 gpr_timespec deadline) {
-    auto ev = ::grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
+    auto ev = grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
         cq_, tag, deadline, nullptr);
     if (ev.type == GRPC_QUEUE_TIMEOUT || ev.type == GRPC_QUEUE_SHUTDOWN) {
       return;
@@ -390,18 +390,18 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   void CompleteAvalanching() {
     if (gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_,
                                      static_cast<gpr_atm>(-1)) == 1) {
-      ::grpc::g_core_codegen_interface->grpc_completion_queue_shutdown(cq_);
+      grpc::g_core_codegen_interface->grpc_completion_queue_shutdown(cq_);
     }
   }
 
-  void RegisterServer(const ::grpc::Server* server) {
+  void RegisterServer(const grpc::Server* server) {
     (void)server;
 #ifndef NDEBUG
     grpc::internal::MutexLock l(&server_list_mutex_);
     server_list_.push_back(server);
 #endif
   }
-  void UnregisterServer(const ::grpc::Server* server) {
+  void UnregisterServer(const grpc::Server* server) {
     (void)server;
 #ifndef NDEBUG
     grpc::internal::MutexLock l(&server_list_mutex_);
@@ -427,7 +427,7 @@ class CompletionQueue : private ::grpc::GrpcLibraryCodegen {
   // NDEBUG, instantiate it in all cases since otherwise the size will be
   // inconsistent.
   mutable grpc::internal::Mutex server_list_mutex_;
-  std::list<const ::grpc::Server*>
+  std::list<const grpc::Server*>
       server_list_ /* GUARDED_BY(server_list_mutex_) */;
 };
 
@@ -457,8 +457,8 @@ class ServerCompletionQueue : public CompletionQueue {
         polling_type_(polling_type) {}
 
   grpc_cq_polling_type polling_type_;
-  friend class ::grpc::ServerBuilder;
-  friend class ::grpc::Server;
+  friend class grpc::ServerBuilder;
+  friend class grpc::Server;
 };
 
 }  // namespace grpc

--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -75,7 +75,7 @@ template <class ServiceType, class RequestType, class ResponseType>
 class ServerStreamingHandler;
 template <class Streamer, bool WriteNeeded>
 class TemplatedBidiStreamingHandler;
-template <::grpc::StatusCode code>
+template <grpc::StatusCode code>
 class ErrorMethodHandler;
 }  // namespace internal
 
@@ -288,7 +288,7 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
   friend class grpc::internal::ServerStreamingHandler;
   template <class Streamer, bool WriteNeeded>
   friend class grpc::internal::TemplatedBidiStreamingHandler;
-  template <::grpc::StatusCode code>
+  template <grpc::StatusCode code>
   friend class grpc::internal::ErrorMethodHandler;
   friend class grpc::ServerContextBase;
   friend class grpc::ServerInterface;

--- a/include/grpcpp/impl/codegen/delegating_channel.h
+++ b/include/grpcpp/impl/codegen/delegating_channel.h
@@ -33,14 +33,14 @@ class DelegatingChannel : public grpc::ChannelInterface {
   ~DelegatingChannel() override {}
 
   explicit DelegatingChannel(
-      std::shared_ptr<::grpc::ChannelInterface> delegate_channel)
+      std::shared_ptr<grpc::ChannelInterface> delegate_channel)
       : delegate_channel_(delegate_channel) {}
 
   grpc_connectivity_state GetState(bool try_to_connect) override {
     return delegate_channel()->GetState(try_to_connect);
   }
 
-  std::shared_ptr<::grpc::ChannelInterface> delegate_channel() {
+  std::shared_ptr<grpc::ChannelInterface> delegate_channel() {
     return delegate_channel_;
   }
 
@@ -84,7 +84,7 @@ class DelegatingChannel : public grpc::ChannelInterface {
     return delegate_channel()->CallbackCQ();
   }
 
-  std::shared_ptr<::grpc::ChannelInterface> delegate_channel_;
+  std::shared_ptr<grpc::ChannelInterface> delegate_channel_;
 };
 
 }  // namespace experimental

--- a/include/grpcpp/impl/codegen/delegating_channel.h
+++ b/include/grpcpp/impl/codegen/delegating_channel.h
@@ -28,7 +28,7 @@
 namespace grpc {
 namespace experimental {
 
-class DelegatingChannel : public ::grpc::ChannelInterface {
+class DelegatingChannel : public grpc::ChannelInterface {
  public:
   ~DelegatingChannel() override {}
 
@@ -47,7 +47,7 @@ class DelegatingChannel : public ::grpc::ChannelInterface {
  private:
   internal::Call CreateCall(const internal::RpcMethod& method,
                             ClientContext* context,
-                            ::grpc::CompletionQueue* cq) final {
+                            grpc::CompletionQueue* cq) final {
     return delegate_channel()->CreateCall(method, context, cq);
   }
 
@@ -61,8 +61,7 @@ class DelegatingChannel : public ::grpc::ChannelInterface {
   }
 
   void NotifyOnStateChangeImpl(grpc_connectivity_state last_observed,
-                               gpr_timespec deadline,
-                               ::grpc::CompletionQueue* cq,
+                               gpr_timespec deadline, grpc::CompletionQueue* cq,
                                void* tag) override {
     delegate_channel()->NotifyOnStateChangeImpl(last_observed, deadline, cq,
                                                 tag);
@@ -75,13 +74,13 @@ class DelegatingChannel : public ::grpc::ChannelInterface {
 
   internal::Call CreateCallInternal(const internal::RpcMethod& method,
                                     ClientContext* context,
-                                    ::grpc::CompletionQueue* cq,
+                                    grpc::CompletionQueue* cq,
                                     size_t interceptor_pos) final {
     return delegate_channel()->CreateCallInternal(method, context, cq,
                                                   interceptor_pos);
   }
 
-  ::grpc::CompletionQueue* CallbackCQ() final {
+  grpc::CompletionQueue* CallbackCQ() final {
     return delegate_channel()->CallbackCQ();
   }
 

--- a/include/grpcpp/impl/codegen/intercepted_channel.h
+++ b/include/grpcpp/impl/codegen/intercepted_channel.h
@@ -48,8 +48,8 @@ class InterceptedChannel : public ChannelInterface {
   InterceptedChannel(ChannelInterface* channel, size_t pos)
       : channel_(channel), interceptor_pos_(pos) {}
 
-  Call CreateCall(const RpcMethod& method, ::grpc::ClientContext* context,
-                  ::grpc::CompletionQueue* cq) override {
+  Call CreateCall(const RpcMethod& method, grpc::ClientContext* context,
+                  grpc::CompletionQueue* cq) override {
     return channel_->CreateCallInternal(method, context, cq, interceptor_pos_);
   }
 
@@ -61,8 +61,7 @@ class InterceptedChannel : public ChannelInterface {
   }
 
   void NotifyOnStateChangeImpl(grpc_connectivity_state last_observed,
-                               gpr_timespec deadline,
-                               ::grpc::CompletionQueue* cq,
+                               gpr_timespec deadline, grpc::CompletionQueue* cq,
                                void* tag) override {
     return channel_->NotifyOnStateChangeImpl(last_observed, deadline, cq, tag);
   }
@@ -71,7 +70,7 @@ class InterceptedChannel : public ChannelInterface {
     return channel_->WaitForStateChangeImpl(last_observed, deadline);
   }
 
-  ::grpc::CompletionQueue* CallbackCQ() override {
+  grpc::CompletionQueue* CallbackCQ() override {
     return channel_->CallbackCQ();
   }
 

--- a/include/grpcpp/impl/codegen/method_handler.h
+++ b/include/grpcpp/impl/codegen/method_handler.h
@@ -59,7 +59,7 @@ template <class ResponseType>
 void UnaryRunHandlerHelper(const MethodHandler::HandlerParameter& param,
                            ResponseType* rsp, grpc::Status& status) {
   GPR_CODEGEN_ASSERT(!param.server_context->sent_initial_metadata_);
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpServerSendStatus>
       ops;
@@ -100,7 +100,7 @@ template <class ServiceType, class RequestType, class ResponseType,
 class RpcMethodHandler : public grpc::internal::MethodHandler {
  public:
   RpcMethodHandler(
-      std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
+      std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
                                    const RequestType*, ResponseType*)>
           func,
       ServiceType* service)
@@ -130,7 +130,7 @@ class RpcMethodHandler : public grpc::internal::MethodHandler {
 
  private:
   /// Application provided rpc handler function.
-  std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
+  std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
                                const RequestType*, ResponseType*)>
       func_;
   // The class the above handler function lives in.
@@ -142,7 +142,7 @@ template <class ServiceType, class RequestType, class ResponseType>
 class ClientStreamingHandler : public grpc::internal::MethodHandler {
  public:
   ClientStreamingHandler(
-      std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
+      std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
                                    ServerReader<RequestType>*, ResponseType*)>
           func,
       ServiceType* service)
@@ -159,7 +159,7 @@ class ClientStreamingHandler : public grpc::internal::MethodHandler {
                        &reader, &rsp);
         });
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpServerSendStatus>
         ops;
@@ -179,7 +179,7 @@ class ClientStreamingHandler : public grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
+  std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
                                ServerReader<RequestType>*, ResponseType*)>
       func_;
   ServiceType* service_;
@@ -189,7 +189,7 @@ class ClientStreamingHandler : public grpc::internal::MethodHandler {
 template <class ServiceType, class RequestType, class ResponseType>
 class ServerStreamingHandler : public grpc::internal::MethodHandler {
  public:
-  ServerStreamingHandler(std::function<::grpc::Status(
+  ServerStreamingHandler(std::function<grpc::Status(
                              ServiceType*, grpc::ServerContext*,
                              const RequestType*, ServerWriter<ResponseType>*)>
                              func,
@@ -209,7 +209,7 @@ class ServerStreamingHandler : public grpc::internal::MethodHandler {
       static_cast<RequestType*>(param.request)->~RequestType();
     }
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpServerSendStatus>
         ops;
     if (!param.server_context->sent_initial_metadata_) {
@@ -244,7 +244,7 @@ class ServerStreamingHandler : public grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
+  std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
                                const RequestType*, ServerWriter<ResponseType>*)>
       func_;
   ServiceType* service_;
@@ -261,7 +261,7 @@ template <class Streamer, bool WriteNeeded>
 class TemplatedBidiStreamingHandler : public grpc::internal::MethodHandler {
  public:
   explicit TemplatedBidiStreamingHandler(
-      std::function<::grpc::Status(grpc::ServerContext*, Streamer*)> func)
+      std::function<grpc::Status(grpc::ServerContext*, Streamer*)> func)
       : func_(func), write_needed_(WriteNeeded) {}
 
   void RunHandler(const HandlerParameter& param) final {
@@ -272,7 +272,7 @@ class TemplatedBidiStreamingHandler : public grpc::internal::MethodHandler {
                    &stream);
     });
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpServerSendStatus>
         ops;
     if (!param.server_context->sent_initial_metadata_) {
@@ -297,7 +297,7 @@ class TemplatedBidiStreamingHandler : public grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<::grpc::Status(grpc::ServerContext*, Streamer*)> func_;
+  std::function<grpc::Status(grpc::ServerContext*, Streamer*)> func_;
   const bool write_needed_;
 };
 
@@ -306,7 +306,7 @@ class BidiStreamingHandler
     : public TemplatedBidiStreamingHandler<
           ServerReaderWriter<ResponseType, RequestType>, false> {
  public:
-  BidiStreamingHandler(std::function<::grpc::Status(
+  BidiStreamingHandler(std::function<grpc::Status(
                            ServiceType*, grpc::ServerContext*,
                            ServerReaderWriter<ResponseType, RequestType>*)>
                            func,
@@ -353,7 +353,7 @@ class SplitServerStreamingHandler
 
 /// General method handler class for errors that prevent real method use
 /// e.g., handle unknown method by returning UNIMPLEMENTED error.
-template <::grpc::StatusCode code>
+template <grpc::StatusCode code>
 class ErrorMethodHandler : public grpc::internal::MethodHandler {
  public:
   explicit ErrorMethodHandler(const std::string& message) : message_(message) {}
@@ -374,7 +374,7 @@ class ErrorMethodHandler : public grpc::internal::MethodHandler {
   }
 
   void RunHandler(const HandlerParameter& param) final {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpServerSendStatus>
         ops;
     FillOps(param.server_context, message_, &ops);
@@ -395,9 +395,9 @@ class ErrorMethodHandler : public grpc::internal::MethodHandler {
   const std::string message_;
 };
 
-typedef ErrorMethodHandler<::grpc::StatusCode::UNIMPLEMENTED>
+typedef ErrorMethodHandler<grpc::StatusCode::UNIMPLEMENTED>
     UnknownMethodHandler;
-typedef ErrorMethodHandler<::grpc::StatusCode::RESOURCE_EXHAUSTED>
+typedef ErrorMethodHandler<grpc::StatusCode::RESOURCE_EXHAUSTED>
     ResourceExhaustedHandler;
 
 }  // namespace internal

--- a/include/grpcpp/impl/codegen/method_handler.h
+++ b/include/grpcpp/impl/codegen/method_handler.h
@@ -43,8 +43,8 @@ template <class Callable>
   try {
     return handler();
   } catch (...) {
-    return ::grpc::Status(::grpc::StatusCode::UNKNOWN,
-                          "Unexpected error in RPC handling");
+    return grpc::Status(grpc::StatusCode::UNKNOWN,
+                        "Unexpected error in RPC handling");
   }
 #else   // GRPC_ALLOW_EXCEPTIONS
   return handler();
@@ -57,11 +57,11 @@ template <class Callable>
 
 template <class ResponseType>
 void UnaryRunHandlerHelper(const MethodHandler::HandlerParameter& param,
-                           ResponseType* rsp, ::grpc::Status& status) {
+                           ResponseType* rsp, grpc::Status& status) {
   GPR_CODEGEN_ASSERT(!param.server_context->sent_initial_metadata_);
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage,
-                              ::grpc::internal::CallOpServerSendStatus>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage,
+                            grpc::internal::CallOpServerSendStatus>
       ops;
   ops.SendInitialMetadata(&param.server_context->initial_metadata_,
                           param.server_context->initial_metadata_flags());
@@ -79,11 +79,11 @@ void UnaryRunHandlerHelper(const MethodHandler::HandlerParameter& param,
 /// A helper function with reduced templating to do deserializing.
 
 template <class RequestType>
-void* UnaryDeserializeHelper(grpc_byte_buffer* req, ::grpc::Status* status,
+void* UnaryDeserializeHelper(grpc_byte_buffer* req, grpc::Status* status,
                              RequestType* request) {
-  ::grpc::ByteBuffer buf;
+  grpc::ByteBuffer buf;
   buf.set_buffer(req);
-  *status = ::grpc::SerializationTraits<RequestType>::Deserialize(
+  *status = grpc::SerializationTraits<RequestType>::Deserialize(
       &buf, static_cast<RequestType*>(request));
   buf.Release();
   if (status->ok()) {
@@ -97,10 +97,10 @@ void* UnaryDeserializeHelper(grpc_byte_buffer* req, ::grpc::Status* status,
 template <class ServiceType, class RequestType, class ResponseType,
           class BaseRequestType = RequestType,
           class BaseResponseType = ResponseType>
-class RpcMethodHandler : public ::grpc::internal::MethodHandler {
+class RpcMethodHandler : public grpc::internal::MethodHandler {
  public:
   RpcMethodHandler(
-      std::function<::grpc::Status(ServiceType*, ::grpc::ServerContext*,
+      std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
                                    const RequestType*, ResponseType*)>
           func,
       ServiceType* service)
@@ -108,11 +108,11 @@ class RpcMethodHandler : public ::grpc::internal::MethodHandler {
 
   void RunHandler(const HandlerParameter& param) final {
     ResponseType rsp;
-    ::grpc::Status status = param.status;
+    grpc::Status status = param.status;
     if (status.ok()) {
       status = CatchingFunctionHandler([this, &param, &rsp] {
         return func_(service_,
-                     static_cast<::grpc::ServerContext*>(param.server_context),
+                     static_cast<grpc::ServerContext*>(param.server_context),
                      static_cast<RequestType*>(param.request), &rsp);
       });
       static_cast<RequestType*>(param.request)->~RequestType();
@@ -121,17 +121,16 @@ class RpcMethodHandler : public ::grpc::internal::MethodHandler {
   }
 
   void* Deserialize(grpc_call* call, grpc_byte_buffer* req,
-                    ::grpc::Status* status, void** /*handler_data*/) final {
-    auto* request =
-        new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
-            call, sizeof(RequestType))) RequestType;
+                    grpc::Status* status, void** /*handler_data*/) final {
+    auto* request = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+        call, sizeof(RequestType))) RequestType;
     return UnaryDeserializeHelper(req, status,
                                   static_cast<BaseRequestType*>(request));
   }
 
  private:
   /// Application provided rpc handler function.
-  std::function<::grpc::Status(ServiceType*, ::grpc::ServerContext*,
+  std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
                                const RequestType*, ResponseType*)>
       func_;
   // The class the above handler function lives in.
@@ -140,10 +139,10 @@ class RpcMethodHandler : public ::grpc::internal::MethodHandler {
 
 /// A wrapper class of an application provided client streaming handler.
 template <class ServiceType, class RequestType, class ResponseType>
-class ClientStreamingHandler : public ::grpc::internal::MethodHandler {
+class ClientStreamingHandler : public grpc::internal::MethodHandler {
  public:
   ClientStreamingHandler(
-      std::function<::grpc::Status(ServiceType*, ::grpc::ServerContext*,
+      std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
                                    ServerReader<RequestType>*, ResponseType*)>
           func,
       ServiceType* service)
@@ -151,18 +150,18 @@ class ClientStreamingHandler : public ::grpc::internal::MethodHandler {
 
   void RunHandler(const HandlerParameter& param) final {
     ServerReader<RequestType> reader(
-        param.call, static_cast<::grpc::ServerContext*>(param.server_context));
+        param.call, static_cast<grpc::ServerContext*>(param.server_context));
     ResponseType rsp;
-    ::grpc::Status status = CatchingFunctionHandler([this, &param, &reader,
-                                                     &rsp] {
-      return func_(service_,
-                   static_cast<::grpc::ServerContext*>(param.server_context),
-                   &reader, &rsp);
-    });
+    grpc::Status status =
+        CatchingFunctionHandler([this, &param, &reader, &rsp] {
+          return func_(service_,
+                       static_cast<grpc::ServerContext*>(param.server_context),
+                       &reader, &rsp);
+        });
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpServerSendStatus>
         ops;
     if (!param.server_context->sent_initial_metadata_) {
       ops.SendInitialMetadata(&param.server_context->initial_metadata_,
@@ -180,7 +179,7 @@ class ClientStreamingHandler : public ::grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<::grpc::Status(ServiceType*, ::grpc::ServerContext*,
+  std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
                                ServerReader<RequestType>*, ResponseType*)>
       func_;
   ServiceType* service_;
@@ -188,31 +187,30 @@ class ClientStreamingHandler : public ::grpc::internal::MethodHandler {
 
 /// A wrapper class of an application provided server streaming handler.
 template <class ServiceType, class RequestType, class ResponseType>
-class ServerStreamingHandler : public ::grpc::internal::MethodHandler {
+class ServerStreamingHandler : public grpc::internal::MethodHandler {
  public:
   ServerStreamingHandler(std::function<::grpc::Status(
-                             ServiceType*, ::grpc::ServerContext*,
+                             ServiceType*, grpc::ServerContext*,
                              const RequestType*, ServerWriter<ResponseType>*)>
                              func,
                          ServiceType* service)
       : func_(func), service_(service) {}
 
   void RunHandler(const HandlerParameter& param) final {
-    ::grpc::Status status = param.status;
+    grpc::Status status = param.status;
     if (status.ok()) {
       ServerWriter<ResponseType> writer(
-          param.call,
-          static_cast<::grpc::ServerContext*>(param.server_context));
+          param.call, static_cast<grpc::ServerContext*>(param.server_context));
       status = CatchingFunctionHandler([this, &param, &writer] {
         return func_(service_,
-                     static_cast<::grpc::ServerContext*>(param.server_context),
+                     static_cast<grpc::ServerContext*>(param.server_context),
                      static_cast<RequestType*>(param.request), &writer);
       });
       static_cast<RequestType*>(param.request)->~RequestType();
     }
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpServerSendStatus>
         ops;
     if (!param.server_context->sent_initial_metadata_) {
       ops.SendInitialMetadata(&param.server_context->initial_metadata_,
@@ -230,14 +228,13 @@ class ServerStreamingHandler : public ::grpc::internal::MethodHandler {
   }
 
   void* Deserialize(grpc_call* call, grpc_byte_buffer* req,
-                    ::grpc::Status* status, void** /*handler_data*/) final {
-    ::grpc::ByteBuffer buf;
+                    grpc::Status* status, void** /*handler_data*/) final {
+    grpc::ByteBuffer buf;
     buf.set_buffer(req);
-    auto* request =
-        new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
-            call, sizeof(RequestType))) RequestType();
+    auto* request = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+        call, sizeof(RequestType))) RequestType();
     *status =
-        ::grpc::SerializationTraits<RequestType>::Deserialize(&buf, request);
+        grpc::SerializationTraits<RequestType>::Deserialize(&buf, request);
     buf.Release();
     if (status->ok()) {
       return request;
@@ -247,7 +244,7 @@ class ServerStreamingHandler : public ::grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<::grpc::Status(ServiceType*, ::grpc::ServerContext*,
+  std::function<::grpc::Status(ServiceType*, grpc::ServerContext*,
                                const RequestType*, ServerWriter<ResponseType>*)>
       func_;
   ServiceType* service_;
@@ -261,22 +258,22 @@ class ServerStreamingHandler : public ::grpc::internal::MethodHandler {
 /// Instead, it is expected to be an implicitly-captured argument of func
 /// (through bind or something along those lines)
 template <class Streamer, bool WriteNeeded>
-class TemplatedBidiStreamingHandler : public ::grpc::internal::MethodHandler {
+class TemplatedBidiStreamingHandler : public grpc::internal::MethodHandler {
  public:
   explicit TemplatedBidiStreamingHandler(
-      std::function<::grpc::Status(::grpc::ServerContext*, Streamer*)> func)
+      std::function<::grpc::Status(grpc::ServerContext*, Streamer*)> func)
       : func_(func), write_needed_(WriteNeeded) {}
 
   void RunHandler(const HandlerParameter& param) final {
     Streamer stream(param.call,
-                    static_cast<::grpc::ServerContext*>(param.server_context));
-    ::grpc::Status status = CatchingFunctionHandler([this, &param, &stream] {
-      return func_(static_cast<::grpc::ServerContext*>(param.server_context),
+                    static_cast<grpc::ServerContext*>(param.server_context));
+    grpc::Status status = CatchingFunctionHandler([this, &param, &stream] {
+      return func_(static_cast<grpc::ServerContext*>(param.server_context),
                    &stream);
     });
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpServerSendStatus>
         ops;
     if (!param.server_context->sent_initial_metadata_) {
       ops.SendInitialMetadata(&param.server_context->initial_metadata_,
@@ -287,8 +284,8 @@ class TemplatedBidiStreamingHandler : public ::grpc::internal::MethodHandler {
       if (write_needed_ && status.ok()) {
         // If we needed a write but never did one, we need to mark the
         // status as a fail
-        status = ::grpc::Status(::grpc::StatusCode::INTERNAL,
-                                "Service did not provide response message");
+        status = grpc::Status(grpc::StatusCode::INTERNAL,
+                              "Service did not provide response message");
       }
     }
     ops.ServerSendStatus(&param.server_context->trailing_metadata_, status);
@@ -300,7 +297,7 @@ class TemplatedBidiStreamingHandler : public ::grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<::grpc::Status(::grpc::ServerContext*, Streamer*)> func_;
+  std::function<::grpc::Status(grpc::ServerContext*, Streamer*)> func_;
   const bool write_needed_;
 };
 
@@ -310,7 +307,7 @@ class BidiStreamingHandler
           ServerReaderWriter<ResponseType, RequestType>, false> {
  public:
   BidiStreamingHandler(std::function<::grpc::Status(
-                           ServiceType*, ::grpc::ServerContext*,
+                           ServiceType*, grpc::ServerContext*,
                            ServerReaderWriter<ResponseType, RequestType>*)>
                            func,
                        ServiceType* service)
@@ -318,7 +315,7 @@ class BidiStreamingHandler
       : TemplatedBidiStreamingHandler<
             ServerReaderWriter<ResponseType, RequestType>, false>(
             [func, service](
-                ::grpc::ServerContext* ctx,
+                grpc::ServerContext* ctx,
                 ServerReaderWriter<ResponseType, RequestType>* streamer) {
               return func(service, ctx, streamer);
             }) {}
@@ -331,8 +328,8 @@ class StreamedUnaryHandler
  public:
   explicit StreamedUnaryHandler(
       std::function<
-          ::grpc::Status(::grpc::ServerContext*,
-                         ServerUnaryStreamer<RequestType, ResponseType>*)>
+          grpc::Status(grpc::ServerContext*,
+                       ServerUnaryStreamer<RequestType, ResponseType>*)>
           func)
       : TemplatedBidiStreamingHandler<
             ServerUnaryStreamer<RequestType, ResponseType>, true>(
@@ -346,8 +343,8 @@ class SplitServerStreamingHandler
  public:
   explicit SplitServerStreamingHandler(
       std::function<
-          ::grpc::Status(::grpc::ServerContext*,
-                         ServerSplitStreamer<RequestType, ResponseType>*)>
+          grpc::Status(grpc::ServerContext*,
+                       ServerSplitStreamer<RequestType, ResponseType>*)>
           func)
       : TemplatedBidiStreamingHandler<
             ServerSplitStreamer<RequestType, ResponseType>, false>(
@@ -357,14 +354,14 @@ class SplitServerStreamingHandler
 /// General method handler class for errors that prevent real method use
 /// e.g., handle unknown method by returning UNIMPLEMENTED error.
 template <::grpc::StatusCode code>
-class ErrorMethodHandler : public ::grpc::internal::MethodHandler {
+class ErrorMethodHandler : public grpc::internal::MethodHandler {
  public:
   explicit ErrorMethodHandler(const std::string& message) : message_(message) {}
 
   template <class T>
-  static void FillOps(::grpc::ServerContextBase* context,
+  static void FillOps(grpc::ServerContextBase* context,
                       const std::string& message, T* ops) {
-    ::grpc::Status status(code, message);
+    grpc::Status status(code, message);
     if (!context->sent_initial_metadata_) {
       ops->SendInitialMetadata(&context->initial_metadata_,
                                context->initial_metadata_flags());
@@ -377,8 +374,8 @@ class ErrorMethodHandler : public ::grpc::internal::MethodHandler {
   }
 
   void RunHandler(const HandlerParameter& param) final {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpServerSendStatus>
         ops;
     FillOps(param.server_context, message_, &ops);
     param.call->PerformOps(&ops);
@@ -386,10 +383,10 @@ class ErrorMethodHandler : public ::grpc::internal::MethodHandler {
   }
 
   void* Deserialize(grpc_call* /*call*/, grpc_byte_buffer* req,
-                    ::grpc::Status* /*status*/, void** /*handler_data*/) final {
+                    grpc::Status* /*status*/, void** /*handler_data*/) final {
     // We have to destroy any request payload
     if (req != nullptr) {
-      ::grpc::g_core_codegen_interface->grpc_byte_buffer_destroy(req);
+      grpc::g_core_codegen_interface->grpc_byte_buffer_destroy(req);
     }
     return nullptr;
   }

--- a/include/grpcpp/impl/codegen/method_handler.h
+++ b/include/grpcpp/impl/codegen/method_handler.h
@@ -101,7 +101,7 @@ class RpcMethodHandler : public grpc::internal::MethodHandler {
  public:
   RpcMethodHandler(
       std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
-                                   const RequestType*, ResponseType*)>
+                                 const RequestType*, ResponseType*)>
           func,
       ServiceType* service)
       : func_(func), service_(service) {}
@@ -131,7 +131,7 @@ class RpcMethodHandler : public grpc::internal::MethodHandler {
  private:
   /// Application provided rpc handler function.
   std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
-                               const RequestType*, ResponseType*)>
+                             const RequestType*, ResponseType*)>
       func_;
   // The class the above handler function lives in.
   ServiceType* service_;
@@ -143,7 +143,7 @@ class ClientStreamingHandler : public grpc::internal::MethodHandler {
  public:
   ClientStreamingHandler(
       std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
-                                   ServerReader<RequestType>*, ResponseType*)>
+                                 ServerReader<RequestType>*, ResponseType*)>
           func,
       ServiceType* service)
       : func_(func), service_(service) {}
@@ -180,7 +180,7 @@ class ClientStreamingHandler : public grpc::internal::MethodHandler {
 
  private:
   std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
-                               ServerReader<RequestType>*, ResponseType*)>
+                             ServerReader<RequestType>*, ResponseType*)>
       func_;
   ServiceType* service_;
 };
@@ -245,7 +245,7 @@ class ServerStreamingHandler : public grpc::internal::MethodHandler {
 
  private:
   std::function<grpc::Status(ServiceType*, grpc::ServerContext*,
-                               const RequestType*, ServerWriter<ResponseType>*)>
+                             const RequestType*, ServerWriter<ResponseType>*)>
       func_;
   ServiceType* service_;
 };

--- a/include/grpcpp/impl/codegen/proto_buffer_reader.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_reader.h
@@ -45,7 +45,7 @@ extern CoreCodegenInterface* g_core_codegen_interface;
 ///
 /// Read more about ZeroCopyInputStream interface here:
 /// https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyInputStream
-class ProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
+class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
  public:
   /// Constructs buffer reader from \a buffer. Will set \a status() to non ok
   /// if \a buffer is invalid (the internal buffer has not been initialized).

--- a/include/grpcpp/impl/codegen/proto_buffer_writer.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_writer.h
@@ -52,7 +52,7 @@ const int kProtoBufferWriterMaxBufferLength = 1024 * 1024;
 ///
 /// Read more about ZeroCopyOutputStream interface here:
 /// https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyOutputStream
-class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
+class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
  public:
   /// Constructor for this derived class
   ///

--- a/include/grpcpp/impl/codegen/rpc_service_method.h
+++ b/include/grpcpp/impl/codegen/rpc_service_method.h
@@ -51,7 +51,7 @@ class MethodHandler {
     /// \param requester : used only by the callback API. It is a function
     ///        called by the RPC Controller to request another RPC (and also
     ///        to set up the state required to make that request possible)
-    HandlerParameter(Call* c, ::grpc::ServerContextBase* context, void* req,
+    HandlerParameter(Call* c, grpc::ServerContextBase* context, void* req,
                      Status req_status, void* handler_data,
                      std::function<void()> requester)
         : call(c),
@@ -62,7 +62,7 @@ class MethodHandler {
           call_requester(std::move(requester)) {}
     ~HandlerParameter() {}
     Call* const call;
-    ::grpc::ServerContextBase* const server_context;
+    grpc::ServerContextBase* const server_context;
     void* const request;
     const Status status;
     void* const internal_data;

--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -193,7 +193,7 @@ class ServerBidiReactor;
 class ServerCallbackUnary : public internal::ServerCallbackCall {
  public:
   ~ServerCallbackUnary() override {}
-  virtual void Finish(::grpc::Status s) = 0;
+  virtual void Finish(grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
 
  protected:
@@ -209,7 +209,7 @@ template <class Request>
 class ServerCallbackReader : public internal::ServerCallbackCall {
  public:
   ~ServerCallbackReader() override {}
-  virtual void Finish(::grpc::Status s) = 0;
+  virtual void Finish(grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
   virtual void Read(Request* msg) = 0;
 
@@ -224,11 +224,11 @@ class ServerCallbackWriter : public internal::ServerCallbackCall {
  public:
   ~ServerCallbackWriter() override {}
 
-  virtual void Finish(::grpc::Status s) = 0;
+  virtual void Finish(grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
-  virtual void Write(const Response* msg, ::grpc::WriteOptions options) = 0;
-  virtual void WriteAndFinish(const Response* msg, ::grpc::WriteOptions options,
-                              ::grpc::Status s) = 0;
+  virtual void Write(const Response* msg, grpc::WriteOptions options) = 0;
+  virtual void WriteAndFinish(const Response* msg, grpc::WriteOptions options,
+                              grpc::Status s) = 0;
 
  protected:
   void BindReactor(ServerWriteReactor<Response>* reactor) {
@@ -241,12 +241,12 @@ class ServerCallbackReaderWriter : public internal::ServerCallbackCall {
  public:
   ~ServerCallbackReaderWriter() override {}
 
-  virtual void Finish(::grpc::Status s) = 0;
+  virtual void Finish(grpc::Status s) = 0;
   virtual void SendInitialMetadata() = 0;
   virtual void Read(Request* msg) = 0;
-  virtual void Write(const Response* msg, ::grpc::WriteOptions options) = 0;
-  virtual void WriteAndFinish(const Response* msg, ::grpc::WriteOptions options,
-                              ::grpc::Status s) = 0;
+  virtual void Write(const Response* msg, grpc::WriteOptions options) = 0;
+  virtual void WriteAndFinish(const Response* msg, grpc::WriteOptions options,
+                              grpc::Status s) = 0;
 
  protected:
   void BindReactor(ServerBidiReactor<Request, Response>* reactor) {
@@ -318,7 +318,7 @@ class ServerBidiReactor : public internal::ServerReactor {
   ///                 ownership but the caller must ensure that the message is
   ///                 not deleted or modified until OnWriteDone is called.
   void StartWrite(const Response* resp) {
-    StartWrite(resp, ::grpc::WriteOptions());
+    StartWrite(resp, grpc::WriteOptions());
   }
 
   /// Initiate a write operation with specified options.
@@ -327,7 +327,7 @@ class ServerBidiReactor : public internal::ServerReactor {
   ///                 ownership but the caller must ensure that the message is
   ///                 not deleted or modified until OnWriteDone is called.
   /// \param[in] options The WriteOptions to use for writing this message
-  void StartWrite(const Response* resp, ::grpc::WriteOptions options)
+  void StartWrite(const Response* resp, grpc::WriteOptions options)
       ABSL_LOCKS_EXCLUDED(stream_mu_) {
     ServerCallbackReaderWriter<Request, Response>* stream =
         stream_.load(std::memory_order_acquire);
@@ -356,8 +356,8 @@ class ServerBidiReactor : public internal::ServerReactor {
   ///                 not deleted or modified until OnDone is called.
   /// \param[in] options The WriteOptions to use for writing this message
   /// \param[in] s The status outcome of this RPC
-  void StartWriteAndFinish(const Response* resp, ::grpc::WriteOptions options,
-                           ::grpc::Status s) ABSL_LOCKS_EXCLUDED(stream_mu_) {
+  void StartWriteAndFinish(const Response* resp, grpc::WriteOptions options,
+                           grpc::Status s) ABSL_LOCKS_EXCLUDED(stream_mu_) {
     ServerCallbackReaderWriter<Request, Response>* stream =
         stream_.load(std::memory_order_acquire);
     if (stream == nullptr) {
@@ -382,7 +382,7 @@ class ServerBidiReactor : public internal::ServerReactor {
   ///                 ownership but the caller must ensure that the message is
   ///                 not deleted or modified until OnWriteDone is called.
   /// \param[in] options The WriteOptions to use for writing this message
-  void StartWriteLast(const Response* resp, ::grpc::WriteOptions options) {
+  void StartWriteLast(const Response* resp, grpc::WriteOptions options) {
     StartWrite(resp, options.set_last_message());
   }
 
@@ -392,7 +392,7 @@ class ServerBidiReactor : public internal::ServerReactor {
   /// cancelled.
   ///
   /// \param[in] s The status outcome of this RPC
-  void Finish(::grpc::Status s) ABSL_LOCKS_EXCLUDED(stream_mu_) {
+  void Finish(grpc::Status s) ABSL_LOCKS_EXCLUDED(stream_mu_) {
     ServerCallbackReaderWriter<Request, Response>* stream =
         stream_.load(std::memory_order_acquire);
     if (stream == nullptr) {
@@ -481,8 +481,8 @@ class ServerBidiReactor : public internal::ServerReactor {
     bool finish_wanted = false;
     Request* read_wanted = nullptr;
     const Response* write_wanted = nullptr;
-    ::grpc::WriteOptions write_options_wanted;
-    ::grpc::Status status_wanted;
+    grpc::WriteOptions write_options_wanted;
+    grpc::Status status_wanted;
   };
   PreBindBacklog backlog_ ABSL_GUARDED_BY(stream_mu_);
 };
@@ -521,7 +521,7 @@ class ServerReadReactor : public internal::ServerReactor {
     }
     reader->Read(req);
   }
-  void Finish(::grpc::Status s) ABSL_LOCKS_EXCLUDED(reader_mu_) {
+  void Finish(grpc::Status s) ABSL_LOCKS_EXCLUDED(reader_mu_) {
     ServerCallbackReader<Request>* reader =
         reader_.load(std::memory_order_acquire);
     if (reader == nullptr) {
@@ -570,7 +570,7 @@ class ServerReadReactor : public internal::ServerReactor {
     bool send_initial_metadata_wanted = false;
     bool finish_wanted = false;
     Request* read_wanted = nullptr;
-    ::grpc::Status status_wanted;
+    grpc::Status status_wanted;
   };
   PreBindBacklog backlog_ ABSL_GUARDED_BY(reader_mu_);
 };
@@ -597,9 +597,9 @@ class ServerWriteReactor : public internal::ServerReactor {
     writer->SendInitialMetadata();
   }
   void StartWrite(const Response* resp) {
-    StartWrite(resp, ::grpc::WriteOptions());
+    StartWrite(resp, grpc::WriteOptions());
   }
-  void StartWrite(const Response* resp, ::grpc::WriteOptions options)
+  void StartWrite(const Response* resp, grpc::WriteOptions options)
       ABSL_LOCKS_EXCLUDED(writer_mu_) {
     ServerCallbackWriter<Response>* writer =
         writer_.load(std::memory_order_acquire);
@@ -614,8 +614,8 @@ class ServerWriteReactor : public internal::ServerReactor {
     }
     writer->Write(resp, options);
   }
-  void StartWriteAndFinish(const Response* resp, ::grpc::WriteOptions options,
-                           ::grpc::Status s) ABSL_LOCKS_EXCLUDED(writer_mu_) {
+  void StartWriteAndFinish(const Response* resp, grpc::WriteOptions options,
+                           grpc::Status s) ABSL_LOCKS_EXCLUDED(writer_mu_) {
     ServerCallbackWriter<Response>* writer =
         writer_.load(std::memory_order_acquire);
     if (writer == nullptr) {
@@ -631,10 +631,10 @@ class ServerWriteReactor : public internal::ServerReactor {
     }
     writer->WriteAndFinish(resp, options, std::move(s));
   }
-  void StartWriteLast(const Response* resp, ::grpc::WriteOptions options) {
+  void StartWriteLast(const Response* resp, grpc::WriteOptions options) {
     StartWrite(resp, options.set_last_message());
   }
-  void Finish(::grpc::Status s) ABSL_LOCKS_EXCLUDED(writer_mu_) {
+  void Finish(grpc::Status s) ABSL_LOCKS_EXCLUDED(writer_mu_) {
     ServerCallbackWriter<Response>* writer =
         writer_.load(std::memory_order_acquire);
     if (writer == nullptr) {
@@ -690,8 +690,8 @@ class ServerWriteReactor : public internal::ServerReactor {
     bool write_and_finish_wanted = false;
     bool finish_wanted = false;
     const Response* write_wanted = nullptr;
-    ::grpc::WriteOptions write_options_wanted;
-    ::grpc::Status status_wanted;
+    grpc::WriteOptions write_options_wanted;
+    grpc::Status status_wanted;
   };
   PreBindBacklog backlog_ ABSL_GUARDED_BY(writer_mu_);
 };
@@ -717,7 +717,7 @@ class ServerUnaryReactor : public internal::ServerReactor {
   /// Finish is similar to ServerBidiReactor except for one detail.
   /// If the status is non-OK, any message will not be sent. Instead,
   /// the client will only receive the status and any trailing metadata.
-  void Finish(::grpc::Status s) ABSL_LOCKS_EXCLUDED(call_mu_) {
+  void Finish(grpc::Status s) ABSL_LOCKS_EXCLUDED(call_mu_) {
     ServerCallbackUnary* call = call_.load(std::memory_order_acquire);
     if (call == nullptr) {
       grpc::internal::MutexLock l(&call_mu_);
@@ -759,7 +759,7 @@ class ServerUnaryReactor : public internal::ServerReactor {
   struct PreBindBacklog {
     bool send_initial_metadata_wanted = false;
     bool finish_wanted = false;
-    ::grpc::Status status_wanted;
+    grpc::Status status_wanted;
   };
   PreBindBacklog backlog_ ABSL_GUARDED_BY(call_mu_);
 };
@@ -769,7 +769,7 @@ namespace internal {
 template <class Base>
 class FinishOnlyReactor : public Base {
  public:
-  explicit FinishOnlyReactor(::grpc::Status s) { this->Finish(std::move(s)); }
+  explicit FinishOnlyReactor(grpc::Status s) { this->Finish(std::move(s)); }
   void OnDone() override { this->~FinishOnlyReactor(); }
 };
 

--- a/include/grpcpp/impl/codegen/server_callback_handlers.h
+++ b/include/grpcpp/impl/codegen/server_callback_handlers.h
@@ -30,10 +30,10 @@ namespace grpc {
 namespace internal {
 
 template <class RequestType, class ResponseType>
-class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
+class CallbackUnaryHandler : public grpc::internal::MethodHandler {
  public:
   explicit CallbackUnaryHandler(
-      std::function<ServerUnaryReactor*(::grpc::CallbackServerContext*,
+      std::function<ServerUnaryReactor*(grpc::CallbackServerContext*,
                                         const RequestType*, ResponseType*)>
           get_reactor)
       : get_reactor_(std::move(get_reactor)) {}
@@ -45,12 +45,12 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
 
   void RunHandler(const HandlerParameter& param) final {
     // Arena allocate a controller structure (that includes request/response)
-    ::grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
+    grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
     auto* allocator_state =
         static_cast<MessageHolder<RequestType, ResponseType>*>(
             param.internal_data);
 
-    auto* call = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+    auto* call = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackUnaryImpl)))
         ServerCallbackUnaryImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
@@ -60,7 +60,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
 
     ServerUnaryReactor* reactor = nullptr;
     if (param.status.ok()) {
-      reactor = ::grpc::internal::CatchingReactorGetter<ServerUnaryReactor>(
+      reactor = grpc::internal::CatchingReactorGetter<ServerUnaryReactor>(
           get_reactor_,
           static_cast<::grpc::CallbackServerContext*>(param.server_context),
           call->request(), call->response());
@@ -68,10 +68,10 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
 
     if (reactor == nullptr) {
       // if deserialization or reactor creator failed, we need to fail the call
-      reactor = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+      reactor = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
           param.call->call(), sizeof(UnimplementedUnaryReactor)))
           UnimplementedUnaryReactor(
-              ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, ""));
+              grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""));
     }
 
     /// Invoke SetupReactor as the last part of the handler
@@ -79,8 +79,8 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
   }
 
   void* Deserialize(grpc_call* call, grpc_byte_buffer* req,
-                    ::grpc::Status* status, void** handler_data) final {
-    ::grpc::ByteBuffer buf;
+                    grpc::Status* status, void** handler_data) final {
+    grpc::ByteBuffer buf;
     buf.set_buffer(req);
     RequestType* request = nullptr;
     MessageHolder<RequestType, ResponseType>* allocator_state;
@@ -88,14 +88,14 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
       allocator_state = allocator_->AllocateMessages();
     } else {
       allocator_state =
-          new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+          new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
               call, sizeof(DefaultMessageHolder<RequestType, ResponseType>)))
               DefaultMessageHolder<RequestType, ResponseType>();
     }
     *handler_data = allocator_state;
     request = allocator_state->request();
     *status =
-        ::grpc::SerializationTraits<RequestType>::Deserialize(&buf, request);
+        grpc::SerializationTraits<RequestType>::Deserialize(&buf, request);
     buf.Release();
     if (status->ok()) {
       return request;
@@ -104,14 +104,14 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<ServerUnaryReactor*(::grpc::CallbackServerContext*,
+  std::function<ServerUnaryReactor*(grpc::CallbackServerContext*,
                                     const RequestType*, ResponseType*)>
       get_reactor_;
   MessageAllocator<RequestType, ResponseType>* allocator_ = nullptr;
 
   class ServerCallbackUnaryImpl : public ServerCallbackUnary {
    public:
-    void Finish(::grpc::Status s) override {
+    void Finish(grpc::Status s) override {
       // A callback that only contains a call to MaybeDone can be run as an
       // inline callback regardless of whether or not OnDone is inlineable
       // because if the actual OnDone callback needs to be scheduled, MaybeDone
@@ -177,7 +177,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
     friend class CallbackUnaryHandler<RequestType, ResponseType>;
 
     ServerCallbackUnaryImpl(
-        ::grpc::CallbackServerContext* ctx, ::grpc::internal::Call* call,
+        grpc::CallbackServerContext* ctx, grpc::internal::Call* call,
         MessageHolder<RequestType, ResponseType>* allocator_state,
         std::function<void()> call_requester)
         : ctx_(ctx),
@@ -210,7 +210,7 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
         ctx_->context_allocator()->Release(ctx_);
       }
       this->~ServerCallbackUnaryImpl();  // explicitly call destructor
-      ::grpc::g_core_codegen_interface->grpc_call_unref(call);
+      grpc::g_core_codegen_interface->grpc_call_unref(call);
       call_requester();
     }
 
@@ -218,17 +218,17 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
-    ::grpc::internal::CallbackWithSuccessTag meta_tag_;
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallbackWithSuccessTag meta_tag_;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpServerSendStatus>
         finish_ops_;
-    ::grpc::internal::CallbackWithSuccessTag finish_tag_;
+    grpc::internal::CallbackWithSuccessTag finish_tag_;
 
-    ::grpc::CallbackServerContext* const ctx_;
-    ::grpc::internal::Call call_;
+    grpc::CallbackServerContext* const ctx_;
+    grpc::internal::Call call_;
     MessageHolder<RequestType, ResponseType>* const allocator_state_;
     std::function<void()> call_requester_;
     // reactor_ can always be loaded/stored with relaxed memory ordering because
@@ -249,18 +249,18 @@ class CallbackUnaryHandler : public ::grpc::internal::MethodHandler {
 };
 
 template <class RequestType, class ResponseType>
-class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
+class CallbackClientStreamingHandler : public grpc::internal::MethodHandler {
  public:
   explicit CallbackClientStreamingHandler(
       std::function<ServerReadReactor<RequestType>*(
-          ::grpc::CallbackServerContext*, ResponseType*)>
+          grpc::CallbackServerContext*, ResponseType*)>
           get_reactor)
       : get_reactor_(std::move(get_reactor)) {}
   void RunHandler(const HandlerParameter& param) final {
     // Arena allocate a reader structure (that includes response)
-    ::grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
+    grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
 
-    auto* reader = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+    auto* reader = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackReaderImpl)))
         ServerCallbackReaderImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
@@ -275,32 +275,32 @@ class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
 
     ServerReadReactor<RequestType>* reactor = nullptr;
     if (param.status.ok()) {
-      reactor = ::grpc::internal::CatchingReactorGetter<
-          ServerReadReactor<RequestType>>(
-          get_reactor_,
-          static_cast<::grpc::CallbackServerContext*>(param.server_context),
-          reader->response());
+      reactor =
+          grpc::internal::CatchingReactorGetter<ServerReadReactor<RequestType>>(
+              get_reactor_,
+              static_cast<::grpc::CallbackServerContext*>(param.server_context),
+              reader->response());
     }
 
     if (reactor == nullptr) {
       // if deserialization or reactor creator failed, we need to fail the call
-      reactor = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+      reactor = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
           param.call->call(), sizeof(UnimplementedReadReactor<RequestType>)))
           UnimplementedReadReactor<RequestType>(
-              ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, ""));
+              grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""));
     }
 
     reader->SetupReactor(reactor);
   }
 
  private:
-  std::function<ServerReadReactor<RequestType>*(::grpc::CallbackServerContext*,
+  std::function<ServerReadReactor<RequestType>*(grpc::CallbackServerContext*,
                                                 ResponseType*)>
       get_reactor_;
 
   class ServerCallbackReaderImpl : public ServerCallbackReader<RequestType> {
    public:
-    void Finish(::grpc::Status s) override {
+    void Finish(grpc::Status s) override {
       // A finish tag with only MaybeDone can have its callback inlined
       // regardless even if OnDone is not inlineable because this callback just
       // checks a ref and then decides whether or not to dispatch OnDone.
@@ -366,8 +366,8 @@ class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
    private:
     friend class CallbackClientStreamingHandler<RequestType, ResponseType>;
 
-    ServerCallbackReaderImpl(::grpc::CallbackServerContext* ctx,
-                             ::grpc::internal::Call* call,
+    ServerCallbackReaderImpl(grpc::CallbackServerContext* ctx,
+                             grpc::internal::Call* call,
                              std::function<void()> call_requester)
         : ctx_(ctx), call_(*call), call_requester_(std::move(call_requester)) {}
 
@@ -407,7 +407,7 @@ class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
         ctx_->context_allocator()->Release(ctx_);
       }
       this->~ServerCallbackReaderImpl();  // explicitly call destructor
-      ::grpc::g_core_codegen_interface->grpc_call_unref(call);
+      grpc::g_core_codegen_interface->grpc_call_unref(call);
       call_requester();
     }
 
@@ -415,21 +415,20 @@ class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
-    ::grpc::internal::CallbackWithSuccessTag meta_tag_;
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallbackWithSuccessTag meta_tag_;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpServerSendStatus>
         finish_ops_;
-    ::grpc::internal::CallbackWithSuccessTag finish_tag_;
-    ::grpc::internal::CallOpSet<
-        ::grpc::internal::CallOpRecvMessage<RequestType>>
+    grpc::internal::CallbackWithSuccessTag finish_tag_;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<RequestType>>
         read_ops_;
-    ::grpc::internal::CallbackWithSuccessTag read_tag_;
+    grpc::internal::CallbackWithSuccessTag read_tag_;
 
-    ::grpc::CallbackServerContext* const ctx_;
-    ::grpc::internal::Call call_;
+    grpc::CallbackServerContext* const ctx_;
+    grpc::internal::Call call_;
     ResponseType resp_;
     std::function<void()> call_requester_;
     // The memory ordering of reactor_ follows ServerCallbackUnaryImpl.
@@ -441,18 +440,18 @@ class CallbackClientStreamingHandler : public ::grpc::internal::MethodHandler {
 };
 
 template <class RequestType, class ResponseType>
-class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
+class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
  public:
   explicit CallbackServerStreamingHandler(
       std::function<ServerWriteReactor<ResponseType>*(
-          ::grpc::CallbackServerContext*, const RequestType*)>
+          grpc::CallbackServerContext*, const RequestType*)>
           get_reactor)
       : get_reactor_(std::move(get_reactor)) {}
   void RunHandler(const HandlerParameter& param) final {
     // Arena allocate a writer structure
-    ::grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
+    grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
 
-    auto* writer = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+    auto* writer = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackWriterImpl)))
         ServerCallbackWriterImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
@@ -468,7 +467,7 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
 
     ServerWriteReactor<ResponseType>* reactor = nullptr;
     if (param.status.ok()) {
-      reactor = ::grpc::internal::CatchingReactorGetter<
+      reactor = grpc::internal::CatchingReactorGetter<
           ServerWriteReactor<ResponseType>>(
           get_reactor_,
           static_cast<::grpc::CallbackServerContext*>(param.server_context),
@@ -476,24 +475,23 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
     }
     if (reactor == nullptr) {
       // if deserialization or reactor creator failed, we need to fail the call
-      reactor = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+      reactor = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
           param.call->call(), sizeof(UnimplementedWriteReactor<ResponseType>)))
           UnimplementedWriteReactor<ResponseType>(
-              ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, ""));
+              grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""));
     }
 
     writer->SetupReactor(reactor);
   }
 
   void* Deserialize(grpc_call* call, grpc_byte_buffer* req,
-                    ::grpc::Status* status, void** /*handler_data*/) final {
-    ::grpc::ByteBuffer buf;
+                    grpc::Status* status, void** /*handler_data*/) final {
+    grpc::ByteBuffer buf;
     buf.set_buffer(req);
-    auto* request =
-        new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
-            call, sizeof(RequestType))) RequestType();
+    auto* request = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+        call, sizeof(RequestType))) RequestType();
     *status =
-        ::grpc::SerializationTraits<RequestType>::Deserialize(&buf, request);
+        grpc::SerializationTraits<RequestType>::Deserialize(&buf, request);
     buf.Release();
     if (status->ok()) {
       return request;
@@ -503,13 +501,13 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
   }
 
  private:
-  std::function<ServerWriteReactor<ResponseType>*(
-      ::grpc::CallbackServerContext*, const RequestType*)>
+  std::function<ServerWriteReactor<ResponseType>*(grpc::CallbackServerContext*,
+                                                  const RequestType*)>
       get_reactor_;
 
   class ServerCallbackWriterImpl : public ServerCallbackWriter<ResponseType> {
    public:
-    void Finish(::grpc::Status s) override {
+    void Finish(grpc::Status s) override {
       // A finish tag with only MaybeDone can have its callback inlined
       // regardless even if OnDone is not inlineable because this callback just
       // checks a ref and then decides whether or not to dispatch OnDone.
@@ -561,8 +559,7 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
       call_.PerformOps(&meta_ops_);
     }
 
-    void Write(const ResponseType* resp,
-               ::grpc::WriteOptions options) override {
+    void Write(const ResponseType* resp, grpc::WriteOptions options) override {
       this->Ref();
       if (options.is_last_message()) {
         options.set_buffer_hint();
@@ -580,8 +577,8 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
       call_.PerformOps(&write_ops_);
     }
 
-    void WriteAndFinish(const ResponseType* resp, ::grpc::WriteOptions options,
-                        ::grpc::Status s) override {
+    void WriteAndFinish(const ResponseType* resp, grpc::WriteOptions options,
+                        grpc::Status s) override {
       // This combines the write into the finish callback
       // TODO(vjpai): don't assert
       GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
@@ -591,9 +588,8 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
    private:
     friend class CallbackServerStreamingHandler<RequestType, ResponseType>;
 
-    ServerCallbackWriterImpl(::grpc::CallbackServerContext* ctx,
-                             ::grpc::internal::Call* call,
-                             const RequestType* req,
+    ServerCallbackWriterImpl(grpc::CallbackServerContext* ctx,
+                             grpc::internal::Call* call, const RequestType* req,
                              std::function<void()> call_requester)
         : ctx_(ctx),
           call_(*call),
@@ -636,7 +632,7 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
         ctx_->context_allocator()->Release(ctx_);
       }
       this->~ServerCallbackWriterImpl();  // explicitly call destructor
-      ::grpc::g_core_codegen_interface->grpc_call_unref(call);
+      grpc::g_core_codegen_interface->grpc_call_unref(call);
       call_requester();
     }
 
@@ -644,21 +640,21 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
-    ::grpc::internal::CallbackWithSuccessTag meta_tag_;
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallbackWithSuccessTag meta_tag_;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpServerSendStatus>
         finish_ops_;
-    ::grpc::internal::CallbackWithSuccessTag finish_tag_;
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage>
+    grpc::internal::CallbackWithSuccessTag finish_tag_;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage>
         write_ops_;
-    ::grpc::internal::CallbackWithSuccessTag write_tag_;
+    grpc::internal::CallbackWithSuccessTag write_tag_;
 
-    ::grpc::CallbackServerContext* const ctx_;
-    ::grpc::internal::Call call_;
+    grpc::CallbackServerContext* const ctx_;
+    grpc::internal::Call call_;
     const RequestType* req_;
     std::function<void()> call_requester_;
     // The memory ordering of reactor_ follows ServerCallbackUnaryImpl.
@@ -670,17 +666,17 @@ class CallbackServerStreamingHandler : public ::grpc::internal::MethodHandler {
 };
 
 template <class RequestType, class ResponseType>
-class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
+class CallbackBidiHandler : public grpc::internal::MethodHandler {
  public:
   explicit CallbackBidiHandler(
       std::function<ServerBidiReactor<RequestType, ResponseType>*(
-          ::grpc::CallbackServerContext*)>
+          grpc::CallbackServerContext*)>
           get_reactor)
       : get_reactor_(std::move(get_reactor)) {}
   void RunHandler(const HandlerParameter& param) final {
-    ::grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
+    grpc::g_core_codegen_interface->grpc_call_ref(param.call->call());
 
-    auto* stream = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+    auto* stream = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackReaderWriterImpl)))
         ServerCallbackReaderWriterImpl(
             static_cast<::grpc::CallbackServerContext*>(param.server_context),
@@ -695,7 +691,7 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
 
     ServerBidiReactor<RequestType, ResponseType>* reactor = nullptr;
     if (param.status.ok()) {
-      reactor = ::grpc::internal::CatchingReactorGetter<
+      reactor = grpc::internal::CatchingReactorGetter<
           ServerBidiReactor<RequestType, ResponseType>>(
           get_reactor_,
           static_cast<::grpc::CallbackServerContext*>(param.server_context));
@@ -703,11 +699,11 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
 
     if (reactor == nullptr) {
       // if deserialization or reactor creator failed, we need to fail the call
-      reactor = new (::grpc::g_core_codegen_interface->grpc_call_arena_alloc(
+      reactor = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
           param.call->call(),
           sizeof(UnimplementedBidiReactor<RequestType, ResponseType>)))
           UnimplementedBidiReactor<RequestType, ResponseType>(
-              ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, ""));
+              grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""));
     }
 
     stream->SetupReactor(reactor);
@@ -715,13 +711,13 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
 
  private:
   std::function<ServerBidiReactor<RequestType, ResponseType>*(
-      ::grpc::CallbackServerContext*)>
+      grpc::CallbackServerContext*)>
       get_reactor_;
 
   class ServerCallbackReaderWriterImpl
       : public ServerCallbackReaderWriter<RequestType, ResponseType> {
    public:
-    void Finish(::grpc::Status s) override {
+    void Finish(grpc::Status s) override {
       // A finish tag with only MaybeDone can have its callback inlined
       // regardless even if OnDone is not inlineable because this callback just
       // checks a ref and then decides whether or not to dispatch OnDone.
@@ -773,8 +769,7 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
       call_.PerformOps(&meta_ops_);
     }
 
-    void Write(const ResponseType* resp,
-               ::grpc::WriteOptions options) override {
+    void Write(const ResponseType* resp, grpc::WriteOptions options) override {
       this->Ref();
       if (options.is_last_message()) {
         options.set_buffer_hint();
@@ -792,8 +787,8 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
       call_.PerformOps(&write_ops_);
     }
 
-    void WriteAndFinish(const ResponseType* resp, ::grpc::WriteOptions options,
-                        ::grpc::Status s) override {
+    void WriteAndFinish(const ResponseType* resp, grpc::WriteOptions options,
+                        grpc::Status s) override {
       // TODO(vjpai): don't assert
       GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
       Finish(std::move(s));
@@ -808,8 +803,8 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
    private:
     friend class CallbackBidiHandler<RequestType, ResponseType>;
 
-    ServerCallbackReaderWriterImpl(::grpc::CallbackServerContext* ctx,
-                                   ::grpc::internal::Call* call,
+    ServerCallbackReaderWriterImpl(grpc::CallbackServerContext* ctx,
+                                   grpc::internal::Call* call,
                                    std::function<void()> call_requester)
         : ctx_(ctx), call_(*call), call_requester_(std::move(call_requester)) {}
 
@@ -853,7 +848,7 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
         ctx_->context_allocator()->Release(ctx_);
       }
       this->~ServerCallbackReaderWriterImpl();  // explicitly call destructor
-      ::grpc::g_core_codegen_interface->grpc_call_unref(call);
+      grpc::g_core_codegen_interface->grpc_call_unref(call);
       call_requester();
     }
 
@@ -861,25 +856,24 @@ class CallbackBidiHandler : public ::grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
-    ::grpc::internal::CallbackWithSuccessTag meta_tag_;
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpServerSendStatus>
+    grpc::internal::CallbackWithSuccessTag meta_tag_;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpServerSendStatus>
         finish_ops_;
-    ::grpc::internal::CallbackWithSuccessTag finish_tag_;
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage>
+    grpc::internal::CallbackWithSuccessTag finish_tag_;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage>
         write_ops_;
-    ::grpc::internal::CallbackWithSuccessTag write_tag_;
-    ::grpc::internal::CallOpSet<
-        ::grpc::internal::CallOpRecvMessage<RequestType>>
+    grpc::internal::CallbackWithSuccessTag write_tag_;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<RequestType>>
         read_ops_;
-    ::grpc::internal::CallbackWithSuccessTag read_tag_;
+    grpc::internal::CallbackWithSuccessTag read_tag_;
 
-    ::grpc::CallbackServerContext* const ctx_;
-    ::grpc::internal::Call call_;
+    grpc::CallbackServerContext* const ctx_;
+    grpc::internal::Call call_;
     std::function<void()> call_requester_;
     // The memory ordering of reactor_ follows ServerCallbackUnaryImpl.
     std::atomic<ServerBidiReactor<RequestType, ResponseType>*> reactor_;

--- a/include/grpcpp/impl/codegen/server_callback_handlers.h
+++ b/include/grpcpp/impl/codegen/server_callback_handlers.h
@@ -53,7 +53,7 @@ class CallbackUnaryHandler : public grpc::internal::MethodHandler {
     auto* call = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackUnaryImpl)))
         ServerCallbackUnaryImpl(
-            static_cast<::grpc::CallbackServerContext*>(param.server_context),
+            static_cast<grpc::CallbackServerContext*>(param.server_context),
             param.call, allocator_state, param.call_requester);
     param.server_context->BeginCompletionOp(
         param.call, [call](bool) { call->MaybeDone(); }, call);
@@ -62,7 +62,7 @@ class CallbackUnaryHandler : public grpc::internal::MethodHandler {
     if (param.status.ok()) {
       reactor = grpc::internal::CatchingReactorGetter<ServerUnaryReactor>(
           get_reactor_,
-          static_cast<::grpc::CallbackServerContext*>(param.server_context),
+          static_cast<grpc::CallbackServerContext*>(param.server_context),
           call->request(), call->response());
     }
 
@@ -218,10 +218,10 @@ class CallbackUnaryHandler : public grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
     grpc::internal::CallbackWithSuccessTag meta_tag_;
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpServerSendStatus>
         finish_ops_;
@@ -263,7 +263,7 @@ class CallbackClientStreamingHandler : public grpc::internal::MethodHandler {
     auto* reader = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackReaderImpl)))
         ServerCallbackReaderImpl(
-            static_cast<::grpc::CallbackServerContext*>(param.server_context),
+            static_cast<grpc::CallbackServerContext*>(param.server_context),
             param.call, param.call_requester);
     // Inlineable OnDone can be false in the CompletionOp callback because there
     // is no read reactor that has an inlineable OnDone; this only applies to
@@ -278,7 +278,7 @@ class CallbackClientStreamingHandler : public grpc::internal::MethodHandler {
       reactor =
           grpc::internal::CatchingReactorGetter<ServerReadReactor<RequestType>>(
               get_reactor_,
-              static_cast<::grpc::CallbackServerContext*>(param.server_context),
+              static_cast<grpc::CallbackServerContext*>(param.server_context),
               reader->response());
     }
 
@@ -415,10 +415,10 @@ class CallbackClientStreamingHandler : public grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
     grpc::internal::CallbackWithSuccessTag meta_tag_;
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpServerSendStatus>
         finish_ops_;
@@ -454,7 +454,7 @@ class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
     auto* writer = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackWriterImpl)))
         ServerCallbackWriterImpl(
-            static_cast<::grpc::CallbackServerContext*>(param.server_context),
+            static_cast<grpc::CallbackServerContext*>(param.server_context),
             param.call, static_cast<RequestType*>(param.request),
             param.call_requester);
     // Inlineable OnDone can be false in the CompletionOp callback because there
@@ -470,7 +470,7 @@ class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
       reactor = grpc::internal::CatchingReactorGetter<
           ServerWriteReactor<ResponseType>>(
           get_reactor_,
-          static_cast<::grpc::CallbackServerContext*>(param.server_context),
+          static_cast<grpc::CallbackServerContext*>(param.server_context),
           writer->request());
     }
     if (reactor == nullptr) {
@@ -640,15 +640,15 @@ class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
     grpc::internal::CallbackWithSuccessTag meta_tag_;
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpServerSendStatus>
         finish_ops_;
     grpc::internal::CallbackWithSuccessTag finish_tag_;
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage>
         write_ops_;
     grpc::internal::CallbackWithSuccessTag write_tag_;
@@ -679,7 +679,7 @@ class CallbackBidiHandler : public grpc::internal::MethodHandler {
     auto* stream = new (grpc::g_core_codegen_interface->grpc_call_arena_alloc(
         param.call->call(), sizeof(ServerCallbackReaderWriterImpl)))
         ServerCallbackReaderWriterImpl(
-            static_cast<::grpc::CallbackServerContext*>(param.server_context),
+            static_cast<grpc::CallbackServerContext*>(param.server_context),
             param.call, param.call_requester);
     // Inlineable OnDone can be false in the CompletionOp callback because there
     // is no bidi reactor that has an inlineable OnDone; this only applies to
@@ -694,7 +694,7 @@ class CallbackBidiHandler : public grpc::internal::MethodHandler {
       reactor = grpc::internal::CatchingReactorGetter<
           ServerBidiReactor<RequestType, ResponseType>>(
           get_reactor_,
-          static_cast<::grpc::CallbackServerContext*>(param.server_context));
+          static_cast<grpc::CallbackServerContext*>(param.server_context));
     }
 
     if (reactor == nullptr) {
@@ -856,15 +856,15 @@ class CallbackBidiHandler : public grpc::internal::MethodHandler {
       return reactor_.load(std::memory_order_relaxed);
     }
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
         meta_ops_;
     grpc::internal::CallbackWithSuccessTag meta_tag_;
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpServerSendStatus>
         finish_ops_;
     grpc::internal::CallbackWithSuccessTag finish_tag_;
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage>
         write_ops_;
     grpc::internal::CallbackWithSuccessTag write_tag_;

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -95,7 +95,7 @@ class ServerStreamingHandler;
 class ServerReactor;
 template <class Streamer, bool WriteNeeded>
 class TemplatedBidiStreamingHandler;
-template <::grpc::StatusCode code>
+template <grpc::StatusCode code>
 class ErrorMethodHandler;
 }  // namespace internal
 
@@ -381,7 +381,7 @@ class ServerContextBase {
   friend class grpc::internal::CallbackServerStreamingHandler;
   template <class RequestType, class ResponseType>
   friend class grpc::internal::CallbackBidiHandler;
-  template <::grpc::StatusCode code>
+  template <grpc::StatusCode code>
   friend class grpc::internal::ErrorMethodHandler;
   template <class Base>
   friend class grpc::internal::FinishOnlyReactor;
@@ -458,7 +458,7 @@ class ServerContextBase {
   grpc_compression_level compression_level_;
   grpc_compression_algorithm compression_algorithm_;
 
-  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage>
       pending_ops_;
   bool has_pending_ops_ = false;

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -124,7 +124,7 @@ class ServerContextBase {
 
   /// Return the deadline for the server call.
   std::chrono::system_clock::time_point deadline() const {
-    return ::grpc::Timespec2Timepoint(deadline_);
+    return grpc::Timespec2Timepoint(deadline_);
   }
 
   /// Return a \a gpr_timespec representation of the server call's deadline.
@@ -263,9 +263,9 @@ class ServerContextBase {
   /// Return the authentication context for this server call.
   ///
   /// \see grpc::AuthContext.
-  std::shared_ptr<const ::grpc::AuthContext> auth_context() const {
+  std::shared_ptr<const grpc::AuthContext> auth_context() const {
     if (auth_context_ == nullptr) {
-      auth_context_ = ::grpc::CreateAuthContext(call_.call);
+      auth_context_ = grpc::CreateAuthContext(call_.call);
     }
     return auth_context_;
   }
@@ -313,7 +313,7 @@ class ServerContextBase {
   ///
   /// This method should not be called more than once or called after return
   /// from the method handler.
-  ::grpc::ServerUnaryReactor* DefaultReactor() {
+  grpc::ServerUnaryReactor* DefaultReactor() {
     // Short-circuit the case where a default reactor was already set up by
     // the TestPeer.
     if (test_unary_ != nullptr) {
@@ -341,53 +341,53 @@ class ServerContextBase {
   ContextAllocator* context_allocator() const { return context_allocator_; }
 
  private:
-  friend class ::grpc::testing::InteropServerContextInspector;
-  friend class ::grpc::testing::ServerContextTestSpouse;
-  friend class ::grpc::testing::DefaultReactorTestPeer;
-  friend class ::grpc::ServerInterface;
-  friend class ::grpc::Server;
+  friend class grpc::testing::InteropServerContextInspector;
+  friend class grpc::testing::ServerContextTestSpouse;
+  friend class grpc::testing::DefaultReactorTestPeer;
+  friend class grpc::ServerInterface;
+  friend class grpc::Server;
   template <class W, class R>
-  friend class ::grpc::ServerAsyncReader;
+  friend class grpc::ServerAsyncReader;
   template <class W>
-  friend class ::grpc::ServerAsyncWriter;
+  friend class grpc::ServerAsyncWriter;
   template <class W>
-  friend class ::grpc::ServerAsyncResponseWriter;
+  friend class grpc::ServerAsyncResponseWriter;
   template <class W, class R>
-  friend class ::grpc::ServerAsyncReaderWriter;
+  friend class grpc::ServerAsyncReaderWriter;
   template <class R>
-  friend class ::grpc::ServerReader;
+  friend class grpc::ServerReader;
   template <class W>
-  friend class ::grpc::ServerWriter;
+  friend class grpc::ServerWriter;
   template <class W, class R>
-  friend class ::grpc::internal::ServerReaderWriterBody;
+  friend class grpc::internal::ServerReaderWriterBody;
   template <class ResponseType>
-  friend void ::grpc::internal::UnaryRunHandlerHelper(
+  friend void grpc::internal::UnaryRunHandlerHelper(
       const internal::MethodHandler::HandlerParameter& param, ResponseType* rsp,
       Status& status);
   template <class ServiceType, class RequestType, class ResponseType,
             class BaseRequestType, class BaseResponseType>
-  friend class ::grpc::internal::RpcMethodHandler;
+  friend class grpc::internal::RpcMethodHandler;
   template <class ServiceType, class RequestType, class ResponseType>
-  friend class ::grpc::internal::ClientStreamingHandler;
+  friend class grpc::internal::ClientStreamingHandler;
   template <class ServiceType, class RequestType, class ResponseType>
-  friend class ::grpc::internal::ServerStreamingHandler;
+  friend class grpc::internal::ServerStreamingHandler;
   template <class Streamer, bool WriteNeeded>
-  friend class ::grpc::internal::TemplatedBidiStreamingHandler;
+  friend class grpc::internal::TemplatedBidiStreamingHandler;
   template <class RequestType, class ResponseType>
-  friend class ::grpc::internal::CallbackUnaryHandler;
+  friend class grpc::internal::CallbackUnaryHandler;
   template <class RequestType, class ResponseType>
-  friend class ::grpc::internal::CallbackClientStreamingHandler;
+  friend class grpc::internal::CallbackClientStreamingHandler;
   template <class RequestType, class ResponseType>
-  friend class ::grpc::internal::CallbackServerStreamingHandler;
+  friend class grpc::internal::CallbackServerStreamingHandler;
   template <class RequestType, class ResponseType>
-  friend class ::grpc::internal::CallbackBidiHandler;
+  friend class grpc::internal::CallbackBidiHandler;
   template <::grpc::StatusCode code>
-  friend class ::grpc::internal::ErrorMethodHandler;
+  friend class grpc::internal::ErrorMethodHandler;
   template <class Base>
-  friend class ::grpc::internal::FinishOnlyReactor;
-  friend class ::grpc::ClientContext;
-  friend class ::grpc::GenericServerContext;
-  friend class ::grpc::GenericCallbackServerContext;
+  friend class grpc::internal::FinishOnlyReactor;
+  friend class grpc::ClientContext;
+  friend class grpc::GenericServerContext;
+  friend class grpc::GenericCallbackServerContext;
 
   /// Prevent copying.
   ServerContextBase(const ServerContextBase&);
@@ -396,10 +396,10 @@ class ServerContextBase {
   class CompletionOp;
 
   void BeginCompletionOp(
-      ::grpc::internal::Call* call, std::function<void(bool)> callback,
-      ::grpc::internal::ServerCallbackCall* callback_controller);
+      grpc::internal::Call* call, std::function<void(bool)> callback,
+      grpc::internal::ServerCallbackCall* callback_controller);
   /// Return the tag queued by BeginCompletionOp()
-  ::grpc::internal::CompletionQueueTag* GetCompletionOpTag();
+  grpc::internal::CompletionQueueTag* GetCompletionOpTag();
 
   void set_call(grpc_call* call) { call_.call = call; }
 
@@ -407,12 +407,12 @@ class ServerContextBase {
 
   uint32_t initial_metadata_flags() const { return 0; }
 
-  ::grpc::experimental::ServerRpcInfo* set_server_rpc_info(
-      const char* method, ::grpc::internal::RpcMethod::RpcType type,
+  grpc::experimental::ServerRpcInfo* set_server_rpc_info(
+      const char* method, grpc::internal::RpcMethod::RpcType type,
       const std::vector<std::unique_ptr<
-          ::grpc::experimental::ServerInterceptorFactoryInterface>>& creators) {
+          grpc::experimental::ServerInterceptorFactoryInterface>>& creators) {
     if (!creators.empty()) {
-      rpc_info_ = new ::grpc::experimental::ServerRpcInfo(this, method, type);
+      rpc_info_ = new grpc::experimental::ServerRpcInfo(this, method, type);
       rpc_info_->RegisterInterceptors(creators);
     }
     return rpc_info_;
@@ -444,13 +444,13 @@ class ServerContextBase {
   CompletionOp* completion_op_ = nullptr;
   bool has_notify_when_done_tag_ = false;
   void* async_notify_when_done_tag_ = nullptr;
-  ::grpc::internal::CallbackWithSuccessTag completion_tag_;
+  grpc::internal::CallbackWithSuccessTag completion_tag_;
 
   gpr_timespec deadline_;
-  ::grpc::CompletionQueue* cq_ = nullptr;
+  grpc::CompletionQueue* cq_ = nullptr;
   bool sent_initial_metadata_ = false;
-  mutable std::shared_ptr<const ::grpc::AuthContext> auth_context_;
-  mutable ::grpc::internal::MetadataMap client_metadata_;
+  mutable std::shared_ptr<const grpc::AuthContext> auth_context_;
+  mutable grpc::internal::MetadataMap client_metadata_;
   std::multimap<std::string, std::string> initial_metadata_;
   std::multimap<std::string, std::string> trailing_metadata_;
 
@@ -458,16 +458,16 @@ class ServerContextBase {
   grpc_compression_level compression_level_;
   grpc_compression_algorithm compression_algorithm_;
 
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                              ::grpc::internal::CallOpSendMessage>
+  grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                            grpc::internal::CallOpSendMessage>
       pending_ops_;
   bool has_pending_ops_ = false;
 
-  ::grpc::experimental::ServerRpcInfo* rpc_info_ = nullptr;
+  grpc::experimental::ServerRpcInfo* rpc_info_ = nullptr;
   RpcAllocatorState* message_allocator_state_ = nullptr;
   ContextAllocator* context_allocator_ = nullptr;
 
-  class Reactor : public ::grpc::ServerUnaryReactor {
+  class Reactor : public grpc::ServerUnaryReactor {
    public:
     void OnCancel() override {}
     void OnDone() override {}
@@ -478,23 +478,23 @@ class ServerContextBase {
     bool InternalInlineable() override { return true; }
   };
 
-  void SetupTestDefaultReactor(std::function<void(::grpc::Status)> func) {
+  void SetupTestDefaultReactor(std::function<void(grpc::Status)> func) {
     // NOLINTNEXTLINE(modernize-make-unique)
     test_unary_.reset(new TestServerCallbackUnary(this, std::move(func)));
   }
   bool test_status_set() const {
     return (test_unary_ != nullptr) && test_unary_->status_set();
   }
-  ::grpc::Status test_status() const { return test_unary_->status(); }
+  grpc::Status test_status() const { return test_unary_->status(); }
 
-  class TestServerCallbackUnary : public ::grpc::ServerCallbackUnary {
+  class TestServerCallbackUnary : public grpc::ServerCallbackUnary {
    public:
     TestServerCallbackUnary(ServerContextBase* ctx,
-                            std::function<void(::grpc::Status)> func)
+                            std::function<void(grpc::Status)> func)
         : reactor_(ctx->DefaultReactor()), func_(std::move(func)) {
       this->BindReactor(reactor_);
     }
-    void Finish(::grpc::Status s) override {
+    void Finish(grpc::Status s) override {
       status_ = s;
       func_(std::move(s));
       status_set_.store(true, std::memory_order_release);
@@ -504,16 +504,16 @@ class ServerContextBase {
     bool status_set() const {
       return status_set_.load(std::memory_order_acquire);
     }
-    ::grpc::Status status() const { return status_; }
+    grpc::Status status() const { return status_; }
 
    private:
     void CallOnDone() override {}
-    ::grpc::internal::ServerReactor* reactor() override { return reactor_; }
+    grpc::internal::ServerReactor* reactor() override { return reactor_; }
 
-    ::grpc::ServerUnaryReactor* const reactor_;
+    grpc::ServerUnaryReactor* const reactor_;
     std::atomic_bool status_set_{false};
-    ::grpc::Status status_;
-    const std::function<void(::grpc::Status s)> func_;
+    grpc::Status status_;
+    const std::function<void(grpc::Status s)> func_;
   };
 
   typename std::aligned_storage<sizeof(Reactor), alignof(Reactor)>::type
@@ -568,7 +568,7 @@ class ServerContext : public ServerContextBase {
 
  private:
   // Constructor for internal use by server only
-  friend class ::grpc::Server;
+  friend class grpc::Server;
   ServerContext(gpr_timespec deadline, grpc_metadata_array* arr)
       : ServerContextBase(deadline, arr) {}
 
@@ -643,16 +643,15 @@ class ContextAllocator {
 }  // namespace grpc
 
 static_assert(
-    std::is_base_of<::grpc::ServerContextBase, ::grpc::ServerContext>::value,
+    std::is_base_of<grpc::ServerContextBase, grpc::ServerContext>::value,
     "improper base class");
-static_assert(std::is_base_of<::grpc::ServerContextBase,
-                              ::grpc::CallbackServerContext>::value,
+static_assert(std::is_base_of<grpc::ServerContextBase,
+                              grpc::CallbackServerContext>::value,
               "improper base class");
-static_assert(sizeof(::grpc::ServerContextBase) ==
-                  sizeof(::grpc::ServerContext),
+static_assert(sizeof(grpc::ServerContextBase) == sizeof(grpc::ServerContext),
               "wrong size");
-static_assert(sizeof(::grpc::ServerContextBase) ==
-                  sizeof(::grpc::CallbackServerContext),
+static_assert(sizeof(grpc::ServerContextBase) ==
+                  sizeof(grpc::CallbackServerContext),
               "wrong size");
 
 #endif  // GRPCPP_IMPL_CODEGEN_SERVER_CONTEXT_H

--- a/include/grpcpp/impl/codegen/server_interface.h
+++ b/include/grpcpp/impl/codegen/server_interface.h
@@ -116,7 +116,7 @@ class ServerInterface : public internal::CallHook {
   virtual void Wait() = 0;
 
  protected:
-  friend class ::grpc::Service;
+  friend class grpc::Service;
 
   /// Register a service. This call does not take ownership of the service.
   /// The service must exist for the lifetime of the Server instance.
@@ -153,7 +153,7 @@ class ServerInterface : public internal::CallHook {
   /// caller is required to keep all completion queues live until the server is
   /// destroyed.
   /// \param num_cqs How many completion queues does \a cqs hold.
-  virtual void Start(::grpc::ServerCompletionQueue** cqs, size_t num_cqs) = 0;
+  virtual void Start(grpc::ServerCompletionQueue** cqs, size_t num_cqs) = 0;
 
   virtual void ShutdownInternal(gpr_timespec deadline) = 0;
 
@@ -166,10 +166,10 @@ class ServerInterface : public internal::CallHook {
 
   class BaseAsyncRequest : public internal::CompletionQueueTag {
    public:
-    BaseAsyncRequest(ServerInterface* server, ::grpc::ServerContext* context,
+    BaseAsyncRequest(ServerInterface* server, grpc::ServerContext* context,
                      internal::ServerAsyncStreamingInterface* stream,
-                     ::grpc::CompletionQueue* call_cq,
-                     ::grpc::ServerCompletionQueue* notification_cq, void* tag,
+                     grpc::CompletionQueue* call_cq,
+                     grpc::ServerCompletionQueue* notification_cq, void* tag,
                      bool delete_on_finalize);
     ~BaseAsyncRequest() override;
 
@@ -180,10 +180,10 @@ class ServerInterface : public internal::CallHook {
 
    protected:
     ServerInterface* const server_;
-    ::grpc::ServerContext* const context_;
+    grpc::ServerContext* const context_;
     internal::ServerAsyncStreamingInterface* const stream_;
-    ::grpc::CompletionQueue* const call_cq_;
-    ::grpc::ServerCompletionQueue* const notification_cq_;
+    grpc::CompletionQueue* const call_cq_;
+    grpc::ServerCompletionQueue* const notification_cq_;
     void* const tag_;
     const bool delete_on_finalize_;
     grpc_call* call_;
@@ -196,10 +196,10 @@ class ServerInterface : public internal::CallHook {
   class RegisteredAsyncRequest : public BaseAsyncRequest {
    public:
     RegisteredAsyncRequest(ServerInterface* server,
-                           ::grpc::ServerContext* context,
+                           grpc::ServerContext* context,
                            internal::ServerAsyncStreamingInterface* stream,
-                           ::grpc::CompletionQueue* call_cq,
-                           ::grpc::ServerCompletionQueue* notification_cq,
+                           grpc::CompletionQueue* call_cq,
+                           grpc::ServerCompletionQueue* notification_cq,
                            void* tag, const char* name,
                            internal::RpcMethod::RpcType type);
 
@@ -208,7 +208,7 @@ class ServerInterface : public internal::CallHook {
       if (done_intercepting_) {
         return BaseAsyncRequest::FinalizeResult(tag, status);
       }
-      call_wrapper_ = ::grpc::internal::Call(
+      call_wrapper_ = grpc::internal::Call(
           call_, server_, call_cq_, server_->max_receive_message_size(),
           context_->set_server_rpc_info(name_, type_,
                                         *server_->interceptor_creators()));
@@ -217,7 +217,7 @@ class ServerInterface : public internal::CallHook {
 
    protected:
     void IssueRequest(void* registered_method, grpc_byte_buffer** payload,
-                      ::grpc::ServerCompletionQueue* notification_cq);
+                      grpc::ServerCompletionQueue* notification_cq);
     const char* name_;
     const internal::RpcMethod::RpcType type_;
   };
@@ -225,11 +225,10 @@ class ServerInterface : public internal::CallHook {
   class NoPayloadAsyncRequest final : public RegisteredAsyncRequest {
    public:
     NoPayloadAsyncRequest(internal::RpcServiceMethod* registered_method,
-                          ServerInterface* server,
-                          ::grpc::ServerContext* context,
+                          ServerInterface* server, grpc::ServerContext* context,
                           internal::ServerAsyncStreamingInterface* stream,
-                          ::grpc::CompletionQueue* call_cq,
-                          ::grpc::ServerCompletionQueue* notification_cq,
+                          grpc::CompletionQueue* call_cq,
+                          grpc::ServerCompletionQueue* notification_cq,
                           void* tag)
         : RegisteredAsyncRequest(
               server, context, stream, call_cq, notification_cq, tag,
@@ -244,11 +243,11 @@ class ServerInterface : public internal::CallHook {
   class PayloadAsyncRequest final : public RegisteredAsyncRequest {
    public:
     PayloadAsyncRequest(internal::RpcServiceMethod* registered_method,
-                        ServerInterface* server, ::grpc::ServerContext* context,
+                        ServerInterface* server, grpc::ServerContext* context,
                         internal::ServerAsyncStreamingInterface* stream,
-                        ::grpc::CompletionQueue* call_cq,
-                        ::grpc::ServerCompletionQueue* notification_cq,
-                        void* tag, Message* request)
+                        grpc::CompletionQueue* call_cq,
+                        grpc::ServerCompletionQueue* notification_cq, void* tag,
+                        Message* request)
         : RegisteredAsyncRequest(
               server, context, stream, call_cq, notification_cq, tag,
               registered_method->name(), registered_method->method_type()),
@@ -302,9 +301,9 @@ class ServerInterface : public internal::CallHook {
    public:
     GenericAsyncRequest(ServerInterface* server, GenericServerContext* context,
                         internal::ServerAsyncStreamingInterface* stream,
-                        ::grpc::CompletionQueue* call_cq,
-                        ::grpc::ServerCompletionQueue* notification_cq,
-                        void* tag, bool delete_on_finalize);
+                        grpc::CompletionQueue* call_cq,
+                        grpc::ServerCompletionQueue* notification_cq, void* tag,
+                        bool delete_on_finalize);
 
     bool FinalizeResult(void** tag, bool* status) override;
 
@@ -314,21 +313,21 @@ class ServerInterface : public internal::CallHook {
 
   template <class Message>
   void RequestAsyncCall(internal::RpcServiceMethod* method,
-                        ::grpc::ServerContext* context,
+                        grpc::ServerContext* context,
                         internal::ServerAsyncStreamingInterface* stream,
-                        ::grpc::CompletionQueue* call_cq,
-                        ::grpc::ServerCompletionQueue* notification_cq,
-                        void* tag, Message* message) {
+                        grpc::CompletionQueue* call_cq,
+                        grpc::ServerCompletionQueue* notification_cq, void* tag,
+                        Message* message) {
     GPR_CODEGEN_ASSERT(method);
     new PayloadAsyncRequest<Message>(method, this, context, stream, call_cq,
                                      notification_cq, tag, message);
   }
 
   void RequestAsyncCall(internal::RpcServiceMethod* method,
-                        ::grpc::ServerContext* context,
+                        grpc::ServerContext* context,
                         internal::ServerAsyncStreamingInterface* stream,
-                        ::grpc::CompletionQueue* call_cq,
-                        ::grpc::ServerCompletionQueue* notification_cq,
+                        grpc::CompletionQueue* call_cq,
+                        grpc::ServerCompletionQueue* notification_cq,
                         void* tag) {
     GPR_CODEGEN_ASSERT(method);
     new NoPayloadAsyncRequest(method, this, context, stream, call_cq,
@@ -337,8 +336,8 @@ class ServerInterface : public internal::CallHook {
 
   void RequestAsyncGenericCall(GenericServerContext* context,
                                internal::ServerAsyncStreamingInterface* stream,
-                               ::grpc::CompletionQueue* call_cq,
-                               ::grpc::ServerCompletionQueue* notification_cq,
+                               grpc::CompletionQueue* call_cq,
+                               grpc::ServerCompletionQueue* notification_cq,
                                void* tag) {
     new GenericAsyncRequest(this, context, stream, call_cq, notification_cq,
                             tag, true);
@@ -363,7 +362,7 @@ class ServerInterface : public internal::CallHook {
   // Returns nullptr (rather than being pure) since this is a post-1.0 method
   // and adding a new pure method to an interface would be a breaking change
   // (even though this is private and non-API)
-  virtual ::grpc::CompletionQueue* CallbackCQ() { return nullptr; }
+  virtual grpc::CompletionQueue* CallbackCQ() { return nullptr; }
 };
 
 }  // namespace grpc

--- a/include/grpcpp/impl/codegen/service_type.h
+++ b/include/grpcpp/impl/codegen/service_type.h
@@ -49,7 +49,7 @@ class ServerAsyncStreamingInterface {
   virtual void SendInitialMetadata(void* tag) = 0;
 
  private:
-  friend class ::grpc::ServerInterface;
+  friend class grpc::ServerInterface;
   virtual void BindCall(Call* call) = 0;
 };
 }  // namespace internal
@@ -102,11 +102,11 @@ class Service {
 
  protected:
   template <class Message>
-  void RequestAsyncUnary(int index, ::grpc::ServerContext* context,
+  void RequestAsyncUnary(int index, grpc::ServerContext* context,
                          Message* request,
                          internal::ServerAsyncStreamingInterface* stream,
-                         ::grpc::CompletionQueue* call_cq,
-                         ::grpc::ServerCompletionQueue* notification_cq,
+                         grpc::CompletionQueue* call_cq,
+                         grpc::ServerCompletionQueue* notification_cq,
                          void* tag) {
     // Typecast the index to size_t for indexing into a vector
     // while preserving the API that existed before a compiler
@@ -116,29 +116,29 @@ class Service {
                               notification_cq, tag, request);
   }
   void RequestAsyncClientStreaming(
-      int index, ::grpc::ServerContext* context,
+      int index, grpc::ServerContext* context,
       internal::ServerAsyncStreamingInterface* stream,
-      ::grpc::CompletionQueue* call_cq,
-      ::grpc::ServerCompletionQueue* notification_cq, void* tag) {
+      grpc::CompletionQueue* call_cq,
+      grpc::ServerCompletionQueue* notification_cq, void* tag) {
     size_t idx = static_cast<size_t>(index);
     server_->RequestAsyncCall(methods_[idx].get(), context, stream, call_cq,
                               notification_cq, tag);
   }
   template <class Message>
   void RequestAsyncServerStreaming(
-      int index, ::grpc::ServerContext* context, Message* request,
+      int index, grpc::ServerContext* context, Message* request,
       internal::ServerAsyncStreamingInterface* stream,
-      ::grpc::CompletionQueue* call_cq,
-      ::grpc::ServerCompletionQueue* notification_cq, void* tag) {
+      grpc::CompletionQueue* call_cq,
+      grpc::ServerCompletionQueue* notification_cq, void* tag) {
     size_t idx = static_cast<size_t>(index);
     server_->RequestAsyncCall(methods_[idx].get(), context, stream, call_cq,
                               notification_cq, tag, request);
   }
   void RequestAsyncBidiStreaming(
-      int index, ::grpc::ServerContext* context,
+      int index, grpc::ServerContext* context,
       internal::ServerAsyncStreamingInterface* stream,
-      ::grpc::CompletionQueue* call_cq,
-      ::grpc::ServerCompletionQueue* notification_cq, void* tag) {
+      grpc::CompletionQueue* call_cq,
+      grpc::ServerCompletionQueue* notification_cq, void* tag) {
     size_t idx = static_cast<size_t>(index);
     server_->RequestAsyncCall(methods_[idx].get(), context, stream, call_cq,
                               notification_cq, tag);

--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -187,7 +187,7 @@ class ClientReader final : public ClientReaderInterface<R> {
   void WaitForInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);  /// status ignored
@@ -205,7 +205,7 @@ class ClientReader final : public ClientReaderInterface<R> {
   ///   already received (if initial metadata is received, it can be then
   ///   accessed through the \a ClientContext associated with this call).
   bool Read(R* msg) override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                               grpc::internal::CallOpRecvMessage<R>>
         ops;
     if (!context_->initial_metadata_received_) {
@@ -222,7 +222,7 @@ class ClientReader final : public ClientReaderInterface<R> {
   ///   The \a ClientContext associated with this call is updated with
   ///   possible metadata received from the server.
   grpc::Status Finish() override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpClientRecvStatus> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpClientRecvStatus> ops;
     grpc::Status status;
     ops.ClientRecvStatus(context_, &status);
     call_.PerformOps(&ops);
@@ -248,7 +248,7 @@ class ClientReader final : public ClientReaderInterface<R> {
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
             nullptr}),  // Pluckable cq
         call_(channel->CreateCall(method, context, &cq_)) {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpClientSendClose>
         ops;
@@ -304,7 +304,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   void WaitForInitialMetadata() {
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);  // status ignored
@@ -318,7 +318,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   ///   \a ClientContext associated with this call).
   using internal::WriterInterface<W>::Write;
   bool Write(const W& msg, grpc::WriteOptions options) override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpClientSendClose>
         ops;
@@ -341,7 +341,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   }
 
   bool WritesDone() override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpClientSendClose> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpClientSendClose> ops;
     ops.ClientSendClose();
     call_.PerformOps(&ops);
     return cq_.Pluck(&ops);
@@ -385,7 +385,7 @@ class ClientWriter : public ClientWriterInterface<W> {
     finish_ops_.AllowNoMessage();
 
     if (!context_->initial_metadata_corked_) {
-      grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+      grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
           ops;
       ops.SendInitialMetadata(&context->send_initial_metadata_,
                               context->initial_metadata_flags());
@@ -395,7 +395,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   }
 
   grpc::ClientContext* context_;
-  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+  grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                             grpc::internal::CallOpGenericRecvMessage,
                             grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
@@ -454,7 +454,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   void WaitForInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);  // status ignored
@@ -471,7 +471,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   ///   Also receives initial metadata if not already received (updates the \a
   ///   ClientContext associated with this call in that case).
   bool Read(R* msg) override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                               grpc::internal::CallOpRecvMessage<R>>
         ops;
     if (!context_->initial_metadata_received_) {
@@ -489,7 +489,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   ///   \a ClientContext associated with this call to fill in values).
   using internal::WriterInterface<W>::Write;
   bool Write(const W& msg, grpc::WriteOptions options) override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                               grpc::internal::CallOpSendMessage,
                               grpc::internal::CallOpClientSendClose>
         ops;
@@ -512,7 +512,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   }
 
   bool WritesDone() override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpClientSendClose> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpClientSendClose> ops;
     ops.ClientSendClose();
     call_.PerformOps(&ops);
     return cq_.Pluck(&ops);
@@ -524,7 +524,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible trailing metadata sent from the server.
   grpc::Status Finish() override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata,
                               grpc::internal::CallOpClientRecvStatus>
         ops;
     if (!context_->initial_metadata_received_) {
@@ -556,7 +556,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
             nullptr}),  // Pluckable cq
         call_(channel->CreateCall(method, context, &cq_)) {
     if (!context_->initial_metadata_corked_) {
-      grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+      grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
           ops;
       ops.SendInitialMetadata(&context->send_initial_metadata_,
                               context->initial_metadata_flags());
@@ -583,7 +583,7 @@ class ServerReader final : public ServerReaderInterface<R> {
   void SendInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,
                             ctx_->initial_metadata_flags());
     if (ctx_->compression_level_set()) {
@@ -601,7 +601,7 @@ class ServerReader final : public ServerReaderInterface<R> {
   }
 
   bool Read(R* msg) override {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<R>> ops;
     ops.RecvMessage(msg);
     call_->PerformOps(&ops);
     bool ok = call_->cq()->Pluck(&ops) && ops.got_message;
@@ -640,7 +640,7 @@ class ServerWriter final : public ServerWriterInterface<W> {
   void SendInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
 
-    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,
                             ctx_->initial_metadata_flags());
     if (ctx_->compression_level_set()) {
@@ -731,7 +731,7 @@ class ServerReaderWriterBody final {
   }
 
   bool Read(R* msg) {
-    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> ops;
+    grpc::internal::CallOpSet<grpc::internal::CallOpRecvMessage<R>> ops;
     ops.RecvMessage(msg);
     call_->PerformOps(&ops);
     bool ok = call_->cq()->Pluck(&ops) && ops.got_message;

--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -61,7 +61,7 @@ class ClientStreamingInterface {
   ///   - \a Status contains the status code, message and details for the call
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible trailing metadata sent from the server.
-  virtual ::grpc::Status Finish() = 0;
+  virtual grpc::Status Finish() = 0;
 };
 
 /// Common interface for all synchronous server side streaming.
@@ -114,7 +114,7 @@ class WriterInterface {
   /// \param options The WriteOptions affecting the write operation.
   ///
   /// \return \a true on success, \a false when the stream has been closed.
-  virtual bool Write(const W& msg, ::grpc::WriteOptions options) = 0;
+  virtual bool Write(const W& msg, grpc::WriteOptions options) = 0;
 
   /// Block to write \a msg to the stream with default write options.
   /// This is thread-safe with respect to \a ReaderInterface::Read
@@ -122,7 +122,7 @@ class WriterInterface {
   /// \param msg The message to be written to the stream.
   ///
   /// \return \a true on success, \a false when the stream has been closed.
-  inline bool Write(const W& msg) { return Write(msg, ::grpc::WriteOptions()); }
+  inline bool Write(const W& msg) { return Write(msg, grpc::WriteOptions()); }
 
   /// Write \a msg and coalesce it with the writing of trailing metadata, using
   /// WriteOptions \a options.
@@ -138,7 +138,7 @@ class WriterInterface {
   ///
   /// \param[in] msg The message to be written to the stream.
   /// \param[in] options The WriteOptions to be used to write this message.
-  void WriteLast(const W& msg, ::grpc::WriteOptions options) {
+  void WriteLast(const W& msg, grpc::WriteOptions options) {
     Write(msg, options.set_last_message());
   }
 };
@@ -162,9 +162,9 @@ template <class R>
 class ClientReaderFactory {
  public:
   template <class W>
-  static ClientReader<R>* Create(::grpc::ChannelInterface* channel,
-                                 const ::grpc::internal::RpcMethod& method,
-                                 ::grpc::ClientContext* context,
+  static ClientReader<R>* Create(grpc::ChannelInterface* channel,
+                                 const grpc::internal::RpcMethod& method,
+                                 grpc::ClientContext* context,
                                  const W& request) {
     return new ClientReader<R>(channel, method, context, request);
   }
@@ -187,8 +187,7 @@ class ClientReader final : public ClientReaderInterface<R> {
   void WaitForInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
-        ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);  /// status ignored
@@ -206,8 +205,8 @@ class ClientReader final : public ClientReaderInterface<R> {
   ///   already received (if initial metadata is received, it can be then
   ///   accessed through the \a ClientContext associated with this call).
   bool Read(R* msg) override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                                ::grpc::internal::CallOpRecvMessage<R>>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                              grpc::internal::CallOpRecvMessage<R>>
         ops;
     if (!context_->initial_metadata_received_) {
       ops.RecvInitialMetadata(context_);
@@ -222,9 +221,9 @@ class ClientReader final : public ClientReaderInterface<R> {
   /// Side effect:
   ///   The \a ClientContext associated with this call is updated with
   ///   possible metadata received from the server.
-  ::grpc::Status Finish() override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpClientRecvStatus> ops;
-    ::grpc::Status status;
+  grpc::Status Finish() override {
+    grpc::internal::CallOpSet<::grpc::internal::CallOpClientRecvStatus> ops;
+    grpc::Status status;
     ops.ClientRecvStatus(context_, &status);
     call_.PerformOps(&ops);
     GPR_CODEGEN_ASSERT(cq_.Pluck(&ops));
@@ -233,25 +232,25 @@ class ClientReader final : public ClientReaderInterface<R> {
 
  private:
   friend class internal::ClientReaderFactory<R>;
-  ::grpc::ClientContext* context_;
-  ::grpc::CompletionQueue cq_;
-  ::grpc::internal::Call call_;
+  grpc::ClientContext* context_;
+  grpc::CompletionQueue cq_;
+  grpc::internal::Call call_;
 
   /// Block to create a stream and write the initial metadata and \a request
   /// out. Note that \a context will be used to fill in custom initial
   /// metadata used to send to the server when starting the call.
   template <class W>
-  ClientReader(::grpc::ChannelInterface* channel,
-               const ::grpc::internal::RpcMethod& method,
-               ::grpc::ClientContext* context, const W& request)
+  ClientReader(grpc::ChannelInterface* channel,
+               const grpc::internal::RpcMethod& method,
+               grpc::ClientContext* context, const W& request)
       : context_(context),
         cq_(grpc_completion_queue_attributes{
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
             nullptr}),  // Pluckable cq
         call_(channel->CreateCall(method, context, &cq_)) {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpClientSendClose>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpClientSendClose>
         ops;
     ops.SendInitialMetadata(&context->send_initial_metadata_,
                             context->initial_metadata_flags());
@@ -282,9 +281,9 @@ template <class W>
 class ClientWriterFactory {
  public:
   template <class R>
-  static ClientWriter<W>* Create(::grpc::ChannelInterface* channel,
-                                 const ::grpc::internal::RpcMethod& method,
-                                 ::grpc::ClientContext* context, R* response) {
+  static ClientWriter<W>* Create(grpc::ChannelInterface* channel,
+                                 const grpc::internal::RpcMethod& method,
+                                 grpc::ClientContext* context, R* response) {
     return new ClientWriter<W>(channel, method, context, response);
   }
 };
@@ -305,8 +304,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   void WaitForInitialMetadata() {
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
-        ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);  // status ignored
@@ -319,10 +317,10 @@ class ClientWriter : public ClientWriterInterface<W> {
   ///   Also sends initial metadata if not already sent (using the
   ///   \a ClientContext associated with this call).
   using internal::WriterInterface<W>::Write;
-  bool Write(const W& msg, ::grpc::WriteOptions options) override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpClientSendClose>
+  bool Write(const W& msg, grpc::WriteOptions options) override {
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpClientSendClose>
         ops;
 
     if (options.is_last_message()) {
@@ -343,7 +341,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   }
 
   bool WritesDone() override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpClientSendClose> ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpClientSendClose> ops;
     ops.ClientSendClose();
     call_.PerformOps(&ops);
     return cq_.Pluck(&ops);
@@ -355,8 +353,8 @@ class ClientWriter : public ClientWriterInterface<W> {
   ///   - Attempts to fill in the \a response parameter passed
   ///     to the constructor of this instance with the response
   ///     message from the server.
-  ::grpc::Status Finish() override {
-    ::grpc::Status status;
+  grpc::Status Finish() override {
+    grpc::Status status;
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
     }
@@ -375,9 +373,9 @@ class ClientWriter : public ClientWriterInterface<W> {
   /// single expected response message from the server upon a successful
   /// call to the \a Finish method of this instance.
   template <class R>
-  ClientWriter(::grpc::ChannelInterface* channel,
-               const ::grpc::internal::RpcMethod& method,
-               ::grpc::ClientContext* context, R* response)
+  ClientWriter(grpc::ChannelInterface* channel,
+               const grpc::internal::RpcMethod& method,
+               grpc::ClientContext* context, R* response)
       : context_(context),
         cq_(grpc_completion_queue_attributes{
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
@@ -387,7 +385,7 @@ class ClientWriter : public ClientWriterInterface<W> {
     finish_ops_.AllowNoMessage();
 
     if (!context_->initial_metadata_corked_) {
-      ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+      grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
           ops;
       ops.SendInitialMetadata(&context->send_initial_metadata_,
                               context->initial_metadata_flags());
@@ -396,13 +394,13 @@ class ClientWriter : public ClientWriterInterface<W> {
     }
   }
 
-  ::grpc::ClientContext* context_;
-  ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                              ::grpc::internal::CallOpGenericRecvMessage,
-                              ::grpc::internal::CallOpClientRecvStatus>
+  grpc::ClientContext* context_;
+  grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                            grpc::internal::CallOpGenericRecvMessage,
+                            grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
-  ::grpc::CompletionQueue cq_;
-  ::grpc::internal::Call call_;
+  grpc::CompletionQueue cq_;
+  grpc::internal::Call call_;
 };
 
 /// Client-side interface for bi-directional streaming with
@@ -433,9 +431,8 @@ template <class W, class R>
 class ClientReaderWriterFactory {
  public:
   static ClientReaderWriter<W, R>* Create(
-      ::grpc::ChannelInterface* channel,
-      const ::grpc::internal::RpcMethod& method,
-      ::grpc::ClientContext* context) {
+      grpc::ChannelInterface* channel, const grpc::internal::RpcMethod& method,
+      grpc::ClientContext* context) {
     return new ClientReaderWriter<W, R>(channel, method, context);
   }
 };
@@ -457,8 +454,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   void WaitForInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
-        ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);  // status ignored
@@ -475,8 +471,8 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   ///   Also receives initial metadata if not already received (updates the \a
   ///   ClientContext associated with this call in that case).
   bool Read(R* msg) override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                                ::grpc::internal::CallOpRecvMessage<R>>
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                              grpc::internal::CallOpRecvMessage<R>>
         ops;
     if (!context_->initial_metadata_received_) {
       ops.RecvInitialMetadata(context_);
@@ -492,10 +488,10 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   ///   Also sends initial metadata if not already sent (using the
   ///   \a ClientContext associated with this call to fill in values).
   using internal::WriterInterface<W>::Write;
-  bool Write(const W& msg, ::grpc::WriteOptions options) override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
-                                ::grpc::internal::CallOpSendMessage,
-                                ::grpc::internal::CallOpClientSendClose>
+  bool Write(const W& msg, grpc::WriteOptions options) override {
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
+                              grpc::internal::CallOpSendMessage,
+                              grpc::internal::CallOpClientSendClose>
         ops;
 
     if (options.is_last_message()) {
@@ -516,7 +512,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   }
 
   bool WritesDone() override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpClientSendClose> ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpClientSendClose> ops;
     ops.ClientSendClose();
     call_.PerformOps(&ops);
     return cq_.Pluck(&ops);
@@ -527,14 +523,14 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   /// Side effect:
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible trailing metadata sent from the server.
-  ::grpc::Status Finish() override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
-                                ::grpc::internal::CallOpClientRecvStatus>
+  grpc::Status Finish() override {
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
+                              grpc::internal::CallOpClientRecvStatus>
         ops;
     if (!context_->initial_metadata_received_) {
       ops.RecvInitialMetadata(context_);
     }
-    ::grpc::Status status;
+    grpc::Status status;
     ops.ClientRecvStatus(context_, &status);
     call_.PerformOps(&ops);
     GPR_CODEGEN_ASSERT(cq_.Pluck(&ops));
@@ -544,23 +540,23 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
  private:
   friend class internal::ClientReaderWriterFactory<W, R>;
 
-  ::grpc::ClientContext* context_;
-  ::grpc::CompletionQueue cq_;
-  ::grpc::internal::Call call_;
+  grpc::ClientContext* context_;
+  grpc::CompletionQueue cq_;
+  grpc::internal::Call call_;
 
   /// Block to create a stream and write the initial metadata and \a request
   /// out. Note that \a context will be used to fill in custom initial metadata
   /// used to send to the server when starting the call.
-  ClientReaderWriter(::grpc::ChannelInterface* channel,
-                     const ::grpc::internal::RpcMethod& method,
-                     ::grpc::ClientContext* context)
+  ClientReaderWriter(grpc::ChannelInterface* channel,
+                     const grpc::internal::RpcMethod& method,
+                     grpc::ClientContext* context)
       : context_(context),
         cq_(grpc_completion_queue_attributes{
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
             nullptr}),  // Pluckable cq
         call_(channel->CreateCall(method, context, &cq_)) {
     if (!context_->initial_metadata_corked_) {
-      ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
+      grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
           ops;
       ops.SendInitialMetadata(&context->send_initial_metadata_,
                               context->initial_metadata_flags());
@@ -587,8 +583,7 @@ class ServerReader final : public ServerReaderInterface<R> {
   void SendInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
-        ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,
                             ctx_->initial_metadata_flags());
     if (ctx_->compression_level_set()) {
@@ -606,7 +601,7 @@ class ServerReader final : public ServerReaderInterface<R> {
   }
 
   bool Read(R* msg) override {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> ops;
     ops.RecvMessage(msg);
     call_->PerformOps(&ops);
     bool ok = call_->cq()->Pluck(&ops) && ops.got_message;
@@ -617,13 +612,13 @@ class ServerReader final : public ServerReaderInterface<R> {
   }
 
  private:
-  ::grpc::internal::Call* const call_;
+  grpc::internal::Call* const call_;
   ServerContext* const ctx_;
 
   template <class ServiceType, class RequestType, class ResponseType>
   friend class internal::ClientStreamingHandler;
 
-  ServerReader(::grpc::internal::Call* call, ::grpc::ServerContext* ctx)
+  ServerReader(grpc::internal::Call* call, grpc::ServerContext* ctx)
       : call_(call), ctx_(ctx) {}
 };
 
@@ -645,8 +640,7 @@ class ServerWriter final : public ServerWriterInterface<W> {
   void SendInitialMetadata() override {
     GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
 
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
-        ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,
                             ctx_->initial_metadata_flags());
     if (ctx_->compression_level_set()) {
@@ -663,7 +657,7 @@ class ServerWriter final : public ServerWriterInterface<W> {
   ///   Also sends initial metadata if not already sent (using the
   ///   \a ClientContext associated with this call to fill in values).
   using internal::WriterInterface<W>::Write;
-  bool Write(const W& msg, ::grpc::WriteOptions options) override {
+  bool Write(const W& msg, grpc::WriteOptions options) override {
     if (options.is_last_message()) {
       options.set_buffer_hint();
     }
@@ -692,13 +686,13 @@ class ServerWriter final : public ServerWriterInterface<W> {
   }
 
  private:
-  ::grpc::internal::Call* const call_;
-  ::grpc::ServerContext* const ctx_;
+  grpc::internal::Call* const call_;
+  grpc::ServerContext* const ctx_;
 
   template <class ServiceType, class RequestType, class ResponseType>
   friend class internal::ServerStreamingHandler;
 
-  ServerWriter(::grpc::internal::Call* call, ::grpc::ServerContext* ctx)
+  ServerWriter(grpc::internal::Call* call, grpc::ServerContext* ctx)
       : call_(call), ctx_(ctx) {}
 };
 
@@ -713,7 +707,7 @@ namespace internal {
 template <class W, class R>
 class ServerReaderWriterBody final {
  public:
-  ServerReaderWriterBody(grpc::internal::Call* call, ::grpc::ServerContext* ctx)
+  ServerReaderWriterBody(grpc::internal::Call* call, grpc::ServerContext* ctx)
       : call_(call), ctx_(ctx) {}
 
   void SendInitialMetadata() {
@@ -737,7 +731,7 @@ class ServerReaderWriterBody final {
   }
 
   bool Read(R* msg) {
-    ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> ops;
+    grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> ops;
     ops.RecvMessage(msg);
     call_->PerformOps(&ops);
     bool ok = call_->cq()->Pluck(&ops) && ops.got_message;
@@ -747,7 +741,7 @@ class ServerReaderWriterBody final {
     return ok;
   }
 
-  bool Write(const W& msg, ::grpc::WriteOptions options) {
+  bool Write(const W& msg, grpc::WriteOptions options) {
     if (options.is_last_message()) {
       options.set_buffer_hint();
     }
@@ -776,7 +770,7 @@ class ServerReaderWriterBody final {
 
  private:
   grpc::internal::Call* const call_;
-  ::grpc::ServerContext* const ctx_;
+  grpc::ServerContext* const ctx_;
 };
 
 }  // namespace internal
@@ -805,7 +799,7 @@ class ServerReaderWriter final : public ServerReaderWriterInterface<W, R> {
   ///   Also sends initial metadata if not already sent (using the \a
   ///   ServerContext associated with this call).
   using internal::WriterInterface<W>::Write;
-  bool Write(const W& msg, ::grpc::WriteOptions options) override {
+  bool Write(const W& msg, grpc::WriteOptions options) override {
     return body_.Write(msg, options);
   }
 
@@ -814,7 +808,7 @@ class ServerReaderWriter final : public ServerReaderWriterInterface<W, R> {
 
   friend class internal::TemplatedBidiStreamingHandler<ServerReaderWriter<W, R>,
                                                        false>;
-  ServerReaderWriter(::grpc::internal::Call* call, ::grpc::ServerContext* ctx)
+  ServerReaderWriter(grpc::internal::Call* call, grpc::ServerContext* ctx)
       : body_(call, ctx) {}
 };
 
@@ -868,7 +862,7 @@ class ServerUnaryStreamer final
   /// \return \a true on success, \a false when the stream has been closed.
   using internal::WriterInterface<ResponseType>::Write;
   bool Write(const ResponseType& response,
-             ::grpc::WriteOptions options) override {
+             grpc::WriteOptions options) override {
     if (write_done_ || !read_done_) {
       return false;
     }
@@ -883,7 +877,7 @@ class ServerUnaryStreamer final
 
   friend class internal::TemplatedBidiStreamingHandler<
       ServerUnaryStreamer<RequestType, ResponseType>, true>;
-  ServerUnaryStreamer(::grpc::internal::Call* call, ::grpc::ServerContext* ctx)
+  ServerUnaryStreamer(grpc::internal::Call* call, grpc::ServerContext* ctx)
       : body_(call, ctx), read_done_(false), write_done_(false) {}
 };
 
@@ -934,7 +928,7 @@ class ServerSplitStreamer final
   /// \return \a true on success, \a false when the stream has been closed.
   using internal::WriterInterface<ResponseType>::Write;
   bool Write(const ResponseType& response,
-             ::grpc::WriteOptions options) override {
+             grpc::WriteOptions options) override {
     return read_done_ && body_.Write(response, options);
   }
 
@@ -944,7 +938,7 @@ class ServerSplitStreamer final
 
   friend class internal::TemplatedBidiStreamingHandler<
       ServerSplitStreamer<RequestType, ResponseType>, false>;
-  ServerSplitStreamer(::grpc::internal::Call* call, ::grpc::ServerContext* ctx)
+  ServerSplitStreamer(grpc::internal::Call* call, grpc::ServerContext* ctx)
       : body_(call, ctx), read_done_(false) {}
 };
 

--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -385,8 +385,7 @@ class ClientWriter : public ClientWriterInterface<W> {
     finish_ops_.AllowNoMessage();
 
     if (!context_->initial_metadata_corked_) {
-      grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
-          ops;
+      grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
       ops.SendInitialMetadata(&context->send_initial_metadata_,
                               context->initial_metadata_flags());
       call_.PerformOps(&ops);
@@ -556,8 +555,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
             nullptr}),  // Pluckable cq
         call_(channel->CreateCall(method, context, &cq_)) {
     if (!context_->initial_metadata_corked_) {
-      grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>
-          ops;
+      grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
       ops.SendInitialMetadata(&context->send_initial_metadata_,
                               context->initial_metadata_flags());
       call_.PerformOps(&ops);

--- a/include/grpcpp/resource_quota.h
+++ b/include/grpcpp/resource_quota.h
@@ -31,7 +31,7 @@ namespace grpc {
 /// or a client channel (via \a ChannelArguments).
 /// gRPC will attempt to keep memory and threads used by all attached entities
 /// below the ResourceQuota bound.
-class ResourceQuota final : private ::grpc::GrpcLibraryCodegen {
+class ResourceQuota final : private grpc::GrpcLibraryCodegen {
  public:
   /// \param name - a unique name for this ResourceQuota.
   explicit ResourceQuota(const std::string& name);

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -351,7 +351,7 @@ class ServerBuilder {
   virtual ChannelArguments BuildChannelArgs();
 
  private:
-  friend class ::grpc::testing::ServerBuilderPluginTest;
+  friend class grpc::testing::ServerBuilderPluginTest;
 
   struct SyncServerSettings {
     SyncServerSettings()

--- a/include/grpcpp/test/mock_stream.h
+++ b/include/grpcpp/test/mock_stream.h
@@ -32,7 +32,7 @@ namespace grpc {
 namespace testing {
 
 template <class R>
-class MockClientReader : public ::grpc::ClientReaderInterface<R> {
+class MockClientReader : public grpc::ClientReaderInterface<R> {
  public:
   MockClientReader() = default;
 
@@ -48,7 +48,7 @@ class MockClientReader : public ::grpc::ClientReaderInterface<R> {
 };
 
 template <class W>
-class MockClientWriter : public ::grpc::ClientWriterInterface<W> {
+class MockClientWriter : public grpc::ClientWriterInterface<W> {
  public:
   MockClientWriter() = default;
 
@@ -63,8 +63,7 @@ class MockClientWriter : public ::grpc::ClientWriterInterface<W> {
 };
 
 template <class W, class R>
-class MockClientReaderWriter
-    : public ::grpc::ClientReaderWriterInterface<W, R> {
+class MockClientReaderWriter : public grpc::ClientReaderWriterInterface<W, R> {
  public:
   MockClientReaderWriter() = default;
 
@@ -87,7 +86,7 @@ class MockClientReaderWriter
 
 template <class R>
 class MockClientAsyncResponseReader
-    : public ::grpc::ClientAsyncResponseReaderInterface<R> {
+    : public grpc::ClientAsyncResponseReaderInterface<R> {
  public:
   MockClientAsyncResponseReader() = default;
 
@@ -112,7 +111,7 @@ class MockClientAsyncReader : public ClientAsyncReaderInterface<R> {
 };
 
 template <class W>
-class MockClientAsyncWriter : public ::grpc::ClientAsyncWriterInterface<W> {
+class MockClientAsyncWriter : public grpc::ClientAsyncWriterInterface<W> {
  public:
   MockClientAsyncWriter() = default;
 
@@ -123,7 +122,7 @@ class MockClientAsyncWriter : public ::grpc::ClientAsyncWriterInterface<W> {
 
   /// AsyncWriterInterface
   MOCK_METHOD2_T(Write, void(const W&, void*));
-  MOCK_METHOD3_T(Write, void(const W&, ::grpc::WriteOptions, void*));
+  MOCK_METHOD3_T(Write, void(const W&, grpc::WriteOptions, void*));
 
   /// ClientAsyncWriterInterface
   MOCK_METHOD1_T(WritesDone, void(void*));
@@ -142,7 +141,7 @@ class MockClientAsyncReaderWriter
 
   /// AsyncWriterInterface
   MOCK_METHOD2_T(Write, void(const W&, void*));
-  MOCK_METHOD3_T(Write, void(const W&, ::grpc::WriteOptions, void*));
+  MOCK_METHOD3_T(Write, void(const W&, grpc::WriteOptions, void*));
 
   /// AsyncReaderInterface
   MOCK_METHOD2_T(Read, void(R*, void*));
@@ -152,7 +151,7 @@ class MockClientAsyncReaderWriter
 };
 
 template <class R>
-class MockServerReader : public ::grpc::ServerReaderInterface<R> {
+class MockServerReader : public grpc::ServerReaderInterface<R> {
  public:
   MockServerReader() = default;
 
@@ -165,7 +164,7 @@ class MockServerReader : public ::grpc::ServerReaderInterface<R> {
 };
 
 template <class W>
-class MockServerWriter : public ::grpc::ServerWriterInterface<W> {
+class MockServerWriter : public grpc::ServerWriterInterface<W> {
  public:
   MockServerWriter() = default;
 

--- a/include/grpcpp/xds_server_builder.h
+++ b/include/grpcpp/xds_server_builder.h
@@ -28,7 +28,7 @@ namespace grpc {
 class XdsServerServingStatusNotifierInterface {
  public:
   struct ServingStatusUpdate {
-    ::grpc::Status status;
+    grpc::Status status;
   };
 
   virtual ~XdsServerServingStatusNotifierInterface() = default;
@@ -44,12 +44,12 @@ class XdsServerServingStatusNotifierInterface {
                                      ServingStatusUpdate update) = 0;
 };
 
-class XdsServerBuilder : public ::grpc::ServerBuilder {
+class XdsServerBuilder : public grpc::ServerBuilder {
  public:
   // NOTE: class experimental_type is not part of the public API of this class
   // TODO(yashykt): Integrate into public API when this is no longer
   // experimental.
-  class experimental_type : public ::grpc::ServerBuilder::experimental_type {
+  class experimental_type : public grpc::ServerBuilder::experimental_type {
    public:
     explicit experimental_type(XdsServerBuilder* builder)
         : ServerBuilder::experimental_type(builder), builder_(builder) {}

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -275,16 +275,16 @@ const char* ServerLoadReportingCallData::GetStatusTagForStatus(
     grpc_status_code status) {
   switch (status) {
     case GRPC_STATUS_OK:
-      return ::grpc::load_reporter::kCallStatusOk;
+      return grpc::load_reporter::kCallStatusOk;
     case GRPC_STATUS_UNKNOWN:
     case GRPC_STATUS_DEADLINE_EXCEEDED:
     case GRPC_STATUS_UNIMPLEMENTED:
     case GRPC_STATUS_INTERNAL:
     case GRPC_STATUS_UNAVAILABLE:
     case GRPC_STATUS_DATA_LOSS:
-      return ::grpc::load_reporter::kCallStatusServerError;
+      return grpc::load_reporter::kCallStatusServerError;
     default:
-      return ::grpc::load_reporter::kCallStatusClientError;
+      return grpc::load_reporter::kCallStatusClientError;
   }
 }
 
@@ -309,12 +309,12 @@ struct ServerLoadReportingFilterStaticRegistrar {
         MaybeAddServerLoadReportingFilter);
     // Access measures to ensure they are initialized. Otherwise, we can't
     // create any valid view before the first RPC.
-    ::grpc::load_reporter::MeasureStartCount();
-    ::grpc::load_reporter::MeasureEndCount();
-    ::grpc::load_reporter::MeasureEndBytesSent();
-    ::grpc::load_reporter::MeasureEndBytesReceived();
-    ::grpc::load_reporter::MeasureEndLatencyMs();
-    ::grpc::load_reporter::MeasureOtherCallMetric();
+    grpc::load_reporter::MeasureStartCount();
+    grpc::load_reporter::MeasureEndCount();
+    grpc::load_reporter::MeasureEndBytesSent();
+    grpc::load_reporter::MeasureEndBytesReceived();
+    grpc::load_reporter::MeasureEndLatencyMs();
+    grpc::load_reporter::MeasureOtherCallMetric();
     registered.store(true, std::memory_order_release);
   }
 } server_load_reporting_filter_static_registrar;

--- a/src/core/ext/transport/binder/client/channel_create.cc
+++ b/src/core/ext/transport/binder/client/channel_create.cc
@@ -144,7 +144,7 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
   grpc_binder::GetSecurityPolicySetting()->Set(connection_id, security_policy);
 
   auto channel = CreateChannelInternal(
-      "", ::grpc::internal::CreateClientBinderChannelImpl(new_args),
+      "", grpc::internal::CreateClientBinderChannelImpl(new_args),
       std::vector<
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>());
 

--- a/src/core/ext/transport/binder/utils/ndk_binder.h
+++ b/src/core/ext/transport/binder/utils/ndk_binder.h
@@ -25,7 +25,7 @@
 #include <memory>
 
 // This file defines NdkBinder functions, variables, and types in
-// ::grpc_binder::ndk_util namespace. This allows us to dynamically load
+// grpc_binder::ndk_util namespace. This allows us to dynamically load
 // libbinder_ndk at runtime, and make it possible to compile the code without
 // the library present at compile time.
 

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -194,7 +194,7 @@ class TransportFlowControlBase {
   virtual void TestOnlyForceHugeWindow() {}
 
  protected:
-  friend class ::grpc::testing::TrickledCHTTP2;
+  friend class grpc::testing::TrickledCHTTP2;
   int64_t remote_window_ = kDefaultWindow;
   int64_t target_initial_window_size_ = kDefaultWindow;
   int64_t announced_window_ = kDefaultWindow;
@@ -384,7 +384,7 @@ class StreamFlowControlBase {
   int64_t announced_window_delta() const { return announced_window_delta_; }
 
  protected:
-  friend class ::grpc::testing::TrickledCHTTP2;
+  friend class grpc::testing::TrickledCHTTP2;
   int64_t remote_window_delta_ = 0;
   int64_t local_window_delta_ = 0;
   int64_t announced_window_delta_ = 0;

--- a/src/core/lib/gprpp/global_config_env.h
+++ b/src/core/lib/gprpp/global_config_env.h
@@ -121,7 +121,7 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
   static char g_env_str_##name[] = #name;                                  \
   static ::grpc_core::GlobalConfigEnvString g_env_##name(g_env_str_##name, \
                                                          default_value);   \
-  ::grpc_core::UniquePtr<char> gpr_global_config_get_##name() {            \
+  grpc_core::UniquePtr<char> gpr_global_config_get_##name() {              \
     return g_env_##name.Get();                                             \
   }                                                                        \
   void gpr_global_config_set_##name(const char* value) {                   \

--- a/src/core/lib/gprpp/global_config_env.h
+++ b/src/core/lib/gprpp/global_config_env.h
@@ -121,7 +121,7 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
   static char g_env_str_##name[] = #name;                                  \
   static ::grpc_core::GlobalConfigEnvString g_env_##name(g_env_str_##name, \
                                                          default_value);   \
-  grpc_core::UniquePtr<char> gpr_global_config_get_##name() {              \
+  ::grpc_core::UniquePtr<char> gpr_global_config_get_##name() {            \
     return g_env_##name.Get();                                             \
   }                                                                        \
   void gpr_global_config_set_##name(const char* value) {                   \

--- a/src/cpp/client/create_channel_internal.cc
+++ b/src/cpp/client/create_channel_internal.cc
@@ -31,8 +31,8 @@ namespace grpc {
 
 std::shared_ptr<Channel> CreateChannelInternal(
     const std::string& host, grpc_channel* c_channel,
-    std::vector<std::unique_ptr<
-        ::grpc::experimental::ClientInterceptorFactoryInterface>>
+    std::vector<
+        std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators) {
   return std::shared_ptr<Channel>(
       new Channel(host, c_channel, std::move(interceptor_creators)));

--- a/src/cpp/client/create_channel_internal.h
+++ b/src/cpp/client/create_channel_internal.h
@@ -33,8 +33,8 @@ namespace grpc {
 
 std::shared_ptr<Channel> CreateChannelInternal(
     const std::string& host, grpc_channel* c_channel,
-    std::vector<std::unique_ptr<
-        ::grpc::experimental::ClientInterceptorFactoryInterface>>
+    std::vector<
+        std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);
 
 }  // namespace grpc

--- a/src/cpp/client/insecure_credentials.cc
+++ b/src/cpp/client/insecure_credentials.cc
@@ -46,7 +46,7 @@ class InsecureChannelCredentialsImpl final : public ChannelCredentials {
     grpc_channel_args channel_args;
     args.SetChannelArgs(&channel_args);
     grpc_channel_credentials* creds = grpc_insecure_credentials_create();
-    std::shared_ptr<Channel> channel = ::grpc::CreateChannelInternal(
+    std::shared_ptr<Channel> channel = grpc::CreateChannelInternal(
         "", grpc_channel_create(target.c_str(), creds, &channel_args),
         std::move(interceptor_creators));
     grpc_channel_credentials_release(creds);

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -66,7 +66,7 @@ SecureChannelCredentials::CreateChannelWithInterceptors(
         interceptor_creators) {
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);
-  return ::grpc::CreateChannelInternal(
+  return grpc::CreateChannelInternal(
       args.GetSslTargetNameOverride(),
       grpc_channel_create(target.c_str(), c_creds_, &channel_args),
       std::move(interceptor_creators));

--- a/src/cpp/client/secure_credentials.h
+++ b/src/cpp/client/secure_credentials.h
@@ -51,7 +51,7 @@ class SecureChannelCredentials final : public ChannelCredentials {
   std::shared_ptr<Channel> CreateChannelWithInterceptors(
       const std::string& target, const ChannelArguments& args,
       std::vector<std::unique_ptr<
-          ::grpc::experimental::ClientInterceptorFactoryInterface>>
+          grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators) override;
   grpc_channel_credentials* const c_creds_;
 };

--- a/src/cpp/common/alarm.cc
+++ b/src/cpp/common/alarm.cc
@@ -34,7 +34,7 @@
 namespace grpc {
 
 namespace internal {
-class AlarmImpl : public ::grpc::internal::CompletionQueueTag {
+class AlarmImpl : public grpc::internal::CompletionQueueTag {
  public:
   AlarmImpl() : cq_(nullptr), tag_(nullptr) {
     gpr_ref_init(&refs_, 1);
@@ -46,7 +46,7 @@ class AlarmImpl : public ::grpc::internal::CompletionQueueTag {
     Unref();
     return true;
   }
-  void Set(::grpc::CompletionQueue* cq, gpr_timespec deadline, void* tag) {
+  void Set(grpc::CompletionQueue* cq, gpr_timespec deadline, void* tag) {
     grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
     grpc_core::ExecCtx exec_ctx;
     GRPC_CQ_INTERNAL_REF(cq->cq(), "alarm");
@@ -125,13 +125,13 @@ class AlarmImpl : public ::grpc::internal::CompletionQueueTag {
 };
 }  // namespace internal
 
-static ::grpc::internal::GrpcLibraryInitializer g_gli_initializer;
+static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
 
 Alarm::Alarm() : alarm_(new internal::AlarmImpl()) {
   g_gli_initializer.summon();
 }
 
-void Alarm::SetInternal(::grpc::CompletionQueue* cq, gpr_timespec deadline,
+void Alarm::SetInternal(grpc::CompletionQueue* cq, gpr_timespec deadline,
                         void* tag) {
   // Note that we know that alarm_ is actually an internal::AlarmImpl
   // but we declared it as the base pointer to avoid a forward declaration

--- a/src/cpp/common/completion_queue_cc.cc
+++ b/src/cpp/common/completion_queue_cc.cc
@@ -151,7 +151,7 @@ CompletionQueue::NextStatus CompletionQueue::AsyncNextInternal(
         return SHUTDOWN;
       case GRPC_OP_COMPLETE:
         auto core_cq_tag =
-            static_cast<::grpc::internal::CompletionQueueTag*>(ev.tag);
+            static_cast<grpc::internal::CompletionQueueTag*>(ev.tag);
         *ok = ev.success != 0;
         *tag = core_cq_tag;
         if (core_cq_tag->FinalizeResult(tag, ok)) {
@@ -179,7 +179,7 @@ bool CompletionQueue::CompletionQueueTLSCache::Flush(void** tag, bool* ok) {
   if (grpc_completion_queue_thread_local_cache_flush(cq_->cq_, &res_tag,
                                                      &res)) {
     auto core_cq_tag =
-        static_cast<::grpc::internal::CompletionQueueTag*>(res_tag);
+        static_cast<grpc::internal::CompletionQueueTag*>(res_tag);
     *ok = res == 1;
     if (core_cq_tag->FinalizeResult(tag, ok)) {
       return true;

--- a/src/cpp/ext/proto_server_reflection_plugin.cc
+++ b/src/cpp/ext/proto_server_reflection_plugin.cc
@@ -58,15 +58,15 @@ bool ProtoServerReflectionPlugin::has_async_methods() const {
   return false;
 }
 
-static std::unique_ptr< ::grpc::ServerBuilderPlugin> CreateProtoReflection() {
-  return std::unique_ptr< ::grpc::ServerBuilderPlugin>(
+static std::unique_ptr<grpc::ServerBuilderPlugin> CreateProtoReflection() {
+  return std::unique_ptr<grpc::ServerBuilderPlugin>(
       new ProtoServerReflectionPlugin());
 }
 
 void InitProtoReflectionServerBuilderPlugin() {
   static struct Initialize {
     Initialize() {
-      ::grpc::ServerBuilder::InternalAddPluginFactory(&CreateProtoReflection);
+      grpc::ServerBuilder::InternalAddPluginFactory(&CreateProtoReflection);
     }
   } initializer;
 }

--- a/src/cpp/server/async_generic_service.cc
+++ b/src/cpp/server/async_generic_service.cc
@@ -23,8 +23,8 @@ namespace grpc {
 
 void AsyncGenericService::RequestCall(
     GenericServerContext* ctx, GenericServerAsyncReaderWriter* reader_writer,
-    ::grpc::CompletionQueue* call_cq,
-    ::grpc::ServerCompletionQueue* notification_cq, void* tag) {
+    grpc::CompletionQueue* call_cq,
+    grpc::ServerCompletionQueue* notification_cq, void* tag) {
   server_->RequestAsyncGenericCall(ctx, reader_writer, call_cq, notification_cq,
                                    tag);
 }

--- a/src/cpp/server/channelz/channelz_service_plugin.cc
+++ b/src/cpp/server/channelz/channelz_service_plugin.cc
@@ -29,7 +29,7 @@ namespace grpc {
 namespace channelz {
 namespace experimental {
 
-class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
+class ChannelzServicePlugin : public grpc::ServerBuilderPlugin {
  public:
   ChannelzServicePlugin() : channelz_service_(new grpc::ChannelzService()) {}
 
@@ -61,16 +61,16 @@ class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
   std::shared_ptr<grpc::ChannelzService> channelz_service_;
 };
 
-static std::unique_ptr< ::grpc::ServerBuilderPlugin>
+static std::unique_ptr<grpc::ServerBuilderPlugin>
 CreateChannelzServicePlugin() {
-  return std::unique_ptr< ::grpc::ServerBuilderPlugin>(
+  return std::unique_ptr<grpc::ServerBuilderPlugin>(
       new ChannelzServicePlugin());
 }
 
 void InitChannelzService() {
   static struct Initializer {
     Initializer() {
-      ::grpc::ServerBuilder::InternalAddPluginFactory(
+      grpc::ServerBuilder::InternalAddPluginFactory(
           &grpc::channelz::experimental::CreateChannelzServicePlugin);
     }
   } initialize;

--- a/src/cpp/server/external_connection_acceptor_impl.h
+++ b/src/cpp/server/external_connection_acceptor_impl.h
@@ -53,7 +53,7 @@ class ExternalConnectionAcceptorImpl
 
   ServerCredentials* GetCredentials() { return creds_.get(); }
 
-  void SetToChannelArgs(::grpc::ChannelArguments* args);
+  void SetToChannelArgs(grpc::ChannelArguments* args);
 
  private:
   const std::string name_;

--- a/src/cpp/server/health/default_health_check_service.cc
+++ b/src/cpp/server/health/default_health_check_service.cc
@@ -161,7 +161,7 @@ DefaultHealthCheckService::HealthCheckServiceImpl::HealthCheckServiceImpl(
   AddMethod(new internal::RpcServiceMethod(
       kHealthWatchMethodName, internal::RpcMethod::SERVER_STREAMING, nullptr));
   // Create serving thread.
-  thread_ = absl::make_unique<::grpc_core::Thread>("grpc_health_check_service",
+  thread_ = absl::make_unique<grpc_core::Thread>("grpc_health_check_service",
                                                    Serve, this);
 }
 

--- a/src/cpp/server/health/default_health_check_service.cc
+++ b/src/cpp/server/health/default_health_check_service.cc
@@ -162,7 +162,7 @@ DefaultHealthCheckService::HealthCheckServiceImpl::HealthCheckServiceImpl(
       kHealthWatchMethodName, internal::RpcMethod::SERVER_STREAMING, nullptr));
   // Create serving thread.
   thread_ = absl::make_unique<grpc_core::Thread>("grpc_health_check_service",
-                                                   Serve, this);
+                                                 Serve, this);
 }
 
 DefaultHealthCheckService::HealthCheckServiceImpl::~HealthCheckServiceImpl() {

--- a/src/cpp/server/health/default_health_check_service.h
+++ b/src/cpp/server/health/default_health_check_service.h
@@ -229,7 +229,7 @@ class DefaultHealthCheckService final : public HealthCheckServiceInterface {
     // we don't enqueue new tags into cq_ after it is already shut down.
     grpc_core::Mutex cq_shutdown_mu_;
     std::atomic_bool shutdown_{false};
-    std::unique_ptr<::grpc_core::Thread> thread_;
+    std::unique_ptr<grpc_core::Thread> thread_;
   };
 
   DefaultHealthCheckService();

--- a/src/cpp/server/load_reporter/load_reporter.cc
+++ b/src/cpp/server/load_reporter/load_reporter.cc
@@ -252,7 +252,7 @@ LoadReporter::GenerateLoadBalancingFeedback() {
     feedback_records_.pop_front();
   }
   if (feedback_records_.size() < 2) {
-    return ::grpc::lb::v1::LoadBalancingFeedback::default_instance();
+    return grpc::lb::v1::LoadBalancingFeedback::default_instance();
   }
   // Find the longest range with valid ends.
   auto oldest = feedback_records_.begin();
@@ -267,7 +267,7 @@ LoadReporter::GenerateLoadBalancingFeedback() {
   if (std::distance(oldest, newest) < 1 ||
       oldest->end_time == newest->end_time ||
       newest->cpu_limit == oldest->cpu_limit) {
-    return ::grpc::lb::v1::LoadBalancingFeedback::default_instance();
+    return grpc::lb::v1::LoadBalancingFeedback::default_instance();
   }
   uint64_t rpcs = 0;
   uint64_t errors = 0;
@@ -282,7 +282,7 @@ LoadReporter::GenerateLoadBalancingFeedback() {
   std::chrono::duration<double> duration_seconds =
       newest->end_time - oldest->end_time;
   lock.Release();
-  ::grpc::lb::v1::LoadBalancingFeedback feedback;
+  grpc::lb::v1::LoadBalancingFeedback feedback;
   feedback.set_server_utilization(static_cast<float>(cpu_usage / cpu_limit));
   feedback.set_calls_per_second(
       static_cast<float>(rpcs / duration_seconds.count()));
@@ -354,7 +354,7 @@ LoadReporter::GenerateLoads(const std::string& hostname,
 }
 
 void LoadReporter::AttachOrphanLoadId(
-    ::grpc::lb::v1::Load* load, const PerBalancerStore& per_balancer_store) {
+    grpc::lb::v1::Load* load, const PerBalancerStore& per_balancer_store) {
   if (per_balancer_store.lb_id() == kInvalidLbId) {
     load->set_load_key_unknown(true);
   } else {

--- a/src/cpp/server/load_reporter/load_reporter.cc
+++ b/src/cpp/server/load_reporter/load_reporter.cc
@@ -291,14 +291,14 @@ LoadReporter::GenerateLoadBalancingFeedback() {
   return feedback;
 }
 
-::google::protobuf::RepeatedPtrField<::grpc::lb::v1::Load>
+::google::protobuf::RepeatedPtrField<grpc::lb::v1::Load>
 LoadReporter::GenerateLoads(const std::string& hostname,
                             const std::string& lb_id) {
   grpc_core::MutexLock lock(&store_mu_);
   auto assigned_stores = load_data_store_.GetAssignedStores(hostname, lb_id);
   GPR_ASSERT(assigned_stores != nullptr);
   GPR_ASSERT(!assigned_stores->empty());
-  ::google::protobuf::RepeatedPtrField<::grpc::lb::v1::Load> loads;
+  ::google::protobuf::RepeatedPtrField<grpc::lb::v1::Load> loads;
   for (PerBalancerStore* per_balancer_store : *assigned_stores) {
     GPR_ASSERT(!per_balancer_store->IsSuspended());
     if (!per_balancer_store->load_record_map().empty()) {

--- a/src/cpp/server/load_reporter/load_reporter.h
+++ b/src/cpp/server/load_reporter/load_reporter.h
@@ -146,7 +146,7 @@ class LoadReporter {
   // The feedback is calculated from the stats data recorded in the sliding
   // window. Outdated records are discarded.
   // Thread-safe.
-  ::grpc::lb::v1::LoadBalancingFeedback GenerateLoadBalancingFeedback();
+  grpc::lb::v1::LoadBalancingFeedback GenerateLoadBalancingFeedback();
 
   // Wrapper around LoadDataStore::ReportStreamCreated.
   // Thread-safe.
@@ -209,7 +209,7 @@ class LoadReporter {
 
   // Extracts an OrphanedLoadIdentifier from the per-balancer store and attaches
   // it to the load.
-  void AttachOrphanLoadId(::grpc::lb::v1::Load* load,
+  void AttachOrphanLoadId(grpc::lb::v1::Load* load,
                           const PerBalancerStore& per_balancer_store);
 
   std::atomic<int64_t> next_lb_id_{0};

--- a/src/cpp/server/load_reporter/load_reporter.h
+++ b/src/cpp/server/load_reporter/load_reporter.h
@@ -140,7 +140,7 @@ class LoadReporter {
   // all the stats data accumulated between the last report (i.e., the last
   // consumption) and the last fetch from Census (i.e., the last production).
   // Thread-safe.
-  ::google::protobuf::RepeatedPtrField<::grpc::lb::v1::Load> GenerateLoads(
+  ::google::protobuf::RepeatedPtrField<grpc::lb::v1::Load> GenerateLoads(
       const std::string& hostname, const std::string& lb_id);
 
   // The feedback is calculated from the stats data recorded in the sliding

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -36,7 +36,7 @@ void LoadReporterAsyncServiceImpl::CallableTag::Run(bool ok) {
 LoadReporterAsyncServiceImpl::LoadReporterAsyncServiceImpl(
     std::unique_ptr<ServerCompletionQueue> cq)
     : cq_(std::move(cq)) {
-  thread_ = absl::make_unique<::grpc_core::Thread>("server_load_reporting",
+  thread_ = absl::make_unique<grpc_core::Thread>("server_load_reporting",
                                                    Work, this);
   std::unique_ptr<CpuStatsProvider> cpu_stats_provider = nullptr;
 #if defined(GPR_LINUX) || defined(GPR_WINDOWS) || defined(GPR_APPLE)

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -285,7 +285,7 @@ void LoadReporterAsyncServiceImpl::ReportLoadHandler::SendReport(
     Shutdown(std::move(self), "SendReport");
     return;
   }
-  ::grpc::lb::v1::LoadReportResponse response;
+  grpc::lb::v1::LoadReportResponse response;
   auto loads = load_reporter_->GenerateLoads(load_balanced_hostname_, lb_id_);
   response.mutable_load()->Swap(&loads);
   auto feedback = load_reporter_->GenerateLoadBalancingFeedback();
@@ -294,7 +294,7 @@ void LoadReporterAsyncServiceImpl::ReportLoadHandler::SendReport(
     auto initial_response = response.mutable_initial_response();
     initial_response->set_load_balancer_id(lb_id_);
     initial_response->set_implementation_id(
-        ::grpc::lb::v1::InitialLoadReportResponse::CPP);
+        grpc::lb::v1::InitialLoadReportResponse::CPP);
     initial_response->set_server_version(kVersion);
     call_status_ = INITIAL_RESPONSE_SENT;
   }

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -36,8 +36,8 @@ void LoadReporterAsyncServiceImpl::CallableTag::Run(bool ok) {
 LoadReporterAsyncServiceImpl::LoadReporterAsyncServiceImpl(
     std::unique_ptr<ServerCompletionQueue> cq)
     : cq_(std::move(cq)) {
-  thread_ = absl::make_unique<grpc_core::Thread>("server_load_reporting",
-                                                   Work, this);
+  thread_ =
+      absl::make_unique<grpc_core::Thread>("server_load_reporting", Work, this);
   std::unique_ptr<CpuStatsProvider> cpu_stats_provider = nullptr;
 #if defined(GPR_LINUX) || defined(GPR_WINDOWS) || defined(GPR_APPLE)
   cpu_stats_provider = absl::make_unique<CpuStatsProviderDefaultImpl>();

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.h
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.h
@@ -142,14 +142,14 @@ class LoadReporterAsyncServiceImpl
 
     // The data for RPC communication with the load reportee.
     ServerContext ctx_;
-    ::grpc::lb::v1::LoadReportRequest request_;
+    grpc::lb::v1::LoadReportRequest request_;
 
     // The members passed down from LoadReporterAsyncServiceImpl.
     ServerCompletionQueue* cq_;
     LoadReporterAsyncServiceImpl* service_;
     LoadReporter* load_reporter_;
     ServerAsyncReaderWriter<::grpc::lb::v1::LoadReportResponse,
-                            ::grpc::lb::v1::LoadReportRequest>
+                            grpc::lb::v1::LoadReportRequest>
         stream_;
 
     // The status of the RPC progress.

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.h
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.h
@@ -148,7 +148,7 @@ class LoadReporterAsyncServiceImpl
     ServerCompletionQueue* cq_;
     LoadReporterAsyncServiceImpl* service_;
     LoadReporter* load_reporter_;
-    ServerAsyncReaderWriter<::grpc::lb::v1::LoadReportResponse,
+    ServerAsyncReaderWriter<grpc::lb::v1::LoadReportResponse,
                             grpc::lb::v1::LoadReportRequest>
         stream_;
 
@@ -184,7 +184,7 @@ class LoadReporterAsyncServiceImpl
   // don't enqueue new tags into cq_ after it is already shut down.
   grpc_core::Mutex cq_shutdown_mu_;
   std::atomic_bool shutdown_{false};
-  std::unique_ptr<::grpc_core::Thread> thread_;
+  std::unique_ptr<grpc_core::Thread> thread_;
   std::unique_ptr<LoadReporter> load_reporter_;
   std::unique_ptr<Alarm> next_fetch_and_sample_alarm_;
 };

--- a/src/cpp/server/load_reporter/load_reporting_service_server_builder_option.cc
+++ b/src/cpp/server/load_reporter/load_reporting_service_server_builder_option.cc
@@ -32,7 +32,7 @@ void LoadReportingServiceServerBuilderOption::UpdateArguments(
 }
 
 void LoadReportingServiceServerBuilderOption::UpdatePlugins(
-    std::vector<std::unique_ptr<::grpc::ServerBuilderPlugin>>* plugins) {
+    std::vector<std::unique_ptr<grpc::ServerBuilderPlugin>>* plugins) {
   plugins->emplace_back(
       new grpc::load_reporter::LoadReportingServiceServerBuilderPlugin());
 }

--- a/src/cpp/server/load_reporter/load_reporting_service_server_builder_option.cc
+++ b/src/cpp/server/load_reporter/load_reporting_service_server_builder_option.cc
@@ -27,7 +27,7 @@ namespace load_reporter {
 namespace experimental {
 
 void LoadReportingServiceServerBuilderOption::UpdateArguments(
-    ::grpc::ChannelArguments* args) {
+    grpc::ChannelArguments* args) {
   args->SetInt(GRPC_ARG_ENABLE_LOAD_REPORTING, true);
 }
 

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -48,7 +48,7 @@ class ServerContextBase::CompletionOp final
   // initial refs: one in the server context, one in the cq
   // must ref the call before calling constructor and after deleting this
   CompletionOp(internal::Call* call,
-               ::grpc::internal::ServerCallbackCall* callback_controller)
+               grpc::internal::ServerCallbackCall* callback_controller)
       : call_(*call),
         callback_controller_(callback_controller),
         has_tag_(false),
@@ -141,7 +141,7 @@ class ServerContextBase::CompletionOp final
   }
 
   internal::Call call_;
-  ::grpc::internal::ServerCallbackCall* const callback_controller_;
+  grpc::internal::ServerCallbackCall* const callback_controller_;
   bool has_tag_;
   void* tag_;
   void* core_cq_tag_;
@@ -275,7 +275,7 @@ ServerContextBase::CallWrapper::~CallWrapper() {
 
 void ServerContextBase::BeginCompletionOp(
     internal::Call* call, std::function<void(bool)> callback,
-    ::grpc::internal::ServerCallbackCall* callback_controller) {
+    grpc::internal::ServerCallbackCall* callback_controller) {
   GPR_ASSERT(!completion_op_);
   if (rpc_info_) {
     rpc_info_->Ref();

--- a/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
+++ b/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
@@ -51,7 +51,7 @@ void TryConnectAndDestroy(const char* fake_metadata_server_address) {
   args.SetInt("grpc.testing.google_c2p_resolver_pretend_running_on_gcp", 1);
   args.SetString("grpc.testing.google_c2p_resolver_metadata_server_override",
                  fake_metadata_server_address);
-  auto channel = ::grpc::CreateCustomChannel(
+  auto channel = grpc::CreateCustomChannel(
       target, grpc::InsecureChannelCredentials(), args);
   // Start connecting, and give some time for the google-c2p resolver to begin
   // resolution and start trying to contact the metadata server.

--- a/test/core/config/core_configuration_test.cc
+++ b/test/core/config/core_configuration_test.cc
@@ -29,7 +29,7 @@ static ConfigBuilderFunction g_mock_builder;
 }  // namespace testing
 
 void BuildCoreConfiguration(CoreConfiguration::Builder* builder) {
-  ::grpc_core::testing::g_mock_builder(builder);
+  testing::g_mock_builder(builder);
 }
 
 namespace testing {

--- a/test/core/config/core_configuration_test.cc
+++ b/test/core/config/core_configuration_test.cc
@@ -25,7 +25,7 @@ namespace grpc_core {
 // through all plugins
 namespace {
 using ConfigBuilderFunction = std::function<void(CoreConfiguration::Builder*)>;
-static ConfigBuilderFunction g_mock_builder;
+ConfigBuilderFunction g_mock_builder;
 }  // namespace
 
 void BuildCoreConfiguration(CoreConfiguration::Builder* builder) {

--- a/test/core/config/core_configuration_test.cc
+++ b/test/core/config/core_configuration_test.cc
@@ -23,16 +23,16 @@ namespace grpc_core {
 
 // Allow substitution of config builder - in real code this would iterate
 // through all plugins
-namespace testing {
+namespace {
 using ConfigBuilderFunction = std::function<void(CoreConfiguration::Builder*)>;
 static ConfigBuilderFunction g_mock_builder;
-}  // namespace testing
+}  // namespace
 
 void BuildCoreConfiguration(CoreConfiguration::Builder* builder) {
-  testing::g_mock_builder(builder);
+  g_mock_builder(builder);
 }
 
-namespace testing {
+namespace {
 // Helper for testing - clear out any state, rebuild configuration with fn being
 // the initializer
 void InitConfigWithBuilder(ConfigBuilderFunction fn) {
@@ -63,7 +63,7 @@ TEST(ConfigTest, ThreadedInit) {
   g_mock_builder = nullptr;
   CoreConfiguration::Get();
 }
-}  // namespace testing
+}  // namespace
 
 }  // namespace grpc_core
 

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -110,7 +110,7 @@ class TlsSecurityConnectorTest : public ::testing::Test {
   HostNameCertificateVerifier hostname_certificate_verifier_;
 };
 
-class TlsTestCertificateProvider : public ::grpc_tls_certificate_provider {
+class TlsTestCertificateProvider : public grpc_tls_certificate_provider {
  public:
   explicit TlsTestCertificateProvider(
       RefCountedPtr<grpc_tls_certificate_distributor> distributor)

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -135,7 +135,7 @@ TEST_F(TlsSecurityConnectorTest,
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   RefCountedPtr<grpc_tls_credentials_options> options =
       MakeRefCounted<grpc_tls_credentials_options>();
@@ -189,7 +189,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   // Create options only watching for identity certificates.
   RefCountedPtr<grpc_tls_credentials_options> root_options =
@@ -223,7 +223,7 @@ TEST_F(TlsSecurityConnectorTest,
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   // Create options only watching for root certificates.
   RefCountedPtr<grpc_tls_credentials_options> root_options =
@@ -253,7 +253,7 @@ TEST_F(TlsSecurityConnectorTest,
   RefCountedPtr<grpc_tls_certificate_distributor> distributor =
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   // Registered the options watching both certs, but only root certs are
   // available at distributor right now.
@@ -293,7 +293,7 @@ TEST_F(TlsSecurityConnectorTest,
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   RefCountedPtr<grpc_tls_credentials_options> options =
       MakeRefCounted<grpc_tls_credentials_options>();
@@ -446,7 +446,7 @@ TEST_F(TlsSecurityConnectorTest,
   RefCountedPtr<grpc_tls_certificate_distributor> distributor =
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_certificate_provider(provider);
@@ -470,7 +470,7 @@ TEST_F(TlsSecurityConnectorTest,
   RefCountedPtr<grpc_tls_certificate_distributor> distributor =
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_certificate_provider(provider);
@@ -496,7 +496,7 @@ TEST_F(TlsSecurityConnectorTest,
   RefCountedPtr<grpc_tls_certificate_distributor> distributor =
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_certificate_provider(provider);
@@ -523,7 +523,7 @@ TEST_F(TlsSecurityConnectorTest,
   RefCountedPtr<grpc_tls_certificate_distributor> distributor =
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_certificate_provider(provider);
@@ -735,7 +735,7 @@ TEST_F(TlsSecurityConnectorTest,
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   RefCountedPtr<grpc_tls_credentials_options> options =
       MakeRefCounted<grpc_tls_credentials_options>();
@@ -773,7 +773,7 @@ TEST_F(TlsSecurityConnectorTest,
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   // Create options only watching for identity certificates.
   RefCountedPtr<grpc_tls_credentials_options> identity_options =
@@ -806,7 +806,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   // Registered the options watching both certs, but only root certs are
   // available at distributor right now.
@@ -842,7 +842,7 @@ TEST_F(TlsSecurityConnectorTest,
   distributor->SetKeyMaterials(kRootCertName, root_cert_0_, absl::nullopt);
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   RefCountedPtr<grpc_tls_credentials_options> options =
       MakeRefCounted<grpc_tls_credentials_options>();
@@ -897,7 +897,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_certificate_provider(provider);
@@ -920,7 +920,7 @@ TEST_F(TlsSecurityConnectorTest,
       MakeRefCounted<grpc_tls_certificate_distributor>();
   distributor->SetKeyMaterials(kIdentityCertName, absl::nullopt,
                                identity_pairs_0_);
-  RefCountedPtr<::grpc_tls_certificate_provider> provider =
+  RefCountedPtr<grpc_tls_certificate_provider> provider =
       MakeRefCounted<TlsTestCertificateProvider>(distributor);
   auto options = MakeRefCounted<grpc_tls_credentials_options>();
   options->set_certificate_provider(provider);

--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -368,7 +368,7 @@ int main(int argc, char** argv) {
   // are capable of sending and receiving even in the case that we don't have an
   // active RPC operation on the fd.
   GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
-  ::grpc_core::chttp2::g_test_only_transport_flow_control_window_check = true;
+  grpc_core::chttp2::g_test_only_transport_flow_control_window_check = true;
   g_target_initial_window_size_mocker = new TransportTargetWindowSizeMocker();
   grpc_core::chttp2::g_test_only_transport_target_window_estimates_mocker =
       g_target_initial_window_size_mocker;

--- a/test/core/transport/parsed_metadata_test.cc
+++ b/test/core/transport/parsed_metadata_test.cc
@@ -114,7 +114,7 @@ class FakeContainer {
   void Set(IntptrTrait, intptr_t x) { SetIntptr(x); }
   void Set(StringTrait, std::string x) { SetString(x); }
 
-  void Set(const ::grpc_core::ParsedMetadata<FakeContainer>& metadata) {
+  void Set(const ParsedMetadata<FakeContainer>& metadata) {
     metadata.SetOnContainer(this);
   }
 

--- a/test/cpp/client/client_channel_stress_test.cc
+++ b/test/cpp/client/client_channel_stress_test.cc
@@ -281,8 +281,8 @@ class ClientChannelStressTest {
                     response_generator_.get());
     std::ostringstream uri;
     uri << "fake:///servername_not_used";
-    channel_ = ::grpc::CreateCustomChannel(uri.str(),
-                                           InsecureChannelCredentials(), args);
+    channel_ = grpc::CreateCustomChannel(uri.str(),
+                                         InsecureChannelCredentials(), args);
     stub_ = grpc::testing::EchoTestService::NewStub(channel_);
   }
 

--- a/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
+++ b/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
@@ -85,7 +85,7 @@ void TryConnectAndDestroy() {
               grpc_test_slowdown_factor() * 100);
   std::ostringstream uri;
   uri << "fake:///servername_not_used";
-  auto channel = ::grpc::CreateCustomChannel(
+  auto channel = grpc::CreateCustomChannel(
       uri.str(), grpc::InsecureChannelCredentials(), args);
   // Start connecting, and give some time for the TCP connection attempt to the
   // unreachable balancer to begin. The connection should never become ready

--- a/test/cpp/end2end/admin_services_end2end_test.cc
+++ b/test/cpp/end2end/admin_services_end2end_test.cc
@@ -41,7 +41,7 @@ class AdminServicesTest : public ::testing::Test {
     grpc::reflection::InitProtoReflectionServerBuilderPlugin();
     ServerBuilder builder;
     builder.AddListeningPort(address, InsecureServerCredentials());
-    ::grpc::AddAdminServices(&builder);
+    grpc::AddAdminServices(&builder);
     server_ = builder.BuildAndStart();
     // Create channel
     auto reflection_stub = reflection::v1alpha::ServerReflection::NewStub(

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -211,7 +211,7 @@ bool plugin_has_sync_methods(std::unique_ptr<ServerBuilderPlugin>& plugin) {
 // the server. If there are sync services, UnimplementedRpc test will triger
 // the sync unknown rpc routine on the server side, rather than the async one
 // that needs to be tested here.
-class ServerBuilderSyncPluginDisabler : public ::grpc::ServerBuilderOption {
+class ServerBuilderSyncPluginDisabler : public grpc::ServerBuilderOption {
  public:
   void UpdateArguments(ChannelArguments* /*arg*/) override {}
 
@@ -303,8 +303,8 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<TestScenario> {
     auto channel_creds = GetCredentialsProvider()->GetChannelCredentials(
         GetParam().credentials_type, &args);
     std::shared_ptr<Channel> channel =
-        !(GetParam().inproc) ? ::grpc::CreateCustomChannel(
-                                   server_address_.str(), channel_creds, args)
+        !(GetParam().inproc) ? grpc::CreateCustomChannel(server_address_.str(),
+                                                         channel_creds, args)
                              : server_->InProcessChannel(args);
     stub_ = grpc::testing::EchoTestService::NewStub(channel);
   }
@@ -1311,8 +1311,8 @@ TEST_P(AsyncEnd2endTest, UnimplementedRpc) {
   const auto& channel_creds = GetCredentialsProvider()->GetChannelCredentials(
       GetParam().credentials_type, &args);
   std::shared_ptr<Channel> channel =
-      !(GetParam().inproc) ? ::grpc::CreateCustomChannel(server_address_.str(),
-                                                         channel_creds, args)
+      !(GetParam().inproc) ? grpc::CreateCustomChannel(server_address_.str(),
+                                                       channel_creds, args)
                            : server_->InProcessChannel(args);
   std::unique_ptr<grpc::testing::UnimplementedEchoService::Stub> stub;
   stub = grpc::testing::UnimplementedEchoService::NewStub(channel);
@@ -1491,7 +1491,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
     cli_stream->Finish(&recv_status, tag(10));
     Verifier().Expect(10, true).Verify(&cli_cq);
     EXPECT_FALSE(recv_status.ok());
-    EXPECT_EQ(::grpc::StatusCode::CANCELLED, recv_status.error_code());
+    EXPECT_EQ(grpc::StatusCode::CANCELLED, recv_status.error_code());
 
     cli_cq.Shutdown();
     void* phony_tag;
@@ -1640,7 +1640,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
     cli_stream->Finish(&recv_status, tag(10));
     Verifier().Expect(10, true).Verify(&cli_cq);
     EXPECT_FALSE(recv_status.ok());
-    EXPECT_EQ(::grpc::StatusCode::CANCELLED, recv_status.error_code());
+    EXPECT_EQ(grpc::StatusCode::CANCELLED, recv_status.error_code());
 
     cli_cq.Shutdown();
     void* phony_tag;

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -115,7 +115,7 @@ class Proxy : public grpc::testing::EchoTestService::Service {
   }
 
  private:
-  std::vector<std::unique_ptr<::grpc::testing::EchoTestService::Stub>> stubs_;
+  std::vector<std::unique_ptr<grpc::testing::EchoTestService::Stub>> stubs_;
 };
 
 enum class CredentialsType {

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -77,7 +77,7 @@ bool ValidateAddress(const Address& address) {
 
 // Proxy service supports N backends. Sends RPC to backend dictated by
 // request->backend_channel_idx().
-class Proxy : public ::grpc::testing::EchoTestService::Service {
+class Proxy : public grpc::testing::EchoTestService::Service {
  public:
   Proxy() {}
 
@@ -197,7 +197,7 @@ class ChannelzServerTest : public ::testing::TestWithParam<CredentialsType> {
   }
   void SetUp() override {
     // ensure channel server is brought up on all severs we build.
-    ::grpc::channelz::experimental::InitChannelzService();
+    grpc::channelz::experimental::InitChannelzService();
 
     // We set up a proxy server with channelz enabled.
     proxy_port_ = grpc_pick_unused_port_or_die();
@@ -235,7 +235,7 @@ class ChannelzServerTest : public ::testing::TestWithParam<CredentialsType> {
       ChannelArguments args;
       args.SetInt(GRPC_ARG_ENABLE_CHANNELZ, 1);
       args.SetInt(GRPC_ARG_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE, 1024);
-      std::shared_ptr<Channel> channel_to_backend = ::grpc::CreateCustomChannel(
+      std::shared_ptr<Channel> channel_to_backend = grpc::CreateCustomChannel(
           backend_server_address, GetChannelCredentials(GetParam(), &args),
           args);
       proxy_service_.AddChannelToBackend(channel_to_backend);
@@ -247,7 +247,7 @@ class ChannelzServerTest : public ::testing::TestWithParam<CredentialsType> {
     ChannelArguments args;
     // disable channelz. We only want to focus on proxy to backend outbound.
     args.SetInt(GRPC_ARG_ENABLE_CHANNELZ, 0);
-    std::shared_ptr<Channel> channel = ::grpc::CreateCustomChannel(
+    std::shared_ptr<Channel> channel = grpc::CreateCustomChannel(
         target, GetChannelCredentials(GetParam(), &args), args);
     channelz_stub_ = grpc::channelz::v1::Channelz::NewStub(channel);
     echo_stub_ = grpc::testing::EchoTestService::NewStub(channel);
@@ -260,7 +260,7 @@ class ChannelzServerTest : public ::testing::TestWithParam<CredentialsType> {
     args.SetInt(GRPC_ARG_ENABLE_CHANNELZ, 0);
     // This ensures that gRPC will not do connection sharing.
     args.SetInt(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL, true);
-    std::shared_ptr<Channel> channel = ::grpc::CreateCustomChannel(
+    std::shared_ptr<Channel> channel = grpc::CreateCustomChannel(
         target, GetChannelCredentials(GetParam(), &args), args);
     return grpc::testing::EchoTestService::NewStub(channel);
   }

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -133,8 +133,8 @@ class ClientCallbackEnd2endTest
     switch (GetParam().protocol) {
       case Protocol::TCP:
         if (!GetParam().use_interceptors) {
-          channel_ = ::grpc::CreateCustomChannel(server_address_.str(),
-                                                 channel_creds, args);
+          channel_ = grpc::CreateCustomChannel(server_address_.str(),
+                                               channel_creds, args);
         } else {
           channel_ = CreateCustomChannelWithInterceptors(
               server_address_.str(), channel_creds, args,
@@ -1372,8 +1372,8 @@ TEST_P(ClientCallbackEnd2endTest, UnimplementedRpc) {
       GetParam().credentials_type, &args);
   std::shared_ptr<Channel> channel =
       (GetParam().protocol == Protocol::TCP)
-          ? ::grpc::CreateCustomChannel(server_address_.str(), channel_creds,
-                                        args)
+          ? grpc::CreateCustomChannel(server_address_.str(), channel_creds,
+                                      args)
           : server_->InProcessChannel(args);
   std::unique_ptr<grpc::testing::UnimplementedEchoService::Stub> stub;
   stub = grpc::testing::UnimplementedEchoService::NewStub(channel);

--- a/test/cpp/end2end/client_crash_test_server.cc
+++ b/test/cpp/end2end/client_crash_test_server.cc
@@ -38,7 +38,7 @@ using grpc::testing::EchoResponse;
 namespace grpc {
 namespace testing {
 
-class ServiceImpl final : public ::grpc::testing::EchoTestService::Service {
+class ServiceImpl final : public grpc::testing::EchoTestService::Service {
   Status BidiStream(
       ServerContext* /*context*/,
       ServerReaderWriter<EchoResponse, EchoRequest>* stream) override {

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -307,7 +307,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
     }  // else, default to pick first
     args.SetPointer(GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR,
                     response_generator.Get());
-    return ::grpc::CreateCustomChannel("fake:///", creds_, args);
+    return grpc::CreateCustomChannel("fake:///", creds_, args);
   }
 
   bool SendRpc(

--- a/test/cpp/end2end/context_allocator_end2end_test.cc
+++ b/test/cpp/end2end/context_allocator_end2end_test.cc
@@ -111,8 +111,8 @@ class ContextAllocatorEnd2endTestBase
         GetParam().credentials_type, &args);
     switch (GetParam().protocol) {
       case Protocol::TCP:
-        channel_ = ::grpc::CreateCustomChannel(server_address_.str(),
-                                               channel_creds, args);
+        channel_ = grpc::CreateCustomChannel(server_address_.str(),
+                                             channel_creds, args);
         break;
       case Protocol::INPROC:
         channel_ = server_->InProcessChannel(args);

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -247,7 +247,7 @@ class TestAuthMetadataProcessor : public AuthMetadataProcessor {
 const char TestAuthMetadataProcessor::kGoodGuy[] = "Dr Jekyll";
 const char TestAuthMetadataProcessor::kIdentityPropName[] = "novel identity";
 
-class Proxy : public ::grpc::testing::EchoTestService::Service {
+class Proxy : public grpc::testing::EchoTestService::Service {
  public:
   explicit Proxy(const std::shared_ptr<Channel>& channel)
       : stub_(grpc::testing::EchoTestService::NewStub(channel)) {}
@@ -264,7 +264,7 @@ class Proxy : public ::grpc::testing::EchoTestService::Service {
 };
 
 class TestServiceImplDupPkg
-    : public ::grpc::testing::duplicate::EchoTestService::Service {
+    : public grpc::testing::duplicate::EchoTestService::Service {
  public:
   Status Echo(ServerContext* /*context*/, const EchoRequest* /*request*/,
               EchoResponse* response) override {
@@ -403,8 +403,8 @@ class End2endTest : public ::testing::TestWithParam<TestScenario> {
 
     if (!GetParam().inproc) {
       if (!GetParam().use_interceptors) {
-        channel_ = ::grpc::CreateCustomChannel(server_address_.str(),
-                                               channel_creds, args);
+        channel_ = grpc::CreateCustomChannel(server_address_.str(),
+                                             channel_creds, args);
       } else {
         channel_ = CreateCustomChannelWithInterceptors(
             server_address_.str(), channel_creds, args,

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -260,7 +260,7 @@ class Proxy : public grpc::testing::EchoTestService::Service {
   }
 
  private:
-  std::unique_ptr<::grpc::testing::EchoTestService::Stub> stub_;
+  std::unique_ptr<grpc::testing::EchoTestService::Stub> stub_;
 };
 
 class TestServiceImplDupPkg

--- a/test/cpp/end2end/exception_test.cc
+++ b/test/cpp/end2end/exception_test.cc
@@ -38,7 +38,7 @@ namespace testing {
 const char* kErrorMessage = "This service caused an exception";
 
 #if GRPC_ALLOW_EXCEPTIONS
-class ExceptingServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class ExceptingServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   Status Echo(ServerContext* /*server_context*/, const EchoRequest* /*request*/,
               EchoResponse* /*response*/) override {

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -229,7 +229,7 @@ class GenericEnd2endTest : public ::testing::Test {
         switch (event) {
           case Event::kCallReceived:
             reader_writer.Finish(
-                ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "go away"),
+                grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "go away"),
                 reinterpret_cast<void*>(Event::kResponseSent));
             break;
 

--- a/test/cpp/end2end/grpc_authz_end2end_test.cc
+++ b/test/cpp/end2end/grpc_authz_end2end_test.cc
@@ -126,7 +126,7 @@ class GrpcAuthzEnd2EndTest : public ::testing::Test {
     ChannelArguments args;
     // Override target name for host name check
     args.SetSslTargetNameOverride("foo.test.google.fr");
-    return ::grpc::CreateCustomChannel(server_address_, channel_creds_, args);
+    return grpc::CreateCustomChannel(server_address_, channel_creds_, args);
   }
 
   grpc::Status SendRpc(const std::shared_ptr<Channel>& channel,

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -430,7 +430,7 @@ class GrpclbEnd2endTest : public ::testing::Test {
             channel_creds, call_creds, nullptr)));
     call_creds->Unref();
     channel_creds->Unref();
-    channel_ = ::grpc::CreateCustomChannel(uri.str(), creds, args);
+    channel_ = grpc::CreateCustomChannel(uri.str(), creds, args);
     stub_ = grpc::testing::EchoTestService::NewStub(channel_);
   }
 

--- a/test/cpp/end2end/health_service_end2end_test.cc
+++ b/test/cpp/end2end/health_service_end2end_test.cc
@@ -187,7 +187,7 @@ class HealthServiceEnd2endTest : public ::testing::Test {
     ClientContext context;
     HealthCheckRequest request;
     request.set_service(kServiceName);
-    std::unique_ptr<::grpc::ClientReaderInterface<HealthCheckResponse>> reader =
+    std::unique_ptr<grpc::ClientReaderInterface<HealthCheckResponse>> reader =
         hc_stub_->Watch(&context, request);
     // Initial response will be SERVICE_UNKNOWN.
     HealthCheckResponse response;
@@ -230,7 +230,7 @@ class HealthServiceEnd2endTest : public ::testing::Test {
     ClientContext context;
     HealthCheckRequest request;
     request.set_service(kHealthyService);
-    std::unique_ptr<::grpc::ClientReaderInterface<HealthCheckResponse>> reader =
+    std::unique_ptr<grpc::ClientReaderInterface<HealthCheckResponse>> reader =
         hc_stub_->Watch(&context, request);
 
     HealthCheckResponse response;

--- a/test/cpp/end2end/hybrid_end2end_test.cc
+++ b/test/cpp/end2end/hybrid_end2end_test.cc
@@ -217,7 +217,7 @@ void HandleGenericCall(AsyncGenericService* service,
 }
 
 class TestServiceImplDupPkg
-    : public ::grpc::testing::duplicate::EchoTestService::Service {
+    : public grpc::testing::duplicate::EchoTestService::Service {
  public:
   Status Echo(ServerContext* /*context*/, const EchoRequest* request,
               EchoResponse* response) override {
@@ -245,7 +245,7 @@ class HybridEnd2endTest : public ::testing::TestWithParam<bool> {
                   : false;
   }
 
-  bool SetUpServer(::grpc::Service* service1, ::grpc::Service* service2,
+  bool SetUpServer(grpc::Service* service1, grpc::Service* service2,
                    AsyncGenericService* generic_service,
                    CallbackGenericService* callback_generic_service,
                    int max_message_size = 0) {

--- a/test/cpp/end2end/message_allocator_end2end_test.cc
+++ b/test/cpp/end2end/message_allocator_end2end_test.cc
@@ -136,8 +136,8 @@ class MessageAllocatorEnd2endTestBase
         GetParam().credentials_type, &args);
     switch (GetParam().protocol) {
       case Protocol::TCP:
-        channel_ = ::grpc::CreateCustomChannel(server_address_.str(),
-                                               channel_creds, args);
+        channel_ = grpc::CreateCustomChannel(server_address_.str(),
+                                             channel_creds, args);
         break;
       case Protocol::INPROC:
         channel_ = server_->InProcessChannel(args);

--- a/test/cpp/end2end/mock_test.cc
+++ b/test/cpp/end2end/mock_test.cc
@@ -196,7 +196,7 @@ TEST_F(MockCallbackTest, MockedCallSucceedsWithWait) {
     grpc::internal::CondVar cv;
     absl::optional<grpc::Status> ABSL_GUARDED_BY(mu) status;
   } status;
-  DefaultReactorTestPeer peer(&ctx, [&](::grpc::Status s) {
+  DefaultReactorTestPeer peer(&ctx, [&](grpc::Status s) {
     grpc::internal::MutexLock l(&status.mu);
     status.status = std::move(s);
     status.cv.Signal();

--- a/test/cpp/end2end/raw_end2end_test.cc
+++ b/test/cpp/end2end/raw_end2end_test.cc
@@ -143,21 +143,21 @@ class RawEnd2EndTest : public ::testing::Test {
 
   // For the client application to populate and send to server.
   EchoRequest send_request_;
-  ::grpc::ByteBuffer send_request_buffer_;
+  grpc::ByteBuffer send_request_buffer_;
 
   // For the server to give to gRPC to be populated by incoming request
   // from client.
   EchoRequest recv_request_;
-  ::grpc::ByteBuffer recv_request_buffer_;
+  grpc::ByteBuffer recv_request_buffer_;
 
   // For the server application to populate and send back to client.
   EchoResponse send_response_;
-  ::grpc::ByteBuffer send_response_buffer_;
+  grpc::ByteBuffer send_response_buffer_;
 
   // For the client to give to gRPC to be populated by incoming response
   // from server.
   EchoResponse recv_response_;
-  ::grpc::ByteBuffer recv_response_buffer_;
+  grpc::ByteBuffer recv_response_buffer_;
   Status recv_status_;
 
   // Both sides need contexts

--- a/test/cpp/end2end/rls_end2end_test.cc
+++ b/test/cpp/end2end/rls_end2end_test.cc
@@ -90,9 +90,9 @@ using RlsService =
 
 class RlsServiceImpl : public RlsService {
  public:
-  ::grpc::Status RouteLookup(::grpc::ServerContext* context,
-                             const RouteLookupRequest* request,
-                             RouteLookupResponse* response) override {
+  grpc::Status RouteLookup(grpc::ServerContext* context,
+                           const RouteLookupRequest* request,
+                           RouteLookupResponse* response) override {
     gpr_log(GPR_INFO, "RLS: Received request: %s",
             request->DebugString().c_str());
     // RLS server should see call creds.
@@ -289,7 +289,7 @@ class RlsEnd2endTest : public ::testing::Test {
                                                   nullptr));
     call_creds->Unref();
     channel_creds->Unref();
-    channel_ = ::grpc::CreateCustomChannel(
+    channel_ = grpc::CreateCustomChannel(
         absl::StrCat("fake:///", kServerName).c_str(), std::move(creds), args);
     stub_ = grpc::testing::EchoTestService::NewStub(channel_);
   }

--- a/test/cpp/end2end/server_builder_plugin_test.cc
+++ b/test/cpp/end2end/server_builder_plugin_test.cc
@@ -126,7 +126,7 @@ std::unique_ptr<ServerBuilderPlugin> CreateTestServerBuilderPlugin() {
 // Force AddServerBuilderPlugin() to be called at static initialization time.
 struct StaticTestPluginInitializer {
   StaticTestPluginInitializer() {
-    ::grpc::ServerBuilder::InternalAddPluginFactory(
+    grpc::ServerBuilder::InternalAddPluginFactory(
         &CreateTestServerBuilderPlugin);
   }
 } static_plugin_initializer_test_;

--- a/test/cpp/end2end/server_crash_test.cc
+++ b/test/cpp/end2end/server_crash_test.cc
@@ -46,7 +46,7 @@ namespace testing {
 
 namespace {
 
-class ServiceImpl final : public ::grpc::testing::EchoTestService::Service {
+class ServiceImpl final : public grpc::testing::EchoTestService::Service {
  public:
   ServiceImpl() : bidi_stream_count_(0), response_stream_count_(0) {}
 

--- a/test/cpp/end2end/server_early_return_test.cc
+++ b/test/cpp/end2end/server_early_return_test.cc
@@ -44,7 +44,7 @@ const char kServerReturnStatusCode[] = "server_return_status_code";
 const char kServerDelayBeforeReturnUs[] = "server_delay_before_return_us";
 const char kServerReturnAfterNReads[] = "server_return_after_n_reads";
 
-class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class TestServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   // Unused methods are not implemented.
 

--- a/test/cpp/end2end/server_load_reporting_end2end_test.cc
+++ b/test/cpp/end2end/server_load_reporting_end2end_test.cc
@@ -61,7 +61,7 @@ class EchoTestServiceImpl : public EchoTestService::Service {
       return Status(StatusCode::FAILED_PRECONDITION, "Client error requested");
     }
     response->set_message(request->message());
-    ::grpc::load_reporter::experimental::AddLoadReportingCost(
+    grpc::load_reporter::experimental::AddLoadReportingCost(
         context, kMetricName, kMetricValue);
     return Status::OK;
   }
@@ -77,7 +77,7 @@ class ServerLoadReportingEnd2endTest : public ::testing::Test {
             .AddListeningPort(server_address_, InsecureServerCredentials())
             .RegisterService(&echo_service_)
             .SetOption(std::unique_ptr<::grpc::ServerBuilderOption>(
-                new ::grpc::load_reporter::experimental::
+                new grpc::load_reporter::experimental::
                     LoadReportingServiceServerBuilderOption()))
             .BuildAndStart();
     server_thread_ =
@@ -125,10 +125,10 @@ TEST_F(ServerLoadReportingEnd2endTest, NoCall) {}
 TEST_F(ServerLoadReportingEnd2endTest, BasicReport) {
   auto channel =
       grpc::CreateChannel(server_address_, InsecureChannelCredentials());
-  auto stub = ::grpc::lb::v1::LoadReporter::NewStub(channel);
+  auto stub = grpc::lb::v1::LoadReporter::NewStub(channel);
   ClientContext ctx;
   auto stream = stub->ReportLoad(&ctx);
-  ::grpc::lb::v1::LoadReportRequest request;
+  grpc::lb::v1::LoadReportRequest request;
   request.mutable_initial_request()->set_load_balanced_hostname(
       server_address_);
   request.mutable_initial_request()->set_load_key("LOAD_KEY");
@@ -137,7 +137,7 @@ TEST_F(ServerLoadReportingEnd2endTest, BasicReport) {
       ->set_seconds(5);
   stream->Write(request);
   gpr_log(GPR_INFO, "Initial request sent.");
-  ::grpc::lb::v1::LoadReportResponse response;
+  grpc::lb::v1::LoadReportResponse response;
   stream->Read(&response);
   const std::string& lb_id = response.initial_response().load_balancer_id();
   gpr_log(GPR_INFO, "Initial response received (lb_id: %s).", lb_id.c_str());

--- a/test/cpp/end2end/server_load_reporting_end2end_test.cc
+++ b/test/cpp/end2end/server_load_reporting_end2end_test.cc
@@ -76,7 +76,7 @@ class ServerLoadReportingEnd2endTest : public ::testing::Test {
         ServerBuilder()
             .AddListeningPort(server_address_, InsecureServerCredentials())
             .RegisterService(&echo_service_)
-            .SetOption(std::unique_ptr<::grpc::ServerBuilderOption>(
+            .SetOption(std::unique_ptr<grpc::ServerBuilderOption>(
                 new grpc::load_reporter::experimental::
                     LoadReportingServiceServerBuilderOption()))
             .BuildAndStart();

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -243,7 +243,7 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
     ChannelArguments args;
     args.SetPointer(GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR,
                     response_generator_.get());
-    return ::grpc::CreateCustomChannel("fake:///", creds_, args);
+    return grpc::CreateCustomChannel("fake:///", creds_, args);
   }
 
   std::shared_ptr<Channel> BuildChannelWithDefaultServiceConfig() {
@@ -254,7 +254,7 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
     args.SetServiceConfigJSON(ValidDefaultServiceConfig());
     args.SetPointer(GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR,
                     response_generator_.get());
-    return ::grpc::CreateCustomChannel("fake:///", creds_, args);
+    return grpc::CreateCustomChannel("fake:///", creds_, args);
   }
 
   std::shared_ptr<Channel> BuildChannelWithInvalidDefaultServiceConfig() {
@@ -265,7 +265,7 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
     args.SetServiceConfigJSON(InvalidDefaultServiceConfig());
     args.SetPointer(GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR,
                     response_generator_.get());
-    return ::grpc::CreateCustomChannel("fake:///", creds_, args);
+    return grpc::CreateCustomChannel("fake:///", creds_, args);
   }
 
   bool SendRpc(

--- a/test/cpp/end2end/shutdown_test.cc
+++ b/test/cpp/end2end/shutdown_test.cc
@@ -42,7 +42,7 @@ using grpc::testing::EchoResponse;
 namespace grpc {
 namespace testing {
 
-class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class TestServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   explicit TestServiceImpl(gpr_event* ev) : ev_(ev) {}
 
@@ -86,7 +86,7 @@ class ShutdownTest : public ::testing::TestWithParam<string> {
     ChannelArguments args;
     auto channel_creds =
         GetCredentialsProvider()->GetChannelCredentials(GetParam(), &args);
-    channel_ = ::grpc::CreateCustomChannel(target, channel_creds, args);
+    channel_ = grpc::CreateCustomChannel(target, channel_creds, args);
     stub_ = grpc::testing::EchoTestService::NewStub(channel_);
   }
 

--- a/test/cpp/end2end/streaming_throughput_test.cc
+++ b/test/cpp/end2end/streaming_throughput_test.cc
@@ -85,7 +85,7 @@ const char* kLargeString =
 namespace grpc {
 namespace testing {
 
-class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class TestServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   static void BidiStream_Sender(
       ServerReaderWriter<EchoResponse, EchoRequest>* stream,

--- a/test/cpp/end2end/test_health_check_service_impl.cc
+++ b/test/cpp/end2end/test_health_check_service_impl.cc
@@ -40,7 +40,7 @@ Status HealthCheckServiceImpl::Check(ServerContext* /*context*/,
 
 Status HealthCheckServiceImpl::Watch(
     ServerContext* context, const HealthCheckRequest* request,
-    ::grpc::ServerWriter<HealthCheckResponse>* writer) {
+    grpc::ServerWriter<HealthCheckResponse>* writer) {
   auto last_state = HealthCheckResponse::UNKNOWN;
   while (!context->IsCancelled()) {
     {
@@ -53,7 +53,7 @@ Status HealthCheckServiceImpl::Watch(
         response.set_status(iter->second);
       }
       if (response.status() != last_state) {
-        writer->Write(response, ::grpc::WriteOptions());
+        writer->Write(response, grpc::WriteOptions());
         last_state = response.status();
       }
     }

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -128,7 +128,7 @@ void ServerTryCancelNonblocking(CallbackServerContext* context) {
 ServerUnaryReactor* CallbackTestServiceImpl::Echo(
     CallbackServerContext* context, const EchoRequest* request,
     EchoResponse* response) {
-  class Reactor : public ::grpc::ServerUnaryReactor {
+  class Reactor : public grpc::ServerUnaryReactor {
    public:
     Reactor(CallbackTestServiceImpl* service, CallbackServerContext* ctx,
             const EchoRequest* request, EchoResponse* response)
@@ -323,7 +323,7 @@ ServerUnaryReactor* CallbackTestServiceImpl::Echo(
 
 ServerUnaryReactor* CallbackTestServiceImpl::CheckClientInitialMetadata(
     CallbackServerContext* context, const SimpleRequest*, SimpleResponse*) {
-  class Reactor : public ::grpc::ServerUnaryReactor {
+  class Reactor : public grpc::ServerUnaryReactor {
    public:
     explicit Reactor(CallbackServerContext* ctx) {
       EXPECT_EQ(internal::MetadataMatchCount(ctx->client_metadata(),
@@ -358,7 +358,7 @@ ServerReadReactor<EchoRequest>* CallbackTestServiceImpl::RequestStream(
     return nullptr;
   }
 
-  class Reactor : public ::grpc::ServerReadReactor<EchoRequest> {
+  class Reactor : public grpc::ServerReadReactor<EchoRequest> {
    public:
     Reactor(CallbackServerContext* ctx, EchoResponse* response,
             int server_try_cancel)
@@ -441,7 +441,7 @@ ServerWriteReactor<EchoResponse>* CallbackTestServiceImpl::ResponseStream(
     internal::ServerTryCancelNonblocking(context);
   }
 
-  class Reactor : public ::grpc::ServerWriteReactor<EchoResponse> {
+  class Reactor : public grpc::ServerWriteReactor<EchoResponse> {
    public:
     Reactor(CallbackServerContext* ctx, const EchoRequest* request,
             int server_try_cancel)
@@ -528,7 +528,7 @@ ServerWriteReactor<EchoResponse>* CallbackTestServiceImpl::ResponseStream(
 
 ServerBidiReactor<EchoRequest, EchoResponse>*
 CallbackTestServiceImpl::BidiStream(CallbackServerContext* context) {
-  class Reactor : public ::grpc::ServerBidiReactor<EchoRequest, EchoResponse> {
+  class Reactor : public grpc::ServerBidiReactor<EchoRequest, EchoResponse> {
    public:
     explicit Reactor(CallbackServerContext* ctx) : ctx_(ctx) {
       // If 'server_try_cancel' is set in the metadata, the RPC is cancelled by

--- a/test/cpp/end2end/test_service_impl.h
+++ b/test/cpp/end2end/test_service_impl.h
@@ -490,7 +490,7 @@ class CallbackTestServiceImpl
 };
 
 using TestServiceImpl =
-    TestMultipleServiceImpl<::grpc::testing::EchoTestService::Service>;
+    TestMultipleServiceImpl<grpc::testing::EchoTestService::Service>;
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/end2end/test_service_impl.h
+++ b/test/cpp/end2end/test_service_impl.h
@@ -451,7 +451,7 @@ class TestMultipleServiceImpl : public RpcService {
 };
 
 class CallbackTestServiceImpl
-    : public ::grpc::testing::EchoTestService::CallbackService {
+    : public grpc::testing::EchoTestService::CallbackService {
  public:
   CallbackTestServiceImpl() : signal_client_(false), host_() {}
   explicit CallbackTestServiceImpl(const std::string& host)

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -52,7 +52,7 @@ const int kNumRpcs = 1000;  // Number of RPCs per thread
 namespace grpc {
 namespace testing {
 
-class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class TestServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   TestServiceImpl() {}
 
@@ -256,7 +256,7 @@ class CommonStressTestAsyncServer : public BaseClass {
     enum { READY, DONE } state;
   };
   std::vector<Context> contexts_;
-  ::grpc::testing::EchoTestService::AsyncService service_;
+  grpc::testing::EchoTestService::AsyncService service_;
   std::unique_ptr<ServerCompletionQueue> cq_;
   bool shutting_down_;
   grpc::internal::Mutex mu_;

--- a/test/cpp/end2end/tls_key_export_test.cc
+++ b/test/cpp/end2end/tls_key_export_test.cc
@@ -60,16 +60,16 @@ namespace testing {
 namespace {
 
 class EchoServer final : public EchoTestService::Service {
-  ::grpc::Status Echo(::grpc::ServerContext* /*context*/,
-                      const EchoRequest* request,
-                      EchoResponse* response) override {
+  grpc::Status Echo(grpc::ServerContext* /*context*/,
+                    const EchoRequest* request,
+                    EchoResponse* response) override {
     if (request->param().expected_error().code() == 0) {
       response->set_message(request->message());
-      return ::grpc::Status::OK;
+      return grpc::Status::OK;
     } else {
-      return ::grpc::Status(static_cast<::grpc::StatusCode>(
-                                request->param().expected_error().code()),
-                            "");
+      return grpc::Status(static_cast<::grpc::StatusCode>(
+                              request->param().expected_error().code()),
+                          "");
     }
   }
 };
@@ -131,8 +131,8 @@ class TlsKeyLoggingEnd2EndTest : public ::testing::TestWithParam<TestScenario> {
   }
 
   void SetUp() override {
-    ::grpc::ServerBuilder builder;
-    ::grpc::ChannelArguments args;
+    grpc::ServerBuilder builder;
+    grpc::ChannelArguments args;
     args.SetSslTargetNameOverride("foo.test.google.com.au");
 
     if (GetParam().num_listening_ports() > 0) {
@@ -179,7 +179,7 @@ class TlsKeyLoggingEnd2EndTest : public ::testing::TestWithParam<TestScenario> {
 
       builder.AddListeningPort(
           "0.0.0.0:0",
-          ::grpc::experimental::TlsServerCredentials(server_creds_options),
+          grpc::experimental::TlsServerCredentials(server_creds_options),
           &ports_[i]);
     }
 
@@ -213,9 +213,9 @@ class TlsKeyLoggingEnd2EndTest : public ::testing::TestWithParam<TestScenario> {
             tmp_stub_tls_key_log_file_[i]);
       }
 
-      stubs_.push_back(EchoTestService::NewStub(::grpc::CreateCustomChannel(
+      stubs_.push_back(EchoTestService::NewStub(grpc::CreateCustomChannel(
           server_addresses_[i],
-          ::grpc::experimental::TlsCredentials(channel_creds_options), args)));
+          grpc::experimental::TlsCredentials(channel_creds_options), args)));
     }
   }
 
@@ -256,16 +256,16 @@ TEST_P(TlsKeyLoggingEnd2EndTest, KeyLogging) {
       request.set_message("foo");
       request.mutable_param()->mutable_expected_error()->set_code(0);
       EchoResponse response;
-      ::grpc::ClientContext context;
-      ::grpc::Status status = stubs_[j]->Echo(&context, request, &response);
+      grpc::ClientContext context;
+      grpc::Status status = stubs_[j]->Echo(&context, request, &response);
       EXPECT_TRUE(status.ok());
     }
   }
 
   for (int i = 0; i < GetParam().num_listening_ports(); i++) {
-    std::string server_key_log = ::grpc_core::testing::GetFileContents(
+    std::string server_key_log = grpc_core::testing::GetFileContents(
         tmp_server_tls_key_log_file_by_port_[i].c_str());
-    std::string channel_key_log = ::grpc_core::testing::GetFileContents(
+    std::string channel_key_log = grpc_core::testing::GetFileContents(
         tmp_stub_tls_key_log_file_[i].c_str());
 
     if (!GetParam().enable_tls_key_logging()) {

--- a/test/cpp/end2end/tls_key_export_test.cc
+++ b/test/cpp/end2end/tls_key_export_test.cc
@@ -67,7 +67,7 @@ class EchoServer final : public EchoTestService::Service {
       response->set_message(request->message());
       return grpc::Status::OK;
     } else {
-      return grpc::Status(static_cast<::grpc::StatusCode>(
+      return grpc::Status(static_cast<grpc::StatusCode>(
                               request->param().expected_error().code()),
                           "");
     }
@@ -244,7 +244,7 @@ class TlsKeyLoggingEnd2EndTest : public ::testing::TestWithParam<TestScenario> {
   std::vector<std::string> server_addresses_;
   std::vector<std::unique_ptr<EchoTestService::Stub>> stubs_;
   EchoServer service_;
-  std::unique_ptr<::grpc::Server> server_;
+  std::unique_ptr<grpc::Server> server_;
   std::thread server_thread_;
 };
 

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -1728,15 +1728,15 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
     explicit BackendServerThread(XdsEnd2endTest* test_obj)
         : ServerThread(test_obj, test_obj->use_xds_enabled_server_) {}
 
-    BackendServiceImpl<::grpc::testing::EchoTestService::Service>*
+    BackendServiceImpl<grpc::testing::EchoTestService::Service>*
     backend_service() {
       return &backend_service_;
     }
-    BackendServiceImpl<::grpc::testing::EchoTest1Service::Service>*
+    BackendServiceImpl<grpc::testing::EchoTest1Service::Service>*
     backend_service1() {
       return &backend_service1_;
     }
-    BackendServiceImpl<::grpc::testing::EchoTest2Service::Service>*
+    BackendServiceImpl<grpc::testing::EchoTest2Service::Service>*
     backend_service2() {
       return &backend_service2_;
     }
@@ -1789,11 +1789,11 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
 
     const char* Type() override { return "Backend"; }
 
-    BackendServiceImpl<::grpc::testing::EchoTestService::Service>
+    BackendServiceImpl<grpc::testing::EchoTestService::Service>
         backend_service_;
-    BackendServiceImpl<::grpc::testing::EchoTest1Service::Service>
+    BackendServiceImpl<grpc::testing::EchoTest1Service::Service>
         backend_service1_;
-    BackendServiceImpl<::grpc::testing::EchoTest2Service::Service>
+    BackendServiceImpl<grpc::testing::EchoTest2Service::Service>
         backend_service2_;
   };
 

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -939,7 +939,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
             ? XdsCredentials(CreateTlsFallbackCredentials())
             : std::make_shared<SecureChannelCredentials>(
                   grpc_fake_transport_security_credentials_create());
-    return ::grpc::CreateCustomChannel(uri, channel_creds, args);
+    return grpc::CreateCustomChannel(uri, channel_creds, args);
   }
 
   enum RpcService {
@@ -1686,8 +1686,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<TestType> {
     XdsServingStatusNotifier* notifier() { return &notifier_; }
 
    private:
-    class XdsChannelArgsServerBuilderOption
-        : public ::grpc::ServerBuilderOption {
+    class XdsChannelArgsServerBuilderOption : public grpc::ServerBuilderOption {
      public:
       explicit XdsChannelArgsServerBuilderOption(XdsEnd2endTest* test_obj)
           : test_obj_(test_obj) {}

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -72,7 +72,7 @@ class EchoServer final : public EchoTestService::Service {
       response->set_message(request->message());
       return grpc::Status::OK;
     } else {
-      return grpc::Status(static_cast<::grpc::StatusCode>(
+      return grpc::Status(static_cast<grpc::StatusCode>(
                               request->param().expected_error().code()),
                           "");
     }

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -55,9 +55,8 @@ const auto TEST_TAG_VALUE = "my_value";
 const char* kExpectedTraceIdKey = "expected_trace_id";
 
 class EchoServer final : public EchoTestService::Service {
-  ::grpc::Status Echo(::grpc::ServerContext* context,
-                      const EchoRequest* request,
-                      EchoResponse* response) override {
+  grpc::Status Echo(grpc::ServerContext* context, const EchoRequest* request,
+                    EchoResponse* response) override {
     for (const auto& metadata : context->client_metadata()) {
       if (metadata.first == kExpectedTraceIdKey) {
         EXPECT_EQ(metadata.second, reinterpret_cast<const grpc::CensusContext*>(
@@ -71,11 +70,11 @@ class EchoServer final : public EchoTestService::Service {
     }
     if (request->param().expected_error().code() == 0) {
       response->set_message(request->message());
-      return ::grpc::Status::OK;
+      return grpc::Status::OK;
     } else {
-      return ::grpc::Status(static_cast<::grpc::StatusCode>(
-                                request->param().expected_error().code()),
-                            "");
+      return grpc::Status(static_cast<::grpc::StatusCode>(
+                              request->param().expected_error().code()),
+                          "");
     }
   }
 };
@@ -87,10 +86,10 @@ class StatsPluginEnd2EndTest : public ::testing::Test {
   void SetUp() override {
     // Set up a synchronous server on a different thread to avoid the asynch
     // interface.
-    ::grpc::ServerBuilder builder;
+    grpc::ServerBuilder builder;
     int port;
     // Use IPv4 here because it's less flaky than IPv6 ("[::]:0") on Travis.
-    builder.AddListeningPort("0.0.0.0:0", ::grpc::InsecureServerCredentials(),
+    builder.AddListeningPort("0.0.0.0:0", grpc::InsecureServerCredentials(),
                              &port);
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();
@@ -99,8 +98,8 @@ class StatsPluginEnd2EndTest : public ::testing::Test {
     server_address_ = absl::StrCat("localhost:", port);
     server_thread_ = std::thread(&StatsPluginEnd2EndTest::RunServerLoop, this);
 
-    stub_ = EchoTestService::NewStub(::grpc::CreateChannel(
-        server_address_, ::grpc::InsecureChannelCredentials()));
+    stub_ = EchoTestService::NewStub(grpc::CreateChannel(
+        server_address_, grpc::InsecureChannelCredentials()));
   }
 
   void ResetStub(std::shared_ptr<Channel> channel) {
@@ -165,10 +164,10 @@ TEST_F(StatsPluginEnd2EndTest, ErrorCount) {
     request.set_message("foo");
     request.mutable_param()->mutable_expected_error()->set_code(i);
     EchoResponse response;
-    ::grpc::ClientContext context;
+    grpc::ClientContext context;
     {
       WithTagMap tags({{TEST_TAG_KEY, TEST_TAG_VALUE}});
-      ::grpc::Status status = stub_->Echo(&context, request, &response);
+      grpc::Status status = stub_->Echo(&context, request, &response);
     }
   }
   absl::SleepFor(absl::Milliseconds(500));
@@ -253,8 +252,8 @@ TEST_F(StatsPluginEnd2EndTest, RequestReceivedBytesPerRpc) {
     EchoRequest request;
     request.set_message("foo");
     EchoResponse response;
-    ::grpc::ClientContext context;
-    ::grpc::Status status = stub_->Echo(&context, request, &response);
+    grpc::ClientContext context;
+    grpc::Status status = stub_->Echo(&context, request, &response);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ("foo", response.message());
   }
@@ -297,8 +296,8 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
     EchoRequest request;
     request.set_message("foo");
     EchoResponse response;
-    ::grpc::ClientContext context;
-    ::grpc::Status status = stub_->Echo(&context, request, &response);
+    grpc::ClientContext context;
+    grpc::Status status = stub_->Echo(&context, request, &response);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ("foo", response.message());
   }
@@ -360,8 +359,8 @@ TEST_F(StatsPluginEnd2EndTest, CompletedRpcs) {
   const int count = 5;
   for (int i = 0; i < count; ++i) {
     {
-      ::grpc::ClientContext context;
-      ::grpc::Status status = stub_->Echo(&context, request, &response);
+      grpc::ClientContext context;
+      grpc::Status status = stub_->Echo(&context, request, &response);
       ASSERT_TRUE(status.ok());
       EXPECT_EQ("foo", response.message());
     }
@@ -394,8 +393,8 @@ TEST_F(StatsPluginEnd2EndTest, RequestReceivedMessagesPerRpc) {
   const int count = 5;
   for (int i = 0; i < count; ++i) {
     {
-      ::grpc::ClientContext context;
-      ::grpc::Status status = stub_->Echo(&context, request, &response);
+      grpc::ClientContext context;
+      grpc::Status status = stub_->Echo(&context, request, &response);
       ASSERT_TRUE(status.ok());
       EXPECT_EQ("foo", response.message());
     }
@@ -444,8 +443,8 @@ TEST_F(StatsPluginEnd2EndTest, TestRetryStatsWithoutAdditionalRetries) {
   const int count = 5;
   for (int i = 0; i < count; ++i) {
     {
-      ::grpc::ClientContext context;
-      ::grpc::Status status = stub_->Echo(&context, request, &response);
+      grpc::ClientContext context;
+      grpc::Status status = stub_->Echo(&context, request, &response);
       ASSERT_TRUE(status.ok());
       EXPECT_EQ("foo", response.message());
     }
@@ -500,8 +499,8 @@ TEST_F(StatsPluginEnd2EndTest, TestRetryStatsWithAdditionalRetries) {
   const int count = 5;
   for (int i = 0; i < count; ++i) {
     {
-      ::grpc::ClientContext context;
-      ::grpc::Status status = stub_->Echo(&context, request, &response);
+      grpc::ClientContext context;
+      grpc::Status status = stub_->Echo(&context, request, &response);
       EXPECT_EQ(status.error_code(), StatusCode::ABORTED);
     }
     absl::SleepFor(absl::Milliseconds(500));
@@ -537,14 +536,13 @@ TEST_F(StatsPluginEnd2EndTest, TestApplicationCensusContextFlows) {
   EchoRequest request;
   request.set_message("foo");
   EchoResponse response;
-  ::grpc::ClientContext context;
-  ::grpc::CensusContext app_census_context("root",
-                                           ::opencensus::tags::TagMap{});
+  grpc::ClientContext context;
+  grpc::CensusContext app_census_context("root", ::opencensus::tags::TagMap{});
   context.set_census_context(
       reinterpret_cast<census_context*>(&app_census_context));
   context.AddMetadata(kExpectedTraceIdKey,
                       app_census_context.Span().context().trace_id().ToHex());
-  ::grpc::Status status = stub_->Echo(&context, request, &response);
+  grpc::Status status = stub_->Echo(&context, request, &response);
   EXPECT_TRUE(status.ok());
 }
 

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -47,7 +47,7 @@ std::shared_ptr<Channel> CreateChannelForTestCase(
 
 class InteropClientContextInspector {
  public:
-  explicit InteropClientContextInspector(const ::grpc::ClientContext& context)
+  explicit InteropClientContextInspector(const grpc::ClientContext& context)
       : context_(context) {}
 
   // Inspector methods, able to peek inside ClientContext, follow.
@@ -63,7 +63,7 @@ class InteropClientContextInspector {
   }
 
  private:
-  const ::grpc::ClientContext& context_;
+  const grpc::ClientContext& context_;
 };
 
 class AdditionalMetadataInterceptor : public experimental::Interceptor {

--- a/test/cpp/interop/server_helper.cc
+++ b/test/cpp/interop/server_helper.cc
@@ -51,7 +51,7 @@ std::shared_ptr<ServerCredentials> CreateInteropServerCredentials() {
 }
 
 InteropServerContextInspector::InteropServerContextInspector(
-    const ::grpc::ServerContext& context)
+    const grpc::ServerContext& context)
     : context_(context) {}
 
 grpc_compression_algorithm

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -36,7 +36,7 @@ std::shared_ptr<ServerCredentials> CreateInteropServerCredentials();
 
 class InteropServerContextInspector {
  public:
-  explicit InteropServerContextInspector(const ::grpc::ServerContext& context);
+  explicit InteropServerContextInspector(const grpc::ServerContext& context);
 
   // Inspector methods, able to peek inside ServerContext, follow.
   std::shared_ptr<const AuthContext> GetAuthContext() const;
@@ -46,7 +46,7 @@ class InteropServerContextInspector {
   bool WasCompressed() const;
 
  private:
-  const ::grpc::ServerContext& context_;
+  const grpc::ServerContext& context_;
 };
 
 namespace interop {

--- a/test/cpp/microbenchmarks/bm_alarm.cc
+++ b/test/cpp/microbenchmarks/bm_alarm.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_arena.cc
+++ b/test/cpp/microbenchmarks/bm_arena.cc
@@ -75,7 +75,7 @@ void RunTheBenchmarksNamespaced() { RunSpecifiedBenchmarks(); }
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_byte_buffer.cc
+++ b/test/cpp/microbenchmarks/bm_byte_buffer.cc
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
 
   benchmark::RunTheBenchmarksNamespaced();
   return 0;

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -861,7 +861,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_callback_unary_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_callback_unary_ping_pong.cc
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_channel.cc
+++ b/test/cpp/microbenchmarks/bm_channel.cc
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -683,7 +683,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -682,7 +682,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -398,7 +398,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_cq.cc
+++ b/test/cpp/microbenchmarks/bm_cq.cc
@@ -319,7 +319,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
+++ b/test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
@@ -222,7 +222,7 @@ int main(int argc, char** argv) {
   gpr_mu_init(&g_mu);
   gpr_cv_init(&g_cv);
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_error.cc
+++ b/test/cpp/microbenchmarks/bm_error.cc
@@ -323,7 +323,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_fullstack_streaming_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_streaming_ping_pong.cc
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_fullstack_streaming_pump.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_streaming_pump.cc
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_fullstack_unary_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_unary_ping_pong.cc
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_pollset.cc
+++ b/test/cpp/microbenchmarks/bm_pollset.cc
@@ -262,7 +262,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_threadpool.cc
+++ b/test/cpp/microbenchmarks/bm_threadpool.cc
@@ -325,7 +325,7 @@ int main(int argc, char* argv[]) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/bm_timer.cc
+++ b/test/cpp/microbenchmarks/bm_timer.cc
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   LibraryInitializer libInit;
   ::benchmark::Initialize(&argc, argv);
-  ::grpc::testing::InitTest(&argc, &argv, false);
+  grpc::testing::InitTest(&argc, &argv, false);
   benchmark::RunTheBenchmarksNamespaced();
   return 0;
 }

--- a/test/cpp/microbenchmarks/callback_test_service.cc
+++ b/test/cpp/microbenchmarks/callback_test_service.cc
@@ -57,7 +57,7 @@ ServerUnaryReactor* CallbackStreamingTestService::Echo(
     response->set_message("");
   }
   auto* reactor = context->DefaultReactor();
-  reactor->Finish(::grpc::Status::OK);
+  reactor->Finish(grpc::Status::OK);
   return reactor;
 }
 
@@ -78,7 +78,7 @@ CallbackStreamingTestService::BidiStream(CallbackServerContext* context) {
     void OnReadDone(bool ok) override {
       if (!ok) {
         // Stream is over
-        Finish(::grpc::Status::OK);
+        Finish(grpc::Status::OK);
         finished_ = true;
         return;
       }

--- a/test/cpp/microbenchmarks/fullstack_fixtures.h
+++ b/test/cpp/microbenchmarks/fullstack_fixtures.h
@@ -77,8 +77,8 @@ class FullstackFixture : public BaseFixture {
     ChannelArguments args;
     config.ApplyCommonChannelArguments(&args);
     if (address.length() > 0) {
-      channel_ = ::grpc::CreateCustomChannel(
-          address, InsecureChannelCredentials(), args);
+      channel_ = grpc::CreateCustomChannel(address,
+                                           InsecureChannelCredentials(), args);
     } else {
       channel_ = server_->InProcessChannel(args);
     }
@@ -206,7 +206,7 @@ class EndpointPairFixture : public BaseFixture {
       grpc_chttp2_transport_start_reading(client_transport_, nullptr, nullptr,
                                           nullptr);
 
-      channel_ = ::grpc::CreateChannelInternal(
+      channel_ = grpc::CreateChannelInternal(
           "", channel,
           std::vector<std::unique_ptr<
               experimental::ClientInterceptorFactoryInterface>>());

--- a/test/cpp/performance/writes_per_rpc_test.cc
+++ b/test/cpp/performance/writes_per_rpc_test.cc
@@ -100,7 +100,7 @@ class EndpointPairFixture {
           "target", &c_args, GRPC_CLIENT_DIRECT_CHANNEL, transport, nullptr);
       grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
 
-      channel_ = ::grpc::CreateChannelInternal(
+      channel_ = grpc::CreateChannelInternal(
           "", channel,
           std::vector<std::unique_ptr<
               experimental::ClientInterceptorFactoryInterface>>());

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -33,26 +33,26 @@ namespace testing {
 class BenchmarkCallbackServiceImpl final
     : public BenchmarkService::CallbackService {
  public:
-  ::grpc::ServerUnaryReactor* UnaryCall(::grpc::CallbackServerContext* context,
-                                        const SimpleRequest* request,
-                                        SimpleResponse* response) override {
+  grpc::ServerUnaryReactor* UnaryCall(grpc::CallbackServerContext* context,
+                                      const SimpleRequest* request,
+                                      SimpleResponse* response) override {
     auto* reactor = context->DefaultReactor();
     reactor->Finish(SetResponse(request, response));
     return reactor;
   }
 
-  ::grpc::ServerBidiReactor<::grpc::testing::SimpleRequest,
-                            ::grpc::testing::SimpleResponse>*
-  StreamingCall(::grpc::CallbackServerContext*) override {
+  grpc::ServerBidiReactor<::grpc::testing::SimpleRequest,
+                          grpc::testing::SimpleResponse>*
+  StreamingCall(grpc::CallbackServerContext*) override {
     class Reactor
-        : public ::grpc::ServerBidiReactor<::grpc::testing::SimpleRequest,
-                                           ::grpc::testing::SimpleResponse> {
+        : public grpc::ServerBidiReactor<::grpc::testing::SimpleRequest,
+                                         grpc::testing::SimpleResponse> {
      public:
       Reactor() { StartRead(&request_); }
 
       void OnReadDone(bool ok) override {
         if (!ok) {
-          Finish(::grpc::Status::OK);
+          Finish(grpc::Status::OK);
           return;
         }
         auto s = SetResponse(&request_, &response_);
@@ -65,7 +65,7 @@ class BenchmarkCallbackServiceImpl final
 
       void OnWriteDone(bool ok) override {
         if (!ok) {
-          Finish(::grpc::Status::OK);
+          Finish(grpc::Status::OK);
           return;
         }
         StartRead(&request_);

--- a/test/cpp/qps/server_callback.cc
+++ b/test/cpp/qps/server_callback.cc
@@ -41,11 +41,11 @@ class BenchmarkCallbackServiceImpl final
     return reactor;
   }
 
-  grpc::ServerBidiReactor<::grpc::testing::SimpleRequest,
+  grpc::ServerBidiReactor<grpc::testing::SimpleRequest,
                           grpc::testing::SimpleResponse>*
   StreamingCall(grpc::CallbackServerContext*) override {
     class Reactor
-        : public grpc::ServerBidiReactor<::grpc::testing::SimpleRequest,
+        : public grpc::ServerBidiReactor<grpc::testing::SimpleRequest,
                                          grpc::testing::SimpleResponse> {
      public:
       Reactor() { StartRead(&request_); }

--- a/test/cpp/server/load_reporter/get_cpu_stats_test.cc
+++ b/test/cpp/server/load_reporter/get_cpu_stats_test.cc
@@ -31,10 +31,10 @@ namespace grpc {
 namespace testing {
 namespace {
 
-TEST(GetCpuStatsTest, ReadOnce) { ::grpc::load_reporter::GetCpuStatsImpl(); }
+TEST(GetCpuStatsTest, ReadOnce) { grpc::load_reporter::GetCpuStatsImpl(); }
 
 TEST(GetCpuStatsTest, BusyNoLargerThanTotal) {
-  auto p = ::grpc::load_reporter::GetCpuStatsImpl();
+  auto p = grpc::load_reporter::GetCpuStatsImpl();
   uint64_t busy = p.first;
   uint64_t total = p.second;
   ASSERT_LE(busy, total);
@@ -42,9 +42,9 @@ TEST(GetCpuStatsTest, BusyNoLargerThanTotal) {
 
 TEST(GetCpuStatsTest, Ascending) {
   const size_t kRuns = 100;
-  auto prev = ::grpc::load_reporter::GetCpuStatsImpl();
+  auto prev = grpc::load_reporter::GetCpuStatsImpl();
   for (size_t i = 0; i < kRuns; ++i) {
-    auto cur = ::grpc::load_reporter::GetCpuStatsImpl();
+    auto cur = grpc::load_reporter::GetCpuStatsImpl();
     ASSERT_LE(prev.first, cur.first);
     ASSERT_LE(prev.second, cur.second);
     prev = cur;

--- a/test/cpp/server/load_reporter/load_reporter_test.cc
+++ b/test/cpp/server/load_reporter/load_reporter_test.cc
@@ -125,12 +125,12 @@ class LoadReporterTest : public ::testing::Test {
  private:
   void SetUp() override {
     // Access the measures to make them valid.
-    ::grpc::load_reporter::MeasureStartCount();
-    ::grpc::load_reporter::MeasureEndCount();
-    ::grpc::load_reporter::MeasureEndBytesSent();
-    ::grpc::load_reporter::MeasureEndBytesReceived();
-    ::grpc::load_reporter::MeasureEndLatencyMs();
-    ::grpc::load_reporter::MeasureOtherCallMetric();
+    grpc::load_reporter::MeasureStartCount();
+    grpc::load_reporter::MeasureEndCount();
+    grpc::load_reporter::MeasureEndBytesSent();
+    grpc::load_reporter::MeasureEndBytesReceived();
+    grpc::load_reporter::MeasureEndLatencyMs();
+    grpc::load_reporter::MeasureOtherCallMetric();
     // Set up the load reporter.
     auto mock_cpu = new MockCpuStatsProvider();
     auto mock_census = new MockCensusViewProvider();
@@ -189,7 +189,7 @@ TEST_F(LbFeedbackTest, ZeroDuration) {
   PrepareCpuExpectation(kCpuStatsSamples.size());
   EXPECT_CALL(*mock_census_view_provider(), FetchViewData())
       .WillRepeatedly(
-          Return(::grpc::load_reporter::CensusViewProvider::ViewDataMap()));
+          Return(grpc::load_reporter::CensusViewProvider::ViewDataMap()));
   // Verify that divide-by-zero exception doesn't happen.
   for (size_t i = 0; i < kCpuStatsSamples.size(); ++i) {
     load_reporter_->FetchAndSample();
@@ -209,54 +209,54 @@ TEST_F(LbFeedbackTest, Normal) {
     double ok_count_2 = ok_count - ok_count_1;
     auto end_count_vd = ::opencensus::stats::testing::TestUtils::MakeViewData(
         mock_census_view_provider()->FindViewDescriptor(
-            ::grpc::load_reporter::kViewEndCount),
+            grpc::load_reporter::kViewEndCount),
         {{{kClientIp0 + kLbToken1, kHostname1, kUser1,
-           ::grpc::load_reporter::kCallStatusOk},
+           grpc::load_reporter::kCallStatusOk},
           ok_count_1},
          {{kClientIp0 + kLbToken1, kHostname1, kUser2,
-           ::grpc::load_reporter::kCallStatusOk},
+           grpc::load_reporter::kCallStatusOk},
           ok_count_2},
          {{kClientIp0 + kLbToken1, kHostname1, kUser1,
-           ::grpc::load_reporter::kCallStatusClientError},
+           grpc::load_reporter::kCallStatusClientError},
           error_count}});
     // Values for other view data don't matter.
     auto end_bytes_sent_vd =
         ::opencensus::stats::testing::TestUtils::MakeViewData(
             mock_census_view_provider()->FindViewDescriptor(
-                ::grpc::load_reporter::kViewEndBytesSent),
+                grpc::load_reporter::kViewEndBytesSent),
             {{{kClientIp0 + kLbToken1, kHostname1, kUser1,
-               ::grpc::load_reporter::kCallStatusOk},
+               grpc::load_reporter::kCallStatusOk},
               0},
              {{kClientIp0 + kLbToken1, kHostname1, kUser2,
-               ::grpc::load_reporter::kCallStatusOk},
+               grpc::load_reporter::kCallStatusOk},
               0},
              {{kClientIp0 + kLbToken1, kHostname1, kUser1,
-               ::grpc::load_reporter::kCallStatusClientError},
+               grpc::load_reporter::kCallStatusClientError},
               0}});
     auto end_bytes_received_vd =
         ::opencensus::stats::testing::TestUtils::MakeViewData(
             mock_census_view_provider()->FindViewDescriptor(
-                ::grpc::load_reporter::kViewEndBytesReceived),
+                grpc::load_reporter::kViewEndBytesReceived),
             {{{kClientIp0 + kLbToken1, kHostname1, kUser1,
-               ::grpc::load_reporter::kCallStatusOk},
+               grpc::load_reporter::kCallStatusOk},
               0},
              {{kClientIp0 + kLbToken1, kHostname1, kUser2,
-               ::grpc::load_reporter::kCallStatusOk},
+               grpc::load_reporter::kCallStatusOk},
               0},
              {{kClientIp0 + kLbToken1, kHostname1, kUser1,
-               ::grpc::load_reporter::kCallStatusClientError},
+               grpc::load_reporter::kCallStatusClientError},
               0}});
     auto end_latency_vd = ::opencensus::stats::testing::TestUtils::MakeViewData(
         mock_census_view_provider()->FindViewDescriptor(
-            ::grpc::load_reporter::kViewEndLatencyMs),
+            grpc::load_reporter::kViewEndLatencyMs),
         {{{kClientIp0 + kLbToken1, kHostname1, kUser1,
-           ::grpc::load_reporter::kCallStatusOk},
+           grpc::load_reporter::kCallStatusOk},
           0},
          {{kClientIp0 + kLbToken1, kHostname1, kUser2,
-           ::grpc::load_reporter::kCallStatusOk},
+           grpc::load_reporter::kCallStatusOk},
           0},
          {{kClientIp0 + kLbToken1, kHostname1, kUser1,
-           ::grpc::load_reporter::kCallStatusClientError},
+           grpc::load_reporter::kCallStatusClientError},
           0}});
     view_data_map_list.push_back(
         {{::grpc::load_reporter::kViewEndCount, end_count_vd},
@@ -306,10 +306,10 @@ TEST_F(LoadReportTest, BasicReport) {
   // Make up the first view data map.
   CensusViewProvider::ViewDataMap vdm1;
   vdm1.emplace(
-      ::grpc::load_reporter::kViewStartCount,
+      grpc::load_reporter::kViewStartCount,
       ::opencensus::stats::testing::TestUtils::MakeViewData(
           mock_census_view_provider()->FindViewDescriptor(
-              ::grpc::load_reporter::kViewStartCount),
+              grpc::load_reporter::kViewStartCount),
           {{{kClientIp1 + kLbToken1, kHostname1, kUser1}, 1234},
            {{kClientIp2 + kLbToken1, kHostname1, kUser1}, 1225},
            {{kClientIp0 + kLbToken1, kHostname1, kUser1}, 10},
@@ -317,96 +317,96 @@ TEST_F(LoadReportTest, BasicReport) {
            {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3}, 101},
            {{kClientIp1 + kLbToken2, kHostname2, kUser3}, 17},
            {{kClientIp2 + kLbId3 + kLbTag2, kHostname2, kUser3}, 23}}));
-  vdm1.emplace(::grpc::load_reporter::kViewEndCount,
+  vdm1.emplace(grpc::load_reporter::kViewEndCount,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndCount),
+                       grpc::load_reporter::kViewEndCount),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      641},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      272},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      996},
                     {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      34},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      18}}));
-  vdm1.emplace(::grpc::load_reporter::kViewEndBytesSent,
+  vdm1.emplace(grpc::load_reporter::kViewEndBytesSent,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndBytesSent),
+                       grpc::load_reporter::kViewEndBytesSent),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      8977},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      266},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      1276},
                     {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      77823},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      48}}));
-  vdm1.emplace(::grpc::load_reporter::kViewEndBytesReceived,
+  vdm1.emplace(grpc::load_reporter::kViewEndBytesReceived,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndBytesReceived),
+                       grpc::load_reporter::kViewEndBytesReceived),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      2341},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      466},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      518},
                     {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      81},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      27}}));
-  vdm1.emplace(::grpc::load_reporter::kViewEndLatencyMs,
+  vdm1.emplace(grpc::load_reporter::kViewEndLatencyMs,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndLatencyMs),
+                       grpc::load_reporter::kViewEndLatencyMs),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      3.14},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      5.26},
                     {{kClientIp2 + kLbToken1, kHostname1, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      45.4},
                     {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      4.4},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser2,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      2348.0}}));
   vdm1.emplace(
-      ::grpc::load_reporter::kViewOtherCallMetricCount,
+      grpc::load_reporter::kViewOtherCallMetricCount,
       ::opencensus::stats::testing::TestUtils::MakeViewData(
           mock_census_view_provider()->FindViewDescriptor(
-              ::grpc::load_reporter::kViewOtherCallMetricCount),
+              grpc::load_reporter::kViewOtherCallMetricCount),
           {{{kClientIp1 + kLbToken1, kHostname1, kUser2, kMetric1}, 1},
            {{kClientIp1 + kLbToken1, kHostname1, kUser2, kMetric1}, 1},
            {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3, kMetric2},
             1}}));
   vdm1.emplace(
-      ::grpc::load_reporter::kViewOtherCallMetricValue,
+      grpc::load_reporter::kViewOtherCallMetricValue,
       ::opencensus::stats::testing::TestUtils::MakeViewData(
           mock_census_view_provider()->FindViewDescriptor(
-              ::grpc::load_reporter::kViewOtherCallMetricValue),
+              grpc::load_reporter::kViewOtherCallMetricValue),
           {{{kClientIp1 + kLbToken1, kHostname1, kUser2, kMetric1}, 1.2},
            {{kClientIp1 + kLbToken1, kHostname1, kUser2, kMetric1}, 1.2},
            {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3, kMetric2},
@@ -414,65 +414,65 @@ TEST_F(LoadReportTest, BasicReport) {
   // Make up the second view data map.
   CensusViewProvider::ViewDataMap vdm2;
   vdm2.emplace(
-      ::grpc::load_reporter::kViewStartCount,
+      grpc::load_reporter::kViewStartCount,
       ::opencensus::stats::testing::TestUtils::MakeViewData(
           mock_census_view_provider()->FindViewDescriptor(
-              ::grpc::load_reporter::kViewStartCount),
+              grpc::load_reporter::kViewStartCount),
           {{{kClientIp2 + kLbToken1, kHostname1, kUser1}, 3},
            {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3}, 778}}));
-  vdm2.emplace(::grpc::load_reporter::kViewEndCount,
+  vdm2.emplace(grpc::load_reporter::kViewEndCount,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndCount),
+                       grpc::load_reporter::kViewEndCount),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      24},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      546}}));
-  vdm2.emplace(::grpc::load_reporter::kViewEndBytesSent,
+  vdm2.emplace(grpc::load_reporter::kViewEndBytesSent,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndBytesSent),
+                       grpc::load_reporter::kViewEndBytesSent),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      747},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      229}}));
-  vdm2.emplace(::grpc::load_reporter::kViewEndBytesReceived,
+  vdm2.emplace(grpc::load_reporter::kViewEndBytesReceived,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndBytesReceived),
+                       grpc::load_reporter::kViewEndBytesReceived),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      173},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      438}}));
-  vdm2.emplace(::grpc::load_reporter::kViewEndLatencyMs,
+  vdm2.emplace(grpc::load_reporter::kViewEndLatencyMs,
                ::opencensus::stats::testing::TestUtils::MakeViewData(
                    mock_census_view_provider()->FindViewDescriptor(
-                       ::grpc::load_reporter::kViewEndLatencyMs),
+                       grpc::load_reporter::kViewEndLatencyMs),
                    {{{kClientIp1 + kLbToken1, kHostname1, kUser1,
-                      ::grpc::load_reporter::kCallStatusOk},
+                      grpc::load_reporter::kCallStatusOk},
                      187},
                     {{kClientIp1 + kLbToken2, kHostname2, kUser3,
-                      ::grpc::load_reporter::kCallStatusClientError},
+                      grpc::load_reporter::kCallStatusClientError},
                      34}}));
   vdm2.emplace(
-      ::grpc::load_reporter::kViewOtherCallMetricCount,
+      grpc::load_reporter::kViewOtherCallMetricCount,
       ::opencensus::stats::testing::TestUtils::MakeViewData(
           mock_census_view_provider()->FindViewDescriptor(
-              ::grpc::load_reporter::kViewOtherCallMetricCount),
+              grpc::load_reporter::kViewOtherCallMetricCount),
           {{{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3, kMetric1}, 1},
            {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3, kMetric2},
             1}}));
   vdm2.emplace(
-      ::grpc::load_reporter::kViewOtherCallMetricValue,
+      grpc::load_reporter::kViewOtherCallMetricValue,
       ::opencensus::stats::testing::TestUtils::MakeViewData(
           mock_census_view_provider()->FindViewDescriptor(
-              ::grpc::load_reporter::kViewOtherCallMetricValue),
+              grpc::load_reporter::kViewOtherCallMetricValue),
           {{{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3, kMetric1}, 9.6},
            {{kClientIp1 + kLbId2 + kLbTag1, kHostname2, kUser3, kMetric2},
             5.7}}));

--- a/test/cpp/server/server_request_call_test.cc
+++ b/test/cpp/server/server_request_call_test.cc
@@ -130,7 +130,7 @@ TEST(ServerRequestCallTest, ShortDeadlineDoesNotCauseOkayFalse) {
     // deadline, whether due to the sleep or because the server was unable to
     // even fetch the request from the CQ before the deadline elapsed.
     testing::EchoResponse response;
-    ::grpc::ClientContext ctx;
+    grpc::ClientContext ctx;
     ctx.set_fail_fast(false);
     ctx.set_deadline(std::chrono::system_clock::now() +
                      std::chrono::milliseconds(1));

--- a/test/cpp/util/byte_buffer_proto_helper.h
+++ b/test/cpp/util/byte_buffer_proto_helper.h
@@ -27,13 +27,12 @@
 namespace grpc {
 namespace testing {
 
-bool ParseFromByteBuffer(ByteBuffer* buffer,
-                         ::grpc::protobuf::Message* message);
+bool ParseFromByteBuffer(ByteBuffer* buffer, grpc::protobuf::Message* message);
 
 std::unique_ptr<ByteBuffer> SerializeToByteBuffer(
-    ::grpc::protobuf::Message* message);
+    grpc::protobuf::Message* message);
 
-bool SerializeToByteBufferInPlace(::grpc::protobuf::Message* message,
+bool SerializeToByteBufferInPlace(grpc::protobuf::Message* message,
                                   ByteBuffer* buffer);
 
 }  // namespace testing

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -67,7 +67,7 @@ std::string output_json("output.json");
 
 // Creata an echo server
 class EchoServerImpl final : public grpc::testing::TestService::Service {
-  Status EmptyCall(::grpc::ServerContext* /*context*/,
+  Status EmptyCall(grpc::ServerContext* /*context*/,
                    const grpc::testing::Empty* /*request*/,
                    grpc::testing::Empty* /*response*/) override {
     return Status::OK;
@@ -114,7 +114,7 @@ bool WaitForConnection(int wait_server_seconds) {
 // Test the channelz sampler
 TEST(ChannelzSamplerTest, SimpleTest) {
   // start server
-  ::grpc::channelz::experimental::InitChannelzService();
+  grpc::channelz::experimental::InitChannelzService();
   EchoServerImpl service;
   grpc::ServerBuilder builder;
   auto server_creds =

--- a/test/cpp/util/cli_call_test.cc
+++ b/test/cpp/util/cli_call_test.cc
@@ -39,7 +39,7 @@ using grpc::testing::EchoResponse;
 namespace grpc {
 namespace testing {
 
-class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class TestServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   Status Echo(ServerContext* context, const EchoRequest* request,
               EchoResponse* response) override {

--- a/test/cpp/util/create_test_channel.cc
+++ b/test/cpp/util/create_test_channel.cc
@@ -138,7 +138,7 @@ std::shared_ptr<Channel> CreateTestChannel(
   if (creds.get()) {
     channel_creds = grpc::CompositeChannelCredentials(channel_creds, creds);
   }
-  return ::grpc::CreateCustomChannel(server, channel_creds, channel_args);
+  return grpc::CreateCustomChannel(server, channel_creds, channel_args);
 }
 
 std::shared_ptr<Channel> CreateTestChannel(
@@ -153,8 +153,8 @@ std::shared_ptr<Channel> CreateTestChannel(
   std::shared_ptr<ChannelCredentials> channel_creds;
   if (cred_type.empty()) {
     if (interceptor_creators.empty()) {
-      return ::grpc::CreateCustomChannel(server, InsecureChannelCredentials(),
-                                         channel_args);
+      return grpc::CreateCustomChannel(server, InsecureChannelCredentials(),
+                                       channel_args);
     } else {
       return experimental::CreateCustomChannelWithInterceptors(
           server, InsecureChannelCredentials(), channel_args,
@@ -180,8 +180,7 @@ std::shared_ptr<Channel> CreateTestChannel(
       channel_creds = grpc::CompositeChannelCredentials(channel_creds, creds);
     }
     if (interceptor_creators.empty()) {
-      return ::grpc::CreateCustomChannel(connect_to, channel_creds,
-                                         channel_args);
+      return grpc::CreateCustomChannel(connect_to, channel_creds, channel_args);
     } else {
       return experimental::CreateCustomChannelWithInterceptors(
           connect_to, channel_creds, channel_args,
@@ -193,7 +192,7 @@ std::shared_ptr<Channel> CreateTestChannel(
     GPR_ASSERT(channel_creds != nullptr);
 
     if (interceptor_creators.empty()) {
-      return ::grpc::CreateCustomChannel(server, channel_creds, channel_args);
+      return grpc::CreateCustomChannel(server, channel_creds, channel_args);
     } else {
       return experimental::CreateCustomChannelWithInterceptors(
           server, channel_creds, channel_args, std::move(interceptor_creators));

--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -240,8 +240,7 @@ std::shared_ptr<grpc::Channel> CreateCliChannel(
   // See |GRPC_ARG_MAX_METADATA_SIZE| in |grpc_types.h|.
   // Set to large enough size (10M) that should work for most use cases.
   args.SetInt(GRPC_ARG_MAX_METADATA_SIZE, 10 * 1024 * 1024);
-  return ::grpc::CreateCustomChannel(server_address, cred.GetCredentials(),
-                                     args);
+  return grpc::CreateCustomChannel(server_address, cred.GetCredentials(), args);
 }
 
 struct Command {

--- a/test/cpp/util/grpc_tool_test.cc
+++ b/test/cpp/util/grpc_tool_test.cc
@@ -173,7 +173,7 @@ size_t ArraySize(T& a) {
           static_cast<size_t>(!(sizeof(a) % sizeof(*(a)))));
 }
 
-class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
+class TestServiceImpl : public grpc::testing::EchoTestService::Service {
  public:
   Status Echo(ServerContext* context, const EchoRequest* request,
               EchoResponse* response) override {

--- a/test/cpp/util/tls_test_utils.h
+++ b/test/cpp/util/tls_test_utils.h
@@ -29,41 +29,41 @@ namespace grpc {
 namespace testing {
 
 class SyncCertificateVerifier
-    : public ::grpc::experimental::ExternalCertificateVerifier {
+    : public grpc::experimental::ExternalCertificateVerifier {
  public:
   explicit SyncCertificateVerifier(bool success) : success_(success) {}
 
   ~SyncCertificateVerifier() override {}
 
-  bool Verify(::grpc::experimental::TlsCustomVerificationCheckRequest* request,
+  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
               std::function<void(grpc::Status)> callback,
               grpc::Status* sync_status) override;
 
-  void Cancel(
-      ::grpc::experimental::TlsCustomVerificationCheckRequest*) override {}
+  void Cancel(grpc::experimental::TlsCustomVerificationCheckRequest*) override {
+  }
 
  private:
   bool success_ = false;
 };
 
 class AsyncCertificateVerifier
-    : public ::grpc::experimental::ExternalCertificateVerifier {
+    : public grpc::experimental::ExternalCertificateVerifier {
  public:
   explicit AsyncCertificateVerifier(bool success);
 
   ~AsyncCertificateVerifier() override;
 
-  bool Verify(::grpc::experimental::TlsCustomVerificationCheckRequest* request,
+  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
               std::function<void(grpc::Status)> callback,
               grpc::Status* sync_status) override;
 
-  void Cancel(
-      ::grpc::experimental::TlsCustomVerificationCheckRequest*) override {}
+  void Cancel(grpc::experimental::TlsCustomVerificationCheckRequest*) override {
+  }
 
  private:
   // A request to pass to the worker thread.
   struct Request {
-    ::grpc::experimental::TlsCustomVerificationCheckRequest* request;
+    grpc::experimental::TlsCustomVerificationCheckRequest* request;
     std::function<void(grpc::Status)> callback;
     bool shutdown;  // If true, thread will exit.
   };

--- a/tools/distrib/check_namespace_qualification.py
+++ b/tools/distrib/check_namespace_qualification.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import os.path
+import re
+import subprocess
+import sys
+
+# TODO(hork): dedupe args/load/validate/save code with other check scripts.
+
+
+def load(fpath):
+    with open(fpath, 'r') as f:
+        return f.readlines()
+
+
+def save(fpath, contents):
+    with open(fpath, 'w') as f:
+        f.write(contents)
+
+
+class QualificationValidator(object):
+
+    def __init__(self):
+        self.fully_qualified_re = re.compile(r'([ (])::(grpc[A-Za-z_:])')
+        self.using_re = re.compile(
+            r'(using +|using +[A-Za-z_]+ *= *|namespace [A-Za-z_]+ *= *)::')
+        self.define_re = re.compile(r'^#define')
+
+    def check(self, fpath, fix):
+        fcontents = load(fpath)
+        failed = False
+        for (i, line) in enumerate(fcontents):
+            if not self.fully_qualified_re.search(line):
+                continue
+            # skip `using` statements
+            if self.using_re.search(line):
+                continue
+            # skip `#define` statements
+            if self.define_re.search(line):
+                continue
+            # fully-qualified namespace found, which may be unnecessary
+            if fix:
+                fcontents[i] = self.fully_qualified_re.sub(r'\1\2', line)
+            else:
+                print("Found in %s:%d - %s" % (fpath, i, line.strip()))
+                failed = True
+        if fix:
+            save(fpath, ''.join(fcontents))
+        return not failed
+
+
+IGNORED_FILES = [
+    # TODO(hork): rename symbols to avoid the need for fully-qualified names
+    "src/cpp/common/core_codegen.cc",
+    # TODO(hork): This could be a breaking change for users that define their
+    # own (possibly nested) `grpc.*` namespaces that contain conflicting
+    # symbols. It may be worth trying to land this change at some point, as
+    # users would be better off using unique namespaces.
+    "src/compiler/cpp_generator.cc",
+    # multi-line #define statements are not handled
+    "src/core/lib/gprpp/global_config_env.h",
+    "src/core/lib/profiling/timers.h",
+]
+
+# find our home
+ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '../..'))
+os.chdir(ROOT)
+
+# parse command line
+argp = argparse.ArgumentParser(
+    description='c++ namespace full qualification checker')
+argp.add_argument('-f', '--fix', default=False, action='store_true')
+argp.add_argument('--precommit', default=False, action='store_true')
+args = argp.parse_args()
+
+grep_filter = r"grep -E '^(include|src|test).*\.(h|cc)$'"
+if args.precommit:
+    git_command = 'git diff --name-only HEAD'
+else:
+    git_command = 'git ls-tree -r --name-only -r HEAD'
+
+FILE_LIST_COMMAND = ' | '.join((git_command, grep_filter))
+
+# scan files
+ok = True
+filename_list = []
+try:
+    filename_list = subprocess.check_output(FILE_LIST_COMMAND,
+                                            shell=True).decode().splitlines()
+    # Filter out non-existent files (ie, file removed or renamed)
+    filename_list = (f for f in filename_list if os.path.isfile(f))
+except subprocess.CalledProcessError:
+    sys.exit(0)
+
+validator = QualificationValidator()
+
+for filename in filename_list:
+    # Skip check for upb generated code and ignored files.
+    if (filename.endswith('.upb.h') or filename.endswith('.upb.c') or
+            filename.endswith('.upbdefs.h') or
+            filename.endswith('.upbdefs.c') or filename in IGNORED_FILES):
+        continue
+    ok = validator.check(filename, args.fix) and ok
+
+sys.exit(0 if ok else 1)

--- a/tools/distrib/check_namespace_qualification.py
+++ b/tools/distrib/check_namespace_qualification.py
@@ -37,7 +37,7 @@ def save(fpath, contents):
 class QualificationValidator(object):
 
     def __init__(self):
-        self.fully_qualified_re = re.compile(r'([ (])::(grpc[A-Za-z_:])')
+        self.fully_qualified_re = re.compile(r'([ (<])::(grpc[A-Za-z_:])')
         self.using_re = re.compile(
             r'(using +|using +[A-Za-z_]+ *= *|namespace [A-Za-z_]+ *= *)::')
         self.define_re = re.compile(r'^#define')

--- a/tools/distrib/check_redundant_namespace_qualifiers.py
+++ b/tools/distrib/check_redundant_namespace_qualifiers.py
@@ -62,6 +62,14 @@ def find_closing_mustache(contents, initial_depth):
     return None
 
 
+def is_a_define_statement(match, body):
+    """See if the matching line begins with #define"""
+    # This does not yet help with multi-line defines
+    m = re.search(r"^#define.*{}$".format(match.group(0)), body[:match.end()],
+                  re.MULTILINE)
+    return m is not None
+
+
 def update_file(contents, namespaces):
     """Scan the contents of a file, and for top-level namespaces in namespaces remove redundant usages."""
     output = ''
@@ -87,8 +95,11 @@ def update_file(contents, namespaces):
                 m = re.search(r'\b' + namespace + r'::\b', body)
                 if not m:
                     break
-                # But ignore instances of '::namespace::' -- these are usually meant to be there.
+                # Ignore instances of '::namespace::' -- these are usually meant to be there.
                 if m.start() >= 2 and body[m.start() - 2:].startswith('::'):
+                    output += body[:m.end()]
+                # Ignore #defines, since they may be used anywhere
+                elif is_a_define_statement(m, body):
                     output += body[:m.end()]
                 else:
                     output += body[:m.start()]

--- a/tools/distrib/sanitize.sh
+++ b/tools/distrib/sanitize.sh
@@ -25,9 +25,9 @@ tools/distrib/add-iwyu.py
 tools/distrib/check_trailing_newlines.sh --fix
 tools/run_tests/sanity/check_port_platform.py --fix
 tools/run_tests/sanity/check_include_style.py --fix || true
+tools/distrib/check_namespace_qualification.py --fix
 tools/distrib/yapf_code.sh
 tools/distrib/isort_code.sh
 tools/distrib/clang_format_code.sh
 tools/distrib/buildifier_format_code_strict.sh || true
 tools/distrib/check_redundant_namespace_qualifiers.py || true
-tools/distrib/check_namespace_qualification.py --fix

--- a/tools/distrib/sanitize.sh
+++ b/tools/distrib/sanitize.sh
@@ -30,4 +30,4 @@ tools/distrib/isort_code.sh
 tools/distrib/clang_format_code.sh
 tools/distrib/buildifier_format_code_strict.sh || true
 tools/distrib/check_redundant_namespace_qualifiers.py || true
-
+tools/distrib/check_namespace_qualification.py --fix

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -42,4 +42,4 @@
 - script: tools/distrib/check_boringssl_prefix_symbol.sh
 - script: tools/run_tests/sanity/build_banned_constructs.sh
 - script: tools/distrib/check_redundant_namespace_qualifiers.py
-
+- script: tools/distrib/check_namespace_qualification.py


### PR DESCRIPTION
See  #28901. Fixes #define statement problems.