### PR TITLE
Fix documentation typo for compression_level

### DIFF
--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -227,7 +227,7 @@ class ServerContextBase {
     return *client_metadata_.map();
   }
 
-  /// Return the compression algorithm to be used by the server call.
+  /// Return the compression level to be used by the server call.
   grpc_compression_level compression_level() const {
     return compression_level_;
   }


### PR DESCRIPTION
This commit fixes a small documentation typo for the compression_level method.

Old:
`Return the compression algorithm ...`

New:
`Return the compression level ...`




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
