### PR TITLE
exclude arm64 tests from build_submodule_at_head

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -55,4 +55,4 @@ fi
 # commit so that changes are passed to Docker
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --inner_jobs 8 -j 4 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude basictests_arm64 --inner_jobs 8 -j 4 --internal_ci --build_only


### PR DESCRIPTION
Fix b/225037955. Thanks to https://github.com/grpc/grpc/pull/28966/files we started accidentally running tests that were supposed to run on arm64 hardware as part of our *_at_head jobs.

e.g. https://source.cloud.google.com/results/invocations/4358bbee-e5eb-43d0-884a-d9bd0b63244f/targets