### PR TITLE
Restructure HPackParserTable to not use an inline table, and use a std::vector for its ring buffer instead.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -58,7 +58,7 @@ auto MementoRingBuffer::PopOne() -> Memento {
   return std::move(entries_[index]);
 }
 
-auto MementoRingBuffer::Lookup(uint32_t index) const -> const Memento* {
+const Memento* MementoRingBuffer::Lookup(uint32_t index) const {
   if (index >= num_entries_) return nullptr;
   uint32_t offset = (num_entries_ - 1u - index + first_entry_) % max_entries_;
   return &entries_[offset];
@@ -85,16 +85,6 @@ void HPackTable::EvictOne() {
   auto first_entry = entries_.PopOne();
   GPR_ASSERT(first_entry.transport_size() <= mem_used_);
   mem_used_ -= first_entry.transport_size();
-}
-
-void HPackTable::Rebuild(uint32_t new_cap) {
-  EntriesVec entries;
-  entries.resize(new_cap);
-  for (size_t i = 0; i < num_entries_; i++) {
-    entries[i] = std::move(entries_[(first_entry_ + i) % entries_.size()]);
-  }
-  first_entry_ = 0;
-  entries_.swap(entries);
 }
 
 void HPackTable::SetMaxBytes(uint32_t max_bytes) {

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -39,7 +39,7 @@ extern grpc_core::TraceFlag grpc_http_trace;
 
 namespace grpc_core {
 
-void MementoRingBuffer::Put(Memento m) {
+void HPackTable::MementoRingBuffer::Put(Memento m) {
   GPR_ASSERT(num_entries_ < max_entries_);
   if (entries_.size() < max_entries_) {
     ++num_entries_;
@@ -50,7 +50,7 @@ void MementoRingBuffer::Put(Memento m) {
   ++num_entries_;
 }
 
-auto MementoRingBuffer::PopOne() -> Memento {
+auto HPackTable::MementoRingBuffer::PopOne() -> Memento {
   GPR_ASSERT(num_entries_ > 0);
   size_t index = first_entry_ % max_entries_;
   ++first_entry_;
@@ -58,13 +58,13 @@ auto MementoRingBuffer::PopOne() -> Memento {
   return std::move(entries_[index]);
 }
 
-const Memento* MementoRingBuffer::Lookup(uint32_t index) const {
+auto HPackTable::MementoRingBuffer::Lookup(uint32_t index) const -> const Memento* {
   if (index >= num_entries_) return nullptr;
   uint32_t offset = (num_entries_ - 1u - index + first_entry_) % max_entries_;
   return &entries_[offset];
 }
 
-void MementoRingBuffer::Rebuild(uint32_t max_entries) {
+void HPackTable::MementoRingBuffer::Rebuild(uint32_t max_entries) {
   if (max_entries == max_entries_) return;
   std::vector<Memento> entries;
   entries.reserve(num_entries_);
@@ -239,7 +239,7 @@ GPR_ATTRIBUTE_NOINLINE HPackTable::Memento MakeMemento(size_t i) {
 
 }  // namespace
 
-const HPackTable::StaticMementos& HPackTable::GetStaticMementos() {
+auto HPackTable::GetStaticMementos() -> const StaticMementos& {
   static const StaticMementos* const static_mementos = new StaticMementos();
   return *static_mementos;
 }

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -16,18 +16,16 @@
  *
  */
 
-#include <grpc/support/port_platform.h>
-
 #include "src/core/ext/transport/chttp2/transport/hpack_parser_table.h"
 
-#include <assert.h>
-#include <string.h>
-
-#include "absl/strings/str_format.h"
-
+#include <cassert>
+#include <cstring>
+#include <cstddef>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
+#include <grpc/support/port_platform.h>
 
+#include "absl/strings/str_format.h"
 #include "src/core/ext/transport/chttp2/transport/hpack_constants.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/murmur_hash.h"
@@ -38,17 +36,52 @@ extern grpc_core::TraceFlag grpc_http_trace;
 
 namespace grpc_core {
 
+void MementoRingBuffer::Put(Memento m) {
+  GPR_ASSERT(num_entries_ < max_entries_);
+  if (entries_.size() < max_entries_) {
+    ++num_entries_;
+    return entries_.push_back(std::move(m));
+  }
+  size_t index = (first_entry_ + num_entries_) % max_entries_;
+  entries_[index] = std::move(m);
+  ++num_entries_;
+}
+
+auto MementoRingBuffer::PopOne() -> Memento {
+  GPR_ASSERT(num_entries_ > 0);
+  size_t index = first_entry_ % max_entries_;
+  ++first_entry_;
+  --num_entries_;
+  return std::move(entries_[index]);
+}
+
+auto MementoRingBuffer::Lookup(uint32_t index) const -> const Memento* {
+  if (index >= num_entries_) return nullptr;
+  uint32_t offset = (num_entries_ - 1u - index + first_entry_) % max_entries_;
+  return &entries_[offset];
+}
+
+void MementoRingBuffer::Rebuild(uint32_t max_entries) {
+  if (max_entries == max_entries_) return;
+  std::vector<Memento> entries;
+  entries.reserve(num_entries_);
+  for (size_t i = 0; i < num_entries_; i++) {
+    entries.push_back(
+        std::move(entries_[(first_entry_ + i) % entries_.size()]));
+  }
+  first_entry_ = 0;
+  entries_.swap(entries);
+}
+
 HPackTable::HPackTable() : static_metadata_(GetStaticMementos()) {}
 
 HPackTable::~HPackTable() = default;
 
 /* Evict one element from the table */
 void HPackTable::EvictOne() {
-  auto first_entry = std::move(entries_[first_entry_]);
+  auto first_entry = entries_.PopOne();
   GPR_ASSERT(first_entry.transport_size() <= mem_used_);
   mem_used_ -= first_entry.transport_size();
-  first_entry_ = ((first_entry_ + 1) % entries_.size());
-  num_entries_--;
 }
 
 void HPackTable::Rebuild(uint32_t new_cap) {
@@ -90,18 +123,9 @@ grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
     EvictOne();
   }
   current_table_bytes_ = bytes;
-  max_entries_ = hpack_constants::EntriesForBytes(bytes);
-  if (max_entries_ > entries_.size()) {
-    Rebuild(max_entries_);
-  } else if (max_entries_ < entries_.size() / 3) {
-    // TODO(ctiller): move to resource quota system, only shrink under memory
-    // pressure
-    uint32_t new_cap =
-        std::max(max_entries_, static_cast<uint32_t>(kInlineEntries));
-    if (new_cap != entries_.size()) {
-      Rebuild(new_cap);
-    }
-  }
+  uint32_t new_cap = std::max(hpack_constants::EntriesForBytes(bytes),
+                              hpack_constants::kInitialTableEntries);
+  entries_.Rebuild(new_cap);
   return GRPC_ERROR_NONE;
 }
 
@@ -122,7 +146,7 @@ grpc_error_handle HPackTable::Add(Memento md) {
     // attempt to add an entry larger than the entire table causes
     // the table to be emptied of all existing entries, and results in an
     // empty table.
-    while (num_entries_) {
+    while (entries_.num_entries()) {
       EvictOne();
     }
     return GRPC_ERROR_NONE;
@@ -136,10 +160,7 @@ grpc_error_handle HPackTable::Add(Memento md) {
 
   // copy the finalized entry in
   mem_used_ += md.transport_size();
-  entries_[(first_entry_ + num_entries_) % entries_.size()] = std::move(md);
-
-  // update accounting values
-  num_entries_++;
+  entries_.Put(std::move(md));
   return GRPC_ERROR_NONE;
 }
 

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -58,7 +58,8 @@ auto HPackTable::MementoRingBuffer::PopOne() -> Memento {
   return std::move(entries_[index]);
 }
 
-auto HPackTable::MementoRingBuffer::Lookup(uint32_t index) const -> const Memento* {
+auto HPackTable::MementoRingBuffer::Lookup(uint32_t index) const
+    -> const Memento* {
   if (index >= num_entries_) return nullptr;
   uint32_t offset = (num_entries_ - 1u - index + first_entry_) % max_entries_;
   return &entries_[offset];

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -16,16 +16,19 @@
  *
  */
 
+#include <grpc/support/port_platform.h>
+
 #include "src/core/ext/transport/chttp2/transport/hpack_parser_table.h"
 
 #include <cassert>
-#include <cstring>
 #include <cstddef>
-#include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
-#include <grpc/support/port_platform.h>
+#include <cstring>
 
 #include "absl/strings/str_format.h"
+
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+
 #include "src/core/ext/transport/chttp2/transport/hpack_constants.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/murmur_hash.h"

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
@@ -97,8 +97,8 @@ class HPackTable {
     uint32_t first_entry_ = 0;
     // How many entries are in the table.
     uint32_t num_entries_ = 0;
-    // Maximum number of entries we could possibly fit in the table, given defined
-    // overheads.
+    // Maximum number of entries we could possibly fit in the table, given
+    // defined overheads.
     uint32_t max_entries_ = hpack_constants::kInitialTableEntries;
 
     std::vector<Memento> entries_;

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
@@ -32,7 +32,6 @@ namespace grpc_core {
 
 using Memento = ParsedMetadata<grpc_metadata_batch>;
 
-
 class MementoRingBuffer {
  public:
   // Rebuild this buffer with a new max_entries_ size.
@@ -114,7 +113,7 @@ class HPackTable {
   }
 
   void EvictOne();
-  
+
   // The amount of memory used by the table, according to the hpack algorithm
   uint32_t mem_used_ = 0;
   // The max memory allowed to be used by the table, according to the hpack


### PR DESCRIPTION
Before this change, it uses 6.2KiB by default, 2/3 of the size of grpc_chttp2_transport. https://screenshot.googleplex.com/6qdcybty2oCsGjG

After this change, it uses 120 bytes https://screenshot.googleplex.com/4xGWKmZZz68VE4F

This class uses up substantial amounts of memory, as it is allocated on a per-stream basis. This should reduce the size of grpc_chttp2_stream substantially

It should cause a significant memory reduction, as the HPack extension table should almost never be fully populated in terms of number of entries, especially since common headers already exist in a static table and entries are highly likely to take more memory than the absolute minimum.

See cl/441088558 for more internal context
@ctiller 
