### PR TITLE
Change clone command to make it easier to pin test-infra version.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -69,8 +69,8 @@ go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 pushd ..
 git clone https://github.com/grpc/test-infra.git
 cd test-infra
-# Tools are built from a known good version.
-git checkout --detach v1.0.0
+# Tools are built from HEAD.
+git checkout --detach
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -65,12 +65,12 @@ TEST_INFRA_GOVERSION=go1.17.1
 go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 
-# Fetch test-infra repository and build all tools.
-git init -b master ../test-infra
-pushd ../test-infra
+# Clone test-infra repository and build all tools.
+pushd ..
+git clone https://github.com/grpc/test-infra.git
+cd test-infra
 # Tools are built from a known good version.
-git fetch --depth 1 https://github.com/grpc/test-infra.git v1.0.0
-git checkout --detach FETCH_HEAD
+git checkout --detach v1.0.0
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -66,10 +66,11 @@ go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 
 # Fetch test-infra repository and build all tools.
-pushd ..
-git clone --depth 1 https://github.com/grpc/test-infra.git
-cd test-infra
-git log -1 --oneline
+git init -b master ../test-infra
+pushd ../test-infra
+# Tools are built from a known good version.
+git fetch --depth 1 https://github.com/grpc/test-infra.git v1.0.0
+git checkout --detach FETCH_HEAD
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -63,12 +63,12 @@ TEST_INFRA_GOVERSION=go1.17.1
 go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 
-# Fetch test-infra repository and build all tools.
-git init -b master ../test-infra
-pushd ../test-infra
+# Clone test-infra repository and build all tools.
+pushd ..
+git clone https://github.com/grpc/test-infra.git
+cd test-infra
 # Tools are built from HEAD.
-git fetch --depth 1 https://github.com/grpc/test-infra.git
-git checkout --detach FETCH_HEAD
+git checkout --detach
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -63,11 +63,12 @@ TEST_INFRA_GOVERSION=go1.17.1
 go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
 "${TEST_INFRA_GOVERSION}" download
 
-# Note: Submodules are not required for tools build.
-pushd ..
-git clone --depth 1 https://github.com/grpc/test-infra.git
-cd test-infra
-git log -1 --oneline
+# Fetch test-infra repository and build all tools.
+git init -b master ../test-infra
+pushd ../test-infra
+# Tools are built from HEAD.
+git fetch --depth 1 https://github.com/grpc/test-infra.git
+git checkout --detach FETCH_HEAD
 make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
 popd
 


### PR DESCRIPTION
Changed clone and checkout command to print checked-out version:

```
+ pushd ..
/tmpfs/src/github /tmpfs/src/github/grpc
+ git clone https://github.com/grpc/test-infra.git
Cloning into 'test-infra'...
+ cd test-infra
+ git checkout --detach
HEAD is now at 361ac97 Pin driver version (#277)
```

With these commands, we can check out a specific version by changing only one line in the script. For instance:

```shell
git checkout --detach v1.0.0
```