### PR TITLE
Remove unmatched grpc_init from *ChannelFromFd methods

### DIFF
--- a/src/cpp/client/create_channel_posix.cc
+++ b/src/cpp/client/create_channel_posix.cc
@@ -34,8 +34,6 @@ class ChannelArguments;
 
 std::shared_ptr<Channel> CreateInsecureChannelFromFd(const std::string& target,
                                                      int fd) {
-  grpc::internal::GrpcLibrary init_lib;
-  init_lib.init();
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();
   auto channel = CreateChannelInternal(
       "", grpc_channel_create_from_fd(target.c_str(), fd, creds, nullptr),
@@ -47,8 +45,6 @@ std::shared_ptr<Channel> CreateInsecureChannelFromFd(const std::string& target,
 
 std::shared_ptr<Channel> CreateCustomInsecureChannelFromFd(
     const std::string& target, int fd, const grpc::ChannelArguments& args) {
-  internal::GrpcLibrary init_lib;
-  init_lib.init();
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();
@@ -67,8 +63,6 @@ std::shared_ptr<Channel> CreateCustomInsecureChannelWithInterceptorsFromFd(
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators) {
-  grpc::internal::GrpcLibrary init_lib;
-  init_lib.init();
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();

--- a/src/cpp/client/create_channel_posix.cc
+++ b/src/cpp/client/create_channel_posix.cc
@@ -34,17 +34,23 @@ class ChannelArguments;
 
 std::shared_ptr<Channel> CreateInsecureChannelFromFd(const std::string& target,
                                                      int fd) {
+  internal::GrpcLibrary init_lib;
+  init_lib.init();
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();
   auto channel = CreateChannelInternal(
       "", grpc_channel_create_from_fd(target.c_str(), fd, creds, nullptr),
       std::vector<
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>());
   grpc_channel_credentials_release(creds);
+  // Channel also initializes gRPC, so we can decrement the init ref count here.
+  init_lib.shutdown();
   return channel;
 }
 
 std::shared_ptr<Channel> CreateCustomInsecureChannelFromFd(
     const std::string& target, int fd, const grpc::ChannelArguments& args) {
+  internal::GrpcLibrary init_lib;
+  init_lib.init();
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();
@@ -53,6 +59,8 @@ std::shared_ptr<Channel> CreateCustomInsecureChannelFromFd(
       std::vector<
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>());
   grpc_channel_credentials_release(creds);
+  // Channel also initializes gRPC, so we can decrement the init ref count here.
+  init_lib.shutdown();
   return channel;
 }
 
@@ -63,6 +71,8 @@ std::shared_ptr<Channel> CreateCustomInsecureChannelWithInterceptorsFromFd(
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators) {
+  internal::GrpcLibrary init_lib;
+  init_lib.init();
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();
@@ -70,6 +80,8 @@ std::shared_ptr<Channel> CreateCustomInsecureChannelWithInterceptorsFromFd(
       "", grpc_channel_create_from_fd(target.c_str(), fd, creds, &channel_args),
       std::move(interceptor_creators));
   grpc_channel_credentials_release(creds);
+  // Channel also initializes gRPC, so we can decrement the init ref count here.
+  init_lib.shutdown();
   return channel;
 }
 


### PR DESCRIPTION
These unmatched grpc_init calls were preventing grpc_shutdown from
completing, which notably showed up in the only tests we have that
exercise these methods: `client_interceptors_end2end_tests.cc`.

~These inits appear to be unnecessary, so I removed them. But if I've
missed some reason they're needed, an alternative is to find the right
place to add the corresponding `init_lib.shutdown();` call. I'm not sure
where that would be at this point.~ 

I added matched `init_lib.shutdown()` calls for each fd-based channel creation function, on the off chance these functions are called before any other gRPC surface API function.

See b/175634383

Previously, this test would flake 0.3% of the time (~30 failures of 10,000 runs, confirmed 3 times). The odd bit is that every run - even the passing runs - had shutdown problems. The passing tests would have a gRPC shutdown timeout at 10 seconds because `grpc_shutdown` was never attempted (init refs = 6, one for each of the FD tests). The few flaky runs hung 5 minutes waiting for shutdown, indicating that grpc shutdown was actually occurring ... I'll still have to dig more to figure out why.

However, with this fix, I cannot reproduce the test failures in 20,000 runs, and the passing tests also show gRPC shutting down correctly.

This change reduces test time by 10s for the happy path, and 5 minutes for flaky runs.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yashykt
