### PR TITLE
[python] fix main thread raise error, process no quit

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -880,7 +880,11 @@ def _serve(state):
         if state.server_deallocated:
             _begin_shutdown_once(state)
         if event.completion_type != cygrpc.CompletionType.queue_timeout:
-            if not _process_event_and_continue(state, event):
+            try:
+                if not _process_event_and_continue(state, event):
+                    return
+            except RuntimeError:
+                _begin_shutdown_once(state)
                 return
         # We want to force the deletion of the previous event
         # ~before~ we poll again; if the event has a reference


### PR DESCRIPTION
I have the following problem in production environment.

I need to do something(A) after starting the grpc server, at this time, 'A' throws exception. 

The main thread needs to be shutdown, so the thread pool of grpc is also shutdown.

'_serve' thread raise RuntimeError, and shutdown.

'state.server' alive. process alive, but not work.

I hope stop 'state.server' when '_serve' was closed.




* python version: 3.9.5
* grpcio -- 1.44.0

* server.py
```python
from concurrent import futures
import time

import grpc

import test_pb2_grpc
import test_pb2


class OrderDispatcherServicer(test_pb2_grpc.TestServiceServicer):
    def testFunc(self, request, context):
        time.sleep(0.5)
        return test_pb2.TestRespnse()


server = grpc.server(futures.ThreadPoolExecutor(20))
test_pb2_grpc.add_TestServiceServicer_to_server(OrderDispatcherServicer(), server)
server.add_insecure_port("0.0.0.0:50000")
server.start()
print("Start...")

time.sleep(8)
raise Exception('test')
```

* client.py
```python
from concurrent import futures

import grpc

import test_pb2_grpc
import test_pb2

t_pool = futures.ThreadPoolExecutor(30)
channel = grpc.insecure_channel("localhost:50000")
stub = test_pb2_grpc.TestServiceStub(channel)

def request_test_func():
    stub.testFunc(
        test_pb2.TestRequest()
    )


for _ in range(1000):
    t_pool.submit(request_test_func)



```

* test.proto
```
syntax = "proto3";

package test;

message TestRequest {}

message TestRespnse {}

service TestService {
    rpc testFunc(TestRequest) returns (TestRespnse);
}

```

* error
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/libra/Desktop/python-grpc-env/python-grpc-env/lib/python3.9/site-packages/grpc/_server.py", line 883, in _serve
    if not _process_event_and_continue(state, event):
  File "/Users/libra/Desktop/python-grpc-env/python-grpc-env/lib/python3.9/site-packages/grpc/_server.py", line 847, in _process_event_and_continue
    rpc_state, rpc_future = _handle_call(event, state.generic_handlers,
  File "/Users/libra/Desktop/python-grpc-env/python-grpc-env/lib/python3.9/site-packages/grpc/_server.py", line 757, in _handle_call
    return _handle_with_method_handler(rpc_event, method_handler,
  File "/Users/libra/Desktop/python-grpc-env/python-grpc-env/lib/python3.9/site-packages/grpc/_server.py", line 733, in _handle_with_method_handler
    return state, _handle_unary_unary(rpc_event, state,
  File "/Users/libra/Desktop/python-grpc-env/python-grpc-env/lib/python3.9/site-packages/grpc/_server.py", line 637, in _handle_unary_unary
    return thread_pool.submit(_unary_response_in_pool, rpc_event, state,
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/thread.py", line 163, in submit
    raise RuntimeError('cannot schedule new futures after '
RuntimeError: cannot schedule new futures after interpreter shutdown
```

* result
'state.server' alive, receive request.
'_serve' shutdown, no work.
process work.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

