### PR TITLE
Add args to python-helloworld example

### DIFF
--- a/examples/python/helloworld/greeter_client.py
+++ b/examples/python/helloworld/greeter_client.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 
+import argparse
 import logging
 
 import grpc
@@ -22,16 +23,22 @@ import helloworld_pb2
 import helloworld_pb2_grpc
 
 
-def run():
+def run(args):
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
     with grpc.insecure_channel('localhost:50051') as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
-        response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
+        response = stub.SayHello(helloworld_pb2.HelloRequest(name=args.name))
     print("Greeter client received: " + response.message)
 
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('--name', type=str, required=False, default='you',
+                        help='person to say hello to')
+    args = parser.parse_args()
+
     logging.basicConfig()
-    run()
+    run(args)

--- a/examples/python/helloworld/greeter_server.py
+++ b/examples/python/helloworld/greeter_server.py
@@ -24,6 +24,7 @@ import helloworld_pb2_grpc
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
     def SayHello(self, request, context):
+        print("Received:", request.name)
         return helloworld_pb2.HelloReply(message='Hello, %s!' % request.name)
 
 


### PR DESCRIPTION
Hi,

I would like to submit a PR for the Python example to have the same input/output as the [Golang QuickStart example](https://grpc.io/docs/languages/go/quickstart/).

- The Golang example accepts an optional `--name` argument

  - https://github.com/grpc/grpc-go/blob/master/examples/helloworld/greeter_client/main.go
- The Golang example outputs the received `name`
  
  - https://github.com/grpc/grpc-go/blob/master/examples/helloworld/greeter_server/main.go


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
