### PR TITLE
Fix csharp single-job distribtest on grpc-win2016

### DIFF
--- a/tools/internal_ci/windows/grpc_distribtests_csharp.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_csharp.bat
@@ -30,6 +30,14 @@ call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
 call tools/internal_ci/helper_scripts/prepare_ccache.bat || exit /b 1
 
+@rem Install Msys2 zip to avoid crash when using cygwin's zip on grpc-win2016 kokoro workers.
+@rem Downloading from GCS should be very reliables when on a GCP VM.
+@rem TODO(jtattermusch): find a better way of making the build_packages step work on windows workers.
+mkdir C:\zip
+curl -sSL --fail -o C:\zip\zip.exe https://storage.googleapis.com/grpc-build-helper/zip-3.0-1-x86_64/zip.exe || goto :error
+set PATH=C:\zip;%PATH%
+zip --version
+
 @rem Build all C# windows artifacts
 python tools/run_tests/task_runner.py -f artifact windows csharp %TASK_RUNNER_EXTRA_FILTERS% -j 4 --inner_jobs 4 -x build_artifacts_csharp/sponge_log.xml || set FAILED=true
 


### PR DESCRIPTION
The final step in grpc_distribtests_csharp build_packages phase on windows is currently failing with error https://source.cloud.google.com/results/invocations/67d00376-254a-479f-b224-d466265bc718/targets/github%2Fgrpc%2Fbuild_packages/tests
```
+ zip csharp_nugets_windows_dotnetcli.zip Grpc.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Auth.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Core.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Core.Api.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Core.NativeDebug.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Core.Testing.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Core.Xamarin.2.46.0-dev202203221011-singleplatform.nupkg Grpc.HealthCheck.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Reflection.2.46.0-dev202203221011-singleplatform.nupkg Grpc.Tools.2.46.0-dev202203221011-singleplatform.nupkg
      2 [main] zip (7144) C:\cygwin64\bin\zip.exe: *** fatal error - cygheap base mismatch detected - 0x1802F6408/0x1802F3408.
This problem is probably due to using incompatible versions of the cygwin DLL.
```
This PR fixes that by adding an msys2 version of zip.exe.

Passing adhoc run:
https://source.cloud.google.com/results/invocations/d8ba012f-2b73-434b-9827-445307236742