### PR TITLE
Revert "[c++14] Simplify macro thats always the same now"

### DIFF
--- a/src/core/lib/gprpp/bitset.h
+++ b/src/core/lib/gprpp/bitset.h
@@ -24,6 +24,12 @@
 
 #include "src/core/lib/gpr/useful.h"
 
+#if __cplusplus > 201103l
+#define GRPC_BITSET_CONSTEXPR_MUTATOR constexpr
+#else
+#define GRPC_BITSET_CONSTEXPR_MUTATOR
+#endif
+
 namespace grpc_core {
 
 // Given a bit count as an integer, vend as member type `Type` a type with
@@ -84,10 +90,12 @@ class BitSet {
   constexpr BitSet() : units_{} {}
 
   // Set bit i to true
-  constexpr void set(int i) { units_[unit_for(i)] |= mask_for(i); }
+  GRPC_BITSET_CONSTEXPR_MUTATOR void set(int i) {
+    units_[unit_for(i)] |= mask_for(i);
+  }
 
   // Set bit i to is_set
-  constexpr void set(int i, bool is_set) {
+  GRPC_BITSET_CONSTEXPR_MUTATOR void set(int i, bool is_set) {
     if (is_set) {
       set(i);
     } else {
@@ -96,7 +104,9 @@ class BitSet {
   }
 
   // Set bit i to false
-  constexpr void clear(int i) { units_[unit_for(i)] &= ~mask_for(i); }
+  GRPC_BITSET_CONSTEXPR_MUTATOR void clear(int i) {
+    units_[unit_for(i)] &= ~mask_for(i);
+  }
 
   // Return true if bit i is set
   constexpr bool is_set(int i) const {

--- a/src/core/lib/slice/percent_encoding.cc
+++ b/src/core/lib/slice/percent_encoding.cc
@@ -30,12 +30,20 @@
 
 #include "src/core/lib/gprpp/bitset.h"
 
+#if __cplusplus > 201103l
+#define GRPC_PCTENCODE_CONSTEXPR_FN constexpr
+#define GRPC_PCTENCODE_CONSTEXPR_VALUE constexpr
+#else
+#define GRPC_PCTENCODE_CONSTEXPR_FN
+#define GRPC_PCTENCODE_CONSTEXPR_VALUE const
+#endif
+
 namespace grpc_core {
 
 namespace {
 class UrlTable : public BitSet<256> {
  public:
-  constexpr UrlTable() {
+  GRPC_PCTENCODE_CONSTEXPR_FN UrlTable() {
     for (int i = 'a'; i <= 'z'; i++) set(i);
     for (int i = 'A'; i <= 'Z'; i++) set(i);
     for (int i = '0'; i <= '9'; i++) set(i);
@@ -46,11 +54,11 @@ class UrlTable : public BitSet<256> {
   }
 };
 
-constexpr UrlTable g_url_table;
+GRPC_PCTENCODE_CONSTEXPR_VALUE UrlTable g_url_table;
 
 class CompatibleTable : public BitSet<256> {
  public:
-  constexpr CompatibleTable() {
+  GRPC_PCTENCODE_CONSTEXPR_FN CompatibleTable() {
     for (int i = 32; i <= 126; i++) {
       if (i == '%') continue;
       set(i);
@@ -58,7 +66,7 @@ class CompatibleTable : public BitSet<256> {
   }
 };
 
-constexpr CompatibleTable g_compatible_table;
+GRPC_PCTENCODE_CONSTEXPR_VALUE CompatibleTable g_compatible_table;
 
 // Map PercentEncodingType to a lookup table of legal symbols for that encoding.
 const BitSet<256>& LookupTableForPercentEncodingType(PercentEncodingType type) {


### PR DESCRIPTION
Reverts grpc/grpc#29601

Hit merge on the wrong PR