### PR TITLE
C# windows single-job distribtest

### DIFF
--- a/src/csharp/build_nuget.sh
+++ b/src/csharp/build_nuget.sh
@@ -61,6 +61,7 @@ dotnet restore Grpc.sln
 mkdir -p ../../cmake/build
 cp nativelibs/csharp_ext_linux_x64/libgrpc_csharp_ext.so ../../cmake/build
 cp nativelibs/csharp_ext_macos_x64/libgrpc_csharp_ext.dylib ../../cmake/build
+cp nativelibs/csharp_ext_windows_x64/grpc_csharp_ext.dll ../../cmake/build
 
 dotnet pack --configuration Release Grpc.Core.Api --output ../../artifacts
 dotnet pack --configuration Release Grpc.Core --output ../../artifacts

--- a/tools/internal_ci/windows/grpc_distribtests_csharp.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_csharp.bat
@@ -1,0 +1,65 @@
+@rem Copyright 2022 The gRPC Authors
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+@rem Avoid slow finalization after the script has exited.
+@rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
+IF "%cd%"=="T:\src" (
+  call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
+)
+endlocal
+
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+set PREPARE_BUILD_INSTALL_DEPS_CSHARP=true
+call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
+
+call tools/internal_ci/helper_scripts/prepare_ccache.bat || exit /b 1
+
+@rem Build all C# windows artifacts
+python tools/run_tests/task_runner.py -f artifact windows csharp %TASK_RUNNER_EXTRA_FILTERS% -j 4 --inner_jobs 4 -x build_artifacts_csharp/sponge_log.xml || set FAILED=true
+
+@rem Build all protoc windows artifacts
+python tools/run_tests/task_runner.py -f artifact windows protoc %TASK_RUNNER_EXTRA_FILTERS% -j 4 --inner_jobs 4 -x build_artifacts_protoc/sponge_log.xml || set FAILED=true
+
+@rem the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
+bash -c "rm -rf input_artifacts; mkdir -p input_artifacts; cp -r artifacts/* input_artifacts/ || true"
+
+@rem This step builds the nuget packages from input_artifacts
+@rem Set env variable option to build single platform version of the nugets.
+@rem (this is required as we only have the windows artifacts at hand)
+set GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET=1 
+python tools/run_tests/task_runner.py -f package windows csharp nuget -j 2 -x build_packages/sponge_log.xml || set FAILED=true
+
+@rem the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
+@rem in addition to that, preserve the contents of "artifacts" directory since we want kokoro
+@rem to upload its contents as job output artifacts
+bash -c "rm -rf input_artifacts; mkdir -p input_artifacts; cp -r artifacts/* input_artifacts/ || true"
+
+@rem Run all C# windows distribtests
+@rem We run the distribtests even if some of the artifacts have failed to build, since that gives
+@rem a better signal about which distribtest are affected by the currently broken artifact builds.
+python tools/run_tests/task_runner.py -f distribtest windows csharp %TASK_RUNNER_EXTRA_FILTERS% -j 4 -x distribtests/sponge_log.xml || set FAILED=true
+
+@rem show ccache stats
+ccache --show-stats
+
+bash tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh
+
+if not "%FAILED%" == "" (
+  exit /b 1
+)

--- a/tools/internal_ci/windows/grpc_distribtests_csharp.cfg
+++ b/tools/internal_ci/windows/grpc_distribtests_csharp.cfg
@@ -1,0 +1,26 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_csharp.bat"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}

--- a/tools/internal_ci/windows/pull_request/grpc_distribtests_csharp.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_distribtests_csharp.cfg
@@ -1,0 +1,31 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_csharp.bat"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}
+
+env_vars {
+  key: "TASK_RUNNER_EXTRA_FILTERS"
+  value: "presubmit"
+}

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -107,7 +107,7 @@ class CSharpPackage:
             repo_root = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                      '..', '..', '..')
             environ['EXTERNAL_GIT_ROOT'] = repo_root
-            return create_jobspec(self.name, [build_script],
+            return create_jobspec(self.name, ['bash', build_script],
                                   environ=environ,
                                   shell=True)
 
@@ -177,6 +177,7 @@ def targets():
         CSharpPackage('linux'),
         CSharpPackage('linux', unity=True),
         CSharpPackage('macos'),
+        CSharpPackage('windows'),
         RubyPackage(),
         PythonPackage(),
         PHPPackage()


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc/pull/28614, but this time for windows.

After this PR in, we will have full single-job distribtest coverage for C# (linux, macos and windows)
