### PR TITLE
Fix TSAN race

### DIFF
--- a/src/core/ext/filters/channel_idle/channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/channel_idle_filter.cc
@@ -125,10 +125,6 @@ void MaxAgeFilter::Shutdown() {
 }
 
 void MaxAgeFilter::Start() {
-  // Trigger idle timer immediately
-  IncreaseCallCount();
-  DecreaseCallCount();
-
   struct StartupClosure {
     RefCountedPtr<grpc_channel_stack> channel_stack;
     MaxAgeFilter* filter;
@@ -136,6 +132,9 @@ void MaxAgeFilter::Start() {
   };
   auto run_startup = [](void* p, grpc_error_handle) {
     auto* startup = static_cast<StartupClosure*>(p);
+    // Trigger idle timer
+    startup->filter->IncreaseCallCount();
+    startup->filter->DecreaseCallCount();
     grpc_transport_op* op = grpc_make_transport_op(nullptr);
     op->start_connectivity_watch.reset(
         new ConnectivityWatcher(startup->filter));


### PR DESCRIPTION
Fixes b/229679479, which has a race between timer starting and the
channel stack finishing initialization by delaying the timer start until
after the channel stack has been initialized by moving the
increment/decrement into the already existing startup closure on an exec
ctx.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@drfloob
