### PR TITLE
security: don't require system CA certs if certificate verification is disabled (#29667)

### DIFF
--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -418,7 +418,7 @@ grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
     tsi_ssl_client_handshaker_factory** handshaker_factory) {
   const char* root_certs;
   const tsi_ssl_root_certs_store* root_store;
-  if (pem_root_certs == nullptr) {
+  if (pem_root_certs == nullptr && !skip_server_certificate_verification) {
     gpr_log(GPR_INFO,
             "No root certificates specified; use ones stored in system default "
             "locations instead");
@@ -437,7 +437,7 @@ grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
                            pem_key_cert_pair->private_key != nullptr &&
                            pem_key_cert_pair->cert_chain != nullptr;
   tsi_ssl_client_handshaker_options options;
-  GPR_DEBUG_ASSERT(root_certs != nullptr);
+  //GPR_DEBUG_ASSERT(root_certs != nullptr);
   options.pem_root_certs = root_certs;
   options.root_store = root_store;
   options.alpn_protocols =


### PR DESCRIPTION
Presently, when establishing a TLS connection, gRPC will always attempt to load some CA certificates from the file system or user supplied callback mechanism.

However, on popular commercial platforms (MS Windows, Apple OSX) CA certificates are not readily available to be loaded as files.

Therefore, requirement to always load the root certs creates a problem:

1. When custom, platform specific verifier is present.
2. When security is not an issue, but TLS connection is nevertheless required (various testing situations).

