### PR TITLE
xds/cleanup: fix error datetime fromisoformat not available

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -50,7 +50,6 @@ Json = Any
 KubernetesClientRunner = client_app.KubernetesClientRunner
 KubernetesServerRunner = server_app.KubernetesServerRunner
 
-KEEP_PERIOD = datetime.timedelta(days=7)
 GCLOUD = os.environ.get('GCLOUD', 'gcloud')
 GCLOUD_CMD_TIMEOUT_S = datetime.timedelta(seconds=5).total_seconds()
 ZONE = 'us-central1-a'
@@ -59,6 +58,11 @@ SECONDARY_ZONE = 'us-west1-b'
 PSM_SECURITY_PREFIX = 'xds-k8s-security'  # Prefix for gke resources to delete.
 URL_MAP_TEST_PREFIX = 'interop-psm-url-map'  # Prefix for url-map test resources to delete.
 
+KEEP_PERIOD_DAYS = flags.DEFINE_integer(
+    "keep_days",
+    default=7,
+    help="number of days for a resource to keep. Resources older than this will be deleted"
+)
 DRY_RUN = flags.DEFINE_bool(
     "dry_run",
     default=False,
@@ -104,7 +108,7 @@ def is_marked_as_keep_gke(suffix: str) -> bool:
 
 @functools.lru_cache()
 def get_expire_timestamp() -> datetime.datetime:
-    return datetime.datetime.now(datetime.timezone.utc) - KEEP_PERIOD
+    return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=KEEP_PERIOD_DAYS.value)
 
 
 def exec_gcloud(project: str, *cmds: List[str]) -> Json:

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -25,7 +25,6 @@ python3 tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py\
     --td_bootstrap_image='required-but-does-not-matter' --server_image='required-but-does-not-matter' --client_image='required-but-does-not-matter'
 """
 import datetime
-import dateutil
 import functools
 import json
 import logging
@@ -36,6 +35,7 @@ from typing import Any, List
 
 from absl import app
 from absl import flags
+import dateutil
 
 from framework import xds_flags
 from framework import xds_k8s_flags
@@ -61,7 +61,8 @@ URL_MAP_TEST_PREFIX = 'interop-psm-url-map'  # Prefix for url-map test resources
 KEEP_PERIOD_DAYS = flags.DEFINE_integer(
     "keep_days",
     default=7,
-    help="number of days for a resource to keep. Resources older than this will be deleted"
+    help=
+    "number of days for a resource to keep. Resources older than this will be deleted"
 )
 DRY_RUN = flags.DEFINE_bool(
     "dry_run",
@@ -108,7 +109,8 @@ def is_marked_as_keep_gke(suffix: str) -> bool:
 
 @functools.lru_cache()
 def get_expire_timestamp() -> datetime.datetime:
-    return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=KEEP_PERIOD_DAYS.value)
+    return datetime.datetime.now(
+        datetime.timezone.utc) - datetime.timedelta(days=KEEP_PERIOD_DAYS.value)
 
 
 def exec_gcloud(project: str, *cmds: List[str]) -> Json:

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -58,11 +58,11 @@ SECONDARY_ZONE = 'us-west1-b'
 PSM_SECURITY_PREFIX = 'xds-k8s-security'  # Prefix for gke resources to delete.
 URL_MAP_TEST_PREFIX = 'interop-psm-url-map'  # Prefix for url-map test resources to delete.
 
-KEEP_PERIOD_DAYS = flags.DEFINE_integer(
-    "keep_days",
-    default=7,
+KEEP_PERIOD_HOURS = flags.DEFINE_integer(
+    "keep_hours",
+    default=168,
     help=
-    "number of days for a resource to keep. Resources older than this will be deleted"
+    "number of hours for a resource to keep. Resources older than this will be deleted. Default is 168 (7 days)"
 )
 DRY_RUN = flags.DEFINE_bool(
     "dry_run",
@@ -109,8 +109,8 @@ def is_marked_as_keep_gke(suffix: str) -> bool:
 
 @functools.lru_cache()
 def get_expire_timestamp() -> datetime.datetime:
-    return datetime.datetime.now(
-        datetime.timezone.utc) - datetime.timedelta(days=KEEP_PERIOD_DAYS.value)
+    return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        hours=KEEP_PERIOD_HOURS.value)
 
 
 def exec_gcloud(project: str, *cmds: List[str]) -> Json:

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -25,6 +25,7 @@ python3 tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py\
     --td_bootstrap_image='required-but-does-not-matter' --server_image='required-but-does-not-matter' --client_image='required-but-does-not-matter'
 """
 import datetime
+import dateutil
 import functools
 import json
 import logging
@@ -337,7 +338,7 @@ def main(argv):
     compute = gcp.compute.ComputeV1(gcp.api.GcpApiManager(), project)
     leakedHealthChecks = []
     for item in compute.list_health_check()['items']:
-        if datetime.datetime.fromisoformat(
+        if dateutil.parser.isoparse(
                 item['creationTimestamp']) <= get_expire_timestamp():
             leakedHealthChecks.append(item)
 

--- a/tools/run_tests/xds_k8s_test_driver/requirements.txt
+++ b/tools/run_tests/xds_k8s_test_driver/requirements.txt
@@ -16,5 +16,6 @@ six~=1.13
 tenacity~=6.2
 packaging~=21.3
 Pygments~=2.9
+python-dateutil~=2.8
 protobuf~=3.14
 xds-protos~=0.0.8


### PR DESCRIPTION
`datetime.fromisoformat` is available in >=python3.7, kokoro is running python3.6