### PR TITLE
Add v1.44.0, v1.45.0, and v1.46.0 releases of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -198,6 +198,9 @@ LANG_RELEASE_MATRIX = {
             ('v1.41.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.42.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.43.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.44.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.45.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.46.0', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
#29063 and #28693 did not get merged, so including them here.