### PR TITLE
Upgrade http_cli to use http/1.1

### DIFF
--- a/src/core/lib/http/format_request.cc
+++ b/src/core/lib/http/format_request.cc
@@ -40,8 +40,7 @@ static void fill_common_header(const grpc_http_request* request,
                                bool connection_close,
                                std::vector<std::string>* buf) {
   buf->push_back(path);
-  buf->push_back(" HTTP/1.0\r\n");
-  /* just in case some crazy server really expects HTTP/1.1 */
+  buf->push_back(" HTTP/1.1\r\n");
   buf->push_back("Host: ");
   buf->push_back(host);
   buf->push_back("\r\n");


### PR DESCRIPTION
Technically, we'd need to monitor if the server does not, in fact, support http/1.1, and we'd need to fallback to http/1.0, but I'm not sure if this is relevant anymore these days.

Addresses #19173.