### PR TITLE
HTTP2: Invalidate time before using ExecCtx::Now() to avoid time skew

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -447,6 +447,7 @@ static void init_keepalive_pings_if_enabled(grpc_chttp2_transport* t) {
     GRPC_CHTTP2_REF_TRANSPORT(t, "init keepalive ping");
     GRPC_CLOSURE_INIT(&t->init_keepalive_ping_locked, init_keepalive_ping, t,
                       grpc_schedule_on_exec_ctx);
+    grpc_core::ExecCtx::Get()->InvalidateNow();
     grpc_timer_init(&t->keepalive_ping_timer,
                     grpc_core::ExecCtx::Get()->Now() + t->keepalive_time,
                     &t->init_keepalive_ping_locked);
@@ -2735,6 +2736,7 @@ static void init_keepalive_ping_locked(void* arg, grpc_error_handle error) {
       GRPC_CHTTP2_REF_TRANSPORT(t, "init keepalive ping");
       GRPC_CLOSURE_INIT(&t->init_keepalive_ping_locked, init_keepalive_ping, t,
                         grpc_schedule_on_exec_ctx);
+      grpc_core::ExecCtx::Get()->InvalidateNow();
       grpc_timer_init(&t->keepalive_ping_timer,
                       grpc_core::ExecCtx::Get()->Now() + t->keepalive_time,
                       &t->init_keepalive_ping_locked);
@@ -2744,6 +2746,7 @@ static void init_keepalive_ping_locked(void* arg, grpc_error_handle error) {
     GRPC_CHTTP2_REF_TRANSPORT(t, "init keepalive ping");
     GRPC_CLOSURE_INIT(&t->init_keepalive_ping_locked, init_keepalive_ping, t,
                       grpc_schedule_on_exec_ctx);
+    grpc_core::ExecCtx::Get()->InvalidateNow();
     grpc_timer_init(&t->keepalive_ping_timer,
                     grpc_core::ExecCtx::Get()->Now() + t->keepalive_time,
                     &t->init_keepalive_ping_locked);

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -90,6 +90,7 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
       grpc_chttp2_ack_ping(t, p->opaque_8bytes);
     } else {
       if (!t->is_client) {
+        grpc_core::ExecCtx::Get()->InvalidateNow();
         grpc_core::Timestamp now = grpc_core::ExecCtx::Get()->Now();
         grpc_core::Timestamp next_allowed_ping =
             t->ping_recv_state.last_ping_recv_time +

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -520,6 +520,7 @@ void HPackCompressor::Framer::EncodeIndexedKeyWithBinaryValue(
 }
 
 void HPackCompressor::Framer::Encode(GrpcTimeoutMetadata, Timestamp deadline) {
+  grpc_core::ExecCtx::Get()->InvalidateNow();
   Timeout timeout = Timeout::FromDuration(deadline - ExecCtx::Get()->Now());
   for (auto it = compressor_->previous_timeouts_.begin();
        it != compressor_->previous_timeouts_.end(); ++it) {


### PR DESCRIPTION
Fix #28830