### PR TITLE
xds interop: choose correct cluster in grpc_xds_k8s_lb_python.sh

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
@@ -138,8 +138,8 @@ main() {
   echo "Sourcing test driver install script from: ${TEST_DRIVER_INSTALL_SCRIPT_URL}"
   source /dev/stdin <<< "$(curl -s "${TEST_DRIVER_INSTALL_SCRIPT_URL}")"
 
-  activate_gke_cluster GKE_CLUSTER_PSM_SECURITY
-  activate_secondary_gke_cluster GKE_CLUSTER_PSM_SECURITY
+  activate_gke_cluster GKE_CLUSTER_PSM_LB
+  activate_secondary_gke_cluster GKE_CLUSTER_PSM_LB
 
   set -x
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then


### PR DESCRIPTION
Discovered it while investigating the failover test issue. For some reason, python LB tests are using the cluster used for PSM Security tests - and also the same cluster for primary and secondary roles.

cc @YifeiZhuang