### PR TITLE
XdsSecurityTest: Rework infrastructure

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -391,6 +391,9 @@ class XdsSecurityTest : public XdsEnd2endTest {
           DEBUG_LOCATION,
           [&](const RpcResult& result) {
             // Make sure that we are hitting the correct backend.
+            // TODO(yashykt): Even if we haven't moved to the correct backend
+            // and are still using the previous update, we should still check
+            // for the status and make sure that it fits our expectations.
             if (backends_[backend_index_]->backend_service()->request_count() ==
                 0) {
               return true;

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -405,7 +405,7 @@ class XdsSecurityTest : public XdsEnd2endTest {
                       expected_authenticated_identity);
             return false;
           },
-          20 * 1000, RpcOptions());
+          /* timeout_ms= */ 20 * 1000, RpcOptions());
     }
   }
 


### PR DESCRIPTION
Fixes b/237007226

This PR reworks the XdsSecurityTest infrastructure to use two backends and rotates between them when we make CDS updates. We also change the service name in the CDS updates to make sure that when the CDS updates propagates, we try to use a different backend. This allows us to replace the `WaitForBackend` code with a custom `SendRpcsUntil` which just waits for the first hit to the backend that we want.

The infra still needs changes to deal with the error cases in the test cases that expect a failure. Right now, we allow any failing status code, but we should really make sure that we are getting the proper one.