### PR TITLE
Binder transport: Fix server issue when handling many parallel RPC calls

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_transport.h
+++ b/src/core/ext/transport/binder/transport/binder_transport.h
@@ -17,6 +17,7 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <utility>
@@ -68,8 +69,6 @@ struct grpc_binder_transport {
   absl::flat_hash_map<int, grpc_binder_stream*> registered_stream;
   grpc_core::Combiner* combiner;
 
-  grpc_closure accept_stream_closure;
-
   // The callback and the data for the callback when the stream is connected
   // between client and server.
   void (*accept_stream_fn)(void* user_data, grpc_transport* transport,
@@ -80,7 +79,7 @@ struct grpc_binder_transport {
   grpc_core::RefCount refs;
 
  private:
-  int next_free_tx_code = grpc_binder::kFirstCallId;
+  std::atomic<int> next_free_tx_code{grpc_binder::kFirstCallId};
 };
 
 grpc_transport* grpc_create_binder_transport_client(

--- a/test/core/transport/binder/end2end/binder_server_test.cc
+++ b/test/core/transport/binder/end2end/binder_server_test.cc
@@ -207,6 +207,46 @@ TEST_F(BinderServerTest, CreateChannelWithEndpointBinderMultipleConnections) {
   server->Shutdown();
 }
 
+TEST_F(BinderServerTest, CreateChannelWithEndpointBinderParallelRequests) {
+  grpc::ServerBuilder server_builder;
+  grpc::testing::TestServiceImpl service;
+  server_builder.RegisterService(&service);
+  server_builder.AddListeningPort("binder:example.service",
+                                  grpc::testing::BinderServerCredentials());
+  std::unique_ptr<grpc::Server> server = server_builder.BuildAndStart();
+  void* raw_endpoint_binder =
+      grpc::experimental::binder::GetEndpointBinder("example.service");
+  std::unique_ptr<grpc_binder::Binder> endpoint_binder =
+      absl::make_unique<grpc_binder::end2end_testing::FakeBinder>(
+          static_cast<grpc_binder::end2end_testing::FakeEndpoint*>(
+              raw_endpoint_binder));
+  std::shared_ptr<grpc::Channel> channel =
+      grpc::testing::CreateBinderChannel(std::move(endpoint_binder));
+  std::unique_ptr<grpc::testing::EchoTestService::Stub> stub =
+      grpc::testing::EchoTestService::NewStub(channel);
+
+  constexpr size_t kNumRequests = 128;
+
+  auto thread_fn = [&](size_t id) {
+    grpc::testing::EchoRequest request;
+    std::string msg = absl::StrFormat("BinderServerBuilder-%d", id);
+    request.set_message(msg);
+    grpc::testing::EchoResponse response;
+    grpc::ClientContext context;
+    grpc::Status status = stub->Echo(&context, request, &response);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(response.message(), msg);
+  };
+  std::vector<std::thread> threads(kNumRequests);
+  for (size_t i = 0; i < kNumRequests; ++i) {
+    threads[i] = std::thread(thread_fn, i);
+  }
+  for (auto& thr : threads) {
+    thr.join();
+  }
+  server->Shutdown();
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
When single closure is scheduled multiple times before it is run, it
runs less times than the number of times it is scheduled.

As a result, when server receives multiple RPC calls in a very short
time frame, `accept_stream_locked` is not correctly called for every
RPC call received.

We are working on internal server side stress test to make sure this
kind of error won't happen again.