### PR TITLE
Fix tvos test break and pass interop server env

### DIFF
--- a/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/TvTests.xcscheme
+++ b/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/TvTests.xcscheme
@@ -44,8 +44,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Test"
@@ -68,8 +66,23 @@
       </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
+            key = "HOST_PORT_LOCAL"
+            value = "localhost:5050"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "HOST_PORT_REMOTE"
+            value = "grpc-test.sandbox.googleapis.com"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "GRPC_CFSTREAM_RUN_LOOP"
             value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "HOST_PORT_LOCALSSL"
+            value = "localhost:5051"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/src/objective-c/tests/run_one_test.sh
+++ b/src/objective-c/tests/run_one_test.sh
@@ -79,12 +79,16 @@ fi
 
 XCODEBUILD_FILTER_OUTPUT_SCRIPT="./xcodebuild_filter_output.sh"
 
+export HOST_PORT_LOCALSSL=localhost:$TLS_PORT
+export HOST_PORT_LOCAL=localhost:$PLAIN_PORT
+export HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com
+
 time xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme $SCHEME \
     -destination "$DESTINATION" \
-    HOST_PORT_LOCALSSL=localhost:$TLS_PORT \
-    HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
-    HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
+    HOST_PORT_LOCALSSL=$HOST_PORT_LOCALSSL \
+    HOST_PORT_LOCAL=$HOST_PORT_LOCAL \
+    HOST_PORT_REMOTE=$HOST_PORT_REMOTE \
     GCC_OPTIMIZATION_LEVEL=s \
     test | "${XCODEBUILD_FILTER_OUTPUT_SCRIPT}"


### PR DESCRIPTION
Update tvOS test scheme to set default env for interop server info. Also updated run test script to properly export test env. 

---

cc @HannahShiSFB 