### PR TITLE
[chttp2] Fix import related bug

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -774,8 +774,8 @@ void grpc_chttp2_fail_pending_writes(grpc_chttp2_transport* t,
 
 /** Set the default keepalive configurations, must only be called at
     initialization */
-void grpc_chttp2_config_default_keepalive_args(
-    const grpc_core::ChannelArgs& args, bool is_client);
+void grpc_chttp2_config_default_keepalive_args(grpc_channel_args* args,
+                                               bool is_client);
 
 void grpc_chttp2_retry_initiate_ping(void* tp, grpc_error_handle error);
 


### PR DESCRIPTION
This function signature changed by accident; it's not used anywhere in the OSS codebase, only internally (perhaps a good hint that it should be eliminated... I'm going to look into that).

Revert the signature from the change in #30252 to unblock the import.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

