### PR TITLE
[Ruby] Add ruby_abi_version to exported symbols

### DIFF
--- a/src/ruby/ext/grpc/ext-export.clang
+++ b/src/ruby/ext/grpc/ext-export.clang
@@ -1,1 +1,2 @@
 _Init_grpc_c
+_ruby_abi_version

--- a/src/ruby/ext/grpc/ext-export.gcc
+++ b/src/ruby/ext/grpc/ext-export.gcc
@@ -1,6 +1,7 @@
 grpc_1.0 { 
   global: 
     Init_grpc_c;
+    ruby_abi_version;
   local: 
     *;
 };


### PR DESCRIPTION
The next Ruby version, 3.2, will have builtin ABI checking (see ruby/ruby#5474). This requires that the symbol `ruby_abi_version` is present in the shared object, otherwise the object fails to load.

For example, this is a small repro in Ruby 3.2:

```
$ ruby -Isrc/ruby/lib -e "require 'grpc'"
<internal:/home/peter/src/ruby/install/lib/ruby/3.2.0+0/rubygems/core_ext/kernel_require.rb>:85:in `require': /home/peter/src/grpc/src/ruby/lib/grpc/grpc_c.so: undefined symbol: ruby_abi_version - ruby_abi_version (LoadError)
	from <internal:/home/peter/src/ruby/install/lib/ruby/3.2.0+0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /home/peter/src/grpc/src/ruby/lib/grpc/grpc.rb:22:in `<top (required)>'
	from /home/peter/src/grpc/src/ruby/lib/grpc.rb:19:in `require_relative'
	from /home/peter/src/grpc/src/ruby/lib/grpc.rb:19:in `<top (required)>'
	from <internal:/home/peter/src/ruby/install/lib/ruby/3.2.0+0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/home/peter/src/ruby/install/lib/ruby/3.2.0+0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from -e:1:in `<main>'
```




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
