### PR TITLE
[gRPC/iOS] Moving remote interop test cases to interop suite

### DIFF
--- a/src/objective-c/tests/Common/GRPCBlockCallbackResponseHandler.h
+++ b/src/objective-c/tests/Common/GRPCBlockCallbackResponseHandler.h
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import <GRPCClient/GRPCCall.h>
+
+// Convenience class to use blocks as callbacks
+@interface GRPCBlockCallbackResponseHandler : NSObject <GRPCResponseHandler>
+
+- (instancetype)initWithInitialMetadataCallback:(void (^)(NSDictionary *))initialMetadataCallback
+                                messageCallback:(void (^)(id))messageCallback
+                                  closeCallback:(void (^)(NSDictionary *, NSError *))closeCallback
+                              writeDataCallback:(void (^)(void))writeDataCallback;
+
+- (instancetype)initWithInitialMetadataCallback:(void (^)(NSDictionary *))initialMetadataCallback
+                                messageCallback:(void (^)(id))messageCallback
+                                  closeCallback:(void (^)(NSDictionary *, NSError *))closeCallback;
+
+@end

--- a/src/objective-c/tests/Common/GRPCBlockCallbackResponseHandler.m
+++ b/src/objective-c/tests/Common/GRPCBlockCallbackResponseHandler.m
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GRPCBlockCallbackResponseHandler.h"
+
+@implementation GRPCBlockCallbackResponseHandler {
+  void (^_initialMetadataCallback)(NSDictionary *);
+  void (^_messageCallback)(id);
+  void (^_closeCallback)(NSDictionary *, NSError *);
+  void (^_writeDataCallback)(void);
+  dispatch_queue_t _dispatchQueue;
+}
+
+- (instancetype)initWithInitialMetadataCallback:(void (^)(NSDictionary *))initialMetadataCallback
+                                messageCallback:(void (^)(id))messageCallback
+                                  closeCallback:(void (^)(NSDictionary *, NSError *))closeCallback
+                              writeDataCallback:(void (^)(void))writeDataCallback {
+  if ((self = [super init])) {
+    _initialMetadataCallback = initialMetadataCallback;
+    _messageCallback = messageCallback;
+    _closeCallback = closeCallback;
+    _writeDataCallback = writeDataCallback;
+    _dispatchQueue = dispatch_queue_create(nil, DISPATCH_QUEUE_SERIAL);
+  }
+  return self;
+}
+
+- (instancetype)initWithInitialMetadataCallback:(void (^)(NSDictionary *))initialMetadataCallback
+                                messageCallback:(void (^)(id))messageCallback
+                                  closeCallback:(void (^)(NSDictionary *, NSError *))closeCallback {
+  return [self initWithInitialMetadataCallback:initialMetadataCallback
+                               messageCallback:messageCallback
+                                 closeCallback:closeCallback
+                             writeDataCallback:nil];
+}
+
+- (void)didReceiveInitialMetadata:(NSDictionary *)initialMetadata {
+  if (self->_initialMetadataCallback) {
+    self->_initialMetadataCallback(initialMetadata);
+  }
+}
+
+- (void)didReceiveRawMessage:(id)message {
+  if (self->_messageCallback) {
+    self->_messageCallback(message);
+  }
+}
+
+- (void)didCloseWithTrailingMetadata:(NSDictionary *)trailingMetadata error:(NSError *)error {
+  if (self->_closeCallback) {
+    self->_closeCallback(trailingMetadata, error);
+  }
+}
+
+- (void)didWriteData {
+  if (self->_writeDataCallback) {
+    self->_writeDataCallback();
+  }
+}
+
+- (dispatch_queue_t)dispatchQueue {
+  return _dispatchQueue;
+}
+
+@end

--- a/src/objective-c/tests/InteropTests/InteropTestsRemote.m
+++ b/src/objective-c/tests/InteropTests/InteropTestsRemote.m
@@ -17,9 +17,21 @@
  */
 
 #import <GRPCClient/GRPCCall+Tests.h>
