### PR TITLE
Add v1.46.x to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -118,6 +118,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo()),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
+            ('v1.46.0', ReleaseInfo()),
         ]),
     'go':
         OrderedDict([
@@ -410,6 +411,9 @@ LANG_RELEASE_MATRIX = {
                 ('v1.44.0',
                  ReleaseInfo(runtimes=['python'],
                              testcases_file='python__master')),
+                ('v1.46.0',
+                 ReleaseInfo(runtimes=['python'],
+                             testcases_file='python__master')),
             ]),
     'node':
         OrderedDict([
@@ -482,6 +486,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo()),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
+            ('v1.46.0', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([
@@ -527,6 +532,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo()),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
+            ('v1.46.0', ReleaseInfo()),
         ]),
     'csharp':
         OrderedDict([
@@ -578,5 +584,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo(testcases_file='csharp__v1.20.0')),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
+            ('v1.46.0', ReleaseInfo()),
         ]),
 }

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -201,6 +201,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.43.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.44.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.45.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.46.0', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -201,7 +201,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.43.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.44.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.45.0', ReleaseInfo(runtimes=['go1.16'])),
-            ('v1.46.2', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -118,7 +118,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo()),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
-            ('v1.46.0', ReleaseInfo()),
+            ('v1.46.2', ReleaseInfo()),
         ]),
     'go':
         OrderedDict([
@@ -201,7 +201,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.43.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.44.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.45.0', ReleaseInfo(runtimes=['go1.16'])),
-            ('v1.46.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.46.2', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([
@@ -411,7 +411,7 @@ LANG_RELEASE_MATRIX = {
                 ('v1.44.0',
                  ReleaseInfo(runtimes=['python'],
                              testcases_file='python__master')),
-                ('v1.46.0',
+                ('v1.46.2',
                  ReleaseInfo(runtimes=['python'],
                              testcases_file='python__master')),
             ]),
@@ -486,7 +486,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo()),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
-            ('v1.46.0', ReleaseInfo()),
+            ('v1.46.2', ReleaseInfo()),
         ]),
     'php':
         OrderedDict([
@@ -532,7 +532,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo()),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
-            ('v1.46.0', ReleaseInfo()),
+            ('v1.46.2', ReleaseInfo()),
         ]),
     'csharp':
         OrderedDict([
@@ -584,6 +584,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.42.0', ReleaseInfo(testcases_file='csharp__v1.20.0')),
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
-            ('v1.46.0', ReleaseInfo()),
+            ('v1.46.2', ReleaseInfo()),
         ]),
 }


### PR DESCRIPTION
As title.

[prod:grpc/core/experimental/linux/grpc_interop_matrix_adhoc](https://fusion2.corp.google.com/invocations/6f26ca95-11cc-426f-ad8d-01985ead1ad4/targets) [OK]