### PR TITLE
HTTP: Rename PUT allowing channel arg

### DIFF
--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -310,7 +310,7 @@ static grpc_error_handle hs_init_channel_elem(grpc_channel_element* elem,
       true);
   chand->allow_put_requests = grpc_channel_args_find_bool(
       args->channel_args,
-      GRPC_ARG_INTERNAL_ONLY_DO_NOT_USE_UNLESS_YOU_HAVE_PERMISSION_FROM_GRPC_TEAM_ALLOW_BROKEN_PUT_REQUESTS,
+      GRPC_ARG_DO_NOT_USE_UNLESS_YOU_HAVE_PERMISSION_FROM_GRPC_TEAM_ALLOW_BROKEN_PUT_REQUESTS,
       false);
   return GRPC_ERROR_NONE;
 }

--- a/src/core/ext/filters/http/server/http_server_filter.h
+++ b/src/core/ext/filters/http/server/http_server_filter.h
@@ -28,8 +28,8 @@ extern const grpc_channel_filter grpc_http_server_filter;
 
 // A Temporary channel arg that allows servers to accept PUT requests. DO NOT
 // USE WITHOUT PERMISSION.
-#define GRPC_ARG_INTERNAL_ONLY_DO_NOT_USE_UNLESS_YOU_HAVE_PERMISSION_FROM_GRPC_TEAM_ALLOW_BROKEN_PUT_REQUESTS \
-  "grpc.http.internal_only_do_not_use_unless_you_have_permission_from_grpc_"                                  \
-  "team_allow_broken_put_requests"
+#define GRPC_ARG_DO_NOT_USE_UNLESS_YOU_HAVE_PERMISSION_FROM_GRPC_TEAM_ALLOW_BROKEN_PUT_REQUESTS \
+  "grpc.http.do_not_use_unless_you_have_permission_from_grpc_team_allow_"                       \
+  "broken_put_requests"
 
 #endif /* GRPC_CORE_EXT_FILTERS_HTTP_SERVER_HTTP_SERVER_FILTER_H */

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -180,7 +180,7 @@ void XdsEnd2endTest::ServerThread::Serve(grpc_core::Mutex* mu,
     // purposes.
     if (allow_put_requests_) {
       builder.AddChannelArgument(
-          GRPC_ARG_INTERNAL_ONLY_DO_NOT_USE_UNLESS_YOU_HAVE_PERMISSION_FROM_GRPC_TEAM_ALLOW_BROKEN_PUT_REQUESTS,
+          GRPC_ARG_DO_NOT_USE_UNLESS_YOU_HAVE_PERMISSION_FROM_GRPC_TEAM_ALLOW_BROKEN_PUT_REQUESTS,
           true);
     }
     RegisterAllServices(&builder);


### PR DESCRIPTION
Internal tests do not like "internal_only" in the code