### PR TITLE
Add supported Node version ranges in xDS k8s url_map tests

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -64,6 +64,8 @@ def _is_supported(config: skips.TestConfig) -> bool:
         # TODO(https://github.com/grpc/grpc/issues/27430): supported after
         #      the issue is fixed.
         return False
+    elif config.client_lang == _Lang.NODE:
+        return False
     return True
 
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/csds_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/csds_test.py
@@ -19,6 +19,7 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.test_app import client_app
+from framework.helpers import skips
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -28,6 +29,7 @@ DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
+_Lang = skips.Lang
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
@@ -36,6 +38,12 @@ _NUM_RPCS = 50
 
 
 class TestBasicCsds(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        if config.client_lang == _Lang.NODE:
+            return not config.version_lt('v1.5.x')
+        return True
 
     @staticmethod
     def url_map_change(

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/csds_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/csds_test.py
@@ -18,8 +18,8 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_url_map_testcase
-from framework.test_app import client_app
 from framework.helpers import skips
+from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py
@@ -21,6 +21,7 @@ import grpc
 
 from framework import xds_url_map_testcase
 from framework.test_app import client_app
+from framework.helpers import skips
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -31,6 +32,7 @@ RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 ExpectedResult = xds_url_map_testcase.ExpectedResult
+_Lang = skips.Lang
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
@@ -115,8 +117,16 @@ def _wait_until_backlog_cleared(test_client: XdsTestClient,
 
     raise RuntimeError('failed to clear RPC backlog in %s seconds' % timeout)
 
+def _is_supported(config: skips.TestConfig) -> bool:
+    if config.client_lang == _Lang.NODE:
+        return not config.version_lt('v1.4.x')
+    return True
 
 class TestZeroPercentFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -158,6 +168,10 @@ class TestZeroPercentFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
 
 class TestNonMatchingFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
     """EMPTY_CALL is not fault injected, so it should succeed."""
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def client_init_config(rpc: str, metadata: str):
@@ -215,6 +229,10 @@ class TestNonMatchingFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
 class TestAlwaysDelay(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
+
+    @staticmethod
     def url_map_change(
             host_rule: HostRule,
             path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
@@ -253,6 +271,10 @@ class TestAlwaysDelay(xds_url_map_testcase.XdsUrlMapTestCase):
 class TestAlwaysAbort(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
+
+    @staticmethod
     def url_map_change(
             host_rule: HostRule,
             path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
@@ -287,6 +309,10 @@ class TestAlwaysAbort(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestDelayHalf(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -325,6 +351,10 @@ class TestDelayHalf(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestAbortHalf(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py
@@ -20,8 +20,8 @@ from absl.testing import absltest
 import grpc
 
 from framework import xds_url_map_testcase
-from framework.test_app import client_app
 from framework.helpers import skips
+from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -117,10 +117,12 @@ def _wait_until_backlog_cleared(test_client: XdsTestClient,
 
     raise RuntimeError('failed to clear RPC backlog in %s seconds' % timeout)
 
+
 def _is_supported(config: skips.TestConfig) -> bool:
     if config.client_lang == _Lang.NODE:
         return not config.version_lt('v1.4.x')
     return True
+
 
 class TestZeroPercentFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/header_matching_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/header_matching_test.py
@@ -18,8 +18,8 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_url_map_testcase
-from framework.test_app import client_app
 from framework.helpers import skips
+from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -47,6 +47,7 @@ _TEST_METADATA = (
     (RpcTypeUnaryCall, _TEST_METADATA_NUMERIC_KEY,
      _TEST_METADATA_NUMERIC_VALUE),
 )
+
 
 def _is_supported(config: skips.TestConfig) -> bool:
     if config.client_lang == _Lang.NODE:

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/header_matching_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/header_matching_test.py
@@ -19,6 +19,7 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.test_app import client_app
+from framework.helpers import skips
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -28,6 +29,7 @@ DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
+_Lang = skips.Lang
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
@@ -46,8 +48,17 @@ _TEST_METADATA = (
      _TEST_METADATA_NUMERIC_VALUE),
 )
 
+def _is_supported(config: skips.TestConfig) -> bool:
+    if config.client_lang == _Lang.NODE:
+        return not config.version_lt('v1.3.x')
+    return True
+
 
 class TestExactMatch(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -92,6 +103,10 @@ class TestExactMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 class TestPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
+
+    @staticmethod
     def url_map_change(
             host_rule: HostRule,
             path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
@@ -132,6 +147,10 @@ class TestPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestSuffixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -175,6 +194,10 @@ class TestSuffixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 class TestPresentMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
+
+    @staticmethod
     def url_map_change(
             host_rule: HostRule,
             path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
@@ -215,6 +238,10 @@ class TestPresentMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestInvertMatch(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -261,6 +288,10 @@ class TestInvertMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestRangeMatch(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -311,6 +342,10 @@ class TestRangeMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/path_matching_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/path_matching_test.py
@@ -19,6 +19,7 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.test_app import client_app
+from framework.helpers import skips
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -28,14 +29,24 @@ DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
+_Lang = skips.Lang
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
 
 _NUM_RPCS = 150
 
+def _is_supported(config: skips.TestConfig) -> bool:
+    if config.client_lang == _Lang.NODE:
+        return not config.version_lt('v1.3.x')
+    return True
+
 
 class TestFullPathMatchEmptyCall(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -67,6 +78,10 @@ class TestFullPathMatchEmptyCall(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestFullPathMatchUnaryCall(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -101,6 +116,10 @@ class TestTwoRoutesAndPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     swapped). This test has two routes (full_path and the default) to match
     EmptyCall, and both routes set alternative_backend_service as the action.
     This forces the client to handle duplicate Clusters in the RDS response."""
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(
@@ -150,6 +169,10 @@ class TestTwoRoutesAndPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
     @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
+
+    @staticmethod
     def url_map_change(
             host_rule: HostRule,
             path_matcher: PathMatcher) -> Tuple[HostRule, PathMatcher]:
@@ -179,6 +202,10 @@ class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
 
 class TestCaseInsensitiveMatch(xds_url_map_testcase.XdsUrlMapTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        return _is_supported(config)
 
     @staticmethod
     def url_map_change(

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/path_matching_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/path_matching_test.py
@@ -18,8 +18,8 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_url_map_testcase
-from framework.test_app import client_app
 from framework.helpers import skips
+from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_url_map_testcase)
 
 _NUM_RPCS = 150
+
 
 def _is_supported(config: skips.TestConfig) -> bool:
     if config.client_lang == _Lang.NODE:

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -70,6 +70,8 @@ def _is_supported(config: skips.TestConfig) -> bool:
         return not config.version_lt('v1.40.x')
     elif config.client_lang == _Lang.GO:
         return not config.version_lt('v1.41.x')
+    elif config.client_lang == _Lang.NODE:
+        return False
     return True
 
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
@@ -81,11 +81,13 @@ class TestTimeoutInRouteRule(_BaseXdsTimeOutTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang == skips.Lang.NODE:
-            return not config.version_lt('v1.4.x')
         # TODO(lidiz) either add support for rpc-behavior to other languages, or we
         # should always use Java server as backend.
-        return config.server_lang == 'java'
+        if config.server_lang != 'java':
+            return False
+        if config.client_lang == skips.Lang.NODE:
+            return not config.version_lt('v1.4.x')
+        return True
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
@@ -114,9 +116,13 @@ class TestTimeoutInApplication(_BaseXdsTimeOutTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
+        # TODO(lidiz) either add support for rpc-behavior to other languages, or we
+        # should always use Java server as backend.
+        if config.server_lang != 'java':
+            return False
         if config.client_lang == skips.Lang.NODE:
             return not config.version_lt('v1.4.x')
-        return config.server_lang == 'java'
+        return True
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
@@ -81,6 +81,8 @@ class TestTimeoutInRouteRule(_BaseXdsTimeOutTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
+        if config.client_lang == skips.Lang.NODE:
+            return not config.version_lt('v1.4.x')
         # TODO(lidiz) either add support for rpc-behavior to other languages, or we
         # should always use Java server as backend.
         return config.server_lang == 'java'
@@ -112,6 +114,8 @@ class TestTimeoutInApplication(_BaseXdsTimeOutTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
+        if config.client_lang == skips.Lang.NODE:
+            return not config.version_lt('v1.4.x')
         return config.server_lang == 'java'
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
@@ -132,6 +136,12 @@ class TestTimeoutInApplication(_BaseXdsTimeOutTestCase):
 
 
 class TestTimeoutNotExceeded(_BaseXdsTimeOutTestCase):
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        if config.client_lang == skips.Lang.NODE:
+            return not config.version_lt('v1.4.x')
+        return True
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(


### PR DESCRIPTION
This adds is_supported implementations for most of the url_map tests that didn't already have them. The exception is metadata_filter_test because it doesn't use any specific client features.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

