### PR TITLE
GracefulGoaway: Fix shutdown_finishes_tags test

### DIFF
--- a/test/core/end2end/tests/shutdown_finishes_tags.cc
+++ b/test/core/end2end/tests/shutdown_finishes_tags.cc
@@ -63,8 +63,6 @@ static void shutdown_client(grpc_end2end_test_fixture* f) {
 }
 
 static void end_test(grpc_end2end_test_fixture* f) {
-  shutdown_client(f);
-
   grpc_completion_queue_shutdown(f->cq);
   drain_cq(f->cq);
   grpc_completion_queue_destroy(f->cq);
@@ -87,6 +85,7 @@ static void test_early_server_shutdown_finishes_tags(
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(
                                  f.server, &s, &call_details,
                                  &request_metadata_recv, f.cq, f.cq, tag(101)));
+  shutdown_client(&f);
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(1000));
   CQ_EXPECT_COMPLETION(cqv, tag(101), 0);
   CQ_EXPECT_COMPLETION(cqv, tag(1000), 1);


### PR DESCRIPTION
Also needed for Graceful Goaways. The test is expecting the shutdown tags to be returned but the channel is still active preventing shutdown, so we destroy the channel before expecting the shutdown tags to be returned.