### PR TITLE
Reduce spam log messages at server under high memory pressure

### DIFF
--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -29,6 +29,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <string.h>
@@ -60,6 +61,8 @@
 #include "src/core/lib/iomgr/tcp_server_utils_posix.h"
 #include "src/core/lib/iomgr/unix_sockets_posix.h"
 #include "src/core/lib/resource_quota/api.h"
+
+static std::atomic<int64_t> num_dropped_connections{0};
 
 static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
                                            const grpc_channel_args* args,
@@ -221,7 +224,13 @@ static void on_read(void* arg, grpc_error_handle err) {
     }
 
     if (sp->server->memory_quota->IsMemoryPressureHigh()) {
-      gpr_log(GPR_INFO, "Drop incoming connection: high memory pressure");
+      int64_t dropped_connections_count = ++num_dropped_connections;
+      if (dropped_connections_count % 1000 == 0) {
+        gpr_log(GPR_INFO,
+                "Dropped >= %" PRId64
+                " new connection attempts due to high memory pressure",
+                dropped_connections_count);
+      }
       close(fd);
       continue;
     }

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -226,7 +226,7 @@ static void on_read(void* arg, grpc_error_handle err) {
     if (sp->server->memory_quota->IsMemoryPressureHigh()) {
       int64_t dropped_connections_count =
           num_dropped_connections.fetch_add(1, std::memory_order_relaxed) + 1;
-      if (dropped_connections_count % 1000 == 0) {
+      if (dropped_connections_count % 1000 == 1) {
         gpr_log(GPR_INFO,
                 "Dropped >= %" PRId64
                 " new connection attempts due to high memory pressure",

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -224,7 +224,8 @@ static void on_read(void* arg, grpc_error_handle err) {
     }
 
     if (sp->server->memory_quota->IsMemoryPressureHigh()) {
-      int64_t dropped_connections_count = ++num_dropped_connections;
+      int64_t dropped_connections_count =
+          num_dropped_connections.fetch_add(1, std::memory_order_relaxed);
       if (dropped_connections_count % 1000 == 0) {
         gpr_log(GPR_INFO,
                 "Dropped >= %" PRId64

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -225,7 +225,7 @@ static void on_read(void* arg, grpc_error_handle err) {
 
     if (sp->server->memory_quota->IsMemoryPressureHigh()) {
       int64_t dropped_connections_count =
-          num_dropped_connections.fetch_add(1, std::memory_order_relaxed);
+          num_dropped_connections.fetch_add(1, std::memory_order_relaxed) + 1;
       if (dropped_connections_count % 1000 == 0) {
         gpr_log(GPR_INFO,
                 "Dropped >= %" PRId64


### PR DESCRIPTION
Only log one message for every 1000 dropped incoming connections due to high memory pressure.

@ctiller 

