### PR TITLE
[Backport][v1.44.x] Support musllinux binary wheels on x64 and x86

### DIFF
--- a/test/distrib/python/test_packages.sh
+++ b/test/distrib/python/test_packages.sh
@@ -83,6 +83,6 @@ at_least_one_installs "${TESTING_ARCHIVES[@]}"
 
 # TODO(jtattermusch): add a .proto file to the distribtest, generate python
 # code from it and then use the generated code from distribtest.py
-"$PYTHON" -m grpc.tools.protoc --help
+"$PYTHON" -m grpc_tools.protoc --help
 
 "$PYTHON" distribtest.py

--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -139,7 +139,7 @@ Given protobuf include directories :code:`$INCLUDE`, an output directory
 
 ::
 
-  $ python -m grpc.tools.protoc -I$INCLUDE --python_out=$OUTPUT --grpc_python_out=$OUTPUT $PROTO_FILES
+  $ python -m grpc_tools.protoc -I$INCLUDE --python_out=$OUTPUT --grpc_python_out=$OUTPUT $PROTO_FILES
 
 To use as a build step in distutils-based projects, you may use the provided
 command class in your :code:`setup.py`:
@@ -149,7 +149,7 @@ command class in your :code:`setup.py`:
   setuptools.setup(
     # ...
     cmdclass={
-      'build_proto_modules': grpc.tools.command.BuildPackageProtos,
+      'build_proto_modules': grpc_tools.command.BuildPackageProtos,
     }
     # ...
   )
@@ -160,7 +160,7 @@ Invocation of the command will walk the project tree and transpile every
 Note that this particular approach requires :code:`grpcio-tools` to be
 installed on the machine before the setup script is invoked (i.e. no
 combination of :code:`setup_requires` or :code:`install_requires` will provide
-access to :code:`grpc.tools.command.BuildPackageProtos` if it isn't already
+access to :code:`grpc_tools.command.BuildPackageProtos` if it isn't already
 installed). One way to work around this can be found in our
 :code:`grpcio-health-checking`
 `package <https://pypi.python.org/pypi/grpcio-health-checking>`_:
@@ -171,7 +171,7 @@ installed). One way to work around this can be found in our
     """Command to generate project *_pb2.py modules from proto files."""
     # ...
     def run(self):
-      from grpc.tools import command
+      from grpc_tools import command
       command.build_package_protos(self.distribution.package_dir[''])
 
 Now including :code:`grpcio-tools` in :code:`setup_requires` will provide the

--- a/tools/dockerfile/distribtest/python_alpine_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_alpine_x64/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.10-alpine3.14
+
+# Our test infrastructure demands bash
+RUN apk update && apk add bash
+
+RUN pip3 install virtualenv

--- a/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x64/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM quay.io/pypa/musllinux_1_1_x86_64:2021-11-15-a808c18
+
+###################################
+# Install Python build requirements
+RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython
+RUN /opt/python/cp39-cp39/bin/pip install --upgrade cython
+RUN /opt/python/cp310-cp310/bin/pip install --upgrade cython
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x86/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM quay.io/pypa/musllinux_1_1_i686:2021-11-15-a808c18
+
+###################################
+# Install Python build requirements
+RUN /opt/python/cp36-cp36m/bin/pip install --upgrade cython
+RUN /opt/python/cp37-cp37m/bin/pip install --upgrade cython
+RUN /opt/python/cp38-cp38/bin/pip install --upgrade cython
+RUN /opt/python/cp39-cp39/bin/pip install --upgrade cython
+RUN /opt/python/cp310-cp310/bin/pip install --upgrade cython
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -114,6 +114,8 @@ class PythonArtifact:
             # Their build is now much faster, so they can be included
             # in the regular artifact build.
             self.labels.append('linux')
+        if 'musllinux' in platform:
+            self.labels.append('linux')
 
     def pre_build_jobspecs(self):
         return []
@@ -158,6 +160,20 @@ class PythonArtifact:
                 # - they require protoc to run on current architecture
                 # - they only have sdist packages anyway, so it's useless to build them again
                 environ['GRPC_BUILD_GRPCIO_TOOLS_DEPENDENTS'] = 'TRUE'
