### PR TITLE
Run tests using the correct runtime for C# (.NET Framework vs .NET Core)

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -907,11 +907,11 @@ class CSharpLanguage(object):
 
         specs = []
         for test_runtime in self.test_runtimes:
-            if self.args.compiler == 'coreclr':
+            if test_runtime == 'coreclr':
                 assembly_extension = '.dll'
                 assembly_subdir = 'bin/%s/netcoreapp3.1' % msbuild_config
                 runtime_cmd = ['dotnet', 'exec']
-            else:
+            elif test_runtime == 'mono':
                 assembly_extension = '.exe'
                 assembly_subdir = 'bin/%s/net45' % msbuild_config
                 if self.platform == 'windows':
@@ -921,6 +921,8 @@ class CSharpLanguage(object):
                     runtime_cmd = ['mono', '--arch=64']
                 else:
                     runtime_cmd = ['mono']
+            else:
+                raise Exception('Illegal runtime "%s" was specified.')
 
             for assembly in six.iterkeys(tests_by_assembly):
                 assembly_file = 'src/csharp/%s/%s/%s%s' % (


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/28587. 
Fix the runtime selection logic in run_tests.py so that  we end up running both "coreclr" and "mono" version of all tests.

Currently both "coreclr" and "mono" tests only run the "mono" variant.

This can be seen e.g. in this experiment (I tweaked the UserAgentStringTest to print the user agent string and die).
The "coreclr" test should run the .NET Core runtime (but it does not)
https://source.cloud.google.com/results/invocations/1aed7c9d-aa14-4804-927c-9567c0d9c92e/targets/github%2Fgrpc%2Frun_tests%2Fcsharp_windows_dbg_native%2Fcsharp.coreclr.Grpc.Core.Tests.UserAgentStringTest/tests

And the "mono" test should run the legacy .NET Framework (and it does)
https://source.cloud.google.com/results/invocations/1aed7c9d-aa14-4804-927c-9567c0d9c92e/targets/github%2Fgrpc%2Frun_tests%2Fcsharp_windows_dbg_native%2Fcsharp.mono.Grpc.Core.Tests.UserAgentStringTest/tests

@rburns1293 