### PR TITLE
Do not segfault when peer CN is absent

### DIFF
--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
@@ -142,7 +142,8 @@ bool HostNameCertificateVerifier::Verify(
     const char* common_name = request->peer_info.common_name;
     // We are using the target name sent from the client as a matcher to match
     // against identity name on the peer cert.
-    if (VerifySubjectAlternativeName(common_name, std::string(target_host))) {
+    if (common_name != nullptr &&
+        VerifySubjectAlternativeName(common_name, std::string(target_host))) {
       return true;  // synchronous check
     }
   }


### PR DESCRIPTION
In `HostNameCertificateVerifier::Verify`, do not use the `peer_info->common_name` if it is a null pointer.

Fixes tracebacks like:

```
Thread 1 "grpc_tls_certif" received signal SIGSEGV, Segmentation fault.
0x00007ffff75f617d in __strlen_avx2 () from /lib64/libc.so.6
#0  0x00007ffff75f617d in __strlen_avx2 () from /lib64/libc.so.6
#1  0x00007ffff7de39e2 in std::char_traits<char>::length (__s=0x0) at /usr/include/c++/12/bits/char_traits.h:395
#2  std::basic_string_view<char, std::char_traits<char> >::basic_string_view (__str=0x0, this=<optimized out>) at /usr/include/c++/12/string_view:134
#3  grpc_core::HostNameCertificateVerifier::Verify(grpc_tls_custom_verification_check_request*, std::function<void (absl::lts_20211102::Status)>, absl::lts_20211102::Status*) (this=<optimized out>, request=<optimized out>, sync_status=sync_status@entry=0x7fffffffd978) at /builddir/build/BUILD/grpc-1.45.1/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc:137
#4  0x000055555556c95a in grpc_core::testing::GrpcTlsCertificateVerifierTest_HostnameVerifierIpCheckFails_Test::TestBody (this=<optimized out>) at /builddir/build/BUILD/grpc-1.45.1/test/core/security/grpc_tls_certificate_verifier_test.cc:225
#5  0x00005555555a4d4f in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (location=0x5555555b887a "the test body", method=<optimized out>, object=0x555555612910) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2654
#6  testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=object@entry=0x555555612910, method=<optimized out>, location=location@entry=0x5555555b887a "the test body") at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2690
#7  0x0000555555591b26 in testing::Test::Run (this=0x555555612910) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2729
#8  testing::Test::Run (this=0x555555612910) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2719
#9  0x0000555555591d5d in testing::TestInfo::Run (this=0x5555555f0570) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2908
#10 0x0000555555591ee2 in testing::TestSuite::Run (this=0x5555555eeb80) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:3067
#11 0x0000555555599f27 in testing::TestSuite::Run (this=<optimized out>) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:3041
#12 testing::internal::UnitTestImpl::RunAllTests (this=0x5555555ee7b0) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:5937
#13 0x00005555555a5337 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (location=0x5555555ba960 "auxiliary test code (environments or event listeners)", method=<optimized out>, object=0x5555555ee7b0) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2654
#14 testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x5555555ee7b0, method=<optimized out>, location=location@entry=0x5555555ba960 "auxiliary test code (environments or event listeners)") at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:2690
#15 0x0000555555592143 in testing::UnitTest::Run (this=0x5555555d9500 <testing::UnitTest::GetInstance()::instance>) at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/src/gtest.cc:5506
#16 0x00005555555657f2 in RUN_ALL_TESTS () at /builddir/build/BUILD/grpc-1.45.1/third_party/googletest/googletest/include/gtest/gtest.h:2311
#17 main (argc=<optimized out>, argv=0x7fffffffddd8) at /builddir/build/BUILD/grpc-1.45.1/test/core/security/grpc_tls_certificate_verifier_test.cc:262

```

We’ve been seeing these segfaults in practice since 1.42.0 when running the tests for Fedora Linux’s `grpc` package. Of course, we unbundle dependencies, don’t use Docker, and use OpenSSL rather than BoringSSL, so the environment is a little different than Google’s CI testing. This patch fixes the problem.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