+#import <GRPCClient/GRPCCall.h>
 #import <GRPCClient/internal_testing/GRPCCall+InternalTests.h>
+#import <RxLibrary/GRXWriter+Immediate.h>
+
+#import "../Common/GRPCBlockCallbackResponseHandler.h"
+
+#import "src/objective-c/tests/RemoteTestClient/Messages.pbobjc.h"
+#import "src/objective-c/tests/RemoteTestClient/Test.pbobjc.h"
+#import "src/objective-c/tests/RemoteTestClient/Test.pbrpc.h"
 
 #import "InteropTests.h"
+
+// Package and service name of test server
+static NSString *const kPackage = @"grpc.testing";
+static NSString *const kService = @"TestService";
 
 // The server address is derived from preprocessor macro, which is
 // in turn derived from environment variable of the same name.
@@ -31,11 +43,17 @@ static NSString *const kRemoteSSLHost = NSStringize(HOST_PORT_REMOTE);
 // by experiment. Adjust this when server's proto file changes.
 static int32_t kRemoteInteropServerOverhead = 12;
 
+static const NSTimeInterval kTestTimeout = 8;
+
+static GRPCProtoMethod *kUnaryCallMethod;
+
 /** Tests in InteropTests.m, sending the RPCs to a remote SSL server. */
 @interface InteropTestsRemote : InteropTests
 @end
 
 @implementation InteropTestsRemote
