### PR TITLE
Fix undefined reference errors in asylo builds

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -207,6 +207,7 @@
 #define GPR_CPU_POSIX 1
 #define GPR_PLATFORM_STRING "asylo"
 #define GPR_GCC_SYNC 1
+#define GPR_POSIX_STAT 1
 #define GPR_POSIX_SYNC 1
 #define GPR_POSIX_STRING 1
 #define GPR_POSIX_LOG 1


### PR DESCRIPTION
Fix undefined reference to `grpc_core::GetFileModificationTime(char const*, long*)' in asylo builds.

@drfloob
