### PR TITLE
Include darwin-stub.h for latest libuv v1.44.1 build break for iOS

### DIFF
--- a/third_party/libuv.BUILD
+++ b/third_party/libuv.BUILD
@@ -225,6 +225,7 @@ ANDROID_LIBUV_SOURCES = [
 DARWIN_LIBUV_SOURCES = [
     "src/unix/bsd-ifaddrs.c",
     "src/unix/darwin.c",
+    "src/unix/darwin-stub.h",
     "src/unix/fsevents.c",
     "src/unix/kqueue.c",
     "src/unix/darwin-proctitle.c",


### PR DESCRIPTION
Include darwin-stub.h for libuv build for MacOS/iOS platform.  This file is needed in order to build latest libuv release (v1.44.1) on onwards 

NOTES: 
 - not merging until PR 27531 timer impl is landed with libuv version bump 


@HannahShiSFB 

---

Upstream libuv patch for iOS at  https://github.com/libuv/libuv/pull/3563
