### PR TITLE
outlier detection LB: don't include channel args in subchannel map key

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4389,6 +4389,7 @@ grpc_cc_library(
         "ref_counted",
         "ref_counted_ptr",
         "server_address",
+        "sockaddr_utils",
     ],
 )
 

--- a/src/core/ext/filters/client_channel/lb_policy/outlier_detection/outlier_detection.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/outlier_detection/outlier_detection.cc
@@ -48,6 +48,7 @@
 #include "src/core/ext/filters/client_channel/lb_policy_factory.h"
 #include "src/core/ext/filters/client_channel/lb_policy_registry.h"
 #include "src/core/ext/filters/client_channel/subchannel_interface.h"
+#include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/env.h"
@@ -554,10 +555,9 @@ OutlierDetectionLb::~OutlierDetectionLb() {
 
 std::string OutlierDetectionLb::MakeKeyForAddress(
     const ServerAddress& address) {
-  // Strip off attributes to construct the key.
-  return ServerAddress(address.address(),
-                       grpc_channel_args_copy(address.args()))
-      .ToString();
+  // Use only the address, not the attributes.
+  auto addr_str = grpc_sockaddr_to_string(&address.address(), false);
+  return addr_str.ok() ? addr_str.value() : addr_str.status().ToString();
 }
 
 void OutlierDetectionLb::ShutdownLocked() {


### PR DESCRIPTION
Including the channel args wasn't actually working correctly, since it was looking only at the per-address args and not at the global args, but both sets are actually needed to determine the unique identity of the subchannel.  However, if we did start looking at the global args as well, that would actually break things in the xDS case, because the xds_cluster_impl policy adds a channel arg for the xDS cluster name, which will be present when `CreateSubchannel()` is called from the child, but that channel arg is not present in the channel args passed down from the parent, which are used to populate the subchannel map, so the two would never match up.

After discussion with the other languages, we've decided for now to key by only the address, excluding the channel args.  In practice, there probably won't be any cases where there are multiple subchannels for the same address with different args, and if we run into this in the future, we can reevaluate at that point.