### PR TITLE
Update Ruby readme to list Ruby 3.x support

### DIFF
--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -7,7 +7,7 @@ A Ruby implementation of gRPC.
 PREREQUISITES
 -------------
 
-- Ruby 2.x. The gRPC API uses keyword args.
+- Ruby 2.x or 3.x
 
 INSTALLATION
 ---------------


### PR DESCRIPTION
grpc works Ruby 3.x along with Ruby 2.x

Ruby 3.0 was released in December 2020 and is seeing increased adoption
in the community.

I am also happy to say "Ruby 2.x or higher", but I thought that explicitly including 3.x was more clear. 

My understanding of the keyword args comment is that it was explaining why grpc will not work with Ruby 1.x. That is less relevant now that fewer people are using Ruby 1.x. (Support for Ruby 1.x ended in 2015)

Sadly, I don't think I can add the `area/documentation` and `lang/ruby` labels that this seems to need.
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
