### PR TITLE
Improve ObjC bazel test and add TODOs.

### DIFF
--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -75,10 +75,12 @@ INTEROP_SERVER_BINARY=bazel-bin/test/cpp/interop/interop_server
 trap 'echo "KILLING interop_server binaries running on the background"; kill -9 $(jobs -p)' EXIT
 # === END SECTION: run interop_server on the background ====
 
-# TODO(jtattermusch): set GRPC_VERBOSITY=debug when running tests on a simulator (how to do that?)
-
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path objc_bazel_tests
 
+# NOTE: When using bazel to run the tests, test env variables like GRPC_VERBOSITY or GRPC_TRACE
+# seem to be correctly applied to the test environment even when running tests on a simulator.
+# The below configuration runs all the tests with --test_env=GRPC_VERBOSITY=debug, which makes
+# the test logs much more useful.
 objc_bazel_tests/bazel_wrapper \
   --bazelrc=tools/remote_build/include/test_locally_with_resultstore_results.bazelrc \
   test \

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -46,8 +46,8 @@ EXAMPLE_TARGETS=(
 
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
-  # TODO(jtattermusch): make //src/objective-c/tests:TvTests build reliably
-  //src/objective-c/tests:InteropTests
+  # TODO(jtattermusch): make //src/objective-c/tests:TvTests test pass with bazel
+  # TODO(jtattermusch): make sure the //src/objective-c/tests:InteropTests test passes reliably under bazel
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
 )

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -46,9 +46,9 @@ EXAMPLE_TARGETS=(
 
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
+  # TODO(jtattermusch): make //src/objective-c/tests:TvTests build reliably
   //src/objective-c/tests:InteropTests
   //src/objective-c/tests:MacTests
-  //src/objective-c/tests:TvTests
   //src/objective-c/tests:UnitTests
 )
 

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -47,7 +47,8 @@ EXAMPLE_TARGETS=(
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
   # TODO(jtattermusch): make //src/objective-c/tests:TvTests build reliably
-  # TODO(jtattermusch): make //src/objective-c/tests:MacTests build reliably
+  //src/objective-c/tests:InteropTests
+  //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
 )
 

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -46,9 +46,9 @@ EXAMPLE_TARGETS=(
 
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
-  # TODO(jtattermusch): make //src/objective-c/tests:TvTests build reliably
   //src/objective-c/tests:InteropTests
   //src/objective-c/tests:MacTests
+  //src/objective-c/tests:TvTests
   //src/objective-c/tests:UnitTests
 )
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1021,7 +1021,7 @@ class ObjCLanguage(object):
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example_bazel.sh'],
-                timeout_seconds=10 * 60,
+                timeout_seconds=20 * 60,
                 shortname='ios-buildtest-example-tvOS-sample',
                 cpu_cost=1e6,
                 environ={

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -981,6 +981,7 @@ class ObjCLanguage(object):
 
     def test_specs(self):
         out = []
+        # TODO(jtattermusch): Remove this task since the sample is already being built as part of the grpc_objc_bazel_test job.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example_bazel.sh'],
@@ -993,6 +994,7 @@ class ObjCLanguage(object):
                     'FRAMEWORKS': 'NO'
                 }))
         # Currently not supporting compiling as frameworks in Bazel
+        # TODO(jtattermusch): verify the above claim is still accurate.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1004,6 +1006,7 @@ class ObjCLanguage(object):
                     'EXAMPLE_PATH': 'src/objective-c/examples/Sample',
                     'FRAMEWORKS': 'YES'
                 }))
+        # TODO(jtattermusch): Create bazel target for the sample and remove the test task from here.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1014,6 +1017,7 @@ class ObjCLanguage(object):
                     'SCHEME': 'SwiftSample',
                     'EXAMPLE_PATH': 'src/objective-c/examples/SwiftSample'
                 }))
+        # TODO(jtattermusch): Remove this task since the sample is already being built as part of the grpc_objc_bazel_test job.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example_bazel.sh'],
@@ -1038,12 +1042,17 @@ class ObjCLanguage(object):
         #             'EXAMPLE_PATH': 'src/objective-c/examples/watchOS-sample',
         #             'FRAMEWORKS': 'NO'
         #         }))
