### PR TITLE
Include an invalid config to custom LB test

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py
@@ -38,8 +38,17 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
         # Configures a custom, test LB on the client to instruct the servers
         # to always respond with a specific error code.
+        #
+        # The first policy in the list is a non-existent one to verify that
+        # the gRPC client can gracefully move down the list to the valid one
+        # once it determines the first one is not available.
         with self.subTest('1_create_backend_service'):
             self.td.create_backend_service(locality_lb_policies=[{
+                'customPolicy': {
+                    'name': 'test.ThisLoadBalancerDoesNotExist',
+                    'data': '{ "foo": "bar" }'
+                },
+            }, {
                 'customPolicy': {
                     'name':
                         'test.RpcBehaviorLoadBalancer',


### PR DESCRIPTION
This will verify that the configuration for a missing LB gets skipped
in favor of the valid one.
