### PR TITLE
[build] Remove str_format.h from server_address.h

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2845,6 +2845,7 @@ grpc_cc_library(
         "absl/hash",
         "absl/memory",
         "absl/strings",
+        "absl/strings:str_format",
         "upb_lib",
     ],
     language = "c++",

--- a/src/core/ext/filters/client_channel/lb_policy/rls/rls.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/rls/rls.cc
@@ -38,6 +38,7 @@
 #include "absl/hash/hash.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"

--- a/src/core/lib/resolver/server_address.cc
+++ b/src/core/lib/resolver/server_address.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
@@ -80,6 +81,7 @@ ServerAddress::ServerAddress(ServerAddress&& other) noexcept
       attributes_(std::move(other.attributes_)) {
   other.args_ = nullptr;
 }
+
 ServerAddress& ServerAddress::operator=(ServerAddress&& other) noexcept {
   address_ = other.address_;
   grpc_channel_args_destroy(args_);
@@ -165,6 +167,10 @@ std::string ServerAddress::ToString() const {
         absl::StrCat("attributes={", absl::StrJoin(attrs, ", "), "}"));
   }
   return absl::StrJoin(parts, " ");
+}
+
+std::string ServerAddressWeightAttribute::ToString() const {
+  return absl::StrFormat("%d", weight_);
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/resolver/server_address.h
+++ b/src/core/lib/resolver/server_address.h
@@ -25,7 +25,6 @@
 #include <memory>
 
 #include "absl/container/inlined_vector.h"
-#include "absl/strings/str_format.h"
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/useful.h"
@@ -134,9 +133,7 @@ class ServerAddressWeightAttribute : public ServerAddress::AttributeInterface {
     return QsortCompare(weight_, other_locality_attr->weight_);
   }
 
-  std::string ToString() const override {
-    return absl::StrFormat("%d", weight_);
-  }
+  std::string ToString() const override;
 
  private:
   uint32_t weight_;

--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -23,6 +23,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>

--- a/test/core/http/httpscli_test.cc
+++ b/test/core/http/httpscli_test.cc
@@ -21,6 +21,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/strings/str_format.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>


### PR DESCRIPTION
This file gets included by resolver, which gets included by
core_configuration, which in turn sprays this inclusion everywhere (and
it's a costly file to parse)




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@donnadionne
