### PR TITLE
Do not set custom bio size in ssl_transport_security_test when openssl version < 1.1.0

### DIFF
--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1044,7 +1044,7 @@ void ssl_tsi_test_do_handshake_with_custom_bio_pair() {
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
-#if OPENSSL_VERSION_NUMBER >= 0x10100000 || defined(OPENSSL_IS_BORINGSSL)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
   ssl_fixture->network_bio_buf_size = TSI_TEST_DEFAULT_BUFFER_SIZE;
   ssl_fixture->ssl_bio_buf_size = 256;
 #endif

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1044,8 +1044,10 @@ void ssl_tsi_test_do_handshake_with_custom_bio_pair() {
   tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 || defined(OPENSSL_IS_BORINGSSL)
   ssl_fixture->network_bio_buf_size = TSI_TEST_DEFAULT_BUFFER_SIZE;
   ssl_fixture->ssl_bio_buf_size = 256;
+#endif
   ssl_fixture->force_client_auth = true;
   tsi_test_do_handshake(fixture);
   tsi_test_fixture_destroy(fixture);


### PR DESCRIPTION
When using openssl version < 1.1.0, `ssl_tsi_test_do_handshake_with_custom_bio_pair` fails by complaining the bio buffer is too small to hold ClientHello message. For now, let's use the default bio buffer size for 1.0.2.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