+
+        # TODO(jtattermusch): Create bazel target for the test and remove the test from here
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_plugin_tests.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-test-plugintest',
                                  cpu_cost=1e6,
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS))
+        # Note that this test basically tests whether the codegen plugin works correctly by running protoc and checking the contents of the generated *.pbrpc.* files.
+        # it doesn't really build any ObjC code.
+        # TODO(jtattermusch): turn this test into a bazel test or come up with a better place where to put this test.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/run_plugin_option_tests.sh'],
@@ -1051,6 +1060,8 @@ class ObjCLanguage(object):
                 shortname='ios-test-plugin-option-test',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
+        # TODO(jtattermusch): move the test out of the test/core/iomgr/CFStreamTests directory?
+        # How does one add the cfstream dependency in bazel?
         out.append(
             self.config.job_spec(
                 ['test/core/iomgr/ios/CFStreamTests/build_and_run_tests.sh'],
@@ -1058,6 +1069,8 @@ class ObjCLanguage(object):
                 shortname='ios-test-cfstream-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
+        # TODO(jtattermusch): Create bazel target for the test and remove the test from here
+        # TODO(jtattermusch): Clarify what do these tests do?
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/CoreTests/build_and_run_tests.sh'],
@@ -1065,43 +1078,52 @@ class ObjCLanguage(object):
                 shortname='ios-test-core-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
-        # TODO: replace with run_one_test_bazel.sh when Bazel-Xcode is stable
+        # TODO(jtattermusch): Remove this task since the tests are already being run as part of the grpc_objc_bazel_test job.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-test-unittests',
                                  cpu_cost=1e6,
                                  environ={'SCHEME': 'UnitTests'}))
+        # TODO(jtattermusch): Make sure the //src/objective-c/tests:InteropTests bazel test passes reliably and remove the test from there.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-test-interoptests',
                                  cpu_cost=1e6,
                                  environ={'SCHEME': 'InteropTests'}))
+        # TODO(jtattermusch): Create bazel target for the test and remove the test from here
+        # (how does one add the cronet dependency in bazel?)
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-test-cronettests',
                                  cpu_cost=1e6,
                                  environ={'SCHEME': 'CronetTests'}))
+        # TODO(jtattermusch): Create bazel target for the test and remove the test from here.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=30 * 60,
                                  shortname='ios-perf-test',
                                  cpu_cost=1e6,
                                  environ={'SCHEME': 'PerfTests'}))
+        # TODO(jtattermusch): Clarify what's the difference between PerfTests and PerfTestsPosix
+        # TODO(jtattermusch): Create bazel target for the test and remove the test from here.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=30 * 60,
                                  shortname='ios-perf-test-posix',
                                  cpu_cost=1e6,
                                  environ={'SCHEME': 'PerfTestsPosix'}))
+        # TODO(jtattermusch): Create bazel target for the test (how does one add the cronet dependency in bazel?)
+        # TODO(jtattermusch): move the test out of the test/cpp/ios directory?
         out.append(
             self.config.job_spec(['test/cpp/ios/build_and_run_tests.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-cpp-test-cronet',
                                  cpu_cost=1e6,
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS))
+        # TODO(jtattermusch): Remove this task since the tests are already being run as part of the grpc_objc_bazel_test job.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=60 * 60,
@@ -1111,6 +1133,7 @@ class ObjCLanguage(object):
                                      'SCHEME': 'MacTests',
                                      'PLATFORM': 'macos'
                                  }))
+        # TODO(jtattermusch): Make sure the //src/objective-c/tests:TvTests bazel test passes and remove the test from here.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
                                  timeout_seconds=30 * 60,


### PR DESCRIPTION
- run more tests as part of the objc bazel test job
- clarify the situation with setting GRPC_VERBOSITY when using bazel test (turns out GRPC_VERBOSITY=debug is already being applied to the tests).
- add many TODOs to the run_tests.py section that defines ObjC test tasks. These TODOs pretty much determine what should be the next steps in ObjC test cleanup.

The ObjC bazel test job is now running both continuously on master, as well as presubmit on PRs, so we are now in good shape for others to step in and address all the TODOs. Just to make sure we're on the same page, `TODO(jtattermusch)` convention means that jtattermusch has created the TODO item, not that I'm going to be the one who addresses it.