### PR TITLE
XdsClient: drop refs to ChannelState objects upon XdsClient shutdown

### DIFF
--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -1193,9 +1193,11 @@ void XdsClient::ChannelState::LrsCallState::Reporter::OnReportDoneLocked() {
   // If there are no more registered stats to report, cancel the call.
   auto it =
       xds_client()->xds_load_report_server_map_.find(parent_->chand()->server_);
-  if (it == xds_client()->xds_load_report_server_map_.end() ||
-      it->second.load_report_map.empty()) {
-    it->second.channel_state->StopLrsCallLocked();
+  if (it == xds_client()->xds_load_report_server_map_.end()) return;
+  if (it->second.load_report_map.empty()) {
+    if (it->second.channel_state != nullptr) {
+      it->second.channel_state->StopLrsCallLocked();
+    }
     return;
   }
   // Otherwise, schedule the next load report.

--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -1414,6 +1414,13 @@ void XdsClient::Orphan() {
   // Clear cache and any remaining watchers that may not have been cancelled.
   authority_state_map_.clear();
   invalid_watchers_.clear();
+  // We may still be sending lingering queued load report data, so don't
+  // just clear the load reporting map, but we do want to clear the refs
+  // we're holding to the ChannelState objects, to make sure that
+  // everything shuts down properly.
+  for (auto& p : xds_load_report_server_map_) {
+    p.second.channel_state.reset(DEBUG_LOCATION, "XdsClient::Orphan()");
+  }
 }
 
 RefCountedPtr<XdsClient::ChannelState> XdsClient::GetOrCreateChannelStateLocked(


### PR DESCRIPTION
Possible fix for b/238634105.