### PR TITLE
Revert "Adjusting tcp min read chunk size growth to reduce wastage of incoming buffer size"

### DIFF
--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -29,7 +29,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <string.h>
@@ -61,8 +60,6 @@
 #include "src/core/lib/iomgr/tcp_server_utils_posix.h"
 #include "src/core/lib/iomgr/unix_sockets_posix.h"
 #include "src/core/lib/resource_quota/api.h"
-
-static std::atomic<int64_t> num_dropped_connections{0};
 
 static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
                                            const grpc_channel_args* args,
@@ -224,13 +221,7 @@ static void on_read(void* arg, grpc_error_handle err) {
     }
 
     if (sp->server->memory_quota->IsMemoryPressureHigh()) {
-      int64_t dropped_connections_count = ++num_dropped_connections;
-      if (dropped_connections_count % 1000 == 0) {
-        gpr_log(GPR_INFO,
-                "Dropped >= %" PRId64
-                " new connection attempts due to high memory pressure",
-                dropped_connections_count);
-      }
+      gpr_log(GPR_INFO, "Drop incoming connection: high memory pressure");
       close(fd);
       continue;
     }


### PR DESCRIPTION
Reverts grpc/grpc#29334 due to internal breakage