### PR TITLE
client_lb_end2end_test: refactor connection delay injection into its own library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9119,6 +9119,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
     test/core/util/test_lb_policies.cc
     test/cpp/end2end/client_lb_end2end_test.cc
+    test/cpp/end2end/connection_delay_injector.cc
     test/cpp/end2end/test_service_impl.cc
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5129,6 +5129,7 @@ targets:
   language: c++
   headers:
   - test/core/util/test_lb_policies.h
+  - test/cpp/end2end/connection_delay_injector.h
   - test/cpp/end2end/test_service_impl.h
   src:
   - src/proto/grpc/testing/duplicate/echo_duplicate.proto
@@ -5138,6 +5139,7 @@ targets:
   - src/proto/grpc/testing/xds/v3/orca_load_report.proto
   - test/core/util/test_lb_policies.cc
   - test/cpp/end2end/client_lb_end2end_test.cc
+  - test/cpp/end2end/connection_delay_injector.cc
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - grpc++_test_util

--- a/src/core/lib/gprpp/time.h
+++ b/src/core/lib/gprpp/time.h
@@ -120,7 +120,7 @@ class Timestamp {
 // Duration represents a span of time.
 class Duration {
  public:
-  constexpr Duration() : millis_(0) {}
+  constexpr Duration() noexcept : millis_(0) {}
 
   static Duration FromTimespec(gpr_timespec t);
   static Duration FromSecondsAndNanoseconds(int64_t seconds, int32_t nanos);

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -59,8 +59,8 @@ grpc_cc_library(
 grpc_cc_library(
     name = "connection_delay_injector",
     testonly = True,
-    hdrs = ["connection_delay_injector.h"],
     srcs = ["connection_delay_injector.cc"],
+    hdrs = ["connection_delay_injector.h"],
     deps = [
         "//:grpc",
     ],
@@ -488,8 +488,8 @@ grpc_cc_test(
     flaky = True,  # TODO(b/151315347)
     tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
     deps = [
-        ":test_service_impl",
         ":connection_delay_injector",
+        ":test_service_impl",
         "//:gpr",
         "//:grpc",
         "//:grpc++",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -57,6 +57,16 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "connection_delay_injector",
+    testonly = True,
+    hdrs = ["connection_delay_injector.h"],
+    srcs = ["connection_delay_injector.cc"],
+    deps = [
+        "//:grpc",
+    ],
+)
+
+grpc_cc_library(
     name = "interceptors_util",
     testonly = True,
     srcs = ["interceptors_util.cc"],
@@ -479,6 +489,7 @@ grpc_cc_test(
     tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
     deps = [
         ":test_service_impl",
+        ":connection_delay_injector",
         "//:gpr",
         "//:grpc",
         "//:grpc++",

--- a/test/cpp/end2end/connection_delay_injector.cc
+++ b/test/cpp/end2end/connection_delay_injector.cc
@@ -22,8 +22,8 @@
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/iomgr/tcp_client.h"
+#include "src/core/lib/iomgr/timer.h"
 
 // defined in tcp_client.cc
 extern grpc_tcp_client_vtable* grpc_tcp_client_impl;

--- a/test/cpp/end2end/connection_delay_injector.cc
+++ b/test/cpp/end2end/connection_delay_injector.cc
@@ -1,0 +1,116 @@
+// Copyright 2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/cpp/end2end/connection_delay_injector.h"
+
+#include <atomic>
+#include <memory>
+
+#include "absl/memory/memory.h"
+#include "absl/utility/utility.h"
+
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/gprpp/time.h"
+#include "src/core/lib/iomgr/timer.h"
+#include "src/core/lib/iomgr/tcp_client.h"
+
+// defined in tcp_client.cc
+extern grpc_tcp_client_vtable* grpc_tcp_client_impl;
+
+namespace grpc {
+namespace testing {
+
+namespace {
+
+grpc_tcp_client_vtable* g_original_vtable = nullptr;
+
+std::atomic<grpc_core::Duration> g_delay;
+
+class InjectedDelay {
+ public:
+  InjectedDelay(grpc_closure* closure, grpc_endpoint** ep,
+                grpc_pollset_set* interested_parties,
+                const grpc_channel_args* channel_args,
+                const grpc_resolved_address* addr,
+                grpc_core::Timestamp deadline)
+      : closure_(closure),
+        endpoint_(ep),
+        interested_parties_(interested_parties),
+        channel_args_(grpc_channel_args_copy(channel_args)),
+        deadline_(deadline) {
+    memcpy(&address_, addr, sizeof(grpc_resolved_address));
+    GRPC_CLOSURE_INIT(&timer_callback_, TimerCallback, this, nullptr);
+    auto duration = g_delay.load();
+    deadline_ += duration;
+    grpc_timer_init(&timer_, grpc_core::ExecCtx::Get()->Now() + duration,
+                    &timer_callback_);
+  }
+
+  ~InjectedDelay() { grpc_channel_args_destroy(channel_args_); }
+
+ private:
+  static void TimerCallback(void* arg, grpc_error_handle error) {
+    auto* self = static_cast<InjectedDelay*>(arg);
+    g_original_vtable->connect(self->closure_, self->endpoint_,
+                               self->interested_parties_, self->channel_args_,
+                               &self->address_, self->deadline_);
+    delete self;
+  }
+
+  grpc_timer timer_;
+  grpc_closure timer_callback_;
+
+  // Original args.
+  grpc_closure* closure_;
+  grpc_endpoint** endpoint_;
+  grpc_pollset_set* interested_parties_;
+  const grpc_channel_args* channel_args_;
+  grpc_resolved_address address_;
+  grpc_core::Timestamp deadline_;
+};
+
+void TcpConnectWithDelay(grpc_closure* closure, grpc_endpoint** ep,
+                         grpc_pollset_set* interested_parties,
+                         const grpc_channel_args* channel_args,
+                         const grpc_resolved_address* addr,
+                         grpc_core::Timestamp deadline) {
+  new InjectedDelay(closure, ep, interested_parties, channel_args, addr,
+                    deadline);
+}
+
+grpc_tcp_client_vtable kDelayedConnectVTable = {TcpConnectWithDelay};
+
+}  // namespace
+
+ConnectionDelayInjector::InjectedDelay::~InjectedDelay() {
+  g_delay.store(grpc_core::Duration());
+}
+
+ConnectionDelayInjector::ConnectionDelayInjector() {
+  g_original_vtable =
+      absl::exchange(grpc_tcp_client_impl, &kDelayedConnectVTable);
+}
+
+ConnectionDelayInjector::~ConnectionDelayInjector() {
+  grpc_tcp_client_impl = g_original_vtable;
+}
+
+std::unique_ptr<ConnectionDelayInjector::InjectedDelay>
+ConnectionDelayInjector::SetDelay(grpc_core::Duration duration) {
+  GPR_ASSERT(g_delay.exchange(duration) == grpc_core::Duration());
+  return absl::make_unique<ConnectionDelayInjector::InjectedDelay>();
+}
+
+}  // namespace testing
+}  // namespace grpc

--- a/test/cpp/end2end/connection_delay_injector.cc
+++ b/test/cpp/end2end/connection_delay_injector.cc
@@ -60,7 +60,7 @@ class InjectedDelay {
   ~InjectedDelay() { grpc_channel_args_destroy(channel_args_); }
 
  private:
-  static void TimerCallback(void* arg, grpc_error_handle error) {
+  static void TimerCallback(void* arg, grpc_error_handle /*error*/) {
     auto* self = static_cast<InjectedDelay*>(arg);
     g_original_vtable->connect(self->closure_, self->endpoint_,
                                self->interested_parties_, self->channel_args_,

--- a/test/cpp/end2end/connection_delay_injector.h
+++ b/test/cpp/end2end/connection_delay_injector.h
@@ -1,0 +1,58 @@
+// Copyright 2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_TEST_CPP_END2END_CONNECTION_DELAY_INJECTOR_H
+#define GRPC_TEST_CPP_END2END_CONNECTION_DELAY_INJECTOR_H
+
+#include <memory>
+
+#include "src/core/lib/gprpp/time.h"
+
+namespace grpc {
+namespace testing {
+
+// Allows injecting connection-establishment delays into C-core.
+// Typical usage:
+//
+//  ConnectionDelayInjector delay_injector;
+//  auto scoped_delay =
+//      delay_injector.SetDelay(grpc_core::Duration::Seconds(10));
+//
+// When ConnectionDelayInjector is instantiated, it replaces the iomgr
+// TCP client vtable, and it sets it back to the original value when it
+// is destroyed.
+//
+// When SetDelay() is called, it sets the global delay, which will
+// automatically be unset when the result goes out of scope.
+//
+// The injection is global, so there must be only one ConnectionDelayInjector
+// object at any one time, and there must be only one scoped delay in effect
+// at any one time.
+class ConnectionDelayInjector {
+ public:
+  class InjectedDelay {
+   public:
+    ~InjectedDelay();
+  };
+
+  ConnectionDelayInjector();
+  ~ConnectionDelayInjector();
+
+  std::unique_ptr<InjectedDelay> SetDelay(grpc_core::Duration duration);
+};
+
+}  // namespace testing
+}  // namespace grpc
+
+#endif  // GRPC_TEST_CPP_END2END_CONNECTION_DELAY_INJECTOR_H


### PR DESCRIPTION
Also change the delay to work asynchronously, via a timer, rather than blocking a thread.

This is in preparation for using this code in other tests.