### PR TITLE
Fix cancellation on async server filters

### DIFF
--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -628,6 +628,7 @@ void ServerCallData::WakeInsideCombiner(
             destroy_md = false;
           }
           forward_send_trailing_metadata = true;
+          send_trailing_state_ = SendTrailingState::kForwarded;
         } break;
         case SendTrailingState::kForwarded:
           abort();  // unreachable


### PR DESCRIPTION
Pulls a one-line fix out of #28958 so that we can land it separately and consequently land a bunch of server based filters.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
