### PR TITLE
Add templates for PSM test.

### DIFF
--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -80,6 +80,19 @@ scenarios=(
     "ruby_protobuf_sync_streaming_ping_pong"
 )
 
+psm_scenarios=(
+    "cpp_protobuf_async_unary_5000rpcs_1KB_psm"
+    "csharp_protobuf_async_unary_5000rpcs_1KB_psm"
+    "go_protobuf_async_unary_5000rpcs_1KB_psm"
+    "java_protobuf_async_unary_5000rpcs_1KB_psm"
+    "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm"
+    "php7_protobuf_php_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
+    "php7_protobuf_c_extension_to_cpp_protobuf_async_unary_5000rpcs_1KB_psm"
+    "python_protobuf_async_unary_5000rpcs_1KB_psm"
+    "python_asyncio_protobuf_async_unary_5000rpcs_1KB_psm"
+    "ruby_protobuf_async_unary_5000rpcs_1KB_psm"
+)
+
 # Basic examples are intended to be runnable _as is_, so substitution keys
 # are stripped. Fields can be inserted manually following the pattern of the
 # prebuilt examples.
@@ -121,10 +134,76 @@ prebuilt_example() {
     echo "Created example: ${outputdir}/${outputfile}"
 }
 
+# PSM basic examples are intended to be runnable with only subsituding the
+# xds-server and sidecar images, so substitution keys for xds-server and 
+# sidecar images are kept. 
+psm_basic_example() {
+    local -r scenario="${1}"
+    local -r outputdir="${2}"
+    local -r uniquifier="${3}"
+    local -r outputfile="$(example_file "${scenario}" _example_loadtest_"${uniquifier}".yaml)"
+    local -r language="$(example_language "${outputfile}")"
+    ${LOADTEST_CONFIG} \
+        -l "${language}" \
+        -t ./tools/run_tests/performance/templates/loadtest_template_psm_"${uniquifier}"_basic_all_languages.yaml \
+        -s client_pool= -s server_pool= -s big_query_table= \
+        -s psm_image_prefix="\${psm_image_prefix}" \
+        -s psm_image_tag="\${psm_image_tag}" \
+        -s timeout_seconds=900 --prefix=psm-examples -u "${uniquifier}" -r "^${scenario}$" \
+        --allow_client_language=c++ --allow_server_language=c++ \
+        --allow_server_language=node \
+        --client_channels=8 \
+        --category=psm \
+        --server_threads=16 \
+        --offered_loads 5000 \
+        -o "${outputdir}/${outputfile}"
+    echo "Created example: ${outputdir}/${outputfile}"
+}
+
+# PSM prebuilt examples contain substitution keys, so must be processed before
+# running.
+psm_prebuilt_example() {
+    local -r scenario="${1}"
+    local -r outputdir="${2}"
+    local -r uniquifier="${3}"
+    local -r outputfile="$(example_file "${scenario}" _example_loadtest_"${uniquifier}"_with_prebuilt_workers.yaml)"
+    local -r language="$(example_language "${outputfile}")"
+    ${LOADTEST_CONFIG} \
+        -l "${language}" \
+        -t ./tools/run_tests/performance/templates/loadtest_template_psm_"${uniquifier}"_prebuilt_all_languages.yaml \
+        -s driver_pool="\${driver_pool}" -s driver_image="\${driver_image}" \
+        -s client_pool="\${workers_pool}" -s server_pool="\${workers_pool}" \
+        -s big_query_table="\${big_query_table}" -s timeout_seconds=900 \
+        -s prebuilt_image_prefix="\${prebuilt_image_prefix}" \
+        -s prebuilt_image_tag="\${prebuilt_image_tag}" \
+        -s psm_image_prefix="\${psm_image_prefix}" \
+        -s psm_image_tag="\${psm_image_tag}" \
+        --prefix=psm-examples -u prebuilt-"${uniquifier}" -r "^${scenario}$" \
+        -a pool="\${workers_pool}" \
+        --allow_client_language=c++ --allow_server_language=c++ \
+        --allow_server_language=node \
+        --client_channels=8 \
+        --category=psm \
+        --server_threads=16 \
+        --offered_loads 5000 \
+        -o "${outputdir}/${outputfile}"
+    echo "Created example: ${outputdir}/${outputfile}"
+}
+
 for scenario in "${scenarios[@]}"; do
     basic_example "${scenario}" "${outputbasedir}"
 done
 
 for scenario in "${scenarios[@]}"; do
     prebuilt_example "${scenario}" "${outputbasedir}/templates"
