### PR TITLE
Mark the definitions of constinit variables as constinit.

### DIFF
--- a/src/core/ext/transport/binder/wire_format/binder_constants.cc
+++ b/src/core/ext/transport/binder/wire_format/binder_constants.cc
@@ -18,12 +18,12 @@
 
 #include "src/core/ext/transport/binder/wire_format/binder_constants.h"
 
-const int FIRST_CALL_TRANSACTION = 0x00000001;
-const int LAST_CALL_TRANSACTION = 0x00FFFFFF;
+ABSL_CONST_INIT const int FIRST_CALL_TRANSACTION = 0x00000001;
+ABSL_CONST_INIT const int LAST_CALL_TRANSACTION = 0x00FFFFFF;
 
 namespace grpc_binder {
 
-const int kFirstCallId = FIRST_CALL_TRANSACTION + 1000;
+ABSL_CONST_INIT const int kFirstCallId = FIRST_CALL_TRANSACTION + 1000;
 
 }  // namespace grpc_binder
 #endif

--- a/src/core/ext/transport/binder/wire_format/transaction.cc
+++ b/src/core/ext/transport/binder/wire_format/transaction.cc
@@ -20,14 +20,14 @@
 
 namespace grpc_binder {
 
-const int kFlagPrefix = 0x1;
-const int kFlagMessageData = 0x2;
-const int kFlagSuffix = 0x4;
-const int kFlagOutOfBandClose = 0x8;
-const int kFlagExpectSingleMessage = 0x10;
-const int kFlagStatusDescription = 0x20;
-const int kFlagMessageDataIsParcelable = 0x40;
-const int kFlagMessageDataIsPartial = 0x80;
+ABSL_CONST_INIT const int kFlagPrefix = 0x1;
+ABSL_CONST_INIT const int kFlagMessageData = 0x2;
+ABSL_CONST_INIT const int kFlagSuffix = 0x4;
+ABSL_CONST_INIT const int kFlagOutOfBandClose = 0x8;
+ABSL_CONST_INIT const int kFlagExpectSingleMessage = 0x10;
+ABSL_CONST_INIT const int kFlagStatusDescription = 0x20;
+ABSL_CONST_INIT const int kFlagMessageDataIsParcelable = 0x40;
+ABSL_CONST_INIT const int kFlagMessageDataIsPartial = 0x80;
 
 }  // namespace grpc_binder
 #endif


### PR DESCRIPTION
This is necessary to compile with --std=c++20.

Bug: chromium:1284275




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

