### PR TITLE
xds-k8s: Fix the issue with Java PSM security tests skipped

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -34,11 +34,6 @@ class Lang(enum.Flag):
     JAVA = enum.auto()
     PYTHON = enum.auto()
     NODE = enum.auto()
-    # Languages supported by the framework, that follow the same gRPC version
-    # release scheme.
-    VERSION_TYPE_1 = CPP | GO | JAVA | PYTHON
-    # Nodejs doesn't follow the same versioning scheme as other languages.
-    VERSION_TYPE_2 = NODE
 
     def __str__(self):
         return str(self.name).lower()

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 import enum
 import logging
 import re
-from typing import Callable
+from typing import Callable, Optional
 import unittest
 
 from packaging import version as pkg_version
@@ -56,7 +56,7 @@ class TestConfig:
     """Describes the config for the test suite."""
     client_lang: Lang
     server_lang: Lang
-    version: str
+    version: Optional[str]
 
     def version_gte(self, another: str) -> bool:
         """Returns a bool for whether the version is >= another one.
@@ -65,8 +65,10 @@ class TestConfig:
         number is greater than or equal to another version's number. Version
         "master" is always considered latest.
         E.g., master >= v1.41.x >= v1.40.x >= v1.9.x.
+
+        Unspecified version is treated as 'master', but isn't explicitly set.
         """
-        if self.version == 'master':
+        if self.version == 'master' or self.version is None:
             return True
         return self._parse_version(self.version) >= self._parse_version(another)
 
@@ -75,14 +77,16 @@ class TestConfig:
 
         Version "master" is always considered latest.
         E.g., v1.9.x < v1.40.x < v1.41.x < master.
+
+        Unspecified version is treated as 'master', but isn't explicitly set.
         """
-        if self.version == 'master':
+        if self.version == 'master' or self.version is None:
             return False
         return self._parse_version(self.version) < self._parse_version(another)
 
     def __str__(self):
-        return (f'TestConfig(client_lang="{self.client_lang}", '
-                f'server_lang="{self.server_lang}", version="{self.version}")')
+        return (f"TestConfig(client_lang='{self.client_lang}', "
+                f"server_lang='{self.server_lang}', version={self.version!r})")
 
     @staticmethod
     def _parse_version(s: str) -> pkg_version.Version:

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -41,7 +41,7 @@ class Lang(enum.Flag):
     VERSION_TYPE_2 = NODE
 
     def __str__(self):
-        return self.name.lower()
+        return str(self.name).lower()
 
     @classmethod
     def from_string(cls, lang: str):
@@ -113,5 +113,5 @@ def evaluate_test_config(check: Callable[[TestConfig], bool]) -> None:
     if not check(test_config):
         logger.info('Skipping %s', test_config)
         raise unittest.SkipTest(f'Unsupported test config: {test_config}')
-    else:
-        logger.info('Detected language and version: %s', test_config)
+
+    logger.info('Detected language and version: %s', test_config)

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -116,7 +116,7 @@ CLIENT_PORT = flags.DEFINE_integer(
 # Testing metadata
 TESTING_VERSION = flags.DEFINE_string(
     "testing_version",
-    default="master",
+    default=None,
     help="The testing gRPC version branch name. Like master, v1.41.x, v1.37.x")
 
 FORCE_CLEANUP = flags.DEFINE_bool(

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -85,7 +85,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
     td: TrafficDirectorManager
 
     @staticmethod
-    def isSupported(config: skips.TestConfig) -> bool:
+    def is_supported(config: skips.TestConfig) -> bool:
         """Overridden by the test class to decide if the config is supported.
 
         Returns:
@@ -104,7 +104,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
 
         # Raises unittest.SkipTest if given client/server/version does not
         # support current test case.
-        skips.evaluate_test_config(cls.isSupported)
+        skips.evaluate_test_config(cls.is_supported)
 
         # GCP
         cls.project: str = xds_flags.PROJECT.value

--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -43,10 +43,11 @@ _RPC_COUNT = 100
 class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
-    def isSupported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java', 'python', 'go']:
-            return config.version_ge('v1.40.x')
-        return False
+    def is_supported(config: skips.TestConfig) -> bool:
+        if config.is_common_lang_client:
+            # Versions prior to v1.40.x don't support Affinity.
+            return not config.version_lt('v1.40.x')
+        return True
 
     def test_affinity(self) -> None:  # pylint: disable=too-many-statements
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -44,7 +44,7 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.is_common_lang_client:
+        if config.client_lang in skips.Lang.VERSION_TYPE_1:
             # Versions prior to v1.40.x don't support Affinity.
             return not config.version_lt('v1.40.x')
         return True

