### PR TITLE
[xDS Proto] Remove Python's usage of copied proto files

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -17,3 +17,4 @@ googleapis-common-protos==1.5.5
 gevent==21.1.2
 zope.event==4.5.0
 setuptools==44.1.1
+xds-protos==0.0.11

--- a/src/python/grpcio_csds/grpc_csds/BUILD.bazel
+++ b/src/python/grpcio_csds/grpc_csds/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
@@ -19,11 +21,7 @@ py_library(
     srcs = glob(["*.py"]),
     imports = ["../"],
     deps = [
-        "//src/proto/grpc/testing/xds/v3:base_py_pb2",
-        "//src/proto/grpc/testing/xds/v3:config_dump_py_pb2",
-        "//src/proto/grpc/testing/xds/v3:csds_py_pb2",
-        "//src/proto/grpc/testing/xds/v3:csds_py_pb2_grpc",
-        "//src/proto/grpc/testing/xds/v3:percent_py_pb2",
+        requirement("xds-protos"),
         "//src/python/grpcio/grpc:grpcio",
     ],
 )

--- a/src/python/grpcio_csds/grpc_csds/__init__.py
+++ b/src/python/grpcio_csds/grpc_csds/__init__.py
@@ -13,15 +13,10 @@
 # limitations under the License.
 """Channelz debug service implementation in gRPC Python."""
 
+from envoy.service.status.v3 import csds_pb2
+from envoy.service.status.v3 import csds_pb2_grpc
 from google.protobuf import json_format
 from grpc._cython import cygrpc
-
-try:
-    from envoy.service.status.v3 import csds_pb2
-    from envoy.service.status.v3 import csds_pb2_grpc
-except ImportError:
-    from src.proto.grpc.testing.xds.v3 import csds_pb2
-    from src.proto.grpc.testing.xds.v3 import csds_pb2_grpc
 
 
 class ClientStatusDiscoveryServiceServicer(
@@ -49,7 +44,7 @@ def add_csds_servicer(server):
     CSDS is part of xDS protocol used to expose in-effective traffic
     configuration (or xDS resources). It focuses on simplify the debugging of
     unexpected routing behaviors, which could be due to a misconfiguration,
-    unhealthy backends or issues in the control or data plane. 
+    unhealthy backends or issues in the control or data plane.
 
     Args:
         server: A gRPC server to which the CSDS service will be added.

--- a/src/python/grpcio_tests/tests/csds/test_csds.py
+++ b/src/python/grpcio_tests/tests/csds/test_csds.py
@@ -20,17 +20,12 @@ import sys
 import time
 import unittest
 
+from envoy.service.status.v3 import csds_pb2
+from envoy.service.status.v3 import csds_pb2_grpc
 from google.protobuf import json_format
 import grpc
 import grpc_csds
 from six.moves import queue
-
-try:
-    from envoy.service.status.v3 import csds_pb2
-    from envoy.service.status.v3 import csds_pb2_grpc
-except ImportError:
-    from src.proto.grpc.testing.xds.v3 import csds_pb2
-    from src.proto.grpc.testing.xds.v3 import csds_pb2_grpc
 
 _DUMMY_XDS_ADDRESS = 'xds:///foo.bar'
 _DUMMY_BOOTSTRAP_FILE = """


### PR DESCRIPTION
Originated from https://github.com/grpc/grpc/pull/29474, part of https://github.com/grpc/grpc/pull/25272.

This PR removes our Bazel usage of our copied xDS protos during testing.