### PR TITLE
Fix C# "dotnet restore" on grpc-win2016 kokoro workers.

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -56,6 +56,11 @@ ccache --version
 If "%PREPARE_BUILD_INSTALL_DEPS_CSHARP%" == "true" (
   @rem C# prerequisites: Install dotnet SDK
   powershell -File src\csharp\install_dotnet_sdk.ps1 || goto :error
+
+  @rem Explicitly add default nuget source.
+  @rem (on Kokoro grpc-win2016 workers, the default nuget source is not configured,
+  @rem which results in errors when "dotnet restore" is run)
+  %LOCALAPPDATA%\Microsoft\dotnet\dotnet nuget add source https://api.nuget.org/v3/index.json -n "nuget.org"
 )
 
 @rem Add dotnet on path and disable some unwanted dotnet


### PR DESCRIPTION
While trying to upgrade the grpc basictests windows job to grpc-win2016 kokoro pool, I'm got errors:
```
T:\altsrc\github\grpc\workspace_csharp_windows_opt_native\src\csharp\Grpc.Core.NativeDebug\Grpc.Core.NativeDebug.csproj : error NU1101: Unable to find package Microsoft.NETFramework.ReferenceAssemblies. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\altsrc\github\grpc\workspace_csharp_windows_opt_native\src\csharp\Grpc.sln]





T:\altsrc\github\grpc\workspace_csharp_windows_opt_native\src\csharp\Grpc.Reflection.Tests\Grpc.Reflection.Tests.csproj : error NU1101: Unable to find package NUnit. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\altsrc\github\grpc\workspace_csharp_windows_opt_native\src\csharp\Grpc.sln]





T:\altsrc\github\grpc\workspace_csharp_windows_opt_native\src\csharp\Grpc.Examples.MathClient\Grpc.Examples.MathClient.csproj : error NU1101: Unable to find package Microsoft.NETFramework.ReferenceAssemblies. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages [T:\altsrc\github\grpc\workspace_csharp_windows_opt_native\src\csharp\Grpc.sln]
```
(example: https://source.cloud.google.com/results/invocations/cd81a482-8fcb-459e-844a-99fa1913e32a)

Looks like this is becuase the nuget sources are misconfigured on grpc-win2016 workers. This should fix it.