### PR TITLE
Add a job for ObjC bazel tests

### DIFF
--- a/tools/internal_ci/macos/grpc_objc_bazel_test.cfg
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.cfg
@@ -1,0 +1,47 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_objc_bazel_test.sh"
+timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}
+
+env_vars {
+  # flags will be passed to bazel invocation
+  key: "BAZEL_FLAGS"
+  value: "--cache_test_results=no"
+}
+
+env_vars {
+  key: "UPLOAD_TEST_RESULTS"
+  value: "true"
+}

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# avoid slow finalization after the script has exited.
+source $(dirname $0)/../../../tools/internal_ci/helper_scripts/move_src_tree_and_respawn_itself_rc
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_macos_rc
+
+# make sure bazel is available
+tools/bazel version
+
+# for kokoro mac workers, exact image version is store in a well-known location on disk
+KOKORO_IMAGE_VERSION="$(cat /VERSION)"
+
+BAZEL_REMOTE_CACHE_ARGS=(
+  # Enable uploading to remote cache. Requires the "roles/remotebuildexecution.actionCacheWriter" permission.
+  --remote_upload_local_results=true
+  # allow invalidating the old cache by setting to a new random key
+  --remote_default_exec_properties="grpc_cache_silo_key1=83d8e488-1ca9-40fd-929e-d37d13529c99"
+  # make sure we only get cache hits from binaries built on exact same macos image
+  --remote_default_exec_properties="grpc_cache_silo_key2=${KOKORO_IMAGE_VERSION}"
+)
+
+EXAMPLE_TARGETS=(
+  # TODO(jtattermusch): ideally we'd say "//src/objective-c/examples/..." but not all the targets currently build
+  //src/objective-c/examples:Sample
+  //src/objective-c/examples:tvOS-sample
+)
+
+TEST_TARGETS=(
+  # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
+  # TODO(jtattermusch): make //src/objective-c/tests:TvTests build reliably
+  # TODO(jtattermusch): make //src/objective-c/tests:MacTests build reliably
+  //src/objective-c/tests:UnitTests
+)
+
+# === BEGIN SECTION: run interop_server on the background ====
+# Before testing objC at all, build the interop server since many of the ObjC test rely on it.
+# Use remote cache to build the interop_server binary as quickly as possible (interop_server
+# is not what we want to test actually, we just use it as a backend for ObjC test).
+# TODO(jtattermusch): can we make ObjC test not depend on running a local interop_server?
+python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path build_interop_server
+build_interop_server/bazel_wrapper \
+  --bazelrc=tools/remote_build/mac.bazelrc \
+  build \
+  --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
+  "${BAZEL_REMOTE_CACHE_ARGS[@]}" \
+  -- \
+  //test/cpp/interop:interop_server
+
+INTEROP_SERVER_BINARY=bazel-bin/test/cpp/interop/interop_server
+# run the interop server on the background. The port numbers must match TestConfigs in BUILD.
+# TODO(jtattermusch): can we make the ports configurable (but avoid breaking bazel build cache at the same time?)
+"${INTEROP_SERVER_BINARY}" --port=5050 --max_send_message_size=8388608 &
+"${INTEROP_SERVER_BINARY}" --port=5051 --max_send_message_size=8388608 --use_tls &
+# make sure the interop_server processes we started on the background are killed upon exit.
+trap 'echo "KILLING interop_server binaries running on the background"; kill -9 $(jobs -p)' EXIT
+# === END SECTION: run interop_server on the background ====
+
+# TODO(jtattermusch): set GRPC_VERBOSITY=debug when running tests on a simulator (how to do that?)
+
+python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path objc_bazel_tests
+
+objc_bazel_tests/bazel_wrapper \
+  --bazelrc=tools/remote_build/include/test_locally_with_resultstore_results.bazelrc \
+  test \
+  --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
+  $BAZEL_FLAGS \
+  -- \
+  "${EXAMPLE_TARGETS[@]}" \
+  "${TEST_TARGETS[@]}"

--- a/tools/internal_ci/macos/pull_request/grpc_objc_bazel_test.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_objc_bazel_test.cfg
@@ -1,0 +1,36 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_objc_bazel_test.sh"
+timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}


### PR DESCRIPTION
Progress on https://github.com/grpc/grpc-ios/issues/74 and related issues.

Create a test job that runs bazel test for targets under `//src/objective-c/` that currently seem to be buildable.

- having a working bazel test for stuff under //src/objective-c is a good starting point for more bazelification of objC
- it makes sure that at least some objC stuff is buildable and runnable under bazel
- it makes sense to build more targets in a single job, since bazel will only build everything that's needed once and there's a significant overlap
- since running objC tests requires having an interop_server to be running locally, the script first builds interop_server locally (and uses remote cache to speed that up) and then runs it on background

Future work (ideally not done by me, others can pick it up from here)
- run more targets with bazel (lots of objC test tasks from run_tests.py https://github.com/grpc/grpc/blob/1d94aa92d883c40abe8b064d79e682f27b432cd3/tools/run_tests/run_tests.py#L984-L1122 currently lack corresponding bazel targets). Once bazel targets are added/fixed (see TODOs), they can be added under this test job).
- make it easier to run tests locally with bazel as well
          - currently staring the interop server locally is a pain and requires a lot of boilerplate
          - currently running locally is a pain with bazel 4.2.1 since it has a bug in python3 support (bazel 5.1.1 works just fine) and installing python2 locally is a pain recent version of OS X (which is what our laptops have). At the same time we don't want to update the bazel version throughout our repository just because of this. For context on the bug (see https://github.com/google/mediapipe/issues/3184 and bazel fix https://github.com/bazelbuild/bazel/commit/2945ef5072f659878dfd88b421c7b80aa4fb6c80)
- remove some test tasks from run_tests.py once we have enough coverage for them in bazel.

