### PR TITLE
xDS Istio Interop: Forward ForwardEcho requests for unhandled protocols

### DIFF
--- a/test/cpp/interop/istio_echo_server.cc
+++ b/test/cpp/interop/istio_echo_server.cc
@@ -62,6 +62,8 @@ ABSL_FLAG(std::vector<std::string>, xds_grpc_server,
           "Ports that should rely on XDS configuration to serve");
 ABSL_FLAG(std::string, crt, "", "gRPC TLS server-side certificate");
 ABSL_FLAG(std::string, key, "", "gRPC TLS server-side key");
+ABSL_FLAG(std::string, forwarding_address, "0.0.0.0:7072",
+          "Forwarding address for unhandled protocols");
 
 // The following flags must be defined, but are not used for now. Some may be
 // necessary for certain tests.
@@ -97,7 +99,8 @@ void RunServer(std::vector<int> grpc_ports, std::set<int> xds_ports,
     hostname = hostname_p;
     free(hostname_p);
   }
-  EchoTestServiceImpl echo_test_service(hostname);
+  EchoTestServiceImpl echo_test_service(
+      std::move(hostname), absl::GetFlag(FLAGS_forwarding_address));
   ServerBuilder builder;
   XdsServerBuilder xds_builder;
   bool has_xds_listeners = false;

--- a/test/cpp/interop/istio_echo_server_lib.cc
+++ b/test/cpp/interop/istio_echo_server_lib.cc
@@ -111,7 +111,7 @@ Status EchoTestServiceImpl::Echo(ServerContext* context,
   return Status::OK;
 }
 
