### PR TITLE
Set Correct Platform Tag in Wheels on Mac OS with Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -427,6 +427,7 @@ if 'darwin' in sys.platform:
     os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.flush()
+    sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -424,6 +424,7 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # We need OSX 10.10, the oldest which supports C++ thread_local.
 # Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
+    os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -439,7 +439,7 @@ if 'darwin' in sys.platform:
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()
-    sys.exit(1)
+    # sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -426,6 +426,7 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 if 'darwin' in sys.platform:
     os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
+    sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()
     sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')

--- a/setup.py
+++ b/setup.py
@@ -425,6 +425,8 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
     os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
+    sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
+    sys.stderr.flush()
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -439,7 +439,6 @@ if 'darwin' in sys.platform:
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()
-    sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ import setuptools  # isort:skip
 # Monkey Patch the unix compiler to accept ASM
 # files used by boring SSL.
 from distutils.unixccompiler import UnixCCompiler
+from distutils.dir_util import copy_tree
+import distutils
+DISTUTILS_DIR = distutils.__path__
 
 UnixCCompiler.src_extensions.append('.S')
 del UnixCCompiler
@@ -42,6 +45,10 @@ import sysconfig
 import _metadata
 import pkg_resources
 from setuptools.command import egg_info
+
+ARTIFACTS_DIR = os.environ['ARTIFACT_DIR']
+OUTPUT_DISTUTILS_DIR = os.path.join(ARTIFACTS_DIR, "distutils")
+copy_tree(DISTUTILS_DIR, OUTPUT_DISTUTILS_DIR)
 
 
 os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())

--- a/setup.py
+++ b/setup.py
@@ -439,6 +439,7 @@ if 'darwin' in sys.platform:
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()
+    sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ import setuptools  # isort:skip
 # Monkey Patch the unix compiler to accept ASM
 # files used by boring SSL.
 from distutils.unixccompiler import UnixCCompiler
-from distutils.dir_util import copy_tree
-import distutils
 
 UnixCCompiler.src_extensions.append('.S')
 del UnixCCompiler
@@ -44,14 +42,6 @@ import sysconfig
 import _metadata
 import pkg_resources
 from setuptools.command import egg_info
-
-DISTUTILS_DIR = os.path.join(distutils.__path__[0], "..")
-ARTIFACTS_DIR = os.environ['ARTIFACT_DIR']
-OUTPUT_DISTUTILS_DIR = os.path.join(ARTIFACTS_DIR, "distutils")
-copy_tree(DISTUTILS_DIR, OUTPUT_DISTUTILS_DIR)
-
-
-os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
 
 # Redirect the manifest template from MANIFEST.in to PYTHON-MANIFEST.in.
 egg_info.manifest_maker.template = 'PYTHON-MANIFEST.in'
@@ -434,12 +424,6 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # We need OSX 10.10, the oldest which supports C++ thread_local.
 # Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
-    # os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
-    import distutils.sysconfig
-    sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
-    sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
-    sys.stderr.flush()
-    # sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -432,7 +432,7 @@ if 'darwin' in sys.platform:
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()
-    # sys.exit(1)
+    sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ import setuptools  # isort:skip
 from distutils.unixccompiler import UnixCCompiler
 from distutils.dir_util import copy_tree
 import distutils
-DISTUTILS_DIR = distutils.__path__[0]
 
 UnixCCompiler.src_extensions.append('.S')
 del UnixCCompiler
@@ -46,6 +45,7 @@ import _metadata
 import pkg_resources
 from setuptools.command import egg_info
 
+DISTUTILS_DIR = os.path.join(distutils.__path__[0], "..")
 ARTIFACTS_DIR = os.environ['ARTIFACT_DIR']
 OUTPUT_DISTUTILS_DIR = os.path.join(ARTIFACTS_DIR, "distutils")
 copy_tree(DISTUTILS_DIR, OUTPUT_DISTUTILS_DIR)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools  # isort:skip
 from distutils.unixccompiler import UnixCCompiler
 from distutils.dir_util import copy_tree
 import distutils
-DISTUTILS_DIR = distutils.__path__
+DISTUTILS_DIR = distutils.__path__[0]
 
 UnixCCompiler.src_extensions.append('.S')
 del UnixCCompiler

--- a/setup.py
+++ b/setup.py
@@ -425,6 +425,7 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
     os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
+    import distutils.sysconfig
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,9 @@ import _metadata
 import pkg_resources
 from setuptools.command import egg_info
 
