### PR TITLE
Revert "[chttp2] Use Closure::Run to invoke callbacks"

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1216,7 +1216,12 @@ static grpc_closure* add_closure_barrier(grpc_closure* closure) {
 static void null_then_sched_closure(grpc_closure** closure) {
   grpc_closure* c = *closure;
   *closure = nullptr;
-  // null_then_schedule_closure might be run during a start_batch which might subsequently examine the batch for more operations contained within. However, the closure run might make it back to the call object, push a completion, have the application see it, and make a new operation on the call which recycles the batch BEFORE the call to start_batch completes, forcing a race.
+  // null_then_schedule_closure might be run during a start_batch which might
+  // subsequently examine the batch for more operations contained within.
+  // However, the closure run might make it back to the call object, push a
+  // completion, have the application see it, and make a new operation on the
+  // call which recycles the batch BEFORE the call to start_batch completes,
+  // forcing a race.
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
 }
 

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1216,7 +1216,7 @@ static grpc_closure* add_closure_barrier(grpc_closure* closure) {
 static void null_then_sched_closure(grpc_closure** closure) {
   grpc_closure* c = *closure;
   *closure = nullptr;
-  grpc_core::Closure::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
 }
 
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1216,6 +1216,7 @@ static grpc_closure* add_closure_barrier(grpc_closure* closure) {
 static void null_then_sched_closure(grpc_closure** closure) {
   grpc_closure* c = *closure;
   *closure = nullptr;
+  // null_then_schedule_closure might be run during a start_batch which might subsequently examine the batch for more operations contained within. However, the closure run might make it back to the call object, push a completion, have the application see it, and make a new operation on the call which recycles the batch BEFORE the call to start_batch completes, forcing a race.
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
 }
 


### PR DESCRIPTION
This is ultimately responsible for much of our TSAN flakiness (at least).

The issue comes up in that `null_then_schedule_closure` might be run during a `start_batch` which might subsequently examine the batch for more operations contained within. However, the closure run might make it back to the call object, push a completion, have the application see it, and make a new operation on the call which recycles the batch **BEFORE** the call to `start_batch` completes, forcing a race.

Reverts grpc/grpc#29844