### PR TITLE
[gRPC/iOS] Remove libuv pod dependnecy from iOS cocoapod build

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -172,7 +172,6 @@ Pod::Spec.new do |s|
     ss.libraries = 'z'
     ss.dependency "#{s.name}/Interface", version
     ss.dependency 'BoringSSL-GRPC', '0.0.24'
-    ss.dependency 'Libuv-gRPC', '0.0.10'
     ss.dependency 'abseil/base/base', abseil_version
     ss.dependency 'abseil/base/core_headers', abseil_version
     ss.dependency 'abseil/container/flat_hash_map', abseil_version

--- a/src/objective-c/examples/Sample/Podfile
+++ b/src/objective-c/examples/Sample/Podfile
@@ -23,7 +23,6 @@ target 'Sample' do
   pod 'Protobuf', :path => "#{GRPC_LOCAL_SRC}/third_party/protobuf"
 
   pod 'BoringSSL-GRPC', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c"
-  pod 'Libuv-gRPC', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c"
 
   pod 'gRPC', :path => GRPC_LOCAL_SRC
   pod 'gRPC-Core', :path => GRPC_LOCAL_SRC

--- a/src/objective-c/examples/SwiftSample/Podfile
+++ b/src/objective-c/examples/SwiftSample/Podfile
@@ -20,7 +20,6 @@ target 'SwiftSample' do
   pod 'Protobuf', :path => "#{GRPC_LOCAL_SRC}/third_party/protobuf"
 
   pod 'BoringSSL-GRPC', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c"
-  pod 'Libuv-gRPC', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c"
 
   pod 'gRPC', :path => GRPC_LOCAL_SRC
   pod 'gRPC-Core', :path => GRPC_LOCAL_SRC

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -12,7 +12,6 @@ def grpc_deps
   pod '!ProtoCompiler-gRPCPlugin', :path => "#{GRPC_LOCAL_SRC}/src/objective-c"
 
   pod 'BoringSSL-GRPC',       :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
-  pod 'Libuv-gRPC',       :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
 
   pod 'gRPC/InternalTesting',           :path => GRPC_LOCAL_SRC
   pod 'gRPC-Core',                      :path => GRPC_LOCAL_SRC, :inhibit_warnings => true

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -196,7 +196,6 @@
       ss.libraries = 'z'
       ss.dependency "#{s.name}/Interface", version
       ss.dependency 'BoringSSL-GRPC', '0.0.24'
-      ss.dependency 'Libuv-gRPC', '0.0.10'
       % for abseil_spec in grpc_abseil_specs:
       ss.dependency '${abseil_spec}', abseil_version
       % endfor


### PR DESCRIPTION
Libuv is no longer used in iOS build for event engine impl. Removing it from cocoapod build targets. 

---
cc @drfloob  @HannahShiSFB 

https://github.com/grpc/grpc-ios/issues/106