-Status EchoTestServiceImpl::ForwardEcho(ServerContext* /*context*/,
+Status EchoTestServiceImpl::ForwardEcho(ServerContext* context,
                                         const ForwardEchoRequest* request,
                                         ForwardEchoResponse* response) {
   std::string raw_url = request->url();
@@ -142,6 +142,7 @@ Status EchoTestServiceImpl::ForwardEcho(ServerContext* /*context*/,
     gpr_log(GPR_INFO, "Protocol %s not supported. Forwarding to %s",
             scheme.c_str(), forwarding_address_.c_str());
     ClientContext forwarding_ctx;
+    forwarding_ctx.set_deadline(context->deadline());
     return forwarding_stub_->ForwardEcho(&forwarding_ctx, *request, response);
   }
   auto stub = EchoTestService::NewStub(channel);

--- a/test/cpp/interop/istio_echo_server_lib.h
+++ b/test/cpp/interop/istio_echo_server_lib.h
@@ -24,8 +24,7 @@ namespace testing {
 
 class EchoTestServiceImpl : public proto::EchoTestService::Service {
  public:
-  explicit EchoTestServiceImpl(const std::string& hostname)
-      : hostname_(hostname) {}
+  EchoTestServiceImpl(std::string hostname, std::string forwarding_address);
 
   grpc::Status Echo(grpc::ServerContext* context,
                     const proto::EchoRequest* request,
@@ -37,6 +36,8 @@ class EchoTestServiceImpl : public proto::EchoTestService::Service {
 
  private:
   std::string hostname_;
+  std::string forwarding_address_;
+  std::unique_ptr<proto::EchoTestService::Stub> forwarding_stub_;
   // The following fields are not set yet. But we may need them later.
   //  int port_;
   //  std::string version_;

--- a/test/cpp/interop/istio_echo_server_test.cc
+++ b/test/cpp/interop/istio_echo_server_test.cc
@@ -49,14 +49,14 @@ class SimpleEchoTestServerImpl : public proto::EchoTestService::Service {
 
   grpc::Status Echo(grpc::ServerContext* context,
                     const proto::EchoRequest* request,
-                    proto::EchoResponse* response) {
+                    proto::EchoResponse* response) override {
     GPR_ASSERT(false);
     return Status(StatusCode::INVALID_ARGUMENT, "Unexpected");
   }
 
   grpc::Status ForwardEcho(grpc::ServerContext* /*context*/,
                            const proto::ForwardEchoRequest* request,
-                           proto::ForwardEchoResponse* response) {
+                           proto::ForwardEchoResponse* response) override {
     response->add_output(request->message());
     return Status::OK;
   }

--- a/test/cpp/interop/istio_echo_server_test.cc
+++ b/test/cpp/interop/istio_echo_server_test.cc
@@ -41,8 +41,8 @@ using proto::EchoTestService;
 using proto::ForwardEchoRequest;
 using proto::ForwardEchoResponse;
 
-// A ver simple EchoTestService implementation that just echoes back the message
-// without handling any other expectations for ForwardEcho.
+// A very simple EchoTestService implementation that just echoes back the
+// message without handling any other expectations for ForwardEcho.
 class SimpleEchoTestServerImpl : public proto::EchoTestService::Service {
  public:
   explicit SimpleEchoTestServerImpl() {}
@@ -160,7 +160,7 @@ TEST_F(EchoTest, ForwardEchoTestUnhandledProtocols) {
   auto status = stub_->ForwardEcho(&context, request, &response);
   ASSERT_TRUE(status.ok()) << "Code = " << status.error_code()
                            << " Message = " << status.error_message();
-  ASSERT_TRUE(!response.output().empty());
+  ASSERT_FALSE(response.output().empty());
   EXPECT_EQ(response.output()[0], "hello");
 }
 

--- a/test/cpp/interop/istio_echo_server_test.cc
+++ b/test/cpp/interop/istio_echo_server_test.cc
@@ -41,23 +41,68 @@ using proto::EchoTestService;
 using proto::ForwardEchoRequest;
 using proto::ForwardEchoResponse;
 
+// A ver simple EchoTestService implementation that just echoes back the message
+// without handling any other expectations for ForwardEcho.
+class SimpleEchoTestServerImpl : public proto::EchoTestService::Service {
+ public:
+  explicit SimpleEchoTestServerImpl() {}
+
+  grpc::Status Echo(grpc::ServerContext* context,
+                    const proto::EchoRequest* request,
+                    proto::EchoResponse* response) {
+    GPR_ASSERT(false);
+    return Status(StatusCode::INVALID_ARGUMENT, "Unexpected");
+  }
+
+  grpc::Status ForwardEcho(grpc::ServerContext* /*context*/,
+                           const proto::ForwardEchoRequest* request,
+                           proto::ForwardEchoResponse* response) {
+    response->add_output(request->message());
+    return Status::OK;
+  }
+
+ private:
+  std::string hostname_;
+  std::string forwarding_address_;
+  // The following fields are not set yet. But we may need them later.
+  //  int port_;
+  //  std::string version_;
+  //  std::string cluster_;
+  //  std::string istio_version_;
+};
+
 class EchoTest : public ::testing::Test {
  protected:
-  EchoTest() : echo_test_service_impl_("hostname") {
+  EchoTest() {
+    // Start the simple server which will handle protocols that
+    // EchoTestServiceImpl does not handle.
+    int forwarding_port = grpc_pick_unused_port_or_die();
+    forwarding_address_ = grpc_core::JoinHostPort("localhost", forwarding_port);
+    ServerBuilder simple_builder;
+    simple_builder.RegisterService(&simple_test_service_impl_);
+    simple_builder.AddListeningPort(forwarding_address_,
+                                    InsecureServerCredentials());
+    simple_server_ = simple_builder.BuildAndStart();
+    // Start the EchoTestServiceImpl server
     ServerBuilder builder;
-    builder.RegisterService(&echo_test_service_impl_);
+    echo_test_service_impl_ =
+        std::make_unique<EchoTestServiceImpl>("hostname", forwarding_address_);
+    builder.RegisterService(echo_test_service_impl_.get());
     int port = grpc_pick_unused_port_or_die();
     server_address_ = grpc_core::JoinHostPort("localhost", port);
-    builder.AddListeningPort(grpc_core::JoinHostPort("localhost", port),
-                             InsecureServerCredentials());
+    builder.AddListeningPort(server_address_, InsecureServerCredentials());
     server_ = builder.BuildAndStart();
+
     auto channel = CreateChannel(server_address_, InsecureChannelCredentials());
     stub_ = EchoTestService::NewStub(channel);
   }
 
-  EchoTestServiceImpl echo_test_service_impl_;
+  std::string forwarding_address_;
+  SimpleEchoTestServerImpl simple_test_service_impl_;
+  std::unique_ptr<EchoTestServiceImpl> echo_test_service_impl_;
   std::string server_address_;
   std::unique_ptr<Server> server_;
+  std::unique_ptr<Server> simple_server_;
   std::unique_ptr<EchoTestService::Stub> stub_;
 };
 
@@ -67,7 +112,7 @@ TEST_F(EchoTest, SimpleEchoTest) {
   EchoResponse response;
   request.set_message("hello");
   auto status = stub_->Echo(&context, request, &response);
-  EXPECT_TRUE(status.ok());
+  ASSERT_TRUE(status.ok());
   EXPECT_THAT(response.message(),
               ::testing::AllOf(::testing::HasSubstr("StatusCode=200\n"),
                                ::testing::HasSubstr("Hostname=hostname\n"),
@@ -86,7 +131,7 @@ TEST_F(EchoTest, ForwardEchoTest) {
   request.set_url(absl::StrCat("grpc://", server_address_));
   request.set_message("hello");
   auto status = stub_->ForwardEcho(&context, request, &response);
-  EXPECT_TRUE(status.ok());
+  ASSERT_TRUE(status.ok());
   for (int i = 0; i < 3; ++i) {
     EXPECT_THAT(
         response.output()[i],
@@ -99,6 +144,24 @@ TEST_F(EchoTest, ForwardEchoTest) {
             ::testing::HasSubstr(absl::StrFormat("[%d body] Host=", i)),
             ::testing::HasSubstr(absl::StrFormat("[%d body] IP=", i))));
   }
+}
+
+TEST_F(EchoTest, ForwardEchoTestUnhandledProtocols) {
+  ClientContext context;
+  ForwardEchoRequest request;
+  ForwardEchoResponse response;
+  request.set_count(3);
+  request.set_qps(1);
+  request.set_timeout_micros(20 * 1000 * 1000);  // 20 seconds
+  // http protocol is unhandled by EchoTestServiceImpl and should be forwarded
+  // to SimpleEchoTestServiceImpl
+  request.set_url(absl::StrCat("http://", server_address_));
+  request.set_message("hello");
+  auto status = stub_->ForwardEcho(&context, request, &response);
+  ASSERT_TRUE(status.ok()) << "Code = " << status.error_code()
+                           << " Message = " << status.error_message();
+  ASSERT_TRUE(!response.output().empty());
+  EXPECT_EQ(response.output()[0], "hello");
 }
 
 }  // namespace


### PR DESCRIPTION
Changes -
1) Adds a new command-line argument `forwarding_address` with a default value of `0.0.0.0:7072`
2) This `forwarding_address` is used as the address for forwarding all requests that we do not handle.