### PR TITLE
Use a non-root user in Node interop docker images

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile.template
@@ -18,8 +18,8 @@
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
-  <%include file="../../node_deps.include"/>
   <%include file="../../run_tests_addons.include"/>
+  <%include file="../../node_deps.include"/>
   # Define the default command.
   CMD ["bash"]
   

--- a/templates/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile.template
@@ -17,7 +17,7 @@
   FROM debian:jessie
 
   <%include file="../../apt_get_basic.include"/>
-  <%include file="../../node_deps.include"/>
   <%include file="../../run_tests_addons.include"/>
+  <%include file="../../node_deps.include"/>
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/node_deps.include
+++ b/templates/tools/dockerfile/node_deps.include
@@ -2,13 +2,11 @@
 # Node dependencies
 
 # Install nvm
-RUN touch .profile
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser
+RUN mkdir -p /home/appuser && chown appuser /home/appuser
+USER appuser
+RUN touch ~/.profile
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 # Install all versions of node that we want to test
-RUN /bin/bash -l -c "nvm install 4 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 5 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 6 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 8 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 9 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 10 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm alias default 10"
+RUN /bin/bash -l -c "nvm install 16 && npm config set cache /tmp/npm-cache"
+RUN /bin/bash -l -c "nvm alias default 16"

--- a/templates/tools/dockerfile/node_deps.include
+++ b/templates/tools/dockerfile/node_deps.include
@@ -4,6 +4,7 @@
 # Install nvm
 RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser
 RUN mkdir -p /home/appuser && chown appuser /home/appuser
+RUN chmod 777 /root
 USER appuser
 RUN touch ~/.profile
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash

--- a/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
@@ -87,6 +87,7 @@ RUN mkdir /var/local/jenkins
 # Install nvm
 RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser
 RUN mkdir -p /home/appuser && chown appuser /home/appuser
+RUN chmod 777 /root
 USER appuser
 RUN touch ~/.profile
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash

--- a/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
@@ -78,22 +78,20 @@ RUN python3 -m pip install six==1.16.0
 RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-client==1.12.8 oauth2client==4.1.0
 
 
+
+RUN mkdir /var/local/jenkins
+
 #==================
 # Node dependencies
 
 # Install nvm
-RUN touch .profile
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser
+RUN mkdir -p /home/appuser && chown appuser /home/appuser
+USER appuser
+RUN touch ~/.profile
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 # Install all versions of node that we want to test
-RUN /bin/bash -l -c "nvm install 4 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 5 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 6 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 8 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 9 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 10 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm alias default 10"
-
-RUN mkdir /var/local/jenkins
-
+RUN /bin/bash -l -c "nvm install 16 && npm config set cache /tmp/npm-cache"
+RUN /bin/bash -l -c "nvm alias default 16"
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
@@ -23,7 +23,7 @@ git clone /var/local/jenkins/grpc-node ~/grpc-node
 ${name}')
 
 # copy service account keys if available
-cp -r /var/local/jenkins/service_account $HOME || true
+cp -r /var/local/jenkins/service_account /root/ || true
 
 cd ~/grpc-node
 

--- a/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
@@ -18,7 +18,7 @@ set -e
 
 git clone /var/local/jenkins/grpc-node ~/grpc-node
 # clone gRPC submodules, use data from locally cloned submodules where possible
