### PR TITLE
interop-test: add orca_per_rpc and orca_oob test cases

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_interop_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_interop_rc
@@ -26,7 +26,7 @@ git submodule update --init
 # Clone repositories for languages tested by the interop test suite
 # Also show the current commit SHA that will be tested.
 git clone --recursive https://github.com/grpc/grpc-go ./../grpc-go && (cd ../grpc-go; git rev-parse HEAD)
-git clone --recursive https://github.com/YifeiZhuang/grpc-java ./../grpc-java && (cd ../grpc-java; git checkout fix-interop-local; git rev-parse HEAD)
+git clone --recursive https://github.com/grpc/grpc-java ./../grpc-java && (cd ../grpc-java; git rev-parse HEAD)
 git clone --recursive https://github.com/grpc/grpc-node ./../grpc-node && (cd ../grpc-node; git rev-parse HEAD)
 git clone --recursive https://github.com/grpc/grpc-dart ./../grpc-dart && (cd ../grpc-dart; git rev-parse HEAD)
 git clone --recursive https://github.com/grpc/grpc-dotnet ./../grpc-dotnet && (cd ../grpc-dotnet; git rev-parse HEAD)

--- a/tools/internal_ci/helper_scripts/prepare_build_interop_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_interop_rc
@@ -26,7 +26,7 @@ git submodule update --init
 # Clone repositories for languages tested by the interop test suite
 # Also show the current commit SHA that will be tested.
 git clone --recursive https://github.com/grpc/grpc-go ./../grpc-go && (cd ../grpc-go; git rev-parse HEAD)