--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -31,6 +31,7 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _ChannelzChannelState = grpc_channelz.ChannelState
+_Lang = skips.Lang
 
 # Testing consts
 _TEST_AFFINITY_METADATA_KEY = 'xds_md'
@@ -44,7 +45,8 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in skips.Lang.VERSION_TYPE_1:
+        if config.client_lang in (_Lang.CPP | _Lang.GO | _Lang.JAVA |
+                                  _Lang.PYTHON):
             # Versions prior to v1.40.x don't support Affinity.
             return not config.version_lt('v1.40.x')
         return True

--- a/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
@@ -47,12 +47,12 @@ class AuthzTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
     }
 
     @staticmethod
-    def isSupported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'python']:
-            return config.version_ge('v1.44.x')
-        elif config.client_lang in ['java', 'go']:
-            return config.version_ge('v1.42.x')
-        return False
+    def is_supported(config: skips.TestConfig) -> bool:
+        if config.client_lang in frozenset({'cpp', 'python'}):
+            return not config.version_lt('v1.44.x')
+        elif config.client_lang in frozenset({'java', 'go'}):
+            return not config.version_lt('v1.42.x')
+        return True
 
     def setUp(self):
         super().setUp()

--- a/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
@@ -29,6 +29,7 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _SecurityMode = xds_k8s_testcase.SecurityXdsKubernetesTestCase.SecurityMode
+_Lang = skips.Lang
 
 # The client generates QPS even when it is still loading information from xDS.
 # Once it finally connects there will be an outpouring of the bufferred RPCs and
@@ -48,9 +49,11 @@ class AuthzTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in frozenset({'cpp', 'python'}):
+        # Per "Authorization (RBAC)" in
+        # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
+        if config.client_lang in _Lang.CPP | _Lang.PYTHON:
             return not config.version_lt('v1.44.x')
-        elif config.client_lang in frozenset({'java', 'go'}):
+        elif config.client_lang in _Lang.GO | _Lang.JAVA:
             return not config.version_lt('v1.42.x')
         return True
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
@@ -32,10 +32,12 @@ _SecurityMode = xds_k8s_testcase.SecurityXdsKubernetesTestCase.SecurityMode
 class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
 
     @staticmethod
