### PR TITLE
[build] Make compile_commands.json use NDEBUG

### DIFF
--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -90,6 +90,9 @@ def modifyCompileCommand(target, args):
     options = options.replace("-std=c++0x ", "")
     options = options.replace("-std=c++14 ", "")
 
+    # Add -DNDEBUG so that editors show the correct size information for structs.
+    options += " -DNDEBUG"
+
     if args.vscode:
         # Visual Studio Code doesn't seem to like "-iquote". Replace it with
         # old-style "-I".

--- a/tools/dockerfile/grpc_iwyu/iwyu.sh
+++ b/tools/dockerfile/grpc_iwyu/iwyu.sh
@@ -37,7 +37,10 @@ cd ${IWYU_ROOT}
 sed -i 's,^#!/usr/bin/env python,#!/usr/bin/env python3,g' ${IWYU_ROOT}/iwyu/iwyu_tool.py
 sed -i 's,^#!/usr/bin/env python,#!/usr/bin/env python3,g' ${IWYU_ROOT}/iwyu/fix_includes.py
 
-cat compile_commands.json | sed "s,\"file\": \",\"file\": \"${IWYU_ROOT}/,g" > compile_commands_for_iwyu.json
+cat compile_commands.json                            \
+  | sed "s/ -DNEBUG//g"                              \
+  | sed "s,\"file\": \",\"file\": \"${IWYU_ROOT}/,g" \
+  > compile_commands_for_iwyu.json
 
 export ENABLED_MODULES='
   src/core/ext

--- a/tools/dockerfile/grpc_iwyu/iwyu.sh
+++ b/tools/dockerfile/grpc_iwyu/iwyu.sh
@@ -38,7 +38,7 @@ sed -i 's,^#!/usr/bin/env python,#!/usr/bin/env python3,g' ${IWYU_ROOT}/iwyu/iwy
 sed -i 's,^#!/usr/bin/env python,#!/usr/bin/env python3,g' ${IWYU_ROOT}/iwyu/fix_includes.py
 
 cat compile_commands.json                            \
-  | sed "s/ -DNEBUG//g"                              \
+  | sed "s/ -DNDEBUG//g"                              \
   | sed "s,\"file\": \",\"file\": \"${IWYU_ROOT}/,g" \
   > compile_commands_for_iwyu.json
 


### PR DESCRIPTION
Ensures that things like clangd report the correct size information for
structures, which makes optimization a lot easier.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

