### PR TITLE
Rename LookupTaskHandle internal variable

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -259,7 +259,7 @@ class EventEngine {
    public:
     /// Task handle for DNS Resolution requests.
     struct LookupTaskHandle {
-      intptr_t key[2];
+      intptr_t keys[2];
     };
     /// Optional configuration for DNSResolvers.
     struct ResolverOptions {


### PR DESCRIPTION
All handle types are now the same internally, which makes generic code a
bit easier to write.

Requires a cherrypick.