### PR TITLE
[PHP] fix in-tree build on clang

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -542,7 +542,7 @@ GRPCAPI void grpc_resource_quota_set_max_threads(
 
 /** EXPERIMENTAL.  Dumps xDS configs as a serialized ClientConfig proto.
     The full name of the proto is envoy.service.status.v3.ClientConfig. */
-GRPCAPI grpc_slice grpc_dump_xds_configs();
+GRPCAPI grpc_slice grpc_dump_xds_configs(void);
 
 /** Fetch a vtable for a grpc_channel_arg that points to a grpc_resource_quota
  */

--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -733,7 +733,7 @@ typedef struct grpc_tls_identity_pairs grpc_tls_identity_pairs;
  * Creates a grpc_tls_identity_pairs that stores a list of identity credential
  * data, including identity private key and identity certificate chain.
  */
-GRPCAPI grpc_tls_identity_pairs* grpc_tls_identity_pairs_create();
+GRPCAPI grpc_tls_identity_pairs* grpc_tls_identity_pairs_create(void);
 
 /**
  * EXPERIMENTAL API - Subject to change
@@ -1053,7 +1053,7 @@ grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_external_create(
  * Factory function for an internal verifier that will do the default hostname
  * check.
  */
-grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_host_name_create();
+grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_host_name_create(void);
 
 /**
  * EXPERIMENTAL API - Subject to change
@@ -1143,14 +1143,14 @@ grpc_server_credentials* grpc_tls_server_credentials_create(
  *
  * This method creates an insecure channel credentials object.
  */
-GRPCAPI grpc_channel_credentials* grpc_insecure_credentials_create();
+GRPCAPI grpc_channel_credentials* grpc_insecure_credentials_create(void);
 
 /**
  * EXPERIMENTAL API - Subject to change
  *
  * This method creates an insecure server credentials object.
  */
-GRPCAPI grpc_server_credentials* grpc_insecure_server_credentials_create();
+GRPCAPI grpc_server_credentials* grpc_insecure_server_credentials_create(void);
 
 /**
  * EXPERIMENTAL API - Subject to change

--- a/src/php/ext/grpc/completion_queue.h
+++ b/src/php/ext/grpc/completion_queue.h
@@ -24,7 +24,7 @@
 #include <grpc/grpc.h>
 
 #if PHP_MAJOR_VERSION >= 8
-#define TSRMLS_D
+#define TSRMLS_D void
 #endif
 
 /* The global completion queue for all operations */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -120,7 +120,7 @@ void create_new_channel(
   }
 }
 
