### PR TITLE
[xDS interop] Fix the affinity test support range

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -45,10 +45,14 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in (_Lang.CPP | _Lang.GO | _Lang.JAVA |
-                                  _Lang.PYTHON):
-            # Versions prior to v1.40.x don't support Affinity.
+        if config.client_lang in _Lang.CPP | _Lang.JAVA:
             return not config.version_lt('v1.40.x')
+        elif config.client_lang == _Lang.GO:
+            return not config.version_lt('v1.41.x')
+        elif config.client_lang == _Lang.PYTHON:
+            # TODO(https://github.com/grpc/grpc/issues/27430): supported after
+            #      the issue is fixed.
+            return False
         return True
 
     def test_affinity(self) -> None:  # pylint: disable=too-many-statements


### PR DESCRIPTION
As title.

This matches the description in https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md.

Related https://github.com/grpc/grpc-go/pull/5411 and https://github.com/grpc/grpc-go/pull/5410

This PR can't be tested since we don't have k8s-lb jobs for v1.39.x and v1.40.x branches.