### PR TITLE
Disable PHP valgrind memoryleak test on arm64

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -43,8 +43,12 @@ export ZEND_DONT_UNLOAD_MODULES=1
 export USE_ZEND_ALLOC=0
 # Detect whether valgrind is executable
 if [ -x "$(command -v valgrind)" ]; then
-  $(which valgrind) --error-exitcode=10 --leak-check=yes \
-    $VALGRIND_UNDEF_VALUE_ERRORS \
-    $(which php) $extension_dir -d max_execution_time=300 \
-    ../tests/MemoryLeakTest/MemoryLeakTest.php
+  # skip the memory leak test on ARM64
+  # TODO(jtattermusch): reenable the test once https://github.com/grpc/grpc/issues/29098 is fixed.
+  if [ "$(uname -m)" != "aarch64" ]; then
+    $(which valgrind) --error-exitcode=10 --leak-check=yes \
+      $VALGRIND_UNDEF_VALUE_ERRORS \
+      $(which php) $extension_dir -d max_execution_time=300 \
+      ../tests/MemoryLeakTest/MemoryLeakTest.php
+  fi
 fi


### PR DESCRIPTION
Temporarily disable the test on ARM64 to avoid continuous failure.
See https://github.com/grpc/grpc/issues/29098