### PR TITLE
Switching to ios test runner for unit tests

### DIFF
--- a/src/objective-c/grpc_objc_internal_library.bzl
+++ b/src/objective-c/grpc_objc_internal_library.bzl
@@ -31,6 +31,43 @@ load(
     "generate_objc_non_arc_srcs",
     "generate_objc_srcs",
 )
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load(
+    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    "ios_test_runner",
+)
+
+# The default device type for ios objc unit tests
+IOS_UNIT_TEST_DEVICE_TYPE = "iPhone 11"
+
+# The default iOS version for ios objc unit tests
+# IOS_UNIT_TEST_OS_VERSION = "13.3"
+
+def grpc_objc_ios_unit_test(
+        name,
+        deps,
+        env = {}):
+    """ios unit test for running objc test suite on iOS simulator runner
+
+    Args:
+        name: The name of the unit test target.
+        deps: The dependencies of the target.
+        env: Optional test environment variables passed to the test
+    """
+    test_runner = "grpc_ios_sim_runner_" + name
+    ios_test_runner(
+        name = test_runner,
+        device_type = IOS_UNIT_TEST_DEVICE_TYPE,
+        # os_version = IOS_UNIT_TEST_OS_VERSION,
+        test_environment = env,
+    )
+
+    ios_unit_test(
+        name = name,
+        minimum_os_version = "9.0",
+        runner = test_runner,
+        deps = deps,
+    )
 
 def proto_library_objc_wrapper(
         name,

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -17,6 +17,7 @@
 load("//bazel:grpc_build_system.bzl", "grpc_sh_test")
 load(
     "//src/objective-c:grpc_objc_internal_library.bzl",
+    "grpc_objc_ios_unit_test",
     "grpc_objc_testing_library",
     "local_objc_grpc_library",
     "proto_library_objc_wrapper",
@@ -183,10 +184,8 @@ grpc_objc_testing_library(
     hdrs = ["MacTests/StressTests.h"],
 )
 
-ios_unit_test(
+grpc_objc_ios_unit_test(
     name = "UnitTests",
-    minimum_os_version = "9.0",
-    test_host = ":ios-host",
     deps = [
         ":APIv2Tests-lib",
         ":ChannelPoolTest-lib",


### PR DESCRIPTION
### Change Summary

Switching to dedicated ios test runner for bazel-based unit test. Test runner has several upsides  

* This appears to be a default required parameters for [ios_unit_test](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_unit_test), and we observed a fairly large set of simulator launch failure from recent samples as seem in https://github.com/grpc/grpc-ios/issues/94. 
* Test runner allow us to specify exact device and iOS version for the xctest environment which will make our overall test environment more consistent
* test runner are in general more lightweight than ios host since it does not requires loading [full iOS app environment](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_unit_test). This should also help speed up initial launch time for the test  


### Test locally 

```bash
bazel test //src/objective-c/tests:UnitTests --test_filter=CallAPIv2Tests --test_output=all --test_env=GRPC_VERBOSITY=DEBUG 
```
----

https://github.com/grpc/grpc-ios/issues/94

-- 

cc @HannahShiSFB  @jtattermusch 