### PR TITLE
[call] Remove unused field from grpc_cq_completion

### DIFF
--- a/src/core/lib/surface/completion_queue.h
+++ b/src/core/lib/surface/completion_queue.h
@@ -41,9 +41,6 @@ extern grpc_core::DebugOnlyTraceFlag grpc_trace_pending_tags;
 extern grpc_core::DebugOnlyTraceFlag grpc_trace_cq_refcount;
 
 typedef struct grpc_cq_completion {
-  grpc_core::ManualConstructor<grpc_core::MultiProducerSingleConsumerQueue>
-      node;
-
   /** user supplied tag */
   void* tag;
   /** done callback - called when this queue element is no longer


### PR DESCRIPTION
1. This field is unused, and therefore unnecessary
2. In https://github.com/grpc/grpc/pull/20119 this field was changed
   from a node (8 bytes) to a queue (80 bytes)

Removing this field should save 480 bytes per outstanding call on each
of the client and server.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

