### PR TITLE
Support for prebuilt Ruby binary on x64-mingw-ucrt platform

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
   ext.lib_dir = File.join('src', 'ruby', 'lib', 'grpc')
   ext.cross_compile = true
   ext.cross_platform = [
-    'x86-mingw32', 'x64-mingw32',
+    'x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt',
     'x86_64-linux', 'x86-linux',
     'x86_64-darwin', 'arm64-darwin',
     'universal-darwin'
@@ -38,7 +38,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
       |file| file.start_with?(
         "src/ruby/bin/", "src/ruby/ext/", "src/ruby/lib/", "src/ruby/pb/")
     }
-    spec.files += %w( etc/roots.pem grpc_c.32.ruby grpc_c.64.ruby )
+    spec.files += %w( etc/roots.pem grpc_c.32.ruby grpc_c.64.ruby grpc_c.64-ucrt.ruby )
   end
 end
 
@@ -87,9 +87,10 @@ task 'dlls', [:plat] do |t, args|
   plat_list = args[:plat]
 
   build_configs = []
+  w64_ucrt = { cross: 'mingw-w64-ucrt-x86_64', out: 'grpc_c.64-ucrt.ruby', platform: 'x64-mingw-ucrt' }
   w64 = { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64.ruby', platform: 'x64-mingw32' }
   w32 = { cross: 'i686-w64-mingw32', out: 'grpc_c.32.ruby', platform: 'x86-mingw32' }
-  [w64, w32].each do |config|
+  [w64_ucrt, w64, w32].each do |config|
     if plat_list.include?(config[:platform])
       # build the DLL (as grpc_c.*.ruby)
       build_configs.append(config)
@@ -151,6 +152,7 @@ task 'gem:native', [:plat] do |t, args|
 
     FileUtils.touch 'grpc_c.32.ruby'
     FileUtils.touch 'grpc_c.64.ruby'
+    FileUtils.touch 'grpc_c.64-ucrt.ruby'
     unless '2.5' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
       fail "rake gem:native (the rake task to build the binary packages) is being " \
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
@@ -168,7 +170,7 @@ task 'gem:native', [:plat] do |t, args|
     prepare_ccache_cmd += "export PATH=\"$PATH:/usr/local/bin\" && "
     prepare_ccache_cmd += "source tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc "
 
-    supported_windows_platforms = ['x86-mingw32', 'x64-mingw32']
+    supported_windows_platforms = ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt']
     supported_unix_platforms = ['x86_64-linux', 'x86-linux', 'x86_64-darwin', 'arm64-darwin']
     supported_platforms = supported_windows_platforms + supported_unix_platforms
 
@@ -210,6 +212,7 @@ task 'gem:native', [:plat] do |t, args|
     # them to take up space in the gems that don't target windows.
     File.truncate('grpc_c.32.ruby', 0)
     File.truncate('grpc_c.64.ruby', 0)
+    File.truncate('grpc_c.64-ucrt.ruby', 0)
 
     unix_platforms.each do |plat|
       run_rake_compiler(plat, <<~EOT)

--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ task 'dlls', [:plat] do |t, args|
   plat_list = args[:plat]
 
   build_configs = []
-  w64_ucrt = { cross: 'mingw-w64-ucrt-x86_64', out: 'grpc_c.64-ucrt.ruby', platform: 'x64-mingw-ucrt' }
+  w64_ucrt = { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64-ucrt.ruby', platform: 'x64-mingw-ucrt' }
   w64 = { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64.ruby', platform: 'x64-mingw32' }
   w32 = { cross: 'i686-w64-mingw32', out: 'grpc_c.32.ruby', platform: 'x86-mingw32' }
   [w64_ucrt, w64, w32].each do |config|

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
@@ -1,0 +1,17 @@
+FROM larskanis/rake-compiler-dock-mri-x64-mingw-ucrt:1.2.1
+
+RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
+
+#=================
+# Install ccache
+
+# Install ccache from source since ccache 3.x packaged with most linux distributions
+# does not support Redis backend for caching.
+RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/download/v4.5.1/ccache-4.5.1.tar.gz \
+    && tar -zxf ccache.tar.gz \
+    && cd ccache-4.5.1 \
+    && mkdir build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON -DHIREDIS_FROM_INTERNET=ON .. \
+    && make -j4 && make install \
+    && cd ../.. \
+    && rm -rf ccache-4.5.1 ccache.tar.gz


### PR DESCRIPTION
Fixes #29666

Add support for prebuilt Ruby binary on x64-mingw-ucrt platform, which is used for Windows RubyInstaller Ruby 3.1+
