### PR TITLE
google-c2p resolver: add authority entry to bootstrap config

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -395,11 +395,13 @@ void GoogleCloud2ProdResolver::StartXdsResolver() {
   };
   Json bootstrap = Json::Object{
       {"xds_servers", xds_server},
-      {"authorities", Json::Object{
-          {"traffic-director-c2p.xds.googleapis.com", Json::Object{
-              {"xds_servers", std::move(xds_server)},
-          }},
-      }},
+      {"authorities",
+       Json::Object{
+           {"traffic-director-c2p.xds.googleapis.com",
+            Json::Object{
+                {"xds_servers", std::move(xds_server)},
+            }},
+       }},
       {"node", std::move(node)},
   };
   // Inject bootstrap JSON as fallback config.

--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -381,20 +381,25 @@ void GoogleCloud2ProdResolver::StartXdsResolver() {
       override_server != nullptr && strlen(override_server.get()) > 0
           ? override_server.get()
           : "directpath-pa.googleapis.com";
+  Json xds_server = Json::Array{
+      Json::Object{
+          {"server_uri", server_uri},
+          {"channel_creds",
+           Json::Array{
+               Json::Object{
+                   {"type", "google_default"},
+               },
+           }},
+          {"server_features", Json::Array{"xds_v3"}},
+      },
+  };
   Json bootstrap = Json::Object{
-      {"xds_servers",
-       Json::Array{
-           Json::Object{
-               {"server_uri", server_uri},
-               {"channel_creds",
-                Json::Array{
-                    Json::Object{
-                        {"type", "google_default"},
-                    },
-                }},
-               {"server_features", Json::Array{"xds_v3"}},
-           },
-       }},
+      {"xds_servers", xds_server},
+      {"authorities", Json::Object{
+          {"traffic-director-c2p.xds.googleapis.com", Json::Object{
+              {"xds_servers", std::move(xds_server)},
+          }},
+      }},
       {"node", std::move(node)},
   };
   // Inject bootstrap JSON as fallback config.


### PR DESCRIPTION
We'll need more bootstrap config changes later to fully move to the new naming scheme, but this can be added now, so that the initial migration steps will continue to work even if the federation env var is enabled on the client.