### PR TITLE
Removed c++14 option from bazel.rc

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,7 +2,6 @@
 
 build --client_env=CC=clang
 build --copt=-DGRPC_BAZEL_BUILD
-build --cxxopt='-std=c++14'
 build --action_env=GRPC_BAZEL_RUNTIME=1
 build --define=use_fast_cpp_protos=true
 


### PR DESCRIPTION
Remove `-std=c++14' since all supported compilers default to c++14 and it's interfering with MSVC which has a different option for that.