### PR TITLE
increase orca oob test verification timeout

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1135,7 +1135,7 @@ Procedures:
     ```
 The call carries a reference to receive the load report, e.g. using CallOptions.
 The reference will be passed to the custom LB policy as part of the `OrcaOobReportListener` API.
-* Client asserts that, after 1 second, the latest OOB load report received is equal to the test load report.
+* Client asserts that, after 1.5 second, the latest OOB load report received is equal to the test load report.
 * Client sends another unary call to the server. The call request sets `orca_oob_report` to a 
 different test load report. 
     ```
@@ -1150,7 +1150,7 @@ different test load report.
     }
     ```
 The call still carries a reference to receive the load report.
-* Client asserts that, after 1 second, the latest OOB load report received is equal to the new test load report.
+* Client asserts that, after 1.5 second, the latest OOB load report received is equal to the new test load report.
 
 ### Experimental Tests
 


### PR DESCRIPTION
After a little refactor (or optimization), java `orca_oob` test would occasionally fail (local machine test, very high reproduce rate)only at the first assertion after start. It looks report was sent slightly after 1s. 
Setting assertion timeout to 1500millis, 1100millis, or even 1010 millis always successful. 

cc. @markdroth @dfawley 