### PR TITLE
Changed num_threads based on slowness factor for xSAN

### DIFF
--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -43,7 +43,13 @@
 using grpc::testing::EchoRequest;
 using grpc::testing::EchoResponse;
 
+#if defined(__APPLE__)
+// Use less # of threads on Mac because its test machines are less powerful
+// to finish the test on time. (context: b/185231823)
+const int kNumThreads = 100;  // Number of threads
+#else
 const int kNumThreads = 300;  // Number of threads
+#endif
 const int kNumAsyncSendThreads = 2;
 const int kNumAsyncReceiveThreads = 50;
 const int kNumAsyncServerThreads = 50;

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -314,12 +314,13 @@ TYPED_TEST(End2endTest, ThreadStress) {
   std::vector<std::thread> threads;
   gpr_atm errors;
   gpr_atm_rel_store(&errors, static_cast<gpr_atm>(0));
-  threads.reserve(kNumThreads);
-  for (int i = 0; i < kNumThreads; ++i) {
+  int num_threads = kNumThreads / grpc_test_slowdown_factor();
+  threads.reserve(num_threads);
+  for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back(SendRpc, this->common_.GetStub(), kNumRpcs,
                          this->common_.AllowExhaustion(), &errors);
   }
-  for (int i = 0; i < kNumThreads; ++i) {
+  for (int i = 0; i < num_threads; ++i) {
     threads[i].join();
   }
   uint64_t error_cnt = static_cast<uint64_t>(gpr_atm_no_barrier_load(&errors));

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -315,6 +315,8 @@ TYPED_TEST(End2endTest, ThreadStress) {
   gpr_atm errors;
   gpr_atm_rel_store(&errors, static_cast<gpr_atm>(0));
   int num_threads = kNumThreads / grpc_test_slowdown_factor();
+  // The number of threads should be > 10 to be able to catch errors
+  ASSERT_GT(num_threads, 10);
   threads.reserve(num_threads);
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back(SendRpc, this->common_.GetStub(), kNumRpcs,


### PR DESCRIPTION
Details: b/236048892 

Recently the duration of `test/cpp/end2end:thread_stress_test` kept increasing and got close to the limit of 30min under mSAN particularly so I changed this test to use less threads based on `grpc_test_slowdown_factor`.