### PR TITLE
[zlib] Remove dependency on zlib version

### DIFF
--- a/test/core/end2end/tests/max_message_length.cc
+++ b/test/core/end2end/tests/max_message_length.cc
@@ -19,6 +19,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "absl/strings/match.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -765,9 +767,8 @@ static void test_max_receive_message_length_on_compressed_response(
     GPR_ASSERT(status == GRPC_STATUS_OK);
   } else {
     GPR_ASSERT(status == GRPC_STATUS_RESOURCE_EXHAUSTED);
-    GPR_ASSERT(grpc_slice_str_cmp(
-                   details, "Received message larger than max (29 vs. 5)") ==
-               0);
+    GPR_ASSERT(absl::StartsWith(grpc_core::StringViewFromSlice(details),
+                                "Received message larger than max"));
   }
   grpc_slice_unref(details);
   grpc_slice_unref(response_payload_slice);


### PR DESCRIPTION
By encoding the compressed length of a message by zlib into a string, we're inadvertently taking a dependency on the exact algorithm used by zlib to compress those bytes, which makes upgrading zlib hard.

Instead, just check the load bearing part of the message for us.

Intended to fix b/239733566

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

