### PR TITLE
fix security connector segfault

### DIFF
--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -48,7 +48,7 @@ class grpc_httpcli_ssl_channel_security_connector final
  public:
   explicit grpc_httpcli_ssl_channel_security_connector(char* secure_peer_name)
       : grpc_channel_security_connector(
-            /*url_scheme=*/nullptr,
+            /*url_scheme=*/{},
             /*channel_creds=*/nullptr,
             /*request_metadata_creds=*/nullptr),
         secure_peer_name_(secure_peer_name) {}


### PR DESCRIPTION


<!--

[Here](https://github.com/grpc/grpc/blob/c0e2fe9ea040b6e1e901b540eb29f318d9c1c541/src/core/lib/http/httpcli_security_connector.cc#L51) grpc passes a `nullptr` into the constructor of `grpc_channel_security_connector`.
But the data member `url_scheme ` (https://github.com/grpc/grpc/blob/c0e2fe9ea040b6e1e901b540eb29f318d9c1c541/src/core/lib/security/security_connector/security_connector.cc#L48) is of type `absl::string_view`, which is not allowed for now.

-->

@veblush
