### PR TITLE
Revert "Fix gRPC C++ init bug"

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -105,7 +105,10 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
  public:
   /// Default constructor. Implicitly creates a \a grpc_completion_queue
   /// instance.
-  CompletionQueue();
+  CompletionQueue()
+      : CompletionQueue(grpc_completion_queue_attributes{
+            GRPC_CQ_CURRENT_VERSION, GRPC_CQ_NEXT, GRPC_CQ_DEFAULT_POLLING,
+            nullptr}) {}
 
   /// Wrap \a take, taking ownership of the instance.
   ///
@@ -247,7 +250,13 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
 
  protected:
   /// Private constructor of CompletionQueue only visible to friend classes
-  explicit CompletionQueue(const grpc_completion_queue_attributes& attributes);
+  explicit CompletionQueue(const grpc_completion_queue_attributes& attributes) {
+    cq_ = grpc::g_core_codegen_interface->grpc_completion_queue_create(
+        grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
+            &attributes),
+        &attributes, nullptr);
+    InitialAvalanching();  // reserve this for the future shutdown
+  }
 
  private:
   // Friends for access to server registration lists that enable checking and

--- a/include/grpcpp/impl/codegen/grpc_library.h
+++ b/include/grpcpp/impl/codegen/grpc_library.h
@@ -21,8 +21,6 @@
 
 // IWYU pragma: private, include <grpcpp/impl/grpc_library.h>
 
-#include <assert.h>
-
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 
 namespace grpc {
@@ -44,22 +42,18 @@ class GrpcLibraryCodegen {
   explicit GrpcLibraryCodegen(bool call_grpc_init = true)
       : grpc_init_called_(false) {
     if (call_grpc_init) {
-      // Use assert instead of GPR_CODEGEN_ASSERT which requires gRPC++ to be
-      // initialized.
-      assert(g_glip &&
-             "gRPC library not initialized. See "
-             "grpc::internal::GrpcLibraryInitializer.");
+      GPR_CODEGEN_ASSERT(g_glip &&
+                         "gRPC library not initialized. See "
+                         "grpc::internal::GrpcLibraryInitializer.");
       g_glip->init();
       grpc_init_called_ = true;
     }
   }
   virtual ~GrpcLibraryCodegen() {
     if (grpc_init_called_) {
-      // Use assert instead of GPR_CODEGEN_ASSERT which requires gRPC++ to be
-      // initialized.
-      assert(g_glip &&
-             "gRPC library not initialized. See "
-             "grpc::internal::GrpcLibraryInitializer.");
+      GPR_CODEGEN_ASSERT(g_glip &&
+                         "gRPC library not initialized. See "
+                         "grpc::internal::GrpcLibraryInitializer.");
       g_glip->shutdown();
     }
   }

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -45,7 +45,6 @@
 namespace grpc {
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
-
 Channel::Channel(
     const std::string& host, grpc_channel* channel,
     std::vector<

--- a/src/cpp/client/credentials_cc.cc
+++ b/src/cpp/client/credentials_cc.cc
@@ -22,7 +22,6 @@
 namespace grpc {
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
-
 ChannelCredentials::ChannelCredentials() { g_gli_initializer.summon(); }
 
 ChannelCredentials::~ChannelCredentials() {}

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -44,7 +44,6 @@
 namespace grpc {
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
-
 SecureChannelCredentials::SecureChannelCredentials(
     grpc_channel_credentials* c_creds)
     : c_creds_(c_creds) {

--- a/src/cpp/common/completion_queue_cc.cc
+++ b/src/cpp/common/completion_queue_cc.cc
@@ -120,29 +120,13 @@ CallbackAlternativeCQ g_callback_alternative_cq;
 
 }  // namespace
 
-CompletionQueue::CompletionQueue()
-    : CompletionQueue(grpc_completion_queue_attributes{
-          GRPC_CQ_CURRENT_VERSION, GRPC_CQ_NEXT, GRPC_CQ_DEFAULT_POLLING,
-          nullptr}) {}
-
 // 'CompletionQueue' constructor can safely call GrpcLibraryCodegen(false) here
 // i.e not have GrpcLibraryCodegen call grpc_init(). This is because, to create
 // a 'grpc_completion_queue' instance (which is being passed as the input to
 // this constructor), one must have already called grpc_init().
 CompletionQueue::CompletionQueue(grpc_completion_queue* take)
     : GrpcLibraryCodegen(false), cq_(take) {
-  g_gli_initializer.summon();
   InitialAvalanching();
-}
-
-CompletionQueue::CompletionQueue(
-    const grpc_completion_queue_attributes& attributes) {
-  g_gli_initializer.summon();
-  cq_ = grpc::g_core_codegen_interface->grpc_completion_queue_create(
-      grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
-          &attributes),
-      &attributes, nullptr);
-  InitialAvalanching();  // reserve this for the future shutdown
 }
 
 void CompletionQueue::Shutdown() {

--- a/src/cpp/common/resource_quota_cc.cc
+++ b/src/cpp/common/resource_quota_cc.cc
@@ -17,21 +17,14 @@
  */
 
 #include <grpc/grpc.h>
-#include <grpcpp/impl/grpc_library.h>
 #include <grpcpp/resource_quota.h>
 
 namespace grpc {
 
-static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
-
-ResourceQuota::ResourceQuota() : impl_(grpc_resource_quota_create(nullptr)) {
-  g_gli_initializer.summon();
-}
+ResourceQuota::ResourceQuota() : impl_(grpc_resource_quota_create(nullptr)) {}
 
 ResourceQuota::ResourceQuota(const std::string& name)
-    : impl_(grpc_resource_quota_create(name.c_str())) {
-  g_gli_initializer.summon();
-}
+    : impl_(grpc_resource_quota_create(name.c_str())) {}
 
 ResourceQuota::~ResourceQuota() { grpc_resource_quota_unref(impl_); }
 
@@ -44,5 +37,4 @@ ResourceQuota& ResourceQuota::SetMaxThreads(int new_max_threads) {
   grpc_resource_quota_set_max_threads(impl_, new_max_threads);
   return *this;
 }
-
 }  // namespace grpc

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -848,7 +848,6 @@ class Server::SyncRequestThreadManager : public grpc::ThreadManager {
 };
 
 static grpc::internal::GrpcLibraryInitializer g_gli_initializer;
-
 Server::Server(
     grpc::ChannelArguments* args,
     std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue>>>


### PR DESCRIPTION
Reverts grpc/grpc#29689. Breaks internal targets.