### PR TITLE
Disable flaky grpc_authz test case on mac

### DIFF
--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -668,7 +668,7 @@ static void test_file_watcher_recovers_from_failure(
   grpc_channel_args server_args = {GPR_ARRAY_SIZE(args), args};
 
   grpc_end2end_test_fixture f = begin_test(
-      config, "test_file_watcher_valid_policy_reload", nullptr, &server_args);
+      config, "test_file_watcher_recovers_from_failure", nullptr, &server_args);
   grpc_authorization_policy_provider_release(provider);
   test_allow_authorized_request(f);
   // Replace exisiting policy in file with an invalid policy.
@@ -719,7 +719,10 @@ void grpc_authz(grpc_end2end_test_config config) {
   test_file_watcher_init_deny_request_no_match_in_policy(config);
   test_file_watcher_valid_policy_reload(config);
   test_file_watcher_invalid_policy_skip_reload(config);
+#ifndef GPR_APPLE  // test case highly flaky on Mac
+  // TODO(jtattermusch): reenable the test once b/204329811 is fixed.
   test_file_watcher_recovers_from_failure(config);
+#endif
 }
 
 void grpc_authz_pre_init(void) {}


### PR DESCRIPTION
- based on historical data, this seems to be the test case that is responsible for vast majority of flakiness (see https://source.cloud.google.com/results/invocations/ce30bd5a-e0ba-4c02-8e8b-7c54e2b243da/targets/%2F%2Ftest%2Fcore%2Fend2end:h2_full_no_retry_test@grpc_authz/log for reference) 
- fix the test label printed to the logs (so actually we want to disable `test_file_watcher_recovers_from_failure`)

