### PR TITLE
Pc file path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19820,7 +19820,7 @@ function(generate_pkgconfig name description version requires
     "${output_filepath}"
     @ONLY)
   install(FILES "${output_filepath}"
-    DESTINATION "lib/pkgconfig/")
+    DESTINATION "${gRPC_INSTALL_LIBDIR}/pkgconfig")
 endfunction()
 
 # gpr .pc file

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -850,7 +850,7 @@
       "<%text>${output_filepath}</%text>"
       @ONLY)
     install(FILES "<%text>${output_filepath}</%text>"
-      DESTINATION "lib/pkgconfig/")
+      DESTINATION "<%text>${gRPC_INSTALL_LIBDIR}/pkgconfig</%text>")
   endfunction()
 
   # gpr .pc file


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

@veblush

This implements my suggested fix for #25635.

On distributions where grpc shared libraries are installed in, for example, `/usr/lib64`, this PR would ensure that `.pc` files end up in `/usr/lib64/pkgconfig` rather than `/usr/lib/pkgconfig`.