### PR TITLE
xds-k8s: handle missing edge case in TestConfig version comparison

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -65,6 +65,8 @@ class TestConfig:
         """
         if self.version == 'master' or self.version is None:
             return True
+        if another == 'master':
+            return False
         return self._parse_version(self.version) >= self._parse_version(another)
 
     def version_lt(self, another: str) -> bool:
@@ -77,6 +79,8 @@ class TestConfig:
         """
         if self.version == 'master' or self.version is None:
             return False
+        if another == 'master':
+            return True
         return self._parse_version(self.version) < self._parse_version(another)
 
     def __str__(self):


### PR DESCRIPTION
Fixes incorrect `master` version handling in subsetting_test.

Ref b/235825277