### PR TITLE
[gRPC/iOS] Adding debug info for interop server host info

### DIFF
--- a/src/objective-c/tests/Common/TestUtils.h
+++ b/src/objective-c/tests/Common/TestUtils.h
@@ -41,4 +41,9 @@ FOUNDATION_EXPORT NSString *GRPCGetLocalInteropTestServerAddressSSL(void);
  */
 FOUNDATION_EXPORT NSString *GRPCGetRemoteInteropTestServerAddress(void);
 
+/**
+ * Common utility to print interop server address information to console via NSLog.
+ */
+FOUNDATION_EXPORT void GRPCPrintInteropTestServerDebugInfo(void);
+
 NS_ASSUME_NONNULL_END

--- a/src/objective-c/tests/Common/TestUtils.m
+++ b/src/objective-c/tests/Common/TestUtils.m
@@ -49,3 +49,14 @@ NSString *GRPCGetRemoteInteropTestServerAddress() {
   });
   return address;
 }
+
+void GRPCPrintInteropTestServerDebugInfo() {
+  NSLog(@"local interop env: %@  macro: %@",
+        [NSProcessInfo processInfo].environment[@"HOST_PORT_LOCAL"], NSStringize(HOST_PORT_LOCAL));
+  NSLog(@"local interop ssl env: %@  macro: %@",
+        [NSProcessInfo processInfo].environment[@"HOST_PORT_LOCALSSL"],
+        NSStringize(HOST_PORT_LOCALSSL));
+  NSLog(@"remote interop env: %@  macro: %@",
+        [NSProcessInfo processInfo].environment[@"HOST_PORT_REMOTE"],
+        NSStringize(HOST_PORT_REMOTE));
+}

--- a/src/objective-c/tests/UnitTests/APIv2Tests.m
+++ b/src/objective-c/tests/UnitTests/APIv2Tests.m
@@ -131,6 +131,10 @@ static const NSTimeInterval kInvertedTimeout = 2;
 
 @implementation CallAPIv2Tests
 
++ (void)setUp {
+  GRPCPrintInteropTestServerDebugInfo();
+}
+
 - (void)setUp {
   // This method isn't implemented by the remote server.
   kInexistentMethod = [[GRPCProtoMethod alloc] initWithPackage:kPackage


### PR DESCRIPTION
Adding additional debug info on start of test suite to identify interop server address configuration.  