### PR TITLE
xds: accept resources wrapped in a Resource message

### DIFF
--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -403,7 +403,7 @@ absl::Status XdsApi::ParseAdsResponse(const XdsBootstrap::XdsServer& server,
     absl::string_view serialized_resource =
         UpbStringToAbsl(google_protobuf_Any_value(resources[i]));
     // Unwrap Resource messages, if so wrapped.
-    if (type_url == "envoy.service.discovery.v2.Resource" ||
+    if (type_url == "envoy.api.v2.Resource" ||
         type_url == "envoy.service.discovery.v3.Resource") {
       const auto* resource_wrapper = envoy_service_discovery_v3_Resource_parse(
           serialized_resource.data(), serialized_resource.size(), arena.ptr());

--- a/src/proto/grpc/testing/xds/v3/discovery.proto
+++ b/src/proto/grpc/testing/xds/v3/discovery.proto
@@ -21,6 +21,7 @@ package envoy.service.discovery.v3;
 import "src/proto/grpc/testing/xds/v3/base.proto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 
 message Status {
   // The status code, which should be an enum value of [google.rpc.Code][].
@@ -119,4 +120,48 @@ message DiscoveryResponse {
   // DiscoveryRequest bearing the nonce. The nonce is optional and is not
   // required for non-stream based xDS implementations.
   string nonce = 5;
+}
+
+// [#next-free-field: 8]
+message Resource {
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
+  message CacheControl {
+    // If true, xDS proxies may not cache this resource.
+    // Note that this does not apply to clients other than xDS proxies, which must cache resources
+    // for their own use, regardless of the value of this field.
+    bool do_not_cache = 1;
+  }
+
+  // The resource's name, to distinguish it from others of the same type of resource.
+  string name = 3;
+
+  // The aliases are a list of other names that this resource can go by.
+  repeated string aliases = 4;
+
+  // The resource level version. It allows xDS to track the state of individual
+  // resources.
+  string version = 1;
+
+  // The resource being tracked.
+  google.protobuf.Any resource = 2;
+
+  // Time-to-live value for the resource. For each resource, a timer is started. The timer is
+  // reset each time the resource is received with a new TTL. If the resource is received with
+  // no TTL set, the timer is removed for the resource. Upon expiration of the timer, the
+  // configuration for the resource will be removed.
+  //
+  // The TTL can be refreshed or changed by sending a response that doesn't change the resource
+  // version. In this case the resource field does not need to be populated, which allows for
+  // light-weight "heartbeat" updates to keep a resource with a TTL alive.
+  //
+  // The TTL feature is meant to support configurations that should be removed in the event of
+  // a management server failure. For example, the feature may be used for fault injection
+  // testing where the fault injection should be terminated in the event that Envoy loses contact
+  // with the management server.
+  google.protobuf.Duration ttl = 6;
+
+  // Cache control properties for the resource.
+  // [#not-implemented-hide:]
+  CacheControl cache_control = 7;
 }


### PR DESCRIPTION
The client sends the `xds.config.resource-in-sotw` capability to let the server know it can do this.