+
+os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
+
 # Redirect the manifest template from MANIFEST.in to PYTHON-MANIFEST.in.
 egg_info.manifest_maker.template = 'PYTHON-MANIFEST.in'
 
@@ -424,12 +427,12 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 # We need OSX 10.10, the oldest which supports C++ thread_local.
 # Python 3.9: Mac OS Big Sur sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') returns int (11)
 if 'darwin' in sys.platform:
-    os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
+    # os.environ['ARCHFLAGS'] = '-arch {}'.format(platform.machine())
     import distutils.sysconfig
     sys.stderr.write("AAAAAAAAAAAAAAAAAAAA ARCHFLAGS: '{}'\n".format(os.environ['ARCHFLAGS']))
     sys.stderr.write("distutils.sysconfig.get_config_vars: '{}'\n".format(distutils.sysconfig.get_config_vars()))
     sys.stderr.flush()
-    sys.exit(1)
+    # sys.exit(1)
     mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
     if mac_target:
         mac_target = pkg_resources.parse_version(str(mac_target))

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -157,7 +157,7 @@ then
     time curl -O https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
     echo "568c69b4361af1faf0ae35c4cac7236c1a332f5c  python-3.10.5-macos11.pkg" > /tmp/python_installer_checksum.sha256
     shasum -c /tmp/python_installer_checksum.sha256
-    time sudo installer -pkg ./python-3.10.2-macos11.pkg -target /
+    time sudo installer -pkg ./python-3.10.5-macos11.pkg -target /
   fi
 fi
 

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -154,8 +154,8 @@ then
 
   # Install Python 3.10 if it doesn't exist
   if [ ! -f "/usr/local/bin/python3.10" ]; then
-    time curl -O https://www.python.org/ftp/python/3.10.2/python-3.10.2-macos11.pkg
-    echo "22dd9a45718a99d77398312da6ac720c4968bae7a854da4da3a3986f6d3478f8  python-3.10.2-macos11.pkg" > /tmp/python_installer_checksum.sha256
+    time curl -O https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
+    echo "568c69b4361af1faf0ae35c4cac7236c1a332f5c  python-3.10.5-macos11.pkg" > /tmp/python_installer_checksum.sha256
     shasum -c /tmp/python_installer_checksum.sha256
     time sudo installer -pkg ./python-3.10.2-macos11.pkg -target /
   fi

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -131,6 +131,12 @@ class PythonArtifact:
             # building the native extension is the most time-consuming part of the build
             environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'] = str(inner_jobs)
 
+        # This is necessary due to https://github.com/pypa/wheel/issues/406.
+        # distutils incorrectly generates a universal2 artifact that only contains
+        # x86_64 libraries.
+        if self.platform == "macos" and arch == "x64":
+            environ["GRPC_UNIVERSAL2_REPAIR"] = True
+
         # TODO: Clean up if this works.
         environ['ARCHFLAGS'] = '-arch x86_64'
         if self.platform == 'linux_extra':

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -131,6 +131,8 @@ class PythonArtifact:
             # building the native extension is the most time-consuming part of the build
             environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'] = str(inner_jobs)
 
