### PR TITLE
Fix usage of `cxx` variable in libatomic check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ def check_linker_need_libatomic():
     # Double-check to see if -latomic actually can solve the problem.
     # https://github.com/grpc/grpc/issues/22491
     cpp_test = subprocess.Popen(
-        [cxx, '-x', 'c++', '-std=c++14', '-', '-latomic'],
+        cxx + ['-x', 'c++', '-std=c++14', '-', '-latomic'],
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE)


### PR DESCRIPTION
#28873 made the `cxx` variable into a list, but only updated the first usage. This causes build failures on armv6l, which requires libatomic.

cc @lidizheng @kacper-ka  



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

