### PR TITLE
Add instruction for building on macOS with M1 chip

### DIFF
--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -64,7 +64,10 @@ package named :code:`python-dev`).
   $ GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
 
 
-If you're on macOS with M1 chip (Apple Silicone), allow using system OpenSSL and zlib. If you don't have :code:`OpenSSL` and :code:`zlib` installed already, you can install them with Homebrew first, then follow the instructions in the installation output for exporting the two libraries' build flags.
+If you're on macOS with M1 chip (Apple Silicon), allow using system OpenSSL
+and zlib. If you don't have :code:`OpenSSL` and :code:`zlib` installed already,
+you can install them with Homebrew first, then follow the instructions in the
+installation output for exporting the two libraries' build flags.
 
 
 ::
@@ -133,4 +136,3 @@ Help, I ...
   ::
 
     export CPPFLAGS="$CPPFLAGS -I/path/to/python/include/python3.10"
-

--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -60,8 +60,15 @@ package named :code:`python-dev`).
   $ git submodule update --init
 
   # For the next two commands do `sudo pip install` if you get permission-denied errors
-  $ pip install -rrequirements.txt
+  $ pip install -r requirements.txt
   $ GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
+
+
+If you're on macOS with M1 chip (Apple Silicone), add :code:`GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1` and :code:`GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1`
+
+::
+
+  $ GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
 
 You cannot currently install Python from source on Windows. Things might work
 out for you in MSYS2 (follow the Linux instructions), but it isn't officially
@@ -107,9 +114,15 @@ Help, I ...
                     ^
     compilation terminated.
 
-  You can fix it by installing `python-dev` package. i.e
+  You can fix it by installing :code:`python-dev` package. i.e
 
   ::
 
     sudo apt-get install python-dev
+    
+  On macOS: append the path to the headers to :code:`CPPFLAGS`. For example:
+
+  ::
+
+    export CPPFLAGS="$CPPFLAGS -I/path/to/python/include/python3.10"
 

--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -64,7 +64,15 @@ package named :code:`python-dev`).
   $ GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
 
 
-If you're on macOS with M1 chip (Apple Silicone), add :code:`GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1` and :code:`GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1`
+If you're on macOS with M1 chip (Apple Silicone), allow using system OpenSSL and zlib. If you don't have :code:`OpenSSL` and :code:`zlib` installed already, you can install them with Homebrew first, then follow the instructions in the installation output for exporting the two libraries' build flags.
+
+
+::
+
+  $ brew install openssl zlib
+
+
+Then build the package with the following variables:
 
 ::
 


### PR DESCRIPTION
**This PR aims to add necessary instructions on building `grpcio` package for Python on macOS with M1 chip.**

Building `grpcio` fails on macOS with M1 chip.

**Addition 1:** Build initially fails because the header files and static libraries for python dev cannot be found. While this can be solved by installing `python-devel` on most Linux system as described in `README`, it's a little different on macOS. If Python was installed with Homebrew, then the relevant headers should be installed and their path is passed along as a build flag if the user install Python correctly. The relevant build flags need to be exported in the shell environment (i.e., the user needs to append the headers path to  `CPPFLAGS` and export the variable). I updated `README` to show this information.


**Addition 2:** Build fails because "ASM Builds for BoringSSL are not supported on macOS-arm64.

Short traceback:

```
Processing /Users/Alyetama/grpc
  Preparing metadata (setup.py) ... done
Requirement already satisfied: six>=1.5.2 in /Users/Alyetama/miniforge3/lib/python3.10/site-packages (from grpcio==1.47.1) (1.16.0)
Building wheels for collected packages: grpcio
  Building wheel for grpcio (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [859 lines of output]
      ASM Builds for BoringSSL currently not supported on: macosx-11.0-arm64
...
```

Full traceback can be viewed [here](https://gist.github.com/Alyetama/080009096c11fab3805be65370226ea5).

The error can be fixed by using system libraries for `OpenSSL` and `zlib`. I updated the `README` file to add the relevant instructions.

