### PR TITLE
Define a test rollout strategy for EventEngine conformance tests

### DIFF
--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -30,9 +30,27 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "timer_rc",
+    testonly = True,
+    srcs = ["timer_rc_test.cc"],
+    hdrs = COMMON_HEADERS,
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
     name = "dns",
     testonly = True,
     srcs = ["dns_test.cc"],
+    hdrs = COMMON_HEADERS,
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "dns_rc",
+    testonly = True,
+    srcs = ["dns_rc_test.cc"],
     hdrs = COMMON_HEADERS,
     deps = [":conformance_test_base_lib"],
     alwayslink = 1,
@@ -48,6 +66,15 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "client_rc",
+    testonly = True,
+    srcs = ["client_rc_test.cc"],
+    hdrs = COMMON_HEADERS,
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
     name = "server",
     testonly = True,
     srcs = ["server_test.cc"],
@@ -57,7 +84,16 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
-    name = "complete",
+    name = "server_rc",
+    testonly = True,
+    srcs = ["server_rc_test.cc"],
+    hdrs = COMMON_HEADERS,
+    deps = [":conformance_test_base_lib"],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "complete_no_rc",
     testonly = 1,
     hdrs = COMMON_HEADERS,
     deps = [

--- a/test/core/event_engine/test_suite/README.md
+++ b/test/core/event_engine/test_suite/README.md
@@ -1,7 +1,7 @@
 A reusable test suite for EventEngine implementations.
 
 To exercise a custom EventEngine, create a new bazel test target that links
-against the `//test/core/event_engine/test_suite:complete` library, and provide
+against the `//test/core/event_engine/test_suite:all` target, and provide
 a testing `main` function that sets a custom EventEngine factory.
 
 Your custom test target will look something like:
@@ -11,7 +11,7 @@ grpc_cc_test(
     name = "my_custom_event_engine_test",
     srcs = ["my_custom_event_engine_test.cc"],
     uses_polling = False,
-    deps = ["//test/core/event_engine/test_suite:complete"],
+    deps = ["//test/core/event_engine/test_suite:all"],
 )
 ```
 
@@ -37,3 +37,28 @@ you could depend on any subset of the following:
 * `//test/core/event_engine/test_suite:dns`
 * `//test/core/event_engine/test_suite:client`
 * `//test/core/event_engine/test_suite:server`
+
+
+## Breaking Changes
+
+As the conformance test suite evolves, it may introduce changes that break your
+implementation. We want to be able to improve the conformance test suite freely
+without harming everyone's EventEngine builds or requiring lock-step engine
+improvements, so a test rollout strategy is required.
+
+New conformance tests will be added to `*_rc` (release candidate) targets,
+such as:
+
+* `//test/core/event_engine/test_suite:timer_rc`
+* `//test/core/event_engine/test_suite:dns_rc`
+* `//test/core/event_engine/test_suite:client_rc`
+* `//test/core/event_engine/test_suite:server_rc`
+
+Quarterly, these additional tests will be rolled up into the main test suite
+targets. As an EventEngine implementer, it's recommended that you:
+
+* add dependencies on the all of the main _and_ `rc` targets to your EventEngine
+  test suite BUILD target.
+* remove `rc` target dependencies if they reveal problems with your
+  implementation, and fix your engine before the next test rollup occurs.
+* re-enable the `rc` dependencies to maintain up-to-date test coverage.

--- a/test/core/event_engine/test_suite/client_rc_test.cc
+++ b/test/core/event_engine/test_suite/client_rc_test.cc
@@ -1,0 +1,20 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+class EventEngineClientRCTest : public EventEngineTest {};
+
+// TODO(hork): establish meaningful tests
+TEST_F(EventEngineClientRCTest, TODO) {}

--- a/test/core/event_engine/test_suite/client_test.cc
+++ b/test/core/event_engine/test_suite/client_test.cc
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+////////////////////////////////////////////////////////////////////////////////
+// DO NOT ADD NEW TESTS TO THIS FILE
+//
+// New conformance tests are added to the client_rc_test.cc file, and
+// periodically rolled up into the main targets. See the README for details.
+////////////////////////////////////////////////////////////////////////////////
+
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineClientTest : public EventEngineTest {};

--- a/test/core/event_engine/test_suite/dns_rc_test.cc
+++ b/test/core/event_engine/test_suite/dns_rc_test.cc
@@ -1,0 +1,20 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+class EventEngineDNSRCTest : public EventEngineTest {};
+
+// TODO(hork): establish meaningful tests
+TEST_F(EventEngineDNSRCTest, TODO) {}

--- a/test/core/event_engine/test_suite/dns_test.cc
+++ b/test/core/event_engine/test_suite/dns_test.cc
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+////////////////////////////////////////////////////////////////////////////////
+// DO NOT ADD NEW TESTS TO THIS FILE
+//
+// New conformance tests are added to the dns_rc_test.cc file, and periodically
+// rolled up into the main targets. See the README for details.
+////////////////////////////////////////////////////////////////////////////////
+
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineDNSTest : public EventEngineTest {};

--- a/test/core/event_engine/test_suite/server_rc_test.cc
+++ b/test/core/event_engine/test_suite/server_rc_test.cc
@@ -1,0 +1,20 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+class EventEngineServerRCTest : public EventEngineTest {};
+
+// TODO(hork): establish meaningful tests
+TEST_F(EventEngineServerRCTest, TODO) {}

--- a/test/core/event_engine/test_suite/server_test.cc
+++ b/test/core/event_engine/test_suite/server_test.cc
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+////////////////////////////////////////////////////////////////////////////////
+// DO NOT ADD NEW TESTS TO THIS FILE
+//
+// New conformance tests are added to the server_rc_test.cc file, and
+// periodically rolled up into the main targets. See the README for details.
+////////////////////////////////////////////////////////////////////////////////
+
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineServerTest : public EventEngineTest {};

--- a/test/core/event_engine/test_suite/timer_rc_test.cc
+++ b/test/core/event_engine/test_suite/timer_rc_test.cc
@@ -1,0 +1,59 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <random>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "absl/functional/bind_front.h"
+#include "absl/time/time.h"
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gprpp/sync.h"
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+
+using ::testing::ElementsAre;
+
+class EventEngineTimerRCTest : public EventEngineTest {
+ protected:
+  grpc_core::Mutex mu_;
+  grpc_core::CondVar cv_;
+  bool signaled_ ABSL_GUARDED_BY(mu_) = false;
+};
+
+TEST_F(EventEngineTimerRCTest, DestroyedFromCallback) {
+  // Helps transfer unique_ptr ownership to the callback.
+  struct EngineOwner {
+    std::unique_ptr<grpc_event_engine::experimental::EventEngine> engine;
+  };
+  EngineOwner* h = new EngineOwner{this->NewEventEngine()};
+  // Destroy the engine from within an engine thread
+  grpc_core::MutexLock lock(&mu_);
+  signaled_ = false;
+  h->engine->RunAt(absl::Now(), [this, h]() {
+    ASSERT_TRUE(h->engine->IsWorkerThread());
+    h->engine.reset();
+    delete h;
+    grpc_core::MutexLock lock(&mu_);
+    signaled_ = true;
+    cv_.Signal();
+  });
+  while (!signaled_) {
+    cv_.Wait(&mu_);
+  }
+}

--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+////////////////////////////////////////////////////////////////////////////////
+// DO NOT ADD NEW TESTS TO THIS FILE
+//
+// New conformance tests are added to the timer_rc_test.cc file, and
+// periodically rolled up into the main targets. See the README for details.
+////////////////////////////////////////////////////////////////////////////////
+
 #include <random>
 #include <thread>
 


### PR DESCRIPTION
See `test/core/event_engine/test_suite/README.md` for details.

This also adds a general test that broke my own implementation, and may
break a handful of others upon import without such a test strategy.

@tamird @Vignesh2208 