+            return create_docker_jobspec(
+                self.name,
+                'tools/dockerfile/grpc_artifact_python_%s_%s' %
+                (self.platform, self.arch),
+                'tools/run_tests/artifacts/build_artifact_python.sh',
+                environ=environ,
+                timeout_seconds=60 * 60 * 2)
+        elif 'musllinux' in self.platform:
+            environ['PYTHON'] = '/opt/python/{}/bin/python'.format(
+                self.py_version)
+            environ['PIP'] = '/opt/python/{}/bin/pip'.format(self.py_version)
+            environ['GRPC_SKIP_PIP_CYTHON_UPGRADE'] = 'TRUE'
+            environ['GRPC_RUN_AUDITWHEEL_REPAIR'] = 'TRUE'
+            environ['GRPC_PYTHON_BUILD_WITH_STATIC_LIBSTDCXX'] = 'TRUE'
             return create_docker_jobspec(
                 self.name,
                 'tools/dockerfile/grpc_artifact_python_%s_%s' %
@@ -442,6 +458,16 @@ def targets():
         PythonArtifact('linux_extra', 'armv7', 'cp38-cp38'),
         PythonArtifact('linux_extra', 'armv7', 'cp39-cp39'),
         PythonArtifact('linux_extra', 'armv7', 'cp310-cp310', presubmit=True),
+        PythonArtifact('musllinux_1_1', 'x64', 'cp310-cp310', presubmit=True),
+        PythonArtifact('musllinux_1_1', 'x64', 'cp36-cp36m', presubmit=True),
+        PythonArtifact('musllinux_1_1', 'x64', 'cp37-cp37m'),
+        PythonArtifact('musllinux_1_1', 'x64', 'cp38-cp38'),
+        PythonArtifact('musllinux_1_1', 'x64', 'cp39-cp39'),
+        PythonArtifact('musllinux_1_1', 'x86', 'cp310-cp310', presubmit=True),
+        PythonArtifact('musllinux_1_1', 'x86', 'cp36-cp36m', presubmit=True),
+        PythonArtifact('musllinux_1_1', 'x86', 'cp37-cp37m'),
+        PythonArtifact('musllinux_1_1', 'x86', 'cp38-cp38'),
+        PythonArtifact('musllinux_1_1', 'x86', 'cp39-cp39'),
         PythonArtifact('macos', 'x64', 'python3.6', presubmit=True),
         PythonArtifact('macos', 'x64', 'python3.7'),
         PythonArtifact('macos', 'x64', 'python3.8'),

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -90,7 +90,7 @@ ${SETARCH_CMD} "${PYTHON}" setup.py bdist_wheel $WHEEL_PLAT_NAME_FLAG
 GRPCIO_STRIP_TEMPDIR=$(mktemp -d)
 GRPCIO_TAR_GZ_LIST=( dist/grpcio-*.tar.gz )
 GRPCIO_TAR_GZ=${GRPCIO_TAR_GZ_LIST[0]}
-GRPCIO_STRIPPED_TAR_GZ=$(mktemp -t "XXXXXXXXXX.tar.gz")
+GRPCIO_STRIPPED_TAR_GZ=$(mktemp -t "TAR_GZ_XXXXXXXXXX")
 
 clean_non_source_files() {
 ( cd "$1"

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -426,6 +426,7 @@ def targets():
         PythonDistribTest('linux', 'x64', 'fedora34'),
         PythonDistribTest('linux', 'x64', 'opensuse'),
         PythonDistribTest('linux', 'x64', 'arch'),
+        PythonDistribTest('linux', 'x64', 'alpine'),
         PythonDistribTest('linux', 'x64', 'ubuntu1804'),
         PythonDistribTest('linux', 'aarch64', 'python38_buster',
                           presubmit=True),


### PR DESCRIPTION
Original #28092.
Fixes https://github.com/grpc/grpc/issues/28906.

Realistically, v1.45.0 might be released in a month, or being delayed for a couple more weeks. The musllinux wheels can be helpful to our users with Alpine Linux. I hope we can release it as a patch.

@jtattermusch PTAL.