### PR TITLE
test: increase test slowdown factor on MacOS

### DIFF
--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -48,7 +48,7 @@ int64_t g_fixture_slowdown_factor = 1;
 int64_t g_poller_slowdown_factor = 1;
 
 #if GPR_APPLE
-static const int64_t kPlatformSlowdownFactor = 2;
+static const int64_t kPlatformSlowdownFactor = 3;
 #else
 static const int64_t kPlatformSlowdownFactor = 1;
 #endif

--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -47,6 +47,12 @@
 int64_t g_fixture_slowdown_factor = 1;
 int64_t g_poller_slowdown_factor = 1;
 
+#if GPR_APPLE
+static const int64_t kPlatformSlowdownFactor = 2;
+#else
+static const int64_t kPlatformSlowdownFactor = 1;
+#endif
+
 #if GPR_GETPID_IN_UNISTD_H
 #include <unistd.h>
 static unsigned seed(void) { return static_cast<unsigned>(getpid()); }
@@ -75,7 +81,7 @@ int64_t grpc_test_sanitizer_slowdown_factor() {
 
 int64_t grpc_test_slowdown_factor() {
   return grpc_test_sanitizer_slowdown_factor() * g_fixture_slowdown_factor *
-         g_poller_slowdown_factor;
+         g_poller_slowdown_factor * kPlatformSlowdownFactor;
 }
 
 gpr_timespec grpc_timeout_seconds_to_deadline(int64_t time_s) {


### PR DESCRIPTION
As suggested by @ctiller in https://github.com/grpc/grpc/pull/29779#discussion_r881785552.

Is `GPR_APPLE` the right macro to use here?