### PR TITLE
Disable performance labeler for Github PRs

### DIFF
--- a/tools/profiling/microbenchmarks/bm_diff/bm_main.py
+++ b/tools/profiling/microbenchmarks/bm_diff/bm_main.py
@@ -147,7 +147,6 @@ def main(args):
         text = note + '\n\n' + text
     print('%s' % text)
     check_on_pr.check_on_pr('Benchmark', '```\n%s\n```' % text)
-    check_on_pr.label_significance_on_pr('perf-change', significance)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/295906/160726835-fa599047-f650-43f3-9d85-f43856ac1760.png)


(not shown: the performance *improvement* claimed on this PR with no functional changes to the microbenchmarks)

This is quite noisy. I think it might be informative for sufficient performant hits, but I have not yet seen an actionable performance label.