### PR TITLE
Remove invalid validation for listener

### DIFF
--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -976,10 +976,8 @@ grpc_error_handle LdsResourceParse(
       envoy_config_listener_v3_Listener_api_listener(listener);
   const envoy_config_core_v3_Address* address =
       envoy_config_listener_v3_Listener_address(listener);
-  if (api_listener != nullptr && address != nullptr) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Listener has both address and ApiListener");
-  }
+  // Current envoy proto has address as required, validators will reject if
+  // missing.
   if (api_listener == nullptr && address == nullptr) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Listener has neither address nor ApiListener");


### PR DESCRIPTION
Current envoy proto has the 'address' field marked as required - and the auto-generated proto validators used in Istio will reject listeners without that field.

IMO the field should not be required - but oneof - but I suspect such a change will be difficult to make in the current proto.  

@markdroth
