### PR TITLE
Add ring_hash_lb to trace logs for Python/C++ xds interop clients

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
@@ -20,7 +20,7 @@ FROM phusion/baseimage:master@sha256:65ea10d5f757e5e86272625f8675d437dd83d8db64b
 COPY --from=0 /artifacts ./
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE="xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb"
+ENV GRPC_TRACE="xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb,ring_hash_lb"
 
 RUN apt-get update -y && apt-get install -y python3
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
@@ -36,6 +36,6 @@ FROM phusion/baseimage:master@sha256:65ea10d5f757e5e86272625f8675d437dd83d8db64b
 COPY --from=0 /artifacts ./
 
 ENV GRPC_VERBOSITY="DEBUG"
-ENV GRPC_TRACE="xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,eds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb,lrs_lb,xds_server_config_fetcher"
+ENV GRPC_TRACE="xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,eds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb,lrs_lb,xds_server_config_fetcher,ring_hash_lb"
 
 ENTRYPOINT ["/xds_interop_client"]


### PR DESCRIPTION
This PR allows us to better debug issues related to ring_hash_lb (like b/231690283).

However, this flag won't be automatically backported to older releases, and the flags don't include all xDS features (like fault injection). In future, we might want a more controllable way of updating what kinds of logs we are generating. For example, documenting this step somewhere.