### PR TITLE
Temporarily require ExecCtx to be on the thread's stack for EventEngine

### DIFF
--- a/src/core/lib/event_engine/iomgr_engine.cc
+++ b/src/core/lib/event_engine/iomgr_engine.cc
@@ -70,6 +70,7 @@ std::string HandleToString(EventEngine::TaskHandle handle) {
 IomgrEventEngine::IomgrEventEngine() {}
 
 IomgrEventEngine::~IomgrEventEngine() {
+  grpc_core::ExecCtx::Get()->Flush();
   grpc_core::MutexLock lock(&mu_);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_event_engine_trace)) {
     for (auto handle : known_handles_) {

--- a/src/core/lib/event_engine/iomgr_engine.cc
+++ b/src/core/lib/event_engine/iomgr_engine.cc
@@ -83,7 +83,6 @@ IomgrEventEngine::~IomgrEventEngine() {
 }
 
 bool IomgrEventEngine::Cancel(EventEngine::TaskHandle handle) {
-  grpc_core::ExecCtx ctx;
   grpc_core::MutexLock lock(&mu_);
   if (!known_handles_.contains(handle)) return false;
   auto* cd = reinterpret_cast<ClosureData*>(handle.keys[0]);
@@ -114,7 +113,6 @@ EventEngine::TaskHandle IomgrEventEngine::RunAtInternal(
     absl::Time when,
     absl::variant<std::function<void()>, EventEngine::Closure*> cb) {
   when = Clamp(when);
-  grpc_core::ExecCtx ctx;
   auto* cd = new ClosureData;
   cd->cb = std::move(cb);
   cd->engine = this;

--- a/src/core/lib/event_engine/iomgr_engine.h
+++ b/src/core/lib/event_engine/iomgr_engine.h
@@ -39,6 +39,8 @@
 namespace grpc_event_engine {
 namespace experimental {
 
+// An iomgr-based EventEngine implementation.
+// All methods require an ExecCtx to already exist on the thread's stack.
 class IomgrEventEngine final : public EventEngine {
  public:
   class IomgrEndpoint : public EventEngine::Endpoint {

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -87,6 +87,7 @@ grpc_cc_library(
     hdrs = COMMON_HEADERS,
     external_deps = ["gtest"],
     deps = [
+        "//:exec_ctx",
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],

--- a/test/core/event_engine/test_suite/client_test.cc
+++ b/test/core/event_engine/test_suite/client_test.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineClientTest : public EventEngineTest {};
 
 // TODO(hork): establish meaningful tests
-TEST_F(EventEngineClientTest, TODO) {}
+TEST_F(EventEngineClientTest, TODO) { grpc_core::ExecCtx exec_ctx; }

--- a/test/core/event_engine/test_suite/dns_test.cc
+++ b/test/core/event_engine/test_suite/dns_test.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineDNSTest : public EventEngineTest {};
 
 // TODO(hork): establish meaningful tests
-TEST_F(EventEngineDNSTest, TODO) {}
+TEST_F(EventEngineDNSTest, TODO) { grpc_core::ExecCtx exec_ctx; }

--- a/test/core/event_engine/test_suite/server_test.cc
+++ b/test/core/event_engine/test_suite/server_test.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 class EventEngineServerTest : public EventEngineTest {};
 
 // TODO(hork): establish meaningful tests
-TEST_F(EventEngineServerTest, TODO) {}
+TEST_F(EventEngineServerTest, TODO) { grpc_core::ExecCtx exec_ctx; }


### PR DESCRIPTION
There's a migration path that allows us to remove this requirement
eventually, but for now it is the simplest way forward. After
`ExecCtx::Run` and `grpc_timer_*` calls have been replaced, this can be
removed.
