### PR TITLE
Support pre-built binaries for Ruby 3.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
   ext.cross_compile = true
   ext.cross_platform = [
     'x86-mingw32', 'x64-mingw32',
+    'x64-mingw-ucrt',
     'x86_64-linux', 'x86-linux',
     'x86_64-darwin', 'arm64-darwin',
     'universal-darwin'

--- a/Rakefile
+++ b/Rakefile
@@ -141,7 +141,7 @@ task 'gem:native', [:plat] do |t, args|
   verbose = ENV['V'] || '0'
 
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
-  ruby_cc_versions = ['3.1.1', '3.0.0', '2.7.0', '2.6.0', '2.5.0'].join(':')
+  ruby_cc_versions = ['3.1.0', '3.0.0', '2.7.0', '2.6.0', '2.5.0'].join(':')
   selected_plat = "#{args[:plat]}"
 
   if RUBY_PLATFORM =~ /darwin/
@@ -195,7 +195,7 @@ task 'gem:native', [:plat] do |t, args|
     windows_platforms.each do |plat|
       # x64-mingw-ucrt only supports 3.1+ whereas 'x64-mingw32' only supports up to 3.0
       versions = if plat == 'x64-mingw-ucrt'
-        '3.1.1'
+        '3.1.0'
       elsif plat == 'x64-mingw32'
         ['3.0.0', '2.7.0', '2.6.0', '2.5.0'].join(':')
       else

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,6 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
   ext.cross_compile = true
   ext.cross_platform = [
     'x86-mingw32', 'x64-mingw32',
-    'x64-mingw-ucrt',
     'x86_64-linux', 'x86-linux',
     'x86_64-darwin', 'arm64-darwin',
     'universal-darwin'
@@ -169,7 +168,7 @@ task 'gem:native', [:plat] do |t, args|
     prepare_ccache_cmd += "export PATH=\"$PATH:/usr/local/bin\" && "
     prepare_ccache_cmd += "source tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc "
 
-    supported_windows_platforms = ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt']
+    supported_windows_platforms = ['x86-mingw32', 'x64-mingw32']
     supported_unix_platforms = ['x86_64-linux', 'x86-linux', 'x86_64-darwin', 'arm64-darwin']
     supported_platforms = supported_windows_platforms + supported_unix_platforms
 
@@ -194,21 +193,13 @@ task 'gem:native', [:plat] do |t, args|
     Rake::Task['dlls'].execute(plat: windows_platforms)
 
     windows_platforms.each do |plat|
-      # x64-mingw-ucrt only supports 3.1+ whereas 'x64-mingw32' only supports up to 3.0
-      versions = if plat == 'x64-mingw-ucrt'
-        '3.1.0'
-      elsif plat == 'x64-mingw32'
-        ['3.0.0', '2.7.0', '2.6.0', '2.5.0'].join(':')
-      else
-        ruby_cc_versions
-      end
       run_rake_compiler(plat, <<~EOT)
         #{prepare_ccache_cmd} && \
         gem update --system --no-document && \
         bundle && \
         bundle exec rake clean && \
         bundle exec rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem pkg/#{spec.full_name}.gem \
-          RUBY_CC_VERSION=#{versions} \
+          RUBY_CC_VERSION=#{ruby_cc_versions} \
           V=#{verbose} \
           GRPC_CONFIG=#{grpc_config} \
           GRPC_RUBY_BUILD_PROCS=#{nproc_override}

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov',          '~> 0.14.1'
   s.add_development_dependency 'rake',               '~> 13.0'
   s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
-  s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
+  s.add_development_dependency 'rake-compiler-dock', '~> 1.2'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'
   s.add_development_dependency 'signet',             '~> 0.7'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -43,7 +43,7 @@
     s.add_development_dependency 'simplecov',          '~> 0.14.1'
     s.add_development_dependency 'rake',               '~> 13.0'
     s.add_development_dependency 'rake-compiler',      '<= 1.1.1'
-    s.add_development_dependency 'rake-compiler-dock', '~> 1.1'
+    s.add_development_dependency 'rake-compiler-dock', '~> 1.2'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'
     s.add_development_dependency 'signet',             '~> 0.7'

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -51,8 +51,8 @@ EOF
 
 MAKE="make -j8"
 
-# Install ruby 3.0.0 for rake-compiler
-# Download ruby 3.0.0 sources outside of the cross-ruby.rake file, since the
+
+# Download ruby 3.0.0 and 3.1.0 sources outside of the cross-ruby.rake file, since the
 # latest rake-compiler/v1.1.1 cross-ruby.rake file requires tar.bz2 source
 # files.
 # TODO(apolcyn): remove this hack when tar.bz2 sources are available for ruby
@@ -60,6 +60,19 @@ MAKE="make -j8"
 # https://stackoverflow.com/questions/65477613/rvm-where-is-ruby-3-0-0.
 set +x # rvm commands are very verbose
 source ~/.rvm/scripts/rvm
+# Install ruby 3.1.0 for rake-compiler
+echo "rvm use 3.1.0"
+rvm use 3.1.0
+set -x
+RUBY_3_0_0_TAR="${HOME}/.rake-compiler/sources/ruby-3.1.0.tar.gz"
+mkdir -p "$(dirname $RUBY_3_0_0_TAR)"
+curl -L "https://ftp.ruby-lang.org/pub/ruby/3.0/$(basename $RUBY_3_0_0_TAR)" -o "$RUBY_3_0_0_TAR"
+ccache -c
+ruby --version | grep 'ruby 3.1.0'
+tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+bundle exec rake -f "$CROSS_RUBY" cross-ruby VERSION=3.1.0 HOST=x86_64-darwin11 MAKE="$MAKE" SOURCE="$RUBY_3_0_0_TAR"
+echo "installed ruby 3.1.0 build targets"
+# Install ruby 3.0.0 for rake-compiler
 echo "rvm use 3.0.0"
 rvm use 3.0.0
 set -x

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -64,13 +64,13 @@ source ~/.rvm/scripts/rvm
 echo "rvm use 3.1.0"
 rvm use 3.1.0
 set -x
-RUBY_3_0_0_TAR="${HOME}/.rake-compiler/sources/ruby-3.1.0.tar.gz"
-mkdir -p "$(dirname $RUBY_3_0_0_TAR)"
-curl -L "https://ftp.ruby-lang.org/pub/ruby/3.0/$(basename $RUBY_3_0_0_TAR)" -o "$RUBY_3_0_0_TAR"
+RUBY_3_1_0_TAR="${HOME}/.rake-compiler/sources/ruby-3.1.0.tar.gz"
+mkdir -p "$(dirname $RUBY_3_1_0_TAR)"
+curl -L "https://ftp.ruby-lang.org/pub/ruby/3.0/$(basename $RUBY_3_1_0_TAR)" -o "$RUBY_3_1_0_TAR"
 ccache -c
 ruby --version | grep 'ruby 3.1.0'
 tools/run_tests/helper_scripts/bundle_install_wrapper.sh
-bundle exec rake -f "$CROSS_RUBY" cross-ruby VERSION=3.1.0 HOST=x86_64-darwin11 MAKE="$MAKE" SOURCE="$RUBY_3_0_0_TAR"
+bundle exec rake -f "$CROSS_RUBY" cross-ruby VERSION=3.1.0 HOST=x86_64-darwin11 MAKE="$MAKE" SOURCE="$RUBY_3_1_0_TAR"
 echo "installed ruby 3.1.0 build targets"
 # Install ruby 3.0.0 for rake-compiler
 echo "rvm use 3.0.0"

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -66,7 +66,7 @@ rvm use 3.1.0
 set -x
 RUBY_3_1_0_TAR="${HOME}/.rake-compiler/sources/ruby-3.1.0.tar.gz"
 mkdir -p "$(dirname $RUBY_3_1_0_TAR)"
-curl -L "https://ftp.ruby-lang.org/pub/ruby/3.0/$(basename $RUBY_3_1_0_TAR)" -o "$RUBY_3_1_0_TAR"
+curl -L "https://ftp.ruby-lang.org/pub/ruby/3.1/$(basename $RUBY_3_1_0_TAR)" -o "$RUBY_3_1_0_TAR"
 ccache -c
 ruby --version | grep 'ruby 3.1.0'
 tools/run_tests/helper_scripts/bundle_install_wrapper.sh

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -77,7 +77,7 @@ then
   set +x
   source $HOME/.rvm/scripts/rvm
 
-  for RUBY_VERSION in 2.5.0 2.7.0 3.0.0; do
+  for RUBY_VERSION in 2.5.0 2.7.0 3.0.0 3.1.0; do
     echo "Installing ruby-${RUBY_VERSION}"
     time rvm install "ruby-${RUBY_VERSION}"
   done;


### PR DESCRIPTION
## Why?
Fixes #28627

## What are the changes?
I added 3.1.1 as a RUBY_CC_VERSION. I had to upgrade rake-compiler-dock to 1.2.0 as this is the only version of this gem that supports compilation for ruby 3.1+