### PR TITLE
Set uses polling to true for oracle_event_engine_posix_test

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -7113,7 +7113,6 @@ targets:
   - linux
   - posix
   - mac
-  uses_polling: false
 - name: orca_service_end2end_test
   gtest: true
   build: test

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -117,7 +117,7 @@ grpc_cc_test(
         "no_test_ios",
         "no_windows",
     ],
-    uses_polling = False,
+    uses_polling = True,
     deps = [
         ":client",
         ":oracle_event_engine_posix",

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -117,6 +117,11 @@ grpc_cc_test(
         "no_test_ios",
         "no_windows",
     ],
+    # TODO(vignesbabu): This is required because the oracle event engine uses
+    # poll syscall. If uses_polling is set to False, there will be an attempt
+    # to run this test with GRPC_POLL_STRATEGY=none which will hijack the poll
+    # c-wrapper causing the test to fail. A more generic posix oracle event
+    # engine design which doesn't rely on poll is required.
     uses_polling = True,
     deps = [
         ":client",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5543,7 +5543,7 @@
       "mac",
       "posix"
     ],
-    "uses_polling": false
+    "uses_polling": true
   },
   {
     "args": [],


### PR DESCRIPTION
This is required because the oracle event engine uses poll syscall. If uses_polling is set to False, there will be an attempt to run this test with GRPC_POLL_STRATEGY=none which will hijack the poll c-wrapper causing the test to fail.


