### PR TITLE
Fix #24421: UnobservedTaskException when server Unavailable (C# on v1.46.x branch)

### DIFF
--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -648,14 +648,20 @@ namespace Grpc.Core.Internal
             if (status.StatusCode != StatusCode.OK)
             {
                 streamingResponseCallFinishedTcs.SetException(new RpcException(status, receivedStatus.Trailers));
-                if (status.StatusCode == StatusCode.Cancelled || origCancelRequested)
-                {
-                    // Make sure the exception set to the Task is observed,
-                    // otherwise this can trigger "Unobserved exception" when the response stream
-                    // is not read until its end and the task created by the TCS is garbage collected.
-                    // See https://github.com/grpc/grpc/issues/17458
-                    var _ = streamingResponseCallFinishedTcs.Task.Exception;
-                }
+                // Make sure the exception set to the Task is observed,
+                // otherwise this can trigger "Unobserved exception" when the response stream
+                // is not read until its end (by invoking MoveNext() until the point where it either returns false or throws an exception)
+                // and the task created by the TCS is garbage collected.
+                // Note that the streamingResponseCallFinishedTcs.Task itself is never exposed to the user
+                // and its result only ever "observed" by MoveNext() implementation:
+                // https://github.com/grpc/grpc/blob/1cd6e69347cbf62a012477fe184ee6fa8f25d32c/src/csharp/Grpc.Core/Internal/ClientResponseStream.cs#L59.
+                // Even though generally the response stream should always be read until the end (since that's how you get streaming call's responses and status code)
+                // there are cases where this shouldn't be strictly required and thus the user
+                // shouldn't need to worry about observing result of an internal task that's
+                // only exposed to them indirectly.
+                // See https://github.com/grpc/grpc/issues/17458
+                // See https://github.com/grpc/grpc/issues/24421
+                var _ = streamingResponseCallFinishedTcs.Task.Exception;
                 return;
             }
 


### PR DESCRIPTION
Fixes #24421

Similar to https://github.com/grpc/grpc/pull/29419 (test code is taken from there) but with a few differences:
- target the v1.46.x branch (which is Grpc.Core now lives)
- always observe the streamingResponseCallFinishedTcs error (and provide explanation why that makes sense)
- cleanup the test proposed in https://github.com/grpc/grpc/pull/29419