-(cd ~/grpc-node/ && git submodule foreach 'cd ~/grpc-node \
+(cd /var/local/jenkins/grpc-node/ && git submodule foreach 'cd ~/grpc-node \
 && git submodule update --init --recursive --reference /var/local/jenkins/grpc-node/${name} \
 ${name}')
 

--- a/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
@@ -16,17 +16,16 @@
 # Builds Node interop server and client in a base image.
 set -e
 
-mkdir -p /var/local/git
-git clone /var/local/jenkins/grpc-node /var/local/git/grpc-node
+git clone /var/local/jenkins/grpc-node ~/grpc-node
 # clone gRPC submodules, use data from locally cloned submodules where possible
-(cd /var/local/jenkins/grpc-node/ && git submodule foreach 'cd /var/local/git/grpc-node \
+(cd ~/grpc-node/ && git submodule foreach 'cd ~/grpc-node \
 && git submodule update --init --recursive --reference /var/local/jenkins/grpc-node/${name} \
 ${name}')
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
-cd /var/local/git/grpc-node
+cd ~/grpc-node
 
 # build Node interop client & server
 ./setup_interop.sh

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
@@ -53,22 +53,20 @@ RUN apt-get update && apt-get install -y \
   zip \
   && apt-get clean
 
+
+RUN mkdir /var/local/jenkins
+
 #==================
 # Node dependencies
 
 # Install nvm
-RUN touch .profile
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser
+RUN mkdir -p /home/appuser && chown appuser /home/appuser
+USER appuser
+RUN touch ~/.profile
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 # Install all versions of node that we want to test
-RUN /bin/bash -l -c "nvm install 4 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 5 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 6 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 8 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 9 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm install 10 && npm config set cache /tmp/npm-cache"
-RUN /bin/bash -l -c "nvm alias default 10"
-
-RUN mkdir /var/local/jenkins
-
+RUN /bin/bash -l -c "nvm install 16 && npm config set cache /tmp/npm-cache"
+RUN /bin/bash -l -c "nvm alias default 16"
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
@@ -62,6 +62,7 @@ RUN mkdir /var/local/jenkins
 # Install nvm
 RUN groupadd -g 999 appuser && useradd -r -u 999 -g appuser appuser
 RUN mkdir -p /home/appuser && chown appuser /home/appuser
+RUN chmod 777 /root
 USER appuser
 RUN touch ~/.profile
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
@@ -23,7 +23,7 @@ git clone /var/local/jenkins/grpc-node ~/grpc-node
 ${name}')
 
 # copy service account keys if available
-cp -r /var/local/jenkins/service_account $HOME || true
+cp -r /var/local/jenkins/service_account /root/ || true
 
 cd ~/grpc-node
 

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
@@ -18,7 +18,7 @@ set -e
 
 git clone /var/local/jenkins/grpc-node ~/grpc-node
 # clone gRPC submodules, use data from locally cloned submodules where possible
-(cd ~/grpc-node/ && git submodule foreach 'cd ~/grpc-node \
+(cd /var/local/jenkins/grpc-node/ && git submodule foreach 'cd ~/grpc-node \
 && git submodule update --init --recursive --reference /var/local/jenkins/grpc-node/${name} \
 ${name}')
 

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
@@ -16,17 +16,16 @@
 # Builds Node interop server and client in a base image.
 set -e
 
-mkdir -p /var/local/git
-git clone /var/local/jenkins/grpc-node /var/local/git/grpc-node
+git clone /var/local/jenkins/grpc-node ~/grpc-node
 # clone gRPC submodules, use data from locally cloned submodules where possible
-(cd /var/local/jenkins/grpc-node/ && git submodule foreach 'cd /var/local/git/grpc-node \
+(cd ~/grpc-node/ && git submodule foreach 'cd ~/grpc-node \
 && git submodule update --init --recursive --reference /var/local/jenkins/grpc-node/${name} \
 ${name}')
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
-cd /var/local/git/grpc-node
+cd ~/grpc-node
 
 # build Node interop client & server
 ./setup_interop_purejs.sh

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -415,8 +415,8 @@ class Http2Client:
 class NodeLanguage:
 
     def __init__(self):
-        self.client_cwd = '~/grpc-node'
-        self.server_cwd = '~/grpc-node'
+        self.client_cwd = '../../../../grpc-node'
+        self.server_cwd = '../../../../grpc-node'
         self.safename = str(self)
 
     def client_cmd(self, args):
@@ -455,8 +455,8 @@ class NodeLanguage:
 class NodePureJSLanguage:
 
     def __init__(self):
-        self.client_cwd = '~/grpc-node'
-        self.server_cwd = '~/grpc-node'
+        self.client_cwd = '../../../../grpc-node'
+        self.server_cwd = '../../../../grpc-node'
         self.safename = str(self)
 
     def client_cmd(self, args):

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1234,7 +1234,7 @@ argp.add_argument(
     '--service_account_key_file',
     type=str,
     help='The service account key file to use for some auth interop tests.',
-    default='/var/local/jenkins/service_account/grpc-testing-ebe7c1ac7381.json')
+    default='/root/service_account/grpc-testing-ebe7c1ac7381.json')
 argp.add_argument(
     '--default_service_account',
     type=str,

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -415,8 +415,8 @@ class Http2Client:
 class NodeLanguage:
 
     def __init__(self):
-        self.client_cwd = '../../../../grpc-node'
-        self.server_cwd = '../../../../grpc-node'
+        self.client_cwd = '../../../../home/appuser/grpc-node'
+        self.server_cwd = '../../../../home/appuser/grpc-node'
         self.safename = str(self)
 
     def client_cmd(self, args):
@@ -455,8 +455,8 @@ class NodeLanguage:
 class NodePureJSLanguage:
 
     def __init__(self):
-        self.client_cwd = '../../../../grpc-node'
-        self.server_cwd = '../../../../grpc-node'
+        self.client_cwd = '../../../../home/appuser/grpc-node'
+        self.server_cwd = '../../../../home/appuser/grpc-node'
         self.safename = str(self)
 
     def client_cmd(self, args):

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -415,8 +415,8 @@ class Http2Client:
 class NodeLanguage:
 
     def __init__(self):
-        self.client_cwd = '../grpc-node'
-        self.server_cwd = '../grpc-node'
+        self.client_cwd = '~/grpc-node'
+        self.server_cwd = '~/grpc-node'
         self.safename = str(self)
 
     def client_cmd(self, args):

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1234,7 +1234,7 @@ argp.add_argument(
     '--service_account_key_file',
     type=str,
     help='The service account key file to use for some auth interop tests.',
-    default='~/service_account/grpc-testing-ebe7c1ac7381.json')
+    default='/var/local/jenkins/service_account/grpc-testing-ebe7c1ac7381.json')
 argp.add_argument(
     '--default_service_account',
     type=str,

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1234,7 +1234,7 @@ argp.add_argument(
     '--service_account_key_file',
     type=str,
     help='The service account key file to use for some auth interop tests.',
-    default='/root/service_account/grpc-testing-ebe7c1ac7381.json')
+    default='~/service_account/grpc-testing-ebe7c1ac7381.json')
 argp.add_argument(
     '--default_service_account',
     type=str,

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -455,8 +455,8 @@ class NodeLanguage:
 class NodePureJSLanguage:
 
     def __init__(self):
-        self.client_cwd = '../grpc-node'
-        self.server_cwd = '../grpc-node'
+        self.client_cwd = '~/grpc-node'
+        self.server_cwd = '~/grpc-node'
         self.safename = str(self)
 
     def client_cmd(self, args):


### PR DESCRIPTION
A recent interop build error, demonstrated in [this log](https://source.cloud.google.com/results/invocations/bd2a383a-8194-4a9a-8f31-527949b45197/targets/github%2Fgrpc%2Finterop_docker_build/tests;group=tests;test=build_docker_nodepurejs;row=1), appears to be the result of a change in the `gulp` npm package triggering nvm-sh/nvm#1407. The recommended solution in that bug, and the only one that I could get to work, was to use a non-root user. I tested it locally, and with the change, `npm install -g gulp` succeeds.

While I was modifying these docker files, I took the opportunity to switch to a newer version of nvm and the newest LTS version of Node. The previous installation of multiple versions of Node was there to support unit tests, but the unit test docker images for Node are no longer built using that template so that part is no longer necessary.