### PR TITLE
ObjC: Optional support to skip methods with types without prefixes.

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -156,6 +156,8 @@ inline map< ::std::string, ::std::string> GetMethodVars(
 }
 
 void PrintMethodDeclarations(Printer* printer, const MethodDescriptor* method) {
+  if (!ShouldIncludeMethod(method)) return;
+
   map< ::std::string, ::std::string> vars = GetMethodVars(method);
 
   PrintProtoRpcDeclarationAsPragma(printer, method, vars);
@@ -168,6 +170,8 @@ void PrintMethodDeclarations(Printer* printer, const MethodDescriptor* method) {
 
 void PrintV2MethodDeclarations(Printer* printer,
                                const MethodDescriptor* method) {
+  if (!ShouldIncludeMethod(method)) return;
+
   map< ::std::string, ::std::string> vars = GetMethodVars(method);
 
   PrintProtoRpcDeclarationAsPragma(printer, method, vars);
@@ -240,6 +244,8 @@ void PrintV2Implementation(Printer* printer, const MethodDescriptor* method,
 void PrintMethodImplementations(Printer* printer,
                                 const MethodDescriptor* method,
                                 const Parameters& generator_params) {
+  if (!ShouldIncludeMethod(method)) return;
+
   map< ::std::string, ::std::string> vars = GetMethodVars(method);
 
   PrintProtoRpcDeclarationAsPragma(printer, method, vars);
@@ -267,8 +273,10 @@ void PrintMethodImplementations(Printer* printer,
     const auto service = file->service(i);
     for (int i = 0; i < service->method_count(); i++) {
       const auto method = service->method(i);
-      classes.insert(ClassName(method->input_type()));
-      classes.insert(ClassName(method->output_type()));
+      if (ShouldIncludeMethod(method)) {
+        classes.insert(ClassName(method->input_type()));
+        classes.insert(ClassName(method->output_type()));
+      }
     }
   }
   for (auto one_class : classes) {

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -29,6 +29,7 @@
 namespace grpc_objective_c_generator {
 
 using ::grpc::protobuf::FileDescriptor;
+using ::grpc::protobuf::MethodDescriptor;
 using ::grpc::protobuf::ServiceDescriptor;
 using ::std::string;
 
@@ -109,6 +110,16 @@ inline ::std::string PreprocIfNotElse(const ::std::string& symbol,
                                       const ::std::string& if_false) {
   return ::std::string("#if " + PreprocConditional(symbol, true) + "\n" +
                        if_true + "#else\n" + if_false + "#endif\n");
+}
+
+inline bool ShouldIncludeMethod(const MethodDescriptor* method) {
+#ifdef OBJC_SKIP_METHODS_WITHOUT_MESSAGE_PREFIX
+  return (method->input_type()->file()->options().has_objc_class_prefix() &&
+          method->output_type()->file()->options().has_objc_class_prefix());
+#else
+  (void)method;  // to silence the unused warning for method.
+  return true;
+#endif
 }
 
 }  // namespace grpc_objective_c_generator


### PR DESCRIPTION
The existing optional support for objc_class_prefix only checks the file
defining the service, but the types for the messages can come from other files.
This allows those methods to be skipped if the other files didn't have a
objc_class_prefix set.

@donnadionne
@veblush
