### PR TITLE
Add Java 1.45.0 to the interop client matrix.

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -275,6 +275,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.41.1', ReleaseInfo()),
             ('v1.42.1', ReleaseInfo()),
             ('v1.43.1', ReleaseInfo()),
+            ('v1.45.0', ReleaseInfo()),
         ]),
     'python':
         OrderedDict(


### PR DESCRIPTION
Green one off run: https://fusion2.corp.google.com/invocations/7f865867-b50a-4e7a-8d00-4bb4f824105d/targets/grpc%2Fcore%2Fexperimental%2Flinux%2Fgrpc_interop_matrix_adhoc;config=default/log

@ejona86 