### PR TITLE
Add xDS interop test specification for outlier detection

### DIFF
--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -745,3 +745,36 @@ the forwarding rule port `80` and the URL map host rule `myservice`.
 1. No traffic goes to backends when configuring the target URI
 `xds:///myservice`, the forwarding rule port `80` and the host rule 
 `myservice::80`.
+
+### outlier_detection
+This test verifies that the client applies the outlier detection configuration
+and temporarily drops traffic to a server that fails requests.
+
+Client parameters:
+
+1.  --num_channels=1
+2.  --qps=100
+
+Load balancer configuration:
+
+1.  One MIG with five backends, with a `backendService` configuration with the
+    following `outlierDetection` entry
+    ```json
+    {
+      "interval": {
+        "seconds": 2,
+        "nanos": 0
+      },
+      "successRateRequestVolume": 20
+    }
+    ```
+Assert:
+
+1.  The test driver chooses one of the five backends to fail requests, and
+configures the client to send the metadata
+`hostname=<chosen backend> error-code-2`. The driver asserts that during some
+10-second interval, all traffic goes to the other four backends and all
+requests end with the `OK` status.
+2.  The test driver removes the client configuration to send metadata. The
+driver asserts that during some 10-second interval, all 5 backends receive
+traffic and all requests end with the `OK` status.

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -770,11 +770,13 @@ Load balancer configuration:
     ```
 Assert:
 
-1.  The test driver chooses one of the five backends to fail requests, and
+1.  The test driver asserts that traffic is equally distribted among the
+five backends, and all requests end with the `OK` status.
+2.  The test driver chooses one of the five backends to fail requests, and
 configures the client to send the metadata
-`hostname=<chosen backend> error-code-2`. The driver asserts that during some
-10-second interval, all traffic goes to the other four backends and all
-requests end with the `OK` status.
-2.  The test driver removes the client configuration to send metadata. The
-driver asserts that during some 10-second interval, all 5 backends receive
-traffic and all requests end with the `OK` status.
+`rpc-behavior: hostname=<chosen backend> error-code-2`. The driver asserts
+that during some 10-second interval, all traffic goes to the other four
+backends and all requests end with the `OK` status.
+3.  The test driver removes the client configuration to send metadata. The
+driver asserts that during some 10-second interval, traffic is equally
+distributed among the five backends, and all requests end with the `OK` status.


### PR DESCRIPTION
The intersection of "outlier detection ejection conditions supported in gRPC" and "outlier detection ejection conditions configurable in TD" is just success rate, so that is the only one we will test here. The goal is to test two things: that the client properly ejects a server that is failing requests, and that it eventually unejects that server to try sending more traffic to it.

We need to have enough QPS so that within the configured `interval`, the client sends at least `successRateRequestVolume` requests to each server. We also want an `interval` short enough that ejections and unejections happen frequently compared with the time period that the driver examines. The default `baseEjectionTime` is 30 seconds, which is long enough that we should see a full 10-second window with no requests to the failing backend, and short enough that when we want to let it be unejected, it should happen quickly enough that the driver sees it before it gives up.

The error code is arbitrary. I don't think it makes a difference.