### PR TITLE
client channel: record call completion even if recv_trailing_metadata was not started

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2527,7 +2527,8 @@ class ClientChannel::LoadBalancedCall::BackendMetricAccessor
       : lb_call_(lb_call) {}
 
   const BackendMetricData* GetBackendMetricData() override {
-    if (lb_call_->backend_metric_data_ == nullptr) {
+    if (lb_call_->backend_metric_data_ == nullptr &&
+        lb_call_->recv_trailing_metadata_ != nullptr) {
       if (const auto* md = lb_call_->recv_trailing_metadata_->get_pointer(
               XEndpointLoadMetricsBinMetadata())) {
         lb_call_->backend_metric_data_ =

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2427,6 +2427,7 @@ class ClientChannel::LoadBalancedCall::Metadata
   explicit Metadata(grpc_metadata_batch* batch) : batch_(batch) {}
 
   void Add(absl::string_view key, absl::string_view value) override {
+    if (batch_ == nullptr) return;
     // Gross, egregious hack to support legacy grpclb behavior.
     // TODO(ctiller): Use a promise context for this once that plumbing is done.
     if (key == GrpcLbClientStatsMetadata::key()) {
@@ -2447,6 +2448,7 @@ class ClientChannel::LoadBalancedCall::Metadata
 
   std::vector<std::pair<std::string, std::string>> TestOnlyCopyToVector()
       override {
+    if (batch_ == nullptr) return {};
     Encoder encoder;
     batch_->Encode(&encoder);
     return encoder.Take();
@@ -2454,6 +2456,7 @@ class ClientChannel::LoadBalancedCall::Metadata
 
   absl::optional<absl::string_view> Lookup(absl::string_view key,
                                            std::string* buffer) const override {
+    if (batch_ == nullptr) return absl::nullopt;
     return batch_->GetStringValue(key, buffer);
   }
 
@@ -2594,6 +2597,12 @@ ClientChannel::LoadBalancedCall::~LoadBalancedCall() {
 }
 
 void ClientChannel::LoadBalancedCall::Orphan() {
+  // If the recv_trailing_metadata op was never started, then notify
+  // about call completion here, as best we can.  We assume status
+  // CANCELLED in this case.
+  if (recv_trailing_metadata_ == nullptr) {
+    RecordCallCompletion(absl::CancelledError("call cancelled"));
+  }
   // Compute latency and report it to the tracer.
   if (call_attempt_tracer_ != nullptr) {
     gpr_timespec latency =
@@ -2905,22 +2914,7 @@ void ClientChannel::LoadBalancedCall::RecvTrailingMetadataReady(
         status = absl::Status(static_cast<absl::StatusCode>(code), message);
       }
     }
-    // If we have a tracer, notify it.
-    if (self->call_attempt_tracer_ != nullptr) {
-      self->call_attempt_tracer_->RecordReceivedTrailingMetadata(
-          status, self->recv_trailing_metadata_,
-          *self->transport_stream_stats_);
-    }
-    // If the LB policy requested a callback for trailing metadata, invoke
-    // the callback.
-    if (self->lb_subchannel_call_tracker_ != nullptr) {
-      Metadata trailing_metadata(self->recv_trailing_metadata_);
-      BackendMetricAccessor backend_metric_accessor(self);
-      LoadBalancingPolicy::SubchannelCallTrackerInterface::FinishArgs args = {
-          status, &trailing_metadata, &backend_metric_accessor};
-      self->lb_subchannel_call_tracker_->Finish(args);
-      self->lb_subchannel_call_tracker_.reset();
-    }
+    self->RecordCallCompletion(status);
   }
   // Chain to original callback.
   if (self->failure_error_ != GRPC_ERROR_NONE) {
@@ -2931,6 +2925,25 @@ void ClientChannel::LoadBalancedCall::RecvTrailingMetadataReady(
   }
   Closure::Run(DEBUG_LOCATION, self->original_recv_trailing_metadata_ready_,
                error);
+}
+
+void ClientChannel::LoadBalancedCall::RecordCallCompletion(
+    absl::Status status) {
+  // If we have a tracer, notify it.
+  if (call_attempt_tracer_ != nullptr) {
+    call_attempt_tracer_->RecordReceivedTrailingMetadata(
+        status, recv_trailing_metadata_, transport_stream_stats_);
+  }
+  // If the LB policy requested a callback for trailing metadata, invoke
+  // the callback.
+  if (lb_subchannel_call_tracker_ != nullptr) {
+    Metadata trailing_metadata(recv_trailing_metadata_);
+    BackendMetricAccessor backend_metric_accessor(this);
+    LoadBalancingPolicy::SubchannelCallTrackerInterface::FinishArgs args = {
+        status, &trailing_metadata, &backend_metric_accessor};
+    lb_subchannel_call_tracker_->Finish(args);
+    lb_subchannel_call_tracker_.reset();
+  }
 }
 
 void ClientChannel::LoadBalancedCall::CreateSubchannelCall() {

--- a/src/core/ext/filters/client_channel/client_channel.h
+++ b/src/core/ext/filters/client_channel/client_channel.h
@@ -433,6 +433,8 @@ class ClientChannel::LoadBalancedCall
   static void RecvMessageReady(void* arg, grpc_error_handle error);
   static void RecvTrailingMetadataReady(void* arg, grpc_error_handle error);
 
+  void RecordCallCompletion(absl::Status status);
+
   void CreateSubchannelCall();
   // Invoked when a pick is completed, on both success or failure.
   static void PickDone(void* arg, grpc_error_handle error);

--- a/src/core/lib/channel/call_tracer.h
+++ b/src/core/lib/channel/call_tracer.h
@@ -59,9 +59,12 @@ class CallTracer {
     virtual void RecordReceivedInitialMetadata(
         grpc_metadata_batch* recv_initial_metadata, uint32_t flags) = 0;
     virtual void RecordReceivedMessage(const ByteStream& recv_message) = 0;
+    // If the call was cancelled before the recv_trailing_metadata op
+    // was started, recv_trailing_metadata and transport_stream_stats
+    // will be null.
     virtual void RecordReceivedTrailingMetadata(
         absl::Status status, grpc_metadata_batch* recv_trailing_metadata,
-        const grpc_transport_stream_stats& transport_stream_stats) = 0;
+        const grpc_transport_stream_stats* transport_stream_stats) = 0;
     virtual void RecordCancel(grpc_error_handle cancel_error) = 0;
     // Should be the last API call to the object. Once invoked, the tracer
     // library is free to destroy the object.

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -152,9 +152,6 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
   tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
   std::string final_status = absl::StatusCodeToString(status_code_);
   tags.emplace_back(ClientStatusTagKey(), final_status);
-  absl::InlinedVector<::opencensus::stats::Measurement, 3> measurements = {
-      {RpcClientServerLatency(),
-       ToDoubleMilliseconds(absl::Nanoseconds(elapsed_time))}};
   ::opencensus::stats::Record(
       {{RpcClientSentBytesPerRpc(),
         static_cast<double>(transport_stream_stats->outgoing.data_bytes)},

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -63,8 +63,6 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
     CensusContext context_;
     // Start time (for measuring latency).
     absl::Time start_time_;
-    // Server elapsed time in nanoseconds.
-    uint64_t elapsed_time_ = 0;
     // Number of messages in this RPC.
     uint64_t recv_message_count_ = 0;
     uint64_t sent_message_count_ = 0;

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -33,25 +33,23 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
     OpenCensusCallAttemptTracer(OpenCensusCallTracer* parent,
                                 uint64_t attempt_num, bool is_transparent_retry,
                                 bool arena_allocated);
-    void RecordSendInitialMetadata(
-        grpc_metadata_batch* /* send_initial_metadata */,
-        uint32_t /* flags */) override;
-    void RecordOnDoneSendInitialMetadata(gpr_atm* /* peer_string */) override {}
+    void RecordSendInitialMetadata(grpc_metadata_batch* send_initial_metadata,
+                                   uint32_t /*flags*/) override;
+    void RecordOnDoneSendInitialMetadata(gpr_atm* /*peer_string*/) override {}
     void RecordSendTrailingMetadata(
-        grpc_metadata_batch* /* send_trailing_metadata */) override {}
+        grpc_metadata_batch* /*send_trailing_metadata*/) override {}
     void RecordSendMessage(
-        const grpc_core::ByteStream& /* send_message */) override;
+        const grpc_core::ByteStream& /*send_message*/) override;
     void RecordReceivedInitialMetadata(
-        grpc_metadata_batch* /* recv_initial_metadata */,
-        uint32_t /* flags */) override {}
+        grpc_metadata_batch* /*recv_initial_metadata*/,
+        uint32_t /*flags*/) override {}
     void RecordReceivedMessage(
-        const grpc_core::ByteStream& /* recv_message */) override;
+        const grpc_core::ByteStream& /*recv_message*/) override;
     void RecordReceivedTrailingMetadata(
-        absl::Status /* status */, grpc_metadata_batch* recv_trailing_metadata,
-        const grpc_transport_stream_stats& /* transport_stream_stats */)
-        override;
+        absl::Status status, grpc_metadata_batch* recv_trailing_metadata,
+        const grpc_transport_stream_stats* transport_stream_stats) override;
     void RecordCancel(grpc_error_handle cancel_error) override;
-    void RecordEnd(const gpr_timespec& /* latency */) override;
+    void RecordEnd(const gpr_timespec& /*latency*/) override;
 
     CensusContext* context() { return &context_; }
 

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -281,6 +281,7 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
 
     void Finish(FinishArgs args) override {
       TrailingMetadataArgsSeen args_seen;
+      args_seen.status = args.status;
       args_seen.backend_metric_data =
           args.backend_metric_accessor->GetBackendMetricData();
       args_seen.metadata = args.trailing_metadata->TestOnlyCopyToVector();

--- a/test/core/util/test_lb_policies.h
+++ b/test/core/util/test_lb_policies.h
@@ -36,6 +36,7 @@ void RegisterTestPickArgsLoadBalancingPolicy(
     TestPickArgsCallback cb, const char* delegate_policy_name = "pick_first");
 
 struct TrailingMetadataArgsSeen {
+  absl::Status status;
   const LoadBalancingPolicy::BackendMetricAccessor::BackendMetricData*
       backend_metric_data;
   MetadataVector metadata;

--- a/test/cpp/ext/filters/census/BUILD
+++ b/test/cpp/ext/filters/census/BUILD
@@ -37,6 +37,7 @@ grpc_cc_test(
         "//:grpc_opencensus_plugin",
         "//src/proto/grpc/testing:echo_proto",
         "//test/core/util:grpc_test_util",
+        "//test/cpp/end2end:test_service_impl",
         "//test/cpp/util:test_config",
         "//test/cpp/util:test_util",
     ],

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -37,6 +37,7 @@
 #include "src/cpp/ext/filters/census/grpc_plugin.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/test_config.h"
+#include "test/cpp/end2end/test_service_impl.h"
 
 namespace grpc {
 namespace testing {
@@ -54,12 +55,25 @@ const auto TEST_TAG_KEY = TagKey::Register("my_key");
 const auto TEST_TAG_VALUE = "my_value";
 const char* kExpectedTraceIdKey = "expected_trace_id";
 
-class EchoServer final : public EchoTestService::Service {
-  grpc::Status Echo(grpc::ServerContext* context, const EchoRequest* request,
-                    EchoResponse* response) override {
+class EchoServer final : public TestServiceImpl {
+  Status Echo(ServerContext* context, const EchoRequest* request,
+              EchoResponse* response) override {
+    CheckMetadata(context);
+    return TestServiceImpl::Echo(context, request, response);
+  }
+
+  Status BidiStream(
+      ServerContext* context,
+      ServerReaderWriter<EchoResponse, EchoRequest>* stream) override {
+    CheckMetadata(context);
+    return TestServiceImpl::BidiStream(context, stream);
+  }
+
+ private:
+  void CheckMetadata(ServerContext* context) {
     for (const auto& metadata : context->client_metadata()) {
       if (metadata.first == kExpectedTraceIdKey) {
-        EXPECT_EQ(metadata.second, reinterpret_cast<const grpc::CensusContext*>(
+        EXPECT_EQ(metadata.second, reinterpret_cast<const CensusContext*>(
                                        context->census_context())
                                        ->Span()
                                        .context()
@@ -67,14 +81,6 @@ class EchoServer final : public EchoTestService::Service {
                                        .ToHex());
         break;
       }
-    }
-    if (request->param().expected_error().code() == 0) {
-      response->set_message(request->message());
-      return grpc::Status::OK;
-    } else {
-      return grpc::Status(static_cast<grpc::StatusCode>(
-                              request->param().expected_error().code()),
-                          "");
     }
   }
 };
@@ -374,6 +380,20 @@ TEST_F(StatsPluginEnd2EndTest, CompletedRpcs) {
                 ::testing::UnorderedElementsAre(::testing::Pair(
                     ::testing::ElementsAre(server_method_name_, "OK"), i + 1)));
   }
+
+  // Client should see calls that are cancelled without calling Finish().
+  {
+    ClientContext ctx;
+    auto stream = stub_->BidiStream(&ctx);
+    ctx.TryCancel();
+  }
+  absl::SleepFor(absl::Milliseconds(500));
+  TestUtils::Flush();
+  EXPECT_THAT(client_completed_rpcs_view.GetData().int_data(),
+              ::testing::Contains(::testing::Pair(
+                  ::testing::ElementsAre(
+                      "grpc.testing.EchoTestService/BidiStream", "CANCELLED"),
+                  1)));
 }
 
 TEST_F(StatsPluginEnd2EndTest, RequestReceivedMessagesPerRpc) {
@@ -472,7 +492,6 @@ TEST_F(StatsPluginEnd2EndTest, TestRetryStatsWithAdditionalRetries) {
       ClientTransparentRetriesCumulative());
   View client_retry_delay_per_call_view(ClientRetryDelayPerCallCumulative());
   ChannelArguments args;
-  args.SetInt(GRPC_ARG_ENABLE_RETRIES, 1);
   args.SetString(GRPC_ARG_SERVICE_CONFIG,
                  "{\n"
                  "  \"methodConfig\": [ {\n"


### PR DESCRIPTION
We are definitely seeing cases in the wild where a call is cancelled and unreffed without starting the recv_trailing_metadata op.  See internal b/226204301 for details.

Note that the place where we actually detected this was an assertion in the LB policy `SubchannelCallTracker` API, not the `CallTracer` API, but it's the same symptom in both cases.

Can you please add a test to test/cpp/ext/filters/census/stats_plugin_end2end_test.cc to make sure the OpenCensus code is correctly handling this case?  It looks like it should work, but let's be sure.

I am going to work on adding a test for the LB policy API.