### PR TITLE
Revert "Make grpc_core::Call an interface type"

### DIFF
--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -60,6 +60,20 @@ grpc_error_handle grpc_call_create(grpc_call_create_args* args,
 
 void grpc_call_set_completion_queue(grpc_call* call, grpc_completion_queue* cq);
 
+#ifndef NDEBUG
+void grpc_call_internal_ref(grpc_call* call, const char* reason);
+void grpc_call_internal_unref(grpc_call* call, const char* reason);
+#define GRPC_CALL_INTERNAL_REF(call, reason) \
+  grpc_call_internal_ref(call, reason)
+#define GRPC_CALL_INTERNAL_UNREF(call, reason) \
+  grpc_call_internal_unref(call, reason)
+#else
+void grpc_call_internal_ref(grpc_call* call);
+void grpc_call_internal_unref(grpc_call* call);
+#define GRPC_CALL_INTERNAL_REF(call, reason) grpc_call_internal_ref(call)
+#define GRPC_CALL_INTERNAL_UNREF(call, reason) grpc_call_internal_unref(call)
+#endif
+
 grpc_core::Arena* grpc_call_get_arena(grpc_call* call);
 
 grpc_call_stack* grpc_call_get_call_stack(grpc_call* call);


### PR DESCRIPTION
Reverts grpc/grpc#29149. Caused high flakiness in internal test - see b/227267024 for details.