### PR TITLE
Add package links to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -545,6 +545,11 @@ setuptools.setup(
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',
+    project_urls={
+        'Changelog': 'https://github.com/grpc/grpc/releases',
+        'Documentation': 'https://grpc.io/docs/languages/python/',
+        'Source': 'https://github.com/grpc/grpc',
+    },
     license=LICENSE,
     classifiers=CLASSIFIERS,
     long_description=open(README).read(),


### PR DESCRIPTION
Add two links to the sidebar on PyPI, to make it easier for folks to jump to the relevant pages. Example: https://pypi.org/project/django-htmx/ (PyPI adds the icons based on the link names).