-git clone --recursive https://github.com/grpc/grpc-java ./../grpc-java && (cd ../grpc-java; git rev-parse HEAD)
+git clone --recursive https://github.com/YifeiZhuang/grpc-java ./../grpc-java && (cd ../grpc-java; git checkout fix-interop-local; git rev-parse HEAD)
 git clone --recursive https://github.com/grpc/grpc-node ./../grpc-node && (cd ../grpc-node; git rev-parse HEAD)
 git clone --recursive https://github.com/grpc/grpc-dart ./../grpc-dart && (cd ../grpc-dart; git rev-parse HEAD)
 git clone --recursive https://github.com/grpc/grpc-dotnet ./../grpc-dotnet && (cd ../grpc-dotnet; git rev-parse HEAD)

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -67,9 +67,7 @@ _SKIP_ADVANCED = [
 
 _SKIP_SPECIAL_STATUS_MESSAGE = ['special_status_message']
 
-_SKIP_ORCA = [
-  'orca_per_rpc', 'orca_oob'
-]
+_SKIP_ORCA = ['orca_per_rpc', 'orca_oob']
 
 _GOOGLE_DEFAULT_CREDS_TEST_CASE = 'google_default_credentials'
 
@@ -681,8 +679,8 @@ _TEST_CASES = [
     'custom_metadata', 'status_code_and_message', 'unimplemented_method',
     'client_compressed_unary', 'server_compressed_unary',
     'client_compressed_streaming', 'server_compressed_streaming',
-    'unimplemented_service', 'special_status_message',
-    'orca_per_rpc', 'orca_oob'
+    'unimplemented_service', 'special_status_message', 'orca_per_rpc',
+    'orca_oob'
 ]
 
 _AUTH_TEST_CASES = [

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -679,13 +679,14 @@ _SERVERS = [
 ]
 
 _TEST_CASES = [
-    'large_unary', 'empty_unary', 'ping_pong', 'empty_stream',
-    'client_streaming', 'server_streaming', 'cancel_after_begin',
-    'cancel_after_first_response', 'timeout_on_sleeping_server',
-    'custom_metadata', 'status_code_and_message', 'unimplemented_method',
-    'client_compressed_unary', 'server_compressed_unary',
-    'client_compressed_streaming', 'server_compressed_streaming',
-    'unimplemented_service', 'special_status_message', 'orca_per_rpc',
+    # 'large_unary', 'empty_unary', 'ping_pong', 'empty_stream',
+    # 'client_streaming', 'server_streaming', 'cancel_after_begin',
+    # 'cancel_after_first_response', 'timeout_on_sleeping_server',
+    # 'custom_metadata', 'status_code_and_message', 'unimplemented_method',
+    # 'client_compressed_unary', 'server_compressed_unary',
+    # 'client_compressed_streaming', 'server_compressed_streaming',
+    # 'unimplemented_service', 'special_status_message',
+    # 'orca_per_rpc',
     'orca_oob'
 ]
 

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -67,6 +67,10 @@ _SKIP_ADVANCED = [
 
 _SKIP_SPECIAL_STATUS_MESSAGE = ['special_status_message']
 
+_SKIP_ORCA = [
+  'orca_per_rpc', 'orca_oob'
+]
+
 _GOOGLE_DEFAULT_CREDS_TEST_CASE = 'google_default_credentials'
 
 _SKIP_GOOGLE_DEFAULT_CREDS = [
@@ -116,7 +120,8 @@ class CXXLanguage:
     def unimplemented_test_cases(self):
         return _SKIP_DATA_FRAME_PADDING + \
             _SKIP_SPECIAL_STATUS_MESSAGE + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return []
@@ -146,7 +151,8 @@ class AspNetCoreLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return []
@@ -179,7 +185,8 @@ class DartLanguage:
         return _SKIP_COMPRESSION + \
             _SKIP_SPECIAL_STATUS_MESSAGE + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION + _SKIP_SPECIAL_STATUS_MESSAGE
@@ -272,7 +279,8 @@ class GoLanguage:
         return {'GO111MODULE': 'on'}
 
     def unimplemented_test_cases(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -379,7 +387,8 @@ class NodeLanguage:
         return _SKIP_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -412,7 +421,8 @@ class NodePureJSLanguage:
         return _SKIP_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return []
@@ -444,7 +454,8 @@ class PHP7Language:
         return _SKIP_SERVER_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -484,7 +495,8 @@ class ObjcLanguage:
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_SPECIAL_STATUS_MESSAGE + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -523,7 +535,8 @@ class RubyLanguage:
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_SPECIAL_STATUS_MESSAGE + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -574,7 +587,8 @@ class PythonLanguage:
         return _SKIP_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -624,7 +638,8 @@ class PythonAsyncIOLanguage:
         return _SKIP_COMPRESSION + \
             _SKIP_DATA_FRAME_PADDING + \
             _AUTH_TEST_CASES + \
-            ['timeout_on_sleeping_server']
+            ['timeout_on_sleeping_server'] + \
+            _SKIP_ORCA
 
     def unimplemented_test_cases_server(self):
         # TODO(https://github.com/grpc/grpc/issues/21749)
@@ -666,7 +681,8 @@ _TEST_CASES = [
     'custom_metadata', 'status_code_and_message', 'unimplemented_method',
     'client_compressed_unary', 'server_compressed_unary',
     'client_compressed_streaming', 'server_compressed_streaming',
-    'unimplemented_service', 'special_status_message'
+    'unimplemented_service', 'special_status_message',
+    'orca_per_rpc', 'orca_oob'
 ]
 
 _AUTH_TEST_CASES = [

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -122,7 +122,7 @@ class CXXLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return []
+        return _ORCA_TEST_CASES
 
     def __str__(self):
         return 'c++'
@@ -187,7 +187,7 @@ class DartLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION + _SKIP_SPECIAL_STATUS_MESSAGE
+        return _SKIP_COMPRESSION + _SKIP_SPECIAL_STATUS_MESSAGE + _ORCA_TEST_CASES
 
     def __str__(self):
         return 'dart'

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -687,7 +687,8 @@ _TEST_CASES = [
     'custom_metadata', 'status_code_and_message', 'unimplemented_method',
     'client_compressed_unary', 'server_compressed_unary',
     'client_compressed_streaming', 'server_compressed_streaming',
-    'unimplemented_service', 'special_status_message', 'orca_per_rpc', 'orca_oob'
+    'unimplemented_service', 'special_status_message', 'orca_per_rpc',
+    'orca_oob'
 ]
 
 _AUTH_TEST_CASES = [
@@ -699,9 +700,7 @@ _AUTH_TEST_CASES = [
     _COMPUTE_ENGINE_CHANNEL_CREDS_TEST_CASE,
 ]
 
-_HTTP2_TEST_CASES = [
-  'tls', 'framing'
-]
+_HTTP2_TEST_CASES = ['tls', 'framing']
 
 _HTTP2_SERVER_TEST_CASES = [
     'rst_after_header', 'rst_after_data', 'rst_during_data', 'goaway', 'ping',
@@ -1533,7 +1532,8 @@ try:
                             docker_image=docker_images.get(str(language)),
                             transport_security=args.transport_security,
                             manual_cmd_log=client_manual_cmd_log)
-                        if test_case in _SERIALIZING_TEST_CASES and len(jobs_sets[-1]) > 0:
+                        if test_case in _SERIALIZING_TEST_CASES and len(
+                                jobs_sets[-1]) > 0:
                             jobs_sets.append([])
                         jobs_sets[-1].append(test_job)
 

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -67,7 +67,7 @@ _SKIP_ADVANCED = [
 
 _SKIP_SPECIAL_STATUS_MESSAGE = ['special_status_message']
 
-_SKIP_ORCA = ['orca_per_rpc', 'orca_oob']
+_ORCA_TEST_CASES = ['orca_per_rpc', 'orca_oob']
 
 _GOOGLE_DEFAULT_CREDS_TEST_CASE = 'google_default_credentials'
 
@@ -117,9 +117,9 @@ class CXXLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_SPECIAL_STATUS_MESSAGE + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_SPECIAL_STATUS_MESSAGE + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return []
@@ -149,8 +149,8 @@ class AspNetCoreLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return []
@@ -181,10 +181,10 @@ class DartLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-            _SKIP_SPECIAL_STATUS_MESSAGE + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_SPECIAL_STATUS_MESSAGE + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION + _SKIP_SPECIAL_STATUS_MESSAGE
@@ -278,7 +278,7 @@ class GoLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-               _SKIP_ORCA
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -383,10 +383,10 @@ class NodeLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_DATA_FRAME_PADDING + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -417,10 +417,10 @@ class NodePureJSLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_DATA_FRAME_PADDING + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return []
@@ -450,10 +450,10 @@ class PHP7Language:
 
     def unimplemented_test_cases(self):
         return _SKIP_SERVER_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_DATA_FRAME_PADDING + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -489,12 +489,12 @@ class ObjcLanguage:
         # and depend upon ObjC test's behavior that it runs all cases even when
         # we tell it to run just one.
         return _TEST_CASES[1:] + \
-            _SKIP_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_SPECIAL_STATUS_MESSAGE + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_COMPRESSION + \
+               _SKIP_DATA_FRAME_PADDING + \
+               _SKIP_SPECIAL_STATUS_MESSAGE + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -530,11 +530,11 @@ class RubyLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_SERVER_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_SPECIAL_STATUS_MESSAGE + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_DATA_FRAME_PADDING + \
+               _SKIP_SPECIAL_STATUS_MESSAGE + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -583,10 +583,10 @@ class PythonLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _SKIP_GOOGLE_DEFAULT_CREDS + \
-            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
-            _SKIP_ORCA
+               _SKIP_DATA_FRAME_PADDING + \
+               _SKIP_GOOGLE_DEFAULT_CREDS + \
+               _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -634,10 +634,10 @@ class PythonAsyncIOLanguage:
     def unimplemented_test_cases(self):
         # TODO(https://github.com/grpc/grpc/issues/21707)
         return _SKIP_COMPRESSION + \
-            _SKIP_DATA_FRAME_PADDING + \
-            _AUTH_TEST_CASES + \
-            ['timeout_on_sleeping_server'] + \
-            _SKIP_ORCA
+               _SKIP_DATA_FRAME_PADDING + \
+               _AUTH_TEST_CASES + \
+               ['timeout_on_sleeping_server'] + \
+               _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
         # TODO(https://github.com/grpc/grpc/issues/21749)
@@ -879,6 +879,10 @@ def cloud_to_prod_jobspec(language,
             % (str(language), transport_security))
         sys.exit(1)
     cmdargs = cmdargs + transport_security_options
+    if test_case in _ORCA_TEST_CASES:
+        cmdargs = cmdargs + [
+            '--service_config_json=\'{"loadBalancingConfig":[{"test_backend_metrics_load_balancer":{}}]}\''
+        ]
     environ = dict(language.cloud_to_prod_env(), **language.global_env())
     if auth:
         auth_cmdargs, auth_env = auth_options(
@@ -973,8 +977,12 @@ def cloud_to_cloud_jobspec(language,
                 language.client_cmd_http2interop(common_options))
             cwd = language.http2_cwd
     else:
-        cmdline = bash_cmdline(
-            language.client_cmd(common_options + interop_only_options))
+        cmd_options = common_options + interop_only_options
+        if test_case in _ORCA_TEST_CASES:
+            cmd_options = common_options + [
+                '--service_config_json=\'{"loadBalancingConfig":[{"test_backend_metrics_load_balancer":{}}]}\''
+            ]
+        cmdline = bash_cmdline(language.client_cmd(cmd_options))
         cwd = language.client_cwd
 
     environ = language.global_env()

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -681,15 +681,13 @@ _SERVERS = [
 ]
 
 _TEST_CASES = [
-    # 'large_unary', 'empty_unary', 'ping_pong', 'empty_stream',
-    # 'client_streaming', 'server_streaming', 'cancel_after_begin',
-    # 'cancel_after_first_response', 'timeout_on_sleeping_server',
-    # 'custom_metadata', 'status_code_and_message', 'unimplemented_method',
-    # 'client_compressed_unary', 'server_compressed_unary',
-    # 'client_compressed_streaming', 'server_compressed_streaming',
-    # 'unimplemented_service', 'special_status_message',
-    # 'orca_per_rpc',
-    'orca_oob'
+    'large_unary', 'empty_unary', 'ping_pong', 'empty_stream',
+    'client_streaming', 'server_streaming', 'cancel_after_begin',
+    'cancel_after_first_response', 'timeout_on_sleeping_server',
+    'custom_metadata', 'status_code_and_message', 'unimplemented_method',
+    'client_compressed_unary', 'server_compressed_unary',
+    'client_compressed_streaming', 'server_compressed_streaming',
+    'unimplemented_service', 'special_status_message', 'orca_per_rpc', 'orca_oob'
 ]
 
 _AUTH_TEST_CASES = [
@@ -702,7 +700,7 @@ _AUTH_TEST_CASES = [
 ]
 
 _HTTP2_TEST_CASES = [
-  # 'tls', 'framing'
+  'tls', 'framing'
 ]
 
 _HTTP2_SERVER_TEST_CASES = [

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -153,7 +153,7 @@ class AspNetCoreLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return []
+        return _ORCA_TEST_CASES
 
     def __str__(self):
         return 'aspnetcore'

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1535,7 +1535,7 @@ try:
                             docker_image=docker_images.get(str(language)),
                             transport_security=args.transport_security,
                             manual_cmd_log=client_manual_cmd_log)
-                        if test_case in _SERIALIZING_TEST_CASES:
+                        if test_case in _SERIALIZING_TEST_CASES and len(jobs_sets[-1]) > 0:
                             jobs_sets.append([])
                         jobs_sets[-1].append(test_job)
 

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -699,7 +699,9 @@ _AUTH_TEST_CASES = [
     _COMPUTE_ENGINE_CHANNEL_CREDS_TEST_CASE,
 ]
 
-_HTTP2_TEST_CASES = ['tls', 'framing']
+_HTTP2_TEST_CASES = [
+  # 'tls', 'framing'
+]
 
 _HTTP2_SERVER_TEST_CASES = [
     'rst_after_header', 'rst_after_data', 'rst_during_data', 'goaway', 'ping',

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -281,7 +281,8 @@ class GoLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _ORCA_TEST_CASES
 
     def __str__(self):
         return 'go'
@@ -389,7 +390,8 @@ class NodeLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _ORCA_TEST_CASES
 
     def __str__(self):
         return 'node'
@@ -423,7 +425,7 @@ class NodePureJSLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return []
+        return _ORCA_TEST_CASES
 
     def __str__(self):
         return 'nodepurejs'
@@ -456,7 +458,8 @@ class PHP7Language:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _ORCA_TEST_CASES
 
     def __str__(self):
         return 'php7'
@@ -497,7 +500,8 @@ class ObjcLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _ORCA_TEST_CASES
 
     def __str__(self):
         return 'objc'
@@ -537,7 +541,8 @@ class RubyLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _ORCA_TEST_CASES
 
     def __str__(self):
         return 'ruby'
@@ -589,7 +594,8 @@ class PythonLanguage:
                _ORCA_TEST_CASES
 
     def unimplemented_test_cases_server(self):
-        return _SKIP_COMPRESSION
+        return _SKIP_COMPRESSION + \
+               _ORCA_TEST_CASES
 
     def __str__(self):
         return 'python'
@@ -879,10 +885,6 @@ def cloud_to_prod_jobspec(language,
             % (str(language), transport_security))
         sys.exit(1)
     cmdargs = cmdargs + transport_security_options
-    if test_case in _ORCA_TEST_CASES:
-        cmdargs = cmdargs + [
-            '--service_config_json=\'{"loadBalancingConfig":[{"test_backend_metrics_load_balancer":{}}]}\''
-        ]
     environ = dict(language.cloud_to_prod_env(), **language.global_env())
     if auth:
         auth_cmdargs, auth_env = auth_options(
@@ -979,7 +981,7 @@ def cloud_to_cloud_jobspec(language,
     else:
         cmd_options = common_options + interop_only_options
         if test_case in _ORCA_TEST_CASES:
-            cmd_options = common_options + [
+            cmd_options = cmd_options + [
                 '--service_config_json=\'{"loadBalancingConfig":[{"test_backend_metrics_load_balancer":{}}]}\''
             ]
         cmdline = bash_cmdline(language.client_cmd(cmd_options))
@@ -1423,7 +1425,7 @@ try:
             for language in languages:
                 for test_case in _TEST_CASES:
                     if not test_case in language.unimplemented_test_cases():
-                        if not test_case in _SKIP_ADVANCED + _SKIP_COMPRESSION + _SKIP_SPECIAL_STATUS_MESSAGE:
+                        if not test_case in _SKIP_ADVANCED + _SKIP_COMPRESSION + _SKIP_SPECIAL_STATUS_MESSAGE + _ORCA_TEST_CASES:
                             for transport_security in args.custom_credentials_type:
                                 # google_default_credentials not yet supported by all languages
                                 if transport_security == 'google_default_credentials' and str(


### PR DESCRIPTION
newly added orca related test cases:
https://github.com/grpc/grpc/pull/29632

will watch fusion tests after merge:
https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_interop_toprod

