### PR TITLE
[WIP] Teach iomgr’s DNSResolver to use EventEngine::ResolvedAddress

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1767,6 +1767,7 @@ grpc_cc_library(
     deps = [
         "gpr_base",
         "iomgr_port",
+        "event_engine_base_hdrs",
     ],
 )
 

--- a/src/core/lib/http/httpcli.h
+++ b/src/core/lib/http/httpcli.h
@@ -215,7 +215,9 @@ class HttpRequest : public InternallyRefCounted<HttpRequest> {
   void NextAddress(grpc_error_handle error) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   void OnResolved(
-      absl::StatusOr<std::vector<grpc_resolved_address>> addresses_or);
+      absl::StatusOr<std::vector<
+          grpc_event_engine::experimental::EventEngine::ResolvedAddress>>
+          addresses_or);
 
   const URI uri_;
   const grpc_slice request_text_;

--- a/src/core/lib/iomgr/resolve_address.h
+++ b/src/core/lib/iomgr/resolve_address.h
@@ -23,6 +23,8 @@
 
 #include <stddef.h>
 
+#include <grpc/event_engine/event_engine.h>
+
 #include "absl/status/statusor.h"
 
 #include "src/core/lib/gprpp/orphanable.h"
@@ -62,12 +64,13 @@ class DNSResolver {
   virtual OrphanablePtr<Request> ResolveName(
       absl::string_view name, absl::string_view default_port,
       grpc_pollset_set* interested_parties,
-      std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-          on_done) GRPC_MUST_USE_RESULT = 0;
+      grpc_event_engine::experimental::EventEngine::DNSResolver::
+          LookupHostnameCallback on_done) GRPC_MUST_USE_RESULT = 0;
 
   // Resolve name in a blocking fashion. Use \a default_port if a port isn't
   // designated in \a name, otherwise use the port in \a name.
-  virtual absl::StatusOr<std::vector<grpc_resolved_address>>
+  virtual absl::StatusOr<std::vector<
+      grpc_event_engine::experimental::EventEngine::ResolvedAddress>>
   ResolveNameBlocking(absl::string_view name,
                       absl::string_view default_port) = 0;
 };

--- a/src/core/lib/iomgr/resolve_address_impl.h
+++ b/src/core/lib/iomgr/resolve_address_impl.h
@@ -21,6 +21,8 @@
 
 #include <stddef.h>
 
+#include <grpc/event_engine/event_engine.h>
+
 #include "src/core/lib/iomgr/port.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 
