### PR TITLE
[chttp2] Use Closure::Run to invoke callbacks

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1251,7 +1251,7 @@ static grpc_closure* add_closure_barrier(grpc_closure* closure) {
 static void null_then_sched_closure(grpc_closure** closure) {
   grpc_closure* c = *closure;
   *closure = nullptr;
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
+  grpc_core::Closure::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
 }
 
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,


### PR DESCRIPTION
Partially undo #20892 and have chttp2 directly invoke closures going up the stack.
Doing so has the small performance advantage of not entering/leaving the chttp2 combiner as frequently for busy connections full of small requests.
It has a larger performance advantage of preserving more cache as we process up the stack.
Finally, the obvious translation of this code to EventEngine will likely involve a thread hop - and that thread hop (and associated context switch) will likely be perilous to performance as it happens so frequently.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

