### PR TITLE
[bazel] fix python detection on windows

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -345,7 +345,7 @@ def _python_autoconf_impl(repository_ctx):
         repository_ctx,
         "_python3",
         _PYTHON3_BIN_PATH,
-        "python3",
+        "python3" if not _is_windows(repository_ctx) else "python.exe",
         _PYTHON3_LIB_PATH,
         False
     )


### PR DESCRIPTION
This adds a patch that has been used internally for our project (https://github.com/ray-project/ray) for some time. Thought, I'd upstream it so that others can enjoy windows support.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

@gnossen 

