### PR TITLE
Fix typo in scenario names when generated by loadtest_config.py

### DIFF
--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -128,7 +128,7 @@ def scenario_name(base_name: str, client_channels: Optional[int],
     if server_threads:
         elements.append('{:d}threads'.format(server_threads))
     if offered_load:
-        elements.append('{:d}offered_load'.format(offered_load))
+        elements.append('{:d}load'.format(offered_load))
     return '_'.join(elements)
 
 


### PR DESCRIPTION
This commit use `load` instead of `offered_load` when a scenario further updated within loadtest_config.py.