+done
+
+for scenario in "${psm_scenarios[@]}"; do
+    psm_basic_example "${scenario}" "${outputbasedir}/templates/psm" "proxied"
+    psm_basic_example "${scenario}" "${outputbasedir}/templates/psm" "proxyless"
+done
+
+for scenario in "${psm_scenarios[@]}"; do
+    psm_prebuilt_example "${scenario}" "${outputbasedir}/templates/psm/prebuilt" "proxied"
+    psm_prebuilt_example "${scenario}" "${outputbasedir}/templates/psm/prebuilt" "proxyless"
 done

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml
@@ -1,0 +1,613 @@
+# Template generated from load test configurations by loadtest_template.py.
+#
+# Configuration templates contain client and server configurations for multiple
+# languages, and may contain template substitution keys. These templates are
+# used to generate load test configurations by selecting clients and servers for
+# the required languages. The source files for template generation may be load
+# test configurations or load test configuration templates. Load test
+# configuration generation is performed by loadtest_config.py. See documentation
+# below:
+# https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/README.md
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  name: psm_proxied_all_languages
+spec:
+  clients:
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      args:
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      args:
+      - build
+      - -o
+      - /src/workspace/bin/worker
+      - ./benchmark/worker
+      command:
+      - go
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-go.git
+    language: go
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      args:
+      - -PskipAndroid=true
+      - -PskipCodegen=true
+      - :grpc-benchmarks:installDist
+      command:
+      - gradle
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-java.git
+    language: java
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: php7
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_worker.sh
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: gcr.io/grpc-testing/e2etest/runtime/xds-server:v1.2.0-pre.1
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: gcr.io/grpc-testing/e2etest/runtime/side-car:v1.2.0-pre.1
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: php7_protobuf_c
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_protobuf_c_worker.sh
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc
+    language: ruby
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  driver:
+    language: cxx
+    run: []
+  results:
+    bigQueryTable: ${big_query_table}
+  servers:
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - -o
+      - /src/workspace/bin/worker
+      - ./benchmark/worker
+      command:
+      - go
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-go.git
+    language: go
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
+        value: '99'
+      - name: GRPC_GO_LOG_SEVERITY_LEVEL
+        value: info
+      name: main
+  - build:
+      args:
+      - -PskipAndroid=true
+      - -PskipCodegen=true
+      - :grpc-benchmarks:installDist
+      command:
+      - gradle
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-java.git
+    language: java
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      name: main
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc
+    language: ruby
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  timeoutSeconds: ${timeout_seconds}
+  ttlSeconds: 86400

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml
@@ -499,11 +499,6 @@ spec:
             /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   - build:
       args:

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml
@@ -1,0 +1,467 @@
+# Template generated from load test configurations by loadtest_template.py.
+#
+# Configuration templates contain client and server configurations for multiple
+# languages, and may contain template substitution keys. These templates are
+# used to generate load test configurations by selecting clients and servers for
+# the required languages. The source files for template generation may be load
+# test configurations or load test configuration templates. Load test
+# configuration generation is performed by loadtest_config.py. See documentation
+# below:
+# https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/README.md
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  name: psm_proxied_prebuilt_all_languages
+spec:
+  clients:
+  - language: csharp
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: cxx
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: go
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: java
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: node
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: php7
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_worker.sh
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: php7_protobuf_c
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_protobuf_c_worker.sh
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: python
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: python_asyncio
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  - language: ruby
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+    - image: ${psm_image_prefix}/sidecar:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: sidecar
+  driver:
+    language: cxx
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
+  servers:
+  - language: csharp
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
+      name: main
+  - language: cxx
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
+      name: main
+  - language: go
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
+      name: main
+  - language: java
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
+      name: main
+  - language: node
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
+      name: main
+  - language: python
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+  - language: python_asyncio
+    pool: ${server_pool}
+    run:
+    - command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+      rgs:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
+  - language: ruby
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
+      name: main
+  timeoutSeconds: ${timeout_seconds}
+  ttlSeconds: 86400

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml
@@ -456,11 +456,6 @@ spec:
             /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
       command:
       - bash
