### PR TITLE
ObjC: End2EndTests fix

### DIFF
--- a/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
+++ b/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
@@ -66,7 +66,6 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create_for_next(NULL);
-  f.shutdown_cq = grpc_completion_queue_create_for_pluck(NULL);
 
   return f;
 }


### PR DESCRIPTION
Following up from https://github.com/grpc/grpc/pull/29049