### PR TITLE
Revert "Add DNS Server address override to the EventEngine API"

### DIFF
--- a/doc/naming.md
+++ b/doc/naming.md
@@ -46,8 +46,11 @@ Most gRPC implementations support the following URI schemes:
   - The name has no connection with filesystem pathnames.
   - No permissions will apply to the socket - any process/user may access the socket.
   - The underlying implementation of Abstract sockets uses a null byte ('\0')
-    as the first character; the implementation will prepend this null. Do not include
+    as the first character; the implementation will prepend this null. Do not include 
     the null in `abstract_path`.
+  - `abstract_path` cannot contain null bytes.
+    - TODO(https://github.com/grpc/grpc/issues/24638): Unix allows abstract socket names to contain null bytes, 
+      but this is not supported by the gRPC C-core implementation.
 
 The following schemes are supported by the gRPC C-core implementation,
 but may not be supported in other languages:

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -261,12 +261,6 @@ class EventEngine {
     struct LookupTaskHandle {
       intptr_t key[2];
     };
-    /// Optional configuration for DNSResolvers.
-    struct ResolverOptions {
-      /// If empty, default DNS servers will be used.
-      /// Must be in the "IP:port" format as described in naming.md.
-      std::string dns_server;
-    };
     /// DNS SRV record type.
     struct SRVRecord {
       std::string host;
@@ -299,7 +293,7 @@ class EventEngine {
     ///
     /// If cancelled, \a on_resolve will not be executed.
     virtual LookupTaskHandle LookupHostname(LookupHostnameCallback on_resolve,
-                                            absl::string_view name,
+                                            absl::string_view address,
                                             absl::string_view default_port,
                                             absl::Time deadline) = 0;
     /// Asynchronously perform an SRV record lookup.
@@ -337,10 +331,8 @@ class EventEngine {
   // de-experimentalize this API.
   virtual bool IsWorkerThread() = 0;
 
-  /// Creates and returns an instance of a DNSResolver, optionally configured by
-  /// the \a options struct.
-  virtual std::unique_ptr<DNSResolver> GetDNSResolver(
-      const DNSResolver::ResolverOptions& options) = 0;
+  /// Creates and returns an instance of a DNSResolver.
+  virtual std::unique_ptr<DNSResolver> GetDNSResolver() = 0;
 
   /// Asynchronously executes a task as soon as possible.
   ///


### PR DESCRIPTION
Reverts grpc/grpc#29485. Requires a cherrypick.