### PR TITLE
Fixing Python 3.9 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ def check_linker_need_libatomic():
     # Double-check to see if -latomic actually can solve the problem.
     # https://github.com/grpc/grpc/issues/22491
     cpp_test = subprocess.Popen(
-        [cxx, '-x', 'c++', '-std=c++14', '-', '-latomic'],
+        cxx + ['-x', 'c++', '-std=c++14', '-', '-latomic'],
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE)


### PR DESCRIPTION
Problem:
on Python3.9, doing `GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .`
results in the following error:

      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/homeassistant/grpc/setup.py", line 263, in <module>
          if check_linker_need_libatomic():
        File "/home/homeassistant/grpc/setup.py", line 219, in check_linker_need_libatomic
          cpp_test = subprocess.Popen(
        File "/usr/local/lib/python3.9/subprocess.py", line 951, in __init__
          self._execute_child(args, executable, preexec_fn, close_fds,
        File "/usr/local/lib/python3.9/subprocess.py", line 1696, in _execute_child
          and os.path.dirname(executable)
        File "/usr/local/lib/python3.9/posixpath.py", line 152, in dirname
          p = os.fspath(p)
      TypeError: expected str, bytes or os.PathLike object, not list

Solution:
	Use same pattern as on line 210 and the install/build proceeds
normally.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

