### PR TITLE
Switch run_xds_tests.py shebang to python3

### DIFF
--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2020 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Same as https://github.com/grpc/grpc/pull/28963, but updates the `run_xds_tests.py` script.
Since it touches the PSM interop tests, I wanted to have a separate change to avoid accidentally breaking stuff.

- it would be useful if we had some presubmit tests for xds interop, since currently the tests are both fragile AND we don't run them on presubmit. Of course to do that we'd need to make sure the tests are compatible with running on PRs from from the perspective of hermeticity and speed (they'd need to take less than 30mins).