-      env:
-      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
-        value: '99'
-      - name: GRPC_GO_LOG_SEVERITY_LEVEL
-        value: info
       name: main
   - build:
       args:

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml
@@ -1,0 +1,570 @@
+# Template generated from load test configurations by loadtest_template.py.
+#
+# Configuration templates contain client and server configurations for multiple
+# languages, and may contain template substitution keys. These templates are
+# used to generate load test configurations by selecting clients and servers for
+# the required languages. The source files for template generation may be load
+# test configurations or load test configuration templates. Load test
+# configuration generation is performed by loadtest_config.py. See documentation
+# below:
+# https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/README.md
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  name: psm_proxyless_all_languages
+spec:
+  clients:
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      args:
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      args:
+      - build
+      - -o
+      - /src/workspace/bin/worker
+      - ./benchmark/worker
+      command:
+      - go
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-go.git
+    language: go
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      args:
+      - -PskipAndroid=true
+      - -PskipCodegen=true
+      - :grpc-benchmarks:installDist
+      command:
+      - gradle
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-java.git
+    language: java
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: php7
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: php7_protobuf_c
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_protobuf_c_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc
+    language: ruby
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  driver:
+    language: cxx
+    run: []
+  results:
+    bigQueryTable: ${big_query_table}
+  servers:
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: csharp
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - --config
+      - opt
+      - //test/cpp/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: cxx
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/test/cpp/qps/qps_worker --driver_port="${DRIVER_PORT}" \
+            --server_port=10010
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - -o
+      - /src/workspace/bin/worker
+      - ./benchmark/worker
+      command:
+      - go
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-go.git
+    language: go
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /src/workspace/bin/worker --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_GO_LOG_VERBOSITY_LEVEL
+        value: '99'
+      - name: GRPC_GO_LOG_SEVERITY_LEVEL
+        value: info
+      name: main
+  - build:
+      args:
+      - -PskipAndroid=true
+      - -PskipCodegen=true
+      - :grpc-benchmarks:installDist
+      command:
+      - gradle
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-java.git
+    language: java
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      name: main
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc-node.git
+    language: node
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" node -r \
+            ./test/fixtures/native_native.js test/performance/worker.js \
+            --benchmark_impl=grpc --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests/qps:qps_worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      args:
+      - build
+      - --compilation_mode
+      - opt
+      - //src/python/grpcio_tests/tests_aio/benchmark:worker
+      command:
+      - bazel
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc.git
+    language: python_asyncio
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            bazel-bin/src/python/grpcio_tests/tests_aio/benchmark/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  - build:
+      command:
+      - bash
+      - /build_scripts/build_qps_worker.sh
+    clone:
+      gitRef: master
+      repo: https://github.com/grpc/grpc
+    language: ruby
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" ruby \
+            src/ruby/qps/worker.rb --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      name: main
+  timeoutSeconds: ${timeout_seconds}
+  ttlSeconds: 86400

