### PR TITLE
Modify ContextList to include the relative start position and size of a traced stream within the output buffer.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/context_list.cc
+++ b/src/core/ext/transport/chttp2/transport/context_list.cc
@@ -31,7 +31,8 @@ void* (*get_copied_context_fn_g)(void*) = nullptr;
 }  // namespace
 
 namespace grpc_core {
-void ContextList::Append(ContextList** head, grpc_chttp2_stream* s) {
+void ContextList::Append(ContextList** head, grpc_chttp2_stream* s,
+                         int64_t outbuf_relative_start_pos, int64_t num_bytes) {
   if (get_copied_context_fn_g == nullptr ||
       write_timestamps_callback_g == nullptr) {
     return;
@@ -39,6 +40,8 @@ void ContextList::Append(ContextList** head, grpc_chttp2_stream* s) {
   /* Create a new element in the list and add it at the front */
   ContextList* elem = new ContextList();
   elem->trace_context_ = get_copied_context_fn_g(s->context);
+  elem->outbuf_relative_start_pos_ = outbuf_relative_start_pos;
+  elem->num_bytes_ = num_bytes;
   elem->byte_offset_ = s->byte_counter;
   elem->next_ = *head;
   *head = elem;

--- a/src/core/ext/transport/chttp2/transport/context_list.h
+++ b/src/core/ext/transport/chttp2/transport/context_list.h
@@ -33,7 +33,8 @@ class ContextList {
  public:
   /* Creates a new element with \a context as the value and appends it to the
    * list. */
-  static void Append(ContextList** head, grpc_chttp2_stream* s);
+  static void Append(ContextList** head, grpc_chttp2_stream* s,
+                     int64_t outbuf_relative_start_pos, int64_t num_bytes);
 
   /* Executes a function \a fn with each context in the list and \a ts. It also
    * frees up the entire list after this operation. It is intended as a callback
@@ -43,6 +44,8 @@ class ContextList {
  private:
   void* trace_context_ = nullptr;
   ContextList* next_ = nullptr;
+  int64_t outbuf_relative_start_pos_ = 0;
+  int64_t num_bytes_ = 0;
   size_t byte_offset_ = 0;
 };
 

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -629,6 +629,7 @@ class StreamWriteContext {
 
 grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
     grpc_chttp2_transport* t) {
+  int64_t outbuf_relative_start_pos = 0;
   WriteContext ctx(t);
   ctx.FlushSettings();
   ctx.FlushPingAcks();
@@ -644,16 +645,20 @@ grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
   while (grpc_chttp2_stream* s = ctx.NextStream()) {
     StreamWriteContext stream_ctx(&ctx, s);
     size_t orig_len = t->outbuf.length;
+    int64_t num_stream_bytes = 0;
     stream_ctx.FlushInitialMetadata();
     stream_ctx.FlushWindowUpdates();
     stream_ctx.FlushData();
     stream_ctx.FlushTrailingMetadata();
     if (t->outbuf.length > orig_len) {
       /* Add this stream to the list of the contexts to be traced at TCP */
-      s->byte_counter += t->outbuf.length - orig_len;
+      num_stream_bytes = t->outbuf.length - orig_len;
+      s->byte_counter += static_cast<size_t>(num_stream_bytes);
       if (s->traced && grpc_endpoint_can_track_err(t->ep)) {
-        grpc_core::ContextList::Append(&t->cl, s);
+        grpc_core::ContextList::Append(&t->cl, s, outbuf_relative_start_pos,
+                                       num_stream_bytes);
       }
+      outbuf_relative_start_pos += num_stream_bytes;
     }
     if (stream_ctx.stream_became_writable()) {
       if (!grpc_chttp2_list_add_writing_stream(t, s)) {

--- a/test/core/transport/chttp2/context_list_test.cc
+++ b/test/core/transport/chttp2/context_list_test.cc
@@ -91,7 +91,8 @@ TEST_F(ContextListTest, ExecuteFlushesList) {
     s[i]->context = &verifier_called[i];
     s[i]->byte_counter = kByteOffset;
     gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
-    ContextList::Append(&list, s[i]);
+    ContextList::Append(&list, s[i], static_cast<int64_t>(i * kByteOffset),
+                        static_cast<int64_t>(kByteOffset));
   }
   Timestamps ts;
   ContextList::Execute(list, &ts, GRPC_ERROR_NONE);
@@ -147,7 +148,8 @@ TEST_F(ContextListTest, NonEmptyListEmptyTimestamp) {
     s[i]->context = &verifier_called[i];
     s[i]->byte_counter = kByteOffset;
     gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
-    ContextList::Append(&list, s[i]);
+    ContextList::Append(&list, s[i], static_cast<int64_t>(i * kByteOffset),
+                        static_cast<int64_t>(kByteOffset));
   }
   ContextList::Execute(list, nullptr, GRPC_ERROR_NONE);
   for (auto i = 0; i < kNumElems; i++) {


### PR DESCRIPTION
This change is required as we internally move to a new API to export timestamps associated with traced RPCs.

@ctiller 

