### PR TITLE
xds_cluster_resolver: fix bug that caused us to incorrectly reuse priority child names

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -495,8 +495,8 @@ void XdsClusterResolverLb::LogicalDNSDiscoveryMechanism::ResolverResultHandler::
 
 const XdsClusterResolverLbConfig::DiscoveryMechanism&
 XdsClusterResolverLb::DiscoveryMechanismEntry::config() const {
-  return discovery_mechanism->parent()->config_->discovery_mechanisms()[
-      discovery_mechanism->index()];
+  return discovery_mechanism->parent()
+      ->config_->discovery_mechanisms()[discovery_mechanism->index()];
 }
 
 std::string XdsClusterResolverLb::DiscoveryMechanismEntry::GetChildPolicyName(
@@ -504,8 +504,7 @@ std::string XdsClusterResolverLb::DiscoveryMechanismEntry::GetChildPolicyName(
   const size_t child_number = priority_child_numbers[priority];
   const auto& discovery_config = config();
   absl::InlinedVector<absl::string_view, 9> parts = {
-    "{cluster=", discovery_config.cluster_name, ","
-  };
+      "{cluster=", discovery_config.cluster_name, ","};
   if (!discovery_config.eds_service_name.empty()) {
     parts.push_back("eds_service_name=");
     parts.push_back(discovery_config.eds_service_name);
@@ -761,9 +760,9 @@ ServerAddressList XdsClusterResolverLb::CreateChildPolicyAddressesLocked() {
           }
           addresses.emplace_back(
               endpoint
-                  .WithAttribute(kHierarchicalPathAttributeKey,
-                                 MakeHierarchicalPathAttribute(
-                                     hierarchical_path))
+                  .WithAttribute(
+                      kHierarchicalPathAttributeKey,
+                      MakeHierarchicalPathAttribute(hierarchical_path))
                   .WithAttribute(kXdsLocalityNameAttributeKey,
                                  absl::make_unique<XdsLocalityAttribute>(
                                      locality_name->Ref()))
@@ -791,7 +790,7 @@ XdsClusterResolverLb::CreateChildPolicyConfigLocked() {
           discovery_entry.latest_update->priorities[priority];
       Json child_policy;
       if (!discovery_entry.discovery_mechanism->override_child_policy()
-              .empty()) {
+               .empty()) {
         child_policy =
             discovery_entry.discovery_mechanism->override_child_policy();
       } else {

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -131,23 +131,13 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
         RefCountedPtr<XdsClusterResolverLb> xds_cluster_resolver_lb,
         size_t index)
         : parent_(std::move(xds_cluster_resolver_lb)), index_(index) {}
-    virtual void Start() = 0;
-    void Orphan() override = 0;
-    virtual Json::Array override_child_policy() = 0;
-    virtual bool disable_reresolution() = 0;
 
-    // Returns a pair containing the cluster and eds_service_name
-    // to use for LRS load reporting. Caller must ensure that config_ is set
-    // before calling.
-    std::pair<absl::string_view, absl::string_view> GetLrsClusterKey() const {
-      return {
-          parent_->config_->discovery_mechanisms()[index_].cluster_name,
-          parent_->config_->discovery_mechanisms()[index_].eds_service_name};
-    }
-
-   protected:
     XdsClusterResolverLb* parent() const { return parent_.get(); }
     size_t index() const { return index_; }
+
+    virtual void Start() = 0;
+    virtual Json::Array override_child_policy() = 0;
+    virtual bool disable_reresolution() = 0;
 
    private:
     RefCountedPtr<XdsClusterResolverLb> parent_;
@@ -229,14 +219,9 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
     friend class EndpointWatcher;
 
     absl::string_view GetEdsResourceName() const {
-      if (!parent()
-               ->config_->discovery_mechanisms()[index()]
-               .eds_service_name.empty()) {
-        return parent()
-            ->config_->discovery_mechanisms()[index()]
-            .eds_service_name;
-      }
-      return parent()->config_->discovery_mechanisms()[index()].cluster_name;
+      auto& config = parent()->config_->discovery_mechanisms()[index()];
+      if (!config.eds_service_name.empty()) return config.eds_service_name;
+      return config.cluster_name;
     }
 
     // Note that this is not owned, so this pointer must never be dereferenced.
@@ -284,15 +269,15 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
 
   struct DiscoveryMechanismEntry {
     OrphanablePtr<DiscoveryMechanism> discovery_mechanism;
-    bool first_update_received = false;
-    // Number of priorities this mechanism has contributed to priority_list_.
-    // (The sum of this across all discovery mechanisms should always equal
-    // the number of priorities in priority_list_.)
-    uint32_t num_priorities = 0;
-    RefCountedPtr<XdsEndpointResource::DropConfig> drop_config;
-    // Populated only when an update has been delivered by the mechanism
-    // but has not yet been applied to the LB policy's combined priority_list_.
-    absl::optional<XdsEndpointResource::PriorityList> pending_priority_list;
+    // Most recent update reported by the discovery mechanism.
+    absl::optional<XdsEndpointResource> latest_update;
+    // State used to retain child policy names for priority policy.
+    std::vector<size_t /*child_number*/> priority_child_numbers;
+
+    const XdsClusterResolverLbConfig::DiscoveryMechanism& config() const;
+
+    // Returns the child policy name for a given priority.
+    std::string GetChildPolicyName(size_t priority) const;
   };
 
   class Helper : public ChannelControlHelper {
@@ -331,7 +316,6 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
 
   void MaybeDestroyChildPolicyLocked();
 
-  void UpdatePriorityList(XdsEndpointResource::PriorityList priority_list);
   void UpdateChildPolicyLocked();
   OrphanablePtr<LoadBalancingPolicy> CreateChildPolicyLocked(
       const grpc_channel_args* args);
@@ -352,11 +336,6 @@ class XdsClusterResolverLb : public LoadBalancingPolicy {
 
   // Vector of discovery mechansism entries in priority order.
   std::vector<DiscoveryMechanismEntry> discovery_mechanisms_;
-
-  // The latest data from the endpoint watcher.
-  XdsEndpointResource::PriorityList priority_list_;
-  // State used to retain child policy names for priority policy.
-  std::vector<size_t /*child_number*/> priority_child_numbers_;
 
   OrphanablePtr<LoadBalancingPolicy> child_policy_;
 };
@@ -511,6 +490,36 @@ void XdsClusterResolverLb::LogicalDNSDiscoveryMechanism::ResolverResultHandler::
 }
 
 //
+// XdsClusterResolverLb::DiscoveryMechanismEntry
+//
+
+const XdsClusterResolverLbConfig::DiscoveryMechanism&
+XdsClusterResolverLb::DiscoveryMechanismEntry::config() const {
+  return discovery_mechanism->parent()->config_->discovery_mechanisms()[
+      discovery_mechanism->index()];
+}
+
+std::string XdsClusterResolverLb::DiscoveryMechanismEntry::GetChildPolicyName(
+    size_t priority) const {
+  const size_t child_number = priority_child_numbers[priority];
+  const auto& discovery_config = config();
+  absl::InlinedVector<absl::string_view, 9> parts = {
+    "{cluster=", discovery_config.cluster_name, ","
+  };
+  if (!discovery_config.eds_service_name.empty()) {
+    parts.push_back("eds_service_name=");
+    parts.push_back(discovery_config.eds_service_name);
+    parts.push_back(",");
+  } else if (!discovery_config.dns_hostname.empty()) {
+    parts.push_back("dns_hostname=");
+    parts.push_back(discovery_config.dns_hostname);
+    parts.push_back(",");
+  }
+  parts.push_back("child_number=");
+  return absl::StrCat(absl::StrJoin(parts, ""), child_number, "}");
+}
+
+//
 // XdsClusterResolverLb public methods
 //
 
@@ -613,15 +622,77 @@ void XdsClusterResolverLb::OnEndpointChanged(size_t index,
             " for discovery mechanism %" PRIuPTR "",
             this, index);
   }
+  DiscoveryMechanismEntry& discovery_entry = discovery_mechanisms_[index];
   // We need at least one priority for each discovery mechanism, just so that we
   // have a child in which to create the xds_cluster_impl policy.  This ensures
   // that we properly handle the case of a discovery mechanism dropping 100% of
   // calls, the OnError() case, and the OnResourceDoesNotExist() case.
   if (update.priorities.empty()) update.priorities.emplace_back();
-  discovery_mechanisms_[index].drop_config = std::move(update.drop_config);
-  discovery_mechanisms_[index].pending_priority_list =
-      std::move(update.priorities);
-  discovery_mechanisms_[index].first_update_received = true;
+  // Update priority_child_numbers, reusing old child numbers in an
+  // intelligent way to avoid unnecessary churn.
+  // First, build some maps from locality to child number and the reverse
+  // from the old data in the entry's update and priority_child_numbers.
+  std::map<XdsLocalityName*, size_t /*child_number*/, XdsLocalityName::Less>
+      locality_child_map;
+  std::map<size_t, std::set<XdsLocalityName*, XdsLocalityName::Less>>
+      child_locality_map;
+  if (discovery_entry.latest_update.has_value()) {
+    const auto& prev_priority_list = discovery_entry.latest_update->priorities;
+    for (size_t priority = 0; priority < prev_priority_list.size();
+         ++priority) {
+      size_t child_number = discovery_entry.priority_child_numbers[priority];
+      const auto& localities = prev_priority_list[priority].localities;
+      for (const auto& p : localities) {
+        XdsLocalityName* locality_name = p.first;
+        locality_child_map[locality_name] = child_number;
+        child_locality_map[child_number].insert(locality_name);
+      }
+    }
+  }
+  // Construct new list of children.
+  std::vector<size_t> priority_child_numbers;
+  for (size_t priority = 0; priority < update.priorities.size(); ++priority) {
+    const auto& localities = update.priorities[priority].localities;
+    absl::optional<size_t> child_number;
+    // If one of the localities in this priority already existed, reuse its
+    // child number.
+    for (const auto& p : localities) {
+      XdsLocalityName* locality_name = p.first;
+      if (!child_number.has_value()) {
+        auto it = locality_child_map.find(locality_name);
+        if (it != locality_child_map.end()) {
+          child_number = it->second;
+          locality_child_map.erase(it);
+          // Remove localities that *used* to be in this child number, so
+          // that we don't incorrectly reuse this child number for a
+          // subsequent priority.
+          for (XdsLocalityName* old_locality :
+               child_locality_map[*child_number]) {
+            locality_child_map.erase(old_locality);
+          }
+        }
+      } else {
+        // Remove all localities that are now in this child number, so
+        // that we don't accidentally reuse this child number for a
+        // subsequent priority.
+        locality_child_map.erase(locality_name);
+      }
+    }
+    // If we didn't find an existing child number, assign a new one.
+    if (!child_number.has_value()) {
+      for (child_number = 0;
+           child_locality_map.find(*child_number) != child_locality_map.end();
+           ++(*child_number)) {
+      }
+      // Add entry so we know that the child number is in use.
+      // (Don't need to add the list of localities, since we won't use them.)
+      child_locality_map[*child_number];
+    }
+    priority_child_numbers.push_back(*child_number);
+  }
+  // Save update.
+  discovery_entry.latest_update = std::move(update);
+  discovery_entry.priority_child_numbers = std::move(priority_child_numbers);
   // If any discovery mechanism has not received its first update,
   // wait until that happens before creating the child policy.
   // TODO(roth): If this becomes problematic in the future (e.g., a
@@ -632,31 +703,10 @@ void XdsClusterResolverLb::OnEndpointChanged(size_t index,
   // will put the channel into TRANSIENT_FAILURE instead of CONNECTING
   // while we're still waiting for the other discovery mechanism(s).
   for (DiscoveryMechanismEntry& mechanism : discovery_mechanisms_) {
-    if (!mechanism.first_update_received) return;
-  }
-  // Construct new priority list.
-  XdsEndpointResource::PriorityList priority_list;
-  size_t priority_index = 0;
-  for (DiscoveryMechanismEntry& mechanism : discovery_mechanisms_) {
-    // If the mechanism has a pending update, use that.
-    // Otherwise, use the priorities that it previously contributed to the
-    // combined list.
-    if (mechanism.pending_priority_list.has_value()) {
-      priority_list.insert(priority_list.end(),
-                           mechanism.pending_priority_list->begin(),
-                           mechanism.pending_priority_list->end());
-      priority_index += mechanism.num_priorities;
-      mechanism.num_priorities = mechanism.pending_priority_list->size();
-      mechanism.pending_priority_list.reset();
-    } else {
-      priority_list.insert(
-          priority_list.end(), priority_list_.begin() + priority_index,
-          priority_list_.begin() + priority_index + mechanism.num_priorities);
-      priority_index += mechanism.num_priorities;
-    }
+    if (!mechanism.latest_update.has_value()) return;
   }
   // Update child policy.
-  UpdatePriorityList(std::move(priority_list));
+  UpdateChildPolicyLocked();
 }
 
 void XdsClusterResolverLb::OnError(size_t index, absl::Status status) {
@@ -665,7 +715,7 @@ void XdsClusterResolverLb::OnError(size_t index, absl::Status status) {
           " xds watcher reported error: %s",
           this, index, status.ToString().c_str());
   if (shutting_down_) return;
-  if (!discovery_mechanisms_[index].first_update_received) {
+  if (!discovery_mechanisms_[index].latest_update.has_value()) {
     // Call OnEndpointChanged with an empty update just like
     // OnResourceDoesNotExist.
     OnEndpointChanged(index, XdsEndpointResource());
@@ -686,110 +736,42 @@ void XdsClusterResolverLb::OnResourceDoesNotExist(size_t index) {
 // child policy-related methods
 //
 
-void XdsClusterResolverLb::UpdatePriorityList(
-    XdsEndpointResource::PriorityList priority_list) {
-  // Build some maps from locality to child number and the reverse from
-  // the old data in priority_list_ and priority_child_numbers_.
-  std::map<XdsLocalityName*, size_t /*child_number*/, XdsLocalityName::Less>
-      locality_child_map;
-  std::map<size_t, std::set<XdsLocalityName*, XdsLocalityName::Less>>
-      child_locality_map;
-  for (size_t priority = 0; priority < priority_list_.size(); ++priority) {
-    size_t child_number = priority_child_numbers_[priority];
-    const auto& localities = priority_list_[priority].localities;
-    for (const auto& p : localities) {
-      XdsLocalityName* locality_name = p.first;
-      locality_child_map[locality_name] = child_number;
-      child_locality_map[child_number].insert(locality_name);
-    }
-  }
-  // Construct new list of children.
-  std::vector<size_t> priority_child_numbers;
-  for (size_t priority = 0; priority < priority_list.size(); ++priority) {
-gpr_log(GPR_INFO, "FINDING CHILD NUMBER FOR PRIORITY %" PRIuPTR, priority);
-    const auto& localities = priority_list[priority].localities;
-    absl::optional<size_t> child_number;
-    // If one of the localities in this priority already existed, reuse its
-    // child number.
-    for (const auto& p : localities) {
-      XdsLocalityName* locality_name = p.first;
-gpr_log(GPR_INFO, "  CHECKING LOCALITY: %s", locality_name->AsHumanReadableString().c_str());
-      if (!child_number.has_value()) {
-gpr_log(GPR_INFO, "    CHILD NOT FOUND YET, CHECKING FOR LOCALITY IN PREVIOUS UPDATE");
-        auto it = locality_child_map.find(locality_name);
-        if (it != locality_child_map.end()) {
-          child_number = it->second;
-gpr_log(GPR_INFO, "      LOCALITY FOUND IN PREVIOUS UPDATE, REUSING CHILD NUMBER %" PRIuPTR, *child_number);
-          locality_child_map.erase(it);
-          // Remove localities that *used* to be in this child number, so
-          // that we don't incorrectly reuse this child number for a
-          // subsequent priority.
-          for (XdsLocalityName* old_locality :
-               child_locality_map[*child_number]) {
-gpr_log(GPR_INFO, "      REMOVING OTHER LOCALITIES FROM THIS CHILD FROM PREVIOUS UPDATES: %s", old_locality->AsHumanReadableString().c_str());
-            locality_child_map.erase(old_locality);
-          }
-        }
-      } else {
-gpr_log(GPR_INFO, "    CHILD ALREADY FOUND, REMOVING NEW LOCALITY FROM MAP");
-        // Remove all localities that are now in this child number, so
-        // that we don't accidentally reuse this child number for a
-        // subsequent priority.
-        locality_child_map.erase(locality_name);
-      }
-    }
-    // If we didn't find an existing child number, assign a new one.
-    if (!child_number.has_value()) {
-gpr_log(GPR_INFO, "  DID NOT REUSE ANY CHILD NUMBER, CHOOSING A NEW ONE");
-      for (child_number = 0;
-           child_locality_map.find(*child_number) != child_locality_map.end();
-           ++(*child_number)) {
-gpr_log(GPR_INFO, "    CHILD NUMBER %" PRIuPTR " FOUND IN MAP", *child_number);
-      }
-gpr_log(GPR_INFO, "  USING CHILD NUMBER %" PRIuPTR, *child_number);
-      // Add entry so we know that the child number is in use.
-      // (Don't need to add the list of localities, since we won't use them.)
-      child_locality_map[*child_number];
-    }
-    priority_child_numbers.push_back(*child_number);
-  }
-  // Save update.
-  priority_list_ = std::move(priority_list);
-  priority_child_numbers_ = std::move(priority_child_numbers);
-  // Update child policy.
-  UpdateChildPolicyLocked();
-}
-
 ServerAddressList XdsClusterResolverLb::CreateChildPolicyAddressesLocked() {
   ServerAddressList addresses;
-  for (size_t priority = 0; priority < priority_list_.size(); ++priority) {
-    const auto& localities = priority_list_[priority].localities;
-    std::string priority_child_name =
-        absl::StrCat("child", priority_child_numbers_[priority]);
-    for (const auto& p : localities) {
-      const auto& locality_name = p.first;
-      const auto& locality = p.second;
-      std::vector<std::string> hierarchical_path = {
-          priority_child_name, locality_name->AsHumanReadableString()};
-      for (const auto& endpoint : locality.endpoints) {
-        const ServerAddressWeightAttribute* weight_attribute = static_cast<
-            const ServerAddressWeightAttribute*>(endpoint.GetAttribute(
-            ServerAddressWeightAttribute::kServerAddressWeightAttributeKey));
-        uint32_t weight = locality.lb_weight;
-        if (weight_attribute != nullptr) {
-          weight = locality.lb_weight * weight_attribute->weight();
+  for (const auto& discovery_entry : discovery_mechanisms_) {
+    for (size_t priority = 0;
+         priority < discovery_entry.latest_update->priorities.size();
+         ++priority) {
+      const auto& priority_entry =
+          discovery_entry.latest_update->priorities[priority];
+      std::string priority_child_name =
+          discovery_entry.GetChildPolicyName(priority);
+      for (const auto& p : priority_entry.localities) {
+        const auto& locality_name = p.first;
+        const auto& locality = p.second;
+        std::vector<std::string> hierarchical_path = {
+            priority_child_name, locality_name->AsHumanReadableString()};
+        for (const auto& endpoint : locality.endpoints) {
+          const ServerAddressWeightAttribute* weight_attribute = static_cast<
+              const ServerAddressWeightAttribute*>(endpoint.GetAttribute(
+              ServerAddressWeightAttribute::kServerAddressWeightAttributeKey));
+          uint32_t weight = locality.lb_weight;
+          if (weight_attribute != nullptr) {
+            weight = locality.lb_weight * weight_attribute->weight();
+          }
+          addresses.emplace_back(
+              endpoint
+                  .WithAttribute(kHierarchicalPathAttributeKey,
+                                 MakeHierarchicalPathAttribute(
+                                     hierarchical_path))
+                  .WithAttribute(kXdsLocalityNameAttributeKey,
+                                 absl::make_unique<XdsLocalityAttribute>(
+                                     locality_name->Ref()))
+                  .WithAttribute(
+                      ServerAddressWeightAttribute::
+                          kServerAddressWeightAttributeKey,
+                      absl::make_unique<ServerAddressWeightAttribute>(weight)));
         }
-        addresses.emplace_back(
-            endpoint
-                .WithAttribute(kHierarchicalPathAttributeKey,
-                               MakeHierarchicalPathAttribute(hierarchical_path))
-                .WithAttribute(kXdsLocalityNameAttributeKey,
-                               absl::make_unique<XdsLocalityAttribute>(
-                                   locality_name->Ref()))
-                .WithAttribute(
-                    ServerAddressWeightAttribute::
-                        kServerAddressWeightAttributeKey,
-                    absl::make_unique<ServerAddressWeightAttribute>(weight)));
       }
     }
   }
@@ -800,139 +782,117 @@ RefCountedPtr<LoadBalancingPolicy::Config>
 XdsClusterResolverLb::CreateChildPolicyConfigLocked() {
   Json::Object priority_children;
   Json::Array priority_priorities;
-  // Setting up index to iterate through the discovery mechanisms and keeping
-  // track the discovery_mechanism each priority belongs to.
-  size_t discovery_index = 0;
-  // Setting up num_priorities_remaining to track the priorities in each
-  // discovery_mechanism.
-  size_t num_priorities_remaining_in_discovery =
-      discovery_mechanisms_[discovery_index].num_priorities;
-  for (size_t priority = 0; priority < priority_list_.size(); ++priority) {
-    Json child_policy;
-    if (!discovery_mechanisms_[discovery_index]
-             .discovery_mechanism->override_child_policy()
-             .empty()) {
-      child_policy = discovery_mechanisms_[discovery_index]
-                         .discovery_mechanism->override_child_policy();
-    } else {
-      const auto& xds_lb_policy = config_->xds_lb_policy().object_value();
-      if (xds_lb_policy.find("ROUND_ROBIN") != xds_lb_policy.end()) {
-        const auto& localities = priority_list_[priority].localities;
-        Json::Object weighted_targets;
-        for (const auto& p : localities) {
-          XdsLocalityName* locality_name = p.first;
-          const auto& locality = p.second;
-          // Construct JSON object containing locality name.
-          Json::Object locality_name_json;
-          if (!locality_name->region().empty()) {
-            locality_name_json["region"] = locality_name->region();
-          }
-          if (!locality_name->zone().empty()) {
-            locality_name_json["zone"] = locality_name->zone();
-          }
-          if (!locality_name->sub_zone().empty()) {
-            locality_name_json["sub_zone"] = locality_name->sub_zone();
-          }
-          // Add weighted target entry.
-          weighted_targets[locality_name->AsHumanReadableString()] =
-              Json::Object{
-                  {"weight", locality.lb_weight},
-                  {"childPolicy",
-                   Json::Array{
-                       Json::Object{
-                           {"round_robin", Json::Object()},
-                       },
-                   }},
-              };
-        }
-        // Construct locality-picking policy.
-        // Start with field from our config and add the "targets" field.
-        child_policy = Json::Array{
-            Json::Object{
-                {"weighted_target_experimental",
-                 Json::Object{
-                     {"targets", Json::Object()},
-                 }},
-            },
-        };
-        Json::Object& config =
-            *(*child_policy.mutable_array())[0].mutable_object();
-        auto it = config.begin();
-        GPR_ASSERT(it != config.end());
-        (*it->second.mutable_object())["targets"] = std::move(weighted_targets);
+  for (const auto& discovery_entry : discovery_mechanisms_) {
+    const auto& discovery_config = discovery_entry.config();
+    for (size_t priority = 0;
+         priority < discovery_entry.latest_update->priorities.size();
+         ++priority) {
+      const auto& priority_entry =
+          discovery_entry.latest_update->priorities[priority];
+      Json child_policy;
+      if (!discovery_entry.discovery_mechanism->override_child_policy()
+              .empty()) {
+        child_policy =
+            discovery_entry.discovery_mechanism->override_child_policy();
       } else {
-        auto it = xds_lb_policy.find("RING_HASH");
-        GPR_ASSERT(it != xds_lb_policy.end());
-        Json::Object ring_hash_experimental_policy = it->second.object_value();
-        child_policy = Json::Array{
-            Json::Object{
-                {"ring_hash_experimental", ring_hash_experimental_policy},
-            },
-        };
+        const auto& xds_lb_policy = config_->xds_lb_policy().object_value();
+        if (xds_lb_policy.find("ROUND_ROBIN") != xds_lb_policy.end()) {
+          const auto& localities = priority_entry.localities;
+          Json::Object weighted_targets;
+          for (const auto& p : localities) {
+            XdsLocalityName* locality_name = p.first;
+            const auto& locality = p.second;
+            // Construct JSON object containing locality name.
+            Json::Object locality_name_json;
+            if (!locality_name->region().empty()) {
+              locality_name_json["region"] = locality_name->region();
+            }
+            if (!locality_name->zone().empty()) {
+              locality_name_json["zone"] = locality_name->zone();
+            }
+            if (!locality_name->sub_zone().empty()) {
+              locality_name_json["sub_zone"] = locality_name->sub_zone();
+            }
+            // Add weighted target entry.
+            weighted_targets[locality_name->AsHumanReadableString()] =
+                Json::Object{
+                    {"weight", locality.lb_weight},
+                    {"childPolicy",
+                     Json::Array{
+                         Json::Object{
+                             {"round_robin", Json::Object()},
+                         },
+                     }},
+                };
+          }
+          // Construct locality-picking policy.
+          // Start with field from our config and add the "targets" field.
+          child_policy = Json::Array{
+              Json::Object{
+                  {"weighted_target_experimental",
+                   Json::Object{
+                       {"targets", Json::Object()},
+                   }},
+              },
+          };
+          Json::Object& config =
+              *(*child_policy.mutable_array())[0].mutable_object();
+          auto it = config.begin();
+          GPR_ASSERT(it != config.end());
+          (*it->second.mutable_object())["targets"] =
+              std::move(weighted_targets);
+        } else {
+          auto it = xds_lb_policy.find("RING_HASH");
+          GPR_ASSERT(it != xds_lb_policy.end());
+          Json::Object ring_hash_experimental_policy =
+              it->second.object_value();
+          child_policy = Json::Array{
+              Json::Object{
+                  {"ring_hash_experimental", ring_hash_experimental_policy},
+              },
+          };
+        }
       }
-    }
-    // Wrap it in the drop policy.
-    Json::Array drop_categories;
-    if (discovery_mechanisms_[discovery_index].drop_config != nullptr) {
-      for (const auto& category : discovery_mechanisms_[discovery_index]
-                                      .drop_config->drop_category_list()) {
-        drop_categories.push_back(Json::Object{
-            {"category", category.name},
-            {"requests_per_million", category.parts_per_million},
-        });
+      // Wrap it in the drop policy.
+      Json::Array drop_categories;
+      if (discovery_entry.latest_update->drop_config != nullptr) {
+        for (const auto& category :
+             discovery_entry.latest_update->drop_config->drop_category_list()) {
+          drop_categories.push_back(Json::Object{
+              {"category", category.name},
+              {"requests_per_million", category.parts_per_million},
+          });
+        }
       }
-    }
-    const auto lrs_key = discovery_mechanisms_[discovery_index]
-                             .discovery_mechanism->GetLrsClusterKey();
-    Json::Object xds_cluster_impl_config = {
-        {"clusterName", std::string(lrs_key.first)},
-        {"childPolicy", std::move(child_policy)},
-        {"dropCategories", std::move(drop_categories)},
-        {"maxConcurrentRequests",
-         config_->discovery_mechanisms()[discovery_index]
-             .max_concurrent_requests},
-    };
-    if (!lrs_key.second.empty()) {
-      xds_cluster_impl_config["edsServiceName"] = std::string(lrs_key.second);
-    }
-    if (config_->discovery_mechanisms()[discovery_index]
-            .lrs_load_reporting_server.has_value()) {
-      xds_cluster_impl_config["lrsLoadReportingServer"] =
-          config_->discovery_mechanisms()[discovery_index]
-              .lrs_load_reporting_server->ToJson();
-    }
-    Json locality_picking_policy = Json::Array{Json::Object{
-        {"xds_cluster_impl_experimental", std::move(xds_cluster_impl_config)},
-    }};
-    // Add priority entry.
-    const size_t child_number = priority_child_numbers_[priority];
-    std::string child_name = absl::StrCat("child", child_number);
-    priority_priorities.emplace_back(child_name);
-    Json::Object child_config = {
-        {"config", std::move(locality_picking_policy)},
-    };
-    if (discovery_mechanisms_[discovery_index]
-            .discovery_mechanism->disable_reresolution()) {
-      child_config["ignore_reresolution_requests"] = true;
-    }
-    priority_children[child_name] = std::move(child_config);
-    // Each priority in the priority_list_ should correspond to a priority in a
-    // discovery mechanism in discovery_mechanisms_ (both in the same order).
-    // Keeping track of the discovery_mechanism each priority belongs to.
-    --num_priorities_remaining_in_discovery;
-    while (num_priorities_remaining_in_discovery == 0 &&
-           discovery_index < discovery_mechanisms_.size() - 1) {
-      ++discovery_index;
-      num_priorities_remaining_in_discovery =
-          discovery_mechanisms_[discovery_index].num_priorities;
+      Json::Object xds_cluster_impl_config = {
+          {"clusterName", discovery_config.cluster_name},
+          {"childPolicy", std::move(child_policy)},
+          {"dropCategories", std::move(drop_categories)},
+          {"maxConcurrentRequests", discovery_config.max_concurrent_requests},
+      };
+      if (!discovery_config.eds_service_name.empty()) {
+        xds_cluster_impl_config["edsServiceName"] =
+            discovery_config.eds_service_name;
+      }
+      if (discovery_config.lrs_load_reporting_server.has_value()) {
+        xds_cluster_impl_config["lrsLoadReportingServer"] =
+            discovery_config.lrs_load_reporting_server->ToJson();
+      }
+      Json locality_picking_policy = Json::Array{Json::Object{
+          {"xds_cluster_impl_experimental", std::move(xds_cluster_impl_config)},
+      }};
+      // Add priority entry, with the appropriate child name.
+      std::string child_name = discovery_entry.GetChildPolicyName(priority);
+      priority_priorities.emplace_back(child_name);
+      Json::Object child_config = {
+          {"config", std::move(locality_picking_policy)},
+      };
+      if (discovery_entry.discovery_mechanism->disable_reresolution()) {
+        child_config["ignore_reresolution_requests"] = true;
+      }
+      priority_children[child_name] = std::move(child_config);
     }
   }
-  // There should be matching number of priorities in discovery_mechanisms_ and
-  // in priority_list_; therefore at the end of looping through all the
-  // priorities, num_priorities_remaining should be down to 0, and index should
-  // be the last index in discovery_mechanisms_.
-  GPR_ASSERT(num_priorities_remaining_in_discovery == 0);
-  GPR_ASSERT(discovery_index == discovery_mechanisms_.size() - 1);
   Json json = Json::Array{Json::Object{
       {"priority_experimental",
        Json::Object{

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -788,17 +788,6 @@ XdsClusterResolverLb::CreateChildPolicyConfigLocked() {
           for (const auto& p : localities) {
             XdsLocalityName* locality_name = p.first;
             const auto& locality = p.second;
-            // Construct JSON object containing locality name.
-            Json::Object locality_name_json;
-            if (!locality_name->region().empty()) {
-              locality_name_json["region"] = locality_name->region();
-            }
-            if (!locality_name->zone().empty()) {
-              locality_name_json["zone"] = locality_name->zone();
-            }
-            if (!locality_name->sub_zone().empty()) {
-              locality_name_json["sub_zone"] = locality_name->sub_zone();
-            }
             // Add weighted target entry.
             weighted_targets[locality_name->AsHumanReadableString()] =
                 Json::Object{

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -692,7 +692,8 @@ void XdsClusterResolverLb::UpdatePriorityList(
   // the old data in priority_list_ and priority_child_numbers_.
   std::map<XdsLocalityName*, size_t /*child_number*/, XdsLocalityName::Less>
       locality_child_map;
-  std::map<size_t, std::set<XdsLocalityName*>> child_locality_map;
+  std::map<size_t, std::set<XdsLocalityName*, XdsLocalityName::Less>>
+      child_locality_map;
   for (size_t priority = 0; priority < priority_list_.size(); ++priority) {
     size_t child_number = priority_child_numbers_[priority];
     const auto& localities = priority_list_[priority].localities;

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc
@@ -501,21 +501,8 @@ XdsClusterResolverLb::DiscoveryMechanismEntry::config() const {
 
 std::string XdsClusterResolverLb::DiscoveryMechanismEntry::GetChildPolicyName(
     size_t priority) const {
-  const size_t child_number = priority_child_numbers[priority];
-  const auto& discovery_config = config();
-  absl::InlinedVector<absl::string_view, 9> parts = {
-      "{cluster=", discovery_config.cluster_name, ","};
-  if (!discovery_config.eds_service_name.empty()) {
-    parts.push_back("eds_service_name=");
-    parts.push_back(discovery_config.eds_service_name);
-    parts.push_back(",");
-  } else if (!discovery_config.dns_hostname.empty()) {
-    parts.push_back("dns_hostname=");
-    parts.push_back(discovery_config.dns_hostname);
-    parts.push_back(",");
-  }
-  parts.push_back("child_number=");
-  return absl::StrCat(absl::StrJoin(parts, ""), child_number, "}");
+  return absl::StrCat("{cluster=", config().cluster_name,
+                      ", child_number=", priority_child_numbers[priority], "}");
 }
 
 //

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -6598,6 +6598,128 @@ TEST_P(CdsTest, AggregateClusterLogicalDnsToEds) {
       "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER");
 }
 
+// This test covers a bug seen in the wild where the
+// xds_cluster_resolver policy's code to reuse child policy names did
+// not correctly handle the case where the LOGICAL_DNS priority failed,
+// thus returning a priority with no localities.  This caused the child
+// name to be reused incorrectly, which triggered an assertion failure
+// in the xds_cluster_impl policy caused by changing its cluster name.
+TEST_P(CdsTest, AggregateClusterReconfigEdsWhileLogicalDnsChildFails) {
+  gpr_setenv("GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER",
+             "true");
+  const char* kNewCluster1Name = "new_cluster_1";
+  const char* kNewEdsService1Name = "new_eds_service_name_1";
+  const char* kLogicalDNSClusterName = "logical_dns_cluster";
+  // Populate EDS resource with all unreachable endpoints.
+  // - Priority 0: locality0
+  // - Priority 1: locality1, locality2
+  EdsResourceArgs args1({
+      {"locality0", {MakeNonExistantEndpoint()}, kDefaultLocalityWeight, 0},
+      {"locality1", {MakeNonExistantEndpoint()}, kDefaultLocalityWeight, 1},
+      {"locality2", {MakeNonExistantEndpoint()}, kDefaultLocalityWeight, 1},
+  });
+  balancer_->ads_service()->SetEdsResource(
+      BuildEdsResource(args1, kNewEdsService1Name));
+  // Populate new CDS resources.
+  Cluster new_cluster1 = default_cluster_;
+  new_cluster1.set_name(kNewCluster1Name);
+  new_cluster1.mutable_eds_cluster_config()->set_service_name(
+      kNewEdsService1Name);
+  balancer_->ads_service()->SetCdsResource(new_cluster1);
+  // Create Logical DNS Cluster
+  auto logical_dns_cluster = default_cluster_;
+  logical_dns_cluster.set_name(kLogicalDNSClusterName);
+  logical_dns_cluster.set_type(Cluster::LOGICAL_DNS);
+  auto* address = logical_dns_cluster.mutable_load_assignment()
+                      ->add_endpoints()
+                      ->add_lb_endpoints()
+                      ->mutable_endpoint()
+                      ->mutable_address()
+                      ->mutable_socket_address();
+  address->set_address(kServerName);
+  address->set_port_value(443);
+  balancer_->ads_service()->SetCdsResource(logical_dns_cluster);
+  // Create Aggregate Cluster
+  auto cluster = default_cluster_;
+  CustomClusterType* custom_cluster = cluster.mutable_cluster_type();
+  custom_cluster->set_name("envoy.clusters.aggregate");
+  ClusterConfig cluster_config;
+  cluster_config.add_clusters(kNewCluster1Name);
+  cluster_config.add_clusters(kLogicalDNSClusterName);
+  custom_cluster->mutable_typed_config()->PackFrom(cluster_config);
+  balancer_->ads_service()->SetCdsResource(cluster);
+  // Set Logical DNS result
+  {
+    grpc_core::ExecCtx exec_ctx;
+    grpc_core::Resolver::Result result;
+    result.addresses = absl::UnavailableError("injected error");
+    logical_dns_cluster_resolver_response_generator_->SetResponse(
+        std::move(result));
+  }
+  // When an RPC fails, we know the channel has seen the update.
+  CheckRpcSendFailure();
+  // Send an EDS update that moves locality1 to priority 0.
+  args1 = EdsResourceArgs({
+      {"locality1", CreateEndpointsForBackends(0, 1), kDefaultLocalityWeight,
+       0},
+      {"locality2", CreateEndpointsForBackends(1, 2), kDefaultLocalityWeight,
+       1},
+  });
+  balancer_->ads_service()->SetEdsResource(
+      BuildEdsResource(args1, kNewEdsService1Name));
+  WaitForBackend(0, WaitForBackendOptions().set_allow_failures(true));
+  gpr_unsetenv(
+      "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER");
+}
+
+TEST_P(CdsTest, AggregateClusterMultipleClustersWithSameLocalities) {
+  gpr_setenv("GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER",
+             "true");
+  const char* kNewClusterName1 = "new_cluster_1";
+  const char* kNewEdsServiceName1 = "new_eds_service_name_1";
+  const char* kNewClusterName2 = "new_cluster_2";
+  const char* kNewEdsServiceName2 = "new_eds_service_name_2";
+  // Populate EDS resource for cluster 1 with unreachable endpoint.
+  EdsResourceArgs args1({{"locality0", {MakeNonExistantEndpoint()}}});
+  balancer_->ads_service()->SetEdsResource(
+      BuildEdsResource(args1, kNewEdsServiceName1));
+  // Populate CDS resource for cluster 1.
+  Cluster new_cluster1 = default_cluster_;
+  new_cluster1.set_name(kNewClusterName1);
+  new_cluster1.mutable_eds_cluster_config()->set_service_name(
+      kNewEdsServiceName1);
+  balancer_->ads_service()->SetCdsResource(new_cluster1);
+  // Populate EDS resource for cluster 2.
+  args1 = EdsResourceArgs({{"locality1", CreateEndpointsForBackends(0, 1)}});
+  balancer_->ads_service()->SetEdsResource(
+      BuildEdsResource(args1, kNewEdsServiceName2));
+  // Populate CDS resource for cluster 2.
+  Cluster new_cluster2 = default_cluster_;
+  new_cluster2.set_name(kNewClusterName2);
+  new_cluster2.mutable_eds_cluster_config()->set_service_name(
+      kNewEdsServiceName2);
+  balancer_->ads_service()->SetCdsResource(new_cluster2);
+  // Create Aggregate Cluster
+  auto cluster = default_cluster_;
+  CustomClusterType* custom_cluster = cluster.mutable_cluster_type();
+  custom_cluster->set_name("envoy.clusters.aggregate");
+  ClusterConfig cluster_config;
+  cluster_config.add_clusters(kNewClusterName1);
+  cluster_config.add_clusters(kNewClusterName2);
+  custom_cluster->mutable_typed_config()->PackFrom(cluster_config);
+  balancer_->ads_service()->SetCdsResource(cluster);
+  // Wait for channel to get the resources and get connected.
+  WaitForBackend(0);
+  // Send an EDS update for cluster 1 that reuses the locality name from
+  // cluster 1 and points traffic to backend 1.
+  args1 = EdsResourceArgs({{"locality1", CreateEndpointsForBackends(1, 2)}});
+  balancer_->ads_service()->SetEdsResource(
+      BuildEdsResource(args1, kNewEdsServiceName1));
+  WaitForBackend(1);
+  gpr_unsetenv(
+      "GRPC_XDS_EXPERIMENTAL_ENABLE_AGGREGATE_AND_LOGICAL_DNS_CLUSTER");
+}
+
 // Test that CDS client should send a NACK if cluster type is Logical DNS but
 // the feature is not yet supported.
 TEST_P(CdsTest, LogicalDNSClusterTypeDisabled) {


### PR DESCRIPTION
We were seeing a crash due to [this assertion failure](https://github.com/grpc/grpc/blob/6b89acc7ba5a3d9cd6623841bb5f8bc1609df613/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_impl.cc#L485) in the xds_cluster_impl policy.  It was being triggered by the following scenario:

1. We had an aggregate cluster pointing to an EDS cluster and then a LOGICAL_DNS cluster.  The EDS cluster returned two priorities, priority 0 with locality A and priority 1 with localities B and C, and all of the endpoints in both priorities were unreachable.  The LOGICAL_DNS cluster was failing to return endpoints, which we [treat as an empty priority with no localities](https://github.com/grpc/grpc/blob/6b89acc7ba5a3d9cd6623841bb5f8bc1609df613/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_resolver.cc#L671).  The xds_cluster_resolver policy assigned child policy names "child0" to priority 0 from the EDS cluster, "child1" to priority 1 from the EDS cluster, and "child2" to the LOGICAL_DNS cluster.
2. We got an update for the EDS cluster with priority 0 now containing localities A, B, and C and priority 1 containing locality D.  This caused the code in xds_cluster_resolver to reuse the child policy name "child0" for priority 0, since locality A was in that child in the old update and was still present in the new update.  However, it then incorrectly reused "child2" for priority 1 from the EDS cluster (because it thought that child name was not used due to the LOGICAL_DNS result not containing any localities), which resulted in sending an update to that child that changed its cluster name, this triggering the assertion above.

This PR fixes the xds_cluster_resolver policy to assign child policy names separetely within each discovery mechanism instead of doing it once across all discovery mechanisms.  We avoid conflicts between discovery mechanisms by including the cluster name in the child policy name.  This approach also solves potential problems (not actually seen in the wild) where multiple discovery services might report the same locality name.