### PR TITLE
Build - Use :well_known_type_protos instead of :well_known_protos

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -143,7 +143,7 @@ def generate_cc_impl(ctx):
         f = ctx.attr.well_known_protos.files.to_list()[0].dirname
         if f != "external/com_google_protobuf/src/google/protobuf":
             print(
-                "Error: Only @com_google_protobuf//:well_known_protos is supported",
+                "Error: Only @com_google_protobuf//:well_known_type_protos is supported",
             )  # buildifier: disable=print
         else:
             # f points to "external/com_google_protobuf/src/google/protobuf"
@@ -200,7 +200,7 @@ _generate_cc = rule(
 def generate_cc(well_known_protos, **kwargs):
     if well_known_protos:
         _generate_cc(
-            well_known_protos = "@com_google_protobuf//:well_known_protos",
+            well_known_protos = "@com_google_protobuf//:well_known_type_protos",
             **kwargs
         )
     else:

--- a/bazel/generate_objc.bzl
+++ b/bazel/generate_objc.bzl
@@ -177,7 +177,7 @@ generate_objc = rule(
             default = False,
         ),
         "well_known_protos": attr.label(
-            default = "@com_google_protobuf//:well_known_protos",
+            default = "@com_google_protobuf//:well_known_type_protos",
         ),
         "_protoc": attr.label(
             default = Label("//external:protocol_compiler"),

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -265,8 +265,7 @@ grpc_sh_test(
     data = [
         "@com_google_protobuf//:protoc",
         "//src/compiler:grpc_objective_c_plugin",
-        # NOTE: the :well_known_protos has been recently renamed to :well_known_type_protos on protobuf's main branch
-        "@com_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_type_protos",
     ] + glob(["RemoteTestClient/*.proto"]),
     uses_polling = False,
 )

--- a/tools/distrib/python/grpcio_tools/BUILD.bazel
+++ b/tools/distrib/python/grpcio_tools/BUILD.bazel
@@ -40,7 +40,7 @@ pyx_library(
 
 internal_copied_filegroup(
     name = "well_known_protos",
-    srcs = ["@com_google_protobuf//:well_known_protos"],
+    srcs = ["@com_google_protobuf//:well_known_type_protos"],
     dest = "grpc_tools/_proto/",
     strip_prefix = "src/",
 )
@@ -51,7 +51,7 @@ py_library(
         "grpc_tools/__init__.py",
         "grpc_tools/protoc.py",
     ],
-    data = [":well_known_protos"],
+    data = [":well_known_type_protos"],
     imports = ["."],
     srcs_version = "PY2AND3",
     deps = [

--- a/tools/distrib/python/make_grpcio_tools.py
+++ b/tools/distrib/python/make_grpcio_tools.py
@@ -84,7 +84,7 @@ GRPC_PYTHON_INCLUDE = os.path.join(GRPC_PYTHON_ROOT, 'grpc_root', 'include')
 BAZEL_DEPS = os.path.join(GRPC_ROOT, 'tools', 'distrib', 'python',
                           'bazel_deps.sh')
 BAZEL_DEPS_PROTOC_LIB_QUERY = '//:protoc_lib'
-BAZEL_DEPS_COMMON_PROTOS_QUERY = '//:well_known_protos'
+BAZEL_DEPS_COMMON_PROTOS_QUERY = '//:well_known_type_protos'
 
 
 def protobuf_submodule_commit_hash():


### PR DESCRIPTION
The `:well_known_protos` target has been deprecated and the preference is to use `:well_known_type_protos` instead.

The files available in `descriptor_proto_srcs` and `//src/google/protobuf/compiler:plugin.proto` will no longer be available with this change, but it is not clear to me that those are needed.