### PR TITLE
GCC 6 & Clang 6

### DIFF
--- a/templates/tools/dockerfile/test/cxx_clang_6_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_clang_6_x64/Dockerfile.template
@@ -14,12 +14,14 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM gcc:5
+  FROM silkeh/clang:6
   
-  RUN apt-get update && apt-get install -y curl git time wget zip && apt-get clean
+  RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
   <%include file="../../run_tests_python_deps.include"/>
-  <%include file="../../cmake_jessie_backports.include"/>
+  <%include file="../../cxx_deps.include"/>
+  <%include file="../../cmake.include"/>
+  <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
-
+  
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_gcc_6_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_gcc_6_x64/Dockerfile.template
@@ -14,14 +14,12 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:4
+  FROM gcc:6
   
-  RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
+  RUN apt-get update && apt-get install -y curl git time wget zip && apt-get clean
   <%include file="../../run_tests_python_deps.include"/>
-  <%include file="../../cxx_deps.include"/>
-  <%include file="../../cmake.include"/>
-  <%include file="../../ccache.include"/>
+  <%include file="../../cmake_jessie_backports.include"/>
   <%include file="../../run_tests_addons.include"/>
-  
+
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/cxx_clang_6_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_clang_6_x64/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcc:5
+FROM silkeh/clang:6
 
-RUN apt-get update && apt-get install -y curl git time wget zip && apt-get clean
+RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
 #====================
 # run_tests.py python dependencies
 
@@ -41,13 +41,28 @@ RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-clien
 
 
 #=================
-# Use cmake 3.6 from jessie-backports
-# should only be used for images based on debian jessie.
+# C++ dependencies
+RUN apt-get update && apt-get -y install libc++-dev clang && apt-get clean
 
-RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
-RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz
 
 
 RUN mkdir /var/local/jenkins

--- a/tools/dockerfile/test/cxx_gcc_6_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_6_x64/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:4
+FROM gcc:6
 
-RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
+RUN apt-get update && apt-get install -y curl git time wget zip && apt-get clean
 #====================
 # run_tests.py python dependencies
 
@@ -41,28 +41,13 @@ RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-clien
 
 
 #=================
-# C++ dependencies
-RUN apt-get update && apt-get -y install libc++-dev clang && apt-get clean
+# Use cmake 3.6 from jessie-backports
+# should only be used for images based on debian jessie.
 
-#=================
-# Install cmake
-# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
-
-RUN apt-get update && apt-get install -y cmake && apt-get clean
-
-#=================
-# Install ccache
-
-# Install ccache from source since ccache 3.x packaged with most linux distributions
-# does not support Redis backend for caching.
-RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
-    && tar -zxf ccache.tar.gz \
-    && cd ccache-4.5.1 \
-    && mkdir build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
-    && make -j4 && make install \
-    && cd ../.. \
-    && rm -rf ccache-4.5.1 ccache.tar.gz
+RUN echo "deb http://archive.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
 
 
 RUN mkdir /var/local/jenkins

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -484,8 +484,8 @@ class CLanguage(object):
 
         if compiler == 'default' or compiler == 'cmake':
             return ('debian11', [])
-        elif compiler == 'gcc5':
-            return ('gcc_5', [])
+        elif compiler == 'gcc6':
+            return ('gcc_6', [])
         elif compiler == 'gcc10.2':
             return ('debian11', [])
         elif compiler == 'gcc10.2_openssl102':
@@ -496,8 +496,8 @@ class CLanguage(object):
             return ('gcc_11', [])
         elif compiler == 'gcc_musl':
             return ('alpine', [])
-        elif compiler == 'clang4':
-            return ('clang_4', self._clang_cmake_configure_extra_args())
+        elif compiler == 'clang6':
+            return ('clang_6', self._clang_cmake_configure_extra_args())
         elif compiler == 'clang13':
             return ('clang_13', self._clang_cmake_configure_extra_args())
         else:
@@ -1551,12 +1551,12 @@ argp.add_argument(
     '--compiler',
     choices=[
         'default',
-        'gcc5',
+        'gcc6',
         'gcc10.2',
         'gcc10.2_openssl102',
         'gcc11',
         'gcc_musl',
-        'clang4',
+        'clang6',
         'clang13',
         'python2.7',
         'python3.5',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -300,7 +300,7 @@ def _create_portability_test_jobs(extra_args=[],
 
     # portability C and C++ on x64
     for compiler in [
-            'gcc5', 'gcc10.2_openssl102', 'gcc11', 'gcc_musl', 'clang4',
+            'gcc6', 'gcc10.2_openssl102', 'gcc11', 'gcc_musl', 'clang6',
             'clang13'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],


### PR DESCRIPTION
Per shared C++ foundation support policy, changing the minimum version of gcc and clang for test
- GCC 5 -> 6
- Clang 4 -> 6

Upgrade to gcc 6 particularly is now required because gcc 5 throws an internal compiler error ([log](https://source.cloud.google.com/results/invocations/dc124581-f597-4e53-9d89-dfdfe07f8e1f/targets/github%2Fgrpc%2Ftoplevel_run_tests_invocations%2Frun_tests_c%2B%2B_linux_dbg_native_x64_gcc5_buildonly/tests))

```
[ 36%] Building CXX object CMakeFiles/grpc.dir/src/core/lib/slice/percent_encoding.cc.o
/var/local/git/grpc/src/core/lib/slice/percent_encoding.cc:57:41:   in constexpr expansion of '((grpc_core::{anonymous}::UrlTable*)(& grpc_core::{anonymous}::g_url_table))->grpc_core::{anonymous}::UrlTable::UrlTable()'
/var/local/git/grpc/src/core/lib/slice/percent_encoding.cc:47:41:   in constexpr expansion of '((grpc_core::{anonymous}::UrlTable*)this)->grpc_core::{anonymous}::UrlTable::<anonymous>.grpc_core::BitSet<kTotalBits, kUnitBits>::set<256ul, 64ul>(i)'
/var/local/git/grpc/src/core/lib/slice/percent_encoding.cc:57:41: internal compiler error: in fold_binary_loc, at fold-const.c:9925
 GRPC_PCTENCODE_CONSTEXPR_VALUE UrlTable g_url_table;
                                         ^
```