### PR TITLE
xds: add node ID to status messages generated by XdsClient

### DIFF
--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2163,8 +2163,9 @@ void XdsClient::ResetBackoff() {
 void XdsClient::NotifyOnErrorLocked(absl::Status status) {
   const auto* node = bootstrap_->node();
   if (node != nullptr) {
-    status = absl::Status(status.code(), absl::StrCat(
-        status.message(), " (node ID:", bootstrap_->node()->id, ")"));
+    status = absl::Status(
+        status.code(), absl::StrCat(status.message(),
+                                    " (node ID:", bootstrap_->node()->id, ")"));
   }
   std::set<RefCountedPtr<ResourceWatcherInterface>> watchers;
   for (const auto& a : authority_state_map_) {     // authority
@@ -2193,8 +2194,9 @@ void XdsClient::NotifyWatchersOnErrorLocked(
     absl::Status status) {
   const auto* node = bootstrap_->node();
   if (node != nullptr) {
-    status = absl::Status(status.code(), absl::StrCat(
-        status.message(), " (node ID:", bootstrap_->node()->id, ")"));
+    status = absl::Status(
+        status.code(), absl::StrCat(status.message(),
+                                    " (node ID:", bootstrap_->node()->id, ")"));
   }
   work_serializer_.Schedule(
       [watchers, status]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) {

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2161,6 +2161,11 @@ void XdsClient::ResetBackoff() {
 }
 
 void XdsClient::NotifyOnErrorLocked(absl::Status status) {
+  const auto* node = bootstrap_->node();
+  if (node != nullptr) {
+    status = absl::Status(status.code(), absl::StrCat(
+        status.message(), " (node ID:", bootstrap_->node()->id, ")"));
+  }
   std::set<RefCountedPtr<ResourceWatcherInterface>> watchers;
   for (const auto& a : authority_state_map_) {     // authority
     for (const auto& t : a.second.resource_map) {  // type
@@ -2186,6 +2191,11 @@ void XdsClient::NotifyWatchersOnErrorLocked(
     const std::map<ResourceWatcherInterface*,
                    RefCountedPtr<ResourceWatcherInterface>>& watchers,
     absl::Status status) {
+  const auto* node = bootstrap_->node();
+  if (node != nullptr) {
+    status = absl::Status(status.code(), absl::StrCat(
+        status.message(), " (node ID:", bootstrap_->node()->id, ")"));
+  }
   work_serializer_.Schedule(
       [watchers, status]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) {
         for (const auto& p : watchers) {

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -84,42 +84,6 @@ char* g_fallback_bootstrap_config ABSL_GUARDED_BY(*g_mu) = nullptr;
 
 }  // namespace
 
-class XdsClient::Notifier {
- public:
-  // Helper template function to invoke `OnError()` on a list of watchers \a
-  // watchers_list within \a work_serializer. Works with all 4 resource types.
-  template <class T>
-  static void ScheduleNotifyWatchersOnErrorInWorkSerializer(
-      XdsClient* xds_client, const T& watchers_list, absl::Status status,
-      const DebugLocation& location) {
-    xds_client->work_serializer_.Schedule(
-        [watchers_list, status]()
-            ABSL_EXCLUSIVE_LOCKS_REQUIRED(&xds_client->work_serializer_) {
-              for (const auto& p : watchers_list) {
-                p.first->OnError(status);
-              }
-            },
-        location);
-  }
-
-  // Helper template function to invoke `OnResourceDoesNotExist()` on a list of
-  // watchers \a watchers_list within \a work_serializer. Works with all 4
-  // resource types.
-  template <class T>
-  static void ScheduleNotifyWatchersOnResourceDoesNotExistInWorkSerializer(
-      XdsClient* xds_client, const T& watchers_list,
-      const DebugLocation& location) {
-    xds_client->work_serializer_.Schedule(
-        [watchers_list]()
-            ABSL_EXCLUSIVE_LOCKS_REQUIRED(&xds_client->work_serializer_) {
-              for (const auto& p : watchers_list) {
-                p.first->OnResourceDoesNotExist();
-              }
-            },
-        location);
-  }
-};
-
 //
 // Internal class declarations
 //
@@ -284,9 +248,8 @@ class XdsClient::ChannelState::AdsCallState
             ads_calld_->xds_client()->authority_state_map_[name_.authority];
         ResourceState& state = authority_state.resource_map[type_][name_.key];
         state.meta.client_status = XdsApi::ResourceMetadata::DOES_NOT_EXIST;
-        Notifier::ScheduleNotifyWatchersOnErrorInWorkSerializer(
-            ads_calld_->xds_client(), state.watchers, watcher_error,
-            DEBUG_LOCATION);
+        ads_calld_->xds_client()->NotifyWatchersOnErrorLocked(state.watchers,
+                                                              watcher_error);
       }
       GRPC_ERROR_UNREF(error);
     }
@@ -878,11 +841,10 @@ void XdsClient::ChannelState::AdsCallState::AdsResponseParser::ParseResource(
     result_.errors.emplace_back(absl::StrCat(
         "resource index ", idx, ": ", result->name,
         ": validation error: ", result->resource.status().ToString()));
-    Notifier::ScheduleNotifyWatchersOnErrorInWorkSerializer(
-        xds_client(), resource_state.watchers,
+    xds_client()->NotifyWatchersOnErrorLocked(
+        resource_state.watchers,
         absl::UnavailableError(absl::StrCat(
-            "invalid resource: ", result->resource.status().ToString())),
-        DEBUG_LOCATION);
+            "invalid resource: ", result->resource.status().ToString())));
     UpdateResourceMetadataNacked(result_.version,
                                  result->resource.status().ToString(),
                                  update_time_, &resource_state.meta);
@@ -1250,9 +1212,8 @@ bool XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked() {
             // instead.
             if (resource_state.resource == nullptr) continue;
             resource_state.resource.reset();
-            Notifier::
-                ScheduleNotifyWatchersOnResourceDoesNotExistInWorkSerializer(
-                    xds_client(), resource_state.watchers, DEBUG_LOCATION);
+            xds_client()->NotifyWatchersOnResourceDoesNotExist(
+                resource_state.watchers);
           }
         }
       }
@@ -2216,6 +2177,31 @@ void XdsClient::NotifyOnErrorLocked(absl::Status status) {
       [watchers, status]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer_) {
         for (const auto& watcher : watchers) {
           watcher->OnError(status);
+        }
+      },
+      DEBUG_LOCATION);
+}
+
+void XdsClient::NotifyWatchersOnErrorLocked(
+    const std::map<ResourceWatcherInterface*,
+                   RefCountedPtr<ResourceWatcherInterface>>& watchers,
+    absl::Status status) {
+  work_serializer_.Schedule(
+      [watchers, status]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) {
+        for (const auto& p : watchers) {
+          p.first->OnError(status);
+        }
+      },
+      DEBUG_LOCATION);
+}
+
+void XdsClient::NotifyWatchersOnResourceDoesNotExist(
+    const std::map<ResourceWatcherInterface*,
+                   RefCountedPtr<ResourceWatcherInterface>>& watchers) {
+  work_serializer_.Schedule(
+      [watchers]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&work_serializer_) {
+        for (const auto& p : watchers) {
+          p.first->OnResourceDoesNotExist();
         }
       },
       DEBUG_LOCATION);

--- a/src/core/ext/xds/xds_client.h
+++ b/src/core/ext/xds/xds_client.h
@@ -266,11 +266,18 @@ class XdsClient : public DualRefCounted<XdsClient> {
     LoadReportMap load_report_map;
   };
 
-  class Notifier;
-
   // Sends an error notification to all watchers.
   void NotifyOnErrorLocked(absl::Status status)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  // Sends an error notification to a specific set of watchers.
+  void NotifyWatchersOnErrorLocked(
+      const std::map<ResourceWatcherInterface*,
+                     RefCountedPtr<ResourceWatcherInterface>>& watchers,
+      absl::Status status);
+  // Sends a resource-does-not-exist notification to a specific set of watchers.
+  void NotifyWatchersOnResourceDoesNotExist(
+      const std::map<ResourceWatcherInterface*,
+                     RefCountedPtr<ResourceWatcherInterface>>& watchers);
 
   void MaybeRegisterResourceTypeLocked(const XdsResourceType* resource_type)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -2499,6 +2499,8 @@ TEST_P(XdsResolverOnlyTest, XdsStreamErrorPropagation) {
           status.error_code(), status.error_message().c_str());
   EXPECT_THAT(status.error_code(), StatusCode::UNAVAILABLE);
   EXPECT_THAT(status.error_message(), ::testing::HasSubstr(kErrorMessage));
+  EXPECT_THAT(status.error_message(),
+              ::testing::HasSubstr("(node ID:xds_end2end_test)"));
 }
 
 using GlobalXdsClientTest = BasicTest;


### PR DESCRIPTION
We don't currently have any tests that check the status messages.  That's something we should definitely fix, but it will be part of a broader effort related to reliability.  In the interim, I have manually verified that this works.