### PR TITLE
Objc: reenable bazel interoptests

### DIFF
--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -47,7 +47,7 @@ EXAMPLE_TARGETS=(
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
   # TODO(jtattermusch): make //src/objective-c/tests:TvTests test pass with bazel
-  # TODO(jtattermusch): make sure the //src/objective-c/tests:InteropTests test passes reliably under bazel
+  //src/objective-c/tests:InteropTests
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
   # codegen plugin tests

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1037,13 +1037,6 @@ class ObjCLanguage(object):
                 shortname='ios-test-core-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
-        # TODO(jtattermusch): Make sure the //src/objective-c/tests:InteropTests bazel test passes reliably and remove the test from there.
-        out.append(
-            self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
-                                 timeout_seconds=60 * 60,
-                                 shortname='ios-test-interoptests',
-                                 cpu_cost=1e6,
-                                 environ={'SCHEME': 'InteropTests'}))
         # TODO(jtattermusch): Create bazel target for the test and remove the test from here
         # (how does one add the cronet dependency in bazel?)
         out.append(


### PR DESCRIPTION
Let's add `//src/objective-c/tests:InteropTests` back to objc_bazel_test as soon as they pass at a reasonably high rate.