### PR TITLE
Make objC InteropTests and MacTests buildable with bazel

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -101,6 +101,7 @@ grpc_objc_testing_library(
     hdrs = ["InteropTests/InteropTests.h"],
     deps = [
         ":InteropTestsBlockCallbacks-lib",
+        ":TestBase-lib",
     ],
 )
 
@@ -175,6 +176,15 @@ grpc_objc_testing_library(
         "MacTests/*.m",
     ]),
     hdrs = ["MacTests/StressTests.h"],
+    deps = [
+        ":TestBase-lib",
+    ],
+)
+
+grpc_objc_testing_library(
+    name = "TestBase-lib",
+    srcs = ["TestBase.m"],
+    hdrs = ["TestBase.h"],
 )
 
 ios_unit_test(


### PR DESCRIPTION
Without this, building :InteropTest or :MacTests with bazel fails with missing `TestBase.h`.

