### PR TITLE
Add scenario generation for PSM tests.

### DIFF
--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -118,7 +118,8 @@ def gen_run_indices(runs_per_test: int) -> Iterable[str]:
         yield index_fmt.format(i)
 
 
-def scenario_name(base_name, client_channels, server_threads, offered_load):
+def scenario_name(base_name: str, client_channels: Optional[int],
+                  server_threads: Optional[int], offered_load: Optional[int]):
     """Constructs scenario name from base name and modifiers."""
 
     elements = [base_name]
@@ -132,7 +133,8 @@ def scenario_name(base_name, client_channels, server_threads, offered_load):
 
 
 def scenario_transform_function(
-    client_channels: int, server_threads: int, offered_loads: Iterable[int]
+    client_channels: Optional[int], server_threads: Optional[int],
+    offered_loads: Optional[Iterable[int]]
 ) -> Optional[Callable[[Iterable[Mapping[str, Any]]], Iterable[Mapping[str,
                                                                        Any]]]]:
     """Returns a transform to be applied to a list of scenarios."""
@@ -451,7 +453,8 @@ def main() -> None:
         nargs="*",
         type=int,
         default=[],
-        help='A list of offered loads that the tests are running with.')
+        help='A list of QPS values at which each load test scenario will be run.'
+    )
     args = argp.parse_args()
 
     if args.instances_per_client < 1:

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -119,13 +119,15 @@ def gen_run_indices(runs_per_test: int) -> Iterable[str]:
 
 
 def scenario_name(base_name, client_channels, server_threads, offered_load):
+    """Constructs scenario name from base name and modifiers."""
+
     elements = [base_name]
     if client_channels:
-        elements.append(f'{client_channels}channels')
+        elements.append('{:d}channels'.format(client_channels))
     if server_threads:
-        elements.append(f'{server_threads}threads')
+        elements.append('{:d}threads'.format(server_threads))
     if offered_load:
-        elements.append(f'{offered_load}load')
+        elements.append('{:d}offered_load'.format(offered_load))
     return '_'.join(elements)
 
 
@@ -134,7 +136,7 @@ def scenario_transform_function(
 ) -> Optional[Callable[[Iterable[Mapping[str, Any]]], Iterable[Mapping[str,
                                                                        Any]]]]:
     """Returns a transform to be applied to a list of scenarios."""
