### PR TITLE
Fix bazel RBE builds broken on master

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
@@ -16,5 +16,4 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-EXTRA_FLAGS="--config=dbg --cache_test_results=no"
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=dbg --cache_test_results=no

--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
@@ -16,5 +16,4 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-EXTRA_FLAGS="--config=opt --cache_test_results=no"
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=opt --cache_test_results=no

--- a/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh
@@ -24,5 +24,4 @@ export USE_BAZEL_VERSION=latest
 # Use bazelisk instead of our usual //tools/bazel wrapper
 mv bazelisk-linux-amd64 github/grpc/tools/bazel
 
-EXTRA_FLAGS="--config=opt --cache_test_results=no"
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=opt --cache_test_results=no

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh
@@ -15,5 +15,4 @@
 
 set -ex
 
-EXTRA_FLAGS="--config=dbg"
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=dbg

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh
@@ -15,5 +15,4 @@
 
 set -ex
 
-EXTRA_FLAGS="--config=opt"
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=opt


### PR DESCRIPTION
Fixup for #29353.
Supersedes https://github.com/grpc/grpc/pull/29387.

Sorry for the breakage.

The concern in https://github.com/grpc/grpc/pull/29353/files#diff-fb339b3529fae792999cdf0604ce818c3a873177ee85aca0c52ac08435cb2353R31 turns out to be fair, I missed that some of the job configs are explicitly passing e.g. `"--config=dbg --cache_test_results=no"` as a single arg (which makes no sense).