### PR TITLE
Upload results from bazel C/C++ ARM64 tests to bigquery

### DIFF
--- a/tools/internal_ci/linux/arm64/grpc_bazel.sh
+++ b/tools/internal_ci/linux/arm64/grpc_bazel.sh
@@ -22,6 +22,7 @@ source $(dirname $0)/../../../../tools/internal_ci/helper_scripts/move_src_tree_
 cd $(dirname $0)/../../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
-
 export DOCKERFILE_DIR=tools/dockerfile/test/bazel_arm64
+# propagate the UPLOAD_TEST_RESULTS env variable to the docker container
+export EXTRA_DOCKER_ARGS="-e=UPLOAD_TEST_RESULTS"
 exec tools/run_tests/dockerize/build_and_run_docker.sh "${BAZEL_SCRIPT}"

--- a/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
@@ -28,3 +28,8 @@ env_vars {
   key: "BAZEL_SCRIPT"
   value: "tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp_in_docker.sh"
 }
+
+env_vars {
+  key: "UPLOAD_TEST_RESULTS"
+  value: "true"
+}

--- a/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
@@ -24,6 +24,16 @@ action {
   }
 }
 
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}
+
 env_vars {
   key: "BAZEL_SCRIPT"
   value: "tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp_in_docker.sh"

--- a/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
@@ -24,6 +24,7 @@ action {
   }
 }
 
+# necessary for the upload_rbe_results.py to be able to fetch the test results that will be upload to bigquery.
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
 
 bazel_setting {


### PR DESCRIPTION
as title.

Access to historical data is invaluable for deflaking/flakiness tracking.