### PR TITLE
Remove deprecated use_cfstream arg from gRPC build system

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -50,12 +50,6 @@ def if_windows(a):
         "//conditions:default": [],
     })
 
-def if_mac(a):
-    return select({
-        "//:mac_x86_64": a,
-        "//conditions:default": [],
-    })
-
 def _get_external_deps(external_deps):
     ret = []
     for dep in external_deps:
@@ -130,7 +124,6 @@ def grpc_cc_library(
         visibility = None,
         alwayslink = 0,
         data = [],
-        use_cfstream = False,
         tags = [],
         linkstatic = False):
     """An internal wrapper around cc_library.
@@ -150,19 +143,14 @@ def grpc_cc_library(
       visibility: The visibility of the target.
       alwayslink: Whether to enable alwayslink on the cc_library.
       data: Data dependencies.
-      use_cfstream: Whether to use cfstream.
       tags: Tags to apply to the rule.
       linkstatic: Whether to enable linkstatic on the cc_library.
     """
     visibility = _update_visibility(visibility)
     copts = []
-    if use_cfstream:
-        copts = if_mac(["-DGRPC_CFSTREAM"])
     if language.upper() == "C":
         copts = copts + if_not_windows(["-std=c99"])
     linkopts = if_not_windows(["-pthread"]) + if_windows(["-defaultlib:ws2_32.lib"])
-    if use_cfstream:
-        linkopts = linkopts + if_mac(["-framework CoreFoundation"])
 
     if select_deps:
         for select_deps_entry in select_deps:
@@ -295,7 +283,6 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         copts: Add these to the compiler invocation.
         linkstatic: link the binary in static mode
     """
-    copts = copts + if_mac(["-DGRPC_CFSTREAM"])
     if language.upper() == "C":
         copts = copts + if_not_windows(["-std=c99"])
 


### PR DESCRIPTION
It is unused. This removal helps with #28667, and requires a
cherry-pick.


<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

CC @dennycd 
