### PR TITLE
Remove decompression from the minimal http stack

### DIFF
--- a/src/core/ext/filters/http/http_filters_plugin.cc
+++ b/src/core/ext/filters/http/http_filters_plugin.cc
@@ -66,6 +66,9 @@ void RegisterHttpFilters(CoreConfiguration::Builder* builder) {
           return true;
         });
   };
+  // TODO(ctiller): return this flag to true once the promise conversion is
+  // complete.
+  static constexpr bool kMinimalStackHasDecompression = false;
   optional(GRPC_CLIENT_SUBCHANNEL, false,
            GRPC_ARG_ENABLE_PER_MESSAGE_COMPRESSION,
            &grpc_message_compress_filter);
@@ -74,12 +77,12 @@ void RegisterHttpFilters(CoreConfiguration::Builder* builder) {
            &grpc_message_compress_filter);
   optional(GRPC_SERVER_CHANNEL, false, GRPC_ARG_ENABLE_PER_MESSAGE_COMPRESSION,
            &grpc_message_compress_filter);
-  optional(GRPC_CLIENT_SUBCHANNEL, true,
+  optional(GRPC_CLIENT_SUBCHANNEL, kMinimalStackHasDecompression,
            GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION, &MessageDecompressFilter);
-  optional(GRPC_CLIENT_DIRECT_CHANNEL, true,
+  optional(GRPC_CLIENT_DIRECT_CHANNEL, kMinimalStackHasDecompression,
            GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION, &MessageDecompressFilter);
-  optional(GRPC_SERVER_CHANNEL, true, GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION,
-           &MessageDecompressFilter);
+  optional(GRPC_SERVER_CHANNEL, kMinimalStackHasDecompression,
+           GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION, &MessageDecompressFilter);
   required(GRPC_CLIENT_SUBCHANNEL, &grpc_http_client_filter);
   required(GRPC_CLIENT_DIRECT_CHANNEL, &grpc_http_client_filter);
   required(GRPC_SERVER_CHANNEL, &grpc_http_server_filter);

--- a/test/core/channel/minimal_stack_is_minimal_test.cc
+++ b/test/core/channel/minimal_stack_is_minimal_test.cc
@@ -79,15 +79,13 @@ int main(int argc, char** argv) {
                         "authority", "connected", NULL);
   errors += CHECK_STACK("unknown", &minimal_stack_args, GRPC_SERVER_CHANNEL,
                         "server", "connected", NULL);
-  errors += CHECK_STACK("chttp2", &minimal_stack_args,
-                        GRPC_CLIENT_DIRECT_CHANNEL, "authority", "http-client",
-                        "message_decompress", "connected", NULL);
-  errors += CHECK_STACK("chttp2", &minimal_stack_args, GRPC_CLIENT_SUBCHANNEL,
-                        "authority", "http-client", "message_decompress",
-                        "connected", NULL);
   errors +=
-      CHECK_STACK("chttp2", &minimal_stack_args, GRPC_SERVER_CHANNEL, "server",
-                  "http-server", "message_decompress", "connected", NULL);
+      CHECK_STACK("chttp2", &minimal_stack_args, GRPC_CLIENT_DIRECT_CHANNEL,
+                  "authority", "http-client", "connected", NULL);
+  errors += CHECK_STACK("chttp2", &minimal_stack_args, GRPC_CLIENT_SUBCHANNEL,
+                        "authority", "http-client", "connected", NULL);
+  errors += CHECK_STACK("chttp2", &minimal_stack_args, GRPC_SERVER_CHANNEL,
+                        "server", "http-server", "connected", NULL);
   errors += CHECK_STACK(nullptr, &minimal_stack_args, GRPC_CLIENT_CHANNEL,
                         "client-channel", NULL);
 


### PR DESCRIPTION
The minimal stack was original intended as a benchmarking apparatus: how fast could we go if we didn't have all the optional pieces in the path.

Nobody uses this besides us though... and whilst that benchmark is useful, having a suite of tests with which to develop the promise-native call apparatus is more useful, and I'd like to get started on this prior to the compression pieces being converted.

So, as a temporary step let's disable decompression in the minimal stack and return in in a month or two once more pieces are complete.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
