### PR TITLE
Make sure to always receive initial metadata in ruby

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -164,7 +164,13 @@ module GRPC
     end
 
     def receive_and_check_status
-      batch_result = @call.run_batch(RECV_STATUS_ON_CLIENT => nil)
+      ops = { RECV_STATUS_ON_CLIENT => nil }
+      ops[RECV_INITIAL_METADATA] = nil unless @metadata_received
+      batch_result = @call.run_batch(ops)
+      unless @metadata_received
+        @call.metadata = batch_result.metadata
+        @metadata_received = true
+      end
       set_input_stream_done
       attach_status_results_and_complete_call(batch_result)
     end


### PR DESCRIPTION
Fixes test failures in https://github.com/grpc/grpc/pull/29145 like https://source.cloud.google.com/results/invocations/5d22ddb2-c1f1-4344-aa1e-19a65394ddaf/targets/github%2Fgrpc%2Frun_tests%2Fruby_macos_dbg_native%2Ftools%2Frun_tests%2Fhelper_scripts%2Frun_ruby.sh/tests
