### PR TITLE
Call: Send cancel op down the stack even when no ops are sent

### DIFF
--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -984,6 +984,26 @@ TEST_F(ClientInterceptorsCallbackEnd2endTest,
 }
 
 TEST_F(ClientInterceptorsCallbackEnd2endTest,
+       ClientInterceptorHijackingTestWithCallback) {
+  ChannelArguments args;
+  PhonyInterceptor::Reset();
+  std::vector<std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
+      creators;
+  creators.push_back(absl::make_unique<LoggingInterceptorFactory>());
+  // Add 20 phony interceptors
+  for (auto i = 0; i < 20; i++) {
+    creators.push_back(absl::make_unique<PhonyInterceptorFactory>());
+  }
+  creators.push_back(absl::make_unique<HijackingInterceptorFactory>());
+  auto channel = server_->experimental().InProcessChannelWithInterceptors(
+      args, std::move(creators));
+  MakeCallbackCall(channel);
+  LoggingInterceptor::VerifyUnaryCall();
+  // Make sure all 20 phony interceptors were run
+  EXPECT_EQ(PhonyInterceptor::GetNumTimesRun(), 20);
+}
+
+TEST_F(ClientInterceptorsCallbackEnd2endTest,
        ClientInterceptorFactoryAllowsNullptrReturn) {
   ChannelArguments args;
   PhonyInterceptor::Reset();
@@ -1240,5 +1260,8 @@ TEST_F(ClientGlobalInterceptorEnd2endTest, HijackingGlobalInterceptor) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+  // Make sure that gRPC shuts down cleanly
+  GPR_ASSERT(grpc_wait_until_shutdown(1));
+  return ret;
 }

--- a/test/cpp/end2end/interceptors_util.cc
+++ b/test/cpp/end2end/interceptors_util.cc
@@ -20,6 +20,8 @@
 
 #include "absl/memory/memory.h"
 
+#include "test/core/util/test_config.h"
+
 namespace grpc {
 namespace testing {
 
@@ -157,6 +159,7 @@ void MakeAsyncCQBidiStreamingCall(const std::shared_ptr<Channel>& /*channel*/) {
 void MakeCallbackCall(const std::shared_ptr<Channel>& channel) {
   auto stub = grpc::testing::EchoTestService::NewStub(channel);
   ClientContext ctx;
+  ctx.set_deadline(grpc_timeout_milliseconds_to_deadline(20000));
   EchoRequest req;
   std::mutex mu;
   std::condition_variable cv;


### PR DESCRIPTION
Fixes b/204470117

When we create a call, depending on the configuration of the stack and the call, we might take a few references on the call such as - `deadline_timer` and `chttp2`.

In the case that we unref the call without sending any ops, these refs don't get cleaned up, and we need to wait for those refs to 
 get cleaned up on their own, for example, waiting for the deadline timer to fire which would send a cancel op and let go of the refs. Even though this is not a leak, this still results in an unnecessary memory buildup.

To avoid letting these refs lie around unnecessarily, we need to send down a cancel op even when ops are not started.

The specific case where we ran into this issue was with hijacking interceptors on direct channels.