### PR TITLE
Clean up absl-base and time external binds.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5064,8 +5064,8 @@ grpc_cc_library(
         "src/cpp/ext/filters/census/server_filter.h",
     ],
     external_deps = [
-        "absl-base",
-        "absl-time",
+        "absl/base",
+        "absl/time",
         "absl/strings",
         "opencensus-trace",
         "opencensus-trace-context_util",

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -56,21 +56,6 @@ def grpc_deps():
     )
 
     native.bind(
-        name = "absl",
-        actual = "@com_google_absl//absl",
-    )
-
-    native.bind(
-        name = "absl-base",
-        actual = "@com_google_absl//absl/base",
-    )
-
-    native.bind(
-        name = "absl-time",
-        actual = "@com_google_absl//absl/time:time",
-    )
-
-    native.bind(
         name = "libssl",
         actual = "@boringssl//:ssl",
     )


### PR DESCRIPTION
The 3 absl external binds are no long necessary.