### PR TITLE
Adding lock and reset call_ in ~ClientContext to avoid race condition

### DIFF
--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -77,8 +77,12 @@ ClientContext::ClientContext()
 }
 
 ClientContext::~ClientContext() {
-  if (call_) {
-    grpc_call_unref(call_);
+  {
+    internal::MutexLock lock(&mu_);
+    if (call_) {
+      grpc_call_unref(call_);
+      call_ = nullptr;
+    }
   }
   g_client_callbacks->Destructor(this);
 }

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -77,12 +77,9 @@ ClientContext::ClientContext()
 }
 
 ClientContext::~ClientContext() {
-  {
-    internal::MutexLock lock(&mu_);
-    if (call_) {
-      grpc_call_unref(call_);
-      call_ = nullptr;
-    }
+  if (call_) {
+    grpc_call_unref(call_);
+    call_ = nullptr;
   }
   g_client_callbacks->Destructor(this);
 }


### PR DESCRIPTION
Adding lock and reset call_ in ~ClientContext to avoid race condition

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

