### PR TITLE
[init] Remove channelz from grpc_init path

### DIFF
--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -40,20 +40,13 @@ namespace grpc_core {
 namespace channelz {
 namespace {
 
-// singleton instance of the registry.
-ChannelzRegistry* g_channelz_registry = nullptr;
-
 const int kPaginationLimit = 100;
 
 }  // anonymous namespace
 
-void ChannelzRegistry::Init() { g_channelz_registry = new ChannelzRegistry(); }
-
-void ChannelzRegistry::Shutdown() { delete g_channelz_registry; }
-
 ChannelzRegistry* ChannelzRegistry::Default() {
-  GPR_DEBUG_ASSERT(g_channelz_registry != nullptr);
-  return g_channelz_registry;
+  static ChannelzRegistry* singleton = new ChannelzRegistry();
+  return singleton;
 }
 
 void ChannelzRegistry::InternalRegister(BaseNode* node) {

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/channel/channelz_registry.h"
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstring>

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -20,8 +20,6 @@
 
 #include "src/core/lib/channel/channelz_registry.h"
 
-#include <stdint.h>
-
 #include <algorithm>
 #include <cstdint>
 #include <cstring>

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -37,12 +37,6 @@ namespace channelz {
 // channelz bookkeeping. All objects share globally distributed uuids.
 class ChannelzRegistry {
  public:
-  // To be called in grpc_init()
-  static void Init();
-
-  // To be called in grpc_shutdown();
-  static void Shutdown();
-
   static void Register(BaseNode* node) {
     return Default()->InternalRegister(node);
   }
@@ -66,6 +60,14 @@ class ChannelzRegistry {
   // Test only helper function to dump the JSON representation to std out.
   // This can aid in debugging channelz code.
   static void LogAllEntities() { Default()->InternalLogAllEntities(); }
+
+  // Test only helper function to reset to initial state.
+  static void TestOnlyReset() {
+    auto* p = Default();
+    MutexLock lock(&p->mu_);
+    p->node_map_.clear();
+    p->uuid_generator_ = 0;
+  }
 
  private:
   // Returned the singleton instance of ChannelzRegistry;

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -21,8 +21,7 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -32,7 +32,6 @@
 
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/channel_stack_builder.h"
-#include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/channel/connected_channel.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/debug/stats.h"
@@ -164,7 +163,6 @@ void grpc_init(void) {
     grpc_core::Fork::GlobalInit();
     grpc_fork_handlers_auto_register();
     grpc_stats_init();
-    grpc_core::channelz::ChannelzRegistry::Init();
     grpc_core::ApplicationCallbackExecCtx::GlobalInit();
     grpc_iomgr_init();
     gpr_timers_global_init();
@@ -197,7 +195,6 @@ void grpc_shutdown_internal_locked(void)
     grpc_iomgr_shutdown();
     gpr_timers_global_destroy();
     grpc_tracer_shutdown();
-    grpc_core::channelz::ChannelzRegistry::Shutdown();
     grpc_stats_shutdown();
     grpc_core::Fork::GlobalShutdown();
   }

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -44,9 +44,7 @@ namespace testing {
 class ChannelzRegistryTest : public ::testing::Test {
  protected:
   // ensure we always have a fresh registry for tests.
-  void SetUp() override { ChannelzRegistry::Init(); }
-
-  void TearDown() override { ChannelzRegistry::Shutdown(); }
+  void SetUp() override { ChannelzRegistry::TestOnlyReset(); }
 };
 
 static RefCountedPtr<BaseNode> CreateTestNode() {

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -328,15 +328,9 @@ TEST_P(ChannelzChannelTest, LastCallStartedTime) {
 class ChannelzRegistryBasedTest : public ::testing::TestWithParam<size_t> {
  protected:
   // ensure we always have a fresh registry for tests.
-  void SetUp() override {
-    ChannelzRegistry::Shutdown();
-    ChannelzRegistry::Init();
-  }
+  void SetUp() override { ChannelzRegistry::TestOnlyReset(); }
 
-  void TearDown() override {
-    ChannelzRegistry::Shutdown();
-    ChannelzRegistry::Init();
-  }
+  void TearDown() override { ChannelzRegistry::TestOnlyReset(); }
 };
 
 TEST_F(ChannelzRegistryBasedTest, BasicGetTopChannelsTest) {


### PR DESCRIPTION
Should fix b/231887614 and furthers our work to eliminate grpc_init.
<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@markdroth
