### PR TITLE
Using string rep for status-time

### DIFF
--- a/src/core/lib/gprpp/status_helper.cc
+++ b/src/core/lib/gprpp/status_helper.cc
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <new>
 #include <utility>
 
 #include "absl/strings/cord.h"
@@ -227,23 +226,10 @@ absl::optional<std::string> StatusGetStr(const absl::Status& status,
 
 void StatusSetTime(absl::Status* status, StatusTimeProperty key,
                    absl::Time time) {
-#if !defined(__clang__) && defined(_MSC_VER) && _MSC_VER < 1910
-  // Abseil has a workaround for MSVC 2015 which prevents absl::Time
-  // from being is_trivially_copyable but it's still safe to be
-  // memcopied.
-#elif defined(__GNUG__) && __GNUC__ < 5
-  // GCC versions < 5 do not support std::is_trivially_copyable
-#else
-  static_assert(std::is_trivially_copyable<absl::Time>::value,
-                "absl::Time needs to be able to be memcopied");
-#endif
-  // This is required not to get uninitialized padding of absl::Time.
-  alignas(absl::Time) char buf[sizeof(time)] = {
-      0,
-  };
-  new (buf) absl::Time(time);
+  std::string time_str =
+      absl::FormatTime(absl::RFC3339_full, time, absl::UTCTimeZone());
   status->SetPayload(GetStatusTimePropertyUrl(key),
-                     absl::Cord(absl::string_view(buf, sizeof(time))));
+                     absl::Cord(std::move(time_str)));
 }
 
 absl::optional<absl::Time> StatusGetTime(const absl::Status& status,
@@ -252,14 +238,16 @@ absl::optional<absl::Time> StatusGetTime(const absl::Status& status,
       status.GetPayload(GetStatusTimePropertyUrl(key));
   if (p.has_value()) {
     absl::optional<absl::string_view> sv = p->TryFlat();
+    absl::Time time;
     if (sv.has_value()) {
-      // copy the content before casting to avoid misaligned address access
-      alignas(absl::Time) char buf[sizeof(const absl::Time)];
-      memcpy(buf, sv->data(), sizeof(const absl::Time));
-      return *reinterpret_cast<const absl::Time*>(buf);
+      if (absl::ParseTime(absl::RFC3339_full, sv.value(), &time, nullptr)) {
+        return time;
+      }
     } else {
       std::string s = std::string(*p);
-      return *reinterpret_cast<const absl::Time*>(s.c_str());
+      if (absl::ParseTime(absl::RFC3339_full, s, &time, nullptr)) {
+        return time;
+      }
     }
   }
   return {};
@@ -327,11 +315,14 @@ std::string StatusToString(const absl::Status& status) {
                                    absl::CHexEscape(payload_view), "\""));
       } else if (absl::StartsWith(type_url, kTypeTimeTag)) {
         type_url.remove_prefix(kTypeTimeTag.size());
-        // copy the content before casting to avoid misaligned address access
-        alignas(absl::Time) char buf[sizeof(const absl::Time)];
-        memcpy(buf, payload_view.data(), sizeof(const absl::Time));
-        absl::Time t = *reinterpret_cast<const absl::Time*>(buf);
-        kvs.push_back(absl::StrCat(type_url, ":\"", absl::FormatTime(t), "\""));
+        absl::Time t;
+        if (absl::ParseTime(absl::RFC3339_full, payload_view, &t, nullptr)) {
+          kvs.push_back(
+              absl::StrCat(type_url, ":\"", absl::FormatTime(t), "\""));
+        } else {
+          kvs.push_back(absl::StrCat(type_url, ":\"",
+                                     absl::CHexEscape(payload_view), "\""));
+        }
       } else {
         kvs.push_back(absl::StrCat(type_url, ":\"",
                                    absl::CHexEscape(payload_view), "\""));


### PR DESCRIPTION
Using a string representation of time when storing as a payload of status to avoid dumping its internal representation.