### PR TITLE
Resize channel resource quota to account for secure_endpoint

### DIFF
--- a/src/core/lib/resource_quota/api.h
+++ b/src/core/lib/resource_quota/api.h
@@ -27,7 +27,7 @@ namespace grpc_core {
 
 // TODO(ctiller): This is a hack. We need to do real accounting instead of
 // hard coding.
-constexpr size_t kResourceQuotaChannelSize = 50 * 1024;
+constexpr size_t kResourceQuotaChannelSize = 34 * 1024;
 
 // Retrieve the resource quota from the channel args.
 // UB if not set.

--- a/src/core/lib/security/transport/secure_endpoint.cc
+++ b/src/core/lib/security/transport/secure_endpoint.cc
@@ -71,7 +71,7 @@ struct secure_endpoint {
             ->memory_quota()
             ->CreateMemoryOwner(absl::StrCat(grpc_endpoint_get_peer(transport),
                                              ":secure_endpoint"));
-    self_reservation = memory_owner.MakeReservation(sizeof(this));
+    self_reservation = memory_owner.MakeReservation(sizeof(*this));
     read_staging_buffer =
         memory_owner.MakeSlice(grpc_core::MemoryRequest(STAGING_BUFFER_SIZE));
     write_staging_buffer =


### PR DESCRIPTION
We can remove 16 kilobytes from the estimated channel RQ now that secure_endpoint's RQ is being tracked (8 kilobytes per staging buffer x 2 staging buffers).