### PR TITLE
[PSM Interop] disable python authz

### DIFF
--- a/tools/internal_ci/linux/psm-security-python.sh
+++ b/tools/internal_ci/linux/psm-security-python.sh
@@ -174,7 +174,6 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
-  run_test authz_test
 }
 
 main "$@"


### PR DESCRIPTION
As title.

Related https://b.corp.google.com/issues/227306294 and https://github.com/grpc/grpc/pull/29289