### PR TITLE
[objc] Migrate interop remote test target to test runner

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -23,7 +23,6 @@ load(
     "proto_library_objc_wrapper",
 )
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_unit_test")
 load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_application", "tvos_unit_test")
 
@@ -80,18 +79,6 @@ objc_library(
     name = "host-lib",
     srcs = glob(["Hosts/ios-host/*.m"]),
     hdrs = glob(["Hosts/ios-host/*.h"]),
-)
-
-ios_application(
-    name = "ios-host",
-    bundle_id = "grpc.objc.tests.ios-host",
-    families = [
-        "iphone",
-        "ipad",
-    ],
-    infoplists = ["Hosts/ios-host/Info.plist"],
-    minimum_os_version = "9.0",
-    deps = ["host-lib"],
 )
 
 tvos_application(
@@ -211,10 +198,8 @@ grpc_objc_ios_unit_test(
     ],
 )
 
-ios_unit_test(
+grpc_objc_ios_unit_test(
     name = "InteropTestsRemote",
-    minimum_os_version = "9.0",
-    test_host = ":ios-host",
     deps = [
         ":InteropTestsRemote-lib",
     ],

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -100,7 +100,7 @@ objc_bazel_tests/bazel_wrapper \
   $BAZEL_FLAGS \
   --test_env HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
   --test_env HOST_PORT_LOCALSSL=localhost:$TLS_PORT \
-  --test_env FLAKE_TEST_REPEATS=3 \
+  --test_env FLAKE_TEST_REPEATS=10 \
   -- \
   "${EXAMPLE_TARGETS[@]}" \
   "${TEST_TARGETS[@]}"


### PR DESCRIPTION
Migrate last ios test to grpc_objc_ios_unit_test using test runner which has lower failure rate of simulator launch on kokoro nodes. 

### Change Summary 

* Update InteropTestsRemote to using grpc_objc_ios_unit_test. 
   - Clean up and removal of ios_host targets since it is no longer in use. 

* Bumping up retry count to 10 for network flakes. 
   - Since our current timeout wait is very short  (3 seconds), the overall timeout in worst scenario (30 seconds) would still be shorter than our original 64 seconds test timeout. This should allow us to accomodate most kokoro flakes for objc bazel tests.   

### Test & Verify 

objc bazel test pass green for interop remote test

---
https://github.com/grpc/grpc-ios/issues/107 

cc @HannahShiSFB  @jtattermusch 