### PR TITLE
Revert "xds-k8s: Fix incorrect type hint in the baseline test (#29577)"

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/baseline_test.py
@@ -44,14 +44,16 @@ class BaselineTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         with self.subTest('4_create_forwarding_rule'):
             self.td.create_forwarding_rule(self.server_xds_port)
 
+        test_servers: _XdsTestServer
         with self.subTest('5_start_test_server'):
-            test_server: _XdsTestServer = self.startTestServers()[0]
+            test_servers = self.startTestServers()
 
         with self.subTest('6_add_server_backends_to_backend_service'):
             self.setupServerBackends()
 
+        test_client: _XdsTestClient
         with self.subTest('7_start_test_client'):
-            test_client: _XdsTestClient = self.startTestClient(test_server)
+            test_client = self.startTestClient(test_servers[0])
 
         with self.subTest('8_test_client_xds_config_exists'):
             self.assertXdsConfigExists(test_client)


### PR DESCRIPTION
This reverts commit f36e84f093e7bf3cc7bab48a1e07a1a77b6b87c8.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

