### PR TITLE
grpc_authz test: longer wait for authz policy reload

### DIFF
--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -53,8 +53,8 @@ static gpr_timespec five_seconds_from_now(void) {
 
 static void wait_for_policy_reload(void) {
   // Wait for the provider's refresh thread to read the updated files.
-  // TODO: Refactor the tests to use a more reliable mechanism of detecting
-  // policy has been reloaded. See b/204329811
+  // TODO(jtattermusch): Refactor the tests to use a more reliable mechanism of
+  // detecting that the policy has been reloaded. See b/204329811
   gpr_sleep_until(grpc_timeout_seconds_to_deadline(5));
 }
 

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -51,6 +51,13 @@ static gpr_timespec five_seconds_from_now(void) {
   return n_seconds_from_now(5);
 }
 
+static void wait_for_policy_reload(void) {
+  // Wait for the provider's refresh thread to read the updated files.
+  // TODO: Refactor the tests to use a more reliable mechanism of detecting
+  // policy has been reloaded. See b/204329811
+  gpr_sleep_until(grpc_timeout_seconds_to_deadline(5));
+}
+
 static void drain_cq(grpc_completion_queue* cq) {
   grpc_event ev;
   do {
@@ -576,8 +583,7 @@ static void test_file_watcher_valid_policy_reload(
       "  ]"
       "}";
   tmp_policy.RewriteFile(authz_policy);
-  // Wait 2 seconds for the provider's refresh thread to read the updated files.
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
+  wait_for_policy_reload();
   test_deny_unauthorized_request(f);
 
   end_test(&f);
@@ -623,8 +629,7 @@ static void test_file_watcher_invalid_policy_skip_reload(
   // Replace exisiting policy in file with an invalid policy.
   authz_policy = "{}";
   tmp_policy.RewriteFile(authz_policy);
-  // Wait 2 seconds for the provider's refresh thread to read the updated files.
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
+  wait_for_policy_reload();
   test_allow_authorized_request(f);
 
   end_test(&f);
@@ -669,8 +674,7 @@ static void test_file_watcher_recovers_from_failure(
   // Replace exisiting policy in file with an invalid policy.
   authz_policy = "{}";
   tmp_policy.RewriteFile(authz_policy);
-  // Wait 2 seconds for the provider's refresh thread to read the updated files.
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
+  wait_for_policy_reload();
   test_allow_authorized_request(f);
   // Recover from reload errors, by replacing invalid policy in file with a
   // valid policy.
@@ -699,8 +703,7 @@ static void test_file_watcher_recovers_from_failure(
       "  ]"
       "}";
   tmp_policy.RewriteFile(authz_policy);
-  // Wait 2 seconds for the provider's refresh thread to read the updated files.
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
+  wait_for_policy_reload();
   test_deny_unauthorized_request(f);
 
   end_test(&f);


### PR DESCRIPTION
See internal b/204329811.

Increase the sleep from 2 to 5 seconds.

The grpc_authz tests seems badly designed, this should prevent it from flaking heavily on mac.