### PR TITLE
Convert ObjC codegen plugin tests to bazel tests.

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//bazel:grpc_build_system.bzl", "grpc_sh_test")
 load(
     "//src/objective-c:grpc_objc_internal_library.bzl",
     "grpc_objc_testing_library",
@@ -240,4 +241,26 @@ tvos_unit_test(
         ":NSErrorUnitTests-lib",
         ":RxLibraryUnitTests-lib",
     ],
+)
+
+grpc_sh_test(
+    name = "objc_codegen_plugin_test",
+    srcs = ["PluginTest/plugin_test.sh"],
+    data = [
+        "@com_google_protobuf//:protoc",
+        "//src/compiler:grpc_objective_c_plugin",
+    ] + glob(["PluginTest/*.proto"]),
+    uses_polling = False,
+)
+
+grpc_sh_test(
+    name = "objc_codegen_plugin_option_test",
+    srcs = ["PluginTest/plugin_option_test.sh"],
+    data = [
+        "@com_google_protobuf//:protoc",
+        "//src/compiler:grpc_objective_c_plugin",
+        # NOTE: the :well_known_protos has been recently renamed to :well_known_type_protos on protobuf's main branch
+        "@com_google_protobuf//:well_known_protos",
+    ] + glob(["RemoteTestClient/*.proto"]),
+    uses_polling = False,
 )

