### PR TITLE
HTTP2: Don't throttle pings from the server

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -219,7 +219,7 @@ typedef struct {
   "grpc.http2.min_ping_interval_without_data_ms"
 /** Channel arg to override the http2 :scheme header */
 #define GRPC_ARG_HTTP2_SCHEME "grpc.http2_scheme"
-/** How many pings can we send before needing to send a
+/** How many pings can the client send before needing to send a
    data/header frame? (0 indicates that an infinite number of
    pings can be sent without sending a data frame or header frame) */
 #define GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA \
@@ -241,8 +241,8 @@ typedef struct {
     not receive the ping ack, it will close the transport. Int valued,
     milliseconds. */
 #define GRPC_ARG_KEEPALIVE_TIMEOUT_MS "grpc.keepalive_timeout_ms"
-/** Is it permissible to send keepalive pings without any outstanding streams.
-    Int valued, 0(false)/1(true). */
+/** Is it permissible to send keepalive pings from the client without any
+   outstanding streams. Int valued, 0(false)/1(true). */
 #define GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS \
   "grpc.keepalive_permit_without_calls"
 /** Default authority to pass if none specified on call construction. A string.

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -60,59 +60,63 @@ static void maybe_initiate_ping(grpc_chttp2_transport* t) {
     }
     return;
   }
-  if (t->ping_state.pings_before_data_required == 0 &&
-      t->ping_policy.max_pings_without_data != 0) {
-    /* need to receive something of substance before sending a ping again */
-    if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
-        GRPC_TRACE_FLAG_ENABLED(grpc_bdp_estimator_trace) ||
-        GRPC_TRACE_FLAG_ENABLED(grpc_keepalive_trace)) {
-      gpr_log(GPR_INFO, "%s: Ping delayed [%s]: too many recent pings: %d/%d",
-              t->is_client ? "CLIENT" : "SERVER", t->peer_string.c_str(),
-              t->ping_state.pings_before_data_required,
-              t->ping_policy.max_pings_without_data);
+  if (t->is_client) {
+    if (t->ping_state.pings_before_data_required == 0 &&
+        t->ping_policy.max_pings_without_data != 0) {
+      /* need to receive something of substance before sending a ping again */
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
+          GRPC_TRACE_FLAG_ENABLED(grpc_bdp_estimator_trace) ||
+          GRPC_TRACE_FLAG_ENABLED(grpc_keepalive_trace)) {
+        gpr_log(
+            GPR_INFO, "CLIENT: Ping delayed [%s]: too many recent pings: %d/%d",
+            t->peer_string.c_str(), t->ping_state.pings_before_data_required,
+            t->ping_policy.max_pings_without_data);
+      }
+      return;
     }
-    return;
-  }
-  // InvalidateNow to avoid getting stuck re-initializing the ping timer
-  // in a loop while draining the currently-held combiner. Also see
-  // https://github.com/grpc/grpc/issues/26079.
-  grpc_core::ExecCtx::Get()->InvalidateNow();
-  grpc_core::Timestamp now = grpc_core::ExecCtx::Get()->Now();
+    // InvalidateNow to avoid getting stuck re-initializing the ping timer
+    // in a loop while draining the currently-held combiner. Also see
+    // https://github.com/grpc/grpc/issues/26079.
+    grpc_core::ExecCtx::Get()->InvalidateNow();
+    grpc_core::Timestamp now = grpc_core::ExecCtx::Get()->Now();
 
-  grpc_core::Duration next_allowed_ping_interval =
-      (t->keepalive_permit_without_calls == 0 &&
-       grpc_chttp2_stream_map_size(&t->stream_map) == 0)
-          ? grpc_core::Duration::Hours(2)
-          : grpc_core::Duration::Seconds(
-                1); /* A second is added to deal with network delays and timing
-                       imprecision */
-  grpc_core::Timestamp next_allowed_ping =
-      t->ping_state.last_ping_sent_time + next_allowed_ping_interval;
+    grpc_core::Duration next_allowed_ping_interval =
+        (t->keepalive_permit_without_calls == 0 &&
+         grpc_chttp2_stream_map_size(&t->stream_map) == 0)
+            ? grpc_core::Duration::Hours(2)
+            : grpc_core::Duration::Seconds(
+                  1); /* A second is added to deal with network delays and
+                         timing imprecision */
+    grpc_core::Timestamp next_allowed_ping =
+        t->ping_state.last_ping_sent_time + next_allowed_ping_interval;
 
-  if (next_allowed_ping > now) {
-    /* not enough elapsed time between successive pings */
-    if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
-        GRPC_TRACE_FLAG_ENABLED(grpc_bdp_estimator_trace) ||
-        GRPC_TRACE_FLAG_ENABLED(grpc_keepalive_trace)) {
-      gpr_log(
-          GPR_INFO,
-          "%s: Ping delayed [%s]: not enough time elapsed since last ping. "
-          " Last ping %" PRId64 ": Next ping %" PRId64 ": Now %" PRId64,
-          t->is_client ? "CLIENT" : "SERVER", t->peer_string.c_str(),
-          t->ping_state.last_ping_sent_time.milliseconds_after_process_epoch(),
-          next_allowed_ping.milliseconds_after_process_epoch(),
-          now.milliseconds_after_process_epoch());
+    if (next_allowed_ping > now) {
+      /* not enough elapsed time between successive pings */
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
+          GRPC_TRACE_FLAG_ENABLED(grpc_bdp_estimator_trace) ||
+          GRPC_TRACE_FLAG_ENABLED(grpc_keepalive_trace)) {
+        gpr_log(GPR_INFO,
+                "CLIENT: Ping delayed [%s]: not enough time elapsed since last "
+                "ping. "
+                " Last ping %" PRId64 ": Next ping %" PRId64 ": Now %" PRId64,
+                t->peer_string.c_str(),
+                t->ping_state.last_ping_sent_time
+                    .milliseconds_after_process_epoch(),
+                next_allowed_ping.milliseconds_after_process_epoch(),
+                now.milliseconds_after_process_epoch());
+      }
+      if (!t->ping_state.is_delayed_ping_timer_set) {
+        t->ping_state.is_delayed_ping_timer_set = true;
+        GRPC_CHTTP2_REF_TRANSPORT(t, "retry_initiate_ping_locked");
+        GRPC_CLOSURE_INIT(&t->retry_initiate_ping_locked,
+                          grpc_chttp2_retry_initiate_ping, t,
+                          grpc_schedule_on_exec_ctx);
+        grpc_timer_init(&t->ping_state.delayed_ping_timer, next_allowed_ping,
+                        &t->retry_initiate_ping_locked);
+      }
+      return;
     }
-    if (!t->ping_state.is_delayed_ping_timer_set) {
-      t->ping_state.is_delayed_ping_timer_set = true;
-      GRPC_CHTTP2_REF_TRANSPORT(t, "retry_initiate_ping_locked");
-      GRPC_CLOSURE_INIT(&t->retry_initiate_ping_locked,
-                        grpc_chttp2_retry_initiate_ping, t,
-                        grpc_schedule_on_exec_ctx);
-      grpc_timer_init(&t->ping_state.delayed_ping_timer, next_allowed_ping,
-                      &t->retry_initiate_ping_locked);
-    }
-    return;
+    t->ping_state.last_ping_sent_time = now;
   }
 
   pq->inflight_id = t->ping_ctr;
@@ -124,7 +128,6 @@ static void maybe_initiate_ping(grpc_chttp2_transport* t) {
   grpc_slice_buffer_add(&t->outbuf,
                         grpc_chttp2_ping_create(false, pq->inflight_id));
   GRPC_STATS_INC_HTTP2_PINGS_SENT();
-  t->ping_state.last_ping_sent_time = now;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
       GRPC_TRACE_FLAG_ENABLED(grpc_bdp_estimator_trace) ||
       GRPC_TRACE_FLAG_ENABLED(grpc_keepalive_trace)) {


### PR DESCRIPTION
The channel args `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` and `GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS` should not throttle pings from the server.

To be safe and not cause any unintended outages, an artificial throttling of `keepalive_time / 2` or 20 seconds is being set on the server to throttle pings when there is no receive side data/header activity.

Additional notes - 
* `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` should ideally not be present at all, but we need it to play nice with an internal proxy that does not like clients sending keepalive pings.
* `GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS` should only be throttling keepalive pings from the client as mentioned in https://github.com/grpc/proposal/blob/master/A8-client-side-keepalive.md