### PR TITLE
Fix crash when sockaddr cannot be converted to string

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -676,7 +676,8 @@ Subchannel::Subchannel(SubchannelKey key,
             {GRPC_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE_DEFAULT, 0,
              INT_MAX}));
     channelz_node_ = MakeRefCounted<channelz::SubchannelNode>(
-        grpc_sockaddr_to_uri(&key_.address()).value(),
+        grpc_sockaddr_to_uri(&key_.address())
+            .value_or("<unknown address type>"),
         channel_tracer_max_memory);
     channelz_node_->AddTraceEvent(
         channelz::ChannelTrace::Severity::Info,


### PR DESCRIPTION
`grpc_sockaddr_to_uri()` does not support binder transport URI scheme
(which uses an invalid sa_family (`AF_MAX`) to avoid misuse) at
this moment. Fallback to empty string here to keep the old behavior.