### PR TITLE
Python: Unify API between RPCState and ServicerContext(s)

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi
@@ -66,6 +66,9 @@ cdef class AioChannel:
                 try_to_connect,
             )
 
+    def target(self):
+        return self._target
+
     async def watch_connectivity_state(self,
                                        grpc_connectivity_state last_observed_state,
                                        object deadline):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -36,6 +36,7 @@ cdef class RPCState(GrpcCallWrapper):
     cdef object callbacks
 
     cdef bytes method(self)
+    cdef bytes host(self)
     cdef tuple invocation_metadata(self)
     cdef void raise_for_termination(self) except *
     cdef int get_write_flag(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -64,6 +64,9 @@ cdef class RPCState:
     cdef bytes method(self):
         return _slice_bytes(self.details.method)
 
+    cdef bytes host(self):
+        return _slice_bytes(self.details.host)
+
     cdef tuple invocation_metadata(self):
         return _metadata(&self.request_metadata)
 
@@ -223,6 +226,12 @@ cdef class _ServicerContext:
     def details(self):
         return self._rpc_state.status_details
 
+    def host(self):
+        return self._rpc_state.host()
+
+    def method(self):
+        return self._rpc_state.method()
+
     def set_compression(self, object compression):
         if self._rpc_state.metadata_sent:
             raise RuntimeError('Compression setting must be specified before sending initial metadata')
@@ -346,6 +355,18 @@ cdef class _SyncServicerContext:
 
     def time_remaining(self):
         return self._context.time_remaining()
+
+    def trailing_metadata(self):
+        return self._context.trailing_metadata()
+
+    def code(self):
+        return self._context.code()
+
+    def host(self):
+        return self._context.host()
+
+    def method(self):
+        return self._context.method()
 
 
 async def _run_interceptor(object interceptors, object query_handler,

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -371,3 +371,23 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         Returns:
           A bool indicates if the RPC is done.
         """
+
+    def host(self):
+        """Accesses the value of the host used to connect to the RPC.
+
+        This is an EXPERIMENTAL API.
+
+        Returns:
+          The Host value for the RPC.
+        """
+        raise NotImplementedError()
+
+    def method(self):
+        """Accesses the value of the method used to connect to the RPC.
+
+        This is an EXPERIMENTAL API.
+
+        Returns:
+          The Method value for the RPC.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne

# Overview

New Relic is looking to provide instrumentation to customers on the Python async implementation of gRPC. The information required to report properly attributed telemetry to customers is not completely available, the following changes are designed to fix that.

* Information available on SyncServicerContext differs from ServicerContext making available information different between sync and async handlers.
  * Fixed by supplying missing attributes on the SyncServicerContext
* RPCState contains the host but is irretrievable from Python level, only available in binary extension.
  * Add method to allow extraction of host that matches the extraction for method, as well as providing this API on the ServicerContext and SyncServicerContext to make available from Python.
* Target attribute is not available on channel objects from the Python level which differs from sync gRPC's implementation.
  * Add method to extract it.
