### PR TITLE
Document specifying lists in MsBuild properties

### DIFF
--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -343,7 +343,7 @@ The following metadata are recognized on the `<Protobuf>` items.
 | Name           | Default   | Value                | Synopsis                         |
 |----------------|-----------|----------------------|----------------------------------|
 | Access         | `public`  | `public`, `internal`               | Generated class access           |
-| AdditionalProtocArguments | | arbitrary cmdline arguments | Extra command line flags passed to `protoc` command |
+| AdditionalProtocArguments | | arbitrary cmdline arguments | Extra command line flags passed to `protoc` command. To specify multiple arguments use semi-colons (;) to separate them. See example below |
 | ProtoCompile   | `true`    | `true`, `false`                    | Pass files to protoc?            |
 | ProtoRoot      | See notes | A directory                        | Common root for set of files     |
 | CompileOutputs | `true`    | `true`, `false`                    | C#-compile generated files?      |
@@ -388,6 +388,23 @@ Normally this option should not be used as it's values are already controlled by
 and "GrpcServices" metadata, but it might be useful in situations where you want
 to explicitly pass some otherwise unsupported (e.g. experimental) options to the
 `grpc_csharp_plugin`.
+
+__Specifying multiple values in properties__
+
+Some properties allow you to specify multiple values in a list. The items in a list need to
+be separated by semi-colons (;). This is the syntax that MsBuild uses for lists.
+
+The properties that can have lists of items are: __OutputOptions__, __AdditionalProtocArguments__, __GrpcOutputOptions__
+
+Example: to specify two additional arguments: ```--plugin=protoc-gen-myplugin=D:\myplugin.exe --myplugin_out=.```
+
+```xml
+  <ItemGroup>
+    <Protobuf Include="proto_root/**/*.proto" ProtoRoot="proto_root"
+              OutputDir="%(RelativeDir)" CompileOutputs="false"
+              AdditionalProtocArguments="--plugin=protoc-gen-myplugin=D:\myplugin.exe;--myplugin_out=." />
+  </ItemGroup>
+```
 
 `grpc_csharp_plugin` command line options
 ---------


### PR DESCRIPTION
This documentation change in src/csharp/BUILD-INTEGRATION.md is in response to the issue
https://github.com/grpc/grpc/issues/26743  where there was a misunderstanding of how to specify multiple additional arguments.
@jtattermusch 

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

