### PR TITLE
Added cmake abseil include guard

### DIFF
--- a/cmake/abseil-cpp.cmake
+++ b/cmake/abseil-cpp.cmake
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(gRPC_ABSL_PROVIDER STREQUAL "module")
+if(TARGET absl::strings)
+  # If absl is included already, skip including it.
+  # (https://github.com/grpc/grpc/issues/29608)
+elseif(gRPC_ABSL_PROVIDER STREQUAL "module")
   if(NOT ABSL_ROOT_DIR)
     set(ABSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/abseil-cpp)
   endif()


### PR DESCRIPTION
To fix the current protobuf-head fix which is caused by including abseil cmake file twice, inclusion guard is added to make sure that abseil cmake is included once throughout the cmake build. #29608 is open to discuss a better approach on this but this should be good enough as a short-term solution to fix this error.

The same change is just filed on the protobuf side. https://github.com/protocolbuffers/protobuf/pull/9928