### PR TITLE
Enable bazel remote cache for macos C/C++ CI tests

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -21,6 +21,7 @@ echo "CPU type: $(sysctl -n machdep.cpu.brand_string)"
 echo "CPU: $(sysctl -n machdep.cpu.vendor) $(uname -m) Family $(sysctl -n machdep.cpu.family) Model $(sysctl -n machdep.cpu.brand_string)"
 echo "CPU Cores: $(sysctl -n hw.ncpu)"
 echo "Memory: $(sysctl -n hw.memsize)"
+echo "Kokoro image version: $(cat /VERSION)"
 
 # Info on disk usage and mounted volumes
 mount

--- a/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
@@ -21,7 +21,6 @@ source $(dirname $0)/../../../tools/internal_ci/helper_scripts/move_src_tree_and
 # change to grpc repo root
 cd $(dirname $0)/../../..
 
-# TODO(jtattermusch): most of the prepare steps should not be needed for bazel
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # make sure bazel is available
@@ -37,6 +36,18 @@ tools/bazel version
 BAZEL_INVOCATION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 echo "${BAZEL_INVOCATION_ID}" >"${KOKORO_ARTIFACTS_DIR}/bazel_invocation_ids"
 
+# for kokoro mac workers, exact image version is store in a well-known location on disk
+KOKORO_IMAGE_VERSION="$(cat /VERSION)"
+
+BAZEL_REMOTE_CACHE_ARGS=(
+  # Enable uploading to remote cache. Requires the "roles/remotebuildexecution.actionCacheWriter" permission.
+  --remote_upload_local_results=true
+  # allow invalidating the old cache by setting to a new random key
+  --remote_default_exec_properties="grpc_cache_silo_key1=83d8e488-1ca9-40fd-929e-d37d13529c99"
+  # make sure we only get cache hits from binaries built on exact same macos image
+  --remote_default_exec_properties="grpc_cache_silo_key2=${KOKORO_IMAGE_VERSION}"
+)
+
 # run all C/C++ tests
 tools/bazel \
   --bazelrc=tools/remote_build/mac.bazelrc \
@@ -44,6 +55,7 @@ tools/bazel \
   --invocation_id="${BAZEL_INVOCATION_ID}" \
   --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh \
   --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
+  "${BAZEL_REMOTE_CACHE_ARGS[@]}" \
   $BAZEL_FLAGS \
   -- //test/... || FAILED="true"
 

--- a/tools/remote_build/mac.bazelrc
+++ b/tools/remote_build/mac.bazelrc
@@ -6,12 +6,16 @@
 
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 
-# remote cache is needed not only for build speedup,
-# but also for the test logs to be available in ResultStore
-# for now, don't upload results to cache, only the test logs.
-# TODO(jtattermusch): setup a "cache-silo-key" before enabling uploads to build cache
+# Configure remote cache. Note that remote cache is needed
+# not only for build speedup, but also for the test logs
+# to become available in ResultStore.
 build --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build --remote_instance_name=projects/grpc-testing/instances/default_instance
+# Disable uploading to build cache by default. This is to prevent
+# polluting the build cache with locally-started builds.
+# When running on CI, we will override this setting along
+# with cache silo keys that prevent the build from being broken
+# by unintentional cache hits.
 build --remote_upload_local_results=false
 
 build --auth_enabled=true


### PR DESCRIPTION
speedup macos kokoro C/C++ bazel test by using remote build cache
- only use cache on kokoro mac workers
- invalidate cache if kokoro macos worker image changes (to avoid false hits)