### PR TITLE
XdsSecurityTest flakiness: Add broken pipe to expected error messages

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -384,7 +384,7 @@ class XdsSecurityTest : public XdsEnd2endTest {
                     "(UNKNOWN: Failed to connect to remote host: Connection "
                     "(refused|reset by peer)|UNAVAILABLE: Failed to connect "
                     "to remote host: FD shutdown|UNKNOWN: Tls handshake failed|"
-                    "UNAVAILABLE: Socket closed)"));
+                    "UNAVAILABLE: Socket closed|UNAVAILABLE: Broken pipe)"));
           }
         });
         Status status = SendRpc();


### PR DESCRIPTION
Fixes b/237007226
Such a status was seen on https://source.cloud.google.com/results/invocations/b34339ca-b15a-4c53-b38a-2124bff54e1c/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_end2end_test@poller%3Dpoll/log for example