### PR TITLE
Make scenario results to include start and end time for a test scenario.

### DIFF
--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -42,6 +42,7 @@ grpc_proto_library(
     name = "control_proto",
     srcs = ["control.proto"],
     has_services = False,
+    well_known_protos = True,
     deps = [
         "payloads_proto",
         "stats_proto",
@@ -277,6 +278,7 @@ proto_library(
     deps = [
         ":payloads_descriptor",
         ":stats_descriptor",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 import "src/proto/grpc/testing/payloads.proto";
 import "src/proto/grpc/testing/stats.proto";
+import "google/protobuf/timestamp.proto";
 
 package grpc.testing;
 
@@ -265,6 +266,11 @@ message ScenarioResultSummary
   // Queries per CPU-sec over all servers or clients
   double server_queries_per_cpu_sec = 17;
   double client_queries_per_cpu_sec = 18;
+
+
+  // Start and end time for the test scenario
+  google.protobuf.Timestamp start_time = 19;
+  google.protobuf.Timestamp end_time =20;
 }
 
 // Results of a single benchmark scenario.

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -576,7 +576,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
   // Start a run
   gpr_log(GPR_INFO, "Starting");
 
-  auto start_time = time(NULL);
+  auto start_time = time(nullptr);
 
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
@@ -629,7 +629,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
   bool client_finish_first =
       (client_config.rpc_type() != STREAMING_FROM_SERVER);
 
-  auto end_time = time(NULL);
+  auto end_time = time(nullptr);
 
   FinishClients(clients, client_mark);
 

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -25,6 +25,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "google/protobuf/timestamp.pb.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -32,7 +34,6 @@
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
 
-#include "google/protobuf/timestamp.pb.h"
 #include "src/core/lib/gpr/env.h"
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/profiling/timers.h"
@@ -575,9 +576,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
   // Start a run
   gpr_log(GPR_INFO, "Starting");
 
-  google::protobuf::Timestamp start_timestamp;
-  start_timestamp.set_seconds(time(NULL));
-  start_timestamp.set_nanos(0);
+  auto start_time = time(NULL);
 
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
@@ -630,9 +629,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
   bool client_finish_first =
       (client_config.rpc_type() != STREAMING_FROM_SERVER);
 
-  google::protobuf::Timestamp end_timestamp;
-  end_timestamp.set_seconds(time(NULL));
-  end_timestamp.set_nanos(0);
+  auto end_time = time(NULL);
 
   FinishClients(clients, client_mark);
 
@@ -662,8 +659,8 @@ std::unique_ptr<ScenarioResult> RunScenario(
   }
 
   // Fill in start and end time for the test scenario
-  result->mutable_summary()->mutable_start_time()->CopyFrom(start_timestamp);
-  result->mutable_summary()->mutable_end_time()->CopyFrom(end_timestamp);
+  result->mutable_summary()->mutable_start_time()->set_seconds(start_time);
+  result->mutable_summary()->mutable_end_time()->set_seconds(end_time);
 
   postprocess_scenario_result(result.get());
   return result;


### PR DESCRIPTION
This commit update the scenario results to include the start_timestamp
and end_timestamp. These two fields are used in prometheus range queries
to indicate the period we are pulling data for.