### PR TITLE
[xDS Proto] Add protoc-gen-validate back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ compile_commands.json
 compile_commands_for_iwyu.json
 iwyu.out
 iwyu_files.txt
+
+# CMake intermediate directories
+third_party/protoc-gen-validate/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,16 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opencensus-proto/src)
     opencensus-proto-0.3.0/src
   )
 endif()
+# Setup external proto library at third_party/protoc-gen-validate if it doesn't exist
+if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protoc-gen-validate)
+  # Download the archive via HTTP, validate the checksum, and extract to third_party/protoc-gen-validate.
+  download_archive(
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protoc-gen-validate
+    https://github.com/envoyproxy/protoc-gen-validate/archive/4694024279bdac52b77e22dc87808bd0fd732b69.tar.gz
+    1e490b98005664d149b379a9529a6aa05932b8a11b76b4cd86f3d22d76346f47
+    protoc-gen-validate-4694024279bdac52b77e22dc87808bd0fd732b69
+  )
+endif()
 # Setup external proto library at third_party/xds with 2 download URLs
 if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/xds)
   # Download the archive via HTTP, validate the checksum, and extract to third_party/xds.

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -8966,6 +8966,12 @@ external_proto_libraries:
   urls:
   - https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz
   - https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz
+- destination: third_party/protoc-gen-validate
+  hash: 1e490b98005664d149b379a9529a6aa05932b8a11b76b4cd86f3d22d76346f47
+  proto_prefix: third_party/protoc-gen-validate/
+  strip_prefix: protoc-gen-validate-4694024279bdac52b77e22dc87808bd0fd732b69
+  urls:
+  - https://github.com/envoyproxy/protoc-gen-validate/archive/4694024279bdac52b77e22dc87808bd0fd732b69.tar.gz
 - destination: third_party/xds
   hash: 5bc8365613fe2f8ce6cc33959b7667b13b7fe56cb9d16ba740c06e1a7c4242fc
   proto_prefix: third_party/xds/

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -92,6 +92,9 @@ EXTERNAL_PROTO_LIBRARIES = {
     'opencensus_proto':
         ExternalProtoLibrary(destination='third_party/opencensus-proto/src',
                              proto_prefix='third_party/opencensus-proto/src/'),
+    'com_envoyproxy_protoc_gen_validate':
+        ExternalProtoLibrary(destination='third_party/protoc-gen-validate',
+                             proto_prefix='third_party/protoc-gen-validate/'),
 }
 
 


### PR DESCRIPTION
Originated from https://github.com/grpc/grpc/pull/29474, part of https://github.com/grpc/grpc/pull/25272.

Certain xDS Protos depends on `validate/validate.proto`, which I missed in my previous attempt. This PR makes protoc-gen-validate library back, so its proto file will be available to CMake. (It's always available for our Bazel build.)

Why not adding the `protoc-gen-validate` as a submodule (reverting part of https://github.com/grpc/grpc/pull/29219)? Our infra/build code does not require this dependency library to be a submodule. CMake and Bazel can incur this dependency now in build-time. We don't want to make every single dependency our submodule.