### PR TITLE
[event engine] Handle spurious wakeups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1024,7 +1024,9 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx flaky_network_test)
   add_dependencies(buildtests_cxx flow_control_test)
   add_dependencies(buildtests_cxx for_each_test)
-  add_dependencies(buildtests_cxx fuzzing_event_engine_test)
+  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
+    add_dependencies(buildtests_cxx fuzzing_event_engine_test)
+  endif()
   add_dependencies(buildtests_cxx generic_end2end_test)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_cxx global_config_env_test)
@@ -10856,47 +10858,49 @@ target_link_libraries(for_each_test
 
 endif()
 if(gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
 
-add_executable(fuzzing_event_engine_test
-  ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.cc
-  ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.cc
-  ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h
-  ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.h
-  test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  test/core/event_engine/test_suite/event_engine_test.cc
-  test/core/event_engine/test_suite/event_engine_test_utils.cc
-  test/core/event_engine/test_suite/fuzzing_event_engine_test.cc
-  test/core/event_engine/test_suite/timer_test.cc
-  third_party/googletest/googletest/src/gtest-all.cc
-  third_party/googletest/googlemock/src/gmock-all.cc
-)
+  add_executable(fuzzing_event_engine_test
+    ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.cc
+    ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.cc
+    ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h
+    ${_gRPC_PROTO_GENS_DIR}/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.grpc.pb.h
+    test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+    test/core/event_engine/test_suite/event_engine_test.cc
+    test/core/event_engine/test_suite/event_engine_test_utils.cc
+    test/core/event_engine/test_suite/fuzzing_event_engine_test.cc
+    test/core/event_engine/test_suite/timer_test.cc
+    third_party/googletest/googletest/src/gtest-all.cc
+    third_party/googletest/googlemock/src/gmock-all.cc
+  )
 
-target_include_directories(fuzzing_event_engine_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-    third_party/googletest/googletest/include
-    third_party/googletest/googletest
-    third_party/googletest/googlemock/include
-    third_party/googletest/googlemock
-    ${_gRPC_PROTO_GENS_DIR}
-)
+  target_include_directories(fuzzing_event_engine_test
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+      ${_gRPC_RE2_INCLUDE_DIR}
+      ${_gRPC_SSL_INCLUDE_DIR}
+      ${_gRPC_UPB_GENERATED_DIR}
+      ${_gRPC_UPB_GRPC_GENERATED_DIR}
+      ${_gRPC_UPB_INCLUDE_DIR}
+      ${_gRPC_XXHASH_INCLUDE_DIR}
+      ${_gRPC_ZLIB_INCLUDE_DIR}
+      third_party/googletest/googletest/include
+      third_party/googletest/googletest
+      third_party/googletest/googlemock/include
+      third_party/googletest/googlemock
+      ${_gRPC_PROTO_GENS_DIR}
+  )
 
-target_link_libraries(fuzzing_event_engine_test
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-)
+  target_link_libraries(fuzzing_event_engine_test
+    ${_gRPC_PROTOBUF_LIBRARIES}
+    ${_gRPC_ALLTARGETS_LIBRARIES}
+    grpc_test_util
+  )
 
 
+endif()
 endif()
 if(gRPC_BUILD_TESTS)
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -6020,6 +6020,9 @@ targets:
   - test/core/event_engine/test_suite/timer_test.cc
   deps:
   - grpc_test_util
+  platforms:
+  - linux
+  - posix
   uses_polling: false
 - name: generic_end2end_test
   gtest: true

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -85,6 +85,10 @@ grpc_cc_test(
     name = "fuzzing_event_engine_test",
     srcs = ["fuzzing_event_engine_test.cc"],
     uses_polling = False,
+    tags = [
+        "no_mac",
+        "no_windows",
+    ],
     deps = [
         "//test/core/event_engine/fuzzing_event_engine",
         "//test/core/event_engine/test_suite:timer",

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -84,11 +84,11 @@ grpc_cc_test(
 grpc_cc_test(
     name = "fuzzing_event_engine_test",
     srcs = ["fuzzing_event_engine_test.cc"],
-    uses_polling = False,
     tags = [
         "no_mac",
         "no_windows",
     ],
+    uses_polling = False,
     deps = [
         "//test/core/event_engine/fuzzing_event_engine",
         "//test/core/event_engine/test_suite:timer",

--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -38,6 +38,16 @@ class EventEngineTimerTest : public EventEngineTest {
                        std::atomic<int>* fail_count, int total_expected);
 
  protected:
+  void WaitForSignalled(absl::Duration timeout)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    absl::Time deadline = absl::Now() + timeout;
+    while (!signaled_) {
+      timeout = deadline - absl::Now();
+      GPR_ASSERT(timeout > absl::ZeroDuration());
+      cv_.WaitWithTimeout(&mu_, timeout);
+    }
+  }
+
   grpc_core::Mutex mu_;
   grpc_core::CondVar cv_;
   bool signaled_ ABSL_GUARDED_BY(mu_) = false;
@@ -52,8 +62,7 @@ TEST_F(EventEngineTimerTest, ImmediateCallbackIsExecutedQuickly) {
     signaled_ = true;
     cv_.Signal();
   });
-  cv_.WaitWithTimeout(&mu_, absl::Seconds(5));
-  ASSERT_TRUE(signaled_);
+  WaitForSignalled(absl::Seconds(5));
 }
 
 TEST_F(EventEngineTimerTest, SupportsCancellation) {
@@ -117,8 +126,7 @@ TEST_F(EventEngineTimerTest, CancellingExecutedCallbackIsNoopAndReturnsFalse) {
     signaled_ = true;
     cv_.Signal();
   });
-  cv_.WaitWithTimeout(&mu_, absl::Seconds(10));
-  ASSERT_TRUE(signaled_);
+  WaitForSignalled(absl::Seconds(10));
   // The callback has run, and now we'll try to cancel it.
   ASSERT_FALSE(engine->Cancel(handle));
 }

--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -43,7 +43,7 @@ class EventEngineTimerTest : public EventEngineTest {
     absl::Time deadline = absl::Now() + timeout;
     while (!signaled_) {
       timeout = deadline - absl::Now();
-      GPR_ASSERT(timeout > absl::ZeroDuration());
+      ASSERT_GT(timeout, absl::ZeroDuration());
       cv_.WaitWithTimeout(&mu_, timeout);
     }
   }

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4290,9 +4290,7 @@
     "benchmark": false,
     "ci_platforms": [
       "linux",
-      "mac",
-      "posix",
-      "windows"
+      "posix"
     ],
     "cpu_cost": 1.0,
     "exclude_configs": [],
@@ -4303,9 +4301,7 @@
     "name": "fuzzing_event_engine_test",
     "platforms": [
       "linux",
-      "mac",
-      "posix",
-      "windows"
+      "posix"
     ],
     "uses_polling": false
   },


### PR DESCRIPTION
Fixes some fuzzing event engine flakiness, disable on platforms which we don't actually care if this works.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

