### PR TITLE
Fix internal test timeouts

### DIFF
--- a/test/core/debug/BUILD
+++ b/test/core/debug/BUILD
@@ -20,6 +20,7 @@ licenses(["notice"])
 
 grpc_cc_test(
     name = "stats_test",
+    timeout = "long",
     srcs = ["stats_test.cc"],
     external_deps = [
         "gtest",


### PR DESCRIPTION
This has timed out 3% of the time in the last week. Automatically
identified, ported manually.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
