### PR TITLE
doc# fix: udpate Protocol ABNF syntax link url

### DIFF
--- a/doc/PROTOCOL-HTTP2.md
+++ b/doc/PROTOCOL-HTTP2.md
@@ -4,7 +4,7 @@
 This document serves as a detailed description for an implementation of gRPC carried over <a href="https://tools.ietf.org/html/rfc7540">HTTP2 framing</a>. It assumes familiarity with the HTTP2 specification.
 
 ## Protocol
-Production rules are using <a href="http://tools.ietf.org/html/rfc5234">ABNF syntax</a>.
+Production rules are using <a href="https://tools.ietf.org/html/rfc5234">ABNF syntax</a>.
 
 ### Outline
 


### PR DESCRIPTION
change rfc5234 link protocol to https.

