### PR TITLE
Update the scenario results to include start and end time for a test scenario.

### DIFF
--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -42,9 +42,18 @@ grpc_proto_library(
     name = "control_proto",
     srcs = ["control.proto"],
     has_services = False,
+    well_known_protos = True,
     deps = [
         "payloads_proto",
         "stats_proto",
+    ],
+)
+
+proto_library(
+    name = "control_proto_descriptors",
+    srcs = ["control.proto"],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 import "src/proto/grpc/testing/payloads.proto";
 import "src/proto/grpc/testing/stats.proto";
+import "google/protobuf/timestamp.proto";
 
 package grpc.testing;
 
@@ -267,8 +268,8 @@ message ScenarioResultSummary
   double client_queries_per_cpu_sec = 18;
 
   // Start and end time for the test scenario
-  int64 start = 19;
-  int64 end =20;
+  google.protobuf.Timestamp start_time = 19;
+  google.protobuf.Timestamp end_time =20;
 }
 
 // Results of a single benchmark scenario.

--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -265,6 +265,10 @@ message ScenarioResultSummary
   // Queries per CPU-sec over all servers or clients
   double server_queries_per_cpu_sec = 17;
   double client_queries_per_cpu_sec = 18;
+
+  // Start and end time for the test scenario
+  int64 start = 19;
+  int64 end =20;
 }
 
 // Results of a single benchmark scenario.

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -18,13 +18,15 @@
 
 #include "test/cpp/qps/driver.h"
 
+#include <chrono>
 #include <cinttypes>
 #include <deque>
 #include <list>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-#include <chrono>
+
+#include <google/protobuf/util/time_util.h>
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -575,9 +577,8 @@ std::unique_ptr<ScenarioResult> RunScenario(
   // Start a run
   gpr_log(GPR_INFO, "Starting");
 
-  std::chrono::seconds start_epoch_time =
-        std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch());
+  google::protobuf::Timestamp start_timestamp =
+      google::protobuf::util::TimeUtil::GetCurrentTime();
 
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
@@ -629,10 +630,9 @@ std::unique_ptr<ScenarioResult> RunScenario(
   // the result.
   bool client_finish_first =
       (client_config.rpc_type() != STREAMING_FROM_SERVER);
-  
-  std::chrono::seconds end_epoch_time =
-        std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch());
+
+  google::protobuf::Timestamp end_timestamp =
+      google::protobuf::util::TimeUtil::GetCurrentTime();
 
   FinishClients(clients, client_mark);
 
@@ -660,10 +660,9 @@ std::unique_ptr<ScenarioResult> RunScenario(
     rrc->set_status_code(it->first);
     rrc->set_count(it->second);
   }
-  
   // Fill in start and end time for the test scenario
-  result->mutable_summary()->set_start(start_epoch_time.count());
-  result->mutable_summary()->set_end(end_epoch_time.count());
+  result->mutable_summary()->mutable_start_time()->CopyFrom(start_timestamp);
+  result->mutable_summary()->mutable_end_time()->CopyFrom(end_timestamp);
 
   postprocess_scenario_result(result.get());
   return result;


### PR DESCRIPTION
This commit update the scenario results to include the start and end time (in Epoch Unix Timestamp) for the current test. The start and end time will be used in prometheus range query to obtain cpu and memory usage data.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
