### PR TITLE
Remove Windows Python27 build support

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -186,10 +186,7 @@ class PythonArtifact:
                 environ=environ,
                 timeout_seconds=60 * 60 * 2)
         elif self.platform == 'windows':
-            if 'Python27' in self.py_version:
-                environ['EXT_COMPILER'] = 'mingw32'
-            else:
-                environ['EXT_COMPILER'] = 'msvc'
+            environ['EXT_COMPILER'] = 'msvc'
             # For some reason, the batch script %random% always runs with the same
             # seed.  We create a random temp-dir here
             dir = ''.join(

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -15,8 +15,6 @@
 @rem set path to python
 set PATH=C:\%1;C:\%1\scripts;%PATH%
 
-if "%1" == "Python27" goto :install_mingw64_with_msvcr90
-if "%1" == "Python27_32bit" goto :install_mingw64_with_msvcr90
 @rem set path to the existed mingw compiler
 set PATH=C:\msys64\mingw%2\bin;C:\tools\msys64\mingw%2\bin;%PATH%
 :end_mingw64_installation
@@ -69,13 +67,3 @@ goto :EOF
 :error
 popd
 exit /b 1
-
-:install_mingw64_with_msvcr90
-set MSYS64_DOWNLOAD_URL=https://storage.googleapis.com/grpc-build-helper/msys64.zip
-set MSYS64_PATH=C:\tools\msys64_win7
-set PATH=%MSYS64_PATH%\mingw%2\bin;%PATH%
-@rem Skip the installation if the directory exists
-if exist "%MSYS64_PATH%" goto :end_mingw64_installation
-python -m pip install requests || goto :error
-python tools\run_tests\python_utils\download_and_unzip.py "%MSYS64_DOWNLOAD_URL%" "%MSYS64_PATH%" || goto :error
-goto :end_mingw64_installation


### PR DESCRIPTION
As title.

This Python27 Windows support caused us lots of pain to build, but I guess it's time to remove them.