### PR TITLE
Python examples: change localhost to 127.0.0.1

### DIFF
--- a/examples/python/async_streaming/client.py
+++ b/examples/python/async_streaming/client.py
@@ -108,7 +108,7 @@ def process_call(executor: ThreadPoolExecutor, channel: grpc.Channel,
 
 def run():
     executor = ThreadPoolExecutor()
-    with grpc.insecure_channel("localhost:50051") as channel:
+    with grpc.insecure_channel("127.0.0.1:50051") as channel:
         future = executor.submit(process_call, executor, channel,
                                  "555-0100-XXXX")
         future.result()

--- a/examples/python/auth/async_customized_auth_client.py
+++ b/examples/python/auth/async_customized_auth_client.py
@@ -26,7 +26,7 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
 
-_SERVER_ADDR_TEMPLATE = 'localhost:%d'
+_SERVER_ADDR_TEMPLATE = '127.0.0.1:%d'
 _SIGNATURE_HEADER_KEY = 'x-signature'
 
 
@@ -46,7 +46,7 @@ class AuthGateway(grpc.AuthMetadataPlugin):
         """
         # Example AuthMetadataContext object:
         # AuthMetadataContext(
-        #     service_url=u'https://localhost:50051/helloworld.Greeter',
+        #     service_url=u'https://127.0.0.1:50051/helloworld.Greeter',
         #     method_name=u'SayHello')
         signature = context.method_name[::-1]
         callback(((_SIGNATURE_HEADER_KEY, signature),), None)

--- a/examples/python/auth/async_customized_auth_server.py
+++ b/examples/python/auth/async_customized_auth_server.py
@@ -27,7 +27,7 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
 
-_LISTEN_ADDRESS_TEMPLATE = 'localhost:%d'
+_LISTEN_ADDRESS_TEMPLATE = '127.0.0.1:%d'
 _SIGNATURE_HEADER_KEY = 'x-signature'
 
 

--- a/examples/python/auth/customized_auth_client.py
+++ b/examples/python/auth/customized_auth_client.py
@@ -26,7 +26,7 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
 
-_SERVER_ADDR_TEMPLATE = 'localhost:%d'
+_SERVER_ADDR_TEMPLATE = '127.0.0.1:%d'
 _SIGNATURE_HEADER_KEY = 'x-signature'
 
 
@@ -45,7 +45,7 @@ class AuthGateway(grpc.AuthMetadataPlugin):
         """
         # Example AuthMetadataContext object:
         # AuthMetadataContext(
-        #     service_url=u'https://localhost:50051/helloworld.Greeter',
+        #     service_url=u'https://127.0.0.1:50051/helloworld.Greeter',
         #     method_name=u'SayHello')
         signature = context.method_name[::-1]
         callback(((_SIGNATURE_HEADER_KEY, signature),), None)

--- a/examples/python/auth/customized_auth_server.py
+++ b/examples/python/auth/customized_auth_server.py
@@ -27,7 +27,7 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
 
-_LISTEN_ADDRESS_TEMPLATE = 'localhost:%d'
+_LISTEN_ADDRESS_TEMPLATE = '127.0.0.1:%d'
 _SIGNATURE_HEADER_KEY = 'x-signature'
 
 

--- a/examples/python/auth/test/_auth_example_test.py
+++ b/examples/python/auth/test/_auth_example_test.py
@@ -24,7 +24,7 @@ from examples.python.auth import async_customized_auth_server
 from examples.python.auth import customized_auth_client
 from examples.python.auth import customized_auth_server
 
-_SERVER_ADDR_TEMPLATE = 'localhost:%d'
+_SERVER_ADDR_TEMPLATE = '127.0.0.1:%d'
 
 
 class AuthExampleTest(unittest.TestCase):

--- a/examples/python/cancellation/client.py
+++ b/examples/python/cancellation/client.py
@@ -75,7 +75,7 @@ def main():
                         type=int,
                         help="The desired Hamming distance.")
     parser.add_argument('--server',
-                        default='localhost:50051',
+                        default='127.0.0.1:50051',
                         type=str,
                         nargs='?',
                         help='The host-port pair at which to reach the server.')

--- a/examples/python/cancellation/server.py
+++ b/examples/python/cancellation/server.py
@@ -29,7 +29,7 @@ from examples.python.cancellation import hash_name_pb2
 from examples.python.cancellation import hash_name_pb2_grpc
 
 _LOGGER = logging.getLogger(__name__)
