### PR TITLE
Add regular tests for PSM benchmarks CI

### DIFF
--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -53,8 +53,6 @@ GRPC_JAVA_GITREF="$(git ls-remote https://github.com/grpc/grpc-java.git master |
 # Kokoro jobs run on dedicated pools.
 DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
-# c2-standard-30 is the closest machine spec to 32 core there is
-WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
@@ -80,8 +78,8 @@ popd
 PSM_IMAGE_PREFIX=gcr.io/grpc-testing/e2etest/runtime
 PSM_IMAGE_TAG=${TEST_INFRA_VERSION}
 
-# Build test configurations.
-buildConfigs() {
+# Build psm test configurations.
+psmBuildConfigs() {
     local -r pool="$1"
     local -r table="$2"
     local -r proxy_type="$3"
@@ -109,9 +107,34 @@ buildConfigs() {
         -o "psm_${proxy_type}_loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" proxied -a queue="${WORKER_POOL_8CORE}-proxied"  -l c++ -l java --client_channels=8 --server_threads=16 --offered_loads 100 300 500 700 900 1000 1500 2000 2500 4000 6000 8000 10000 12000 14000 16000 18000 20000 22000 24000 26000 28000 30000
+psmBuildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" proxied -a queue="${WORKER_POOL_8CORE}-proxied"  -l c++ -l java --client_channels=8 --server_threads=16 --offered_loads 100 300 500 700 900 1000 1500 2000 2500 4000 6000 8000 10000 12000 14000 16000 18000 20000 22000 24000 26000 28000 30000
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" proxyless -a queue="${WORKER_POOL_8CORE}-proxyless" -l c++ -l java --client_channels=8 --server_threads=16 --offered_loads 100 300 500 700 900 1000 1500 2000 2500 4000 6000 8000 10000 12000 14000 16000 18000 20000 22000 24000 26000 28000 30000
+psmBuildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" proxyless -a queue="${WORKER_POOL_8CORE}-proxyless" -l c++ -l java --client_channels=8 --server_threads=16 --offered_loads 100 300 500 700 900 1000 1500 2000 2500 4000 6000 8000 10000 12000 14000 16000 18000 20000 22000 24000 26000 28000 30000
+
+# Build regular test configurations.
+buildConfigs() {
+    local -r pool="$1"
+    local -r table="$2"
+    shift 2
+    tools/run_tests/performance/loadtest_config.py "$@" \
+        -t ./tools/run_tests/performance/templates/loadtest_template_prebuilt_all_languages.yaml \
+        -s driver_pool="${DRIVER_POOL}" -s driver_image= \
+        -s client_pool="${pool}" -s server_pool="${pool}" \
+        -s big_query_table="${table}" -s timeout_seconds=900 \
+        -s prebuilt_image_prefix="${PREBUILT_IMAGE_PREFIX}" \
+        -s prebuilt_image_tag="${UNIQUE_IDENTIFIER}" \
+        -a ci_buildNumber="${KOKORO_BUILD_NUMBER}" \
+        -a ci_buildUrl="${CLOUD_LOGGING_URL}" \
+        -a ci_jobName="${KOKORO_JOB_NAME}" \
+        -a ci_gitCommit="${GRPC_GITREF}" \
+        -a ci_gitCommit_java="${GRPC_JAVA_GITREF}" \
+        -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
+        --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
+        -a pool="${pool}" --category=psm \
+        --allow_client_language=c++ --allow_server_language=c++ \
+        -o "regular_loadtest_with_prebuilt_workers_${pool}.yaml"
+}
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" -a queue="${WORKER_POOL_8CORE}-regular" -l c++ -l java --client_channels=8 --server_threads=16 --offered_loads 100 300 500 700 900 1000 1500 2000 2500 4000 6000 8000 10000 12000 14000 16000 18000 20000 22000 24000 26000 28000 30000
 
 # Delete prebuilt images on exit.
 deleteImages() {
@@ -134,10 +157,12 @@ time ../test-infra/bin/prepare_prebuilt_workers \
 time ../test-infra/bin/runner \
     -i "psm_proxied_loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
     -i "psm_proxyless_loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
+    -i "regular_loadtest_with_prebuilt_workers_${WORKER_POOL_8CORE}.yaml" \
     -log-url-prefix "${LOG_URL_PREFIX}" \
     -annotation-key queue \
     -polling-interval 5s \
     -delete-successful-tests \
     -c "${WORKER_POOL_8CORE}-proxied:1" \
     -c "${WORKER_POOL_8CORE}-proxyless:1" \
+    -c "${WORKER_POOL_8CORE}-regular:1" \
     -o "runner/sponge_log.xml"

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -134,6 +134,7 @@ buildConfigs() {
         --allow_client_language=c++ --allow_server_language=c++ \
         -o "regular_loadtest_with_prebuilt_workers_${pool}.yaml"
 }
+
 buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" -a queue="${WORKER_POOL_8CORE}-regular" -l c++ -l java --client_channels=8 --server_threads=16 --offered_loads 100 300 500 700 900 1000 1500 2000 2500 4000 6000 8000 10000 12000 14000 16000 18000 20000 22000 24000 26000 28000 30000
 
 # Delete prebuilt images on exit.


### PR DESCRIPTION
According to the design, we will be running proxyless, proxied and regular
tests in the PSM benchmark CI, this PR adds the regular tests to the CI.


