### PR TITLE
Simplify fallback test client and parameterize fallback deadline

### DIFF
--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -45,6 +45,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/time:time",
     ],
     language = "C++",
     tags = ["no_windows"],

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -191,11 +191,13 @@ void RunCommand(const std::string& command) {
 void WaitForFallbackAndDoRPCs(TestService::Stub* stub) {
   int fallback_retry_count = 0;
   bool fallback = false;
-  absl::Time fallback_deadline = absl::Now() + absl::Seconds(FLAGS_fallback_deadline_seconds);
+  absl::Time fallback_deadline =
+      absl::Now() + absl::Seconds(FLAGS_fallback_deadline_seconds);
   while (absl::Now() < fallback_deadline) {
     GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub.get(), 1);
     if (grpclb_route_type == GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND) {
-      gpr_log(GPR_ERROR, "Got grpclb route type backend. Backends are "
+      gpr_log(GPR_ERROR,
+              "Got grpclb route type backend. Backends are "
               "supposed to be unreachable, so this test is broken");
       GPR_ASSERT(0);
     }
@@ -204,7 +206,8 @@ void WaitForFallbackAndDoRPCs(TestService::Stub* stub) {
               grpclb_route_type);
       abort();
     } else {
-      gpr_log(GPR_ERROR, "Retryable RPC failure on iteration: %d" + fallback_retry_count);
+      gpr_log(GPR_ERROR,
+              "Retryable RPC failure on iteration: %d" + fallback_retry_count);
     }
     fallback_retry_count++;
   }

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -55,9 +55,9 @@
 ABSL_FLAG(std::string, custom_credentials_type, "",
           "User provided credentials type.");
 ABSL_FLAG(std::string, server_uri, "localhost:1000", "Server URI target");
-ABSL_FLAG(std::string, FLAGS_induce_fallback_cmd, "exit 1",
+ABSL_FLAG(std::string, induce_fallback_cmd, "exit 1",
           "Shell command to induce fallback, e.g. by unrouting addresses");
-ABSL_FLAG(int, FLAGS_fallback_deadline_seconds, 1,
+ABSL_FLAG(int, fallback_deadline_seconds, 1,
           "Number of seconds to wait for fallback to occur after inducing it");
 ABSL_FLAG(
     std::string, test_case, "",
@@ -194,7 +194,7 @@ void WaitForFallbackAndDoRPCs(TestService::Stub* stub) {
   absl::Time fallback_deadline =
       absl::Now() + absl::Seconds(FLAGS_fallback_deadline_seconds);
   while (absl::Now() < fallback_deadline) {
-    GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub.get(), 1);
+    GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub, 1);
     if (grpclb_route_type == GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND) {
       gpr_log(GPR_ERROR,
               "Got grpclb route type backend. Backends are "
@@ -212,7 +212,7 @@ void WaitForFallbackAndDoRPCs(TestService::Stub* stub) {
     fallback_retry_count++;
   }
   for (int i = 0; i < 30; i++) {
-    GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub.get(), 20);
+    GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub, 20);
     GPR_ASSERT(grpclb_route_type == GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND);
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -33,6 +33,7 @@
 #include <thread>
 
 #include "absl/flags/flag.h"
+#include "absl/time/time.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -59,17 +59,10 @@ ABSL_FLAG(std::string, induce_fallback_cmd, "exit 1",
           "Shell command to induce fallback, e.g. by unrouting addresses");
 ABSL_FLAG(int, fallback_deadline_seconds, 1,
           "Number of seconds to wait for fallback to occur after inducing it");
-ABSL_FLAG(
-    std::string, test_case, "",
-    "Test case to run. Valid options are:\n\n"
-    "fast_fallback_before_startup : fallback before establishing connection to "
-    "LB;\n"
-    "fast_fallback_after_startup : fallback after startup due to LB/backend "
-    "addresses becoming unroutable;\n"
-    "slow_fallback_before_startup : fallback before startup due to LB address "
-    "being blackholed;\n"
-    "slow_fallback_after_startup : fallback after startup due to LB/backend "
-    "addresses becoming blackholed;\n");
+ABSL_FLAG(std::string, test_case, "",
+          "Test case to run. Valid options are:\n\n"
+          "fallback_before_startup : fallback before making RPCs to backends"
+          "fallback_after_startup : fallback after making RPCs to backends");
 
 #ifdef LINUX_VERSION_CODE
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)
@@ -248,7 +241,7 @@ int main(int argc, char** argv) {
   if (absl::GetFlag(FLAGS_test_case) == "fallback_before_startup") {
     DoFallbackBeforeStartupTest();
     gpr_log(GPR_INFO, "DoFallbackBeforeStartup done!");
-  } else if (absl::GetFlag(FLAGS_test_case) == "fallback_before_startup") {
+  } else if (absl::GetFlag(FLAGS_test_case) == "fallback_after_startup") {
     DoFallbackAfterStartupTest();
     gpr_log(GPR_INFO, "DoFallbackBeforeStartup done!");
   } else {

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -55,10 +55,10 @@
 ABSL_FLAG(std::string, custom_credentials_type, "",
           "User provided credentials type.");
 ABSL_FLAG(std::string, server_uri, "localhost:1000", "Server URI target");
-ABSL_FLAG(std::string, unroute_lb_and_backend_addrs_cmd, "exit 1",
-          "Shell command used to make LB and backend addresses unroutable");
-ABSL_FLAG(std::string, blackhole_lb_and_backend_addrs_cmd, "exit 1",
-          "Shell command used to make LB and backend addresses blackholed");
+ABSL_FLAG(std::string, FLAGS_induce_fallback_cmd, "exit 1",
+          "Shell command to induce fallback, e.g. by unrouting addresses");
+ABSL_FLAG(int, FLAGS_fallback_deadline_seconds, 1,
+          "Number of seconds to wait for fallback to occur after inducing it");
 ABSL_FLAG(
     std::string, test_case, "",
     "Test case to run. Valid options are:\n\n"


### PR DESCRIPTION
C++ analogue of https://github.com/grpc/grpc-java/pull/8989

This also revises the C++ implementation to make it follow the structure of java