-_SERVER_HOST = 'localhost'
+_SERVER_HOST = '127.0.0.1'
 
 _DESCRIPTION = "A server for finding hashes similar to names."
 

--- a/examples/python/cancellation/test/_cancellation_example_test.py
+++ b/examples/python/cancellation/test/_cancellation_example_test.py
@@ -46,7 +46,7 @@ def _start_client(server_port,
     interesting_distance_args = () if interesting_distance is None else (
         '--show-inferior', interesting_distance)
     return subprocess.Popen((_CLIENT_PATH, desired_string, '--server',
-                             'localhost:{}'.format(server_port),
+                             '127.0.0.1:{}'.format(server_port),
                              '--ideal-distance', str(ideal_distance)) +
                             interesting_distance_args)
 

--- a/examples/python/compression/client.py
+++ b/examples/python/compression/client.py
@@ -59,7 +59,7 @@ def main():
         choices=_COMPRESSION_OPTIONS.keys(),
         help='The compression method to use for an individual call.')
     parser.add_argument('--server',
-                        default='localhost:50051',
+                        default='127.0.0.1:50051',
                         type=str,
                         nargs='?',
                         help='The host-port pair at which to reach the server.')

--- a/examples/python/compression/server.py
+++ b/examples/python/compression/server.py
@@ -35,7 +35,7 @@ _COMPRESSION_OPTIONS = {
 }
 _LOGGER = logging.getLogger(__name__)
 
-_SERVER_HOST = 'localhost'
+_SERVER_HOST = '127.0.0.1'
 
 
 class Greeter(helloworld_pb2_grpc.GreeterServicer):

--- a/examples/python/compression/test/compression_example_test.py
+++ b/examples/python/compression/test/compression_example_test.py
@@ -46,7 +46,7 @@ class CompressionExampleTest(unittest.TestCase):
                 (_SERVER_PATH, '--port', str(test_port), '--server_compression',
                  'gzip'))
             try:
-                server_target = 'localhost:{}'.format(test_port)
+                server_target = '127.0.0.1:{}'.format(test_port)
                 client_process = subprocess.Popen(
                     (_CLIENT_PATH, '--server', server_target,
                      '--channel_compression', 'gzip'))

--- a/examples/python/data_transmission/alts_client.py
+++ b/examples/python/data_transmission/alts_client.py
@@ -23,7 +23,7 @@ from client import server_streaming_method
 from client import simple_method
 import demo_pb2_grpc
 
-SERVER_ADDRESS = "localhost:23333"
+SERVER_ADDRESS = "127.0.0.1:23333"
 
 
 def main():

--- a/examples/python/data_transmission/alts_server.py
+++ b/examples/python/data_transmission/alts_server.py
@@ -22,7 +22,7 @@ import grpc
 import demo_pb2_grpc
 from server import DemoServer
 
-SERVER_ADDRESS = 'localhost:23333'
+SERVER_ADDRESS = '127.0.0.1:23333'
 
 
 def main():

--- a/examples/python/data_transmission/client.py
+++ b/examples/python/data_transmission/client.py
@@ -25,7 +25,7 @@ __all__ = [
     'bidirectional_streaming_method'
 ]
 
-SERVER_ADDRESS = "localhost:23333"
+SERVER_ADDRESS = "127.0.0.1:23333"
 CLIENT_ID = 1
 
 # 中文注释和英文翻译

--- a/examples/python/data_transmission/server.py
+++ b/examples/python/data_transmission/server.py
@@ -22,7 +22,7 @@ import demo_pb2
 import demo_pb2_grpc
 
 __all__ = 'DemoServer'
-SERVER_ADDRESS = 'localhost:23333'
+SERVER_ADDRESS = '127.0.0.1:23333'
 SERVER_ID = 1
 
 

--- a/examples/python/debug/test/_debug_example_test.py
+++ b/examples/python/debug/test/_debug_example_test.py
@@ -30,7 +30,7 @@ _LOGGER.setLevel(logging.INFO)
 _FAILURE_RATE = 0.5
 _NUMBER_OF_MESSAGES = 100
 
-_ADDR_TEMPLATE = 'localhost:%d'
+_ADDR_TEMPLATE = '127.0.0.1:%d'
 
 
 class DebugExampleTest(unittest.TestCase):

--- a/examples/python/errors/client.py
+++ b/examples/python/errors/client.py
@@ -47,7 +47,7 @@ def main():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         process(stub)
 

