### PR TITLE
[xDS interop] api_listener_test: allow transient failures

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -371,7 +371,6 @@ class XdsKubernetesTestCase(absltest.TestCase, metaclass=abc.ABCMeta):
         try:
             for attempt in retryer:
                 with attempt:
-                    self.assertSuccessfulRpcs(test_client)
                     raw_config = test_client.csds.fetch_client_status(
                         log_level=logging.INFO)
                     dumped_config = xds_url_map_testcase.DumpedXdsConfig(


### PR DESCRIPTION
More context: b/235145855

This PR offers the same level of coverage as the GCE tests: https://github.com/grpc/grpc/blob/cb2a92b5bb8bc8c1263c4daa591026ddec791d83/tools/run_tests/run_xds_tests.py#L1217