### PR TITLE
Reduce keepalive time period for test

### DIFF
--- a/test/core/end2end/tests/keepalive_timeout.cc
+++ b/test/core/end2end/tests/keepalive_timeout.cc
@@ -105,7 +105,7 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
   grpc_arg keepalive_arg_elems[3];
   keepalive_arg_elems[0].type = GRPC_ARG_INTEGER;
   keepalive_arg_elems[0].key = const_cast<char*>(GRPC_ARG_KEEPALIVE_TIME_MS);
-  keepalive_arg_elems[0].value.integer = 3500;
+  keepalive_arg_elems[0].value.integer = 10;
   keepalive_arg_elems[1].type = GRPC_ARG_INTEGER;
   keepalive_arg_elems[1].key = const_cast<char*>(GRPC_ARG_KEEPALIVE_TIMEOUT_MS);
   keepalive_arg_elems[1].value.integer = 0;

--- a/test/core/end2end/tests/keepalive_timeout.cc
+++ b/test/core/end2end/tests/keepalive_timeout.cc
@@ -105,7 +105,7 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
   grpc_arg keepalive_arg_elems[3];
   keepalive_arg_elems[0].type = GRPC_ARG_INTEGER;
   keepalive_arg_elems[0].key = const_cast<char*>(GRPC_ARG_KEEPALIVE_TIME_MS);
-  keepalive_arg_elems[0].value.integer = 10;
+  keepalive_arg_elems[0].value.integer = 100;
   keepalive_arg_elems[1].type = GRPC_ARG_INTEGER;
   keepalive_arg_elems[1].key = const_cast<char*>(GRPC_ARG_KEEPALIVE_TIMEOUT_MS);
   keepalive_arg_elems[1].value.integer = 0;


### PR DESCRIPTION
Reducing flakiness on MacOS.
Internal bug - https://b.corp.google.com/issues/162328224

After this change, no test failed on 100 runs - https://source.cloud.google.com/results/invocations/4db1bb24-bd09-430b-aad3-c6195bf82f2d/targets/%2F%2Ftest%2Fcore%2Fend2end:h2_tls_test@keepalive_timeout/tests