### PR TITLE
[iwyu] Better sanity stability

### DIFF
--- a/tools/dockerfile/grpc_iwyu/iwyu.sh
+++ b/tools/dockerfile/grpc_iwyu/iwyu.sh
@@ -78,12 +78,4 @@ xargs -n 1 -P $CPU_COUNT -a iwyu_files.txt ${IWYU_ROOT}/iwyu/run_iwyu_on.sh
 cat iwyu/iwyu.*.out > iwyu.out
 
 # apply the suggested changes
-${IWYU_ROOT}/iwyu/fix_includes.py --nocomments --nosafe_headers < iwyu.out || true
-
-# reformat sources, since iwyu gets this wrong
-xargs -a iwyu_files.txt ${CLANG_FORMAT:-clang-format} -i
-
-# TODO(ctiller): expand this to match the clang-tidy directories:
-#  | grep -E "(^include/|^src/core/|^src/cpp/|^test/core/|^test/cpp/)"
-
-git diff --exit-code > /dev/null
+${IWYU_ROOT}/iwyu/fix_includes.py --nocomments --nosafe_headers < iwyu.out

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -31,6 +31,7 @@
 - script: tools/distrib/check_pytype.sh
 - script: tools/codegen/core/gen_grpc_tls_credentials_options.py --test
 - script: tools/distrib/clang_format_code.sh
+  cpu_cost: 1000
 - script: tools/distrib/clang_tidy_code.sh
   # ClangTidy needs to run exclusively because it uses files under the bazel output
   # directory and this will be removed by another bazel invocation.


### PR DESCRIPTION
Improve IWYU script to not try and run clang-format, since that integration was a bit wonky.
Also improve sanity to make clang-format use CPUs exclusively so that it's not racing with other sanity scripts.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
