### PR TITLE
[gRPC/iOS] Interop test deflake

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -197,13 +197,19 @@ grpc_objc_ios_unit_test(
     ],
 )
 
-ios_unit_test(
-    name = "InteropTests",
-    minimum_os_version = "9.0",
-    test_host = ":ios-host",
+grpc_objc_ios_unit_test(
+    name = "InteropTestsLocal",
     deps = [
         ":InteropTestsLocalCleartext-lib",
         ":InteropTestsLocalSSL-lib",
+    ],
+)
+
+ios_unit_test(
+    name = "InteropTestsRemote",
+    minimum_os_version = "9.0",
+    test_host = ":ios-host",
+    deps = [
         ":InteropTestsRemote-lib",
     ],
 )

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -47,7 +47,8 @@ EXAMPLE_TARGETS=(
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
   # TODO(jtattermusch): make //src/objective-c/tests:TvTests test pass with bazel
-  //src/objective-c/tests:InteropTests
+  //src/objective-c/tests:InteropTestsLocal
+  //src/objective-c/tests:InteropTestsRemote
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
   # codegen plugin tests


### PR DESCRIPTION
Deflake objc interop test by switching to runner-based ios test (https://github.com/grpc/grpc/pull/29740). Also splitting interop local and remote test suites so we can analyze and examine them separately 

---
cc @HannahShiSFB 