### PR TITLE
Replace grpc_chttp2_stream::included with a grpc_core::BitSet.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -708,7 +708,7 @@ grpc_chttp2_stream::~grpc_chttp2_stream() {
   grpc_slice_buffer_destroy_internal(&frame_storage);
 
   for (int i = 0; i < STREAM_LIST_COUNT; i++) {
-    if (GPR_UNLIKELY(included[i])) {
+    if (GPR_UNLIKELY(included.is_set(i))) {
       gpr_log(GPR_ERROR, "%s stream %d still included in list %d",
               t->is_client ? "client" : "server", id, i);
       abort();

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -36,6 +36,7 @@
 #include "src/core/ext/transport/chttp2/transport/hpack_parser.h"
 #include "src/core/ext/transport/chttp2/transport/stream_map.h"
 #include "src/core/lib/channel/channelz.h"
+#include "src/core/lib/gprpp/bitset.h"
 #include "src/core/lib/gprpp/manual_constructor.h"
 #include "src/core/lib/iomgr/combiner.h"
 #include "src/core/lib/iomgr/endpoint.h"
@@ -526,7 +527,7 @@ struct grpc_chttp2_stream {
   grpc_closure* destroy_stream_arg;
 
   grpc_chttp2_stream_link links[STREAM_LIST_COUNT];
-  uint8_t included[STREAM_LIST_COUNT] = {};
+  grpc_core::BitSet<STREAM_LIST_COUNT> included;
 
   /** HTTP2 stream id for this stream, or zero if one has not been assigned */
   uint32_t id = 0;

--- a/src/core/ext/transport/chttp2/transport/stream_lists.cc
+++ b/src/core/ext/transport/chttp2/transport/stream_lists.cc
@@ -56,7 +56,7 @@ static bool stream_list_pop(grpc_chttp2_transport* t,
   grpc_chttp2_stream* s = t->lists[id].head;
   if (s) {
     grpc_chttp2_stream* new_head = s->links[id].next;
-    GPR_ASSERT(s->included[id]);
+    GPR_ASSERT(s->included.is_set(id));
     if (new_head) {
       t->lists[id].head = new_head;
       new_head->links[id].prev = nullptr;
@@ -64,7 +64,7 @@ static bool stream_list_pop(grpc_chttp2_transport* t,
       t->lists[id].head = nullptr;
       t->lists[id].tail = nullptr;
     }
-    s->included[id] = 0;
+    s->included.clear(id);
   }
   *stream = s;
   if (s && GRPC_TRACE_FLAG_ENABLED(grpc_trace_http2_stream_state)) {
@@ -76,8 +76,8 @@ static bool stream_list_pop(grpc_chttp2_transport* t,
 
 static void stream_list_remove(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                                grpc_chttp2_stream_list_id id) {
-  GPR_ASSERT(s->included[id]);
-  s->included[id] = 0;
+  GPR_ASSERT(s->included.is_set(id));
+  s->included.clear(id);
   if (s->links[id].prev) {
     s->links[id].prev->links[id].next = s->links[id].next;
   } else {
@@ -98,7 +98,7 @@ static void stream_list_remove(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 static bool stream_list_maybe_remove(grpc_chttp2_transport* t,
                                      grpc_chttp2_stream* s,
                                      grpc_chttp2_stream_list_id id) {
-  if (s->included[id]) {
+  if (s->included.is_set(id)) {
     stream_list_remove(t, s, id);
     return true;
   } else {
@@ -110,7 +110,7 @@ static void stream_list_add_tail(grpc_chttp2_transport* t,
                                  grpc_chttp2_stream* s,
                                  grpc_chttp2_stream_list_id id) {
   grpc_chttp2_stream* old_tail;
-  GPR_ASSERT(!s->included[id]);
+  GPR_ASSERT(!s->included.is_set(id));
   old_tail = t->lists[id].tail;
   s->links[id].next = nullptr;
   s->links[id].prev = old_tail;
@@ -120,7 +120,7 @@ static void stream_list_add_tail(grpc_chttp2_transport* t,
     t->lists[id].head = s;
   }
   t->lists[id].tail = s;
-  s->included[id] = 1;
+  s->included.set(id);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_http2_stream_state)) {
     gpr_log(GPR_INFO, "%p[%d][%s]: add to %s", t, s->id,
             t->is_client ? "cli" : "svr", stream_list_id_string(id));
@@ -129,7 +129,7 @@ static void stream_list_add_tail(grpc_chttp2_transport* t,
 
 static bool stream_list_add(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                             grpc_chttp2_stream_list_id id) {
-  if (s->included[id]) {
+  if (s->included.is_set(id)) {
     return false;
   }
   stream_list_add_tail(t, s, id);


### PR DESCRIPTION
This should reduce the size of grpc_chttp2_stream

@markdroth 