+
+#pragma mark - InteropTests
 
 + (NSString *)host {
   return kRemoteSSLHost;
@@ -59,6 +77,137 @@ static int32_t kRemoteInteropServerOverhead = 12;
 
 + (BOOL)isRemoteTest {
   return YES;
+}
+
+#pragma mark - InteropTestsRemote tests
+
+- (void)setUp {
+  [super setUp];
+
+  kUnaryCallMethod = [[GRPCProtoMethod alloc] initWithPackage:kPackage
+                                                      service:kService
+                                                       method:@"UnaryCall"];
+}
+
+- (void)testMetadataForV2Call {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
+
+  RMTSimpleRequest *request = [RMTSimpleRequest message];
+  request.fillUsername = YES;
+  request.fillOauthScope = YES;
+
+  GRPCRequestOptions *callRequest =
+      [[GRPCRequestOptions alloc] initWithHost:[[self class] host]
+                                          path:kUnaryCallMethod.HTTPPath
+                                        safety:GRPCCallSafetyDefault];
+  __block NSDictionary *init_md;
+  __block NSDictionary *trailing_md;
+  GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
+  options.oauth2AccessToken = @"bogusToken";
+
+  GRPCCall2 *call = [[GRPCCall2 alloc]
+      initWithRequestOptions:callRequest
+             responseHandler:[[GRPCBlockCallbackResponseHandler alloc]
+                                 initWithInitialMetadataCallback:^(NSDictionary *initialMetadata) {
+                                   init_md = initialMetadata;
+                                 }
+                                 messageCallback:^(id message) {
+                                   XCTFail(@"Received unexpected response.");
+                                 }
+                                 closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+                                   trailing_md = trailingMetadata;
+                                   if (error) {
+                                     XCTAssertEqual(error.code, 16,
+                                                    @"Finished with unexpected error: %@", error);
+                                     XCTAssertEqualObjects(init_md,
+                                                           error.userInfo[kGRPCHeadersKey]);
+                                     XCTAssertEqualObjects(trailing_md,
+                                                           error.userInfo[kGRPCTrailersKey]);
+                                     NSString *challengeHeader = init_md[@"www-authenticate"];
+                                     XCTAssertGreaterThan(challengeHeader.length, 0,
+                                                          @"No challenge in response headers %@",
+                                                          init_md);
+                                     [expectation fulfill];
+                                   }
+                                 }]
+                 callOptions:options];
+
+  [call start];
+  [call writeData:[request data]];
+  [call finish];
+
+  [self waitForExpectationsWithTimeout:kTestTimeout handler:nil];
+}
+
+- (void)testMetadataForV1Call {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
+
+  RMTSimpleRequest *request = [RMTSimpleRequest message];
+  request.fillUsername = YES;
+  request.fillOauthScope = YES;
+  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
+
+  GRPCCall *call = [[GRPCCall alloc] initWithHost:kRemoteSSLHost
+                                             path:kUnaryCallMethod.HTTPPath
+                                   requestsWriter:requestsWriter];
+
+  call.oauth2AccessToken = @"bogusToken";
+
+  id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc]
+      initWithValueHandler:^(NSData *value) {
+        XCTFail(@"Received unexpected response: %@", value);
+      }
+      completionHandler:^(NSError *errorOrNil) {
+        XCTAssertNotNil(errorOrNil, @"Finished without error!");
+        XCTAssertEqual(errorOrNil.code, 16, @"Finished with unexpected error: %@", errorOrNil);
+        XCTAssertEqualObjects(call.responseHeaders, errorOrNil.userInfo[kGRPCHeadersKey],
+                              @"Headers in the NSError object and call object differ.");
+        XCTAssertEqualObjects(call.responseTrailers, errorOrNil.userInfo[kGRPCTrailersKey],
+                              @"Trailers in the NSError object and call object differ.");
+        NSString *challengeHeader = call.oauth2ChallengeHeader;
+        XCTAssertGreaterThan(challengeHeader.length, 0, @"No challenge in response headers %@",
+                             call.responseHeaders);
+        [expectation fulfill];
+      }];
+
+  [call startWithWriteable:responsesWriteable];
+
+  [self waitForExpectationsWithTimeout:kTestTimeout handler:nil];
+}
+
+- (void)testErrorDebugInformation {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
+
+  RMTSimpleRequest *request = [RMTSimpleRequest message];
+  request.fillUsername = YES;
+  request.fillOauthScope = YES;
+  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
+
+  GRPCCall *call = [[GRPCCall alloc] initWithHost:kRemoteSSLHost
+                                             path:kUnaryCallMethod.HTTPPath
+                                   requestsWriter:requestsWriter];
+
+  call.oauth2AccessToken = @"bogusToken";
+
+  id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc]
+      initWithValueHandler:^(NSData *value) {
+        XCTFail(@"Received unexpected response: %@", value);
+      }
+      completionHandler:^(NSError *errorOrNil) {
+        XCTAssertNotNil(errorOrNil, @"Finished without error!");
+        NSDictionary *userInfo = errorOrNil.userInfo;
+        NSString *debugInformation = userInfo[NSDebugDescriptionErrorKey];
+        XCTAssertNotNil(debugInformation);
+        XCTAssertNotEqual([debugInformation length], 0);
+        NSString *challengeHeader = call.oauth2ChallengeHeader;
+        XCTAssertGreaterThan(challengeHeader.length, 0, @"No challenge in response headers %@",
+                             call.responseHeaders);
+        [expectation fulfill];
+      }];
+
+  [call startWithWriteable:responsesWriteable];
+
+  [self waitForExpectationsWithTimeout:kTestTimeout handler:nil];
 }
 
 @end

--- a/src/objective-c/tests/UnitTests/GRPCClientTests.m
+++ b/src/objective-c/tests/UnitTests/GRPCClientTests.m
@@ -44,7 +44,6 @@
 static NSString *const kHostAddress = NSStringize(HOST_PORT_LOCAL);
 static NSString *const kPackage = @"grpc.testing";
 static NSString *const kService = @"TestService";
-static NSString *const kRemoteSSLHost = NSStringize(HOST_PORT_REMOTE);
 
 static GRPCProtoMethod *kInexistentMethod;
 static GRPCProtoMethod *kEmptyCallMethod;