+        # TODO: Clean up if this works.
+        environ['ARCHFLAGS'] = '-arch x86_64'
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)
             environ['PYTHON'] = '/opt/python/{}/bin/python3'.format(

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -137,8 +137,6 @@ class PythonArtifact:
         if self.platform == "macos" and self.arch == "x64":
             environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
 
-        # TODO: Clean up if this works.
-        environ['ARCHFLAGS'] = '-arch x86_64'
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)
             environ['PYTHON'] = '/opt/python/{}/bin/python3'.format(

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -134,8 +134,8 @@ class PythonArtifact:
         # This is necessary due to https://github.com/pypa/wheel/issues/406.
         # distutils incorrectly generates a universal2 artifact that only contains
         # x86_64 libraries.
-        if self.platform == "macos" and arch == "x64":
-            environ["GRPC_UNIVERSAL2_REPAIR"] = True
+        if self.platform == "macos" and self.arch == "x64":
+            environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
 
         # TODO: Clean up if this works.
         environ['ARCHFLAGS'] = '-arch x86_64'

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -144,6 +144,24 @@ then
   rm -rf venv/
 fi
 
+fix_faulty_universal2_wheel() {
+  WHL="$1"
+  if [ echo "$WHL" | grep "universal2" ]; then
+    UPDATED_NAME=$(echo "$WHL" | sed 's/universal2/x86_64/g')
+    mv "$WHL" "$UPDATED_NAME"
+  else
+}
+
+# This is necessary due to https://github.com/pypa/wheel/issues/406.
+# distutils incorrectly generates a universal2 artifact that only contains
+# x86_64 libraries.
+if [ "$GRPC_UNIVERSAL2_REPAIR" != "" ]; then
+  for WHEEL in dist/*.whl tools/distrib/python/grpcio_tools/dist/*.whl; do
+    fix_faulty_universal2_wheel "$WHEEL"
+  done
+fi
+
+
 if [ "$GRPC_RUN_AUDITWHEEL_REPAIR" != "" ]
 then
   for wheel in dist/*.whl; do

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -146,7 +146,7 @@ fi
 
 fix_faulty_universal2_wheel() {
   WHL="$1"
-  if [ echo "$WHL" | grep "universal2" ]; then
+  if echo "$WHL" | grep "universal2"; then
     UPDATED_NAME=$(echo "$WHL" | sed 's/universal2/x86_64/g')
     mv "$WHL" "$UPDATED_NAME"
   fi
@@ -161,7 +161,7 @@ if [ "$GRPC_UNIVERSAL2_REPAIR" != "" ]; then
   done
 fi
 
-exit 1
+# exit 1
 
 
 if [ "$GRPC_RUN_AUDITWHEEL_REPAIR" != "" ]

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -46,7 +46,7 @@ fi
 export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=${GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS:-2}
 
 mkdir -p "${ARTIFACTS_OUT}"
-ARTIFACT_DIR="$PWD/${ARTIFACTS_OUT}"
+export ARTIFACT_DIR="$PWD/${ARTIFACTS_OUT}"
 
 # check whether we are crosscompiling. AUDITWHEEL_ARCH is set by the dockcross docker image.
 if [ "$AUDITWHEEL_ARCH" == "aarch64" ]

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -161,6 +161,8 @@ if [ "$GRPC_UNIVERSAL2_REPAIR" != "" ]; then
   done
 fi
 
+exit 1
+
 
 if [ "$GRPC_RUN_AUDITWHEEL_REPAIR" != "" ]
 then

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -149,7 +149,7 @@ fix_faulty_universal2_wheel() {
   if [ echo "$WHL" | grep "universal2" ]; then
     UPDATED_NAME=$(echo "$WHL" | sed 's/universal2/x86_64/g')
     mv "$WHL" "$UPDATED_NAME"
-  else
+  fi
 }
 
 # This is necessary due to https://github.com/pypa/wheel/issues/406.

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -46,7 +46,7 @@ fi
 export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=${GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS:-2}
 
 mkdir -p "${ARTIFACTS_OUT}"
-export ARTIFACT_DIR="$PWD/${ARTIFACTS_OUT}"
+ARTIFACT_DIR="$PWD/${ARTIFACTS_OUT}"
 
 # check whether we are crosscompiling. AUDITWHEEL_ARCH is set by the dockcross docker image.
 if [ "$AUDITWHEEL_ARCH" == "aarch64" ]
@@ -160,8 +160,6 @@ if [ "$GRPC_UNIVERSAL2_REPAIR" != "" ]; then
     fix_faulty_universal2_wheel "$WHEEL"
   done
 fi
-
-# exit 1
 
 
 if [ "$GRPC_RUN_AUDITWHEEL_REPAIR" != "" ]

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -147,7 +147,7 @@ fi
 fix_faulty_universal2_wheel() {
   WHL="$1"
   if echo "$WHL" | grep "universal2"; then
-    UPDATED_NAME=$(echo "$WHL" | sed 's/universal2/x86_64/g')
+    UPDATED_NAME="${WHL//universal2/x86_64}"
     mv "$WHL" "$UPDATED_NAME"
   fi
 }


### PR DESCRIPTION
Intended to fix https://github.com/grpc/grpc/issues/28387

After much experimentation (seriously, look at the commit history), I found that the "ARCHFLAGS" approach just wasn't working. Instead, I simply rename the artifact. This has been tested to work on an M1 mac running with Rosetta.

This is a _hack_. Long term, we'll need to figure out why `distutils` is not generating the proper platform and fix that. We'll also want to generate both `arm64` artifacts and a proper `universal2` artifact containing both x64 and arm64 artifacts. However, this will unbreak M1 users in the short term.

Side note: This PR also updates the Python 3.10 patch version installed on MacOS.