### PR TITLE
Cleanup config for existing macos kokoro jobs that run bazel

### DIFF
--- a/tools/internal_ci/macos/grpc_bazel_c_cpp_dbg.cfg
+++ b/tools/internal_ci/macos/grpc_bazel_c_cpp_dbg.cfg
@@ -17,6 +17,12 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
 timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/macos/grpc_bazel_c_cpp_opt.cfg
+++ b/tools/internal_ci/macos/grpc_bazel_c_cpp_opt.cfg
@@ -17,6 +17,12 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
 timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/macos/grpc_bazel_cpp_ios_tests.cfg
+++ b/tools/internal_ci/macos/grpc_bazel_cpp_ios_tests.cfg
@@ -16,6 +16,13 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_cpp_ios_tests.sh"
+timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_dbg.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_dbg.cfg
@@ -17,6 +17,12 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
 timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"

--- a/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_opt.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_opt.cfg
@@ -17,6 +17,12 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
 timeout_mins: 90
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
 
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"


### PR DESCRIPTION
To unify the config and to make sure that the sponge_log.xml reports get displayed.