### PR TITLE
[ObjC]fix 64 to 32 bit clang conversion warning in src/core/ext/filters

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -409,7 +409,7 @@ RingHash::Ring::Ring(RingHash* parent,
       std::ceil(min_normalized_weight * min_ring_size) / min_normalized_weight,
       static_cast<double>(max_ring_size));
   // Reserve memory for the entire ring up front.
-  const uint64_t ring_size = std::ceil(scale);
+  const size_t ring_size = std::ceil(scale);
   ring_.reserve(ring_size);
   // Populate the hash ring by walking through the (host, weight) pairs in
   // normalized_host_weights, and generating (scale * weight) hashes for each
@@ -473,12 +473,12 @@ RingHash::PickResult RingHash::Picker::Pick(PickArgs args) {
   // Ported from https://github.com/RJ/ketama/blob/master/libketama/ketama.c
   // (ketama_get_server) NOTE: The algorithm depends on using signed integers
   // for lowp, highp, and first_index. Do not change them!
-  int64_t lowp = 0;
-  int64_t highp = ring.size();
-  int64_t first_index = 0;
+  size_t lowp = 0;
+  size_t highp = ring.size();
+  size_t first_index = 0;
   while (true) {
     first_index = (lowp + highp) / 2;
-    if (first_index == static_cast<int64_t>(ring.size())) {
+    if (first_index == ring.size()) {
       first_index = 0;
       break;
     }

--- a/src/core/ext/filters/client_channel/lb_policy/rls/rls.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/rls/rls.cc
@@ -1980,7 +1980,7 @@ void RlsLb::UpdateLocked(UpdateArgs args) {
     // Resize cache if needed.
     if (old_config == nullptr ||
         config_->cache_size_bytes() != old_config->cache_size_bytes()) {
-      cache_.Resize(config_->cache_size_bytes());
+      cache_.Resize(static_cast<size_t>(config_->cache_size_bytes()));
     }
     // Start update of child policies if needed.
     if (update_child_policies) {

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.h
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.h
@@ -58,7 +58,7 @@ class FaultInjectionFilter : public ChannelFilter {
       const ClientMetadataHandle& initial_metadata);
 
   // The relative index of instances of the same filter.
-  int index_;
+  size_t index_;
   const size_t service_config_parser_index_;
 };
 

--- a/src/core/ext/filters/fault_injection/service_config_parser.h
+++ b/src/core/ext/filters/fault_injection/service_config_parser.h
@@ -72,8 +72,8 @@ class FaultInjectionMethodParsedConfig
   // keep track of their relative positions. The FaultInjectionFilter uses this
   // method to access the parsed fault injection policy in service config,
   // whether it came from xDS resolver or directly from service config
-  const FaultInjectionPolicy* fault_injection_policy(int index) const {
-    if (static_cast<size_t>(index) >= fault_injection_policies_.size()) {
+  const FaultInjectionPolicy* fault_injection_policy(size_t index) const {
+    if (index >= fault_injection_policies_.size()) {
       return nullptr;
     }
     return &fault_injection_policies_[index];

--- a/src/core/ext/filters/rbac/rbac_service_config_parser.h
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.h
@@ -55,8 +55,8 @@ class RbacMethodParsedConfig : public ServiceConfigParser::ParsedConfig {
   // a connection on the server, multiple RBAC policies might be active. The
   // RBAC filter uses this method to get the RBAC policy configured for a
   // instance at a particular instance.
-  const GrpcAuthorizationEngine* authorization_engine(int index) const {
-    if (static_cast<size_t>(index) >= authorization_engines_.size()) {
+  const GrpcAuthorizationEngine* authorization_engine(size_t index) const {
+    if (index >= authorization_engines_.size()) {
       return nullptr;
     }
     return &authorization_engines_[index];


### PR DESCRIPTION
https://github.com/grpc/grpc-ios/issues/83

fix 64 to 32 bit clang conversion warning in src/core/ext/filters

@dennycd

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

