### PR TITLE
Add missing include

### DIFF
--- a/src/core/lib/gpr/tls.h
+++ b/src/core/lib/gpr/tls.h
@@ -50,6 +50,7 @@ class TlsTypeConstrainer {
 
 #include <pthread.h>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 


### PR DESCRIPTION
std::min is defined in `<algorithm>` which is no longer transitively
included following LLVM libc++ include modularization work.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