--- a/examples/python/errors/test/_error_handling_example_test.py
+++ b/examples/python/errors/test/_error_handling_example_test.py
@@ -36,7 +36,7 @@ class ErrorHandlingExampleTest(unittest.TestCase):
     def setUp(self):
         self._server, port = error_handling_server.create_server('[::]:0')
         self._server.start()
-        self._channel = grpc.insecure_channel('localhost:%d' % port)
+        self._channel = grpc.insecure_channel('127.0.0.1:%d' % port)
 
     def tearDown(self):
         self._channel.close()

--- a/examples/python/hellostreamingworld/async_greeter_client.py
+++ b/examples/python/hellostreamingworld/async_greeter_client.py
@@ -22,7 +22,7 @@ import hellostreamingworld_pb2_grpc
 
 
 async def run() -> None:
-    async with grpc.aio.insecure_channel("localhost:50051") as channel:
+    async with grpc.aio.insecure_channel("127.0.0.1:50051") as channel:
         stub = hellostreamingworld_pb2_grpc.MultiGreeterStub(channel)
 
         # Read from an async generator

--- a/examples/python/helloworld/async_greeter_client.py
+++ b/examples/python/helloworld/async_greeter_client.py
@@ -22,7 +22,7 @@ import helloworld_pb2_grpc
 
 
 async def run() -> None:
-    async with grpc.aio.insecure_channel('localhost:50051') as channel:
+    async with grpc.aio.insecure_channel('127.0.0.1:50051') as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         response = await stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
     print("Greeter client received: " + response.message)

