### PR TITLE
xds_cluster_type_end2end_test: fix flake in AggregateClusterTest.FallBackWithConnectivityChurn test

### DIFF
--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -195,6 +195,8 @@ class Server : public InternallyRefCounted<Server>,
   void ShutdownAndNotify(grpc_completion_queue* cq, void* tag)
       ABSL_LOCKS_EXCLUDED(mu_global_, mu_call_);
 
+  void StopListening();
+
   void CancelAllCalls() ABSL_LOCKS_EXCLUDED(mu_global_);
 
   void SendGoaways() ABSL_LOCKS_EXCLUDED(mu_global_, mu_call_);

--- a/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
@@ -524,8 +524,11 @@ TEST_P(AggregateClusterTest, FallBackWithConnectivityChurn) {
   // Increase timeout to account for subchannel connection delays.
   WaitForBackend(DEBUG_LOCATION, 0, WaitForBackendOptions(),
                  RpcOptions().set_timeout_ms(2000));
-  // Bring down the P0 backend.
-  ShutdownBackend(0);
+  // Send GOAWAY from the P0 backend.
+  // We don't actually shut it down here to avoid flakiness caused by
+  // failing an RPC after the client has already sent it but before the
+  // server finished processing it.
+  backends_[0]->StopListeningAndSendGoaways();
   // Allow the connection attempt to the P1 backend to resume.
   connection_attempt_injector.CompletePriority1Connection();
   // Wait for P1 backend to start getting traffic.

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -41,6 +41,7 @@
 #include "src/core/ext/xds/xds_client.h"
 #include "src/core/lib/gpr/env.h"
 #include "src/core/lib/gpr/tmpfile.h"
+#include "src/core/lib/surface/server.h"
 #include "src/cpp/client/secure_credentials.h"
 #include "src/proto/grpc/testing/xds/v3/router.grpc.pb.h"
 #include "test/core/util/resolve_localhost_ip46.h"
@@ -157,6 +158,17 @@ void XdsEnd2endTest::ServerThread::Shutdown() {
   thread_->join();
   gpr_log(GPR_INFO, "%s shutdown completed", Type());
   running_ = false;
+}
+
+void XdsEnd2endTest::ServerThread::StopListeningAndSendGoaways() {
+  gpr_log(GPR_INFO, "%s sending GOAWAYs", Type());
+  {
+    grpc_core::ExecCtx exec_ctx;
+    auto* server = grpc_core::Server::FromC(server_->c_server());
+    server->StopListening();
+    server->SendGoaways();
+  }
+  gpr_log(GPR_INFO, "%s done sending GOAWAYs", Type());
 }
 
 void XdsEnd2endTest::ServerThread::Serve(grpc_core::Mutex* mu,

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -257,6 +257,8 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType> {
       allow_put_requests_ = allow_put_requests;
     }
 
+    void StopListeningAndSendGoaways();
+
    private:
     class XdsChannelArgsServerBuilderOption;
 


### PR DESCRIPTION
This flake was meant to be fixed via a combination of #29462 and #29428, but we're still seeing the flake.  Here's an example of the problem with a bunch of tracing enabled:

https://source.cloud.google.com/results/invocations/141134f0-a1c2-47e7-a08f-7119ac410a08/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_type_end2end_test@poller%3Depoll1/log

The RPC appears to be failing with a "Broken pipe" error because the transport encounters that socket error while writing before it has noticed the GOAWAY sent by the server.  This is a consequence of the fact that we're not doing a graceful shutdown on the server side; the client is seeing the connection close before it has a chance to read the GOAWAY.

To fix this, we change the test such that instead of shutting down the server, it will just send a GOAWAY and stop listening, but it will not break the existing connection.  This simulates proper graceful shutdown behavior and ensures that any already-in-flight RPCs will succeed, but the client will still consider the connection unusable for new RPCs and will not succeed in reconnecting.

I ran this 1000x on RBE and it appears to be fixed.