### PR TITLE
iOS binary size script cleanup

### DIFF
--- a/tools/internal_ci/macos/grpc_ios_binary_size.cfg
+++ b/tools/internal_ci/macos/grpc_ios_binary_size.cfg
@@ -1,0 +1,33 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_ios_binary_size.sh"
+timeout_mins: 90
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "grpc_checks_private_key"
+    }
+  }
+}
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/tools/internal_ci/macos/grpc_ios_binary_size.sh
+++ b/tools/internal_ci/macos/grpc_ios_binary_size.sh
@@ -27,5 +27,14 @@ cd $(dirname $0)/../../..
 export PREPARE_BUILD_INSTALL_DEPS_OBJC=true
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
+if [ "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}" != "" ]
+then
+  # running on PR, generate size diff
+  DIFF_BASE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}"
+else
+  # running as continous build, only generate numbers for the current revision
+  DIFF_BASE=""
+fi
+
 tools/profiling/ios_bin/binary_size.py \
-  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
+  --diff_base="${DIFF_BASE}"


### PR DESCRIPTION
The original version of the script has terrible readability. Tried to improve that at least a bit.
- also made the script always print the sizes, even when diff is not significant.

The next step should be looking into how to speed up the jobs (currently `grpc/core/pull_request/macos/grpc_ios_binary_size` takes about 40mins which is way too much for what it's doing).
I wanted to first get a sense of what exactly the job is doing, before we make modifications (hence the cleanup).