### PR TITLE
Fix typo in psm proxyless template for prebuilt workers.

### DIFF
--- a/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
+++ b/tools/run_tests/performance/templates/loadtest_template_psm_proxyless_prebuilt_all_languages.yaml
@@ -232,6 +232,9 @@ spec:
             --driver_port="${DRIVER_PORT}"
       command:
       - bash
+      env:
+      - name: GRPC_XDS_BOOTSTRAP
+        value: /bootstrap/bootstrap.json
       image: ${prebuilt_image_prefix}/python:${prebuilt_image_tag}
       name: main
     - args:
@@ -241,9 +244,6 @@ spec:
       - containers/runtime/xds-server/bootstrap.json
       command:
       - main
-      env:
-      - name: GRPC_XDS_BOOTSTRAP
-        value: /bootstrap/bootstrap.json
       image: ${psm_image_prefix}/xds-server:${psm_image_tag}
       livenessProbe:
         initialDelaySeconds: 30


### PR DESCRIPTION
This is to fix a displacement of `GRPC_XDS_BOOTSTRAP` ENV for prebuilt python worker. Should be merged together with https://github.com/grpc/test-infra/pull/307