### PR TITLE
Fix Ruby xDS v3 Interop docker image

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_v3_ruby.sh
+++ b/tools/internal_ci/linux/grpc_xds_v3_ruby.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-export DOCKERFILE_DIR=tools/dockerfile/test/ruby_buster_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/ruby_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_v3_ruby_test_in_docker.sh
 export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh


### PR DESCRIPTION
Same as #28859, but for xDS v3.


