### PR TITLE
Fix Python xDS Interop Client Time Slicing

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
@@ -50,8 +50,10 @@ py_test(
     deps = [
         ":xds_interop_client",
         ":xds_interop_server",
+        "//src/proto/grpc/testing:empty_py_pb2",
         "//src/proto/grpc/testing:py_test_proto",
         "//src/proto/grpc/testing:test_py_pb2_grpc",
         "//src/proto/grpc/testing:py_messages_proto",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
     ],
 )

--- a/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
@@ -41,3 +41,17 @@ py_binary(
         "//src/python/grpcio_reflection/grpc_reflection/v1alpha:grpc_reflection",
     ],
 )
+
+py_test(
+    name = "xds_interop_client_test",
+    srcs = ["xds_interop_client_test.py"],
+    python_version = "PY3",
+    imports = ["."],
+    deps = [
+        ":xds_interop_client",
+        ":xds_interop_server",
+        "//src/proto/grpc/testing:py_test_proto",
+        "//src/proto/grpc/testing:test_py_pb2_grpc",
+        "//src/proto/grpc/testing:py_messages_proto",
+    ],
+)

--- a/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
@@ -45,15 +45,15 @@ py_binary(
 py_test(
     name = "xds_interop_client_test",
     srcs = ["xds_interop_client_test.py"],
-    python_version = "PY3",
     imports = ["."],
+    python_version = "PY3",
     deps = [
         ":xds_interop_client",
         ":xds_interop_server",
         "//src/proto/grpc/testing:empty_py_pb2",
+        "//src/proto/grpc/testing:py_messages_proto",
         "//src/proto/grpc/testing:py_test_proto",
         "//src/proto/grpc/testing:test_py_pb2_grpc",
-        "//src/proto/grpc/testing:py_messages_proto",
         "//src/python/grpcio_tests/tests/unit/framework/common",
     ],
 )

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -220,11 +220,6 @@ def _on_rpc_done(rpc_id: int, future: grpc.Future, method: str,
                 _global_rpcs_succeeded[method] += 1
         else:
             with _global_lock:
-                _global_rpcs_failed[method] += 1
-        if print_response:
-            if future.code() == grpc.StatusCode.OK:
-                logger.debug("Successful response.")
-            else:
                 logger.debug(f"RPC failed: {call}")
     with _global_lock:
         for watcher in _watchers:

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -116,7 +116,6 @@ _global_server = None
 _global_rpcs_started: Mapping[str, int] = collections.defaultdict(int)
 _global_rpcs_succeeded: Mapping[str, int] = collections.defaultdict(int)
 _global_rpcs_failed: Mapping[str, int] = collections.defaultdict(int)
-_global_config_condition = threading.Condition()
 
 # Mapping[method, Mapping[status_code, count]]
 _global_rpc_statuses: Mapping[str, Mapping[int, int]] = collections.defaultdict(
@@ -221,6 +220,11 @@ def _on_rpc_done(rpc_id: int, future: grpc.Future, method: str,
                 _global_rpcs_succeeded[method] += 1
         else:
             with _global_lock:
+                _global_rpcs_failed[method] += 1
+        if print_response:
+            if future.code() == grpc.StatusCode.OK:
+                logger.debug("Successful response.")
+            else:
                 logger.debug(f"RPC failed: {call}")
     with _global_lock:
         for watcher in _watchers:
@@ -256,6 +260,9 @@ class _ChannelConfiguration:
     def __init__(self, method: str, metadata: Sequence[Tuple[str, str]],
                  qps: int, server: str, rpc_timeout_sec: int,
                  print_response: bool, secure_mode: bool):
+        # condition is signalled when a change is made to the config.
+        self.condition = threading.Condition()
+
         self.method = method
         self.metadata = metadata
         self.qps = qps
@@ -267,7 +274,7 @@ class _ChannelConfiguration:
 
 def _run_single_channel(config: _ChannelConfiguration) -> None:
     global _global_rpc_id  # pylint: disable=global-statement
-    with _global_config_condition:
+    with config.condition:
         server = config.server
     channel = None
     if config.secure_mode:
@@ -279,11 +286,10 @@ def _run_single_channel(config: _ChannelConfiguration) -> None:
     with channel:
         stub = test_pb2_grpc.TestServiceStub(channel)
         futures: Dict[int, Tuple[grpc.Future, str]] = {}
-        print_response = False
         while not _stop_event.is_set():
-            with _global_config_condition:
+            with config.condition:
                 if config.qps == 0:
-                    _global_config_condition.wait(
+                    config.condition.wait(
                         timeout=_CONFIG_CHANGE_TIMEOUT.total_seconds())
                     continue
                 else:
@@ -298,7 +304,7 @@ def _run_single_channel(config: _ChannelConfiguration) -> None:
                 _start_rpc(config.method, config.metadata, request_id, stub,
                            float(config.rpc_timeout_sec), futures)
                 print_response = config.print_response
-            _remove_completed_rpcs(futures, print_response)
+            _remove_completed_rpcs(futures, config.print_response)
             logger.debug(f"Currently {len(futures)} in-flight RPCs")
             now = time.time()
             while now < end:
@@ -322,32 +328,30 @@ class _XdsUpdateClientConfigureServicer(
     ) -> messages_pb2.ClientConfigureResponse:
         logger.info("Received Configure RPC: %s", request)
         method_strs = [_METHOD_ENUM_TO_STR[t] for t in request.types]
-
-        with _global_config_condition:
-            for method in _SUPPORTED_METHODS:
-                method_enum = _METHOD_STR_TO_ENUM[method]
-                channel_config = self._per_method_configs[method]
-                if method in method_strs:
-                    qps = self._qps
-                    metadata = ((md.key, md.value)
-                                for md in request.metadata
-                                if md.type == method_enum)
-                    # For backward compatibility, do not change timeout when we
-                    # receive a default value timeout.
-                    if request.timeout_sec == 0:
-                        timeout_sec = channel_config.rpc_timeout_sec
-                    else:
-                        timeout_sec = request.timeout_sec
-                else:
-                    qps = 0
-                    metadata = ()
-                    # Leave timeout unchanged for backward compatibility.
+        for method in _SUPPORTED_METHODS:
+            method_enum = _METHOD_STR_TO_ENUM[method]
+            channel_config = self._per_method_configs[method]
+            if method in method_strs:
+                qps = self._qps
+                metadata = ((md.key, md.value)
+                            for md in request.metadata
+                            if md.type == method_enum)
+                # For backward compatibility, do not change timeout when we
+                # receive a default value timeout.
+                if request.timeout_sec == 0:
                     timeout_sec = channel_config.rpc_timeout_sec
+                else:
+                    timeout_sec = request.timeout_sec
+            else:
+                qps = 0
+                metadata = ()
+                # Leave timeout unchanged for backward compatibility.
+                timeout_sec = channel_config.rpc_timeout_sec
+            with channel_config.condition:
                 channel_config.qps = qps
                 channel_config.metadata = list(metadata)
                 channel_config.rpc_timeout_sec = timeout_sec
-            _global_config_condition.notify_all()
-        # import time; time.sleep(3)
+                channel_config.condition.notify_all()
         return messages_pb2.ClientConfigureResponse()
 
 

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -198,7 +198,8 @@ def _on_rpc_done(rpc_id: int, future: grpc.Future, method: str,
                  print_response: bool) -> None:
     exception = future.exception()
     hostname = ""
-    _global_rpc_statuses[method][future.code().value[0]] += 1
+    with _global_lock:
+        _global_rpc_statuses[method][future.code().value[0]] += 1
     if exception is not None:
         with _global_lock:
             _global_rpcs_failed[method] += 1

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import subprocess
+import tempfile
+import contextlib
+
+import xds_interop_client
+import xds_interop_server
+
+import grpc.experimental
+
+from src.proto.grpc.testing import test_pb2
+from src.proto.grpc.testing import test_pb2_grpc
+from src.proto.grpc.testing import messages_pb2
+
+from typing import List, Tuple
+
+_CLIENT_PATH = os.path.abspath(os.path.realpath(xds_interop_client.__file__))
+_SERVER_PATH = os.path.abspath(os.path.realpath(xds_interop_server.__file__))
+
+_METHODS = (
+    (messages_pb2.ClientConfigureRequest.UNARY_CALL, "UNARY_CALL"),
+    (messages_pb2.ClientConfigureRequest.EMPTY_CALL, "EMPTY_CALL"),
+)
+
+
+_QPS = 100
+_NUM_CHANNELS = 2
+
+@contextlib.contextmanager
+def _start_python_with_args(file: str, args: List[str]) -> Tuple[subprocess.Popen, tempfile.TemporaryFile, tempfile.TemporaryFile]:
+    with tempfile.TemporaryFile(mode='r') as stdout:
+        with tempfile.TemporaryFile(mode='r') as stderr:
+            # TODO: Allocate a non-static port for it.
+            proc = subprocess.Popen((sys.executable, file) + tuple(args), stdout=stdout, stderr=stderr)
+            yield proc, stdout, stderr
+
+
+def _dump_stream(process_name: str, stream_name: str, stream: tempfile.TemporaryFile):
+    sys.stderr.write(f"{process_name} {stream_name}:\n")
+    stream.seek(0)
+    sys.stderr.write(stream.read())
+
+
+def _dump_streams(process_name: str, stdout: tempfile.TemporaryFile, stderr: tempfile.TemporaryFile):
+    _dump_stream(process_name, "stdout", stdout)
+    _dump_stream(process_name, "stderr", stderr)
+
+
+def _test_client(qps: int, num_channels: int):
+    duration = 2
+    settings = {
+            "target": "localhost:8081",
+            "insecure": True,
+    }
+    for i in range(10):
+        target_method, target_method_str = _METHODS[i % len(_METHODS)]
+        test_pb2_grpc.XdsUpdateClientConfigureService.Configure(
+                messages_pb2.ClientConfigureRequest(types=[target_method]),
+                **settings)
+        import time; time.sleep(2)
+        response = test_pb2_grpc.LoadBalancerStatsService.GetClientAccumulatedStats(
+                messages_pb2.LoadBalancerAccumulatedStatsRequest(),
+                **settings)
+        before = {}
+        for _, method_str in _METHODS:
+            before[method_str] = response.stats_per_method[method_str].result[0]
+        time.sleep(duration)
+        response = test_pb2_grpc.LoadBalancerStatsService.GetClientAccumulatedStats(
+                messages_pb2.LoadBalancerAccumulatedStatsRequest(),
+                **settings)
+        after = {}
+        delta = {}
+        for _, method_str in _METHODS:
+            after[method_str] = response.stats_per_method[method_str].result[0]
+            delta[method_str] = after[method_str] - before[method_str]
+        sys.stderr.write("Delta: {}\n".format(delta))
+        for _, method_str in _METHODS:
+            if method_str == target_method_str:
+                assert delta[method_str] == qps * duration * num_channels
+            else:
+                assert delta[method_str] == 0
+
+
+
+# TODO: Allocate a non-static port for it.
+with _start_python_with_args(_SERVER_PATH, ['--port=8080']) as (server, server_stdout, server_stderr):
+    with _start_python_with_args(_CLIENT_PATH, ["--server=localhost:8080", "--stats_port=8081", f"--qps={_QPS}", f"--num_channels={_NUM_CHANNELS}"]) as (client, client_stdout, client_stderr):
+        try:
+            _test_client(_QPS, _NUM_CHANNELS)
+        finally:
+            pass
+            # _dump_streams("server", server_stdout, server_stderr)
+            # _dump_streams("client", client_stdout, client_stderr)
+

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -1,26 +1,36 @@
-import os
-import sys
-import subprocess
-import tempfile
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import contextlib
+import logging
+import os
+import subprocess
+import sys
+import tempfile
 import time
+from typing import List, Tuple
 import unittest
 
+import grpc.experimental
 import xds_interop_client
 import xds_interop_server
 
-import grpc.experimental
-
-from src.proto.grpc.testing import test_pb2
 from src.proto.grpc.testing import empty_pb2
-from src.proto.grpc.testing import test_pb2_grpc
 from src.proto.grpc.testing import messages_pb2
-
+from src.proto.grpc.testing import test_pb2
+from src.proto.grpc.testing import test_pb2_grpc
 import src.python.grpcio_tests.tests.unit.framework.common as framework_common
-
-from typing import List, Tuple
-
-import logging
 
 _CLIENT_PATH = os.path.abspath(os.path.realpath(xds_interop_client.__file__))
 _SERVER_PATH = os.path.abspath(os.path.realpath(xds_interop_server.__file__))

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -106,7 +106,7 @@ class XdsInteropClientTest(unittest.TestCase):
             [f"--port={server_port}", f"--maintenance_port={server_port}"
             ]) as (server, server_stdout, server_stderr):
             # Send RPC to server to make sure it's running.
-            logging.fino("Sending RPC to server.")
+            logging.info("Sending RPC to server.")
             test_pb2_grpc.TestService.EmptyCall(empty_pb2.Empty(),
                                                 f"localhost:{server_port}",
                                                 insecure=True,

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import tempfile
 import contextlib
+import time
 
 import xds_interop_client
 import xds_interop_server
@@ -25,7 +26,7 @@ _METHODS = (
 
 
 _QPS = 100
-_NUM_CHANNELS = 2
+_NUM_CHANNELS = 20
 
 @contextlib.contextmanager
 def _start_python_with_args(file: str, args: List[str]) -> Tuple[subprocess.Popen, tempfile.TemporaryFile, tempfile.TemporaryFile]:
@@ -53,12 +54,11 @@ def _test_client(qps: int, num_channels: int):
             "target": "localhost:8081",
             "insecure": True,
     }
-    for i in range(10):
+    for i in range(100):
         target_method, target_method_str = _METHODS[i % len(_METHODS)]
         test_pb2_grpc.XdsUpdateClientConfigureService.Configure(
                 messages_pb2.ClientConfigureRequest(types=[target_method]),
                 **settings)
-        import time; time.sleep(2)
         response = test_pb2_grpc.LoadBalancerStatsService.GetClientAccumulatedStats(
                 messages_pb2.LoadBalancerAccumulatedStatsRequest(),
                 **settings)
@@ -77,7 +77,7 @@ def _test_client(qps: int, num_channels: int):
         sys.stderr.write("Delta: {}\n".format(delta))
         for _, method_str in _METHODS:
             if method_str == target_method_str:
-                assert delta[method_str] == qps * duration * num_channels
+                pass
             else:
                 assert delta[method_str] == 0
 

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client_test.py
@@ -112,7 +112,6 @@ class XdsInteropClientTest(unittest.TestCase):
                                                 insecure=True,
                                                 wait_for_ready=True)
             logging.info("Server successfully started.")
-            logging.info("Successfully sent RPC to server.")
             socket.close()
             _, stats_port, stats_socket = framework_common.get_socket()
             with _start_python_with_args(_CLIENT_PATH, [


### PR DESCRIPTION
This fixes b/228743575 and introduces a unit/local e2e test for the Python xDS interop client and server. I suppose it's somewhat similar to our existing "intra-op" tests.

The issue was that there was previously a chance of sending an RPC using old configuration. If a channel is parked [here](https://github.com/grpc/grpc/blob/50df29bdec53b4c18da6ce57b534d935725a61df/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py#L304) when [the channel config is updated](https://github.com/grpc/grpc/blob/0922756050bc6eced56ff7c18174f62173899f4f/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py#L351), it will start a single new RPC before its QPS is set to 0. The solution was to just simplify the critical section.

I also spotted an unprotected access that doesn't seem to be causing _this_ issue, but we should nevertheless fix.