### PR TITLE
Ruby: Fixes for x64-mingw-ucrt (PR to master)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
       |file| file.start_with?(
         "src/ruby/bin/", "src/ruby/ext/", "src/ruby/lib/", "src/ruby/pb/")
     }
-    spec.files += %w( etc/roots.pem grpc_c.32.ruby grpc_c.64.ruby grpc_c.64-ucrt.ruby )
+    spec.files += %w( etc/roots.pem grpc_c.32-msvcrt.ruby grpc_c.64-msvcrt.ruby grpc_c.64-ucrt.ruby )
   end
 end
 
@@ -86,14 +86,16 @@ task 'dlls', [:plat] do |t, args|
   nproc_override = ENV['GRPC_RUBY_BUILD_PROCS'] || `nproc`.strip
   plat_list = args[:plat]
 
-  build_configs = []
-  w64_ucrt = { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64-ucrt.ruby', platform: 'x64-mingw-ucrt' }
-  w64 = { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64.ruby', platform: 'x64-mingw32' }
-  w32 = { cross: 'i686-w64-mingw32', out: 'grpc_c.32.ruby', platform: 'x86-mingw32' }
-  [w64_ucrt, w64, w32].each do |config|
+  build_configs = [
+    { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64-ucrt.ruby', platform: 'x64-mingw-ucrt' },
+    { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64-msvcrt.ruby', platform: 'x64-mingw32' },
+    { cross: 'i686-w64-mingw32', out: 'grpc_c.32-msvcrt.ruby', platform: 'x86-mingw32' }
+  ]
+  selected_build_configs = []
+  build_configs.each do |config|
     if plat_list.include?(config[:platform])
       # build the DLL (as grpc_c.*.ruby)
-      build_configs.append(config)
+      selected_build_configs.append(config)
     else
       # create an empty grpc_c.*.ruby file as a placeholder
       FileUtils.touch config[:out]
@@ -122,7 +124,7 @@ task 'dlls', [:plat] do |t, args|
   prepare_ccache_cmd += "export PATH=\"$PATH:/usr/local/bin\" && "
   prepare_ccache_cmd += "source tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc "
 
-  build_configs.each do |opt|
+  selected_build_configs.each do |opt|
     env_comp = "CC=#{opt[:cross]}-gcc "
     env_comp += "CXX=#{opt[:cross]}-g++ "
     env_comp += "LD=#{opt[:cross]}-gcc "
@@ -150,8 +152,8 @@ task 'gem:native', [:plat] do |t, args|
       fail "Cannot pass platform as an argument when on Darwin."
     end
 
-    FileUtils.touch 'grpc_c.32.ruby'
-    FileUtils.touch 'grpc_c.64.ruby'
+    FileUtils.touch 'grpc_c.32-msvcrt.ruby'
+    FileUtils.touch 'grpc_c.64-msvcrt.ruby'
     FileUtils.touch 'grpc_c.64-ucrt.ruby'
     unless '2.5' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
       fail "rake gem:native (the rake task to build the binary packages) is being " \
@@ -210,8 +212,8 @@ task 'gem:native', [:plat] do |t, args|
 
     # Truncate grpc_c.*.ruby files because they're for Windows only and we don't want
     # them to take up space in the gems that don't target windows.
-    File.truncate('grpc_c.32.ruby', 0)
-    File.truncate('grpc_c.64.ruby', 0)
+    File.truncate('grpc_c.32-msvcrt.ruby', 0)
+    File.truncate('grpc_c.64-msvcrt.ruby', 0)
     File.truncate('grpc_c.64-ucrt.ruby', 0)
 
     unix_platforms.each do |plat|

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -86,7 +86,7 @@ end
 
 env_append 'CPPFLAGS', '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_NAME_SUFFIX="\"RUBY\""'
-env_append 'CPPFLAGS', '-DGPR_WINDOWS_UCRT' if windows_ucrt
+env_append 'CPPFLAGS', '-DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 
 require_relative '../../lib/grpc/version'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="\"' + GRPC::VERSION + '\""'

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -16,6 +16,7 @@ require 'etc'
 require 'mkmf'
 
 windows = RUBY_PLATFORM =~ /mingw|mswin/
+windows_ucrt = RUBY_PLATFORM =~ /(mingw|mswin).*ucrt/
 bsd = RUBY_PLATFORM =~ /bsd/
 darwin = RUBY_PLATFORM =~ /darwin/
 linux = RUBY_PLATFORM =~ /linux/
@@ -85,6 +86,7 @@ end
 
 env_append 'CPPFLAGS', '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_NAME_SUFFIX="\"RUBY\""'
+env_append 'CPPFLAGS', '-DGPR_WINDOWS_UCRT' if windows_ucrt
 
 require_relative '../../lib/grpc/version'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="\"' + GRPC::VERSION + '\""'

--- a/src/ruby/ext/grpc/rb_loader.c
+++ b/src/ruby/ext/grpc/rb_loader.c
@@ -23,9 +23,13 @@
 
 int grpc_rb_load_core() {
 #if GPR_ARCH_64
-  TCHAR fname[] = _T("grpc_c.64.ruby");
+#if GPR_WINDOWS_UCRT
+  TCHAR fname[] = _T("grpc_c.64-ucrt.ruby");
 #else
-  TCHAR fname[] = _T("grpc_c.32.ruby");
+  TCHAR fname[] = _T("grpc_c.64-msvcrt.ruby");
+#endif
+#else
+  TCHAR fname[] = _T("grpc_c.32-msvcrt.ruby");
 #endif
   HMODULE module = GetModuleHandle(_T("grpc_c.so"));
   TCHAR path[2048 + 32] = _T("");

--- a/src/ruby/ext/grpc/rb_loader.c
+++ b/src/ruby/ext/grpc/rb_loader.c
@@ -23,7 +23,7 @@
 
 int grpc_rb_load_core() {
 #if GPR_ARCH_64
-#if GPR_WINDOWS_UCRT
+#if GRPC_RUBY_WINDOWS_UCRT
   TCHAR fname[] = _T("grpc_c.64-ucrt.ruby");
 #else
   TCHAR fname[] = _T("grpc_c.64-msvcrt.ruby");

--- a/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM larskanis/rake-compiler-dock-mri-arm64-darwin:1.2.1
+FROM larskanis/rake-compiler-dock-mri-arm64-darwin:1.2.2

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x64-mingw-ucrt:1.2.1
+FROM larskanis/rake-compiler-dock-mri-x64-mingw-ucrt:1.2.2
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x64-mingw32:1.2.1
+FROM larskanis/rake-compiler-dock-mri-x64-mingw32:1.2.2
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86-linux:1.2.1
+FROM larskanis/rake-compiler-dock-mri-x86-linux:1.2.2
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86-mingw32:1.2.1
+FROM larskanis/rake-compiler-dock-mri-x86-mingw32:1.2.2
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM larskanis/rake-compiler-dock-mri-x86_64-darwin:1.2.1
+FROM larskanis/rake-compiler-dock-mri-x86_64-darwin:1.2.2

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM larskanis/rake-compiler-dock-mri-x86_64-linux:1.2.1
+FROM larskanis/rake-compiler-dock-mri-x86_64-linux:1.2.2
 
 #=================
 # Install ccache

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -486,6 +486,7 @@ def targets():
         PythonArtifact('windows', 'x64', 'Python310', presubmit=True),
         RubyArtifact('linux', 'x86-mingw32', presubmit=True),
         RubyArtifact('linux', 'x64-mingw32', presubmit=True),
+        RubyArtifact('linux', 'x64-mingw-ucrt', presubmit=True),
         RubyArtifact('linux', 'x86_64-linux', presubmit=True),
         RubyArtifact('linux', 'x86-linux', presubmit=True),
         RubyArtifact('linux', 'x86_64-darwin', presubmit=True),


### PR DESCRIPTION
Follow-up to #29684 @apolcyn @gnossen 

#### TODOS

- [x] Add artifact target for x64-mingw-ucrt
- [x] Fix `extconf.rb` to correctly pickup the UCRT grpc build. Adds a `CPP_FLAG` called `GRPC_WINDOWS_UCRT`
- [x] Upgrade rake_compiler_dock to get Ruby [shared object fix](https://github.com/rake-compiler/rake-compiler-dock/issues/69)

In addition, I've renamed intermediate build files for clarity. These are renamed to `grpc_c.so` during the build process, so should not affect anything in the output.

```
grpc_c.32.ruby --> grpc_c.32-msvcrt.ruby
grpc_c.64.ruby --> grpc_c.64-msvcrt.ruby
```
