### PR TITLE
weighted_target and xds_cluster_manager: don't update picker while update is in flight

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -357,6 +357,7 @@ void WeightedTargetLb::UpdateStateLocked() {
     }
     switch (child->connectivity_state()) {
       case GRPC_CHANNEL_READY: {
+        GPR_ASSERT(child->weight() > 0);
         end += child->weight();
         picker_list.push_back(std::make_pair(end, child->picker_wrapper()));
         break;


### PR DESCRIPTION
This is the same change that was made for the priority policy in #29252.  It's not required in these other policies for correctness reasons, but it is a useful optimization that avoids unnecessary picker churn and makes it easier to understand what's happening when reading trace logs.  In general, we want to do this for any LB policy that has multiple active children.