### PR TITLE
Revert "Removed c++14 option from bazel.rc"

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,6 +2,7 @@
 
 build --client_env=CC=clang
 build --copt=-DGRPC_BAZEL_BUILD
+build --cxxopt='-std=c++14'
 build --action_env=GRPC_BAZEL_RUNTIME=1
 build --define=use_fast_cpp_protos=true
 


### PR DESCRIPTION
Reverts grpc/grpc#29711

It turned out that `-std=c++14` is required because bazel explicitly specifies it (e.g. [link](https://github.com/bazelbuild/rules_cc/blob/8bb0eb5c5ccd96b91753bb112096bb6993d16d13/cc/private/toolchain/cc_toolchain_config.bzl#L600)) Although this change generates warnings with MSVC but it's still fine because it just ignores and it will use c++14 by default anyway.