### PR TITLE
xDS test server: document rpc-behavior metadata, add hostname option

### DIFF
--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -20,8 +20,12 @@ Server should accept these arguments:
 In addition, when handling requests, if the initial request metadata contains the `rpc-behavior` key, it should modify its handling of the request as follows:
 
  - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before responding.
- - If the value matches `fail=<status code as int>`, the server should respond with the specified status code.
- - A value can have a prefix `hostname=<string>` followed by a space. In that case, the rest of the value should only be applied if the specified hostname matches the server's hostname. 
+ - If the value matches `keep-open`, the server should never respond to the request.
+ - If the value matches `success-on-retry-attempt-<int>`, the server should force an OK response if the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number.
+ - If the value matches `error-code-<int>`, the server should respond with the specified status code.
+ - A value can have a prefix `hostname=<string>` followed by a space. In that case, the rest of the value should only be applied if the specified hostname matches the server's hostname.
+
+If a request has multiple `rpc-behavior` metadata values, they should be applied in the order listed.
 
 ## Client
 

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -17,6 +17,11 @@ Server should accept these arguments:
     *   When set to true it uses XdsServerCredentials with the test server for security test cases.
         In case of secure mode, port and maintenance_port should be different.
 
+In addition, when handling requests, if the initial request metadata contains the `rpc-behavior` key, it should modify its handling of the request as follows:
+
+ - If the value matches `sleep-<number>`, the server should wait the specified number of seconds before responding.
+ - If the value matches `fail-on=<hostname>`, and the specified hostname matches the server's hostname, the server should respond to the request with an error with the code `ABORTED`.
+
 ## Client
 
 The base behavior of the xDS test client is to send a constant QPS of unary

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -21,11 +21,11 @@ In addition, when handling requests, if the initial request metadata contains th
 
  - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before responding.
  - If the value matches `keep-open`, the server should never respond to the request.
- - If the value matches `success-on-retry-attempt-<int>`, the server should force an OK response if the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number.
  - If the value matches `error-code-<int>`, the server should respond with the specified status code.
+ - If the value matches `success-on-retry-attempt-<int>`, the server should not apply the `error-code` option if the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number.
  - A value can have a prefix `hostname=<string>` followed by a space. In that case, the rest of the value should only be applied if the specified hostname matches the server's hostname.
 
-If a request has multiple `rpc-behavior` metadata values, they should be applied in the order listed.
+The `rpc-behavior` header value can have multiple options separated by commas. In that case, the value should be split by commas and the options should be applied in the order specified. If a request has multiple `rpc-behavior` metadata values, each one should be processed that way in order.
 
 ## Client
 

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -19,10 +19,10 @@ Server should accept these arguments:
 
 In addition, when handling requests, if the initial request metadata contains the `rpc-behavior` key, it should modify its handling of the request as follows:
 
- - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before responding.
- - If the value matches `keep-open`, the server should never respond to the request.
- - If the value matches `error-code-<int>`, the server should respond with the specified status code.
- - If the value matches `success-on-retry-attempt-<int>`, the server should not apply the `error-code` option if the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number.
+ - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before resuming behavior matching and RPC processing.
+ - If the value matches `keep-open`, the server should never respond to the request and behavior matching ends.
+ - If the value matches `error-code-<int>`, the server should respond with the specified status code and behavior matching ends.
+ - If the value matches `success-on-retry-attempt-<int>`, and the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number, the normal RPC processing should resume and behavior matching ends.
  - A value can have a prefix `hostname=<string>` followed by a space. In that case, the rest of the value should only be applied if the specified hostname matches the server's hostname.
 
 The `rpc-behavior` header value can have multiple options separated by commas. In that case, the value should be split by commas and the options should be applied in the order specified. If a request has multiple `rpc-behavior` metadata values, each one should be processed that way in order.

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -19,8 +19,9 @@ Server should accept these arguments:
 
 In addition, when handling requests, if the initial request metadata contains the `rpc-behavior` key, it should modify its handling of the request as follows:
 
- - If the value matches `sleep-<number>`, the server should wait the specified number of seconds before responding.
- - If the value matches `fail-on=<hostname>`, and the specified hostname matches the server's hostname, the server should respond to the request with an error with the code `ABORTED`.
+ - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before responding.
+ - If the value matches `fail=<status code as int>`, the server should respond with the specified status code.
+ - A value can have a prefix `hostname=<string>` followed by a space. In that case, the rest of the value should only be applied if the specified hostname matches the server's hostname. 
 
 ## Client
 


### PR DESCRIPTION
The `sleep-<number>` entry just documents the existing usage in the "timeout" test case. The `fail-on` option is new, and will be used to implement the outlier detection test.

This is an alternative to #29448 for implementing an outlier detection test.