### PR TITLE
Add log urls to junit report.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -132,8 +132,8 @@ time ../test-infra/bin/prepare_prebuilt_workers \
 time ../test-infra/bin/runner \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_32CORE}.yaml" \
+    -log-url-prefix "${LOG_URL_PREFIX}" \
     -polling-interval 5s \
     -delete-successful-tests \
-    -log-url-prefix "${LOG_URL_PREFIX}" \
     -c "${WORKER_POOL_8CORE}:2" -c "${WORKER_POOL_32CORE}:2" \
     -o "runner/sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -126,11 +126,15 @@ time ../test-infra/bin/prepare_prebuilt_workers \
     -t "${UNIQUE_IDENTIFIER}" \
     -r "${ROOT_DIRECTORY_OF_DOCKERFILES}"
 
+# calculate the prefix of the log URL
+LOG_URL_PREFIX="http://cnsviewer2/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
+
 # Run tests.
 time ../test-infra/bin/runner \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_32CORE}.yaml" \
     -polling-interval 5s \
     -delete-successful-tests \
+    -log-url-prefix "${LOG_URL_PREFIX}" \
     -c "${WORKER_POOL_8CORE}:2" -c "${WORKER_POOL_32CORE}:2" \
     -o "runner/sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -60,6 +60,8 @@ DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
 # c2-standard-30 is the closest machine spec to 32 core there is
 WORKER_POOL_32CORE=workers-c2-30core-ci
+# Prefix for log URLs in cnsviewer.
+LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1
@@ -125,9 +127,6 @@ time ../test-infra/bin/prepare_prebuilt_workers \
     -p "${PREBUILT_IMAGE_PREFIX}" \
     -t "${UNIQUE_IDENTIFIER}" \
     -r "${ROOT_DIRECTORY_OF_DOCKERFILES}"
-
-# calculate the prefix of the log URL
-LOG_URL_PREFIX="http://cnsviewer2/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
 # Run tests.
 time ../test-infra/bin/runner \

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -130,8 +130,8 @@ time ../test-infra/bin/prepare_prebuilt_workers \
 time ../test-infra/bin/runner \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_32CORE}.yaml" \
+    -log-url-prefix "${LOG_URL_PREFIX}" \
     -polling-interval 5s \
     -delete-successful-tests \
-    -log-url-prefix "${LOG_URL_PREFIX}" \
     -c "${WORKER_POOL_8CORE}:2" -c "${WORKER_POOL_32CORE}:2" \
     -o "runner/sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -58,6 +58,8 @@ DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
 # c2-standard-30 is the closest machine spec to 32 core there is
 WORKER_POOL_32CORE=workers-c2-30core-ci
+# Prefix for log URLs in cnsviewer.
+LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
 # Update go version.
 TEST_INFRA_GOVERSION=go1.17.1
@@ -123,9 +125,6 @@ time ../test-infra/bin/prepare_prebuilt_workers \
     -p "${PREBUILT_IMAGE_PREFIX}" \
     -t "${UNIQUE_IDENTIFIER}" \
     -r "${ROOT_DIRECTORY_OF_DOCKERFILES}"
-
-# calculate the prefix of the log URL
-LOG_URL_PREFIX="http://cnsviewer2/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
 # Run tests.
 time ../test-infra/bin/runner \

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -124,11 +124,15 @@ time ../test-infra/bin/prepare_prebuilt_workers \
     -t "${UNIQUE_IDENTIFIER}" \
     -r "${ROOT_DIRECTORY_OF_DOCKERFILES}"
 
+# calculate the prefix of the log URL
+LOG_URL_PREFIX="http://cnsviewer2/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
+
 # Run tests.
 time ../test-infra/bin/runner \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
     -i "loadtest_with_prebuilt_workers_${WORKER_POOL_32CORE}.yaml" \
     -polling-interval 5s \
     -delete-successful-tests \
+    -log-url-prefix "${LOG_URL_PREFIX}" \
     -c "${WORKER_POOL_8CORE}:2" -c "${WORKER_POOL_32CORE}:2" \
     -o "runner/sponge_log.xml"


### PR DESCRIPTION
This pr adds the feature of providing links to logs in load test Junit reports.

This pr should be merged after https://github.com/grpc/test-infra/pull/306.