### PR TITLE
issue 27502 - parse warning from libprotobuf

### DIFF
--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -206,6 +206,63 @@ namespace Grpc.Tools
                 }
             },
 
+            // Example warning from plugins that use GOOGLE_LOG
+            // [libprotobuf WARNING T:\altsrc\..\csharp_enum.cc:74] Duplicate enum value Work (originally Work) in PhoneType; adding underscore to distinguish
+            new ErrorListFilter
+            {
+                Pattern = new Regex(
+                    pattern: "^\\[.+? WARNING (?'FILENAME'.+?):(?'LINE'\\d+?)\\] ?(?'TEXT'.*)",
+                    options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                    matchTimeout: s_regexTimeout),
+                LogAction = (log, match) =>
+                {
+                    // The filename and line logged by the plugins may not be useful to the
+                    // end user as they are not the location in the proto file but rather
+                    // in the source code for the plugin. Log them anyway as they may help in
+                    // diagnositics.
+                    int.TryParse(match.Groups["LINE"].Value, out var line);
+                    log.LogWarning(
+                        subcategory: null,
+                        warningCode: null,
+                        helpKeyword: null,
+                        file: match.Groups["FILENAME"].Value,
+                        lineNumber: line,
+                        columnNumber: 0,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: match.Groups["TEXT"].Value);
+                }
+            },
+
+            // Example error from plugins that use GOOGLE_LOG
+            // [libprotobuf ERROR T:\path\...\filename:23] Some message
+            // [libprotobuf FATAL T:\path\...\filename:23] Some message
+            new ErrorListFilter
+            {
+                Pattern = new Regex(
+                    pattern: "^\\[.+? (?'LEVEL'ERROR|FATAL) (?'FILENAME'.+?):(?'LINE'\\d+?)\\] ?(?'TEXT'.*)",
+                    options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                    matchTimeout: s_regexTimeout),
+                LogAction = (log, match) =>
+                {
+                    // The filename and line logged by the plugins may not be useful to the
+                    // end user as they are not the location in the proto file but rather
+                    // in the source code for the plugin. Log them anyway as they may help in
+                    // diagnositics.
+                    int.TryParse(match.Groups["LINE"].Value, out var line);
+                    log.LogError(
+                        subcategory: null,
+                        errorCode: null,
+                        helpKeyword: null,
+                        file: match.Groups["FILENAME"].Value,
+                        lineNumber: line,
+                        columnNumber: 0,
+                        endLineNumber: 0,
+                        endColumnNumber: 0,
+                        message: match.Groups["LEVEL"].Value + " " + match.Groups["TEXT"].Value);
+                }
+            },
+
             // Example error without location
             //../Protos/greet.proto: Import "google/protobuf/empty.proto" was listed twice.
             new ErrorListFilter


### PR DESCRIPTION
Fix for https://github.com/grpc/grpc/issues/27502

The warnings and errors logged by some of the plugins such as the csharp plugin are in a different format from other warnings etc logged by the protobuf compiler (the plugins use GOOGLE_LOG to log message).

The parsing code in Grpc.Tools has been modified to correctly parse these so that warnings are no longer handled as errors.

The unit tests have been extended and fixed (they did not notice if a test case did not match the expected log level).




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

