### PR TITLE
Enable authorization logs for debugging

### DIFF
--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -72,8 +72,7 @@ end:
     grpc_error_handle error_out =
         grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                "Failed to load file", &error, 1),
-                           GRPC_ERROR_STR_FILENAME,
-                           filename);
+                           GRPC_ERROR_STR_FILENAME, filename);
     GRPC_ERROR_UNREF(error);
     error = error_out;
   }

--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -41,6 +41,7 @@ grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
 
   GRPC_SCHEDULING_START_BLOCKING_REGION;
   file = fopen(filename, "rb");
+  gpr_log(GPR_DEBUG, "file opened...");
   if (file == nullptr) {
     error = GRPC_OS_ERROR(errno, "fopen");
     goto end;
@@ -65,17 +66,18 @@ grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
 
 end:
   *output = result;
+  gpr_log(GPR_DEBUG, "got contents...");
   if (file != nullptr) fclose(file);
   if (error != GRPC_ERROR_NONE) {
     grpc_error_handle error_out =
         grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                "Failed to load file", &error, 1),
                            GRPC_ERROR_STR_FILENAME,
-
                            filename);
     GRPC_ERROR_UNREF(error);
     error = error_out;
   }
   GRPC_SCHEDULING_END_BLOCKING_REGION_NO_EXEC_CTX;
