### PR TITLE
Cleanup run_in_docker.sh and corresponding examples.

### DIFF
--- a/tools/docker_runners/examples/bazel_test_in_docker.sh
+++ b/tools/docker_runners/examples/bazel_test_in_docker.sh
@@ -21,9 +21,11 @@ cd "$(dirname "$0")/../../.."
 # TODO(jtattermusch): make sure bazel cache is persisted between runs
 
 # Note that the port server must be running so that the bazel tests can pass.
+# (Run "tools/run_tests/start_port_server.py" first)
 
 # use the default docker image used for bazel builds
 export DOCKERFILE_DIR=tools/dockerfile/test/bazel
-# TODO(jtattermusch): interestingly, the bazel build fails when "--privileged" docker arg is used (it probably has to do with sandboxing)
-export DOCKER_EXTRA_ARGS="--privileged=false"
+# Using host network allows using port server running on the host machine (and not just in the docker container)
+# TODO(jtattermusch): interestingly, the bazel build fails when "--privileged=true" docker arg is used (it probably has to do with sandboxing)
+export DOCKER_EXTRA_ARGS="--network=host"
 tools/docker_runners/run_in_docker.sh bazel test //test/...

--- a/tools/docker_runners/examples/coredump_in_docker.sh
+++ b/tools/docker_runners/examples/coredump_in_docker.sh
@@ -27,8 +27,8 @@ cd "$(dirname "$0")/../../.."
 # by run_tests.py
 export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
 
-# add extra docker args if needed
-export DOCKER_EXTRA_ARGS=""
+# "--privileged" docker arg is required to be able to update /proc/sys/kernel/core_pattern
+export DOCKER_EXTRA_ARGS="--privileged"
 
 # start the docker container with interactive shell
 tools/docker_runners/run_in_docker.sh bash

--- a/tools/docker_runners/examples/coredump_in_docker.sh
+++ b/tools/docker_runners/examples/coredump_in_docker.sh
@@ -18,10 +18,14 @@ set -ex
 # change to grpc repo root
 cd "$(dirname "$0")/../../.."
 
-# use the docker image used as the default for C++ by run_tests.py
-# TODO(jtattermusch): document how to get the right docker image name
-# for given run_tests.py --compiler/--arch params.
-export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian9_x64
+# Use the docker image used as the default for C++ by run_tests.py
+# To use the correct docker image for your experiments,
+# note that every invocation of run_tests.py with "--use_docker"
+# prints the docker image used as a debug message at the end of the run.
+# This is expecially important when --compiler/--arch params are
+# use, since they usually influence with docker image will be used
+# by run_tests.py
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
 
 # add extra docker args if needed
 export DOCKER_EXTRA_ARGS=""

--- a/tools/docker_runners/examples/gdb_in_docker.sh
+++ b/tools/docker_runners/examples/gdb_in_docker.sh
@@ -27,8 +27,9 @@ cd "$(dirname "$0")/../../.."
 # by run_tests.py
 export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
 
-# add extra docker args if needed
-export DOCKER_EXTRA_ARGS=""
+# "--privileged" docker arg is required to be disable address randomization by gdb
+# TODO: is "--security-opt=seccomp=unconfined" actually needed?
+export DOCKER_EXTRA_ARGS="--privileged --security-opt=seccomp=unconfined"
 
 # start the docker container with interactive shell
 tools/docker_runners/run_in_docker.sh bash

--- a/tools/docker_runners/examples/gdb_in_docker.sh
+++ b/tools/docker_runners/examples/gdb_in_docker.sh
@@ -18,10 +18,14 @@ set -ex
 # change to grpc repo root
 cd "$(dirname "$0")/../../.."
 
-# use the docker image used as the default for C++ by run_tests.py
-# TODO(jtattermusch): document how to get the right docker image name
-# for given run_tests.py --compiler/--arch params.
-export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian9_x64
+# Use the docker image used as the default for C++ by run_tests.py
+# To use the correct docker image for your experiments,
+# note that every invocation of run_tests.py with "--use_docker"
+# prints the docker image used as a debug message at the end of the run.
+# This is expecially important when --compiler/--arch params are
+# use, since they usually influence with docker image will be used
+# by run_tests.py
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
 
 # add extra docker args if needed
 export DOCKER_EXTRA_ARGS=""

