### PR TITLE
xds_k8s_install: Allow to override PYTHON_VERSION for local testing

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 # Constants
-readonly PYTHON_VERSION="3.6"
+readonly PYTHON_VERSION="${PYTHON_VERSION:-3.6}"
 # Test driver
 readonly TEST_DRIVER_REPO_NAME="grpc"
 readonly TEST_DRIVER_REPO_URL="https://github.com/${TEST_DRIVER_REPO_OWNER:-grpc}/grpc.git"


### PR DESCRIPTION
While test run environment allows python 3.6, allow local dev to override PYTHON_VERSION for testing.
