### PR TITLE
xds-k8s: Fix incorrect type hint in the baseline test

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
@@ -44,16 +44,14 @@ class BaselineTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         with self.subTest('4_create_forwarding_rule'):
             self.td.create_forwarding_rule(self.server_xds_port)
 
-        test_servers: _XdsTestServer
         with self.subTest('5_start_test_server'):
-            test_servers = self.startTestServers()
+            test_server: _XdsTestServer = self.startTestServers()[0]
 
         with self.subTest('6_add_server_backends_to_backend_service'):
             self.setupServerBackends()
 
-        test_client: _XdsTestClient
         with self.subTest('7_start_test_client'):
-            test_client = self.startTestClient(test_servers[0])
+            test_client: _XdsTestClient = self.startTestClient(test_server)
 
         with self.subTest('8_test_client_xds_config_exists'):
             self.assertXdsConfigExists(test_client)


### PR DESCRIPTION
Minor fix: noticed test_servers should've been a `List[_XdsTestServer]`, but instead of fixing the type I renamed the variable from `test_servers` to `test_server` instead, and grabbed the first element.
