### PR TITLE
Downgrade io_bazel_rules_go to v0.27.0 restore Bazel 3.x support

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -366,10 +366,10 @@ def grpc_deps():
     if "io_bazel_rules_go" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+            sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
             ],
         )
 


### PR DESCRIPTION
Tested builds:

* Bazel 4.2.2 on macOS with v0.27.0 (OK)
* Bazel 4.0.0 on Linux with v0.27.0 (Minimum Bazel 3.0.0) (OK)
* Bazel 4.0.0 on Linux with v0.28.0 (Minimum Bazel 4.0.0) (OK)
* Bazel 4.0.0 on Linux with v0.29.0 (Minimum Bazel 4.2.1) (FAIL)

As @veblush pointed out, we still want to support Bazel 3.x declared in https://github.com/grpc/grpc/blob/master/bazel/supported_versions.txt. So, the best version of `io_bazel_rules_go` to downgrade to at this point is `v0.27.0`.

In future, when we deprecate Bazel 3.x, we should be free to upgrade the Bazel go rules again.

Related https://github.com/grpc/grpc/pull/29593.