### PR TITLE
Revert "server: add method to expose authority seen by server"

### DIFF
--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -297,10 +297,6 @@ class ServerContextBase {
     return call_metric_recorder_;
   }
 
-  /// EXPERIMENTAL API
-  /// Returns the call's authority.
-  grpc::string_ref ExperimentalGetAuthority() const;
-
  protected:
   /// Async only. Has to be called before the rpc starts.
   /// Returns the tag in completion queue when the rpc finishes.

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -104,7 +104,6 @@ class Call : public CppImplOf<Call, grpc_call> {
                                      bool is_notify_tag_closure) = 0;
   virtual bool failed_before_recv_message() const = 0;
   virtual bool is_trailers_only() const = 0;
-  virtual absl::string_view GetServerAuthority() const = 0;
   virtual void ExternalRef() = 0;
   virtual void ExternalUnref() = 0;
   virtual void InternalRef(const char* reason) = 0;
@@ -233,13 +232,6 @@ class FilterStackCall final : public Call {
 
   bool failed_before_recv_message() const override {
     return call_failed_before_recv_message_;
-  }
-
-  absl::string_view GetServerAuthority() const override {
-    const Slice* authority_metadata =
-        recv_initial_metadata_.get_pointer(HttpAuthorityMetadata());
-    if (authority_metadata == nullptr) return "";
-    return authority_metadata->as_string_view();
   }
 
   grpc_compression_algorithm test_only_compression_algorithm() override {
@@ -1948,10 +1940,6 @@ bool grpc_call_is_trailers_only(const grpc_call* call) {
 
 int grpc_call_failed_before_recv_message(const grpc_call* c) {
   return grpc_core::Call::FromC(c)->failed_before_recv_message();
-}
-
-absl::string_view grpc_call_server_authority(const grpc_call* call) {
-  return grpc_core::Call::FromC(call)->GetServerAuthority();
 }
 
 const char* grpc_call_error_to_string(grpc_call_error error) {

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -24,7 +24,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
 #include <grpc/impl/codegen/compression_types.h>
@@ -125,9 +124,6 @@ grpc_compression_algorithm grpc_call_compression_for_level(
 /* TODO(markdroth): This is currently available only to the C++ API.
                     Move to surface API if requested by other languages. */
 bool grpc_call_is_trailers_only(const grpc_call* call);
-
-// Returns the authority for the call, as seen on the server side.
-absl::string_view grpc_call_server_authority(const grpc_call* call);
 
 extern grpc_core::TraceFlag grpc_call_error_trace;
 extern grpc_core::TraceFlag grpc_compression_trace;

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1374,9 +1374,7 @@ void Server::CallData::RecvInitialMetadataReady(void* arg,
   CallData* calld = static_cast<CallData*>(elem->call_data);
   if (error == GRPC_ERROR_NONE) {
     calld->path_ = calld->recv_initial_metadata_->Take(HttpPathMetadata());
-    auto* host =
-        calld->recv_initial_metadata_->get_pointer(HttpAuthorityMetadata());
-    if (host != nullptr) calld->host_.emplace(host->Ref());
+    calld->host_ = calld->recv_initial_metadata_->Take(HttpAuthorityMetadata());
   } else {
     (void)GRPC_ERROR_REF(error);
   }

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -27,8 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/string_view.h"
-
 #include <grpc/compression.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/compression_types.h>
@@ -54,7 +52,6 @@
 #include <grpcpp/support/interceptor.h>
 #include <grpcpp/support/server_callback.h>
 #include <grpcpp/support/server_interceptor.h>
-#include <grpcpp/support/string_ref.h>
 
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/sync.h"
@@ -408,11 +405,6 @@ void ServerContextBase::CreateCallMetricRecorder() {
   GPR_ASSERT(call_metric_recorder_ == nullptr);
   grpc_core::Arena* arena = grpc_call_get_arena(call_.call);
   call_metric_recorder_ = arena->New<experimental::CallMetricRecorder>(arena);
-}
-
-grpc::string_ref ServerContextBase::ExperimentalGetAuthority() const {
-  absl::string_view authority = grpc_call_server_authority(call_.call);
-  return grpc::string_ref(authority.data(), authority.size());
 }
 
 }  // namespace grpc

--- a/src/proto/grpc/testing/echo_messages.proto
+++ b/src/proto/grpc/testing/echo_messages.proto
@@ -54,7 +54,6 @@ message RequestParams {
   bool echo_metadata_initially = 17;
   bool server_notify_client_when_started = 18;
   xds.data.orca.v3.OrcaLoadReport backend_metrics = 19;
-  bool echo_host_from_authority_header = 20;
 }
 
 message EchoRequest {

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -232,11 +232,6 @@ ServerUnaryReactor* CallbackTestServiceImpl::Echo(
       internal::MaybeEchoDeadline(ctx_, req_, resp_);
       if (service_->host_) {
         resp_->mutable_param()->set_host(*service_->host_);
-      } else if (req_->has_param() &&
-                 req_->param().echo_host_from_authority_header()) {
-        auto authority = ctx_->ExperimentalGetAuthority();
-        std::string authority_str(authority.data(), authority.size());
-        resp_->mutable_param()->set_host(std::move(authority_str));
       }
       if (req_->has_param() && req_->param().client_cancel_after_us()) {
         {

--- a/test/cpp/end2end/test_service_impl.h
+++ b/test/cpp/end2end/test_service_impl.h
@@ -161,11 +161,6 @@ class TestMultipleServiceImpl : public RpcService {
     internal::MaybeEchoDeadline(context, request, response);
     if (host_) {
       response->mutable_param()->set_host(*host_);
-    } else if (request->has_param() &&
-               request->param().echo_host_from_authority_header()) {
-      auto authority = context->ExperimentalGetAuthority();
-      std::string authority_str(authority.data(), authority.size());
-      response->mutable_param()->set_host(std::move(authority_str));
     }
     if (request->has_param() && request->param().client_cancel_after_us()) {
       {


### PR DESCRIPTION
Reverts grpc/grpc#29768.

This is causing a test failure on import due to some sort of URI-encoding problem.