### PR TITLE
[PSM interop] Double the operation timeout - misc

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/api.py
@@ -328,7 +328,7 @@ class OperationError(Error):
 
 class GcpProjectApiResource:
     # TODO(sergiitk): move someplace better
-    _WAIT_FOR_OPERATION_SEC = 60 * 5
+    _WAIT_FOR_OPERATION_SEC = 60 * 10
     _WAIT_FIXED_SEC = 2
     _GCP_API_RETRIES = 5
 


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/29004 doubled resource timeouts for backends, but not networksecurity/networkservices resources.

Noticed that networksecurity resources are still capped to 5 minutes.

```
I0509 19:03:45.441527 140121790555968 api.py:399] Creating networksecurity resource:
---
serverValidationCa:
- certificateProviderInstance:
    pluginInstance: google_cloud_private_spiffe
...

I0509 19:08:46.400148 140121790555968 xds_k8s_testcase.py:200] ----- TestMethod __main__.SecurityTest.test_mtls_error teardown -----
```

Internal ref: b/199937345

cc @lidizheng 