### PR TITLE
[objc] Support test assert with flaky retry

### DIFF
--- a/src/objective-c/tests/Common/TestUtils.h
+++ b/src/objective-c/tests/Common/TestUtils.h
@@ -28,9 +28,13 @@ FOUNDATION_EXPORT const NSTimeInterval GRPCInteropTestTimeoutDefault;
 typedef void (^GRPCTestWaiter)(XCTestCase *testCase, NSArray<XCTestExpectation *> *expectations,
                                NSTimeInterval timeout);
 
+// Block typedef for asserting a given expression value with optional retry.
+typedef void (^GRPCTestAssert)(BOOL expressionValue, NSString *message);
+
 // Block typedef for a test run. Test run should call waiter to wait for a group of expectations
-// with timeout.
-typedef void (^GRPCTestRunBlock)(GRPCTestWaiter waiterBlock);
+// with timeout. Test run can also optionally invoke assertBlock to report assertion failure.
+// Failed assertion will be retried up to maximum retry.
+typedef void (^GRPCTestRunBlock)(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock);
 
 /**
  * Common utility to fetch plain text local interop server address.

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -464,7 +464,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testEmptyUnaryRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiter) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiter, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"EmptyUnary"];
 
@@ -489,7 +489,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testEmptyUnaryRPCWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectReceive =
         [self expectationWithDescription:@"EmptyUnaryWithV2API received message"];
@@ -533,7 +533,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
 // Test that responses can be dispatched even if we do not run main run-loop
 - (void)testAsyncDispatchWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
 
     XCTestExpectation *receiveExpect = [self expectationWithDescription:@"receiveExpect"];
@@ -583,7 +583,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testLargeUnaryRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"LargeUnary"];
 
@@ -619,7 +619,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
     return;
   }
 
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
 
     XCTestExpectation *expectComplete = [self expectationWithDescription:@"call complete"];
@@ -693,7 +693,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testLargeUnaryRPCWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectReceive =
         [self expectationWithDescription:@"LargeUnaryWithV2API received message"];
@@ -746,7 +746,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testConcurrentRPCsWithErrorsWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter _Nonnull waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     NSMutableArray *completeExpectations = [NSMutableArray array];
     NSMutableArray *calls = [NSMutableArray array];
@@ -862,7 +862,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testPacketCoalescing {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"LargeUnary"];
 
@@ -907,7 +907,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)test4MBResponsesAreAccepted {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"MaxResponseSize"];
 
@@ -932,7 +932,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testResponsesOverMaxSizeFailWithActionableMessage {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"ResponseOverMaxSize"];
@@ -966,7 +966,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testResponsesOver4MBAreAcceptedIfOptedIn {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"HigherResponseSizeLimit"];
@@ -993,7 +993,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testClientStreamingRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"ClientStreaming"];
 
@@ -1035,7 +1035,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testServerStreamingRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"ServerStreaming"];
 
@@ -1050,37 +1050,50 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     __block int index = 0;
     __weak RMTTestService *weakService = service;
-    [service streamingOutputCallWithRequest:request
-                               eventHandler:^(BOOL done, RMTStreamingOutputCallResponse *response,
-                                              NSError *error) {
-                                 if (weakService == nil) {
-                                   return;
-                                 }
-                                 XCTAssertNil(error, @"Finished with unexpected error: %@", error);
-                                 XCTAssertTrue(done || response,
-                                               @"Event handler called without an event.");
+    [service
+        streamingOutputCallWithRequest:request
+                          eventHandler:^(BOOL done, RMTStreamingOutputCallResponse *response,
+                                         NSError *error) {
+                            if (weakService == nil) {
+                              return;
+                            }
 
-                                 if (response) {
-                                   XCTAssertLessThan(index, 4, @"More than 4 responses received.");
-                                   id expected = [RMTStreamingOutputCallResponse
-                                       messageWithPayloadSize:expectedSizes[index]];
-                                   XCTAssertEqualObjects(response, expected);
-                                   index += 1;
-                                 }
+                            assertBlock(
+                                error == nil,
+                                [NSString
+                                    stringWithFormat:@"Finished with unexpected error: %@", error]);
+                            assertBlock(done || response,
+                                        @"Event handler called without an event.");
 
-                                 if (done) {
-                                   XCTAssertEqual(index, 4, @"Received %i responses instead of 4.",
-                                                  index);
-                                   [expectation fulfill];
-                                 }
-                               }];
+                            if (response) {
+                              assertBlock(index < 4, @"More than 4 responses received.");
+
+                              id expected = [RMTStreamingOutputCallResponse
+                                  messageWithPayloadSize:expectedSizes[index]];
+                              assertBlock(
+                                  [response isEqual:expected],
+                                  [NSString
+                                      stringWithFormat:@"response %@ not equal to expected %@",
+                                                       response, expected]);
+
+                              index += 1;
+                            }
+
+                            if (done) {
+                              assertBlock(
+                                  index == 4,
+                                  [NSString stringWithFormat:@"Received %@ responses instead of 4.",
+                                                             @(index)]);
+                              [expectation fulfill];
+                            }
+                          }];
 
     waiterBlock(self, @[ expectation ], GRPCInteropTestTimeoutDefault);
   });
 }
 
 - (void)testPingPongRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"PingPong"];
 
@@ -1103,15 +1116,25 @@ static dispatch_once_t initGlobalInterceptorFactory;
                               if (weakService == nil) {
                                 return;
                               }
-                              XCTAssertNil(error, @"Finished with unexpected error: %@", error);
-                              XCTAssertTrue(done || response,
-                                            @"Event handler called without an event.");
+
+                              assertBlock(
+                                  error == nil,
+                                  [NSString stringWithFormat:@"Finished with unexpected error: %@",
+                                                             error]);
+                              assertBlock(done || response,
+                                          @"Event handler called without an event.");
 
                               if (response) {
-                                XCTAssertLessThan(index, 4, @"More than 4 responses received.");
+                                assertBlock(index < 4, @"More than 4 responses received.");
+
                                 id expected = [RMTStreamingOutputCallResponse
                                     messageWithPayloadSize:responses[index]];
-                                XCTAssertEqualObjects(response, expected);
+                                assertBlock(
+                                    [response isEqual:expected],
+                                    [NSString
+                                        stringWithFormat:@"response %@ not equal to expected %@",
+                                                         response, expected]);
+
                                 index += 1;
                                 if (index < 4) {
                                   id request = [RMTStreamingOutputCallRequest
@@ -1124,8 +1147,11 @@ static dispatch_once_t initGlobalInterceptorFactory;
                               }
 
                               if (done) {
-                                XCTAssertEqual(index, 4, @"Received %i responses instead of 4.",
-                                               index);
+                                assertBlock(
+                                    index == 4,
+                                    [NSString
+                                        stringWithFormat:@"Received %@ responses instead of 4.",
+                                                         @(index)]);
                                 [expectation fulfill];
                               }
                             }];
@@ -1134,7 +1160,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testPingPongRPCWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"PingPongWithV2API"];
 
@@ -1154,41 +1180,42 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     __weak __block GRPCStreamingProtoCall *weakCall;
     GRPCStreamingProtoCall *call = [service
-        fullDuplexCallWithResponseHandler:[[InteropTestsBlockCallbacks alloc]
-                                              initWithInitialMetadataCallback:nil
-                                              messageCallback:^(id message) {
-                                                GRPCStreamingProtoCall *localCall = weakCall;
-                                                if (localCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertLessThan(
-                                                    index, 4, @"More than 4 responses received.");
-                                                id expected = [RMTStreamingOutputCallResponse
-                                                    messageWithPayloadSize:responses[index]];
-                                                XCTAssertEqualObjects(message, expected);
-                                                index += 1;
-                                                if (index < 4) {
-                                                  id request = [RMTStreamingOutputCallRequest
-                                                      messageWithPayloadSize:requests[index]
-                                                       requestedResponseSize:responses[index]];
-                                                  [localCall writeMessage:request];
-                                                } else {
-                                                  [localCall finish];
-                                                }
-                                              }
-                                              closeCallback:^(NSDictionary *trailingMetadata,
-                                                              NSError *error) {
-                                                if (weakCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertNil(error,
-                                                             @"Finished with unexpected error: %@",
-                                                             error);
-                                                XCTAssertEqual(
-                                                    index, 4,
-                                                    @"Received %i responses instead of 4.", index);
-                                                [expectation fulfill];
-                                              }]
+        fullDuplexCallWithResponseHandler:
+            [[InteropTestsBlockCallbacks alloc] initWithInitialMetadataCallback:nil
+                messageCallback:^(id message) {
+                  GRPCStreamingProtoCall *localCall = weakCall;
+                  if (localCall == nil) {
+                    return;
+                  }
+                  assertBlock(index < 4, @"More than 4 responses received.");
+
+                  id expected =
+                      [RMTStreamingOutputCallResponse messageWithPayloadSize:responses[index]];
+                  assertBlock([message isEqual:expected],
+                              [NSString stringWithFormat:@"message %@ not equal to expected %@",
+                                                         message, expected]);
+                  index += 1;
+                  if (index < 4) {
+                    id request =
+                        [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
+                                                        requestedResponseSize:responses[index]];
+                    [localCall writeMessage:request];
+                  } else {
+                    [localCall finish];
+                  }
+                }
+                closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+                  if (weakCall == nil) {
+                    return;
+                  }
+                  assertBlock(
+                      error == nil,
+                      [NSString stringWithFormat:@"Finished with unexpected error: %@", error]);
+                  assertBlock(
+                      index == 4,
+                      [NSString stringWithFormat:@"Received %@ responses instead of 4.", @(index)]);
+                  [expectation fulfill];
+                }]
                               callOptions:options];
     weakCall = call;
     [call start];
@@ -1199,7 +1226,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testPingPongRPCWithFlowControl {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"PingPongWithV2API"];
 
@@ -1221,46 +1248,48 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     __weak __block GRPCStreamingProtoCall *weakCall;
     GRPCStreamingProtoCall *call = [service
-        fullDuplexCallWithResponseHandler:[[InteropTestsBlockCallbacks alloc]
-                                              initWithInitialMetadataCallback:nil
-                                              messageCallback:^(id message) {
-                                                GRPCStreamingProtoCall *localCall = weakCall;
-                                                if (localCall == nil) {
-                                                  return;
-                                                }
+        fullDuplexCallWithResponseHandler:
+            [[InteropTestsBlockCallbacks alloc] initWithInitialMetadataCallback:nil
+                messageCallback:^(id message) {
+                  GRPCStreamingProtoCall *localCall = weakCall;
+                  if (localCall == nil) {
+                    return;
+                  }
 
-                                                XCTAssertLessThan(
-                                                    index, 4, @"More than 4 responses received.");
-                                                id expected = [RMTStreamingOutputCallResponse
-                                                    messageWithPayloadSize:responses[index]];
-                                                XCTAssertEqualObjects(message, expected);
-                                                index += 1;
-                                                if (index < 4) {
-                                                  id request = [RMTStreamingOutputCallRequest
-                                                      messageWithPayloadSize:requests[index]
-                                                       requestedResponseSize:responses[index]];
-                                                  [localCall writeMessage:request];
-                                                  [localCall receiveNextMessage];
-                                                } else {
-                                                  [localCall finish];
-                                                }
-                                              }
-                                              closeCallback:^(NSDictionary *trailingMetadata,
-                                                              NSError *error) {
-                                                if (weakCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertNil(error,
-                                                             @"Finished with unexpected error: %@",
-                                                             error);
-                                                XCTAssertEqual(
-                                                    index, 4,
-                                                    @"Received %i responses instead of 4.", index);
-                                                [expectation fulfill];
-                                              }
-                                              writeMessageCallback:^{
-                                                writeMessageCount++;
-                                              }]
+                  assertBlock((index < 4), @"More than 4 responses received.");
+                  id expected =
+                      [RMTStreamingOutputCallResponse messageWithPayloadSize:responses[index]];
+                  assertBlock(
+                      [message isEqual:expected],
+                      [NSString stringWithFormat:@"message %@ not equal to %@", message, expected]);
+
+                  index += 1;
+                  if (index < 4) {
+                    id request =
+                        [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
+                                                        requestedResponseSize:responses[index]];
+                    [localCall writeMessage:request];
+                    [localCall receiveNextMessage];
+                  } else {
+                    [localCall finish];
+                  }
+                }
+                closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+                  if (weakCall == nil) {
+                    return;
+                  }
+
+                  assertBlock(
+                      error == nil,
+                      [NSString stringWithFormat:@"Finished with unexpected error: %@", error]);
+                  assertBlock(
+                      index == 4,
+                      [NSString stringWithFormat:@"Received %i responses instead of 4.", index]);
+                  [expectation fulfill];
+                }
+                writeMessageCallback:^{
+                  writeMessageCount++;
+                }]
                               callOptions:options];
     weakCall = call;
     [call start];
@@ -1268,12 +1297,14 @@ static dispatch_once_t initGlobalInterceptorFactory;
     [call writeMessage:request];
 
     waiterBlock(self, @[ expectation ], GRPCInteropTestTimeoutDefault);
-    XCTAssertEqual(writeMessageCount, 4);
+    assertBlock(
+        writeMessageCount == 4,
+        [NSString stringWithFormat:@"writeMessageCount %@ not equal to 4", @(writeMessageCount)]);
   });
 }
 
 - (void)testEmptyStreamRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter _Nonnull waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"EmptyStream"];
     __weak RMTTestService *weakService = service;
@@ -1293,7 +1324,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testCancelAfterBeginRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAfterBegin"];
 
@@ -1324,7 +1355,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testCancelAfterBeginRPCWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"CancelAfterBeginWithV2API"];
@@ -1358,7 +1389,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testCancelAfterFirstResponseRPC {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"CancelAfterFirstResponse"];
@@ -1400,7 +1431,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testCancelAfterFirstResponseRPCWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *completionExpectation =
         [self expectationWithDescription:@"Call completed."];
@@ -1451,7 +1482,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testCancelAfterFirstRequestWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *completionExpectation =
         [self expectationWithDescription:@"Call completed."];
@@ -1493,7 +1524,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testRPCAfterClosingOpenConnections {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"RPC after closing connection"];
@@ -1536,7 +1567,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
     return;
   }
 
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"LargeUnary"];
 
@@ -1570,7 +1601,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testKeepaliveWithV2API {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     if ([[self class] transport] == gGRPCCoreCronetID) {
       // Cronet does not support keepalive
@@ -1619,7 +1650,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testDefaultInterceptor {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"testDefaultInterceptor"];
@@ -1641,41 +1672,46 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     __weak __block GRPCStreamingProtoCall *weakCall;
     GRPCStreamingProtoCall *call = [service
-        fullDuplexCallWithResponseHandler:[[InteropTestsBlockCallbacks alloc]
-                                              initWithInitialMetadataCallback:nil
-                                              messageCallback:^(id message) {
-                                                GRPCStreamingProtoCall *localCall = weakCall;
-                                                if (localCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertLessThan(
-                                                    index, 4, @"More than 4 responses received.");
-                                                id expected = [RMTStreamingOutputCallResponse
-                                                    messageWithPayloadSize:responses[index]];
-                                                XCTAssertEqualObjects(message, expected);
-                                                index += 1;
-                                                if (index < 4) {
-                                                  id request = [RMTStreamingOutputCallRequest
-                                                      messageWithPayloadSize:requests[index]
-                                                       requestedResponseSize:responses[index]];
-                                                  [localCall writeMessage:request];
-                                                } else {
-                                                  [localCall finish];
-                                                }
-                                              }
-                                              closeCallback:^(NSDictionary *trailingMetadata,
-                                                              NSError *error) {
-                                                if (weakCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertNil(error,
-                                                             @"Finished with unexpected error: %@",
-                                                             error);
-                                                XCTAssertEqual(
-                                                    index, 4,
-                                                    @"Received %i responses instead of 4.", index);
-                                                [expectation fulfill];
-                                              }]
+        fullDuplexCallWithResponseHandler:
+            [[InteropTestsBlockCallbacks alloc] initWithInitialMetadataCallback:nil
+                messageCallback:^(id message) {
+                  GRPCStreamingProtoCall *localCall = weakCall;
+                  if (localCall == nil) {
+                    return;
+                  }
+                  assertBlock(index < 4, @"More than 4 responses received.");
+
+                  id expected =
+                      [RMTStreamingOutputCallResponse messageWithPayloadSize:responses[index]];
+                  assertBlock([message isEqual:expected],
+                              [NSString stringWithFormat:@"message %@ not equal to expected %@",
+                                                         message, expected]);
+
+                  index += 1;
+                  if (index < 4) {
+                    id request =
+                        [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
+                                                        requestedResponseSize:responses[index]];
+                    [localCall writeMessage:request];
+                  } else {
+                    [localCall finish];
+                  }
+                }
+                closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+                  if (weakCall == nil) {
+                    return;
+                  }
+
+                  assertBlock(
+                      index == 4,
+                      [NSString stringWithFormat:@"Received %@ responses instead of 4.", @(index)]);
+
+                  assertBlock(
+                      error == nil,
+                      [NSString stringWithFormat:@"Finished with unexpected error: %@", error]);
+
+                  [expectation fulfill];
+                }]
                               callOptions:options];
     weakCall = call;
     [call start];
@@ -1686,7 +1722,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testLoggingInterceptor {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"testLoggingInterceptor"];
@@ -1712,7 +1748,6 @@ static dispatch_once_t initGlobalInterceptorFactory;
         }
         writeDataHook:^(id data, GRPCInterceptorManager *manager) {
           writeDataCount++;
-          NSLog(@"writeDataHook %@", @(writeDataCount));
           [manager writeNextInterceptorWithData:data];
         }
         finishHook:^(GRPCInterceptorManager *manager) {
@@ -1760,42 +1795,48 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     __block int writeMessageCount = 0;
     __block __weak GRPCStreamingProtoCall *weakCall;
-    GRPCStreamingProtoCall *call =
-        [service fullDuplexCallWithResponseHandler:
-                     [[InteropTestsBlockCallbacks alloc] initWithInitialMetadataCallback:nil
-                         messageCallback:^(id message) {
-                           GRPCStreamingProtoCall *localCall = weakCall;
-                           if (localCall == nil) {
-                             return;
-                           }
-                           XCTAssertLessThan(messageIndex, 4, @"More than 4 responses received.");
-                           id expected = [RMTStreamingOutputCallResponse
-                               messageWithPayloadSize:responses[messageIndex]];
-                           XCTAssertEqualObjects(message, expected);
-                           messageIndex += 1;
-                           if (messageIndex < 4) {
-                             id request = [RMTStreamingOutputCallRequest
-                                 messageWithPayloadSize:requests[messageIndex]
-                                  requestedResponseSize:responses[messageIndex]];
-                             [localCall writeMessage:request];
-                             [localCall receiveNextMessage];
-                           } else {
-                             [localCall finish];
-                           }
-                         }
-                         closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
-                           if (weakCall == nil) {
-                             return;
-                           }
-                           XCTAssertNil(error, @"Finished with unexpected error: %@", error);
-                           XCTAssertEqual(messageIndex, 4, @"Received %i responses instead of 4.",
-                                          messageIndex);
-                           [expectation fulfill];
-                         }
-                         writeMessageCallback:^{
-                           writeMessageCount++;
-                         }]
-                                       callOptions:options];
+    GRPCStreamingProtoCall *call = [service
+        fullDuplexCallWithResponseHandler:
+            [[InteropTestsBlockCallbacks alloc] initWithInitialMetadataCallback:nil
+                messageCallback:^(id message) {
+                  GRPCStreamingProtoCall *localCall = weakCall;
+                  if (localCall == nil) {
+                    return;
+                  }
+                  assertBlock((messageIndex < 4), @"More than 4 responses received.");
+
+                  id expected = [RMTStreamingOutputCallResponse
+                      messageWithPayloadSize:responses[messageIndex]];
+                  assertBlock([message isEqual:expected],
+                              [NSString stringWithFormat:@"message %@ not equal to expected %@",
+                                                         message, expected]);
+                  messageIndex += 1;
+                  if (messageIndex < 4) {
+                    id request = [RMTStreamingOutputCallRequest
+                        messageWithPayloadSize:requests[messageIndex]
+                         requestedResponseSize:responses[messageIndex]];
+                    [localCall writeMessage:request];
+                    [localCall receiveNextMessage];
+                  } else {
+                    [localCall finish];
+                  }
+                }
+                closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+                  if (weakCall == nil) {
+                    return;
+                  }
+                  assertBlock(
+                      error == nil,
+                      [NSString stringWithFormat:@"Finished with unexpected error: %@", error]);
+                  assertBlock(messageIndex == 4,
+                              [NSString stringWithFormat:@"Received %@ responses instead of 4.",
+                                                         @(messageIndex)]);
+                  [expectation fulfill];
+                }
+                writeMessageCallback:^{
+                  writeMessageCount++;
+                }]
+                              callOptions:options];
 
     weakCall = call;
     [call start];
@@ -1804,22 +1845,24 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     waiterBlock(self, @[ expectation ], GRPCInteropTestTimeoutDefault);
 
-    XCTAssertEqual(startCount, 1);
-    XCTAssertEqual(writeDataCount, 4);
-    XCTAssertEqual(finishCount, 1);
-    XCTAssertEqual(receiveNextMessageCount, 4);
-    XCTAssertEqual(responseHeaderCount, 1);
-    XCTAssertEqual(responseDataCount, 4);
-    XCTAssertEqual(responseCloseCount, 1);
-    XCTAssertEqual(didWriteDataCount, 4);
-    XCTAssertEqual(writeMessageCount, 4);
+    assertBlock(startCount == 1, [NSString stringWithFormat:@"%@", @(startCount)]);
+    assertBlock(writeDataCount == 4, [NSString stringWithFormat:@"%@", @(writeDataCount)]);
+    assertBlock(finishCount == 1, [NSString stringWithFormat:@"%@", @(finishCount)]);
+    assertBlock(receiveNextMessageCount == 4,
+                [NSString stringWithFormat:@"%@", @(receiveNextMessageCount)]);
+    assertBlock(responseHeaderCount == 1,
+                [NSString stringWithFormat:@"%@", @(responseHeaderCount)]);
+    assertBlock(responseDataCount == 4, [NSString stringWithFormat:@"%@", @(responseDataCount)]);
+    assertBlock(responseCloseCount == 1, [NSString stringWithFormat:@"%@", @(responseCloseCount)]);
+    assertBlock(didWriteDataCount == 4, [NSString stringWithFormat:@"%@", @(didWriteDataCount)]);
+    assertBlock(writeMessageCount == 4, [NSString stringWithFormat:@"%@", @(writeMessageCount)]);
   });
 }
 
 // Chain a default interceptor and a hook interceptor which, after one write, cancels the call
 // under the hood but forward further data to the user.
 - (void)testHijackingInterceptor {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     NSUInteger kCancelAfterWrites = 1;
     __weak XCTestExpectation *expectUserCallComplete =
@@ -1908,10 +1951,13 @@ static dispatch_once_t initGlobalInterceptorFactory;
                     return;
                   }
 
-                  XCTAssertLessThan(index, 4, @"More than 4 responses received.");
+                  assertBlock(index < 4, @"More than 4 responses received.");
+
                   id expected =
                       [RMTStreamingOutputCallResponse messageWithPayloadSize:responses[index]];
-                  XCTAssertEqualObjects(message, expected);
+                  assertBlock([message isEqual:expected],
+                              [NSString stringWithFormat:@"message %@ not equal to expected %@",
+                                                         message, expected]);
                   index += 1;
                   if (index < 4) {
                     id request =
@@ -1929,8 +1975,13 @@ static dispatch_once_t initGlobalInterceptorFactory;
                   if (weakCall == nil) {
                     return;
                   }
-                  XCTAssertNil(error, @"Finished with unexpected error: %@", error);
-                  XCTAssertEqual(index, 4, @"Received %i responses instead of 4.", index);
+                  assertBlock(
+                      error == nil,
+                      [NSString stringWithFormat:@"Finished with unexpected error: %@", error]);
+                  assertBlock(
+                      index == 4,
+                      [NSString stringWithFormat:@"Received %@ responses instead of 4.", @(index)]);
+
                   [expectUserCallComplete fulfill];
                 }]
                               callOptions:options];
@@ -1940,18 +1991,18 @@ static dispatch_once_t initGlobalInterceptorFactory;
     [call writeMessage:request];
 
     waiterBlock(self, @[ expectUserCallComplete ], GRPCInteropTestTimeoutDefault);
-
-    XCTAssertEqual(startCount, 1);
-    XCTAssertEqual(writeDataCount, 4);
-    XCTAssertEqual(finishCount, 1);
-    XCTAssertEqual(responseHeaderCount, 1);
-    XCTAssertEqual(responseDataCount, 1);
-    XCTAssertEqual(responseCloseCount, 1);
+    assertBlock(startCount == 1, [NSString stringWithFormat:@"%@", @(startCount)]);
+    assertBlock(writeDataCount == 4, [NSString stringWithFormat:@"%@", @(writeDataCount)]);
+    assertBlock(finishCount == 1, [NSString stringWithFormat:@"%@", @(finishCount)]);
+    assertBlock(responseHeaderCount == 1,
+                [NSString stringWithFormat:@"%@", @(responseHeaderCount)]);
+    assertBlock(responseDataCount == 1, [NSString stringWithFormat:@"%@", @(responseDataCount)]);
+    assertBlock(responseCloseCount == 1, [NSString stringWithFormat:@"%@", @(responseCloseCount)]);
   });
 }
 
 - (void)testGlobalInterceptor {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"testGlobalInterceptor"];
@@ -2024,39 +2075,38 @@ static dispatch_once_t initGlobalInterceptorFactory;
     __block int writeMessageCount = 0;
     __weak __block GRPCStreamingProtoCall *weakCall;
     __block GRPCStreamingProtoCall *call = [service
-        fullDuplexCallWithResponseHandler:[[InteropTestsBlockCallbacks alloc]
-                                              initWithInitialMetadataCallback:nil
-                                              messageCallback:^(id message) {
-                                                GRPCStreamingProtoCall *localCall = weakCall;
-                                                if (localCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertLessThan(
-                                                    index, 4, @"More than 4 responses received.");
-                                                index += 1;
-                                                if (index < 4) {
-                                                  id request = [RMTStreamingOutputCallRequest
-                                                      messageWithPayloadSize:requests[index]
-                                                       requestedResponseSize:responses[index]];
-                                                  [localCall writeMessage:request];
-                                                  [localCall receiveNextMessage];
-                                                } else {
-                                                  [localCall finish];
-                                                }
-                                              }
-                                              closeCallback:^(NSDictionary *trailingMetadata,
-                                                              NSError *error) {
-                                                if (weakCall == nil) {
-                                                  return;
-                                                }
-                                                XCTAssertNil(error,
-                                                             @"Finished with unexpected error: %@",
-                                                             error);
-                                                [expectation fulfill];
-                                              }
-                                              writeMessageCallback:^{
-                                                writeMessageCount++;
-                                              }]
+        fullDuplexCallWithResponseHandler:
+            [[InteropTestsBlockCallbacks alloc] initWithInitialMetadataCallback:nil
+                messageCallback:^(id message) {
+                  GRPCStreamingProtoCall *localCall = weakCall;
+                  if (localCall == nil) {
+                    return;
+                  }
+                  assertBlock(index < 4, @"More than 4 responses received.");
+
+                  index += 1;
+                  if (index < 4) {
+                    id request =
+                        [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
+                                                        requestedResponseSize:responses[index]];
+                    [localCall writeMessage:request];
+                    [localCall receiveNextMessage];
+                  } else {
+                    [localCall finish];
+                  }
+                }
+                closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+                  if (weakCall == nil) {
+                    return;
+                  }
+                  assertBlock(
+                      error == nil,
+                      [NSString stringWithFormat:@"Finished with unexpected error: %@", error]);
+                  [expectation fulfill];
+                }
+                writeMessageCallback:^{
+                  writeMessageCount++;
+                }]
                               callOptions:options];
     weakCall = call;
     [call start];
@@ -2064,15 +2114,17 @@ static dispatch_once_t initGlobalInterceptorFactory;
     [call writeMessage:request];
     waiterBlock(self, @[ expectation ], GRPCInteropTestTimeoutDefault);
 
-    XCTAssertEqual(startCount, 1);
-    XCTAssertEqual(writeDataCount, 4);
-    XCTAssertEqual(finishCount, 1);
-    XCTAssertEqual(receiveNextMessageCount, 4);
-    XCTAssertEqual(responseHeaderCount, 1);
-    XCTAssertEqual(responseDataCount, 4);
-    XCTAssertEqual(responseCloseCount, 1);
-    XCTAssertEqual(didWriteDataCount, 4);
-    XCTAssertEqual(writeMessageCount, 4);
+    assertBlock(startCount == 1, [NSString stringWithFormat:@"%@", @(startCount)]);
+    assertBlock(writeDataCount == 4, [NSString stringWithFormat:@"%@", @(writeDataCount)]);
+    assertBlock(finishCount == 1, [NSString stringWithFormat:@"%@", @(finishCount)]);
+    assertBlock(receiveNextMessageCount == 4,
+                [NSString stringWithFormat:@"%@", @(receiveNextMessageCount)]);
+    assertBlock(responseHeaderCount == 1,
+                [NSString stringWithFormat:@"%@", @(responseHeaderCount)]);
+    assertBlock(responseDataCount == 4, [NSString stringWithFormat:@"%@", @(responseDataCount)]);
+    assertBlock(responseCloseCount == 1, [NSString stringWithFormat:@"%@", @(responseCloseCount)]);
+    assertBlock(didWriteDataCount == 4, [NSString stringWithFormat:@"%@", @(didWriteDataCount)]);
+    assertBlock(writeMessageCount == 4, [NSString stringWithFormat:@"%@", @(writeMessageCount)]);
     globalInterceptorFactory.enabled = NO;
   });
 }
@@ -2097,7 +2149,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
 }
 
 - (void)testInterceptorAndGlobalInterceptor {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     __weak XCTestExpectation *expectation =
         [self expectationWithDescription:@"testInterceptorAndGlobalInterceptor"];
@@ -2258,24 +2310,31 @@ static dispatch_once_t initGlobalInterceptorFactory;
     [call writeMessage:request];
 
     waiterBlock(self, @[ expectation ], GRPCInteropTestTimeoutDefault);
-
-    XCTAssertEqual(startCount, 1);
-    XCTAssertEqual(writeDataCount, 4);
-    XCTAssertEqual(finishCount, 1);
-    XCTAssertEqual(receiveNextMessageCount, 4);
-    XCTAssertEqual(responseHeaderCount, 1);
-    XCTAssertEqual(responseDataCount, 4);
-    XCTAssertEqual(responseCloseCount, 1);
-    XCTAssertEqual(didWriteDataCount, 4);
-    XCTAssertEqual(globalStartCount, 1);
-    XCTAssertEqual(globalWriteDataCount, 4);
-    XCTAssertEqual(globalFinishCount, 1);
-    XCTAssertEqual(globalReceiveNextMessageCount, 4);
-    XCTAssertEqual(globalResponseHeaderCount, 1);
-    XCTAssertEqual(globalResponseDataCount, 4);
-    XCTAssertEqual(globalResponseCloseCount, 1);
-    XCTAssertEqual(globalDidWriteDataCount, 4);
-    XCTAssertEqual(writeMessageCount, 4);
+    assertBlock(startCount == 1, [NSString stringWithFormat:@"%@", @(startCount)]);
+    assertBlock(writeDataCount == 4, [NSString stringWithFormat:@"%@", @(writeDataCount)]);
+    assertBlock(finishCount == 1, [NSString stringWithFormat:@"%@", @(finishCount)]);
+    assertBlock(receiveNextMessageCount == 4,
+                [NSString stringWithFormat:@"%@", @(receiveNextMessageCount)]);
+    assertBlock(responseHeaderCount == 1,
+                [NSString stringWithFormat:@"%@", @(responseHeaderCount)]);
+    assertBlock(responseDataCount == 4, [NSString stringWithFormat:@"%@", @(responseDataCount)]);
+    assertBlock(responseCloseCount == 1, [NSString stringWithFormat:@"%@", @(responseCloseCount)]);
+    assertBlock(didWriteDataCount == 4, [NSString stringWithFormat:@"%@", @(didWriteDataCount)]);
+    assertBlock(globalStartCount == 1, [NSString stringWithFormat:@"%@", @(globalStartCount)]);
+    assertBlock(globalWriteDataCount == 4,
+                [NSString stringWithFormat:@"%@", @(globalWriteDataCount)]);
+    assertBlock(globalFinishCount == 1, [NSString stringWithFormat:@"%@", @(globalFinishCount)]);
+    assertBlock(globalReceiveNextMessageCount == 4,
+                [NSString stringWithFormat:@"%@", @(globalReceiveNextMessageCount)]);
+    assertBlock(globalResponseHeaderCount == 1,
+                [NSString stringWithFormat:@"%@", @(globalResponseHeaderCount)]);
+    assertBlock(globalResponseDataCount == 4,
+                [NSString stringWithFormat:@"%@", @(globalResponseDataCount)]);
+    assertBlock(globalResponseCloseCount == 1,
+                [NSString stringWithFormat:@"%@", @(globalResponseCloseCount)]);
+    assertBlock(globalDidWriteDataCount == 4,
+                [NSString stringWithFormat:@"%@", @(globalDidWriteDataCount)]);
+    assertBlock(writeMessageCount == 4, [NSString stringWithFormat:@"%@", @(writeMessageCount)]);
     globalInterceptorFactory.enabled = NO;
   });
 }

--- a/src/objective-c/tests/InteropTests/InteropTestsRemote.m
+++ b/src/objective-c/tests/InteropTests/InteropTestsRemote.m
@@ -83,7 +83,7 @@ static GRPCProtoMethod *kUnaryCallMethod;
 }
 
 - (void)testMetadataForV2Call {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
 
     RMTSimpleRequest *request = [RMTSimpleRequest message];
@@ -136,7 +136,7 @@ static GRPCProtoMethod *kUnaryCallMethod;
 }
 
 - (void)testMetadataForV1Call {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
 
     RMTSimpleRequest *request = [RMTSimpleRequest message];
@@ -183,7 +183,7 @@ static GRPCProtoMethod *kUnaryCallMethod;
 }
 
 - (void)testErrorDebugInformation {
-  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock) {
+  GRPCTestRunWithFlakeRepeats(^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"RPC unauthorized."];
 
     RMTSimpleRequest *request = [RMTSimpleRequest message];


### PR DESCRIPTION
Introduce an optional test assert block (GRPCTestAssert) to  GRPCTestRunBlock. This allows test case to assert a given condition with flaky retries.  Direct assertion via XCTest API will exit the entire test case run and report test failure immediately. 

### Change Summary
- TestUtils:   GRPCTestAssert assertion block and updated GRPCTestRunBlock 
- InteropTests: updated test cases that take advantage of the new assert block and enable us to deal with flaky sever state (e.g. remote cancelled earlier during a test run). 

### Test and Verify 

All interop test (local, ssl, remote) passes w/o issue. 



-----
https://github.com/grpc/grpc-ios/issues/107

@HannahShiSFB 
