### PR TITLE
C#: Suppress CS8981 in generated source

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -801,7 +801,7 @@ std::string GetServices(const FileDescriptor* file, bool generate_client,
       out.PrintRaw(leading_comments.c_str());
     }
 
-    out.Print("#pragma warning disable 0414, 1591\n");
+    out.Print("#pragma warning disable 0414, 1591, 8981\n");
 
     out.Print("#region Designer generated code\n");
     out.Print("\n");


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/29672

This is option 2 (see linked issue). It suppresses the new warning in the generated source code. It's the simplest change and I think it's unlikely that any of the namespace aliases would turn into keywords.

@jtattermusch @jskeet 