### PR TITLE
BinderTransport: Support Intent URI

### DIFF
--- a/include/grpcpp/create_channel_binder.h
+++ b/include/grpcpp/create_channel_binder.h
@@ -69,6 +69,37 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
     const ChannelArguments& args);
 
+/// EXPERIMENTAL Create a new \a Channel based on binder transport.
+///
+/// \param jni_env Pointer to a JNIEnv structure
+/// \param context The context that we will use to invoke \a bindService See
+/// https://developer.android.com/reference/android/content/Context#bindService(android.content.Intent,%20android.content.ServiceConnection,%20int)
+/// for detail.
+/// \param uri An URI that can be parsed as an `Intent` with
+/// https://developer.android.com/reference/android/content/Intent#parseUri(java.lang.String,%20int)
+/// \param security_policy Used for checking if remote component is allowed to
+/// connect
+std::shared_ptr<grpc::Channel> CreateBinderChannel(
+    void* jni_env, jobject context, absl::string_view uri,
+    std::shared_ptr<grpc::experimental::binder::SecurityPolicy>
+        security_policy);
+
+/// EXPERIMENTAL Create a new \a Channel based on binder transport.
+///
+/// \param jni_env Pointer to a JNIEnv structure
+/// \param context The context that we will use to invoke \a bindService See
+/// https://developer.android.com/reference/android/content/Context#bindService(android.content.Intent,%20android.content.ServiceConnection,%20int)
+/// for detail.
+/// \param uri An URI that can be parsed as an `Intent` with
+/// https://developer.android.com/reference/android/content/Intent#parseUri(java.lang.String,%20int)
+/// \param security_policy Used for checking if remote component is allowed to
+/// connect
+/// \param args Options for channel creation.
+std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
+    void* jni_env, jobject context, absl::string_view uri,
+    std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
+    const ChannelArguments& args);
+
 /// EXPERIMENTAL Finds internal binder transport Java code. To create channels
 /// in threads created in native code, it is required to call this function
 /// once beforehand in a thread that is not created in native code.

--- a/src/core/ext/transport/binder/client/channel_create.cc
+++ b/src/core/ext/transport/binder/client/channel_create.cc
@@ -35,6 +35,7 @@
 #include <grpc/support/port_platform.h>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 
@@ -59,10 +60,6 @@ namespace {
 // grpc.io.action.BIND is the standard action name for binding to binder
 // transport server.
 const char* kStandardActionName = "grpc.io.action.BIND";
-
-// grpc::ChannelArguments key for specifying custom action name.
-const char* kCustomIntentActionNameArgKey =
-    "grpc.binder.custom_android_intent_action_name";
 }  // namespace
 
 namespace grpc {
@@ -83,6 +80,25 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
     absl::string_view class_name,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
     const ChannelArguments& args) {
+  return CreateCustomBinderChannel(
+      jni_env_void, application,
+      absl::Substitute("android-app://$0#Intent;action=$1;component=$0/$2;end",
+                       package_name, kStandardActionName, class_name),
+      security_policy, args);
+}
+
+std::shared_ptr<grpc::Channel> CreateBinderChannel(
+    void* jni_env_void, jobject application, absl::string_view uri,
+    std::shared_ptr<grpc::experimental::binder::SecurityPolicy>
+        security_policy) {
+  return CreateCustomBinderChannel(jni_env_void, application, uri,
+                                   security_policy, ChannelArguments());
+}
+
+std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
+    void* jni_env_void, jobject application, absl::string_view uri,
+    std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
+    const ChannelArguments& args) {
   grpc::internal::GrpcLibrary init_lib;
   init_lib.init();
 
@@ -91,54 +107,34 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
 
   // Generate an unique connection ID that identifies this connection (Useful
   // for mapping connection between Java and C++ code).
-  std::string connection_id = grpc_binder::GetConnectionIdGenerator()->Generate(
-      std::string(package_name), std::string(class_name));
+  std::string connection_id =
+      grpc_binder::GetConnectionIdGenerator()->Generate(uri);
 
-  grpc_channel_args channel_args_with_custom_action;
-  args.SetChannelArgs(&channel_args_with_custom_action);
-
-  // Check if user set an option to use non-standard action name to bind to
-  // server. At this moment this option is not intend for general production use
-  // and is mainly for stress testing purpose.
-  std::string action_name = kStandardActionName;
-  const grpc_arg* action_name_arg = grpc_channel_args_find(
-      &channel_args_with_custom_action, kCustomIntentActionNameArgKey);
-  if (action_name_arg != nullptr) {
-    // The option is set. Now check if it is a string.
-    char* action_name_arg_string = grpc_channel_arg_get_string(action_name_arg);
-    if (action_name_arg_string != nullptr) {
-      action_name = action_name_arg_string;
-    }
-  }
-  grpc_channel_args* channel_args;
-  {
-    // Passing the key down will cause gRPC internal error for unclear reason.
-    // Remove it here.
-    const char* to_remove[] = {kCustomIntentActionNameArgKey};
-    channel_args = grpc_channel_args_copy_and_remove(
-        &channel_args_with_custom_action, to_remove, 1);
-  }
+  gpr_log(GPR_ERROR, "connection id is %s", connection_id.c_str());
 
   // After invoking this Java method, Java code will put endpoint binder into
   // `EndpointBinderPool` after the connection succeeds
   // TODO(mingcl): Consider if we want to delay the connection establishment
   // until SubchannelConnector start establishing connection. For now we don't
   // see any benifits doing that.
-  grpc_binder::TryEstablishConnection(static_cast<JNIEnv*>(jni_env_void),
-                                      application, package_name, class_name,
-                                      action_name, connection_id);
+  grpc_binder::TryEstablishConnectionWithUri(static_cast<JNIEnv*>(jni_env_void),
+                                             application, uri, connection_id);
+
+  grpc_channel_args channel_args;
+  args.SetChannelArgs(&channel_args);
 
   // Set server URI to a URI that contains connection id. The URI will be used
   // by subchannel connector to obtain correct endpoint binder from
   // `EndpointBinderPool`.
   grpc_channel_args* new_args;
   {
-    grpc_arg server_uri_arg = grpc_channel_arg_string_create(
-        const_cast<char*>(GRPC_ARG_SERVER_URI),
-        const_cast<char*>(("binder:" + connection_id).c_str()));
+    string server_uri = "binder:" + connection_id;
+    grpc_arg server_uri_arg =
+        grpc_channel_arg_string_create(const_cast<char*>(GRPC_ARG_SERVER_URI),
+                                       const_cast<char*>(server_uri.c_str()));
     const char* to_remove[] = {GRPC_ARG_SERVER_URI};
     new_args = grpc_channel_args_copy_and_add_and_remove(
-        channel_args, to_remove, 1, &server_uri_arg, 1);
+        &channel_args, to_remove, 1, &server_uri_arg, 1);
   }
 
   grpc_binder::GetSecurityPolicySetting()->Set(connection_id, security_policy);
