### PR TITLE
Set Correct Platform Tag in Wheels on Mac OS with Python 3.10 (#29857)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -154,10 +154,10 @@ then
 
   # Install Python 3.10 if it doesn't exist
   if [ ! -f "/usr/local/bin/python3.10" ]; then
-    time curl -O https://www.python.org/ftp/python/3.10.2/python-3.10.2-macos11.pkg
-    echo "22dd9a45718a99d77398312da6ac720c4968bae7a854da4da3a3986f6d3478f8  python-3.10.2-macos11.pkg" > /tmp/python_installer_checksum.sha256
+    time curl -O https://www.python.org/ftp/python/3.10.5/python-3.10.5-macos11.pkg
+    echo "568c69b4361af1faf0ae35c4cac7236c1a332f5c  python-3.10.5-macos11.pkg" > /tmp/python_installer_checksum.sha256
     shasum -c /tmp/python_installer_checksum.sha256
-    time sudo installer -pkg ./python-3.10.2-macos11.pkg -target /
+    time sudo installer -pkg ./python-3.10.5-macos11.pkg -target /
   fi
 fi
 

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -131,6 +131,12 @@ class PythonArtifact:
             # building the native extension is the most time-consuming part of the build
             environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'] = str(inner_jobs)
 
+        # This is necessary due to https://github.com/pypa/wheel/issues/406.
+        # distutils incorrectly generates a universal2 artifact that only contains
+        # x86_64 libraries.
+        if self.platform == "macos" and self.arch == "x64":
+            environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
+
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)
             environ['PYTHON'] = '/opt/python/{}/bin/python3'.format(

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -144,6 +144,24 @@ then
   rm -rf venv/
 fi
 
+fix_faulty_universal2_wheel() {
+  WHL="$1"
+  if echo "$WHL" | grep "universal2"; then
+    UPDATED_NAME="${WHL//universal2/x86_64}"
+    mv "$WHL" "$UPDATED_NAME"
+  fi
+}
+
+# This is necessary due to https://github.com/pypa/wheel/issues/406.
+# distutils incorrectly generates a universal2 artifact that only contains
+# x86_64 libraries.
+if [ "$GRPC_UNIVERSAL2_REPAIR" != "" ]; then
+  for WHEEL in dist/*.whl tools/distrib/python/grpcio_tools/dist/*.whl; do
+    fix_faulty_universal2_wheel "$WHEEL"
+  done
+fi
+
+
 if [ "$GRPC_RUN_AUDITWHEEL_REPAIR" != "" ]
 then
   for wheel in dist/*.whl; do


### PR DESCRIPTION
Backport https://github.com/grpc/grpc/pull/29857 to 1.47.