### PR TITLE
Exclude venvs from formatting

### DIFF
--- a/tools/distrib/isort_code.sh
+++ b/tools/distrib/isort_code.sh
@@ -53,5 +53,6 @@ $PYTHON -m isort $ACTION \
   --skip-glob "third_party/*" \
   --skip-glob "*/env/*" \
   --skip-glob "*pb2*.py" \
+  --skip-glob "**/site-packages/**/*" \
   --dont-follow-links \
   "${DIRS[@]}"

--- a/tools/distrib/yapf_code.sh
+++ b/tools/distrib/yapf_code.sh
@@ -35,4 +35,4 @@ python3 -m virtualenv $VIRTUALENV -p $(which python3)
 PYTHON=${VIRTUALENV}/bin/python
 "$PYTHON" -m pip install yapf==0.30.0
 
-$PYTHON -m yapf $ACTION --parallel --recursive --style=setup.cfg "${DIRS[@]}"
+$PYTHON -m yapf $ACTION --parallel --recursive --style=setup.cfg "${DIRS[@]}" -e "**/site-packages/**/*"


### PR DESCRIPTION
I often find that `yapf` and `isort` take a *long* time to complete. It seems this is due to them formatting all of the virtual environments I have scattered throughout my source tree.