### PR TITLE
test: restore original slowdown factor for MSAN and UBSAN

### DIFF
--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -66,9 +66,9 @@ int64_t grpc_test_sanitizer_slowdown_factor() {
   } else if (BuiltUnderAsan()) {
     sanitizer_multiplier = 3;
   } else if (BuiltUnderMsan()) {
-    sanitizer_multiplier = 6;
+    sanitizer_multiplier = 4;
   } else if (BuiltUnderUbsan()) {
-    sanitizer_multiplier = 8;
+    sanitizer_multiplier = 5;
   }
   return sanitizer_multiplier;
 }


### PR DESCRIPTION
Both continuous builds have been red since https://github.com/grpc/grpc/pull/29780, even with the reduced values from #29787, so I think we need to go back to the original values.