### PR TITLE
Update bazel toolchain mirror

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -303,13 +303,13 @@ def grpc_deps():
         )
 
     if "bazel_toolchains" not in native.existing_rules():
-        # list of releases is at https://releases.bazel.build/bazel-toolchains.html
+        # list of releases is at https://github.com/bazelbuild/bazel-toolchains/releases
         http_archive(
             name = "bazel_toolchains",
             sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
             strip_prefix = "bazel-toolchains-4.1.0",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/4.1.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
                 "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
             ],
         )


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-toolchains/issues/891#issuecomment-654877498
and https://github.com/grpc/grpc/pull/27410#discussion_r715420745

Seems like the mirror for bazel toolchains changed the URL and they
mirror downloads but not archives. This should fix any issues with
missing mirror and workaround https://github.com/bazelbuild/bazel-toolchains/issues/972

Signed-off-by: Vihang Mehta <vihang@pixielabs.ai>




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

