### PR TITLE
Backport #29171 to v1.45.x: avoid collision with pre-installed protoc on grpc-win2016 workers

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -36,6 +36,10 @@ netsh interface ip set dns "Local Area Connection 8" static 169.254.169.254 prim
 netsh interface ip add dnsservers "Local Area Connection 8" 8.8.8.8 index=2
 netsh interface ip add dnsservers "Local Area Connection 8" 8.8.4.4 index=3
 
+@rem Uninstall protoc so that it doesn't clash with C++ distribtests.
+@rem (on grpc-win2016 kokoro workers it can result in GOOGLE_PROTOBUF_MIN_PROTOC_VERSION violation)
+choco uninstall protoc -y --limit-output
+
 @rem Install nasm (required for boringssl assembly optimized build as boringssl no long supports yasm)
 @rem Downloading from GCS should be very reliables when on a GCP VM.
 mkdir C:\nasm


### PR DESCRIPTION
Backport https://github.com/grpc/grpc/pull/29171 into v1.45.x

Just to make sure switching the jobs to grpc-win2016 won't break the release branch.
