### PR TITLE
Allow Gradle to use more memory when building Java interop

### DIFF
--- a/templates/tools/dockerfile/java_build_interop.sh.include
+++ b/templates/tools/dockerfile/java_build_interop.sh.include
@@ -21,6 +21,8 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
+export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
+
 pushd /tmp/grpc-java
 # make two attempts; downloads can fail. See https://github.com/grpc/grpc/issues/18892
 ./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true || ${'\\'}

--- a/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
@@ -21,6 +21,8 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
+export GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'"
+
 pushd /tmp/grpc-java
 # make two attempts; downloads can fail. See https://github.com/grpc/grpc/issues/18892
 ./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true -PskipAndroid=true || \


### PR DESCRIPTION
Should fix "Expiring Daemon because JVM heap space is exhausted".

https://github.com/grpc/grpc-java/pull/9269 probably pushed the build
over the edge, but there's been evidence via flakes for a good while
that we've been reaching the limit.

b/238438006