### PR TITLE
[iomgr] Never shut down grpc_event_engine

### DIFF
--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -18,6 +18,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <grpc/support/sync.h>
+
 #include "src/core/lib/iomgr/port.h"
 
 #ifdef GRPC_POSIX_SOCKET_EV
@@ -74,6 +76,7 @@ grpc_poll_function_type grpc_poll_function = aix_poll;
 grpc_wakeup_fd grpc_global_wakeup_fd;
 
 static const grpc_event_engine_vtable* g_event_engine = nullptr;
+static gpr_once g_init_event_engine = GPR_ONCE_INIT;
 static const char* g_poll_strategy_name = nullptr;
 
 typedef const grpc_event_engine_vtable* (*event_engine_factory_fn)(
@@ -208,32 +211,32 @@ void grpc_register_event_engine_factory(const char* name,
 const char* grpc_get_poll_strategy_name() { return g_poll_strategy_name; }
 
 void grpc_event_engine_init(void) {
-  grpc_core::UniquePtr<char> value = GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
+  gpr_once_init(&g_init_event_engine, []() {
+    grpc_core::UniquePtr<char> value =
+        GPR_GLOBAL_CONFIG_GET(grpc_poll_strategy);
 
-  char** strings = nullptr;
-  size_t nstrings = 0;
-  split(value.get(), &strings, &nstrings);
+    char** strings = nullptr;
+    size_t nstrings = 0;
+    split(value.get(), &strings, &nstrings);
 
-  for (size_t i = 0; g_event_engine == nullptr && i < nstrings; i++) {
-    try_engine(strings[i]);
-  }
+    for (size_t i = 0; g_event_engine == nullptr && i < nstrings; i++) {
+      try_engine(strings[i]);
+    }
 
-  for (size_t i = 0; i < nstrings; i++) {
-    gpr_free(strings[i]);
-  }
-  gpr_free(strings);
+    for (size_t i = 0; i < nstrings; i++) {
+      gpr_free(strings[i]);
+    }
+    gpr_free(strings);
 
-  if (g_event_engine == nullptr) {
-    gpr_log(GPR_ERROR, "No event engine could be initialized from %s",
-            value.get());
-    abort();
-  }
+    if (g_event_engine == nullptr) {
+      gpr_log(GPR_ERROR, "No event engine could be initialized from %s",
+              value.get());
+      abort();
+    }
+  });
 }
 
-void grpc_event_engine_shutdown(void) {
-  g_event_engine->shutdown_engine();
-  g_event_engine = nullptr;
-}
+void grpc_event_engine_shutdown(void) {}
 
 bool grpc_event_engine_can_track_errors(void) {
   /* Only track errors if platform supports errqueue. */


### PR DESCRIPTION
There's been an uptick of races against g_event_engine in iomgr (this is not the new event engine but rather the old one that is a component of iomgr on posix). It's of genuinely little interest if this shuts down or not, so instead, just initialize it once at the first grpc_init, and then leave it for the lifetime of the application.

Should solve the majority of our TSAN flakes on Linux, and *I suspect* many of our other flakiness problems at head.

As we move to event engine over the next small amount of time we can transition to a better init/shutdown story for that.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

