### PR TITLE
[ObjC]fix 64 to 32 bit clang conversion warning in src/core/tsi

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1566,7 +1566,7 @@ static tsi_result ssl_handshaker_write_output_buffer(tsi_handshaker* self,
                                                      size_t* bytes_written) {
   tsi_ssl_handshaker* impl = reinterpret_cast<tsi_ssl_handshaker*>(self);
   tsi_result status = TSI_OK;
-  int offset = *bytes_written;
+  size_t offset = *bytes_written;
   do {
     size_t to_send_size = impl->outgoing_bytes_buffer_size - offset;
     status = ssl_handshaker_get_bytes_to_send_to_peer(


### PR DESCRIPTION
https://github.com/grpc/grpc-ios/issues/83

fix 64 to 32 bit clang conversion warning in src/core/tsi

@dennycd

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

