### PR TITLE
xds interop test: temporarily disable failover test

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
@@ -18,6 +18,7 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_k8s_testcase
+from framework.helpers import skips
 from framework.infrastructure import k8s
 from framework.test_app import server_app
 
@@ -27,6 +28,7 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 # Type aliases
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
+_Lang = skips.Lang
 
 
 class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
@@ -35,8 +37,10 @@ class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        # disabled because test case implementation seems wrong b/238226704
-        return False
+        # Test case implementation seems to be broken for Java and Go.
+        # Core (cpp and python), and Node seem to work fine.
+        # TODO(b/238226704): Remove when the test is fixed.
+        return config.client_lang not in _Lang.JAVA | _Lang.GO
 
     def setUp(self):
         super().setUp()

--- a/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
@@ -33,6 +33,11 @@ class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     REPLICA_COUNT = 3
     MAX_RATE_PER_ENDPOINT = 100
 
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        # disabled because test case implementation seems wrong b/238226704
+        return False
+
     def setUp(self):
         super().setUp()
         self.secondary_server_runner = server_app.KubernetesServerRunner(


### PR DESCRIPTION
Blast radius of the test is too high. 
To mitigate, disable until we validate and fix failover test case

Ref b/238226704