### PR TITLE
Fix grpc_binder_transport::registered_stream data race

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_stream.h
+++ b/src/core/ext/transport/binder/transport/binder_stream.h
@@ -41,6 +41,11 @@ struct RecvTrailingMetadataArgs {
   int status;
 };
 
+struct RegisterStreamArgs {
+  grpc_binder_stream* gbs;
+  grpc_binder_transport* gbt;
+};
+
 // TODO(mingcl): Figure out if we want to use class instead of struct here
 struct grpc_binder_stream {
   // server_data will be null for client, and for server it will be whatever
@@ -54,9 +59,6 @@ struct grpc_binder_stream {
         tx_code(tx_code),
         is_client(is_client),
         is_closed(false) {
-    // TODO(waynetu): Should this be protected?
-    t->registered_stream[tx_code] = this;
-
     recv_initial_metadata_args.gbs = this;
     recv_initial_metadata_args.gbt = t;
     recv_message_args.gbs = this;
@@ -95,6 +97,9 @@ struct grpc_binder_stream {
   RecvMessageArgs recv_message_args;
   grpc_closure recv_trailing_metadata_closure;
   RecvTrailingMetadataArgs recv_trailing_metadata_args;
+
+  grpc_closure register_stream_closure;
+  RegisterStreamArgs register_stream_args;
 
   // We store these fields passed from op batch, in order to access them through
   // grpc_binder_stream

--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -96,6 +96,11 @@ static void grpc_binder_unref_transport(grpc_binder_transport* t) {
 #define GRPC_BINDER_UNREF_TRANSPORT(t, r) grpc_binder_unref_transport(t)
 #endif
 
+static void register_stream_locked(void* arg, grpc_error_handle /*error*/) {
+  RegisterStreamArgs* args = static_cast<RegisterStreamArgs*>(arg);
+  args->gbt->registered_stream[args->gbs->GetTxCode()] = args->gbs;
+}
+
 static int init_stream(grpc_transport* gt, grpc_stream* gs,
                        grpc_stream_refcount* refcount, const void* server_data,
                        grpc_core::Arena* arena) {
@@ -107,6 +112,18 @@ static int init_stream(grpc_transport* gt, grpc_stream* gs,
   // here
   new (gs) grpc_binder_stream(t, refcount, server_data, arena,
                               t->NewStreamTxCode(), t->is_client);
+
+  // `grpc_binder_transport::registered_stream` should only be updated in
+  // combiner
+  grpc_binder_stream* gbs = reinterpret_cast<grpc_binder_stream*>(gs);
+  gbs->register_stream_args.gbs = gbs;
+  gbs->register_stream_args.gbt = t;
+  grpc_core::ExecCtx exec_ctx;
+  t->combiner->Run(
+      GRPC_CLOSURE_INIT(&gbs->register_stream_closure, register_stream_locked,
+                        &gbs->register_stream_args, nullptr),
+      GRPC_ERROR_NONE);
+
   return 0;
 }
 


### PR DESCRIPTION
The member variable should only be accessed in combiner to avoid
data race.