--- a/tools/docker_runners/examples/run_tests_c_cpp_in_docker.sh
+++ b/tools/docker_runners/examples/run_tests_c_cpp_in_docker.sh
@@ -19,7 +19,11 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # use the docker image used as the default for C++ by run_tests.py
-# TODO(jtattermusch): document how to get the right docker image name
-# for given run_tests.py --compiler/--arch params.
-export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian9_x64
+# To use the correct docker image for your experiments,
+# note that every invocation of run_tests.py with "--use_docker"
+# prints the docker image used as a debug message at the end of the run.
+# This is expecially important when --compiler/--arch params are
+# use, since they usually influence with docker image will be used
+# by run_tests.py
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
 tools/docker_runners/run_in_docker.sh tools/run_tests/run_tests.py -l c c++ -c dbg

--- a/tools/docker_runners/examples/run_tests_c_in_docker.sh
+++ b/tools/docker_runners/examples/run_tests_c_in_docker.sh
@@ -26,4 +26,4 @@ cd "$(dirname "$0")/../../.."
 # use, since they usually influence with docker image will be used
 # by run_tests.py
 export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
-tools/docker_runners/run_in_docker.sh tools/run_tests/run_tests.py -l c c++ -c dbg
+tools/docker_runners/run_in_docker.sh tools/run_tests/run_tests.py -l c -c dbg

--- a/tools/docker_runners/examples/run_tests_csharp_in_docker.sh
+++ b/tools/docker_runners/examples/run_tests_csharp_in_docker.sh
@@ -19,5 +19,5 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # use the docker image used as the default for C# by run_tests.py
-export DOCKERFILE_DIR=tools/dockerfile/test/csharp_buster_x64
+export DOCKERFILE_DIR=tools/dockerfile/test/csharp_debian11_x64
 tools/docker_runners/run_in_docker.sh tools/run_tests/run_tests.py -l csharp -c dbg --compiler coreclr

--- a/tools/docker_runners/run_in_docker.sh
+++ b/tools/docker_runners/run_in_docker.sh
@@ -34,32 +34,19 @@ then
     exit 1
 fi
 
-# Args on top of what's already set by build_and_run_docker.sh
-DOCKER_EXTRA_PRIVILEGED_ARGS=(
-  # TODO(jtattermusch): is "--privileged" actually needed for coredumps inside docker containers?
-  "--privileged"
-  # TODO(jtattermusch): is "--privileged" actually needed for coredumps inside docker containers?
-  "--security-opt=seccomp=unconfined"
+DOCKER_NONROOT_ARGS=(
+  # run under current user's UID and GID
+  # Uncomment to run the docker container as current user's UID and GID.
+  # That way, the files written by the container won't be owned by root (=you won't end up with polluted workspace),
+  # but it can have some other disadvantages. E.g.:
+  # - you won't be able install stuff inside the container
+  # - the home directory inside the container will be broken (you won't be able to write in it).
+  #   That may actually break some language runtimes completely (e.g. grpc python might not build)
+  # "--user=$(id -u):$(id -g)"
 )
-# Args on top of what's already set by build_and_run_docker.sh
-DOCKER_EXTRA_NETWORK_ARGS=(
-  # Using host network allows using port server running on the host machine (and not just in the docker container)
-  "--network=host"
-)
-
-# Uncomment to run the docker container as current user's UID and GID.
-# That way, the files written by the container won't be owned by root (=you won't end up with polluted workspace),
-# but it can have some other disadvantages. E.g.:
-# - you won't be able install stuff inside the container
-# - the home directory inside the container will be broken (you won't be able to write in it).
-#   That may actually break some language runtimes completely (e.g. grpc python might not build)
-# DOCKER_NONROOT_ARGS=(
-#   # run under current user's UID and GID
-#   "--user=$(id -u):$(id -g)"
-# )
 
 # the original DOCKER_EXTRA_ARGS + all the args defined in this script
-export DOCKER_EXTRA_ARGS=""${DOCKER_EXTRA_PRIVILEGED_ARGS[@]}" ${DOCKER_EXTRA_NETWORK_ARGS[@]} ${DOCKER_EXTRA_ARGS}"
+export DOCKER_EXTRA_ARGS="${DOCKER_NONROOT_ARGS[@]} ${DOCKER_EXTRA_ARGS}"
 # download the docker images from dockerhub instead of building them locally
 export DOCKERHUB_ORGANIZATION=grpctesting
 


### PR DESCRIPTION
~~Based on https://github.com/grpc/grpc/pull/29468.~~ (rebased)

Cleanup `run_in_docker.sh` script and its examples.
- the script can now reuse the logic in build_and_run_docker.sh, which is good because it reduces the amount of duplication (=easier maintenance) and also makes local test invocations more similar to those on CI (because most codepath in the scripts is now shared).
- some of the example scripts were out of date (e.g. out of date docker image name).