### PR TITLE
For CMake only build grpc_plugin_support if gRPC_BUILD_CODEGEN is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3974,6 +3974,7 @@ if(gRPC_INSTALL)
 endif()
 
 
+if(gRPC_BUILD_CODEGEN)
 add_library(grpc_plugin_support
   src/compiler/cpp_generator.cc
   src/compiler/csharp_generator.cc
@@ -4030,7 +4031,9 @@ foreach(_hdr
     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
   )
 endforeach()
+endif()
 
+if(gRPC_BUILD_CODEGEN)
 
 if(gRPC_INSTALL)
   install(TARGETS grpc_plugin_support EXPORT gRPCTargets
@@ -4041,6 +4044,7 @@ if(gRPC_INSTALL)
   )
 endif()
 
+endif()
 
 # grpcpp_channelz doesn't build with protobuf-lite
 # See https://github.com/grpc/grpc/issues/19473

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -589,11 +589,11 @@
   %   else:
   ${cc_library(lib)}
   %     if not lib.build in ["tool"]:
-  %       if any(proto_re.match(src) for src in lib.src):
+  %       if any(proto_re.match(src) for src in lib.src) or lib.name == 'grpc_plugin_support':
   if(gRPC_BUILD_CODEGEN)
   %       endif
   ${cc_install(lib)}
-  %       if any(proto_re.match(src) for src in lib.src):
+  %       if any(proto_re.match(src) for src in lib.src) or lib.name == 'grpc_plugin_support':
   endif()
   %       endif
   %     endif
@@ -627,7 +627,7 @@
   % endfor
 
   <%def name="cc_library(lib)">
-  % if any(proto_re.match(src) for src in lib.src):
+  % if any(proto_re.match(src) for src in lib.src) or lib.name == 'grpc_plugin_support':
   % if lib.name == 'grpcpp_channelz':
   # grpcpp_channelz doesn't build with protobuf-lite
   # See https://github.com/grpc/grpc/issues/19473
@@ -734,7 +734,7 @@
     )
   endforeach()
   % endif
-  % if any(proto_re.match(src) for src in lib.src):
+  % if any(proto_re.match(src) for src in lib.src) or lib.name == 'grpc_plugin_support':
   endif()
   % endif
   </%def>


### PR DESCRIPTION
https://github.com/grpc/grpc/issues/29370

* Update templates/CMakeLists.txt.template to insert gRPC_BUILD_CODEGEN
  around grpc_plugin_support blocks.

* regenerate configs

release notes: no