### PR TITLE
Disable layering check for Objective-C

### DIFF
--- a/src/objective-c/BUILD
+++ b/src/objective-c/BUILD
@@ -19,7 +19,10 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["-layering_check"],
+)
 
 exports_files(["LICENSE"])
 


### PR DESCRIPTION
These targets are currently not layering check clean.  Disabling it
ensures that they will continue to build even when we enable layering
check for Objective-C internally.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
