### PR TITLE
xDS: Workaround to get gRPC clients working with istio

### DIFF
--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -995,8 +995,8 @@ grpc_error_handle LdsResourceParse(
   const envoy_config_core_v3_Address* address =
       envoy_config_listener_v3_Listener_address(listener);
   // TODO(roth): Re-enable the following check once
-  // github.com/istio/istio/issues/38914 is resolved. if (api_listener !=
-  // nullptr && address != nullptr) {
+  // github.com/istio/istio/issues/38914 is resolved.
+  // if (api_listener != nullptr && address != nullptr) {
   //   return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
   //       "Listener has both address and ApiListener");
   // }

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -994,10 +994,12 @@ grpc_error_handle LdsResourceParse(
       envoy_config_listener_v3_Listener_api_listener(listener);
   const envoy_config_core_v3_Address* address =
       envoy_config_listener_v3_Listener_address(listener);
-  if (api_listener != nullptr && address != nullptr) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Listener has both address and ApiListener");
-  }
+  // TODO(roth): Re-enable the following check once
+  // github.com/istio/istio/issues/38914 is resolved. if (api_listener !=
+  // nullptr && address != nullptr) {
+  //   return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+  //       "Listener has both address and ApiListener");
+  // }
   if (api_listener == nullptr && address == nullptr) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Listener has neither address nor ApiListener");

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -1082,19 +1082,21 @@ TEST_P(XdsEnabledServerTest, BadLdsUpdateNoApiListenerNorAddress) {
       ::testing::HasSubstr("Listener has neither address nor ApiListener"));
 }
 
-TEST_P(XdsEnabledServerTest, BadLdsUpdateBothApiListenerAndAddress) {
-  Listener listener = default_server_listener_;
-  listener.mutable_api_listener();
-  SetServerListenerNameAndRouteConfiguration(balancer_.get(), listener,
-                                             backends_[0]->port(),
-                                             default_server_route_config_);
-  backends_[0]->Start();
-  const auto response_state = WaitForLdsNack(DEBUG_LOCATION);
-  ASSERT_TRUE(response_state.has_value()) << "timed out waiting for NACK";
-  EXPECT_THAT(
-      response_state->error_message,
-      ::testing::HasSubstr("Listener has both address and ApiListener"));
-}
+// TODO(roth): Re-enable the following test once
+// github.com/istio/istio/issues/38914 is resolved.
+// TEST_P(XdsEnabledServerTest, BadLdsUpdateBothApiListenerAndAddress) {
+//   Listener listener = default_server_listener_;
+//   listener.mutable_api_listener();
+//   SetServerListenerNameAndRouteConfiguration(balancer_.get(), listener,
+//                                              backends_[0]->port(),
+//                                              default_server_route_config_);
+//   backends_[0]->Start();
+//   const auto response_state = WaitForLdsNack(DEBUG_LOCATION);
+//   ASSERT_TRUE(response_state.has_value()) << "timed out waiting for NACK";
+//   EXPECT_THAT(
+//       response_state->error_message,
+//       ::testing::HasSubstr("Listener has both address and ApiListener"));
+// }
 
 TEST_P(XdsEnabledServerTest, NacksNonZeroXffNumTrusterHops) {
   Listener listener = default_server_listener_;

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -1084,19 +1084,19 @@ TEST_P(XdsEnabledServerTest, BadLdsUpdateNoApiListenerNorAddress) {
 
 // TODO(roth): Re-enable the following test once
 // github.com/istio/istio/issues/38914 is resolved.
-// TEST_P(XdsEnabledServerTest, BadLdsUpdateBothApiListenerAndAddress) {
-//   Listener listener = default_server_listener_;
-//   listener.mutable_api_listener();
-//   SetServerListenerNameAndRouteConfiguration(balancer_.get(), listener,
-//                                              backends_[0]->port(),
-//                                              default_server_route_config_);
-//   backends_[0]->Start();
-//   const auto response_state = WaitForLdsNack(DEBUG_LOCATION);
-//   ASSERT_TRUE(response_state.has_value()) << "timed out waiting for NACK";
-//   EXPECT_THAT(
-//       response_state->error_message,
-//       ::testing::HasSubstr("Listener has both address and ApiListener"));
-// }
+TEST_P(XdsEnabledServerTest, DISABLED_BadLdsUpdateBothApiListenerAndAddress) {
+  Listener listener = default_server_listener_;
+  listener.mutable_api_listener();
+  SetServerListenerNameAndRouteConfiguration(balancer_.get(), listener,
+                                             backends_[0]->port(),
+                                             default_server_route_config_);
+  backends_[0]->Start();
+  const auto response_state = WaitForLdsNack(DEBUG_LOCATION);
+  ASSERT_TRUE(response_state.has_value()) << "timed out waiting for NACK";
+  EXPECT_THAT(
+      response_state->error_message,
+      ::testing::HasSubstr("Listener has both address and ApiListener"));
+}
 
 TEST_P(XdsEnabledServerTest, NacksNonZeroXffNumTrusterHops) {
   Listener listener = default_server_listener_;


### PR DESCRIPTION
Listener protos had an incorrect validation where it expected `Listener.address` to be always present. This does not work so well when clients are trying to decide whether the LDS resource is for a client or a server. This was fixed in https://github.com/envoyproxy/envoy/pull/21132 but till istio performs validation according to the previously incorrect validation rule, we need this workaround so as to be able to work with istio.