### PR TITLE
Expose NoOpCertificateVerifier to C++

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -1050,6 +1050,17 @@ grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_external_create(
 /**
  * EXPERIMENTAL API - Subject to change
  *
+ * Factory function for an internal verifier that won't perform any
+ * post-handshake verification. Note: using this solely without any other
+ * authentication mechanisms on the peer identity will leave your applications
+ * to the MITM(Man-In-The-Middle) attacks. Users should avoid doing so in
+ * production environments.
+ */
+grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_no_op_create();
+
+/**
+ * EXPERIMENTAL API - Subject to change
+ *
  * Factory function for an internal verifier that will do the default hostname
  * check.
  */

--- a/include/grpcpp/security/tls_certificate_verifier.h
+++ b/include/grpcpp/security/tls_certificate_verifier.h
@@ -214,9 +214,30 @@ class ExternalCertificateVerifier {
       request_map_ ABSL_GUARDED_BY(mu_);
 };
 
+// A CertificateVerifier that will perform hostname verification, to see if the
+// target name set from the client side matches the identity information
+// specified on the server's certificate.
 class HostNameCertificateVerifier : public CertificateVerifier {
  public:
   HostNameCertificateVerifier();
+};
+
+// A sample ExternalCertificateVerifier(which is generally implemented by users)
+// that doesn't perform any additional checks other than certificate
+// verification, if specified.
+// Note: using this solely without any other authentication mechanisms on the
+// peer identity will leave your applications to the MITM(Man-In-The-Middle)
+// attacks. Users should avoid doing so in production environments.
+class NoOpCertificateVerifier : public ExternalCertificateVerifier {
+ public:
+  ~NoOpCertificateVerifier() override {}
+
+  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
+              std::function<void(grpc::Status)> callback,
+              grpc::Status* sync_status) override;
+
+  void Cancel(grpc::experimental::TlsCustomVerificationCheckRequest*) override {
+  }
 };
 
 }  // namespace experimental

--- a/include/grpcpp/security/tls_certificate_verifier.h
+++ b/include/grpcpp/security/tls_certificate_verifier.h
@@ -214,30 +214,22 @@ class ExternalCertificateVerifier {
       request_map_ ABSL_GUARDED_BY(mu_);
 };
 
+// A CertificateVerifier that doesn't perform any additional checks other than
+// certificate verification, if specified.
+// Note: using this solely without any other authentication mechanisms on the
+// peer identity will leave your applications to the MITM(Man-In-The-Middle)
+// attacks. Users should avoid doing so in production environments.
+class NoOpCertificateVerifier : public CertificateVerifier {
+ public:
+  NoOpCertificateVerifier();
+};
+
 // A CertificateVerifier that will perform hostname verification, to see if the
 // target name set from the client side matches the identity information
 // specified on the server's certificate.
 class HostNameCertificateVerifier : public CertificateVerifier {
  public:
   HostNameCertificateVerifier();
-};
-
-// A sample ExternalCertificateVerifier(which is generally implemented by users)
-// that doesn't perform any additional checks other than certificate
-// verification, if specified.
-// Note: using this solely without any other authentication mechanisms on the
-// peer identity will leave your applications to the MITM(Man-In-The-Middle)
-// attacks. Users should avoid doing so in production environments.
-class NoOpCertificateVerifier : public ExternalCertificateVerifier {
- public:
-  ~NoOpCertificateVerifier() override {}
-
-  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
-              std::function<void(grpc::Status)> callback,
-              grpc::Status* sync_status) override;
-
-  void Cancel(grpc::experimental::TlsCustomVerificationCheckRequest*) override {
-  }
 };
 
 }  // namespace experimental

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
@@ -194,6 +194,11 @@ grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_external_create(
   return new grpc_core::ExternalCertificateVerifier(external_verifier);
 }
 
+grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_no_op_create() {
+  grpc_core::ExecCtx exec_ctx;
+  return new grpc_core::NoOpCertificateVerifier();
+}
+
 grpc_tls_certificate_verifier*
 grpc_tls_certificate_verifier_host_name_create() {
   grpc_core::ExecCtx exec_ctx;

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.h
@@ -121,6 +121,30 @@ class ExternalCertificateVerifier : public grpc_tls_certificate_verifier {
       request_map_ ABSL_GUARDED_BY(mu_);
 };
 
+// An internal verifier that won't perform any post-handshake checks.
+// Note: using this solely without any other authentication mechanisms on the
+// peer identity will leave your applications to the MITM(Man-In-The-Middle)
+// attacks. Users should avoid doing so in production environments.
+class NoOpCertificateVerifier : public grpc_tls_certificate_verifier {
+ public:
+  bool Verify(grpc_tls_custom_verification_check_request* request,
+              std::function<void(absl::Status)> callback,
+              absl::Status* sync_status) override {
+    return true;  // synchronous check
+  };
+  void Cancel(grpc_tls_custom_verification_check_request*) override {}
+
+  const char* type() const override { return "NoOp"; }
+
+ private:
+  int CompareImpl(
+      const grpc_tls_certificate_verifier* /* other */) const override {
+    // No differentiating factor between different NoOpCertificateVerifier
+    // objects.
+    return 0;
+  }
+};
+
 // An internal verifier that will perform hostname verification check.
 class HostNameCertificateVerifier : public grpc_tls_certificate_verifier {
  public:

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.h
@@ -127,9 +127,8 @@ class ExternalCertificateVerifier : public grpc_tls_certificate_verifier {
 // attacks. Users should avoid doing so in production environments.
 class NoOpCertificateVerifier : public grpc_tls_certificate_verifier {
  public:
-  bool Verify(grpc_tls_custom_verification_check_request* request,
-              std::function<void(absl::Status)> callback,
-              absl::Status* sync_status) override {
+  bool Verify(grpc_tls_custom_verification_check_request*,
+              std::function<void(absl::Status)>, absl::Status*) override {
     return true;  // synchronous check
   };
   void Cancel(grpc_tls_custom_verification_check_request*) override {}

--- a/src/cpp/common/tls_certificate_verifier.cc
+++ b/src/cpp/common/tls_certificate_verifier.cc
@@ -240,5 +240,13 @@ void ExternalCertificateVerifier::DestructInCoreExternalVerifier(
 HostNameCertificateVerifier::HostNameCertificateVerifier()
     : CertificateVerifier(grpc_tls_certificate_verifier_host_name_create()) {}
 
+bool NoOpCertificateVerifier::Verify(
+    grpc::experimental::TlsCustomVerificationCheckRequest* request,
+    std::function<void(grpc::Status)> callback, grpc::Status* sync_status) {
+  *sync_status = grpc::Status(grpc::StatusCode::OK, "");
+  // Sync verifications should always return true.
+  return true;
+}
+
 }  // namespace experimental
 }  // namespace grpc

--- a/src/cpp/common/tls_certificate_verifier.cc
+++ b/src/cpp/common/tls_certificate_verifier.cc
@@ -237,16 +237,11 @@ void ExternalCertificateVerifier::DestructInCoreExternalVerifier(
   delete self;
 }
 
+NoOpCertificateVerifier::NoOpCertificateVerifier()
+    : CertificateVerifier(grpc_tls_certificate_verifier_no_op_create()) {}
+
 HostNameCertificateVerifier::HostNameCertificateVerifier()
     : CertificateVerifier(grpc_tls_certificate_verifier_host_name_create()) {}
-
-bool NoOpCertificateVerifier::Verify(
-    grpc::experimental::TlsCustomVerificationCheckRequest* request,
-    std::function<void(grpc::Status)> callback, grpc::Status* sync_status) {
-  *sync_status = grpc::Status(grpc::StatusCode::OK, "");
-  // Sync verifications should always return true.
-  return true;
-}
 
 }  // namespace experimental
 }  // namespace grpc

--- a/test/core/security/grpc_tls_certificate_verifier_test.cc
+++ b/test/core/security/grpc_tls_certificate_verifier_test.cc
@@ -48,6 +48,7 @@ class GrpcTlsCertificateVerifierTest : public ::testing::Test {
   void TearDown() override {}
 
   grpc_tls_custom_verification_check_request request_;
+  NoOpCertificateVerifier no_op_certificate_verifier_;
   HostNameCertificateVerifier hostname_certificate_verifier_;
 };
 
@@ -118,6 +119,14 @@ TEST_F(GrpcTlsCertificateVerifierTest, AsyncExternalVerifierFails) {
                      gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
                                   gpr_time_from_seconds(10, GPR_TIMESPAN)));
   EXPECT_NE(callback_completed, nullptr);
+}
+
+TEST_F(GrpcTlsCertificateVerifierTest, NoOpCertificateVerifierSucceeds) {
+  absl::Status sync_status;
+  EXPECT_TRUE(no_op_certificate_verifier_.Verify(
+      &request_, [](absl::Status) {}, &sync_status));
+  EXPECT_TRUE(sync_status.ok())
+      << sync_status.code() << " " << sync_status.message();
 }
 
 TEST_F(GrpcTlsCertificateVerifierTest, HostnameVerifierNullTargetName) {

--- a/test/cpp/security/tls_certificate_verifier_test.cc
+++ b/test/cpp/security/tls_certificate_verifier_test.cc
@@ -149,6 +149,17 @@ TEST(TlsCertificateVerifierTest,
   EXPECT_EQ(sync_status.error_message(), "Hostname Verification Check failed.");
 }
 
+TEST(TlsCertificateVerifierTest, NoOpCertificateVerifierSucceeds) {
+  grpc_tls_custom_verification_check_request request;
+  auto verifier = ExternalCertificateVerifier::Create<
+      experimental::NoOpCertificateVerifier>();
+  TlsCustomVerificationCheckRequest cpp_request(&request);
+  grpc::Status sync_status;
+  verifier->Verify(&cpp_request, nullptr, &sync_status);
+  EXPECT_TRUE(sync_status.ok())
+      << sync_status.error_code() << " " << sync_status.error_message();
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace grpc


### PR DESCRIPTION
This is originally raised in an internal bug.
The original idea for not having NoOpCertificateVerifier is to raise security bars. NoOpCertificateVerifier can expose security issues if not properly used. So we tried to "hide" it and hope that will help us limit its usage.
As Advanced TLS becomes popular, there are more usages of  NoOpCertificateVerifier internally, and their reasons for using it are all valid. In that case, we can expose this in C++, with better documentations, so that users would get a sense of what are implied when using this class.
I will clean-up all the internal sites as long as this goes in.