### PR TITLE
Fix leak on ares resolver test

### DIFF
--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -437,10 +437,7 @@ class PollsetSetWrapper {
   ~PollsetSetWrapper() {
     grpc_pollset_set_del_pollset(pss_, ps_);
     grpc_pollset_set_destroy(pss_);
-    grpc_closure do_nothing_cb;
-    GRPC_CLOSURE_INIT(&do_nothing_cb, DoNothing, nullptr,
-                      grpc_schedule_on_exec_ctx);
-    grpc_pollset_shutdown(ps_, &do_nothing_cb);
+    grpc_pollset_shutdown(ps_, nullptr);
     grpc_core::ExecCtx::Get()->Flush();
     grpc_pollset_destroy(ps_);
     gpr_free(ps_);
@@ -457,7 +454,6 @@ class PollsetSetWrapper {
     grpc_pollset_set_add_pollset(pss_, ps_);
     gpr_log(GPR_DEBUG, "PollsetSetWrapper:%p created", this);
   }
-  static void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
 
   gpr_mu* mu_;
   grpc_pollset* ps_;

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -436,9 +436,14 @@ class PollsetSetWrapper {
 
   ~PollsetSetWrapper() {
     grpc_pollset_set_del_pollset(pss_, ps_);
+    grpc_pollset_set_destroy(pss_);
+    grpc_closure do_nothing_cb;
+    GRPC_CLOSURE_INIT(&do_nothing_cb, DoNothing, nullptr,
+                      grpc_schedule_on_exec_ctx);
+    grpc_pollset_shutdown(ps_, &do_nothing_cb);
+    grpc_core::ExecCtx::Get()->Flush();
     grpc_pollset_destroy(ps_);
     gpr_free(ps_);
-    grpc_pollset_set_destroy(pss_);
     gpr_log(GPR_DEBUG, "PollsetSetWrapper:%p deleted", this);
   }
 
@@ -452,6 +457,7 @@ class PollsetSetWrapper {
     grpc_pollset_set_add_pollset(pss_, ps_);
     gpr_log(GPR_DEBUG, "PollsetSetWrapper:%p created", this);
   }
+  static void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
 
   gpr_mu* mu_;
   grpc_pollset* ps_;


### PR DESCRIPTION
The pollset was not being properly shutdown. ASAN was failing 100% on
`resolve_address_using_ares_resolver_test` for a month (commit c11f66faef25f68fc195d11add1a62c9fe61a838, failure not identified in CI).

This only affects the `poll` poller. Command to reproduce:

`bazel test --config=asan --cache_test_results=no --test_output=streamed --test_env='GRPC_VERBOSITY=debug' --test_env='GRPC_TRACE=cares_resolver' --test_filter='*DeleteInterested*' test/core/iomgr:resolve_address_using_ares_resolver_test@poller=poll`


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

