### PR TITLE
GoogleDefaultCreds: check xdstp URI authority

### DIFF
--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -93,7 +93,8 @@ bool IsXdsNonCfeCluster(const char* xds_cluster) {
   if (!absl::StartsWith(xds_cluster, "xdstp:")) return true;
   auto uri = grpc_core::URI::Parse(xds_cluster);
   if (!uri.ok()) return true;  // Shouldn't happen, but assume ALTS.
-  return !absl::StartsWith(uri->path(),
+  return uri->authority() != "traffic-director-c2p.xds.googleapis.com" ||
+         !absl::StartsWith(uri->path(),
                            "/envoy.config.cluster.v3.Cluster/google_cfe_");
 }
 


### PR DESCRIPTION
This is desirable because the established id prefix of "google_cfe_" is specified only for the C2P authority.