### PR TITLE
Added GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING to grpc::Status

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -57,6 +57,6 @@ GRPC_LLVM_WARNING_FLAGS = [
 ]
 
 GRPC_DEFAULT_COPTS = select({
-    "//:use_strict_warning": GRPC_LLVM_WARNING_FLAGS,
+    "//:use_strict_warning": GRPC_LLVM_WARNING_FLAGS + ["-DUSE_STRICT_WARNING=1"],
     "//conditions:default": [],
 })

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -528,6 +528,11 @@ typedef unsigned __int64 uint64_t;
 #define GRPC_MUST_USE_RESULT
 #define GPR_ALIGN_STRUCT(n)
 #endif
+#ifdef USE_STRICT_WARNING
+#define GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING GRPC_MUST_USE_RESULT
+#else
+#define GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING
+#endif
 #endif
 
 #ifndef GRPC_UNUSED

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -529,6 +529,14 @@ typedef unsigned __int64 uint64_t;
 #define GPR_ALIGN_STRUCT(n)
 #endif
 #ifdef USE_STRICT_WARNING
+/* When building with USE_STRICT_WARNING (which -Werror), types with this
+   attribute will be treated as annotated with warn_unused_result, enforcing
+   returned values of this type should be used.
+   This is added in grpc::Status in mind to address the issue where it always
+   has this annotation internally but OSS doesn't, sometimes causing internal
+   build failure. To prevent this, this is added while not introducing
+   a breaking change to existing user code which may not use returned values
+   of grpc::Status. */
 #define GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING GRPC_MUST_USE_RESULT
 #else
 #define GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING

--- a/include/grpcpp/impl/codegen/status.h
+++ b/include/grpcpp/impl/codegen/status.h
@@ -21,6 +21,8 @@
 
 // IWYU pragma: private, include <grpcpp/support/status.h>
 
+#include <grpc/impl/codegen/port_platform.h>
+
 #include <grpc/impl/codegen/status.h>
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/status_code_enum.h>
@@ -30,7 +32,7 @@ namespace grpc {
 /// Did it work? If it didn't, why?
 ///
 /// See \a grpc::StatusCode for details on the available code and their meaning.
-class Status {
+class GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING Status {
  public:
   /// Construct an OK instance.
   Status() : code_(StatusCode::OK) {


### PR DESCRIPTION
To prevent gRPC from having https://github.com/grpc/grpc/pull/29358, `GRPC_MUST_USE_RESULT_WHEN_USE_STRICT_WARNING` is added and applied to `grpc::Status`. This is working as `GRPC_MUST_USE_RESULT` but only when it's built with `USE_STRICT_WARNING`. Since `grpc::Status` is public API, we should be careful when changing its prototype although changing this attribute isn't necessarily a breaking change but it may introduce surprising errors.