### PR TITLE
Prevent double encoding of '%' in grpc_sockaddr_to_uri

### DIFF
--- a/src/core/lib/address_utils/sockaddr_utils.cc
+++ b/src/core/lib/address_utils/sockaddr_utils.cc
@@ -244,7 +244,7 @@ absl::StatusOr<std::string> grpc_sockaddr_to_string(
     if (sin6_scope_id != 0) {
       // Enclose sin6_scope_id with the format defined in RFC 6874 section 2.
       std::string host_with_scope =
-          absl::StrFormat("%s%%25%" PRIu32, ntop_buf, sin6_scope_id);
+          absl::StrFormat("%s%%%" PRIu32, ntop_buf, sin6_scope_id);
       out = grpc_core::JoinHostPort(host_with_scope, port);
     } else {
       out = grpc_core::JoinHostPort(ntop_buf, port);

--- a/test/core/address_utils/sockaddr_utils_test.cc
+++ b/test/core/address_utils/sockaddr_utils_test.cc
@@ -180,19 +180,19 @@ TEST(SockAddrUtilsTest, SockAddrToString) {
 
   SetIPv6ScopeId(&input6, 2);
   EXPECT_EQ(grpc_sockaddr_to_string(&input6, false).value(),
-            "[2001:db8::1%252]:12345");
+            "[2001:db8::1%2]:12345");
   EXPECT_EQ(grpc_sockaddr_to_string(&input6, true).value(),
-            "[2001:db8::1%252]:12345");
+            "[2001:db8::1%2]:12345");
   EXPECT_EQ(grpc_sockaddr_to_uri(&input6).value(),
-            "ipv6:%5B2001:db8::1%25252%5D:12345");
+            "ipv6:%5B2001:db8::1%252%5D:12345");
 
   SetIPv6ScopeId(&input6, 101);
   EXPECT_EQ(grpc_sockaddr_to_string(&input6, false).value(),
-            "[2001:db8::1%25101]:12345");
+            "[2001:db8::1%101]:12345");
   EXPECT_EQ(grpc_sockaddr_to_string(&input6, true).value(),
-            "[2001:db8::1%25101]:12345");
+            "[2001:db8::1%101]:12345");
   EXPECT_EQ(grpc_sockaddr_to_uri(&input6).value(),
-            "ipv6:%5B2001:db8::1%2525101%5D:12345");
+            "ipv6:%5B2001:db8::1%25101%5D:12345");
 
   grpc_resolved_address input6x = MakeAddr6(kMapped, sizeof(kMapped));
   EXPECT_EQ(grpc_sockaddr_to_string(&input6x, false).value(),


### PR DESCRIPTION
grpc_sockaddr_to_uri was changed recently to use the URI library directly. grpc_sockaddr_to_uri uses  grpc_sockaddr_to_string internally and it has explicit logic for URI encoding of %. This causes % to be encoded as %2525 instead of %25 causing issues with decoding later on.

This is especially problematic for IPV6 addresses with zone identifiers where the interface is delimited by %.



@markdroth 