### PR TITLE
[Backport] Revert "Enable authz_test for C++ and Python (#29147)"

### DIFF
--- a/tools/internal_ci/linux/psm-security-python.sh
+++ b/tools/internal_ci/linux/psm-security-python.sh
@@ -174,7 +174,6 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
-  run_test authz_test
 }
 
 main "$@"

--- a/tools/internal_ci/linux/psm-security.sh
+++ b/tools/internal_ci/linux/psm-security.sh
@@ -158,7 +158,6 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   run_test baseline_test
   run_test security_test
-  run_test authz_test
 }
 
 main "$@"


### PR DESCRIPTION
This reverts commit 02bddf201772554cbd588cdaa4e4c12ba1d3e645 from #29147.

Related b/229112753 and https://github.com/grpc/grpc/pull/29428. In https://github.com/grpc/grpc/pull/29428, people suggested to disable Authz on v1.46.x, so here is the code change.
