### PR TITLE
Docker image cleanup (prepare for ARM64 tests)

### DIFF
--- a/templates/tools/dockerfile/apt_get_basic.include
+++ b/templates/tools/dockerfile/apt_get_basic.include
@@ -12,9 +12,7 @@ RUN apt-get update && apt-get install -y ${'\\'}
 # GCC
 RUN apt-get update && apt-get install -y ${'\\'}
   gcc ${'\\'}
-  gcc-multilib ${'\\'}
   g++ ${'\\'}
-  g++-multilib  ${'\\'}
   && apt-get clean
 
 # libc6

--- a/templates/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile.template
@@ -14,7 +14,10 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../python_debian11_base.include"/>
+  FROM debian:11
+  
+  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../run_tests_addons.include"/>
 
   RUN apt-get update && apt-get install -y python3 python3-all-dev python3-pip
   RUN ln -s $(which python3) /usr/bin/python

--- a/templates/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile.template
@@ -14,7 +14,10 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  <%include file="../../python_debian11_base.include"/>
+  FROM debian:11
+  
+  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../run_tests_addons.include"/>
 
   RUN apt-get update && apt-get install -y python3 python3-pip python3-all-dev
   RUN ln -s $(which python3) /usr/bin/python

--- a/templates/tools/dockerfile/python_debian11_base.include
+++ b/templates/tools/dockerfile/python_debian11_base.include
@@ -1,4 +1,0 @@
-FROM debian:11
-  
-<%include file="./apt_get_basic.include"/>
-<%include file="./run_tests_addons.include"/>

--- a/templates/tools/dockerfile/test/cxx_debian11_openssl102_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_debian11_openssl102_x64/Dockerfile.template
@@ -16,7 +16,6 @@
   
   FROM debian:11
   
-  RUN apt-get --allow-releaseinfo-change update
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
   <%include file="../../cxx_deps.include"/>

--- a/templates/tools/dockerfile/test/cxx_debian11_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_debian11_x64/Dockerfile.template
@@ -15,8 +15,6 @@
   # limitations under the License.
   
   FROM debian:11
-  
-  RUN apt-get --allow-releaseinfo-change update
 
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>

--- a/templates/tools/dockerfile/test/python_debian11_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_debian11_default_x64/Dockerfile.template
@@ -14,7 +14,11 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  <%include file="../../python_debian11_base.include"/>
+  FROM debian:11
+  
+  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../run_tests_addons.include"/>
+
   <%include file="../../compile_python_36.include"/>
   <%include file="../../compile_python_37.include"/>
   <%include file="../../compile_python_38.include"/>

--- a/tools/dockerfile/grpc_artifact_android_ndk/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_android_ndk/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM debian:11
-  
+
 #=================
 # Basic C core dependencies
 
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6
@@ -57,7 +55,6 @@ RUN apt-get update && apt-get install -y \
 
 
 RUN mkdir /var/local/jenkins
-
 
 
 RUN apt-get update && apt-get install -y python3 python3-all-dev python3-pip

--- a/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_pythonasyncio/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM debian:11
-  
+
 #=================
 # Basic C core dependencies
 
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6
@@ -57,7 +55,6 @@ RUN apt-get update && apt-get install -y \
 
 
 RUN mkdir /var/local/jenkins
-
 
 
 RUN apt-get update && apt-get install -y python3 python3-pip python3-all-dev

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/csharp_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_debian11_x64/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/cxx_debian11_openssl102_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian11_openssl102_x64/Dockerfile
@@ -14,7 +14,6 @@
 
 FROM debian:11
 
-RUN apt-get --allow-releaseinfo-change update
 #=================
 # Basic C core dependencies
 
@@ -29,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/cxx_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian11_x64/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM debian:11
 
-RUN apt-get --allow-releaseinfo-change update
-
 #=================
 # Basic C core dependencies
 
@@ -30,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/cxx_debian11_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_debian11_x86/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/php7_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_debian11_x64/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/python_debian11_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_debian11_default_x64/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM debian:11
-  
+
 #=================
 # Basic C core dependencies
 
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/ruby_debian11_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_debian11_x64/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -28,9 +28,7 @@ RUN apt-get update && apt-get install -y \
 # GCC
 RUN apt-get update && apt-get install -y \
   gcc \
-  gcc-multilib \
   g++ \
-  g++-multilib  \
   && apt-get clean
 
 # libc6


### PR DESCRIPTION
Prerequisite work for https://github.com/grpc/grpc/pull/28966

Make changes to the docker images that will make it easier to add ARM64 version of docker images without causing too much churn.