### PR TITLE
Update java psm base scenario to have 15 warm up seconds

### DIFF
--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1310,6 +1310,7 @@ class JavaLanguage(Language):
                                   num_clients=1,
                                   secure=False,
                                   async_server_threads=1,
+                                  warmup_seconds=JAVA_WARMUP_SECONDS,
                                   categories=[PSM])
 
         for secure in [True, False]:


### PR DESCRIPTION
This commit updates the Java psm base scenario to have 15 warm up seconds, like other Java scenarios.