-    def isSupported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'python', 'go']:
-            return config.version_ge('v1.41.x')
-        return False
+    def is_supported(config: skips.TestConfig) -> bool:
+        if config.is_common_lang_client:
+            # Versions prior to v1.41.x don't support PSM Security.
+            # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
+            return not config.version_lt('v1.41.x')
+        return True
 
     def test_mtls(self):
         """mTLS test.

--- a/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
@@ -33,7 +33,7 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.is_common_lang_client:
+        if config.client_lang in skips.Lang.VERSION_TYPE_1:
             # Versions prior to v1.41.x don't support PSM Security.
             # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
             return not config.version_lt('v1.41.x')

--- a/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
@@ -27,13 +27,15 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _SecurityMode = xds_k8s_testcase.SecurityXdsKubernetesTestCase.SecurityMode
+_Lang = skips.Lang
 
 
 class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in skips.Lang.VERSION_TYPE_1:
+        if config.client_lang in (_Lang.CPP | _Lang.GO | _Lang.JAVA |
+                                  _Lang.PYTHON):
             # Versions prior to v1.41.x don't support PSM Security.
             # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
             return not config.version_lt('v1.41.x')

--- a/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py
@@ -38,11 +38,11 @@ _NUM_CLIENTS = 3
 class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
-    def isSupported(config: skips.TestConfig) -> bool:
+    def is_supported(config: skips.TestConfig) -> bool:
         # Subsetting is an experimental feature where most work is done on the
         # server-side. We limit it to only run on master branch to save
         # resources.
-        return config.version_ge('master')
+        return config.version_gte('master')
 
     def test_subsetting_basic(self) -> None:
         with self.subTest('00_create_health_check'):

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -52,15 +52,25 @@ _TEST_METADATA = (
 _ChannelzChannelState = grpc_channelz.ChannelState
 
 
+def _is_supported(config: skips.TestConfig) -> bool:
+    # Per "Ring hash" in
+    # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
+    if config.client_lang in frozenset({'cpp', 'java'}):
+        return not config.version_lt('v1.40.x')
+    elif config.client_lang == 'go':
+        return not config.version_lt('v1.41.x')
+    elif config.client_lang == 'python':
+        # TODO(https://github.com/grpc/grpc/issues/27430): supported after
+        #      the issue is fixed.
+        return False
+    return True
+
+
 class TestHeaderBasedAffinity(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java']:
-            return config.version_ge('v1.40.x')
-        if config.client_lang in ['go']:
-            return config.version_ge('v1.41.x')
-        return False
+        return _is_supported(config)
 
     @staticmethod
     def client_init_config(rpc: str, metadata: str):
@@ -125,11 +135,7 @@ class TestHeaderBasedAffinityMultipleHeaders(
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java']:
-            return config.version_ge('v1.40.x')
-        if config.client_lang in ['go']:
-            return config.version_ge('v1.41.x')
-        return False
+        return _is_supported(config)
 
     @staticmethod
     def client_init_config(rpc: str, metadata: str):

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -31,6 +31,7 @@ DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
+_Lang = skips.Lang
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
@@ -55,11 +56,11 @@ _ChannelzChannelState = grpc_channelz.ChannelState
 def _is_supported(config: skips.TestConfig) -> bool:
     # Per "Ring hash" in
     # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
-    if config.client_lang in frozenset({'cpp', 'java'}):
+    if config.client_lang in _Lang.CPP | _Lang.JAVA:
         return not config.version_lt('v1.40.x')
-    elif config.client_lang == 'go':
+    elif config.client_lang in _Lang.GO:
         return not config.version_lt('v1.41.x')
-    elif config.client_lang == 'python':
+    elif config.client_lang in _Lang.PYTHON:
         # TODO(https://github.com/grpc/grpc/issues/27430): supported after
         #      the issue is fixed.
         return False

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -58,9 +58,9 @@ def _is_supported(config: skips.TestConfig) -> bool:
     # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
     if config.client_lang in _Lang.CPP | _Lang.JAVA:
         return not config.version_lt('v1.40.x')
-    elif config.client_lang in _Lang.GO:
+    elif config.client_lang == _Lang.GO:
         return not config.version_lt('v1.41.x')
-    elif config.client_lang in _Lang.PYTHON:
+    elif config.client_lang == _Lang.PYTHON:
         # TODO(https://github.com/grpc/grpc/issues/27430): supported after
         #      the issue is fixed.
         return False

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -62,15 +62,21 @@ def _build_retry_route_rule(retryConditions, num_retries):
     }
 
 
+def _is_supported(config: skips.TestConfig) -> bool:
+    # Per "Retry" in
+    # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
+    if config.client_lang in frozenset({'cpp', 'java', 'python'}):
+        return not config.version_lt('v1.40.x')
+    elif config.client_lang == 'go':
+        return not config.version_lt('v1.41.x')
+    return True
+
+
 class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java', 'python']:
-            return config.version_ge('v1.40.x')
-        elif config.client_lang == 'go':
-            return config.version_ge('v1.41.x')
-        return False
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -111,11 +117,7 @@ class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in ['cpp', 'java', 'python']:
-            return config.version_ge('v1.40.x')
-        elif config.client_lang == 'go':
-            return config.version_ge('v1.41.x')
-        return False
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -68,7 +68,7 @@ def _is_supported(config: skips.TestConfig) -> bool:
     # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
     if config.client_lang in _Lang.CPP | _Lang.JAVA | _Lang.PYTHON:
         return not config.version_lt('v1.40.x')
-    elif config.client_lang in _Lang.GO:
+    elif config.client_lang == _Lang.GO:
         return not config.version_lt('v1.41.x')
     return True
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -30,6 +30,7 @@ DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 XdsTestClient = client_app.XdsTestClient
 ExpectedResult = xds_url_map_testcase.ExpectedResult
+_Lang = skips.Lang
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
@@ -65,9 +66,9 @@ def _build_retry_route_rule(retryConditions, num_retries):
 def _is_supported(config: skips.TestConfig) -> bool:
     # Per "Retry" in
     # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
-    if config.client_lang in frozenset({'cpp', 'java', 'python'}):
+    if config.client_lang in _Lang.CPP | _Lang.JAVA | _Lang.PYTHON:
         return not config.version_lt('v1.40.x')
-    elif config.client_lang == 'go':
+    elif config.client_lang in _Lang.GO:
         return not config.version_lt('v1.41.x')
     return True
 


### PR DESCRIPTION
1. Fixes the issue with Java PSM security tests accidentally skipped because Java was missing from the list of languages, ref https://github.com/grpc/grpc/pull/28978
2. Invert the logic of `is_supported` methods, making them normally open
3. Make languages an `enum.Flag` to avoid accidental typos when listing the languages
4. Rename `XdsKubernetesTestCase.isSupported` to `XdsKubernetesTestCase.is_supported` to be consistent with `XdsUrlMapTestCase.is_supported`
5. Add extra logging
