### PR TITLE
Fix gRPC C++ init bug

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -105,10 +105,7 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
  public:
   /// Default constructor. Implicitly creates a \a grpc_completion_queue
   /// instance.
-  CompletionQueue()
-      : CompletionQueue(grpc_completion_queue_attributes{
-            GRPC_CQ_CURRENT_VERSION, GRPC_CQ_NEXT, GRPC_CQ_DEFAULT_POLLING,
-            nullptr}) {}
+  CompletionQueue();
 
   /// Wrap \a take, taking ownership of the instance.
   ///
@@ -250,13 +247,7 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
 
  protected:
   /// Private constructor of CompletionQueue only visible to friend classes
-  explicit CompletionQueue(const grpc_completion_queue_attributes& attributes) {
-    cq_ = grpc::g_core_codegen_interface->grpc_completion_queue_create(
-        grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
-            &attributes),
-        &attributes, nullptr);
-    InitialAvalanching();  // reserve this for the future shutdown
-  }
+  explicit CompletionQueue(const grpc_completion_queue_attributes& attributes);
 
  private:
   // Friends for access to server registration lists that enable checking and

--- a/include/grpcpp/impl/codegen/grpc_library.h
+++ b/include/grpcpp/impl/codegen/grpc_library.h
@@ -21,6 +21,8 @@
 
 // IWYU pragma: private, include <grpcpp/impl/grpc_library.h>
 
+#include <assert.h>
+
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 
 namespace grpc {
@@ -42,18 +44,22 @@ class GrpcLibraryCodegen {
   explicit GrpcLibraryCodegen(bool call_grpc_init = true)
       : grpc_init_called_(false) {
     if (call_grpc_init) {
-      GPR_CODEGEN_ASSERT(g_glip &&
-                         "gRPC library not initialized. See "
-                         "grpc::internal::GrpcLibraryInitializer.");
+      // Use assert instead of GPR_CODEGEN_ASSERT which requires gRPC++ to be
+      // initialized.
+      assert(g_glip &&
+             "gRPC library not initialized. See "
+             "grpc::internal::GrpcLibraryInitializer.");
       g_glip->init();
       grpc_init_called_ = true;
     }
   }
   virtual ~GrpcLibraryCodegen() {
     if (grpc_init_called_) {
-      GPR_CODEGEN_ASSERT(g_glip &&
-                         "gRPC library not initialized. See "
-                         "grpc::internal::GrpcLibraryInitializer.");
+      // Use assert instead of GPR_CODEGEN_ASSERT which requires gRPC++ to be
+      // initialized.
+      assert(g_glip &&
+             "gRPC library not initialized. See "
+             "grpc::internal::GrpcLibraryInitializer.");
       g_glip->shutdown();
     }
   }

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -45,6 +45,7 @@
 namespace grpc {
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
+
 Channel::Channel(
     const std::string& host, grpc_channel* channel,
     std::vector<

--- a/src/cpp/client/credentials_cc.cc
+++ b/src/cpp/client/credentials_cc.cc
@@ -22,6 +22,7 @@
 namespace grpc {
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
+
 ChannelCredentials::ChannelCredentials() { g_gli_initializer.summon(); }
 
 ChannelCredentials::~ChannelCredentials() {}

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -44,6 +44,7 @@
 namespace grpc {
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
+
 SecureChannelCredentials::SecureChannelCredentials(
     grpc_channel_credentials* c_creds)
     : c_creds_(c_creds) {

--- a/src/cpp/common/resource_quota_cc.cc
+++ b/src/cpp/common/resource_quota_cc.cc
@@ -17,14 +17,21 @@
  */
 
 #include <grpc/grpc.h>
+#include <grpcpp/impl/grpc_library.h>
 #include <grpcpp/resource_quota.h>
 
 namespace grpc {
 
-ResourceQuota::ResourceQuota() : impl_(grpc_resource_quota_create(nullptr)) {}
+static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
+
+ResourceQuota::ResourceQuota() : impl_(grpc_resource_quota_create(nullptr)) {
+  g_gli_initializer.summon();
+}
 
 ResourceQuota::ResourceQuota(const std::string& name)
-    : impl_(grpc_resource_quota_create(name.c_str())) {}
+    : impl_(grpc_resource_quota_create(name.c_str())) {
+  g_gli_initializer.summon();
+}
 
 ResourceQuota::~ResourceQuota() { grpc_resource_quota_unref(impl_); }
 
@@ -37,4 +44,5 @@ ResourceQuota& ResourceQuota::SetMaxThreads(int new_max_threads) {
   grpc_resource_quota_set_max_threads(impl_, new_max_threads);
   return *this;
 }
+
 }  // namespace grpc

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -848,6 +848,7 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
 };
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
+
 Server::Server(
     grpc::ChannelArguments* args,
     std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue>>>


### PR DESCRIPTION
Currently gRPC got a segfault with the following code.

```
int main(int argc, char** argv) {
  grpc::CompletionQueue cq;
  return 0;
}
```

This is because ctor of `CompletionQueue` requires gRPC C++ to be initialized but it's not yet. Although `src/cpp/common/completion_queue_cc.cc` has a static variable, `static internal::GrpcLibraryInitializer g_gli_initializer;` but it isn't necessarily initialized before `CompletionQueue`. (partly ctor of `CompletionQueue` is in the header so a compiler doesn't care of init-ing `g_gli_initializer` before `CompletionQueue`.

To address this, I moved ctors of `CompletionQueue` to its source file and made it call `g_gli_initializer.summon()` to make sure that `g_gli_initializer` is initialized before `CompletionQueue`.

In addition to this, ResourceQuota just got the same change.