### PR TITLE
Replace deprecated Python “inspect.getargspec”

### DIFF
--- a/src/python/grpcio/grpc/_auth.py
+++ b/src/python/grpcio/grpc/_auth.py
@@ -30,7 +30,7 @@ class GoogleCallCredentials(grpc.AuthMetadataPlugin):
         self._credentials = credentials
         # Hack to determine if these are JWT creds and we need to pass
         # additional_claims when getting a token
-        self._is_jwt = 'additional_claims' in inspect.getargspec(  # pylint: disable=deprecated-method
+        self._is_jwt = 'additional_claims' in inspect.getfullargspec(
             credentials.get_access_token).args
 
     def __call__(self, context, callback):


### PR DESCRIPTION
This has been deprecated since Python 3.0 and is removed in Python 3.11.
We can use “`inspect.getfullargspec`” instead.

Fixes #29962.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

