### PR TITLE
xds-k8s: Remove skips.version_lt(), and use only skips.version_gte()

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -69,20 +69,6 @@ class TestConfig:
             return False
         return self._parse_version(self.version) >= self._parse_version(another)
 
-    def version_lt(self, another: str) -> bool:
-        """Returns a bool for whether the version is < another one.
-
-        Version "master" is always considered latest.
-        E.g., v1.9.x < v1.40.x < v1.41.x < master.
-
-        Unspecified version is treated as 'master', but isn't explicitly set.
-        """
-        if self.version == 'master' or self.version is None:
-            return False
-        if another == 'master':
-            return True
-        return self._parse_version(self.version) < self._parse_version(another)
-
     def __str__(self):
         return (f"TestConfig(client_lang='{self.client_lang}', "
                 f"server_lang='{self.server_lang}', version={self.version!r})")

--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -46,9 +46,9 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang in _Lang.CPP | _Lang.JAVA:
-            return not config.version_lt('v1.40.x')
+            return config.version_gte('v1.40.x')
         elif config.client_lang == _Lang.GO:
-            return not config.version_lt('v1.41.x')
+            return config.version_gte('v1.41.x')
         elif config.client_lang == _Lang.PYTHON:
             # TODO(https://github.com/grpc/grpc/issues/27430): supported after
             #      the issue is fixed.

--- a/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/api_listener_test.py
@@ -40,7 +40,7 @@ class ApiListenerTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         if config.client_lang == _Lang.PYTHON:
             # gRPC Python versions prior to v1.43.x don't support handling empty
             # RDS update.
-            return not config.version_lt('v1.43.x')
+            return config.version_gte('v1.43.x')
         return True
 
     def test_api_listener(self) -> None:

--- a/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
@@ -52,9 +52,9 @@ class AuthzTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         # Per "Authorization (RBAC)" in
         # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
         if config.client_lang in _Lang.CPP | _Lang.PYTHON:
-            return not config.version_lt('v1.44.x')
+            return config.version_gte('v1.44.x')
         elif config.client_lang in _Lang.GO | _Lang.JAVA:
-            return not config.version_lt('v1.42.x')
+            return config.version_gte('v1.42.x')
         return True
 
     def setUp(self):

--- a/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/security_test.py
@@ -38,7 +38,7 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
                                   _Lang.PYTHON):
             # Versions prior to v1.41.x don't support PSM Security.
             # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
-            return not config.version_lt('v1.41.x')
+            return config.version_gte('v1.41.x')
         return True
 
     def test_mtls(self):

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -57,9 +57,9 @@ def _is_supported(config: skips.TestConfig) -> bool:
     # Per "Ring hash" in
     # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
     if config.client_lang in _Lang.CPP | _Lang.JAVA:
-        return not config.version_lt('v1.40.x')
+        return config.version_gte('v1.40.x')
     elif config.client_lang == _Lang.GO:
-        return not config.version_lt('v1.41.x')
+        return config.version_gte('v1.41.x')
     elif config.client_lang == _Lang.PYTHON:
         # TODO(https://github.com/grpc/grpc/issues/27430): supported after
         #      the issue is fixed.

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/csds_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/csds_test.py
@@ -42,7 +42,7 @@ class TestBasicCsds(xds_url_map_testcase.XdsUrlMapTestCase):
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang == _Lang.NODE:
-            return not config.version_lt('v1.5.x')
+            return config.version_gte('v1.5.x')
         return True
 
     @staticmethod

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/fault_injection_test.py
@@ -120,7 +120,7 @@ def _wait_until_backlog_cleared(test_client: XdsTestClient,
 
 def _is_supported(config: skips.TestConfig) -> bool:
     if config.client_lang == _Lang.NODE:
-        return not config.version_lt('v1.4.x')
+        return config.version_gte('v1.4.x')
     return True
 
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/header_matching_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/header_matching_test.py
@@ -51,7 +51,7 @@ _TEST_METADATA = (
 
 def _is_supported(config: skips.TestConfig) -> bool:
     if config.client_lang == _Lang.NODE:
-        return not config.version_lt('v1.3.x')
+        return config.version_gte('v1.3.x')
     return True
 
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/path_matching_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/path_matching_test.py
@@ -39,7 +39,7 @@ _NUM_RPCS = 150
 
 def _is_supported(config: skips.TestConfig) -> bool:
     if config.client_lang == _Lang.NODE:
-        return not config.version_lt('v1.3.x')
+        return config.version_gte('v1.3.x')
     return True
 
 

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -67,9 +67,9 @@ def _is_supported(config: skips.TestConfig) -> bool:
     # Per "Retry" in
     # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
     if config.client_lang in _Lang.CPP | _Lang.JAVA | _Lang.PYTHON:
-        return not config.version_lt('v1.40.x')
+        return config.version_gte('v1.40.x')
     elif config.client_lang == _Lang.GO:
-        return not config.version_lt('v1.41.x')
+        return config.version_gte('v1.41.x')
     elif config.client_lang == _Lang.NODE:
         return False
     return True

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
@@ -86,7 +86,7 @@ class TestTimeoutInRouteRule(_BaseXdsTimeOutTestCase):
         if config.server_lang != 'java':
             return False
         if config.client_lang == skips.Lang.NODE:
-            return not config.version_lt('v1.4.x')
+            return config.version_gte('v1.4.x')
         return True
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
@@ -121,7 +121,7 @@ class TestTimeoutInApplication(_BaseXdsTimeOutTestCase):
         if config.server_lang != 'java':
             return False
         if config.client_lang == skips.Lang.NODE:
-            return not config.version_lt('v1.4.x')
+            return config.version_gte('v1.4.x')
         return True
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
@@ -146,7 +146,7 @@ class TestTimeoutNotExceeded(_BaseXdsTimeOutTestCase):
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang == skips.Lang.NODE:
-            return not config.version_lt('v1.4.x')
+            return config.version_gte('v1.4.x')
         return True
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):


### PR DESCRIPTION
A minor refactoring.

cc @temawi 