+  gpr_log(GPR_DEBUG, "load_file snippet complete...");
   return error;
 }

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -130,11 +130,13 @@ absl::Status FileWatcherAuthorizationPolicyProvider::ForceUpdate() {
   if (!rbac_policies_or.ok()) {
     return rbac_policies_or.status();
   }
-  MutexLock lock(&mu_);
-  allow_engine_ = MakeRefCounted<GrpcAuthorizationEngine>(
-      std::move(rbac_policies_or->allow_policy));
-  deny_engine_ = MakeRefCounted<GrpcAuthorizationEngine>(
-      std::move(rbac_policies_or->deny_policy));
+  {
+    MutexLock lock(&mu_);
+    allow_engine_ = MakeRefCounted<GrpcAuthorizationEngine>(
+        std::move(rbac_policies_or->allow_policy));
+    deny_engine_ = MakeRefCounted<GrpcAuthorizationEngine>(
+        std::move(rbac_policies_or->deny_policy));
+  }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_authz_trace)) {
     gpr_log(GPR_INFO,
             "authorization policy reload status: successfully loaded new "

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -102,12 +102,14 @@ FileWatcherAuthorizationPolicyProvider::FileWatcherAuthorizationPolicyProvider(
       if (value != nullptr) {
         return;
       }
+      gpr_log(GPR_DEBUG, "Start Reloading...");
       absl::Status status = provider->ForceUpdate();
       if (GRPC_TRACE_FLAG_ENABLED(grpc_authz_trace) && !status.ok()) {
         gpr_log(GPR_ERROR,
                 "authorization policy reload status. code=%d error_details=%s",
                 status.code(), std::string(status.message()).c_str());
       }
+      gpr_log(GPR_DEBUG, "End Reloading...");
     }
   };
   refresh_thread_ = absl::make_unique<Thread>(
@@ -126,6 +128,7 @@ absl::Status FileWatcherAuthorizationPolicyProvider::ForceUpdate() {
     return absl::OkStatus();
   }
   file_contents_ = std::move(*file_contents);
+  gpr_log(GPR_DEBUG, "File updated...");
   auto rbac_policies_or = GenerateRbacPolicies(file_contents_);
   if (!rbac_policies_or.ok()) {
     return rbac_policies_or.status();

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -121,6 +121,7 @@ FileWatcherAuthorizationPolicyProvider::FileWatcherAuthorizationPolicyProvider(
 absl::Status FileWatcherAuthorizationPolicyProvider::ForceUpdate() {
   absl::StatusOr<std::string> file_contents =
       ReadPolicyFromFile(authz_policy_path_);
+  gpr_log(GPR_DEBUG, "File read...");
   if (!file_contents.ok()) {
     return file_contents.status();
   }
@@ -133,6 +134,7 @@ absl::Status FileWatcherAuthorizationPolicyProvider::ForceUpdate() {
   if (!rbac_policies_or.ok()) {
     return rbac_policies_or.status();
   }
+  gpr_log(GPR_DEBUG, "After generating rbac policies...");
   {
     MutexLock lock(&mu_);
     allow_engine_ = MakeRefCounted<GrpcAuthorizationEngine>(

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -48,8 +48,10 @@ namespace {
 
 absl::StatusOr<std::string> ReadPolicyFromFile(absl::string_view policy_path) {
   grpc_slice policy_slice = grpc_empty_slice();
+  gpr_log(GPR_DEBUG, "Before load file...");
   grpc_error_handle error =
       grpc_load_file(std::string(policy_path).c_str(), 0, &policy_slice);
+  gpr_log(GPR_DEBUG, "After load file...");
   if (error != GRPC_ERROR_NONE) {
     absl::Status status =
         absl::InvalidArgumentError(grpc_error_std_string(error));

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -84,7 +84,7 @@ absl::StatusOr<std::string> ReadPolicyFromFile(absl::string_view policy_path) {
     time_t ts_after = GetModificationTime(std::string(policy_path).c_str());
     if (ts_after != ts_before) {
       gpr_log(GPR_ERROR,
-              "Last modified time different %d %d. Start retrying ...",
+              "Last modified time different %ld %ld. Start retrying ...",
               ts_before, ts_after);
       continue;
     }

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -679,7 +679,9 @@ static void test_file_watcher_recovers_from_failure(
   test_allow_authorized_request(f);
   // Replace exisiting policy in file with an invalid policy.
   authz_policy = "{}";
+  gpr_log(GPR_DEBUG, "Before rewrite:1");
   tmp_policy.RewriteFile(authz_policy);
+  gpr_log(GPR_DEBUG, "After rewrite:1");
   wait_for_policy_reload();
   test_allow_authorized_request(f);
   // Recover from reload errors, by replacing invalid policy in file with a
@@ -708,7 +710,9 @@ static void test_file_watcher_recovers_from_failure(
       "    }"
       "  ]"
       "}";
+  gpr_log(GPR_DEBUG, "Before rewrite:2");
   tmp_policy.RewriteFile(authz_policy);
+  gpr_log(GPR_DEBUG, "After rewrite:2");
   wait_for_policy_reload();
   test_deny_unauthorized_request(f);
 

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -62,7 +62,7 @@ static void wait_for_policy_reload(void) {
 static void drain_cq(grpc_completion_queue* cq) {
   grpc_event ev;
   do {
-    ev = grpc_completion_queue_next(cq, five_seconds_from_now(), nullptr);
+    ev = grpc_completion_queue_next(cq, fifteen_seconds_from_now(), nullptr);
   } while (ev.type != GRPC_QUEUE_SHUTDOWN);
 }
 

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -56,7 +56,7 @@ static void wait_for_policy_reload(void) {
   // Wait for the provider's refresh thread to read the updated files.
   // TODO(jtattermusch): Refactor the tests to use a more reliable mechanism of
   // detecting that the policy has been reloaded. See b/204329811
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(5));
+  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
 }
 
 static void drain_cq(grpc_completion_queue* cq) {

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -674,7 +674,7 @@ static void test_file_watcher_recovers_from_failure(
   grpc_channel_args server_args = {GPR_ARRAY_SIZE(args), args};
 
   grpc_end2end_test_fixture f = begin_test(
-      config, "test_file_watcher_valid_policy_reload", nullptr, &server_args);
+      config, "test_file_watcher_recovers_from_failure", nullptr, &server_args);
   grpc_authorization_policy_provider_release(provider);
   test_allow_authorized_request(f);
   // Replace exisiting policy in file with an invalid policy.

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -22,6 +22,7 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/security/authorization/grpc_authorization_policy_provider.h"
 #include "src/core/lib/security/credentials/credentials.h"
@@ -722,4 +723,11 @@ void grpc_authz(grpc_end2end_test_config config) {
   test_file_watcher_recovers_from_failure(config);
 }
 
-void grpc_authz_pre_init(void) {}
+void grpc_authz_pre_init(void) {
+  // TODO(ashithasantosh): Remove below logs. Logs are enabled for debugging
+  // purpose.
+#if GPR_APPLE
+  gpr_setenv("GRPC_VERBOSITY", "DEBUG");
+  gpr_setenv("GRPC_TRACE", "grpc_authz_api");
+#endif
+}

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -48,21 +48,21 @@ static gpr_timespec n_seconds_from_now(int n) {
   return grpc_timeout_seconds_to_deadline(n);
 }
 
-static gpr_timespec fifteen_seconds_from_now(void) {
-  return n_seconds_from_now(15);
+static gpr_timespec five_seconds_from_now(void) {
+  return n_seconds_from_now(5);
 }
 
 static void wait_for_policy_reload(void) {
   // Wait for the provider's refresh thread to read the updated files.
   // TODO(jtattermusch): Refactor the tests to use a more reliable mechanism of
   // detecting that the policy has been reloaded. See b/204329811
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(5));
+  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
 }
 
 static void drain_cq(grpc_completion_queue* cq) {
   grpc_event ev;
   do {
-    ev = grpc_completion_queue_next(cq, fifteen_seconds_from_now(), nullptr);
+    ev = grpc_completion_queue_next(cq, five_seconds_from_now(), nullptr);
   } while (ev.type != GRPC_QUEUE_SHUTDOWN);
 }
 
@@ -110,7 +110,7 @@ static void test_allow_authorized_request(grpc_end2end_test_fixture f) {
 
   cq_verifier* cqv = cq_verifier_create(f.cq);
 
-  gpr_timespec deadline = fifteen_seconds_from_now();
+  gpr_timespec deadline = five_seconds_from_now();
   c = grpc_channel_create_call(f.client, nullptr, GRPC_PROPAGATE_DEFAULTS, f.cq,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);
@@ -211,7 +211,7 @@ static void test_deny_unauthorized_request(grpc_end2end_test_fixture f) {
 
   cq_verifier* cqv = cq_verifier_create(f.cq);
 
-  gpr_timespec deadline = fifteen_seconds_from_now();
+  gpr_timespec deadline = five_seconds_from_now();
   c = grpc_channel_create_call(f.client, nullptr, GRPC_PROPAGATE_DEFAULTS, f.cq,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -48,15 +48,15 @@ static gpr_timespec n_seconds_from_now(int n) {
   return grpc_timeout_seconds_to_deadline(n);
 }
 
-static gpr_timespec five_seconds_from_now(void) {
-  return n_seconds_from_now(5);
+static gpr_timespec fifteen_seconds_from_now(void) {
+  return n_seconds_from_now(15);
 }
 
 static void wait_for_policy_reload(void) {
   // Wait for the provider's refresh thread to read the updated files.
   // TODO(jtattermusch): Refactor the tests to use a more reliable mechanism of
   // detecting that the policy has been reloaded. See b/204329811
-  gpr_sleep_until(grpc_timeout_seconds_to_deadline(2));
+  gpr_sleep_until(grpc_timeout_seconds_to_deadline(5));
 }
 
 static void drain_cq(grpc_completion_queue* cq) {
@@ -110,7 +110,7 @@ static void test_allow_authorized_request(grpc_end2end_test_fixture f) {
 
   cq_verifier* cqv = cq_verifier_create(f.cq);
 
-  gpr_timespec deadline = five_seconds_from_now();
+  gpr_timespec deadline = fifteen_seconds_from_now();
   c = grpc_channel_create_call(f.client, nullptr, GRPC_PROPAGATE_DEFAULTS, f.cq,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);
@@ -211,7 +211,7 @@ static void test_deny_unauthorized_request(grpc_end2end_test_fixture f) {
 
   cq_verifier* cqv = cq_verifier_create(f.cq);
 
-  gpr_timespec deadline = five_seconds_from_now();
+  gpr_timespec deadline = fifteen_seconds_from_now();
   c = grpc_channel_create_call(f.client, nullptr, GRPC_PROPAGATE_DEFAULTS, f.cq,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -250,6 +250,11 @@ static void test_deny_unauthorized_request(grpc_end2end_test_fixture f) {
   CQ_EXPECT_COMPLETION(cqv, tag(1), 1);
   cq_verify(cqv);
 
+  // Remove
+  char* details_str = grpc_slice_to_c_string(details);
+  gpr_log(GPR_DEBUG, "status=%d details=%s", status, details_str);
+  gpr_free(details_str);
+
   GPR_ASSERT(GRPC_STATUS_PERMISSION_DENIED == status);
   GPR_ASSERT(0 ==
              grpc_slice_str_cmp(details, "Unauthorized RPC request rejected."));

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -737,6 +737,6 @@ void grpc_authz_pre_init(void) {
   // purpose.
 #if GPR_APPLE
   gpr_setenv("GRPC_VERBOSITY", "DEBUG");
-  gpr_setenv("GRPC_TRACE", "grpc_authz_api");
+  gpr_setenv("GRPC_TRACE", "all");
 #endif
 }

--- a/test/core/security/grpc_authorization_policy_provider_test.cc
+++ b/test/core/security/grpc_authorization_policy_provider_test.cc
@@ -21,6 +21,7 @@
 
 #include <grpc/grpc_security.h>
 
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/security/authorization/grpc_authorization_engine.h"
 #include "test/core/util/test_config.h"
 #include "test/core/util/tls_utils.h"
@@ -212,6 +213,12 @@ TEST(AuthorizationPolicyProviderTest, FileWatcherRecoversFromFailure) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  // TODO(ashithasantosh): Remove below logs. Logs are enabled for debugging
+  // purpose.
+#if GPR_APPLE
+  gpr_setenv("GRPC_VERBOSITY", "DEBUG");
+  gpr_setenv("GRPC_TRACE", "grpc_authz_api");
+#endif
   grpc_init();
   int ret = RUN_ALL_TESTS();
   grpc_shutdown();

--- a/test/cpp/end2end/grpc_authz_end2end_test.cc
+++ b/test/cpp/end2end/grpc_authz_end2end_test.cc
@@ -22,6 +22,7 @@
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/iomgr/load_file.h"
 #include "src/core/lib/security/credentials/fake/fake_credentials.h"
 #include "src/cpp/client/secure_credentials.h"
@@ -812,6 +813,12 @@ TEST_F(GrpcAuthzEnd2EndTest, FileWatcherRecoversFromFailure) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(&argc, argv);
+  // TODO(ashithasantosh): Remove below logs. Logs are enabled for debugging
+  // purpose.
+#if GPR_APPLE
+  gpr_setenv("GRPC_VERBOSITY", "DEBUG");
+  gpr_setenv("GRPC_TRACE", "grpc_authz_api");
+#endif
   const auto result = RUN_ALL_TESTS();
   return result;
 }


### PR DESCRIPTION
Enabling authorization logs for authorization test targets to help with debugging MacOS failures.

