### PR TITLE
Run only "dbg" configuration in MacOS cmake C/C++ basic tests on PRs

### DIFF
--- a/tools/internal_ci/macos/pull_request/grpc_basictests_c_cpp.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_c_cpp.cfg
@@ -27,5 +27,6 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos corelang --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
+  # on pull requests, only run the "dbg" configuration due to CI resource constraints
+  value: "-f basictests macos corelang dbg --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
 }


### PR DESCRIPTION
This is a better and simpler version of https://github.com/grpc/grpc/pull/29724.