@@ -149,7 +145,6 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>());
 
   grpc_channel_args_destroy(new_args);
-  grpc_channel_args_destroy(channel_args);
 
   return channel;
 }
@@ -186,6 +181,29 @@ std::shared_ptr<grpc::Channel> CreateBinderChannel(
 
 std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
     void*, jobject, absl::string_view, absl::string_view,
+    std::shared_ptr<grpc::experimental::binder::SecurityPolicy>,
+    const ChannelArguments&) {
+  gpr_log(GPR_ERROR,
+          "This APK is compiled with Android API level = %d, which is not "
+          "supported. See port_platform.h for supported versions.",
+          __ANDROID_API__);
+  GPR_ASSERT(0);
+  return {};
+}
+
+std::shared_ptr<grpc::Channel> CreateBinderChannel(
+    void*, jobject, absl::string_view,
+    std::shared_ptr<grpc::experimental::binder::SecurityPolicy>) {
+  gpr_log(GPR_ERROR,
+          "This APK is compiled with Android API level = %d, which is not "
+          "supported. See port_platform.h for supported versions.",
+          __ANDROID_API__);
+  GPR_ASSERT(0);
+  return {};
+}
+
+std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
+    void*, jobject, absl::string_view,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy>,
     const ChannelArguments&) {
   gpr_log(GPR_ERROR,

--- a/src/core/ext/transport/binder/client/connection_id_generator.cc
+++ b/src/core/ext/transport/binder/client/connection_id_generator.cc
@@ -44,13 +44,11 @@ std::string StripToLength(const std::string& s, size_t len) {
 
 namespace grpc_binder {
 
-std::string ConnectionIdGenerator::Generate(absl::string_view package_name,
-                                            absl::string_view class_name) {
+std::string ConnectionIdGenerator::Generate(absl::string_view uri) {
   // reserve some room for serial number
   const size_t kReserveForNumbers = 15;
-  std::string s = StripToLength(
-      absl::StrCat(Normalize(package_name), "-", Normalize(class_name)),
-      kPathLengthLimit - kReserveForNumbers);
+  std::string s =
+      StripToLength(Normalize(uri), kPathLengthLimit - kReserveForNumbers);
   std::string ret;
   {
     grpc_core::MutexLock l(&m_);

--- a/src/core/ext/transport/binder/client/connection_id_generator.h
+++ b/src/core/ext/transport/binder/client/connection_id_generator.h
@@ -31,8 +31,7 @@ namespace grpc_binder {
 // underscore, and tilde).
 class ConnectionIdGenerator {
  public:
-  std::string Generate(absl::string_view package_name,
-                       absl::string_view class_name);
+  std::string Generate(absl::string_view uri);
 
  private:
   // Our generated Id need to fit in unix socket path length limit. We use 100

--- a/src/core/ext/transport/binder/client/jni_utils.cc
+++ b/src/core/ext/transport/binder/client/jni_utils.cc
@@ -89,6 +89,28 @@ void TryEstablishConnection(JNIEnv* env, jobject application,
                             env->NewStringUTF(std::string(conn_id).c_str()));
 }
 
+void TryEstablishConnectionWithUri(JNIEnv* env, jobject application,
+                                   absl::string_view uri,
+                                   absl::string_view conn_id) {
+  std::string method = "tryEstablishConnectionWithUri";
+  std::string type =
+      "(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)V";
+
+  jclass cl = FindNativeConnectionHelper(env);
+  if (cl == nullptr) {
+    return;
+  }
+
+  jmethodID mid = env->GetStaticMethodID(cl, method.c_str(), type.c_str());
+  if (mid == nullptr) {
+    gpr_log(GPR_ERROR, "No method id %s", method.c_str());
+  }
+
+  env->CallStaticVoidMethod(cl, mid, application,
+                            env->NewStringUTF(std::string(uri).c_str()),
+                            env->NewStringUTF(std::string(conn_id).c_str()));
+}
+
 bool IsSignatureMatch(JNIEnv* env, jobject context, int uid1, int uid2) {
   const std::string method = "isSignatureMatch";
   const std::string type = "(Landroid/content/Context;II)Z";

--- a/src/core/ext/transport/binder/client/jni_utils.h
+++ b/src/core/ext/transport/binder/client/jni_utils.h
@@ -43,6 +43,10 @@ void TryEstablishConnection(JNIEnv* env, jobject application,
                             absl::string_view action_name,
                             absl::string_view conn_id);
 
+void TryEstablishConnectionWithUri(JNIEnv* env, jobject application,
+                                   absl::string_view uri,
+                                   absl::string_view conn_id);
+
 // Calls Java method NativeConnectionHelper.isSignatureMatch.
 // Will also return false if failed to invoke Java.
 bool IsSignatureMatch(JNIEnv* env, jobject context, int uid1, int uid2);

--- a/src/core/ext/transport/binder/java/io/grpc/binder/cpp/NativeConnectionHelper.java
+++ b/src/core/ext/transport/binder/java/io/grpc/binder/cpp/NativeConnectionHelper.java
@@ -28,12 +28,19 @@ import java.util.Map;
  */
 final class NativeConnectionHelper {
   // Maps connection id to GrpcBinderConnection instances
-  static Map<String, GrpcBinderConnection> s = new HashMap<>();
+  static Map<String, GrpcBinderConnection> connectionIdToGrpcBinderConnectionMap = new HashMap<>();
 
-  static void tryEstablishConnection(Context context, String pkg, String cls, String action_name, String connId) {
+  static void tryEstablishConnection(
+      Context context, String pkg, String cls, String actionName, String connId) {
     // TODO(mingcl): Assert that connId is unique
-    s.put(connId, new GrpcBinderConnection(context, connId));
-    s.get(connId).tryConnect(pkg, cls, action_name);
+    connectionIdToGrpcBinderConnectionMap.put(connId, new GrpcBinderConnection(context, connId));
+    connectionIdToGrpcBinderConnectionMap.get(connId).tryConnect(pkg, cls, actionName);
+  }
+
+  static void tryEstablishConnectionWithUri(Context context, String uri, String connId) {
+    // TODO(mingcl): Assert that connId is unique
+    connectionIdToGrpcBinderConnectionMap.put(connId, new GrpcBinderConnection(context, connId));
+    connectionIdToGrpcBinderConnectionMap.get(connId).tryConnect(uri);
   }
 
   // Returns true if the packages signature of the 2 UIDs match.


### PR DESCRIPTION
    This commit adds an new overload of `CreateBinderChannel`, that accepts
    an intent URI (which should be able to be parsed by
    https://developer.android.com/reference/android/content/Intent#parseUri(java.lang.String,%20int) )
    for specifying the component to connect to.

    Later we will deprecate the old APIs that accepts `package_name`,
    `class_name`, and `action_name` separately. Intent URI seems to be a
    better and more flexible way to specify a component to connect to.

    `grpc.binder.custom_android_intent_action_name` channel arg is deprecated now.
    User should use URI to specify custom action instead.