### PR TITLE
Avoid collision with pre-installed protoc on grpc-win2016 workers

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -39,6 +39,10 @@ netsh interface ip set dns "Local Area Connection 8" static 169.254.169.254 prim
 netsh interface ip add dnsservers "Local Area Connection 8" 8.8.8.8 index=2
 netsh interface ip add dnsservers "Local Area Connection 8" 8.8.4.4 index=3
 
+@rem Uninstall protoc so that it doesn't clash with C++ distribtests.
+@rem (on grpc-win2016 kokoro workers it can result in GOOGLE_PROTOBUF_MIN_PROTOC_VERSION violation)
+choco uninstall protoc -y --limit-output
+
 @rem Install nasm (required for boringssl assembly optimized build as boringssl no long supports yasm)
 @rem Downloading from GCS should be very reliables when on a GCP VM.
 mkdir C:\nasm


### PR DESCRIPTION
Currently the windows grpc_distribtests_standalone fails if run on grpc-win2016 worker pool (see https://source.cloud.google.com/results/invocations/e63cc844-2a87-44d4-a67b-48667a26c22f).

This PR makes the test pass on both the legacy "grpc" windows pool as well as the grpc-win2016 pool.

adhoc test run on grpc-win2016: https://source.cloud.google.com/results/invocations/d10e6f30-55a2-43db-9e44-5b94029a8a60 (green).
