### PR TITLE
Bump 'multi_json' dependency from `~> 1.13.1` to `~> 1.15`

### DIFF
--- a/examples/ruby/grpc-demo.gemspec
+++ b/examples/ruby/grpc-demo.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'grpc', '~> 1.0'
-  s.add_dependency 'multi_json', '~> 1.13.1'
+  s.add_dependency 'multi_json', '~> 1.15'
   s.add_development_dependency 'bundler', '>= 1.9'
 end


### PR DESCRIPTION
When I followed https://grpc.io/docs/languages/ruby/basics/, I stumbled upon a
bug in the `examples/ruby/route_guide/route_guide_server.rb` file.

The program would crash on Ruby 3.1.2 with:

```
/Users/kyrylo/.gem/ruby/3.1.2/gems/multi_json-1.13.1/lib/multi_json/options_cache.rb:12:in `new': tried to create Proc object without a block (ArgumentError)
        from /Users/kyrylo/.gem/ruby/3.1.2/gems/multi_json-1.13.1/lib/multi_json/options_cache.rb:12:in `fetch'
        from /Users/kyrylo/.gem/ruby/3.1.2/gems/multi_json-1.13.1/lib/multi_json/adapter.rb:43:in `cached_load_options'
        from /Users/kyrylo/.gem/ruby/3.1.2/gems/multi_json-1.13.1/lib/multi_json/adapter.rb:21:in `load'
        from /Users/kyrylo/.gem/ruby/3.1.2/gems/multi_json-1.13.1/lib/multi_json.rb:122:in `load'
        from route_guide_server.rb:167:in `block in main'
        from route_guide_server.rb:166:in `open'
        from route_guide_server.rb:166:in `main'
        from route_guide_server.rb:181:in `<main>'
```

Running multi_json [v1.15.0][1] fixed the issue.

[1]: https://rubygems.org/gems/multi_json/versions/1.15.0

