### PR TITLE
Correctly handle shebangs when fixing copyright

### DIFF
--- a/tools/distrib/check_copyright.py
+++ b/tools/distrib/check_copyright.py
@@ -200,6 +200,18 @@ def log(cond, why, filename):
         print(filename)
 
 
+def write_copyright(license_text, file_text, filename):
+    shebang = ""
+    lines = file_text.split("\n")
+    if lines and lines[0].startswith("#!"):
+        shebang = lines[0] + "\n"
+        file_text = file_text[len(shebang):]
+
+    rewritten_text = shebang + license_text + "\n" + file_text
+    with open(filename, 'w') as f:
+        f.write(rewritten_text)
+
+
 # scan files, validate the text
 ok = True
 filename_list = []
@@ -236,8 +248,7 @@ for filename in filename_list:
         pass
     elif 'DO NOT EDIT' not in text:
         if args.fix:
-            text = license_text + '\n' + text
-            open(filename, 'w').write(text)
+            write_copyright(license_text, text, filename)
             log(1, 'copyright missing (fixed)', filename)
         else:
             log(1, 'copyright missing', filename)


### PR DESCRIPTION
Previously, when running `tools/distrib/check_copyright.py --fix`, shebangs (e.g. `#!/bin/bash`) would end up placed _after_ copyright notice comment blocks. This PR ensures that shebangs remain at the beginning of files when running this script.