### PR TITLE
[PSM interop] Change restart policy to Never

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -25,6 +25,7 @@ spec:
       - name: ${deployment_name}
         image: ${image_name}
         imagePullPolicy: Always
+        restartPolicy: Never
         args:
           - "--server=${server_target}"
           - "--stats_port=${stats_port}"

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -21,11 +21,11 @@ spec:
       % if service_account_name:
       serviceAccountName: ${service_account_name}
       % endif
-      restartPolicy: Never
       containers:
       - name: ${deployment_name}
         image: ${image_name}
         imagePullPolicy: Always
+        restartPolicy: Never
         args:
           - "--server=${server_target}"
           - "--stats_port=${stats_port}"

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -21,6 +21,7 @@ spec:
       % if service_account_name:
       serviceAccountName: ${service_account_name}
       % endif
+      restartPolicy: Never
       containers:
       - name: ${deployment_name}
         image: ${image_name}

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -25,6 +25,7 @@ spec:
       - name: ${deployment_name}
         image: ${image_name}
         imagePullPolicy: Always
+        restartPolicy: Never
         args:
           - "--port=${test_port}"
           - "--maintenance_port=${maintenance_port}"

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -26,6 +26,7 @@ spec:
       - name: ${deployment_name}
         image: ${image_name}
         imagePullPolicy: Always
+        restartPolicy: Never
         args:
           - "--port=${test_port}"
         ports:

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -21,6 +21,7 @@ spec:
       % if service_account_name:
       serviceAccountName: ${service_account_name}
       % endif
+      restartPolicy: Never
       containers:
       - name: ${deployment_name}
         image: ${image_name}

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -21,7 +21,6 @@ spec:
       % if service_account_name:
       serviceAccountName: ${service_account_name}
       % endif
-      restartPolicy: Never
       containers:
       - name: ${deployment_name}
         image: ${image_name}


### PR DESCRIPTION
In an offline discussion, we discovered that the auto-restart of crashed pods is hiding potential issues. We want to turn off the auto-restart of pods, so setting the `restartPolicy: Never` to client and server pods.

* [grpc_xds_url_map](http://sponge/3f29b42b-5229-40df-8769-ee3561f6a1d3)
* [grpc_xds_url_map_python](http://sponge/11756861-7931-4578-8dd3-823cdc62a32e)
* [grpc_xds_k8s_lb](http://sponge/5d9e2fda-6caf-4af5-b558-fe4ee184f51b)
* [grpc_xds_k8s_lb_python](http://sponge/d5dad7f3-d051-4e3a-8dcd-cadccc6b04e3)
* [grpc_xds_k8s_xlang](http://sponge/aaeb82b3-638d-44d9-b4f1-fccae05a5e14)
* [psm-security](http://sponge/bba550b0-d8b7-4c06-97aa-eef8a229bd73)
* [psm-security-python](http://sponge/0b102d4c-b473-4bfe-8a72-bee89a6fbad7)