### PR TITLE
Fix 64 to 32 bit clang conversion warning

### DIFF
--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -119,7 +119,7 @@ absl::StatusOr<FaultInjectionFilter> FaultInjectionFilter::Create(
 }
 
 FaultInjectionFilter::FaultInjectionFilter(ChannelFilter::Args filter_args)
-    : index_(grpc_channel_stack_filter_instance_number(
+    : index_((int)grpc_channel_stack_filter_instance_number(
           filter_args.channel_stack(),
           filter_args.uninitialized_channel_element())),
       service_config_parser_index_(

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -83,7 +83,7 @@ void RbacFilter::CallData::RecvInitialMetadataReady(void* user_data,
     } else {
       RbacFilter* chand = static_cast<RbacFilter*>(elem->channel_data);
       auto* authorization_engine =
-          method_params->authorization_engine(chand->index_);
+          method_params->authorization_engine((int)chand->index_);
       if (authorization_engine
               ->Evaluate(EvaluateArgs(calld->recv_initial_metadata_,
                                       &chand->per_channel_evaluate_args_))

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2451,7 +2451,7 @@ static void close_from_api(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 
   size_t msg_len = message.length();
   GPR_ASSERT(msg_len <= UINT32_MAX);
-  grpc_core::VarintWriter<1> msg_len_writer(msg_len);
+  grpc_core::VarintWriter<1> msg_len_writer((uint32_t)msg_len);
   message_pfx = GRPC_SLICE_MALLOC(14 + msg_len_writer.length());
   p = GRPC_SLICE_START_PTR(message_pfx);
   *p++ = 0x00; /* literal header, not indexed */

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -211,7 +211,7 @@ class BinaryStringValue {
   explicit BinaryStringValue(Slice value, bool use_true_binary_metadata)
       : wire_value_(
             GetWireValue(std::move(value), use_true_binary_metadata, true)),
-        len_val_(wire_value_.length) {}
+        len_val_((uint32_t)wire_value_.length) {}
 
   size_t prefix_length() const {
     return len_val_.length() +
@@ -235,7 +235,7 @@ class BinaryStringValue {
 class NonBinaryStringValue {
  public:
   explicit NonBinaryStringValue(Slice value)
-      : value_(std::move(value)), len_val_(value_.length()) {}
+      : value_(std::move(value)), len_val_((uint32_t)value_.length()) {}
 
   size_t prefix_length() const { return len_val_.length(); }
 
@@ -251,7 +251,7 @@ class NonBinaryStringValue {
 class StringKey {
  public:
   explicit StringKey(Slice key)
-      : key_(std::move(key)), len_key_(key_.length()) {}
+      : key_(std::move(key)), len_key_((uint32_t)key_.length()) {}
 
   size_t prefix_length() const { return 1 + len_key_.length(); }
 
@@ -338,7 +338,7 @@ void HPackCompressor::SliceIndex::EmitTo(absl::string_view key,
   using It = std::vector<ValueIndex>::iterator;
   It prev = values_.end();
   uint32_t transport_length =
-      key.length() + value.length() + hpack_constants::kEntryOverhead;
+  (uint32_t)(key.length() + value.length() + hpack_constants::kEntryOverhead);
   if (transport_length > HPackEncoderTable::MaxEntrySize()) {
     framer->EmitLitHdrWithNonBinaryStringKeyNotIdx(Slice::FromStaticString(key),
                                                    value.Ref());
@@ -564,7 +564,7 @@ void HPackCompressor::Framer::Encode(UserAgentMetadata, const Slice& slice) {
   }
   EncodeAlwaysIndexed(
       &compressor_->user_agent_index_, "user-agent", slice.Ref(),
-      10 /* user-agent */ + slice.size() + hpack_constants::kEntryOverhead);
+      (uint32_t)(10 /* user-agent */ + slice.size() + hpack_constants::kEntryOverhead));
 }
 
 void HPackCompressor::Framer::Encode(GrpcStatusMetadata,
@@ -581,7 +581,7 @@ void HPackCompressor::Framer::Encode(GrpcStatusMetadata,
   Slice key = Slice::FromStaticString(GrpcStatusMetadata::key());
   Slice value = Slice::FromInt64(code);
   const uint32_t transport_length =
-      key.length() + value.length() + hpack_constants::kEntryOverhead;
+  (uint32_t)(key.length() + value.length() + hpack_constants::kEntryOverhead);
   if (index != nullptr) {
     *index = compressor_->table_.AllocateIndex(transport_length);
     EmitLitHdrWithNonBinaryStringKeyIncIdx(std::move(key), std::move(value));
@@ -603,7 +603,7 @@ void HPackCompressor::Framer::Encode(GrpcEncodingMetadata,
   auto key = Slice::FromStaticString(GrpcEncodingMetadata::key());
   auto encoded_value = GrpcEncodingMetadata::Encode(value);
   uint32_t transport_length =
-      key.length() + encoded_value.length() + hpack_constants::kEntryOverhead;
+  (uint32_t)(key.length() + encoded_value.length() + hpack_constants::kEntryOverhead);
   if (index != nullptr) {
     *index = compressor_->table_.AllocateIndex(transport_length);
     EmitLitHdrWithNonBinaryStringKeyIncIdx(std::move(key),
@@ -627,7 +627,7 @@ void HPackCompressor::Framer::Encode(GrpcAcceptEncodingMetadata,
   auto key = Slice::FromStaticString(GrpcAcceptEncodingMetadata::key());
   auto encoded_value = GrpcAcceptEncodingMetadata::Encode(value);
   uint32_t transport_length =
-      key.length() + encoded_value.length() + hpack_constants::kEntryOverhead;
+  (uint32_t)(key.length() + encoded_value.length() + hpack_constants::kEntryOverhead);
   compressor_->grpc_accept_encoding_index_ =
       compressor_->table_.AllocateIndex(transport_length);
   compressor_->grpc_accept_encoding_ = value;

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder_table.cc
@@ -61,7 +61,7 @@ bool HPackEncoderTable::SetMaxSize(uint32_t max_table_size) {
       hpack_constants::EntriesForBytes(max_table_size);
   // TODO(ctiller): integrate with ResourceQuota to rebuild smaller when we can.
   if (max_table_elems > elem_size_.size()) {
-    Rebuild(std::max(max_table_elems, 2 * elem_size_.size()));
+    Rebuild((uint32_t)std::max(max_table_elems, 2 * elem_size_.size()));
   }
   return true;
 }

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1123,7 +1123,7 @@ class HPackParser::Parser {
     const auto transport_size = key_string.size() + value_slice.size() +
                                 hpack_constants::kEntryOverhead;
     return grpc_metadata_batch::Parse(
-        key->string_view(), std::move(value_slice), transport_size,
+        key->string_view(), std::move(value_slice), (uint32_t)transport_size,
         [key_string](absl::string_view error, const Slice& value) {
           ReportMetadataParseError(key_string, error, value.as_string_view());
         });

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -235,7 +235,7 @@ GPR_ATTRIBUTE_NOINLINE HPackTable::Memento MakeMemento(size_t i) {
   auto sm = kStaticTable[i];
   return grpc_metadata_batch::Parse(
       sm.key, Slice::FromStaticString(sm.value),
-      strlen(sm.key) + strlen(sm.value) + hpack_constants::kEntryOverhead,
+      (uint32_t)(strlen(sm.key) + strlen(sm.value) + hpack_constants::kEntryOverhead),
       [](absl::string_view, const Slice&) {
         abort();  // not expecting to see this
       });

--- a/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
+++ b/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
@@ -131,7 +131,7 @@ FileWatcherCertificateProviderFactory::CreateCertificateProvider(
       file_watcher_config->private_key_file(),
       file_watcher_config->identity_cert_file(),
       file_watcher_config->root_cert_file(),
-      file_watcher_config->refresh_interval().millis() / GPR_MS_PER_SEC);
+      (unsigned int)(file_watcher_config->refresh_interval().millis() / GPR_MS_PER_SEC));
 }
 
 void FileWatcherCertificateProviderInit() {

--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -117,7 +117,7 @@ CompressionAlgorithmSet CompressionAlgorithmSet::FromUint32(uint32_t value) {
   CompressionAlgorithmSet set;
   for (size_t i = 0; i < GRPC_COMPRESS_ALGORITHMS_COUNT; i++) {
     if (value & (1u << i)) {
-      set.set_.set(i);
+      set.set_.set((int)i);
     }
   }
   return set;
@@ -152,7 +152,7 @@ bool CompressionAlgorithmSet::IsSet(
     grpc_compression_algorithm algorithm) const {
   size_t i = static_cast<size_t>(algorithm);
   if (i < GRPC_COMPRESS_ALGORITHMS_COUNT) {
-    return set_.is_set(i);
+    return set_.is_set((int)i);
   } else {
     return false;
   }
@@ -161,14 +161,14 @@ bool CompressionAlgorithmSet::IsSet(
 void CompressionAlgorithmSet::Set(grpc_compression_algorithm algorithm) {
   size_t i = static_cast<size_t>(algorithm);
   if (i < GRPC_COMPRESS_ALGORITHMS_COUNT) {
-    set_.set(i);
+    set_.set((int)i);
   }
 }
 
 std::string CompressionAlgorithmSet::ToString() const {
   absl::InlinedVector<const char*, GRPC_COMPRESS_ALGORITHMS_COUNT> segments;
   for (size_t i = 0; i < GRPC_COMPRESS_ALGORITHMS_COUNT; i++) {
-    if (set_.is_set(i)) {
+    if (set_.is_set((int)i)) {
       segments.push_back(CompressionAlgorithmAsString(
           static_cast<grpc_compression_algorithm>(i)));
     }

--- a/src/core/lib/gpr/time_precise.cc
+++ b/src/core/lib/gpr/time_precise.cc
@@ -149,7 +149,7 @@ gpr_cycle_counter gpr_get_cycle_counter() {
 gpr_timespec gpr_cycle_counter_to_time(gpr_cycle_counter cycles) {
   gpr_timespec ts;
   ts.tv_sec = static_cast<int64_t>(cycles / GPR_US_PER_SEC);
-  ts.tv_nsec = static_cast<int64_t>((cycles - ts.tv_sec * GPR_US_PER_SEC) *
+  ts.tv_nsec = static_cast<int32_t>((cycles - ts.tv_sec * GPR_US_PER_SEC) *
                                     GPR_NS_PER_US);
   ts.clock_type = GPR_CLOCK_PRECISE;
   return ts;

--- a/src/core/lib/gprpp/bitset.h
+++ b/src/core/lib/gprpp/bitset.h
@@ -164,7 +164,7 @@ class BitSet {
   ToInt() const {
     Int result = 0;
     for (size_t i = 0; i < kTotalBits; i++) {
-      if (is_set(i)) result |= (Int(1) << i);
+      if (is_set((int)i)) result |= (Int(1) << i);
     }
     return result;
   }

--- a/src/core/lib/gprpp/status_helper.cc
+++ b/src/core/lib/gprpp/status_helper.cc
@@ -276,7 +276,7 @@ void StatusAddChild(absl::Status* status, absl::Status child) {
     children = *old_children;
   }
   char head_buf[sizeof(uint32_t)];
-  EncodeUInt32ToBytes(buf_len, head_buf);
+  EncodeUInt32ToBytes((uint32_t)buf_len, head_buf);
   children.Append(absl::string_view(head_buf, sizeof(uint32_t)));
   children.Append(absl::string_view(buf, buf_len));
   status->SetPayload(kChildrenPropertyUrl, std::move(children));

--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -484,7 +484,7 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
         "Invalid expire time of service account impersonation response."));
     return;
   }
-  int expire_in = (t - absl::Now()) / absl::Seconds(1);
+  int expire_in = (int)((t - absl::Now()) / absl::Seconds(1));
   std::string body = absl::StrFormat(
       "{\"access_token\":\"%s\",\"expires_in\":%d,\"token_type\":\"Bearer\"}",
       access_token, expire_in);

--- a/src/core/lib/security/credentials/tls/tls_utils.cc
+++ b/src/core/lib/security/credentials/tls/tls_utils.cc
@@ -81,7 +81,7 @@ bool VerifySubjectAlternativeName(absl::string_view subject_alternative_name,
     return false;
   }
   if (!absl::EndsWith(normalized_matcher, suffix)) return false;
-  int suffix_start_index = normalized_matcher.length() - suffix.length();
+  int suffix_start_index = (int)(normalized_matcher.length() - suffix.length());
   // Asterisk matching across domain labels is not permitted.
   return suffix_start_index <= 0 /* should not happen */ ||
          normalized_matcher.find_last_of('.', suffix_start_index - 1) ==

--- a/src/core/lib/surface/channel.h
+++ b/src/core/lib/surface/channel.h
@@ -143,7 +143,7 @@ class Channel : public RefCounted<Channel>,
 
   int TestOnlyRegisteredCalls() {
     MutexLock lock(&registration_table_.mu);
-    return registration_table_.map.size();
+    return (int)registration_table_.map.size();
   }
 
   int TestOnlyRegistrationAttempts() {

--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -488,7 +488,7 @@ class ParseHelper {
     return ParsedMetadata<Container>(
         trait,
         ParseValueToMemento<typename Trait::MementoType, Trait::ParseMemento>(),
-        transport_size_);
+        (uint32_t)transport_size_);
   }
 
   GPR_ATTRIBUTE_NOINLINE ParsedMetadata<Container> NotFound(

--- a/src/core/lib/transport/parsed_metadata.h
+++ b/src/core/lib/transport/parsed_metadata.h
@@ -153,7 +153,7 @@ class ParsedMetadata {
   // Construct metadata from a string key, slice value pair.
   ParsedMetadata(Slice key, Slice value)
       : vtable_(ParsedMetadata::KeyValueVTable(key.as_string_view())),
-        transport_size_(key.size() + value.size() + 32) {
+        transport_size_((uint32_t)(key.size() + value.size() + 32)) {
     value_.pointer =
         new std::pair<Slice, Slice>(std::move(key), std::move(value));
   }
@@ -192,7 +192,7 @@ class ParsedMetadata {
     ParsedMetadata result;
     result.vtable_ = vtable_;
     result.value_ = value_;
-    result.transport_size_ = TransportSize(key().length(), value.length());
+    result.transport_size_ = TransportSize((uint32_t)key().length(), (uint32_t)value.length());
     vtable_->with_new_value(&value, on_error, &result);
     return result;
   }

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -15,10 +15,10 @@ def grpc_deps
   pod 'Libuv-gRPC',       :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
 
   pod 'gRPC/InternalTesting',           :path => GRPC_LOCAL_SRC
-  pod 'gRPC-Core',                      :path => GRPC_LOCAL_SRC, :inhibit_warnings => true
+  pod 'gRPC-Core',                      :path => GRPC_LOCAL_SRC
   pod 'gRPC-RxLibrary',                 :path => GRPC_LOCAL_SRC
-  pod 'gRPC-ProtoRPC',                  :path => GRPC_LOCAL_SRC, :inhibit_warnings => true
-  pod 'RemoteTest', :path => "RemoteTestClient", :inhibit_warnings => true
+  pod 'gRPC-ProtoRPC',                  :path => GRPC_LOCAL_SRC
+  pod 'RemoteTest', :path => "RemoteTestClient"
 end
 
 target 'TvTests' do
@@ -78,7 +78,6 @@ post_install do |installer|
         # function" warning
         config.build_settings['GCC_WARN_ABOUT_RETURN_TYPE'] = 'NO'
         # Abseil isn't free from the following warning
-        config.build_settings['GCC_WARN_64_TO_32_BIT_CONVERSION'] = 'NO'
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited) COCOAPODS=1 GRPC_CRONET_WITH_PACKET_COALESCING=1 GRPC_CFSTREAM=1'
       end
     end

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -15,10 +15,10 @@ def grpc_deps
   pod 'Libuv-gRPC',       :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
 
   pod 'gRPC/InternalTesting',           :path => GRPC_LOCAL_SRC
-  pod 'gRPC-Core',                      :path => GRPC_LOCAL_SRC
+  pod 'gRPC-Core',                      :path => GRPC_LOCAL_SRC, :inhibit_warnings => true
   pod 'gRPC-RxLibrary',                 :path => GRPC_LOCAL_SRC
-  pod 'gRPC-ProtoRPC',                  :path => GRPC_LOCAL_SRC
-  pod 'RemoteTest', :path => "RemoteTestClient"
+  pod 'gRPC-ProtoRPC',                  :path => GRPC_LOCAL_SRC, :inhibit_warnings => true
+  pod 'RemoteTest', :path => "RemoteTestClient", :inhibit_warnings => true
 end
 
 target 'TvTests' do
@@ -78,6 +78,7 @@ post_install do |installer|
         # function" warning
         config.build_settings['GCC_WARN_ABOUT_RETURN_TYPE'] = 'NO'
         # Abseil isn't free from the following warning
+        config.build_settings['GCC_WARN_64_TO_32_BIT_CONVERSION'] = 'NO'
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited) COCOAPODS=1 GRPC_CRONET_WITH_PACKET_COALESCING=1 GRPC_CFSTREAM=1'
       end
     end


### PR DESCRIPTION
Explicit casting to avoid 64 to 32 bit conversion clang warning ([-Wshorten-64-to-32](https://clang.llvm.org/docs/DiagnosticsReference.html#wshorten-64-to-32))  as seen from gRPC iOS and Firebase iOS SDK (e.g. https://github.com/firebase/firebase-ios-sdk/issues/9790, https://github.com/firebase/firebase-ios-sdk/discussions/9700) . This is observed from MacOS/iOS platform but I believe it also applies to others. thanks 


----

https://github.com/grpc/grpc-ios/issues/83