-    if not any([client_channels, server_threads, len(offered_loads)]):
+    if not any((client_channels, server_threads, len(offered_loads))):
         return lambda s: s
 
     def _transform(
@@ -147,15 +149,18 @@ def scenario_transform_function(
             if client_channels:
                 base_scenario['client_config'][
                     'client_channels'] = client_channels
+
             if server_threads:
                 base_scenario['server_config'][
                     'async_server_threads'] = server_threads
+
             if not offered_loads:
                 base_scenario['name'] = scenario_name(base_name,
                                                       client_channels,
                                                       server_threads, 0)
                 yield base_scenario
                 return
+
             for offered_load in offered_loads:
                 scenario = copy.deepcopy(base_scenario)
                 scenario['client_config']['load_params'] = {

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -138,15 +138,13 @@ def scenario_transform_function(
             base_scenario['server_config'][
                 'async_server_threads'] = async_server_threads
             base_name = base_scenario['name']
-            name_components = base_name.split('1channel')
             for offered_load in offered_loads:
                 scenario = copy.deepcopy(base_scenario)
-                name = name_components[
-                    0] + '%dchannel_%dasync_server_thread_%dload' % (
-                        client_channels, async_server_threads,
-                        offered_load) + name_components[1]
+                name = base_name + '_%dchannels_%dthreads_%dload' % (
+                    client_channels, async_server_threads, offered_load)
                 load = {}
                 load['offered_load'] = offered_load
+                scenario['client_config']['load_params'] = {}
                 scenario['client_config']['load_params']['poisson'] = load
                 scenario['name'] = name
                 yield scenario

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -256,7 +256,7 @@ class CXXLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'cpp_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure',
+            'cpp_generic_async_unary_5000rpcs_1KBmsg_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -627,7 +627,7 @@ class CSharpLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'csharp_generic_async_unary_1channel_5000rpc_1KBmsgs_insecure',
+            'csharp_generic_async_unary_5000rpc_1KBmsgs_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -894,7 +894,7 @@ class PythonLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'python_generic_async_unary_1channel_5000rpcs_1KBmsgs_insecure',
+            'python_generic_async_unary_5000rpcs_1KBmsgs_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -982,7 +982,7 @@ class PythonAsyncIOLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'python_asyncio_generic_async_unary_1channel_5000rpcs_1KBs_insecure',
+            'python_asyncio_generic_async_unary_5000rpcs_1KBs_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1141,7 +1141,7 @@ class RubyLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'ruby_asyncio_generic_async_unary_1channel_5000rpcs_1KBmsgs_insecure',
+            'ruby_generic_async_unary_5000rpcs_1KBmsgs_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1231,7 +1231,7 @@ class Php7Language(Language):
             php7_extension_mode = 'php7_protobuf_c_extension'
 
         yield _ping_pong_scenario(
-            '%s_to_cpp_generic_async_unary_1channel_5000rpcs_1KBmsgs_insecure' %
+            '%s_to_cpp_generic_async_unary_5000rpcs_1KBmsgs_psm' %
             php7_extension_mode,
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
@@ -1302,7 +1302,7 @@ class JavaLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'java_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure',
+            'java_generic_async_unary_5000rpcs_1KBmsg_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1416,7 +1416,7 @@ class GoLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'go_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure',
+            'go_generic_async_unary_5000rpcs_1KBmsg_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1523,7 +1523,7 @@ class NodeLanguage(Language):
         node_implementation = 'node_purejs' if self.node_purejs else 'node'
 
         yield _ping_pong_scenario(
-            '%s_to_node_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure' %
+            '%s_to_node_generic_async_unary_5000rpcs_1KBmsg_psm' %
             (node_implementation),
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -24,6 +24,7 @@ SMOKETEST = 'smoketest'
 SCALABLE = 'scalable'
 INPROC = 'inproc'
 SWEEP = 'sweep'
+PSM = 'psm'
 DEFAULT_CATEGORIES = (SCALABLE, SMOKETEST)
 
 SECURE_SECARGS = {
@@ -254,6 +255,19 @@ class CXXLanguage(Language):
         return 0
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_cpp_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         # TODO(ctiller): add 70% load latency test
         yield _ping_pong_scenario(
             'cpp_protobuf_async_unary_1channel_100rpcs_1MB',
@@ -611,6 +625,19 @@ class CSharpLanguage(Language):
         return 100
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_csharp_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         yield _ping_pong_scenario('csharp_generic_async_streaming_ping_pong',
                                   rpc_type='STREAMING',
                                   client_type='ASYNC_CLIENT',
@@ -864,6 +891,19 @@ class PythonLanguage(Language):
         return 500
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_python_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         yield _ping_pong_scenario('python_generic_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
                                   client_type='SYNC_CLIENT',
@@ -938,6 +978,19 @@ class PythonAsyncIOLanguage(Language):
         return 1200
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_python_asyncio_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         for outstanding in [64, 128, 256, 512]:
             for channels in [1, 4]:
                 yield _ping_pong_scenario(
@@ -1083,6 +1136,19 @@ class RubyLanguage(Language):
         return 300
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_ruby_asyncio_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         yield _ping_pong_scenario('ruby_protobuf_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
                                   client_type='SYNC_CLIENT',
@@ -1159,6 +1225,22 @@ class Php7Language(Language):
         if self.php7_protobuf_c:
             php7_extension_mode = 'php7_protobuf_c_extension'
 
+        yield _ping_pong_scenario(
+            'psm_%s_to_cpp_generic_async_unary_1channel_5000rpcs_1KBmsg' %
+            php7_extension_mode,
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            server_language='c++',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
+
         yield _ping_pong_scenario('%s_to_cpp_protobuf_sync_unary_ping_pong' %
                                   php7_extension_mode,
                                   rpc_type='UNARY',
@@ -1214,6 +1296,19 @@ class JavaLanguage(Language):
         return 400
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_java_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
             smoketest_categories = ([SMOKETEST] if secure else []) + [SCALABLE]
@@ -1314,6 +1409,19 @@ class GoLanguage(Language):
         return 600
 
     def scenarios(self):
+        yield _ping_pong_scenario(
+            'psm_go_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
             smoketest_categories = ([SMOKETEST] if secure else []) + [SCALABLE]
@@ -1406,6 +1514,23 @@ class NodeLanguage(Language):
 
     def scenarios(self):
         node_implementation = 'node_purejs' if self.node_purejs else 'node'
+
+        yield _ping_pong_scenario(
+            'psm_%s_to_node_generic_async_unary_1channel_5000rpcs_1KBmsg' %
+            (node_implementation),
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            server_language='node',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
+
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
             smoketest_categories = ([SMOKETEST] if secure else []) + [SCALABLE]

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -255,19 +255,18 @@ class CXXLanguage(Language):
         return 0
 
     def scenarios(self):
-        yield _ping_pong_scenario(
-            'cpp_generic_async_unary_5000rpcs_1KBmsg_psm',
-            rpc_type='UNARY',
-            client_type='ASYNC_CLIENT',
-            server_type='ASYNC_SERVER',
-            req_size=1024,
-            resp_size=1024,
-            outstanding=5000,
-            channels=1,
-            num_clients=1,
-            secure=False,
-            async_server_threads=1,
-            categories=[PSM])
+        yield _ping_pong_scenario('cpp_generic_async_unary_5000rpcs_1KB_psm',
+                                  rpc_type='UNARY',
+                                  client_type='ASYNC_CLIENT',
+                                  server_type='ASYNC_SERVER',
+                                  req_size=1024,
+                                  resp_size=1024,
+                                  outstanding=5000,
+                                  channels=1,
+                                  num_clients=1,
+                                  secure=False,
+                                  async_server_threads=1,
+                                  categories=[PSM])
 
         # TODO(ctiller): add 70% load latency test
         yield _ping_pong_scenario(
@@ -626,19 +625,18 @@ class CSharpLanguage(Language):
         return 100
 
     def scenarios(self):
-        yield _ping_pong_scenario(
-            'csharp_generic_async_unary_5000rpc_1KBmsgs_psm',
-            rpc_type='UNARY',
-            client_type='ASYNC_CLIENT',
-            server_type='ASYNC_SERVER',
-            req_size=1024,
-            resp_size=1024,
-            outstanding=5000,
-            channels=1,
-            num_clients=1,
-            secure=False,
-            async_server_threads=1,
-            categories=[PSM])
+        yield _ping_pong_scenario('csharp_generic_async_unary_5000rpcs_1KB_psm',
+                                  rpc_type='UNARY',
+                                  client_type='ASYNC_CLIENT',
+                                  server_type='ASYNC_SERVER',
+                                  req_size=1024,
+                                  resp_size=1024,
+                                  outstanding=5000,
+                                  channels=1,
+                                  num_clients=1,
+                                  secure=False,
+                                  async_server_threads=1,
+                                  categories=[PSM])
 
         yield _ping_pong_scenario('csharp_generic_async_streaming_ping_pong',
                                   rpc_type='STREAMING',
@@ -893,19 +891,18 @@ class PythonLanguage(Language):
         return 500
 
     def scenarios(self):
-        yield _ping_pong_scenario(
-            'python_generic_async_unary_5000rpcs_1KBmsgs_psm',
-            rpc_type='UNARY',
-            client_type='ASYNC_CLIENT',
-            server_type='ASYNC_SERVER',
-            req_size=1024,
-            resp_size=1024,
-            outstanding=5000,
-            channels=1,
-            num_clients=1,
-            secure=False,
-            async_server_threads=1,
-            categories=[PSM])
+        yield _ping_pong_scenario('python_generic_async_unary_5000rpcs_1KB_psm',
+                                  rpc_type='UNARY',
+                                  client_type='ASYNC_CLIENT',
+                                  server_type='ASYNC_SERVER',
+                                  req_size=1024,
+                                  resp_size=1024,
+                                  outstanding=5000,
+                                  channels=1,
+                                  num_clients=1,
+                                  secure=False,
+                                  async_server_threads=1,
+                                  categories=[PSM])
 
         yield _ping_pong_scenario('python_generic_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
@@ -982,7 +979,7 @@ class PythonAsyncIOLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'python_asyncio_generic_async_unary_5000rpcs_1KBs_psm',
+            'python_asyncio_generic_async_unary_5000rpcs_1KB_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1140,19 +1137,18 @@ class RubyLanguage(Language):
         return 300
 
     def scenarios(self):
-        yield _ping_pong_scenario(
-            'ruby_generic_async_unary_5000rpcs_1KBmsgs_psm',
-            rpc_type='UNARY',
-            client_type='ASYNC_CLIENT',
-            server_type='ASYNC_SERVER',
-            req_size=1024,
-            resp_size=1024,
-            outstanding=5000,
-            channels=1,
-            num_clients=1,
-            secure=False,
-            async_server_threads=1,
-            categories=[PSM])
+        yield _ping_pong_scenario('ruby_generic_async_unary_5000rpcs_1KB_psm',
+                                  rpc_type='UNARY',
+                                  client_type='ASYNC_CLIENT',
+                                  server_type='ASYNC_SERVER',
+                                  req_size=1024,
+                                  resp_size=1024,
+                                  outstanding=5000,
+                                  channels=1,
+                                  num_clients=1,
+                                  secure=False,
+                                  async_server_threads=1,
+                                  categories=[PSM])
 
         yield _ping_pong_scenario('ruby_protobuf_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
@@ -1231,7 +1227,7 @@ class Php7Language(Language):
             php7_extension_mode = 'php7_protobuf_c_extension'
 
         yield _ping_pong_scenario(
-            '%s_to_cpp_generic_async_unary_5000rpcs_1KBmsgs_psm' %
+            '%s_to_cpp_generic_async_unary_5000rpcs_1KB_psm' %
             php7_extension_mode,
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
@@ -1301,19 +1297,18 @@ class JavaLanguage(Language):
         return 400
 
     def scenarios(self):
-        yield _ping_pong_scenario(
-            'java_generic_async_unary_5000rpcs_1KBmsg_psm',
-            rpc_type='UNARY',
-            client_type='ASYNC_CLIENT',
-            server_type='ASYNC_SERVER',
-            req_size=1024,
-            resp_size=1024,
-            outstanding=5000,
-            channels=1,
-            num_clients=1,
-            secure=False,
-            async_server_threads=1,
-            categories=[PSM])
+        yield _ping_pong_scenario('java_generic_async_unary_5000rpcs_1KB_psm',
+                                  rpc_type='UNARY',
+                                  client_type='ASYNC_CLIENT',
+                                  server_type='ASYNC_SERVER',
+                                  req_size=1024,
+                                  resp_size=1024,
+                                  outstanding=5000,
+                                  channels=1,
+                                  num_clients=1,
+                                  secure=False,
+                                  async_server_threads=1,
+                                  categories=[PSM])
 
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
@@ -1415,19 +1410,18 @@ class GoLanguage(Language):
         return 600
 
     def scenarios(self):
-        yield _ping_pong_scenario(
-            'go_generic_async_unary_5000rpcs_1KBmsg_psm',
-            rpc_type='UNARY',
-            client_type='ASYNC_CLIENT',
-            server_type='ASYNC_SERVER',
-            req_size=1024,
-            resp_size=1024,
-            outstanding=5000,
-            channels=1,
-            num_clients=1,
-            secure=False,
-            async_server_threads=1,
-            categories=[PSM])
+        yield _ping_pong_scenario('go_generic_async_unary_5000rpcs_1KB_psm',
+                                  rpc_type='UNARY',
+                                  client_type='ASYNC_CLIENT',
+                                  server_type='ASYNC_SERVER',
+                                  req_size=1024,
+                                  resp_size=1024,
+                                  outstanding=5000,
+                                  channels=1,
+                                  num_clients=1,
+                                  secure=False,
+                                  async_server_threads=1,
+                                  categories=[PSM])
 
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
@@ -1523,7 +1517,7 @@ class NodeLanguage(Language):
         node_implementation = 'node_purejs' if self.node_purejs else 'node'
 
         yield _ping_pong_scenario(
-            '%s_to_node_generic_async_unary_5000rpcs_1KBmsg_psm' %
+            '%s_to_node_generic_async_unary_5000rpcs_1KB_psm' %
             (node_implementation),
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -256,7 +256,7 @@ class CXXLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_cpp_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'cpp_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -268,6 +268,7 @@ class CXXLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         # TODO(ctiller): add 70% load latency test
         yield _ping_pong_scenario(
             'cpp_protobuf_async_unary_1channel_100rpcs_1MB',
@@ -626,7 +627,7 @@ class CSharpLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_csharp_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'csharp_generic_async_unary_1channel_5000rpc_1KBmsgs_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -638,6 +639,7 @@ class CSharpLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         yield _ping_pong_scenario('csharp_generic_async_streaming_ping_pong',
                                   rpc_type='STREAMING',
                                   client_type='ASYNC_CLIENT',
@@ -892,7 +894,7 @@ class PythonLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_python_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'python_generic_async_unary_1channel_5000rpcs_1KBmsgs_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -904,6 +906,7 @@ class PythonLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         yield _ping_pong_scenario('python_generic_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
                                   client_type='SYNC_CLIENT',
@@ -979,7 +982,7 @@ class PythonAsyncIOLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_python_asyncio_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'python_asyncio_generic_async_unary_1channel_5000rpcs_1KBs_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -991,6 +994,7 @@ class PythonAsyncIOLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         for outstanding in [64, 128, 256, 512]:
             for channels in [1, 4]:
                 yield _ping_pong_scenario(
@@ -1137,7 +1141,7 @@ class RubyLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_ruby_asyncio_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'ruby_asyncio_generic_async_unary_1channel_5000rpcs_1KBmsgs_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1149,6 +1153,7 @@ class RubyLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         yield _ping_pong_scenario('ruby_protobuf_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
                                   client_type='SYNC_CLIENT',
@@ -1226,7 +1231,7 @@ class Php7Language(Language):
             php7_extension_mode = 'php7_protobuf_c_extension'
 
         yield _ping_pong_scenario(
-            'psm_%s_to_cpp_generic_async_unary_1channel_5000rpcs_1KBmsg' %
+            '%s_to_cpp_generic_async_unary_1channel_5000rpcs_1KBmsgs_insecure' %
             php7_extension_mode,
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
@@ -1297,7 +1302,7 @@ class JavaLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_java_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'java_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1309,6 +1314,7 @@ class JavaLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
             smoketest_categories = ([SMOKETEST] if secure else []) + [SCALABLE]
@@ -1410,7 +1416,7 @@ class GoLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'psm_go_generic_async_unary_1channel_5000rpcs_1KBmsg',
+            'go_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1422,6 +1428,7 @@ class GoLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM])
+
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
             smoketest_categories = ([SMOKETEST] if secure else []) + [SCALABLE]
@@ -1516,7 +1523,7 @@ class NodeLanguage(Language):
         node_implementation = 'node_purejs' if self.node_purejs else 'node'
 
         yield _ping_pong_scenario(
-            'psm_%s_to_node_generic_async_unary_1channel_5000rpcs_1KBmsg' %
+            '%s_to_node_generic_async_unary_1channel_5000rpcs_1KBmsg_insecure' %
             (node_implementation),
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -255,7 +255,7 @@ class CXXLanguage(Language):
         return 0
 
     def scenarios(self):
-        yield _ping_pong_scenario('cpp_generic_async_unary_5000rpcs_1KB_psm',
+        yield _ping_pong_scenario('cpp_protobuf_async_unary_5000rpcs_1KB_psm',
                                   rpc_type='UNARY',
                                   client_type='ASYNC_CLIENT',
                                   server_type='ASYNC_SERVER',
@@ -625,18 +625,19 @@ class CSharpLanguage(Language):
         return 100
 
     def scenarios(self):
-        yield _ping_pong_scenario('csharp_generic_async_unary_5000rpcs_1KB_psm',
-                                  rpc_type='UNARY',
-                                  client_type='ASYNC_CLIENT',
-                                  server_type='ASYNC_SERVER',
-                                  req_size=1024,
-                                  resp_size=1024,
-                                  outstanding=5000,
-                                  channels=1,
-                                  num_clients=1,
-                                  secure=False,
-                                  async_server_threads=1,
-                                  categories=[PSM])
+        yield _ping_pong_scenario(
+            'csharp_protobuf_async_unary_5000rpcs_1KB_psm',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
 
         yield _ping_pong_scenario('csharp_generic_async_streaming_ping_pong',
                                   rpc_type='STREAMING',
@@ -891,18 +892,19 @@ class PythonLanguage(Language):
         return 500
 
     def scenarios(self):
-        yield _ping_pong_scenario('python_generic_async_unary_5000rpcs_1KB_psm',
-                                  rpc_type='UNARY',
-                                  client_type='ASYNC_CLIENT',
-                                  server_type='ASYNC_SERVER',
-                                  req_size=1024,
-                                  resp_size=1024,
-                                  outstanding=5000,
-                                  channels=1,
-                                  num_clients=1,
-                                  secure=False,
-                                  async_server_threads=1,
-                                  categories=[PSM])
+        yield _ping_pong_scenario(
+            'python_protobuf_async_unary_5000rpcs_1KB_psm',
+            rpc_type='UNARY',
+            client_type='ASYNC_CLIENT',
+            server_type='ASYNC_SERVER',
+            req_size=1024,
+            resp_size=1024,
+            outstanding=5000,
+            channels=1,
+            num_clients=1,
+            secure=False,
+            async_server_threads=1,
+            categories=[PSM])
 
         yield _ping_pong_scenario('python_generic_sync_streaming_ping_pong',
                                   rpc_type='STREAMING',
@@ -979,7 +981,7 @@ class PythonAsyncIOLanguage(Language):
 
     def scenarios(self):
         yield _ping_pong_scenario(
-            'python_asyncio_generic_async_unary_5000rpcs_1KB_psm',
+            'python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm',
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
             server_type='ASYNC_SERVER',
@@ -1137,7 +1139,7 @@ class RubyLanguage(Language):
         return 300
 
     def scenarios(self):
-        yield _ping_pong_scenario('ruby_generic_async_unary_5000rpcs_1KB_psm',
+        yield _ping_pong_scenario('ruby_protobuf_async_unary_5000rpcs_1KB_psm',
                                   rpc_type='UNARY',
                                   client_type='ASYNC_CLIENT',
                                   server_type='ASYNC_SERVER',
@@ -1227,7 +1229,7 @@ class Php7Language(Language):
             php7_extension_mode = 'php7_protobuf_c_extension'
 
         yield _ping_pong_scenario(
-            '%s_to_cpp_generic_async_unary_5000rpcs_1KB_psm' %
+            '%s_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm' %
             php7_extension_mode,
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',
@@ -1297,7 +1299,7 @@ class JavaLanguage(Language):
         return 400
 
     def scenarios(self):
-        yield _ping_pong_scenario('java_generic_async_unary_5000rpcs_1KB_psm',
+        yield _ping_pong_scenario('java_protobuf_async_unary_5000rpcs_1KB_psm',
                                   rpc_type='UNARY',
                                   client_type='ASYNC_CLIENT',
                                   server_type='ASYNC_SERVER',
@@ -1410,7 +1412,7 @@ class GoLanguage(Language):
         return 600
 
     def scenarios(self):
-        yield _ping_pong_scenario('go_generic_async_unary_5000rpcs_1KB_psm',
+        yield _ping_pong_scenario('go_protobuf_async_unary_5000rpcs_1KB_psm',
                                   rpc_type='UNARY',
                                   client_type='ASYNC_CLIENT',
                                   server_type='ASYNC_SERVER',
@@ -1517,7 +1519,7 @@ class NodeLanguage(Language):
         node_implementation = 'node_purejs' if self.node_purejs else 'node'
 
         yield _ping_pong_scenario(
-            '%s_to_node_generic_async_unary_5000rpcs_1KB_psm' %
+            '%s_to_node_protobuf_async_unary_5000rpcs_1KB_psm' %
             (node_implementation),
             rpc_type='UNARY',
             client_type='ASYNC_CLIENT',


### PR DESCRIPTION
This commit adds the PSM base scenario to each language in
scenario_config.py allowing per language generation of PSM
base scenarios. The PSM base scenarios will be further updated
in loadtest_config.py for number of client channels and the
number of async_server_thread. After update of the two
aforementioned fields, scenarios varying offered_load will
be generated from the base scenarios.

loadtest_config.py is updated to take number of client channels,
the number of async_servers and a list of targeted offered_load.