### PR TITLE
HTTP2: Fix keepalive time throttling

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1131,14 +1131,14 @@ void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
     gpr_log(GPR_ERROR,
             "Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug "
             "data equal to \"too_many_pings\"");
-    constexpr auto max_keepalive_time = grpc_core::Duration::Milliseconds(
-        INT_MAX / KEEPALIVE_TIME_BACKOFF_MULTIPLIER);
-    t->keepalive_time =
-        t->keepalive_time > max_keepalive_time
-            ? grpc_core::Duration::Infinity()
-            : t->keepalive_time * KEEPALIVE_TIME_BACKOFF_MULTIPLIER;
+    constexpr int max_keepalive_time_millis =
+        INT_MAX / KEEPALIVE_TIME_BACKOFF_MULTIPLIER;
+    int throttled_keepalive_time =
+        t->keepalive_time.millis() > max_keepalive_time_millis
+            ? INT_MAX
+            : t->keepalive_time.millis() * KEEPALIVE_TIME_BACKOFF_MULTIPLIER;
     status.SetPayload(grpc_core::kKeepaliveThrottlingKey,
-                      absl::Cord(std::to_string(t->keepalive_time.millis())));
+                      absl::Cord(std::to_string(throttled_keepalive_time)));
   }
   // lie: use transient failure from the transport to indicate goaway has been
   // received.


### PR DESCRIPTION
I noticed some error logs of the form - 
```
E0701 01:03:36.197979050 2899029 client_channel.cc:652]      chand=0x15dada0: Illegal keepalive throttling value 9223372036854775807
```

This is happening since the consumer of this throttled time expects an integer value and not an int64 value.

Verified that the error logs go away with this.