--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
@@ -1,0 +1,427 @@
+# Template generated from load test configurations by loadtest_template.py.
+#
+# Configuration templates contain client and server configurations for multiple
+# languages, and may contain template substitution keys. These templates are
+# used to generate load test configurations by selecting clients and servers for
+# the required languages. The source files for template generation may be load
+# test configurations or load test configuration templates. Load test
+# configuration generation is performed by loadtest_config.py. See documentation
+# below:
+# https://github.com/grpc/grpc/blob/master/tools/run_tests/performance/README.md
+apiVersion: e2etest.grpc.io/v1
+kind: LoadTest
+metadata:
+  name: psm_proxyless_prebuilt_all_languages
+spec:
+  clients:
+  - language: csharp
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: cxx
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: go
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: java
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: node
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: php7
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: php7_protobuf_c
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+        /run_scripts/run_protobuf_c_worker.sh
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/php7:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: python
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: python_asyncio
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  - language: ruby
+    pool: ${client_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
+      name: main
+    - args:
+      - -default-config-path
+      - containers/runtime/xds-server/config/default_config.json
+      - -path-to-bootstrap
+      - containers/runtime/xds-server/bootstrap.json
+      command:
+      - main
+      image: ${psm_image_prefix}/xds-server:${psm_image_tag}
+      livenessProbe:
+        initialDelaySeconds: 30
+        periodSeconds: 5
+        tcpSocket:
+          port: 10000
+      name: xds-server
+  driver:
+    language: cxx
+    pool: ${driver_pool}
+    run:
+    - image: ${driver_image}
+      name: main
+  results:
+    bigQueryTable: ${big_query_table}
+  servers:
+  - language: csharp
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" dotnet exec \
+            /execute/qps_worker/Grpc.IntegrationTesting.QpsWorker.dll \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/csharp:${prebuilt_image_tag}
+      name: main
+  - language: cxx
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /source/code/bazel-bin/test/cpp/qps/qps_worker \
+            --driver_port="${DRIVER_PORT}" --server_port=10010
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/cxx:${prebuilt_image_tag}
+      name: main
+  - language: go
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /executable/bin/worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/go:${prebuilt_image_tag}
+      name: main
+  - language: java
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /run_scripts/run_worker.sh
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/java:${prebuilt_image_tag}
+      name: main
+  - language: node
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/worker-linux --benchmark_impl=grpc \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/node:${prebuilt_image_tag}
+      name: main
+  - language: python
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/qps_worker \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+  - language: python_asyncio
+    pool: ${server_pool}
+    run:
+    - command:
+      - bash
+      image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
+      name: main
+      rgs:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/benchmark_worker \
+            --driver_port="${DRIVER_PORT}"
+  - language: ruby
+    pool: ${server_pool}
+    run:
+    - args:
+      - -c
+      - |
+        timeout --kill-after="${KILL_AFTER}" "${POD_TIMEOUT}" \
+            /execute/src/ruby/qps/worker.rb \
+            --driver_port="${DRIVER_PORT}"
+      command:
+      - bash
+      image: ${prebuilt_image_prefix}/ruby:${prebuilt_image_tag}
+      name: main
+  timeoutSeconds: ${timeout_seconds}
+  ttlSeconds: 86400


### PR DESCRIPTION
This commit adds PSM related templates and updates loadtest_example.sh to be able to generate examples in grpc/test-infra based on the templates in this pr.

This PR should be checked in with https://github.com/grpc/test-infra/pull/304

The templates are generated use following commands:
```
./tools/run_tests/performance/loadtest_template.py \
    -i ../test-infra/config/samples/templates/psm/*_example_loadtest_proxyless.yaml \
    --inject_client_pool --inject_server_pool \
    --inject_big_query_table --inject_timeout_seconds \
    -o ./tools/run_tests/performance/templates/loadtest_template_psm_proxyless_basic_all_languages.yaml\
    --name psm_proxyless_all_languages

./tools/run_tests/performance/loadtest_template.py \
    -i ../test-infra/config/samples/templates/psm/*_example_loadtest_proxied.yaml \
    --inject_client_pool --inject_server_pool \
    --inject_big_query_table --inject_timeout_seconds \
    -o ./tools/run_tests/performance/templates/loadtest_template_psm_proxied_basic_all_languages.yaml\
    --name psm_proxied_all_languages

 ./tools/run_tests/performance/loadtest_template.py \
    -i ../test-infra/config/samples/templates/psm/prebuilt/*_example_loadtest_proxyless_with_prebuilt_workers.yaml \
    --inject_client_pool --inject_server_pool \
    --inject_big_query_table --inject_timeout_seconds \
    -o ./tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml\
    --name psm_proxyless_prebuilt_all_languages

./tools/run_tests/performance/loadtest_template.py \
    -i ../test-infra/config/samples/templates/psm/prebuilt/*_example_loadtest_proxied_with_prebuilt_workers.yaml \
    --inject_client_pool --inject_server_pool \
    --inject_big_query_table --inject_timeout_seconds \
    -o ./tools/run_tests/performance/templates/loadtest_template_psm_proxied_prebuilt_all_languages.yaml\
    --name psm_proxied_prebuilt_all_languages
```