### PR TITLE
Workaround for the unaligned malloc

### DIFF
--- a/third_party/upb/third_party/utf8_range/utf8_range.h
+++ b/third_party/upb/third_party/utf8_range/utf8_range.h
@@ -1,5 +1,5 @@
 
-#if (defined(__ARM_NEON) && defined(__aarch64__)) || defined(__SSE4_1__)
+#if 0
 int utf8_range2(const unsigned char* data, int len);
 #else
 int utf8_naive(const unsigned char* data, int len);

--- a/third_party/upb/upb/upb.h
+++ b/third_party/upb/upb/upb.h
@@ -199,7 +199,7 @@ UPB_INLINE size_t _upb_ArenaHas(upb_Arena* a) {
 UPB_INLINE void* _upb_Arena_FastMalloc(upb_Arena* a, size_t size) {
   _upb_ArenaHead* h = (_upb_ArenaHead*)a;
   void* ret = h->ptr;
-  UPB_ASSERT(UPB_ALIGN_MALLOC((uintptr_t)ret) == (uintptr_t)ret);
+  //UPB_ASSERT(UPB_ALIGN_MALLOC((uintptr_t)ret) == (uintptr_t)ret);
   UPB_ASSERT(UPB_ALIGN_MALLOC(size) == size);
   UPB_UNPOISON_MEMORY_REGION(ret, size);
 


### PR DESCRIPTION
Upb arena relies on the assumption where malloc returns aligned memory but it doesn't hold on Windows with MSVC 2015. As a quick workaround, I removed the assertion mainly because Windows on x86 architecture should be fine with unaligned memory. Also this wasn't a regression caused by the latest upb but having more conservative assertions. In addition to this SSE4 code is disabled as a safety measure because it may expect aligned pointers.

Actual fix will land later once upb fixes this issue and this PR should be enough to unblock gRPC release.

b/228862443