### PR TITLE
Revert "Update the scenario results to include start and end time for a test scenario."

### DIFF
--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -42,18 +42,9 @@ grpc_proto_library(
     name = "control_proto",
     srcs = ["control.proto"],
     has_services = False,
-    well_known_protos = True,
     deps = [
         "payloads_proto",
         "stats_proto",
-    ],
-)
-
-proto_library(
-    name = "control_proto_descriptors",
-    srcs = ["control.proto"],
-    deps = [
-        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 import "src/proto/grpc/testing/payloads.proto";
 import "src/proto/grpc/testing/stats.proto";
-import "google/protobuf/timestamp.proto";
 
 package grpc.testing;
 
@@ -266,10 +265,6 @@ message ScenarioResultSummary
   // Queries per CPU-sec over all servers or clients
   double server_queries_per_cpu_sec = 17;
   double client_queries_per_cpu_sec = 18;
-
-  // Start and end time for the test scenario
-  google.protobuf.Timestamp start_time = 19;
-  google.protobuf.Timestamp end_time =20;
 }
 
 // Results of a single benchmark scenario.

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -18,15 +18,12 @@
 
 #include "test/cpp/qps/driver.h"
 
-#include <chrono>
 #include <cinttypes>
 #include <deque>
 #include <list>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-
-#include <google/protobuf/util/time_util.h>
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -576,10 +573,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
 
   // Start a run
   gpr_log(GPR_INFO, "Starting");
-
-  google::protobuf::Timestamp start_timestamp =
-      google::protobuf::util::TimeUtil::GetCurrentTime();
-
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     if (!server->stream->Write(server_mark)) {
@@ -631,9 +624,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
   bool client_finish_first =
       (client_config.rpc_type() != STREAMING_FROM_SERVER);
 
-  google::protobuf::Timestamp end_timestamp =
-      google::protobuf::util::TimeUtil::GetCurrentTime();
-
   FinishClients(clients, client_mark);
 
   if (!client_finish_first) {
@@ -660,10 +650,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
     rrc->set_status_code(it->first);
     rrc->set_count(it->second);
   }
-  // Fill in start and end time for the test scenario
-  result->mutable_summary()->mutable_start_time()->CopyFrom(start_timestamp);
-  result->mutable_summary()->mutable_end_time()->CopyFrom(end_timestamp);
-
   postprocess_scenario_result(result.get());
   return result;
 }


### PR DESCRIPTION
Reverts grpc/grpc#29034 because it fails internal import with

#include <google/protobuf/util/time_util.h> file not found error