### PR TITLE
connection delay injector: fix tsan problems

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -607,6 +607,7 @@ TEST_F(ClientLbEnd2endTest, PickFirstBackOffMinReconnect) {
   // sure we are hitting the codepath that waits for the min reconnect backoff.
   ConnectionDelayInjector delay_injector(
       grpc_core::Duration::Milliseconds(kMinReconnectBackOffMs * 1.10));
+  delay_injector.Start();
   const gpr_timespec t0 = gpr_now(GPR_CLOCK_MONOTONIC);
   channel->WaitForConnected(
       grpc_timeout_milliseconds_to_deadline(kMinReconnectBackOffMs * 2));

--- a/test/cpp/end2end/connection_delay_injector.cc
+++ b/test/cpp/end2end/connection_delay_injector.cc
@@ -14,11 +14,12 @@
 
 #include "test/cpp/end2end/connection_delay_injector.h"
 
-#include <atomic>
 #include <memory>
 
 #include "absl/memory/memory.h"
 #include "absl/utility/utility.h"
+
+#include "src/core/lib/gprpp/sync.h"
 
 // defined in tcp_client.cc
 extern grpc_tcp_client_vtable* grpc_tcp_client_impl;
@@ -33,21 +34,23 @@ namespace testing {
 namespace {
 
 grpc_tcp_client_vtable* g_original_vtable = nullptr;
-std::atomic<ConnectionAttemptInjector*> g_injector{nullptr};
+
+grpc_core::Mutex* g_mu = nullptr;
+ConnectionAttemptInjector* g_injector ABSL_GUARDED_BY(*g_mu) = nullptr;
 
 void TcpConnectWithDelay(grpc_closure* closure, grpc_endpoint** ep,
                          grpc_pollset_set* interested_parties,
                          const grpc_channel_args* channel_args,
                          const grpc_resolved_address* addr,
                          grpc_core::Timestamp deadline) {
-  ConnectionAttemptInjector* injector = g_injector.load();
-  if (injector == nullptr) {
+  grpc_core::MutexLock lock(g_mu);
+  if (g_injector == nullptr) {
     g_original_vtable->connect(closure, ep, interested_parties, channel_args,
                                addr, deadline);
     return;
   }
-  injector->HandleConnection(closure, ep, interested_parties, channel_args,
-                             addr, deadline);
+  g_injector->HandleConnection(closure, ep, interested_parties, channel_args,
+                               addr, deadline);
 }
 
 grpc_tcp_client_vtable kDelayedConnectVTable = {TcpConnectWithDelay};
@@ -55,16 +58,20 @@ grpc_tcp_client_vtable kDelayedConnectVTable = {TcpConnectWithDelay};
 }  // namespace
 
 void ConnectionAttemptInjector::Init() {
+  g_mu = new grpc_core::Mutex();
   g_original_vtable = grpc_tcp_client_impl;
   grpc_tcp_client_impl = &kDelayedConnectVTable;
 }
 
-ConnectionAttemptInjector::ConnectionAttemptInjector() {
-  GPR_ASSERT(g_injector.exchange(this) == nullptr);
+ConnectionAttemptInjector::~ConnectionAttemptInjector() {
+  grpc_core::MutexLock lock(g_mu);
+  g_injector = nullptr;
 }
 
-ConnectionAttemptInjector::~ConnectionAttemptInjector() {
-  g_injector.store(nullptr);
+void ConnectionAttemptInjector::Start() {
+  grpc_core::MutexLock lock(g_mu);
+  GPR_ASSERT(g_injector == nullptr);
+  g_injector = this;
 }
 
 void ConnectionAttemptInjector::AttemptConnection(

--- a/test/cpp/end2end/connection_delay_injector.h
+++ b/test/cpp/end2end/connection_delay_injector.h
@@ -33,6 +33,7 @@ namespace testing {
 //
 //  // When an injection is desired.
 //  ConnectionDelayInjector delay_injector(grpc_core::Duration::Seconds(10));
+//  delay_injector.Start();
 //
 // The injection is global, so there must be only one ConnectionAttemptInjector
 // object at any one time.
@@ -42,8 +43,10 @@ class ConnectionAttemptInjector {
   // Must be called exactly once before any TCP connections are established.
   static void Init();
 
-  ConnectionAttemptInjector();
   virtual ~ConnectionAttemptInjector();
+
+  // Must be called after instantiation.
+  void Start();
 
   // Invoked for every TCP connection attempt.
   // Implementations must eventually either invoke the closure

--- a/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
@@ -559,6 +559,7 @@ TEST_P(AggregateClusterTest, FallBackWithConnectivityChurn) {
   };
   ConnectionInjector connection_attempt_injector(backends_[0]->port(),
                                                  backends_[1]->port());
+  connection_attempt_injector.Start();
   // Wait for P0 backend.
   // Increase timeout to account for subchannel connection delays.
   WaitForBackend(0, WaitForBackendOptions(), RpcOptions().set_timeout_ms(2000));

--- a/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
@@ -212,6 +212,7 @@ TEST_P(RingHashTest,
   // Inject connection delay to make this act more realistically.
   ConnectionDelayInjector delay_injector(
       grpc_core::Duration::Milliseconds(500) * grpc_test_slowdown_factor());
+  delay_injector.Start();
   // Send RPC.  Need the timeout to be long enough to account for the
   // subchannel connection delays.
   CheckRpcSendOk(1, RpcOptions().set_timeout_ms(5000));
@@ -670,6 +671,7 @@ TEST_P(RingHashTest, ContinuesConnectingWithoutPicks) {
     bool seen_port_ ABSL_GUARDED_BY(mu_) = false;
   };
   ConnectionInjector connection_injector(non_existant_endpoint.port);
+  connection_injector.Start();
   // A long-running RPC, just used to send the RPC in another thread.
   LongRunningRpc rpc;
   std::vector<std::pair<std::string, std::string>> metadata = {
@@ -855,6 +857,7 @@ TEST_P(RingHashTest, ContinuesConnectingWithoutPicksOneSubchannelAtATime) {
   ConnectionInjector connection_injector(
       non_existant_endpoint0.port, non_existant_endpoint1.port,
       non_existant_endpoint2.port, backends_[0]->port());
+  connection_injector.Start();
   // A long-running RPC, just used to send the RPC in another thread.
   LongRunningRpc rpc;
   std::vector<std::pair<std::string, std::string>> metadata = {


### PR DESCRIPTION
This fixes a TSAN problem caused by trying to use the injector object via the vtable before the object's vtable has finished being written, resulting in an error like the one below (see [log](https://source.cloud.google.com/results/invocations/74398c6f-58e3-4f19-b54a-2d2144f065cc/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_ring_hash_end2end_test@poller%3Depoll1/log)).  This is fixed by setting the global injector variable from a separate `Start()` method instead of doing it in the base class's ctor.

While I was at it, I also noticed a potential problem where the injector could be destroyed between when the atomic was read and when it was used, so I switched to using a mutex.

```
WARNING: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) (pid=15)
  Read of size 8 at 0x7fff2f97d960 by thread T25 (mutexes: write M149880357038747328):
    #0 grpc::testing::(anonymous namespace)::TcpConnectWithDelay(grpc_closure*, grpc_endpoint**, grpc_pollset_set*, grpc_channel_args const*, grpc_resolved_address const*, grpc_core::Timestamp) /proc/self/cwd/test/cpp/end2end/connection_delay_injector.cc:49:13 (xds_ring_hash_end2end_test@poller=epoll1+0x18f254f)
    #1 grpc_tcp_client_connect(grpc_closure*, grpc_endpoint**, grpc_pollset_set*, grpc_channel_args const*, grpc_resolved_address const*, grpc_core::Timestamp) /proc/self/cwd/src/core/lib/iomgr/tcp_client.cc:30:3 (xds_ring_hash_end2end_test@poller=epoll1+0x249697d)
    #2 grpc_core::Chttp2Connector::Connect(grpc_core::SubchannelConnector::Args const&, grpc_core::SubchannelConnector::Result*, grpc_closure*) /proc/self/cwd/src/core/ext/transport/chttp2/client/chttp2_connector.cc:94:3 (xds_ring_hash_end2end_test@poller=epoll1+0x1d7c52e)
    #3 grpc_core::Subchannel::StartConnectingLocked() /proc/self/cwd/src/core/ext/filters/client_channel/subchannel.cc:893:15 (xds_ring_hash_end2end_test@poller=epoll1+0x1fafa4a)
    #4 grpc_core::Subchannel::RequestConnection() /proc/self/cwd/src/core/ext/filters/client_channel/subchannel.cc:785:5 (xds_ring_hash_end2end_test@poller=epoll1+0x1faf6ce)
    #5 grpc_core::ClientChannel::SubchannelWrapper::RequestConnection() /proc/self/cwd/src/core/ext/filters/client_channel/client_channel.cc:526:52 (xds_ring_hash_end2end_test@poller=epoll1+0x1f9c397)
    #6 grpc_core::(anonymous namespace)::PickFirst::AttemptToConnectUsingLatestUpdateArgsLocked() /proc/self/cwd/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:235:52 (xds_ring_hash_end2end_test@poller=epoll1+0x193cd0e)
    #7 grpc_core::(anonymous namespace)::PickFirst::ExitIdleLocked() /proc/self/cwd/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:170:5 (xds_ring_hash_end2end_test@poller=epoll1+0x193bfcd)
    #8 grpc_core::ChildPolicyHandler::ExitIdleLocked() /proc/self/cwd/src/core/ext/filters/client_channel/lb_policy/child_policy_handler.cc:247:20 (xds_ring_hash_end2end_test@poller=epoll1+0x1ff6866)
    #9 grpc_core::ClientChannel::TryToConnectLocked() /proc/self/cwd/src/core/ext/filters/client_channel/client_channel.cc:1820:17 (xds_ring_hash_end2end_test@poller=epoll1+0x1f6b488)
    #10 grpc_core::ClientChannel::CheckConnectivityState(bool)::$_8::operator()() const /proc/self/cwd/src/core/ext/filters/client_channel/client_channel.cc:1837:52 (xds_ring_hash_end2end_test@poller=epoll1+0x1f77ffb)
    #11 std::_Function_handler<void (), grpc_core::ClientChannel::CheckConnectivityState(bool)::$_8>::_M_invoke(std::_Any_data const&) /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/functional:1871:2 (xds_ring_hash_end2end_test@poller=epoll1+0x1f77dca)
    #12 std::function<void ()>::operator()() const /usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/functional:2267:14 (xds_ring_hash_end2end_test@poller=epoll1+0x126c8f6)
    #13 grpc_core::WorkSerializer::WorkSerializerImpl::DrainQueueOwned() /proc/self/cwd/src/core/lib/iomgr/work_serializer.cc:205:5 (xds_ring_hash_end2end_test@poller=epoll1+0x2468c20)
    #14 grpc_core::WorkSerializer::WorkSerializerImpl::Run(std::function<void ()>, grpc_core::DebugLocation const&) /proc/self/cwd/src/core/lib/iomgr/work_serializer.cc:93:5 (xds_ring_hash_end2end_test@poller=epoll1+0x2467d51)
    #15 grpc_core::WorkSerializer::Run(std::function<void ()>, grpc_core::DebugLocation const&) /proc/self/cwd/src/core/lib/iomgr/work_serializer.cc:221:10 (xds_ring_hash_end2end_test@poller=epoll1+0x246980a)
    #16 grpc_core::ClientChannel::CallData::CheckResolutionLocked(grpc_call_element*, grpc_error**)::$_9::operator()(void*, grpc_error*) const /proc/self/cwd/src/core/ext/filters/client_channel/client_channel.cc:2349:9 (xds_ring_hash_end2end_test@poller=epoll1+0x1f74e84)
    #17 grpc_core::ClientChannel::CallData::CheckResolutionLocked(grpc_call_element*, grpc_error**)::$_9::__invoke(void*, grpc_error*) /proc/self/cwd/src/core/ext/filters/client_channel/client_channel.cc:2349:9 (xds_ring_hash_end2end_test@poller=epoll1+0x1f74db8)
    #18 closure_impl::closure_wrapper(void*, grpc_error*) /proc/self/cwd/./src/core/lib/iomgr/closure.h:134:3 (xds_ring_hash_end2end_test@poller=epoll1+0x1479f6d)
    #19 exec_ctx_run(grpc_closure*) /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:49:3 (xds_ring_hash_end2end_test@poller=epoll1+0x256af32)
    #20 grpc_core::ExecCtx::Flush() /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:79:9 (xds_ring_hash_end2end_test@poller=epoll1+0x256ac37)
    #21 end_worker(grpc_pollset*, grpc_pollset_worker*, grpc_pollset_worker**) /proc/self/cwd/src/core/lib/iomgr/ev_epoll1_linux.cc:995:32 (xds_ring_hash_end2end_test@poller=epoll1+0x24ab49d)
    #22 pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) /proc/self/cwd/src/core/lib/iomgr/ev_epoll1_linux.cc:1059:3 (xds_ring_hash_end2end_test@poller=epoll1+0x24a64be)
    #23 pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) /proc/self/cwd/src/core/lib/iomgr/ev_posix.cc:322:7 (xds_ring_hash_end2end_test@poller=epoll1+0x2472855)
    #24 grpc_pollset_work(grpc_pollset*, grpc_pollset_worker**, grpc_core::Timestamp) /proc/self/cwd/src/core/lib/iomgr/pollset.cc:48:10 (xds_ring_hash_end2end_test@poller=epoll1+0x2496da5)
    #25 run_poller(void*, grpc_error*) /proc/self/cwd/src/core/ext/filters/client_channel/backup_poller.cc:134:7 (xds_ring_hash_end2end_test@poller=epoll1+0x1f5e7a1)
    #26 exec_ctx_run(grpc_closure*) /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:49:3 (xds_ring_hash_end2end_test@poller=epoll1+0x256af32)
    #27 grpc_core::ExecCtx::Flush() /proc/self/cwd/src/core/lib/iomgr/exec_ctx.cc:79:9 (xds_ring_hash_end2end_test@poller=epoll1+0x256ac37)
    #28 run_some_timers() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:134:30 (xds_ring_hash_end2end_test@poller=epoll1+0x24755c7)
    #29 timer_main_loop() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:238:9 (xds_ring_hash_end2end_test@poller=epoll1+0x24751b5)
    #30 timer_thread(void*) /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:285:3 (xds_ring_hash_end2end_test@poller=epoll1+0x24750aa)
    #31 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:140:23 (xds_ring_hash_end2end_test@poller=epoll1+0x2579a7c)
    #32 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:110:21 (xds_ring_hash_end2end_test@poller=epoll1+0x2579868)

  Previous write of size 8 at 0x7fff2f97d960 by main thread:
    #0 grpc::testing::(anonymous namespace)::RingHashTest_ContinuesConnectingWithoutPicks_Test::TestBody()::ConnectionInjector::ConnectionInjector(int) /proc/self/cwd/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc:636:57 (xds_ring_hash_end2end_test@poller=epoll1+0x11eab44)
    #1 grpc::testing::(anonymous namespace)::RingHashTest_ContinuesConnectingWithoutPicks_Test::TestBody() /proc/self/cwd/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc:672:22 (xds_ring_hash_end2end_test@poller=epoll1+0x11e976d)
    #2 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2654:10 (xds_ring_hash_end2end_test@poller=epoll1+0x2758b8c)
    #3 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2690:14 (xds_ring_hash_end2end_test@poller=epoll1+0x2739391)
    #4 testing::Test::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2729:5 (xds_ring_hash_end2end_test@poller=epoll1+0x270e511)
    #5 testing::TestInfo::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2908:11 (xds_ring_hash_end2end_test@poller=epoll1+0x270f68a)
    #6 testing::TestSuite::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:3067:30 (xds_ring_hash_end2end_test@poller=epoll1+0x2710475)
    #7 testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5937:44 (xds_ring_hash_end2end_test@poller=epoll1+0x272a3d0)
    #8 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2654:10 (xds_ring_hash_end2end_test@poller=epoll1+0x275e0ac)
    #9 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:2690:14 (xds_ring_hash_end2end_test@poller=epoll1+0x273d7f7)
    #10 testing::UnitTest::Run() /proc/self/cwd/external/com_google_googletest/googletest/src/gtest.cc:5506:10 (xds_ring_hash_end2end_test@poller=epoll1+0x2729bdb)
    #11 RUN_ALL_TESTS() /proc/self/cwd/external/com_google_googletest/googletest/include/gtest/gtest.h:2311:46 (xds_ring_hash_end2end_test@poller=epoll1+0x1201987)
    #12 main /proc/self/cwd/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc:1167:23 (xds_ring_hash_end2end_test@poller=epoll1+0x11cfb5f)

  Location is stack of main thread.

  Location is global '??' at 0x7fff2f960000 ([stack]+0x00000001d960)

  Mutex M149880357038747328 is already destroyed.

  Thread T25 'grpc_global_tim' (tid=50, running) created by thread T3 at:
    #0 pthread_create /tmp/clang-build/src/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:965:3 (xds_ring_hash_end2end_test@poller=epoll1+0x115d2bb)
    #1 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:108:17 (xds_ring_hash_end2end_test@poller=epoll1+0x25793d6)
    #2 grpc_core::Thread::Thread(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:186:15 (xds_ring_hash_end2end_test@poller=epoll1+0x2578cb6)
    #3 start_timer_thread_and_unlock() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:92:13 (xds_ring_hash_end2end_test@poller=epoll1+0x2475015)
    #4 run_some_timers() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:118:5 (xds_ring_hash_end2end_test@poller=epoll1+0x24754b2)
    #5 timer_main_loop() /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:238:9 (xds_ring_hash_end2end_test@poller=epoll1+0x24751b5)
    #6 timer_thread(void*) /proc/self/cwd/src/core/lib/iomgr/timer_manager.cc:285:3 (xds_ring_hash_end2end_test@poller=epoll1+0x24750aa)
    #7 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:140:23 (xds_ring_hash_end2end_test@poller=epoll1+0x2579a7c)
    #8 grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) /proc/self/cwd/src/core/lib/gprpp/thd_posix.cc:110:21 (xds_ring_hash_end2end_test@poller=epoll1+0x2579868)

SUMMARY: ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) /proc/self/cwd/test/cpp/end2end/connection_delay_injector.cc:49:13 in grpc::testing::(anonymous namespace)::TcpConnectWithDelay(grpc_closure*, grpc_endpoint**, grpc_pollset_set*, grpc_channel_args const*, grpc_resolved_address const*, grpc_core::Timestamp)
```