--- a/examples/python/helloworld/async_greeter_client_with_options.py
+++ b/examples/python/helloworld/async_greeter_client_with_options.py
@@ -27,7 +27,7 @@ CHANNEL_OPTIONS = [('grpc.lb_policy_name', 'pick_first'),
 
 
 async def run() -> None:
-    async with grpc.aio.insecure_channel(target='localhost:50051',
+    async with grpc.aio.insecure_channel(target='127.0.0.1:50051',
                                          options=CHANNEL_OPTIONS) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         # Timeout in seconds.

--- a/examples/python/helloworld/greeter_client.py
+++ b/examples/python/helloworld/greeter_client.py
@@ -26,7 +26,7 @@ def run():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
     print("Greeter client received: " + response.message)

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -28,7 +28,7 @@ def run():
     # of the code.
     #
     # For more channel options, please see https://grpc.io/grpc/core/group__grpc__arg__keys.html
-    with grpc.insecure_channel(target='localhost:50051',
+    with grpc.insecure_channel(target='127.0.0.1:50051',
                                options=[('grpc.lb_policy_name', 'pick_first'),
                                         ('grpc.enable_retries', 0),
                                         ('grpc.keepalive_timeout_ms', 10000)

--- a/examples/python/interceptors/default_value/greeter_client.py
+++ b/examples/python/interceptors/default_value/greeter_client.py
@@ -31,7 +31,7 @@ def run():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         intercept_channel = grpc.intercept_channel(channel,
                                                    default_value_interceptor)
         stub = helloworld_pb2_grpc.GreeterStub(intercept_channel)

--- a/examples/python/interceptors/headers/greeter_client.py
+++ b/examples/python/interceptors/headers/greeter_client.py
@@ -29,7 +29,7 @@ def run():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         intercept_channel = grpc.intercept_channel(channel,
                                                    header_adder_interceptor)
         stub = helloworld_pb2_grpc.GreeterStub(intercept_channel)

--- a/examples/python/metadata/metadata_client.py
+++ b/examples/python/metadata/metadata_client.py
@@ -26,7 +26,7 @@ def run():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         response, call = stub.SayHello.with_call(
             helloworld_pb2.HelloRequest(name='you'),

--- a/examples/python/multiplex/multiplex_client.py
+++ b/examples/python/multiplex/multiplex_client.py
@@ -109,7 +109,7 @@ def run():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         greeter_stub = helloworld_pb2_grpc.GreeterStub(channel)
         route_guide_stub = route_guide_pb2_grpc.RouteGuideStub(channel)
         greeter_response = greeter_stub.SayHello(

--- a/examples/python/multiprocessing/client.py
+++ b/examples/python/multiprocessing/client.py
@@ -77,7 +77,7 @@ def main():
         _MAXIMUM_CANDIDATE)
     parser = argparse.ArgumentParser(description=msg)
     parser.add_argument('server_address',
-                        help='The address of the server (e.g. localhost:50051)')
+                        help='The address of the server (e.g. 127.0.0.1:50051)')
     args = parser.parse_args()
     primes = _calculate_primes(args.server_address)
     print(primes)

--- a/examples/python/multiprocessing/server.py
+++ b/examples/python/multiprocessing/server.py
@@ -91,7 +91,7 @@ def _reserve_port():
 
 def main():
     with _reserve_port() as port:
-        bind_address = 'localhost:{}'.format(port)
+        bind_address = '127.0.0.1:{}'.format(port)
         _LOGGER.info("Binding to '%s'", bind_address)
         sys.stdout.flush()
         workers = []

--- a/examples/python/no_codegen/greeter_client.py
+++ b/examples/python/no_codegen/greeter_client.py
@@ -36,6 +36,6 @@ services = grpc.services("helloworld.proto")
 logging.basicConfig()
 
 response = services.Greeter.SayHello(protos.HelloRequest(name='you'),
-                                     'localhost:50051',
+                                     '127.0.0.1:50051',
                                      insecure=True)
 print("Greeter client received: " + response.message)

--- a/examples/python/retry/async_retry_client.py
+++ b/examples/python/retry/async_retry_client.py
@@ -46,7 +46,7 @@ async def run() -> None:
     # NOTE: the retry feature will be enabled by default >=v1.40.0
     options.append(("grpc.enable_retries", 1))
     options.append(("grpc.service_config", service_config_json))
-    async with grpc.aio.insecure_channel('localhost:50051',
+    async with grpc.aio.insecure_channel('127.0.0.1:50051',
                                          options=options) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         response = await stub.SayHello(helloworld_pb2.HelloRequest(name='you'))

--- a/examples/python/retry/retry_client.py
+++ b/examples/python/retry/retry_client.py
@@ -45,7 +45,7 @@ def run():
     # NOTE: the retry feature will be enabled by default >=v1.40.0
     options.append(("grpc.enable_retries", 1))
     options.append(("grpc.service_config", service_config_json))
-    with grpc.insecure_channel('localhost:50051', options=options) as channel:
+    with grpc.insecure_channel('127.0.0.1:50051', options=options) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
     print("Greeter client received: " + response.message)

--- a/examples/python/route_guide/asyncio_route_guide_client.py
+++ b/examples/python/route_guide/asyncio_route_guide_client.py
@@ -112,7 +112,7 @@ async def guide_route_chat(stub: route_guide_pb2_grpc.RouteGuideStub) -> None:
 
 
 async def main() -> None:
-    async with grpc.aio.insecure_channel('localhost:50051') as channel:
+    async with grpc.aio.insecure_channel('127.0.0.1:50051') as channel:
         stub = route_guide_pb2_grpc.RouteGuideStub(channel)
         print("-------------- GetFeature --------------")
         await guide_get_feature(stub)

--- a/examples/python/route_guide/route_guide_client.py
+++ b/examples/python/route_guide/route_guide_client.py
@@ -102,7 +102,7 @@ def run():
     # NOTE(gRPC Python Team): .close() is possible on a channel and should be
     # used in circumstances in which the with statement does not fit the needs
     # of the code.
-    with grpc.insecure_channel('localhost:50051') as channel:
+    with grpc.insecure_channel('127.0.0.1:50051') as channel:
         stub = route_guide_pb2_grpc.RouteGuideStub(channel)
         print("-------------- GetFeature --------------")
         guide_get_feature(stub)

--- a/examples/python/wait_for_ready/asyncio_wait_for_ready_example.py
+++ b/examples/python/wait_for_ready/asyncio_wait_for_ready_example.py
@@ -36,7 +36,7 @@ def get_free_loopback_tcp_port() -> Iterable[str]:
         tcp_socket = socket.socket(socket.AF_INET)
     tcp_socket.bind(('', 0))
     address_tuple = tcp_socket.getsockname()
-    yield f"localhost:{address_tuple[1]}"
+    yield f"127.0.0.1:{address_tuple[1]}"
     tcp_socket.close()
 
 

--- a/examples/python/wait_for_ready/wait_for_ready_example.py
+++ b/examples/python/wait_for_ready/wait_for_ready_example.py
@@ -36,7 +36,7 @@ def get_free_loopback_tcp_port():
         tcp_socket = socket.socket(socket.AF_INET)
     tcp_socket.bind(('', 0))
     address_tuple = tcp_socket.getsockname()
-    yield "localhost:%s" % (address_tuple[1])
+    yield "127.0.0.1:%s" % (address_tuple[1])
     tcp_socket.close()
 
 


### PR DESCRIPTION
This PR changes all `localhost` mentions to `127.0.0.1` in the Python examples, which speeds up requests by > 30 seconds on some machines.

Resolves #30282