--- a/src/objective-c/tests/PluginTest/plugin_option_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_option_test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run this script via bazel test
+# It expects that protoc and grpc_objective_c_plugin have already been built.
+
+set -ev
+
+cd $(dirname $0)
+
+# Run the tests server.
+
+ROOT_DIR=../../../..
+PROTOC=$ROOT_DIR/bazel-bin/external/com_google_protobuf/protoc
+PLUGIN=$ROOT_DIR/bazel-bin/src/compiler/grpc_objective_c_plugin
+RUNTIME_IMPORT_PREFIX=prefix/dir/
+
+PROTO_OUT=./proto_out
+rm -rf ${PROTO_OUT}
+mkdir -p ${PROTO_OUT}
+
+$PROTOC \
+    --plugin=protoc-gen-grpc=$PLUGIN \
+    --objc_out=${PROTO_OUT} \
+    --grpc_out=grpc_local_import_prefix=$RUNTIME_IMPORT_PREFIX,runtime_import_prefix=$RUNTIME_IMPORT_PREFIX:${PROTO_OUT} \
+    -I $ROOT_DIR \
+    -I ../../../../third_party/protobuf/src \
+    $ROOT_DIR/src/objective-c/examples/RemoteTestClient/*.proto
+
+# TODO(jtattermusch): rewrite the tests to make them more readable.
+# Also, the way they are written, they need one extra command to run in order to
+# clear $? after they run (see end of this script)
+
+# Verify the "runtime_import_prefix" option
+# Verify the output proto filename
+[ -e ${PROTO_OUT}/src/objective-c/examples/RemoteTestClient/Test.pbrpc.m ] || {
+    echo >&2 "protoc outputs wrong filename."
+    exit 1
+}
+
+# Verify paths of protobuf WKTs in generated code contain runtime import prefix.
+[ "`cat ${PROTO_OUT}/src/objective-c/examples/RemoteTestClient/Test.pbrpc.m |
+    egrep '#import "'"${RUNTIME_IMPORT_PREFIX}"'GPBEmpty\.pbobjc\.h'`" ] || {
+    echo >&2 "protoc generated import with wrong filename."
+    exit 1
+}
+
+# Verify paths of non WKTs protos in generated code don't contain runtime import prefix.
+[ "`cat ${PROTO_OUT}/src/objective-c/examples/RemoteTestClient/Test.pbrpc.m |
+    egrep '.*\Messages.pbobjc.h"$' | 
+    egrep '#import "'"${RUNTIME_IMPORT_PREFIX}"`" ] && {
+    echo >&2 "protoc generated import with wrong filename."
+    exit 1
+}
+
+# Verify the "grpc_local_import_directory" option
+# Verify system files are imported in a "local" way in header files.
+[ "`cat ${PROTO_OUT}/src/objective-c/examples/RemoteTestClient/Test.pbrpc.h |
+    egrep '#import "'"${RUNTIME_IMPORT_PREFIX}"'/ProtoRPC/.*\.h'`"] || {
+    echo >&2 "grpc system files should be imported with full paths."    
+}
+
+# Verify system files are imported in a "local" way in source files.
+[ "`cat ${PROTO_OUT}/src/objective-c/examples/RemoteTestClient/Test.pbrpc.m |
+    egrep '#import "'"${RUNTIME_IMPORT_PREFIX}"'/ProtoRPC/.*\.h'`"] || {
+    echo >&2 "grpc system files should be imported with full paths."    
+}
+
+# Run one extra command to clear $? before exiting the script to prevent
+# failing even when tests pass.
+echo "Plugin option tests passed."

--- a/src/objective-c/tests/PluginTest/plugin_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run this script via bazel test
+# It expects that protoc and grpc_objective_c_plugin have already been built.
+
+set -ev
+
+cd $(dirname $0)
+
+ROOT_DIR=../../../..
+PROTOC=$ROOT_DIR/bazel-bin/external/com_google_protobuf/protoc
+PLUGIN=$ROOT_DIR/bazel-bin/src/compiler/grpc_objective_c_plugin
+
+PROTO_OUT=./proto_out
+rm -rf ${PROTO_OUT}
+mkdir -p ${PROTO_OUT}
+
+$PROTOC \
+    --plugin=protoc-gen-grpc=$PLUGIN \
+    --objc_out=${PROTO_OUT} \
+    --grpc_out=${PROTO_OUT} \
+    -I . \
+    *.proto
+
+# Verify the output proto filename
+[ -e ${PROTO_OUT}/TestDashFilename.pbrpc.h ] || {
+    echo >&2 "protoc outputs wrong filename."
+    exit 1
+}
+
+# TODO(jtattermusch): rewrite the tests to make them more readable.
+# Also, the way they are written, they need one extra command to run in order to
+# clear $? after they run (see end of this script)
+# Verify names of the imported protos in generated code don't contain dashes.
+[ "`cat ${PROTO_OUT}/TestDashFilename.pbrpc.h |
+    egrep '#import ".*\.pb(objc|rpc)\.h"$' |
+    egrep '-'`" ] && {
+    echo >&2 "protoc generated import with wrong filename."
+    exit 1
+}
+[ "`cat ${PROTO_OUT}/TestDashFilename.pbrpc.m |
+    egrep '#import ".*\.pb(objc|rpc)\.h"$' |
+    egrep '-'`" ] && {
+    echo >&2 "protoc generated import with wrong filename."
+    exit 1
+}
+
+# Run one extra command to clear $? before exiting the script to prevent
+# failing even when tests pass.
+echo "Plugin tests passed."

--- a/src/objective-c/tests/PluginTest/plugin_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_test.sh
@@ -18,11 +18,9 @@
 
 set -ev
 
-cd $(dirname $0)
-
-ROOT_DIR=../../../..
-PROTOC=$ROOT_DIR/bazel-bin/external/com_google_protobuf/protoc
-PLUGIN=$ROOT_DIR/bazel-bin/src/compiler/grpc_objective_c_plugin
+# protoc and grpc_objective_c_plugin binaries are supplied as "data" in bazel
+PROTOC=./external/com_google_protobuf/protoc
+PLUGIN=./src/compiler/grpc_objective_c_plugin
 
 PROTO_OUT=./proto_out
 rm -rf ${PROTO_OUT}
@@ -32,8 +30,8 @@ $PROTOC \
     --plugin=protoc-gen-grpc=$PLUGIN \
     --objc_out=${PROTO_OUT} \
     --grpc_out=${PROTO_OUT} \
-    -I . \
-    *.proto
+    -I src/objective-c/tests/PluginTest \
+    src/objective-c/tests/PluginTest/*.proto
 
 # Verify the output proto filename
 [ -e ${PROTO_OUT}/TestDashFilename.pbrpc.h ] || {

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -50,6 +50,9 @@ TEST_TARGETS=(
   # TODO(jtattermusch): make sure the //src/objective-c/tests:InteropTests test passes reliably under bazel
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
+  # codegen plugin tests
+  //src/objective-c/tests:objc_codegen_plugin_test
+  //src/objective-c/tests:objc_codegen_plugin_option_test
 )
 
 # === BEGIN SECTION: run interop_server on the background ====

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1043,16 +1043,14 @@ class ObjCLanguage(object):
         #             'FRAMEWORKS': 'NO'
         #         }))
 
-        # TODO(jtattermusch): Create bazel target for the test and remove the test from here
+        # TODO(jtattermusch): Remove this task since the test already runs as part of the grpc_objc_bazel_test job.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_plugin_tests.sh'],
                                  timeout_seconds=60 * 60,
                                  shortname='ios-test-plugintest',
                                  cpu_cost=1e6,
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS))
-        # Note that this test basically tests whether the codegen plugin works correctly by running protoc and checking the contents of the generated *.pbrpc.* files.
-        # it doesn't really build any ObjC code.
-        # TODO(jtattermusch): turn this test into a bazel test or come up with a better place where to put this test.
+        # TODO(jtattermusch): Remove this task since the test already runs as part of the grpc_objc_bazel_test job.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/run_plugin_option_tests.sh'],


### PR DESCRIPTION
Based on https://github.com/grpc/grpc/pull/29665 (will rebase later).

- turn the original `ios-test-plugintest` and `ios-test-plugin-option-test` tasks into actual bazel test targets.
- the original test scripts were quite messy so I tried to fix what I could (note that they are actually still quite messy and partially broken and also their coverage is poor, but I'm not in the business of fixing that).
- note that the tests only run the protoc binary and the grpc_objective_c_plugin binaries (which have little to do with the actual objC stack) and then look at the generated files with grep etc, so they form a bit of a special category and they actually might be part of the codegen test suite rather than the objC test suite (but I'm leaving them where they are for now to avoid complicating things).

As a followup, the corresponding run_tests.py tests can be removed.
We should doublecheck that this doesn't break the import.