### PR TITLE
fix a broken link in the binary log document

### DIFF
--- a/doc/binary-logging.md
+++ b/doc/binary-logging.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-The log format is described in [this proto file](/src/proto/grpc/binary_log/v1alpha/log.proto). It is intended that multiple parts of the call will be logged in separate files, and then correlated by analysis tools using the rpc\_id.
+The log format is described in [this proto file](https://github.com/grpc/grpc-proto/blob/master/grpc/binlog/v1/binarylog.proto). It is intended that multiple parts of the call will be logged in separate files, and then correlated by analysis tools using the rpc\_id.
 
 ## API
 


### PR DESCRIPTION
the doc is in the `grpc/doc/binary-logging.md`

