### PR TITLE
Do not take ownership for grpc server global callbacks.

### DIFF
--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -303,8 +303,6 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
 
   internal::CondVar shutdown_cv_;
 
-  std::shared_ptr<GlobalCallbacks> global_callbacks_;
-
   std::vector<std::string> services_;
   bool has_async_generic_service_ = false;
   bool has_callback_generic_service_ = false;


### PR DESCRIPTION
The function comment grpc::Server::SetGlobalCallbacks() states that "Can only be called once per application. Does not take ownership of callbacks". However, the implementation uses shared_ptr which takes ownership. Make it the same as ClientContext's GlobalCallbacks.

Previous PR #17511 was closed without merged.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