@@ -203,42 +202,6 @@ static GRPCProtoMethod *kFullDuplexCallMethod;
       completionHandler:^(NSError *errorOrNil) {
         XCTAssertNil(errorOrNil, @"Finished with unexpected error: %@", errorOrNil);
         [completion fulfill];
-      }];
-
-  [call startWithWriteable:responsesWriteable];
-
-  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
-}
-
-- (void)testMetadata {
-  __weak XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
-
-  RMTSimpleRequest *request = [RMTSimpleRequest message];
-  request.fillUsername = YES;
-  request.fillOauthScope = YES;
-  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
-
-  GRPCCall *call = [[GRPCCall alloc] initWithHost:kRemoteSSLHost
-                                             path:kUnaryCallMethod.HTTPPath
-                                   requestsWriter:requestsWriter];
-
-  call.oauth2AccessToken = @"bogusToken";
-
-  id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc]
-      initWithValueHandler:^(NSData *value) {
-        XCTFail(@"Received unexpected response: %@", value);
-      }
-      completionHandler:^(NSError *errorOrNil) {
-        XCTAssertNotNil(errorOrNil, @"Finished without error!");
-        XCTAssertEqual(errorOrNil.code, 16, @"Finished with unexpected error: %@", errorOrNil);
-        XCTAssertEqualObjects(call.responseHeaders, errorOrNil.userInfo[kGRPCHeadersKey],
-                              @"Headers in the NSError object and call object differ.");
-        XCTAssertEqualObjects(call.responseTrailers, errorOrNil.userInfo[kGRPCTrailersKey],
-                              @"Trailers in the NSError object and call object differ.");
-        NSString *challengeHeader = call.oauth2ChallengeHeader;
-        XCTAssertGreaterThan(challengeHeader.length, 0, @"No challenge in response headers %@",
-                             call.responseHeaders);
-        [expectation fulfill];
       }];
 
   [call startWithWriteable:responsesWriteable];
@@ -567,41 +530,6 @@ static GRPCProtoMethod *kFullDuplexCallMethod;
 
 - (void)testTimeoutBackoff2 {
   [self testTimeoutBackoffWithTimeout:0.3 Backoff:0.7];
-}
-
-- (void)testErrorDebugInformation {
-  __weak XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
-
-  RMTSimpleRequest *request = [RMTSimpleRequest message];
-  request.fillUsername = YES;
-  request.fillOauthScope = YES;
-  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
-
-  GRPCCall *call = [[GRPCCall alloc] initWithHost:kRemoteSSLHost
-                                             path:kUnaryCallMethod.HTTPPath
-                                   requestsWriter:requestsWriter];
-
-  call.oauth2AccessToken = @"bogusToken";
-
-  id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc]
-      initWithValueHandler:^(NSData *value) {
-        XCTFail(@"Received unexpected response: %@", value);
-      }
-      completionHandler:^(NSError *errorOrNil) {
-        XCTAssertNotNil(errorOrNil, @"Finished without error!");
-        NSDictionary *userInfo = errorOrNil.userInfo;
-        NSString *debugInformation = userInfo[NSDebugDescriptionErrorKey];
-        XCTAssertNotNil(debugInformation);
-        XCTAssertNotEqual([debugInformation length], 0);
-        NSString *challengeHeader = call.oauth2ChallengeHeader;
-        XCTAssertGreaterThan(challengeHeader.length, 0, @"No challenge in response headers %@",
-                             call.responseHeaders);
-        [expectation fulfill];
-      }];
-
-  [call startWithWriteable:responsesWriteable];
-
-  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
 @end


### PR DESCRIPTION
Moving 3 unit test case to interop remote test suite as these test cases access remote interop test server.  This makes our unit test suite overall more hermetic as it would no longer require external service outside of the testing node. 

### Test Summary 

```bash 
bazel test UnitTests InteropTests
```

----
cc @HannahShiSFB 