### PR TITLE
[event_engine] Fix initialization

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -432,7 +432,7 @@ class EventEngine {
 /// created, applications must set a custom EventEngine factory method *before*
 /// grpc is initialized.
 void SetDefaultEventEngineFactory(
-    const std::function<std::unique_ptr<EventEngine>()>* factory);
+    std::function<std::unique_ptr<EventEngine>()> factory);
 
 /// Create an EventEngine using the default factory.
 std::unique_ptr<EventEngine> CreateEventEngine();

--- a/src/core/lib/event_engine/event_engine.cc
+++ b/src/core/lib/event_engine/event_engine.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include <grpc/support/port_platform.h>
 
+#include <atomic>
 #include <functional>
 #include <memory>
 
@@ -27,28 +28,41 @@ namespace grpc_event_engine {
 namespace experimental {
 
 namespace {
-const std::function<std::unique_ptr<EventEngine>()>* g_event_engine_factory =
-    nullptr;
-grpc_core::Mutex* g_mu = new grpc_core::Mutex();
+std::atomic<const std::function<std::unique_ptr<EventEngine>()>*>
+    g_event_engine_factory{nullptr};
+std::atomic<EventEngine*> g_event_engine{nullptr};
 }  // namespace
 
 void SetDefaultEventEngineFactory(
-    const std::function<std::unique_ptr<EventEngine>()>* factory) {
-  grpc_core::MutexLock lock(g_mu);
-  g_event_engine_factory = factory;
+    std::function<std::unique_ptr<EventEngine>()> factory) {
+  delete g_event_engine_factory.exchange(
+      new std::function<std::unique_ptr<EventEngine>()>(std::move(factory)));
 }
 
 std::unique_ptr<EventEngine> CreateEventEngine() {
-  grpc_core::MutexLock lock(g_mu);
-  if (g_event_engine_factory != nullptr) {
-    return (*g_event_engine_factory)();
+  if (auto* factory = g_event_engine_factory.load()) {
+    return (*factory)();
   }
   return DefaultEventEngineFactory();
 }
 
 EventEngine* GetDefaultEventEngine() {
-  static EventEngine* default_event_engine = CreateEventEngine().release();
-  return default_event_engine;
+  EventEngine* engine = g_event_engine.load(std::memory_order_acquire);
+  if (engine == nullptr) {
+    auto* created = CreateEventEngine().release();
+    if (g_event_engine.compare_exchange_strong(engine, created,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire)) {
+      engine = created;
+    } else {
+      delete created;
+    }
+  }
+  return engine;
+}
+
+void ResetDefaultEventEngine() {
+  delete g_event_engine.exchange(nullptr, std::memory_order_acq_rel);
 }
 
 void InitializeEventEngine() {

--- a/src/core/lib/event_engine/event_engine_factory.h
+++ b/src/core/lib/event_engine/event_engine_factory.h
@@ -32,6 +32,9 @@ EventEngine* GetDefaultEventEngine();
 /// Create an EventEngine using the default factory provided at link time.
 std::unique_ptr<EventEngine> DefaultEventEngineFactory();
 
+/// Reset the default event engine
+void ResetDefaultEventEngine();
+
 // TODO(hork): remove this when any other EE usage is landed
 void InitializeEventEngine();
 

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -33,18 +33,13 @@ const intptr_t kTaskHandleSalt = 12345;
 FuzzingEventEngine* g_fuzzing_event_engine = nullptr;
 }  // namespace
 
-FuzzingEventEngine::FuzzingEventEngine(Options options)
+FuzzingEventEngine::FuzzingEventEngine(
+    Options options, const fuzzing_event_engine::Actions& actions)
     : final_tick_length_(options.final_tick_length) {
   GPR_ASSERT(g_fuzzing_event_engine == nullptr);
   g_fuzzing_event_engine = this;
 
   gpr_now_impl = GlobalNowImpl;
-
-  Restart(fuzzing_event_engine::Actions());
-}
-
-void FuzzingEventEngine::Restart(const fuzzing_event_engine::Actions& actions) {
-  grpc_core::MutexLock lock(&mu_);
 
   tick_increments_.clear();
   task_delays_.clear();

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
@@ -36,10 +36,10 @@ class FuzzingEventEngine : public EventEngine {
     // time Now() will be incremented each tick.
     Duration final_tick_length = std::chrono::seconds(1);
   };
-  explicit FuzzingEventEngine(Options options);
+  explicit FuzzingEventEngine(Options options,
+                              const fuzzing_event_engine::Actions& actions);
   ~FuzzingEventEngine() override;
 
-  void Restart(const fuzzing_event_engine::Actions& actions);
   void FuzzingDone();
   void Tick();
 

--- a/test/core/event_engine/smoke_test.cc
+++ b/test/core/event_engine/smoke_test.cc
@@ -33,8 +33,8 @@ TEST_F(EventEngineSmokeTest, SetDefaultEventEngineFactoryLinks) {
       std::unique_ptr<grpc_event_engine::experimental::EventEngine>()>
       factory;
   EXPECT_CALL(factory, Call()).Times(1);
-  auto stdfn_fact = factory.AsStdFunction();
-  grpc_event_engine::experimental::SetDefaultEventEngineFactory(&stdfn_fact);
+  grpc_event_engine::experimental::SetDefaultEventEngineFactory(
+      factory.AsStdFunction());
   EXPECT_EQ(nullptr, grpc_event_engine::experimental::CreateEventEngine());
 }
 

--- a/test/core/event_engine/test_suite/fuzzing_event_engine_test.cc
+++ b/test/core/event_engine/test_suite/fuzzing_event_engine_test.cc
@@ -21,6 +21,7 @@
 
 #include <grpc/grpc.h>
 
+#include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 
 namespace grpc_event_engine {
@@ -30,11 +31,13 @@ namespace {
 class ThreadedFuzzingEventEngine : public FuzzingEventEngine {
  public:
   ThreadedFuzzingEventEngine()
-      : FuzzingEventEngine([]() {
-          Options options;
-          options.final_tick_length = std::chrono::milliseconds(10);
-          return options;
-        }()),
+      : FuzzingEventEngine(
+            []() {
+              Options options;
+              options.final_tick_length = std::chrono::milliseconds(10);
+              return options;
+            }(),
+            fuzzing_event_engine::Actions()),
         main_([this]() {
           while (!done_.load()) {
             auto tick_start = absl::Now();


### PR DESCRIPTION
- make the SetDefault function just take a function to make usage a little more idiomatic
- remove the global mutex allowing initialization fiasco quirks to be side stepped
- add a reset function to the global event engine so that the global event engine can be replaced by very careful tests

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