-void acquire_persistent_locks() {
+void acquire_persistent_locks(void) {
   zval *data;
   PHP_GRPC_HASH_FOREACH_VAL_START(&grpc_persistent_list, data)
     php_grpc_zend_resource *rsrc  =
@@ -134,7 +134,7 @@ void acquire_persistent_locks() {
   PHP_GRPC_HASH_FOREACH_END()
 }
 
-void release_persistent_locks() {
+void release_persistent_locks(void) {
   zval *data;
   PHP_GRPC_HASH_FOREACH_VAL_START(&grpc_persistent_list, data)
     php_grpc_zend_resource *rsrc  =
@@ -148,7 +148,7 @@ void release_persistent_locks() {
   PHP_GRPC_HASH_FOREACH_END()
 }
 
-void destroy_grpc_channels() {
+void destroy_grpc_channels(void) {
   zval *data;
   PHP_GRPC_HASH_FOREACH_VAL_START(&grpc_persistent_list, data)
     php_grpc_zend_resource *rsrc  =
@@ -166,7 +166,7 @@ void destroy_grpc_channels() {
   PHP_GRPC_HASH_FOREACH_END()
 }
 
-void prefork() {
+void prefork(void) {
   acquire_persistent_locks();
 }
 
@@ -177,7 +177,7 @@ void php_grpc_clean_persistent_list(TSRMLS_D) {
     zend_hash_clean(&grpc_target_upper_bound_map);
 }
 
-void postfork_child() {
+void postfork_child(void) {
   TSRMLS_FETCH();
 
   // loop through persistent list and destroy all underlying grpc_channel objs
@@ -204,11 +204,11 @@ void postfork_child() {
   grpc_php_init_completion_queue(TSRMLS_C);
 }
 
-void postfork_parent() {
+void postfork_parent(void) {
   release_persistent_locks();
 }
 
-void register_fork_handlers() {
+void register_fork_handlers(void) {
   if (getenv("GRPC_ENABLE_FORK_SUPPORT")) {
 #ifdef GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
     pthread_atfork(&prefork, &postfork_parent, &postfork_child);

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -50,7 +50,7 @@ extern zend_module_entry grpc_module_entry;
 #define TSRMLS_CC
 #define TSRMLS_C
 #define TSRMLS_DC
-#define TSRMLS_D
+#define TSRMLS_D void
 #define TSRMLS_FETCH()
 #endif
 


### PR DESCRIPTION
PHP supports in-tree builds of extensions published by PECL and others, and gRPC can be built successfully with gcc. But, clang will produce a build error.

This is because `-Wall` and `-Werror` are specified simultaneously, and `void` is not explicitly specified in the function declaration when there are no arguments.

```
$ docker run --rm -it debian:11-slim
# apt-get update
# apt-get install -y autoconf dpkg-dev file clang libc-dev make pkg-config re2c bison zlib1g-dev git
# apt-get remove -y gcc g++ cpp g++-10
# export CC="$(which clang)"
# export CXX="$(which clang++)"
# git clone --depth=1 --branch=master --recursive https://github.com/grpc/grpc
# cd grpc
# EXTRA_DEFINES="GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK" make -j"$(nproc)"
# cp -a ./libs/opt/libgrpc.* "/usr/lib"
# cp -a ./libs/opt/libgpr.* "/usr/lib"
# cd -
# git clone --depth=1 --branch=php-8.1.3 https://github.com/php/php-src
# cd php-src
# cp -R "../grpc/src/php/ext/grpc" "./ext"
# ./buildconf --force
# ./configure --disable-all --disable-phpdbg --disable-cgi --disable-fpm --enable-cli --enable-grpc="../grpc"
# make -j"$(nproc)"
In file included from /php-src/ext/grpc/byte_buffer.c:23:
In file included from ext/grpc/byte_buffer.h:22:
/grpc/include/grpc/grpc.h:545:41: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_slice grpc_dump_xds_configs();
                                        ^
                                         void
1 error generated.
make: *** [Makefile:510: ext/grpc/byte_buffer.lo] Error 1
make: *** Waiting for unfinished jobs....
In file included from /php-src/ext/grpc/call.c:24:
In file included from ext/grpc/call.h:22:
In file included from ext/grpc/php_grpc.h:33:
/grpc/include/grpc/grpc.h:545:41: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_slice grpc_dump_xds_configs();
                                        ^
                                         void
In file included from /php-src/ext/grpc/call.c:24:
In file included from ext/grpc/call.h:24:
In file included from ext/grpc/channel.h:22:
In file included from ext/grpc/channel_credentials.h:24:
/grpc/include/grpc/grpc_security.h:736:64: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_tls_identity_pairs* grpc_tls_identity_pairs_create();
                                                               ^
                                                                void
/grpc/include/grpc/grpc_security.h:1056:78: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_host_name_create();
                                                                             ^
                                                                              void
/grpc/include/grpc/grpc_security.h:1146:67: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_channel_credentials* grpc_insecure_credentials_create();
                                                                  ^
                                                                   void
/grpc/include/grpc/grpc_security.h:1153:73: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_server_credentials* grpc_insecure_server_credentials_create();
                                                                        ^
                                                                         void
In file included from /php-src/ext/grpc/call.c:24:
In file included from ext/grpc/call.h:24:
In file included from ext/grpc/channel.h:22:
ext/grpc/channel_credentials.h:44:35: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_channel_credentials(TSRMLS_D);
                                  ^
                                           void
In file included from /php-src/ext/grpc/call.c:24:
ext/grpc/call.h:50:20: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_call(TSRMLS_D);
                   ^
                            void
In file included from /php-src/ext/grpc/call.c:31:
ext/grpc/call_credentials.h:59:32: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_call_credentials(TSRMLS_D);
                               ^
                                        void
In file included from /php-src/ext/grpc/call.c:32:
ext/grpc/completion_queue.h:34:36: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_php_init_completion_queue(TSRMLS_D);
                                   ^
                                            void
ext/grpc/completion_queue.h:37:40: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_php_shutdown_completion_queue(TSRMLS_D);
                                       ^
                                                void
In file included from /php-src/ext/grpc/call.c:33:
ext/grpc/timeval.h:39:23: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_timeval(TSRMLS_D);
                      ^
                               void
ext/grpc/timeval.h:42:27: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_shutdown_timeval(TSRMLS_D);
                          ^
                                   void
/php-src/ext/grpc/call.c:622:20: error: this old-style function definition is not preceded by a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_call(TSRMLS_D) {
                   ^
13 errors generated.
make: *** [Makefile:513: ext/grpc/call.lo] Error 1
In file included from /php-src/ext/grpc/call_credentials.c:24:
In file included from ext/grpc/call_credentials.h:22:
In file included from ext/grpc/php_grpc.h:33:
/grpc/include/grpc/grpc.h:545:41: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_slice grpc_dump_xds_configs();
                                        ^
                                         void
In file included from /php-src/ext/grpc/call_credentials.c:24:
In file included from ext/grpc/call_credentials.h:24:
/grpc/include/grpc/grpc_security.h:736:64: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_tls_identity_pairs* grpc_tls_identity_pairs_create();
                                                               ^
                                                                void
/grpc/include/grpc/grpc_security.h:1056:78: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_host_name_create();
                                                                             ^
                                                                              void
/grpc/include/grpc/grpc_security.h:1146:67: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_channel_credentials* grpc_insecure_credentials_create();
                                                                  ^
                                                                   void
/grpc/include/grpc/grpc_security.h:1153:73: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_server_credentials* grpc_insecure_server_credentials_create();
                                                                        ^
                                                                         void
In file included from /php-src/ext/grpc/call_credentials.c:24:
ext/grpc/call_credentials.h:59:32: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_call_credentials(TSRMLS_D);
                               ^
                                        void
In file included from /php-src/ext/grpc/call_credentials.c:32:
In file included from ext/grpc/call.h:24:
In file included from ext/grpc/channel.h:22:
ext/grpc/channel_credentials.h:44:35: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_channel_credentials(TSRMLS_D);
                                  ^
                                           void
In file included from /php-src/ext/grpc/call_credentials.c:32:
ext/grpc/call.h:50:20: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_call(TSRMLS_D);
                   ^
                            void
/php-src/ext/grpc/call_credentials.c:245:32: error: this old-style function definition is not preceded by a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_call_credentials(TSRMLS_D) {
                               ^
9 errors generated.
make: *** [Makefile:516: ext/grpc/call_credentials.lo] Error 1
In file included from /php-src/ext/grpc/channel.c:24:
In file included from ext/grpc/channel.h:22:
In file included from ext/grpc/channel_credentials.h:22:
In file included from ext/grpc/php_grpc.h:33:
/grpc/include/grpc/grpc.h:545:41: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_slice grpc_dump_xds_configs();
                                        ^
                                         void
In file included from /php-src/ext/grpc/channel.c:24:
In file included from ext/grpc/channel.h:22:
In file included from ext/grpc/channel_credentials.h:24:
/grpc/include/grpc/grpc_security.h:736:64: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_tls_identity_pairs* grpc_tls_identity_pairs_create();
                                                               ^
                                                                void
/grpc/include/grpc/grpc_security.h:1056:78: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_host_name_create();
                                                                             ^
                                                                              void
/grpc/include/grpc/grpc_security.h:1146:67: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_channel_credentials* grpc_insecure_credentials_create();
                                                                  ^
                                                                   void
/grpc/include/grpc/grpc_security.h:1153:73: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
GRPCAPI grpc_server_credentials* grpc_insecure_server_credentials_create();
                                                                        ^
                                                                         void
In file included from /php-src/ext/grpc/channel.c:24:
In file included from ext/grpc/channel.h:22:
ext/grpc/channel_credentials.h:44:35: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_channel_credentials(TSRMLS_D);
                                  ^
                                           void
In file included from /php-src/ext/grpc/channel.c:36:
ext/grpc/completion_queue.h:34:36: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_php_init_completion_queue(TSRMLS_D);
                                   ^
                                            void
ext/grpc/completion_queue.h:37:40: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_php_shutdown_completion_queue(TSRMLS_D);
                                       ^
                                                void
In file included from /php-src/ext/grpc/channel.c:38:
ext/grpc/timeval.h:39:23: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_init_timeval(TSRMLS_D);
                      ^
                               void
ext/grpc/timeval.h:42:27: error: this function declaration is not a prototype [-Werror,-Wstrict-prototypes]
void grpc_shutdown_timeval(TSRMLS_D);
                          ^
                                   void
10 errors generated.
```

@veblush