### PR TITLE
[ObjC]fix 'This function declaration is not a prototype' warning in Xcode

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -542,7 +542,7 @@ GRPCAPI void grpc_resource_quota_set_max_threads(
 
 /** EXPERIMENTAL.  Dumps xDS configs as a serialized ClientConfig proto.
     The full name of the proto is envoy.service.status.v3.ClientConfig. */
-GRPCAPI grpc_slice grpc_dump_xds_configs();
+GRPCAPI grpc_slice grpc_dump_xds_configs(void);
 
 /** Fetch a vtable for a grpc_channel_arg that points to a grpc_resource_quota
  */

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -2571,7 +2571,7 @@ RefCountedPtr<XdsClient> XdsClient::GetFromChannelArgs(
 }  // namespace grpc_core
 
 // The returned bytes may contain NULL(0), so we can't use c-string.
-grpc_slice grpc_dump_xds_configs() {
+grpc_slice grpc_dump_xds_configs(void) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
   grpc_error_handle error = GRPC_ERROR_NONE;

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -278,7 +278,7 @@ extern grpc_resource_quota_resize_type grpc_resource_quota_resize_import;
 typedef void(*grpc_resource_quota_set_max_threads_type)(grpc_resource_quota* resource_quota, int new_max_threads);
 extern grpc_resource_quota_set_max_threads_type grpc_resource_quota_set_max_threads_import;
 #define grpc_resource_quota_set_max_threads grpc_resource_quota_set_max_threads_import
-typedef grpc_slice(*grpc_dump_xds_configs_type)();
+typedef grpc_slice(*grpc_dump_xds_configs_type)(void);
 extern grpc_dump_xds_configs_type grpc_dump_xds_configs_import;
 #define grpc_dump_xds_configs grpc_dump_xds_configs_import
 typedef const grpc_arg_pointer_vtable*(*grpc_resource_quota_arg_vtable_type)(void);


### PR DESCRIPTION
https://github.com/grpc/grpc-ios/issues/83

Fix 'This function declaration is not a prototype' warning in Xcode

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

@dennycd 