### PR TITLE
[xDS interop] Limit subsetting test to master branch

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py
@@ -22,6 +22,7 @@ from google.protobuf import json_format
 
 from framework import xds_k8s_testcase
 from framework import xds_url_map_testcase
+from framework.helpers import skips
 
 flags.adopt_module_key_flags(xds_k8s_testcase)
 
@@ -35,6 +36,13 @@ _NUM_CLIENTS = 3
 
 
 class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
+
+    @staticmethod
+    def isSupported(config: skips.TestConfig) -> bool:
+        # Subsetting is an experimental feature where most work is done on the
+        # server-side. We limit it to only run on master branch to save
+        # resources.
+        return config.version_ge('master')
 
     def test_subsetting_basic(self) -> None:
         with self.subTest('00_create_health_check'):


### PR DESCRIPTION
Subsetting was an alpha feature that hasn't GA yet. In staging, we only test it against the latest branch. We should apply the same coverage in production as well.

* [grpc_xds_k8s_lb](http://sponge/ca9e062e-1fb4-4601-b5e8-ab68a5f55265)
* [grpc_xds_k8s_lb_python](http://sponge/96145bad-c5fe-41f8-b1d5-564596505fe1)