### PR TITLE
[ObjC]fix 64 to 32 bit clang conversion warning in src/core/lib/transport

### DIFF
--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -498,7 +498,7 @@ class ParseHelper {
     return ParsedMetadata<Container>(
         trait,
         ParseValueToMemento<typename Trait::MementoType, Trait::ParseMemento>(),
-        transport_size_);
+        static_cast<uint32_t>(transport_size_));
   }
 
   GPR_ATTRIBUTE_NOINLINE ParsedMetadata<Container> NotFound(

--- a/src/core/lib/transport/parsed_metadata.h
+++ b/src/core/lib/transport/parsed_metadata.h
@@ -152,7 +152,7 @@ class ParsedMetadata {
   // Construct metadata from a string key, slice value pair.
   ParsedMetadata(Slice key, Slice value)
       : vtable_(ParsedMetadata::KeyValueVTable(key.as_string_view())),
-        transport_size_(key.size() + value.size() + 32) {
+        transport_size_(static_cast<uint32_t>(key.size() + value.size() + 32)) {
     value_.pointer =
         new std::pair<Slice, Slice>(std::move(key), std::move(value));
   }
@@ -191,7 +191,9 @@ class ParsedMetadata {
     ParsedMetadata result;
     result.vtable_ = vtable_;
     result.value_ = value_;
-    result.transport_size_ = TransportSize(key().length(), value.length());
+    result.transport_size_ =
+        TransportSize(static_cast<uint32_t>(key().length()),
+                      static_cast<uint32_t>(value.length()));
     vtable_->with_new_value(&value, on_error, &result);
     return result;
   }


### PR DESCRIPTION
https://github.com/grpc/grpc-ios/issues/83

fix 64 to 32 bit clang conversion warning in src/core/lib/transport

@dennycd

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

