### PR TITLE
Remove var type annotations in extract_metadata_from_bazel_xml

### DIFF
--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -47,24 +47,36 @@ BuildDict = Dict[str, BuildMetadata]
 BuildYaml = Dict[str, Any]
 
 
-# ExternalProtoLibrary is the struct storing info about an external proto
-# library.
-#
-# Fields:
-# - destination(int): The relative path of this proto library should be.
-#     Preferably, it should match the submodule path.
-# - proto_prefix(str): The prefix to remove in order to insure the proto import
-#     is correct. For more info, see description of
-#      https://github.com/grpc/grpc/pull/25272.
-# - urls(List[str]): Following 3 fields should be filled by build metadata from
-#     Bazel.
-# - hash(str): The hash of the downloaded archive
-# - strip_prefix(str): The path to be stripped from the extracted directory, see
-#     http_archive in Bazel.
-ExternalProtoLibrary = collections.namedtuple(
-    'ExternalProtoLibrary',
-    ['destination', 'proto_prefix', 'urls', 'hash', 'strip_prefix'],
-    defaults=["", "", [], "", ""])
+class ExternalProtoLibrary:
+    """ExternalProtoLibrary is the struct about an external proto library.
+
+    Fields:
+    - destination(int): The relative path of this proto library should be.
+        Preferably, it should match the submodule path.
+    - proto_prefix(str): The prefix to remove in order to insure the proto import
+        is correct. For more info, see description of
+        https://github.com/grpc/grpc/pull/25272.
+    - urls(List[str]): Following 3 fields should be filled by build metadata from
+        Bazel.
+    - hash(str): The hash of the downloaded archive
+    - strip_prefix(str): The path to be stripped from the extracted directory, see
+        http_archive in Bazel.
+    """
+
+    def __init__(self,
+                 destination,
+                 proto_prefix,
+                 urls=None,
+                 hash="",
+                 strip_prefix=""):
+        self.destination = destination
+        self.proto_prefix = proto_prefix
+        if urls is None:
+            self.urls = []
+        else:
+            self.urls = urls
+        self.hash = hash
+        self.strip_prefix = strip_prefix
 
 
 EXTERNAL_PROTO_LIBRARIES = {
@@ -831,7 +843,7 @@ def _generate_external_proto_libraries() -> List[Dict[str, Any]]:
     xml_tree = _bazel_query_xml_tree('kind(http_archive, //external:*)')
     libraries = _parse_http_archives(xml_tree)
     libraries.sort(key=lambda x: x.destination)
-    return list(map(lambda x: x._asdict(), libraries))
+    return list(map(lambda x: x.__dict__, libraries))
 
 
 def _detect_and_print_issues(build_yaml_like: BuildYaml) -> None:

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -222,7 +222,7 @@ def _extract_sources(bazel_rule: BuildMetadata) -> List[str]:
                 if external_proto_library_name is not None:
                     result.append(
                         src.replace(
-                            f'@{external_proto_library_name}//',
+                            '@%s//' % external_proto_library_name,
                             EXTERNAL_PROTO_LIBRARIES[
                                 external_proto_library_name].proto_prefix).
                         replace(':', '/'))

--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -25,10 +25,6 @@ from typing import Dict, List, Union
 import _utils
 import yaml
 
-if sys.version_info < (3, 6):
-    raise RuntimeError('Expected Python version > 3.6, but got %s at %s' %
-                       (sys.version_info, sys.executable))
-
 PROJECT_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
                             "..")
 os.chdir(PROJECT_ROOT)


### PR DESCRIPTION
As title.

Originated from https://github.com/grpc/grpc/pull/29433.

Mitigates b/229631553.

This PR updates the generate project related Python files to be able to run under 3.5:

* Remove variable type annotation
* Remove f-string
* Remove version check for >=3.6