### PR TITLE
[ObjC]fix 64 to 32 bit clang conversion warning in src/core/lib/security

### DIFF
--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -509,7 +509,7 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
         "Invalid expire time of service account impersonation response."));
     return;
   }
-  int expire_in = (t - absl::Now()) / absl::Seconds(1);
+  int64_t expire_in = (t - absl::Now()) / absl::Seconds(1);
   std::string body = absl::StrFormat(
       "{\"access_token\":\"%s\",\"expires_in\":%d,\"token_type\":\"Bearer\"}",
       access_token, expire_in);

--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -18,6 +18,7 @@
 
 #include "src/core/lib/security/credentials/external/external_account_credentials.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #include <algorithm>

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -120,7 +120,7 @@ gpr_timespec TimeoutSecondsToDeadline(int64_t seconds) {
 
 FileWatcherCertificateProvider::FileWatcherCertificateProvider(
     std::string private_key_path, std::string identity_certificate_path,
-    std::string root_cert_path, unsigned int refresh_interval_sec)
+    std::string root_cert_path, int64_t refresh_interval_sec)
     : private_key_path_(std::move(private_key_path)),
       identity_certificate_path_(std::move(identity_certificate_path)),
       root_cert_path_(std::move(root_cert_path)),
@@ -402,7 +402,8 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
   if (cert_chain.empty()) {
     return absl::InvalidArgumentError("Certificate string is empty.");
   }
-  BIO* cert_bio = BIO_new_mem_buf(cert_chain.data(), cert_chain.size());
+  BIO* cert_bio =
+      BIO_new_mem_buf(cert_chain.data(), static_cast<int>(cert_chain.size()));
   if (cert_bio == nullptr) {
     return absl::InvalidArgumentError(
         "Conversion from certificate string to BIO failed.");
@@ -422,7 +423,7 @@ absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
         "Extraction of public key from x.509 certificate failed.");
   }
   BIO* private_key_bio =
-      BIO_new_mem_buf(private_key.data(), private_key.size());
+      BIO_new_mem_buf(private_key.data(), static_cast<int>(private_key.size()));
   if (private_key_bio == nullptr) {
     EVP_PKEY_free(public_evp_pkey);
     return absl::InvalidArgumentError(

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -19,6 +19,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <stdint.h>
+
 #include <map>
 #include <string>
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -139,7 +139,7 @@ class FileWatcherCertificateProvider final
   FileWatcherCertificateProvider(std::string private_key_path,
                                  std::string identity_certificate_path,
                                  std::string root_cert_path,
-                                 unsigned int refresh_interval_sec);
+                                 int64_t refresh_interval_sec);
 
   ~FileWatcherCertificateProvider() override;
 
@@ -176,7 +176,7 @@ class FileWatcherCertificateProvider final
   std::string private_key_path_;
   std::string identity_certificate_path_;
   std::string root_cert_path_;
-  unsigned int refresh_interval_sec_ = 0;
+  int64_t refresh_interval_sec_ = 0;
 
   RefCountedPtr<grpc_tls_certificate_distributor> distributor_;
   Thread refresh_thread_;

--- a/src/core/lib/security/credentials/tls/tls_utils.cc
+++ b/src/core/lib/security/credentials/tls/tls_utils.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/security/credentials/tls/tls_utils.h"
 
+#include <stddef.h>
+
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"

--- a/src/core/lib/security/credentials/tls/tls_utils.cc
+++ b/src/core/lib/security/credentials/tls/tls_utils.cc
@@ -83,7 +83,7 @@ bool VerifySubjectAlternativeName(absl::string_view subject_alternative_name,
     return false;
   }
   if (!absl::EndsWith(normalized_matcher, suffix)) return false;
-  int suffix_start_index = normalized_matcher.length() - suffix.length();
+  size_t suffix_start_index = normalized_matcher.length() - suffix.length();
   // Asterisk matching across domain labels is not permitted.
   return suffix_start_index <= 0 /* should not happen */ ||
          normalized_matcher.find_last_of('.', suffix_start_index - 1) ==


### PR DESCRIPTION
https://github.com/grpc/grpc-ios/issues/83

fix 64 to 32 bit clang conversion warning in src/core/lib/security

@dennycd

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

