### PR TITLE
remove duplicate ./reports/ mount for xds tests

### DIFF
--- a/tools/internal_ci/linux/grpc_xds.sh
+++ b/tools/internal_ci/linux/grpc_xds.sh
@@ -22,5 +22,4 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 export DOCKERFILE_DIR=tools/dockerfile/test/bazel
 export DOCKER_RUN_SCRIPT=$BAZEL_SCRIPT
-export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_xds_php.sh
+++ b/tools/internal_ci/linux/grpc_xds_php.sh
@@ -22,5 +22,4 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 export DOCKERFILE_DIR=tools/dockerfile/test/php73_zts_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
-export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_xds_ruby.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby.sh
@@ -22,5 +22,4 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 export DOCKERFILE_DIR=tools/dockerfile/test/ruby_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
-export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_xds_v3_php.sh
+++ b/tools/internal_ci/linux/grpc_xds_v3_php.sh
@@ -22,5 +22,4 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 export DOCKERFILE_DIR=tools/dockerfile/test/php73_zts_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_v3_php_test_in_docker.sh
-export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_xds_v3_ruby.sh
+++ b/tools/internal_ci/linux/grpc_xds_v3_ruby.sh
@@ -22,5 +22,4 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 export DOCKERFILE_DIR=tools/dockerfile/test/ruby_debian11_x64
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_xds_v3_ruby_test_in_docker.sh
-export OUTPUT_DIR=reports
 exec tools/run_tests/dockerize/build_and_run_docker.sh


### PR DESCRIPTION
Tentative fix for b/231142315

Combination of https://github.com/grpc/grpc/pull/29468 and https://github.com/grpc/grpc/pull/22444/commits/d22e89f7fc4ae5d530f9b23e44df17687615c4da has broken the XDS tests.

Even though `export OUTPUT_DIR=reports` was originally introduced to enable uploading for files under reports/ to GCS (and to diplay the sponge_log.xml logs in test UI), it seems that this option is currently unused in all the XDS tests impacted (I checked the test results before the breakage and there seems to be no sponge_log.xml files being uploaded even before). Besides that, setting OUTPUT_DIR=reports seems strictly speaking both unnecessary and incorrect
- https://github.com/grpc/grpc/pull/29468 introduces better mechanisms for obtaining the sponge_log.xml files from inside the docker container
- the "OUTPUT_DIR" technique in the build_and_run_docker.sh script was actually intended for uploading artifacts, not reports (reports are handled automatically).

I think we should really think of having some XDS some tests running on PRs as a smoke test (e.g. run a single noop test inside the XDS test setup), since currently it's way too easy to break them.