### PR TITLE
[mac] Disable API fuzzer

### DIFF
--- a/test/core/end2end/fuzzers/BUILD
+++ b/test/core/end2end/fuzzers/BUILD
@@ -29,7 +29,7 @@ grpc_proto_fuzzer(
     proto_deps = [
         "//test/core/event_engine/fuzzing_event_engine:fuzzing_event_engine_proto",
     ],
-    tags = ["no_windows"],
+    tags = ["no_windows", "no_mac"],
     uses_event_engine = False,
     uses_polling = False,
     deps = [


### PR DESCRIPTION
It's having some problems on mac, we don't need it working there so much, disable for now.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

