### PR TITLE
xds interop: resume failover tests

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
@@ -28,12 +28,17 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 # Type aliases
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
-_Lang = skips.Lang
 
 
 class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     REPLICA_COUNT = 3
     MAX_RATE_PER_ENDPOINT = 100
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        # TODO(b/238226704): Remove when the fix for selecting correct
+        #  cluster is backported.
+        return config.version_gte('master')
 
     def setUp(self):
         super().setUp()

--- a/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
@@ -35,13 +35,6 @@ class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     REPLICA_COUNT = 3
     MAX_RATE_PER_ENDPOINT = 100
 
-    @staticmethod
-    def is_supported(config: skips.TestConfig) -> bool:
-        # Test case implementation seems to be broken for Java and Go.
-        # Core (cpp and python), and Node seem to work fine.
-        # TODO(b/238226704): Remove when the test is fixed.
-        return config.client_lang not in _Lang.JAVA | _Lang.GO | _Lang.CPP
-
     def setUp(self):
         super().setUp()
         self.secondary_server_runner = server_app.KubernetesServerRunner(


### PR DESCRIPTION
Resume the failover test. For now, just on master. Will be resumed on other branches, when the fix is backported.
At the moment, the master is fixed in:

- https://github.com/grpc/grpc-go/pull/5508
- https://github.com/grpc/grpc-java/pull/9380

ref b/238226704