### PR TITLE
Remove non-portable ISO646 operator spelling

### DIFF
--- a/src/core/ext/xds/xds_http_fault_filter.cc
+++ b/src/core/ext/xds/xds_http_fault_filter.cc
@@ -106,7 +106,7 @@ absl::StatusOr<Json> ParseHttpFaultIntoJson(
       int abort_http_status_code =
           envoy_extensions_filters_http_fault_v3_FaultAbort_http_status(
               fault_abort);
-      if (abort_http_status_code != 0 and abort_http_status_code != 200) {
+      if (abort_http_status_code != 0 && abort_http_status_code != 200) {
         abort_grpc_status_code =
             grpc_http2_status_to_grpc_status(abort_http_status_code);
       }


### PR DESCRIPTION
A minimal working example is to build grpc with `-DCMAKE_CXX_FLAGS=-fno-operator-names`.

It failed previously, it succeeds after this fix.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
