### PR TITLE
Make repo for patch file explicit

### DIFF
--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -54,7 +54,7 @@ def grpc_python_deps():
             name = "io_bazel_rules_python",
             url = "https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz",
             sha256 = "954aa89b491be4a083304a2cb838019c8b8c3720a7abb9c4cb81ac7a24230cea",
-            patches = ["//third_party:rules_python.patch"],
+            patches = ["@com_github_grpc_grpc//third_party:rules_python.patch"],
             patch_args = ["-p1"],
         )
 


### PR DESCRIPTION
[This comment](https://github.com/grpc/grpc/pull/27507#discussion_r807384888) describes a potential breakage. I'm unable to reproduce, but this change should be harmless in theory, so going ahead with this change.