### PR TITLE
[ObjC] run ios unit tests with bazel

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -24,12 +24,21 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_unit_test")
 load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_application", "tvos_unit_test")
+load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["LICENSE"])
+
+ios_test_runner(
+    name = "ios_test_runner_with_env",
+    test_environment = {
+        "HOST_PORT_LOCAL": "${HOST_PORT_LOCAL}",
+        "HOST_PORT_LOCALSSL": "${HOST_PORT_LOCALSSL}",
+    }
+)
 
 proto_library_objc_wrapper(
     name = "messages_proto",
@@ -200,6 +209,7 @@ ios_unit_test(
         ":NSErrorUnitTests-lib",
         ":RxLibraryUnitTests-lib",
     ],
+    runner = ":ios_test_runner_with_env",
 )
 
 ios_unit_test(

--- a/src/objective-c/tests/UnitTests/APIv2Tests.m
+++ b/src/objective-c/tests/UnitTests/APIv2Tests.m
@@ -30,8 +30,8 @@
 // in turn derived from environment variable of the same name.
 #define NSStringize_helper(x) #x
 #define NSStringize(x) @NSStringize_helper(x)
-static NSString *const kHostAddress = NSStringize(HOST_PORT_LOCAL);
-static NSString *const kRemoteSSLHost = NSStringize(HOST_PORT_REMOTE);
+static NSString *kHostAddress = NSStringize(HOST_PORT_LOCAL);
+static NSString *kRemoteSSLHost = NSStringize(HOST_PORT_REMOTE);
 
 // Package and service name of test server
 static NSString *const kPackage = @"grpc.testing";
@@ -136,6 +136,12 @@ static const NSTimeInterval kInvertedTimeout = 2;
 @end
 
 @implementation CallAPIv2Tests
+
++ (void)setUp {
+  NSDictionary* environment = [[NSProcessInfo processInfo] environment];
+  kHostAddress = environment[@"HOST_PORT_LOCAL"]?: kHostAddress;
+  kRemoteSSLHost = environment[@"HOST_PORT_REMOTE"]?: kRemoteSSLHost;
+}
 
 - (void)setUp {
   // This method isn't implemented by the remote server.

--- a/src/objective-c/tests/UnitTests/GRPCClientTests.m
+++ b/src/objective-c/tests/UnitTests/GRPCClientTests.m
@@ -41,10 +41,10 @@
 // in turn derived from environment variable of the same name.
 #define NSStringize_helper(x) #x
 #define NSStringize(x) @NSStringize_helper(x)
-static NSString *const kHostAddress = NSStringize(HOST_PORT_LOCAL);
+static NSString *kHostAddress = NSStringize(HOST_PORT_LOCAL);
 static NSString *const kPackage = @"grpc.testing";
 static NSString *const kService = @"TestService";
-static NSString *const kRemoteSSLHost = NSStringize(HOST_PORT_REMOTE);
+static NSString *kRemoteSSLHost = NSStringize(HOST_PORT_REMOTE);
 
 static GRPCProtoMethod *kInexistentMethod;
 static GRPCProtoMethod *kEmptyCallMethod;
@@ -104,6 +104,9 @@ static GRPCProtoMethod *kFullDuplexCallMethod;
 @implementation GRPCClientTests
 
 + (void)setUp {
+  NSDictionary* environment = [[NSProcessInfo processInfo] environment];
+  kHostAddress = environment[@"HOST_PORT_LOCAL"]?: kHostAddress;
+  kRemoteSSLHost = environment[@"HOST_PORT_REMOTE"]?: kRemoteSSLHost;
   NSLog(@"GRPCClientTests Started");
 }
 

--- a/src/objective-c/tests/run_one_test_bazel.sh
+++ b/src/objective-c/tests/run_one_test_bazel.sh
@@ -48,4 +48,7 @@ $INTEROP --port=$TLS_PORT --max_send_message_size=8388608 --use_tls &
 
 trap 'kill -9 `jobs -p` ; echo "EXIT TIME:  $(date)"' EXIT
 
-../../../tools/bazel run $SCHEME
+time \
+    HOST_PORT_LOCALSSL=localhost:$TLS_PORT \
+    HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
+    ../../../tools/bazel run $SCHEME

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1067,7 +1067,7 @@ class ObjCLanguage(object):
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
         # TODO: replace with run_one_test_bazel.sh when Bazel-Xcode is stable
         out.append(
-            self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
+            self.config.job_spec(['src/objective-c/tests/run_one_test_bazel.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-test-unittests',
                                  cpu_cost=1e6,


### PR DESCRIPTION
https://github.com/grpc/grpc-ios/issues/74
to run locally,
OVERRIDE_BAZEL_VERSION=5.1.1 ./tools/run_tests/run_tests.py -l objc -r ios-test-unittests

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@dennycd 