@@ -32,9 +34,11 @@ namespace grpc_core {
 class DNSCallbackExecCtxScheduler {
  public:
   DNSCallbackExecCtxScheduler(
-      std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-          on_done,
-      absl::StatusOr<std::vector<grpc_resolved_address>> param)
+      grpc_event_engine::experimental::EventEngine::DNSResolver::
+          LookupHostnameCallback on_done,
+      absl::StatusOr<std::vector<
+          grpc_event_engine::experimental::EventEngine::ResolvedAddress>>
+          param)
       : on_done_(std::move(on_done)), param_(std::move(param)) {
     GRPC_CLOSURE_INIT(&closure_, RunCallback, this, grpc_schedule_on_exec_ctx);
     ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
@@ -48,9 +52,11 @@ class DNSCallbackExecCtxScheduler {
     delete self;
   }
 
-  const std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-      on_done_;
-  absl::StatusOr<std::vector<grpc_resolved_address>> param_;
+  const grpc_event_engine::experimental::EventEngine::DNSResolver::
+      LookupHostnameCallback on_done_;
+  absl::StatusOr<std::vector<
+      grpc_event_engine::experimental::EventEngine::ResolvedAddress>>
+      param_;
   grpc_closure closure_;
 };
 

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include <grpc/event_engine/event_engine.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -45,12 +46,12 @@
 namespace grpc_core {
 namespace {
 
+using ::grpc_event_engine::experimental::EventEngine;
+
 class NativeDNSRequest : public DNSResolver::Request {
  public:
-  NativeDNSRequest(
-      absl::string_view name, absl::string_view default_port,
-      std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-          on_done)
+  NativeDNSRequest(absl::string_view name, absl::string_view default_port,
+                   EventEngine::DNSResolver::LookupHostnameCallback on_done)
       : name_(name), default_port_(default_port), on_done_(std::move(on_done)) {
     GRPC_CLOSURE_INIT(&request_closure_, DoRequestThread, this, nullptr);
   }
@@ -79,8 +80,7 @@ class NativeDNSRequest : public DNSResolver::Request {
 
   const std::string name_;
   const std::string default_port_;
-  const std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-      on_done_;
+  const EventEngine::DNSResolver::LookupHostnameCallback on_done_;
   grpc_closure request_closure_;
 };
 
@@ -94,13 +94,12 @@ NativeDNSResolver* NativeDNSResolver::GetOrCreate() {
 OrphanablePtr<DNSResolver::Request> NativeDNSResolver::ResolveName(
     absl::string_view name, absl::string_view default_port,
     grpc_pollset_set* /* interested_parties */,
-    std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-        on_done) {
+    EventEngine::DNSResolver::LookupHostnameCallback on_done) {
   return MakeOrphanable<NativeDNSRequest>(name, default_port,
                                           std::move(on_done));
 }
 
-absl::StatusOr<std::vector<grpc_resolved_address>>
+absl::StatusOr<std::vector<EventEngine::ResolvedAddress>>
 NativeDNSResolver::ResolveNameBlocking(absl::string_view name,
                                        absl::string_view default_port) {
   ExecCtx exec_ctx;
@@ -109,7 +108,7 @@ NativeDNSResolver::ResolveNameBlocking(absl::string_view name,
   int s;
   size_t i;
   grpc_error_handle err;
-  std::vector<grpc_resolved_address> addresses;
+  std::vector<EventEngine::ResolvedAddress> addresses;
   std::string host;
   std::string port;
   // parse name, splitting it into host and port parts
@@ -163,10 +162,8 @@ NativeDNSResolver::ResolveNameBlocking(absl::string_view name,
   }
   // Success path: fill in addrs
   for (resp = result; resp != nullptr; resp = resp->ai_next) {
-    grpc_resolved_address addr;
-    memcpy(&addr.addr, resp->ai_addr, resp->ai_addrlen);
-    addr.len = resp->ai_addrlen;
-    addresses.push_back(addr);
+    addresses.push_back(EventEngine::ResolvedAddress(
+        reinterpret_cast<const sockaddr*>(resp->ai_addr), resp->ai_addrlen));
   }
   err = GRPC_ERROR_NONE;
 done:

--- a/src/core/lib/iomgr/resolve_address_posix.h
+++ b/src/core/lib/iomgr/resolve_address_posix.h
@@ -21,6 +21,8 @@
 
 #include <functional>
 
+#include <grpc/event_engine/event_engine.h>
+
 #include "src/core/lib/iomgr/port.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 
@@ -35,11 +37,13 @@ class NativeDNSResolver : public DNSResolver {
   OrphanablePtr<DNSResolver::Request> ResolveName(
       absl::string_view name, absl::string_view default_port,
       grpc_pollset_set* interested_parties,
-      std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-          on_done) override;
+      grpc_event_engine::experimental::EventEngine::DNSResolver::
+          LookupHostnameCallback on_done) override;
 
-  absl::StatusOr<std::vector<grpc_resolved_address>> ResolveNameBlocking(
-      absl::string_view name, absl::string_view default_port) override;
+  absl::StatusOr<std::vector<
+      grpc_event_engine::experimental::EventEngine::ResolvedAddress>>
+  ResolveNameBlocking(absl::string_view name,
+                      absl::string_view default_port) override;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/resolve_address_windows.h
+++ b/src/core/lib/iomgr/resolve_address_windows.h
@@ -21,6 +21,8 @@
 
 #include <functional>
 
+#include <grpc/event_engine/event_engine.h>
+
 #include "src/core/lib/iomgr/port.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 
@@ -35,11 +37,13 @@ class NativeDNSResolver : public DNSResolver {
   OrphanablePtr<DNSResolver::Request> ResolveName(
       absl::string_view name, absl::string_view default_port,
       grpc_pollset_set* interested_parties,
-      std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-          on_done) override;
+      grpc_event_engine::experimental::EventEngine::DNSResolver::
+          LookupHostnameCallback on_done) override;
 
-  absl::StatusOr<std::vector<grpc_resolved_address>> ResolveNameBlocking(
-      absl::string_view name, absl::string_view default_port) override;
+  absl::StatusOr<std::vector<
+      grpc_event_engine::experimental::EventEngine::ResolvedAddress>>
+  ResolveNameBlocking(absl::string_view name,
+                      absl::string_view default_port) override;
 };
 
 }  // namespace grpc_core

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <functional>
 
+#include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/gpr_types.h>
 #include <grpc/support/log.h>
@@ -60,6 +61,8 @@ static struct iomgr_args {
 
 namespace {
 
+using ::grpc_event_engine::experimental::EventEngine;
+
 grpc_core::DNSResolver* g_default_dns_resolver;
 
 class TestDNSResolver : public grpc_core::DNSResolver {
@@ -69,8 +72,7 @@ class TestDNSResolver : public grpc_core::DNSResolver {
   grpc_core::OrphanablePtr<grpc_core::DNSResolver::Request> ResolveName(
       absl::string_view name, absl::string_view default_port,
       grpc_pollset_set* interested_parties,
-      std::function<void(absl::StatusOr<std::vector<grpc_resolved_address>>)>
-          on_done) override {
+      EventEngine::DNSResolver::LookupHostnameCallback on_done) override {
     auto result = g_default_dns_resolver->ResolveName(
         name, default_port, interested_parties, std::move(on_done));
     ++g_resolution_count;
@@ -96,7 +98,7 @@ class TestDNSResolver : public grpc_core::DNSResolver {
     return result;
   }
 
-  absl::StatusOr<std::vector<grpc_resolved_address>> ResolveNameBlocking(
+  absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> ResolveNameBlocking(
       absl::string_view name, absl::string_view default_port) override {
     return g_default_dns_resolver->ResolveNameBlocking(name, default_port);
   }

--- a/test/core/util/resolve_localhost_ip46.cc
+++ b/test/core/util/resolve_localhost_ip46.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/util/resolve_localhost_ip46.h"
 
+#include <grpc/event_engine/event_engine.h>
 #include <grpc/support/log.h>
 
 #include "src/core/lib/iomgr/port.h"
@@ -27,17 +28,19 @@
 namespace grpc_core {
 namespace {
 
+using ::grpc_event_engine::experimental::EventEngine;
+
 bool localhost_to_ipv4 = false;
 bool localhost_to_ipv6 = false;
 gpr_once g_resolve_localhost_ipv46 = GPR_ONCE_INIT;
 
 void InitResolveLocalhost() {
-  absl::StatusOr<std::vector<grpc_resolved_address>> addresses_or =
+  absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> addresses_or =
       GetDNSResolver()->ResolveNameBlocking("localhost", "https");
   GPR_ASSERT(addresses_or.ok());
   for (const auto& addr : *addresses_or) {
     const grpc_sockaddr* sock_addr =
-        reinterpret_cast<const grpc_sockaddr*>(&addr);
+        reinterpret_cast<const grpc_sockaddr*>(addr.address());
     if (sock_addr->sa_family == GRPC_AF_INET) {
       localhost_to_ipv4 = true;
     } else if (sock_addr->sa_family == GRPC_AF_INET6) {


### PR DESCRIPTION
See src/core/lib/iomgr/resolve_address.h for the essential changes.

This is a step towards making the iomgr DNS API sufficient to drive a
client channel resolver. In this change, clients will begin handling
EventEngine lookup result types. EventEngine will eventually replace
iomgr, so using EventEngine types now should simplify things a bit
later.
