### PR TITLE
Add a service to dynamically configure the xDS test server

### DIFF
--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -12,7 +12,7 @@ Server should accept these arguments:
 *   --port=PORT
     *   The port the test server will run on.
 *   --maintenance_port=PORT
-    *   The port for the maintenance server running health, channelz, and admin(CSDS) services.
+    *   The port for the maintenance server running health, channelz, configuration, and admin(CSDS) services.
 *   --secure_mode=BOOLEAN
     *   When set to true it uses XdsServerCredentials with the test server for security test cases.
         In case of secure mode, port and maintenance_port should be different.
@@ -92,6 +92,35 @@ service XdsUpdateClientConfigureService {
 The test client changes its behavior right after receiving the
 `ClientConfigureRequest`. Currently it only supports configuring the type(s) 
 of RPCs sent by the test client, metadata attached to each type of RPCs, and the timeout.
+
+### XdsUpdateServerConfigureService
+
+The xDS test server's behavior can be dynamically changed in the middle of tests.
+This is achieved by invoking the `XdsUpdateClientConfigureService` gRPC service
+on the test server.
+
+```
+message EchoStatus {
+  int32 code = 1;
+  string message = 2;
+}
+
+message ServerConfigureRequest {
+  // The status code with which to respond to all requests
+  EchoStatus response_status = 1;
+}
+
+message ServerConfigureResponse {}
+
+service XdsUpdateServerConfigureService {
+  // Update the test server's configuration.
+  rpc Configure(ServerConfigureRequest) returns (ServerConfigureResponse);
+}
+```
+
+The test server changes its behavior right after receiving the
+`ServerConfigureRequest`. Currently it only supports configuring the status
+the server uses to respond to requests.
 
 ## Test Driver
 

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -268,3 +268,12 @@ message ClientConfigureRequest {
 
 // Response for updating a test client's configuration.
 message ClientConfigureResponse {}
+
+// Configurations for a test server
+message ServerConfigureRequest {
+  // The status code with which to respond to all requests
+  EchoStatus response_status = 1;
+}
+
+// Response for updating a test server's configuration.
+message ServerConfigureResponse {}

--- a/src/proto/grpc/testing/test.proto
+++ b/src/proto/grpc/testing/test.proto
@@ -97,6 +97,12 @@ service XdsUpdateHealthService {
 
 // A service to dynamically update the configuration of an xDS test client.
 service XdsUpdateClientConfigureService {
-  // Update the tes client's configuration.
+  // Update the test client's configuration.
   rpc Configure(ClientConfigureRequest) returns (ClientConfigureResponse);
+}
+
+// A service to dynamically update the configuration of an xDS test server.
+service XdsUpdateServerConfigureService {
+  // Update the test server's configuration.
+  rpc Configure(ServerConfigureRequest) returns (ServerConfigureResponse);
 }


### PR DESCRIPTION
This adds a configuration service to the xDS interop test server, analogous to the service that is already defined for the client. The initial purpose of this service is to enable outlier detection tests in which some servers always respond with errors.
