### PR TITLE
Add CoreConfiguration::WithSubstituteBuilder that restores config after test

### DIFF
--- a/src/core/lib/config/core_configuration.h
+++ b/src/core/lib/config/core_configuration.h
@@ -92,10 +92,10 @@ class CoreConfiguration {
   //
   // Useful for running multiple tests back to back in the same process
   // without side effects from previous tests.
-  class Mocker {
+  class WithSubstituteBuilder {
    public:
     template <typename BuildFunc>
-    explicit Mocker(BuildFunc build) {
+    explicit WithSubstituteBuilder(BuildFunc build) {
       // Build core configuration to replace.
       Builder builder;
       build(&builder);
@@ -108,7 +108,7 @@ class CoreConfiguration {
           nullptr, std::memory_order_acquire);
     }
 
-    ~Mocker() {
+    ~WithSubstituteBuilder() {
       // Reset and restore.
       Reset();
       GPR_ASSERT(CoreConfiguration::config_.exchange(
@@ -149,7 +149,7 @@ class CoreConfiguration {
   template <typename BuildFunc, typename RunFunc>
   static void RunWithSpecialConfiguration(BuildFunc build_configuration,
                                           RunFunc code_to_run) {
-    Mocker mocker(build_configuration);
+    WithSubstituteBuilder builder(build_configuration);
     code_to_run();
   }
 

--- a/src/core/lib/config/core_configuration.h
+++ b/src/core/lib/config/core_configuration.h
@@ -20,6 +20,8 @@
 #include <atomic>
 #include <functional>
 
+#include <grpc/support/log.h>
+
 #include "src/core/lib/channel/channel_args_preconditioning.h"
 #include "src/core/lib/resolver/resolver_registry.h"
 #include "src/core/lib/security/credentials/channel_creds_registry.h"
@@ -76,6 +78,50 @@ class CoreConfiguration {
     CoreConfiguration* Build();
   };
 
+  // Stores a builder for RegisterBuilder
+  struct RegisteredBuilder {
+    std::function<void(Builder*)> builder;
+    RegisteredBuilder* next;
+  };
+
+  // Temporarily replaces core configuration with what is built from the
+  // provided BuildFunc that takes (Builder*) and returns void.
+  // Requires no concurrent Get() be called. Restores current core
+  // configuration when this object is destroyed. The default builder
+  // is not backed up or restored.
+  //
+  // Useful for running multiple tests back to back in the same process
+  // without side effects from previous tests.
+  class Mocker {
+   public:
+    template <typename BuildFunc>
+    explicit Mocker(BuildFunc build) {
+      // Build core configuration to replace.
+      Builder builder;
+      build(&builder);
+      CoreConfiguration* p = builder.Build();
+
+      // Backup current core configuration and replace/reset.
+      config_restore_ =
+          CoreConfiguration::config_.exchange(p, std::memory_order_acquire);
+      builders_restore_ = CoreConfiguration::builders_.exchange(
+          nullptr, std::memory_order_acquire);
+    }
+
+    ~Mocker() {
+      // Reset and restore.
+      Reset();
+      GPR_ASSERT(CoreConfiguration::config_.exchange(
+                     config_restore_, std::memory_order_acquire) == nullptr);
+      GPR_ASSERT(CoreConfiguration::builders_.exchange(
+                     builders_restore_, std::memory_order_acquire) == nullptr);
+    }
+
+   private:
+    CoreConfiguration* config_restore_;
+    RegisteredBuilder* builders_restore_;
+  };
+
   // Lifetime methods
 
   // Get the core configuration; if it does not exist, create it.
@@ -87,35 +133,10 @@ class CoreConfiguration {
     return BuildNewAndMaybeSet();
   }
 
-  // Build a special core configuration.
-  // Requires no concurrent Get() be called.
-  // Doesn't call the regular BuildCoreConfiguration function, instead calls
-  // `build`.
-  // BuildFunc is a callable that takes a Builder* and returns void.
-  // We use a template instead of std::function<void(Builder*)> to avoid
-  // including std::function in this widely used header, and to ensure no code
-  // is generated in programs that do not use this function.
-  // This is sometimes useful for testing.
-  template <typename BuildFunc>
-  static void BuildSpecialConfiguration(BuildFunc build) {
-    // Build bespoke configuration
-    Builder builder;
-    build(&builder);
-    CoreConfiguration* p = builder.Build();
-    // Swap in final configuration, deleting anything that was already present.
-    delete config_.exchange(p, std::memory_order_release);
-  }
-
   // Attach a registration function globally.
   // Each registration function is called *in addition to*
-  // BuildCoreConfiguration for the default core configuration. When using
-  // BuildSpecialConfiguration, one can use CallRegisteredBuilders to call them.
-  // Must be called before a configuration is built.
+  // BuildCoreConfiguration for the default core configuration.
   static void RegisterBuilder(std::function<void(Builder*)> builder);
-
-  // Call all registered builders.
-  // See RegisterBuilder for why you might want to call this.
-  static void CallRegisteredBuilders(Builder* builder);
 
   // Drop the core configuration. Users must ensure no other threads are
   // accessing the configuration.
@@ -128,10 +149,8 @@ class CoreConfiguration {
   template <typename BuildFunc, typename RunFunc>
   static void RunWithSpecialConfiguration(BuildFunc build_configuration,
                                           RunFunc code_to_run) {
-    Reset();
-    BuildSpecialConfiguration(build_configuration);
+    Mocker mocker(build_configuration);
     code_to_run();
-    Reset();
   }
 
   // Accessors
@@ -164,12 +183,6 @@ class CoreConfiguration {
 
  private:
   explicit CoreConfiguration(Builder* builder);
-
-  // Stores a builder for RegisterBuilder
-  struct RegisteredBuilder {
-    std::function<void(Builder*)> builder;
-    RegisteredBuilder* next;
-  };
 
   // Create a new CoreConfiguration, and either set it or throw it away.
   // We allow multiple CoreConfiguration's to be created in parallel.

--- a/test/core/client_channel/resolvers/binder_resolver_test.cc
+++ b/test/core/client_channel/resolvers/binder_resolver_test.cc
@@ -50,8 +50,7 @@ class BinderResolverTest : public ::testing::Test {
   }
   ~BinderResolverTest() override {}
   static void SetUpTestSuite() {
-    grpc_core::CoreConfiguration::Reset();
-    grpc_core::CoreConfiguration::BuildSpecialConfiguration(
+    mocker_ = std::make_unique<grpc_core::CoreConfiguration::Mocker>(
         [](grpc_core::CoreConfiguration::Builder* builder) {
           BuildCoreConfiguration(builder);
           if (!builder->resolver_registry()->HasResolverFactory("binder")) {
@@ -69,7 +68,10 @@ class BinderResolverTest : public ::testing::Test {
             .LookupResolverFactory("binder") == nullptr) {
     }
   }
-  static void TearDownTestSuite() { grpc_shutdown(); }
+  static void TearDownTestSuite() {
+    grpc_shutdown();
+    mocker_.reset();
+  }
 
   void SetUp() override { ASSERT_TRUE(factory_); }
 
@@ -133,7 +135,11 @@ class BinderResolverTest : public ::testing::Test {
 
  private:
   grpc_core::ResolverFactory* factory_;
+  static std::unique_ptr<grpc_core::CoreConfiguration::Mocker> mocker_;
 };
+
+std::unique_ptr<grpc_core::CoreConfiguration::Mocker>
+    BinderResolverTest::mocker_;
 
 }  // namespace
 

--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -169,8 +169,7 @@ class ErrorParser : public ServiceConfigParser::Parser {
 class ServiceConfigTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    CoreConfiguration::Reset();
-    CoreConfiguration::BuildSpecialConfiguration(
+    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<TestParser1>());
@@ -184,6 +183,9 @@ class ServiceConfigTest : public ::testing::Test {
                   "test_parser_2"),
               1);
   }
+
+ private:
+  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
 };
 
 TEST_F(ServiceConfigTest, ErrorCheck1) {
@@ -447,13 +449,12 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidValue) {
 TEST(ServiceConfigParserTest, DoubleRegistration) {
   CoreConfiguration::Reset();
   ASSERT_DEATH_IF_SUPPORTED(
-      CoreConfiguration::BuildSpecialConfiguration(
-          [](CoreConfiguration::Builder* builder) {
-            builder->service_config_parser()->RegisterParser(
-                absl::make_unique<ErrorParser>("xyzabc"));
-            builder->service_config_parser()->RegisterParser(
-                absl::make_unique<ErrorParser>("xyzabc"));
-          }),
+      CoreConfiguration::Mocker mocker([](CoreConfiguration::Builder* builder) {
+        builder->service_config_parser()->RegisterParser(
+            absl::make_unique<ErrorParser>("xyzabc"));
+        builder->service_config_parser()->RegisterParser(
+            absl::make_unique<ErrorParser>("xyzabc"));
+      }),
       "xyzabc.*already registered");
 }
 
@@ -461,8 +462,7 @@ TEST(ServiceConfigParserTest, DoubleRegistration) {
 class ErroredParsersScopingTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    CoreConfiguration::Reset();
-    CoreConfiguration::BuildSpecialConfiguration(
+    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<ErrorParser>("ep1"));
@@ -476,6 +476,9 @@ class ErroredParsersScopingTest : public ::testing::Test {
         CoreConfiguration::Get().service_config_parser().GetParserIndex("ep2"),
         1);
   }
+
+ private:
+  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
 };
 
 TEST_F(ErroredParsersScopingTest, GlobalParams) {
@@ -513,8 +516,7 @@ TEST_F(ErroredParsersScopingTest, MethodParams) {
 class ClientChannelParserTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    CoreConfiguration::Reset();
-    CoreConfiguration::BuildSpecialConfiguration(
+    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<internal::ClientChannelServiceConfigParser>());
@@ -523,6 +525,9 @@ class ClientChannelParserTest : public ::testing::Test {
                   "client_channel"),
               0);
   }
+
+ private:
+  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
 };
 
 TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigPickFirst) {
@@ -807,8 +812,7 @@ TEST_F(ClientChannelParserTest, InvalidHealthCheckMultipleEntries) {
 class RetryParserTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    CoreConfiguration::Reset();
-    CoreConfiguration::BuildSpecialConfiguration(
+    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<internal::RetryServiceConfigParser>());
@@ -817,6 +821,9 @@ class RetryParserTest : public ::testing::Test {
                   "retry"),
               0);
   }
+
+ private:
+  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
 };
 
 TEST_F(RetryParserTest, ValidRetryThrottling) {
@@ -1494,8 +1501,7 @@ TEST_F(RetryParserTest, InvalidRetryPolicyPerAttemptRecvTimeoutBadValue) {
 class MessageSizeParserTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    CoreConfiguration::Reset();
-    CoreConfiguration::BuildSpecialConfiguration(
+    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<MessageSizeParser>());
@@ -1504,6 +1510,9 @@ class MessageSizeParserTest : public ::testing::Test {
                   "message_size"),
               0);
   }
+
+ private:
+  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
 };
 
 TEST_F(MessageSizeParserTest, Valid) {

--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -169,7 +169,7 @@ class ErrorParser : public ServiceConfigParser::Parser {
 class ServiceConfigTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
+    builder_ = std::make_unique<CoreConfiguration::WithSubstituteBuilder>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<TestParser1>());
@@ -185,7 +185,7 @@ class ServiceConfigTest : public ::testing::Test {
   }
 
  private:
-  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
+  std::unique_ptr<CoreConfiguration::WithSubstituteBuilder> builder_;
 };
 
 TEST_F(ServiceConfigTest, ErrorCheck1) {
@@ -449,12 +449,13 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidValue) {
 TEST(ServiceConfigParserTest, DoubleRegistration) {
   CoreConfiguration::Reset();
   ASSERT_DEATH_IF_SUPPORTED(
-      CoreConfiguration::Mocker mocker([](CoreConfiguration::Builder* builder) {
-        builder->service_config_parser()->RegisterParser(
-            absl::make_unique<ErrorParser>("xyzabc"));
-        builder->service_config_parser()->RegisterParser(
-            absl::make_unique<ErrorParser>("xyzabc"));
-      }),
+      CoreConfiguration::WithSubstituteBuilder builder(
+          [](CoreConfiguration::Builder* builder) {
+            builder->service_config_parser()->RegisterParser(
+                absl::make_unique<ErrorParser>("xyzabc"));
+            builder->service_config_parser()->RegisterParser(
+                absl::make_unique<ErrorParser>("xyzabc"));
+          }),
       "xyzabc.*already registered");
 }
 
@@ -462,7 +463,7 @@ TEST(ServiceConfigParserTest, DoubleRegistration) {
 class ErroredParsersScopingTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
+    builder_ = std::make_unique<CoreConfiguration::WithSubstituteBuilder>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<ErrorParser>("ep1"));
@@ -478,7 +479,7 @@ class ErroredParsersScopingTest : public ::testing::Test {
   }
 
  private:
-  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
+  std::unique_ptr<CoreConfiguration::WithSubstituteBuilder> builder_;
 };
 
 TEST_F(ErroredParsersScopingTest, GlobalParams) {
@@ -516,7 +517,7 @@ TEST_F(ErroredParsersScopingTest, MethodParams) {
 class ClientChannelParserTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
+    builder_ = std::make_unique<CoreConfiguration::WithSubstituteBuilder>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<internal::ClientChannelServiceConfigParser>());
@@ -527,7 +528,7 @@ class ClientChannelParserTest : public ::testing::Test {
   }
 
  private:
-  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
+  std::unique_ptr<CoreConfiguration::WithSubstituteBuilder> builder_;
 };
 
 TEST_F(ClientChannelParserTest, ValidLoadBalancingConfigPickFirst) {
@@ -812,7 +813,7 @@ TEST_F(ClientChannelParserTest, InvalidHealthCheckMultipleEntries) {
 class RetryParserTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
+    builder_ = std::make_unique<CoreConfiguration::WithSubstituteBuilder>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<internal::RetryServiceConfigParser>());
@@ -823,7 +824,7 @@ class RetryParserTest : public ::testing::Test {
   }
 
  private:
-  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
+  std::unique_ptr<CoreConfiguration::WithSubstituteBuilder> builder_;
 };
 
 TEST_F(RetryParserTest, ValidRetryThrottling) {
@@ -1501,7 +1502,7 @@ TEST_F(RetryParserTest, InvalidRetryPolicyPerAttemptRecvTimeoutBadValue) {
 class MessageSizeParserTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    mocker_ = std::make_unique<CoreConfiguration::Mocker>(
+    builder_ = std::make_unique<CoreConfiguration::WithSubstituteBuilder>(
         [](CoreConfiguration::Builder* builder) {
           builder->service_config_parser()->RegisterParser(
               absl::make_unique<MessageSizeParser>());
@@ -1512,7 +1513,7 @@ class MessageSizeParserTest : public ::testing::Test {
   }
 
  private:
-  std::unique_ptr<CoreConfiguration::Mocker> mocker_;
+  std::unique_ptr<CoreConfiguration::WithSubstituteBuilder> builder_;
 };
 
 TEST_F(MessageSizeParserTest, Valid) {

--- a/test/core/handshake/readahead_handshaker_server_ssl.cc
+++ b/test/core/handshake/readahead_handshaker_server_ssl.cc
@@ -79,7 +79,7 @@ class ReadAheadHandshakerFactory : public HandshakerFactory {
 }  // namespace grpc_core
 
 TEST(HandshakeServerWithReadaheadHandshakerTest, MainTest) {
-  grpc_core::CoreConfiguration::BuildSpecialConfiguration(
+  grpc_core::CoreConfiguration::Mocker mocker(
       [](grpc_core::CoreConfiguration::Builder* builder) {
         BuildCoreConfiguration(builder);
         builder->handshaker_registry()->RegisterHandshakerFactory(

--- a/test/core/handshake/readahead_handshaker_server_ssl.cc
+++ b/test/core/handshake/readahead_handshaker_server_ssl.cc
@@ -79,7 +79,7 @@ class ReadAheadHandshakerFactory : public HandshakerFactory {
 }  // namespace grpc_core
 
 TEST(HandshakeServerWithReadaheadHandshakerTest, MainTest) {
-  grpc_core::CoreConfiguration::Mocker mocker(
+  grpc_core::CoreConfiguration::WithSubstituteBuilder builder(
       [](grpc_core::CoreConfiguration::Builder* builder) {
         BuildCoreConfiguration(builder);
         builder->handshaker_registry()->RegisterHandshakerFactory(

--- a/test/core/security/channel_creds_registry_test.cc
+++ b/test/core/security/channel_creds_registry_test.cc
@@ -81,12 +81,11 @@ TEST_F(ChannelCredsRegistryTest, Register) {
       nullptr);
 
   // Registration.
-  CoreConfiguration::BuildSpecialConfiguration(
-      [](CoreConfiguration::Builder* builder) {
-        BuildCoreConfiguration(builder);
-        builder->channel_creds_registry()->RegisterChannelCredsFactory(
-            absl::make_unique<TestChannelCredsFactory>());
-      });
+  CoreConfiguration::Mocker mocker([](CoreConfiguration::Builder* builder) {
+    BuildCoreConfiguration(builder);
+    builder->channel_creds_registry()->RegisterChannelCredsFactory(
+        absl::make_unique<TestChannelCredsFactory>());
+  });
 
   RefCountedPtr<grpc_channel_credentials> test_cred(
       CoreConfiguration::Get().channel_creds_registry().CreateChannelCreds(

--- a/test/core/security/channel_creds_registry_test.cc
+++ b/test/core/security/channel_creds_registry_test.cc
@@ -81,11 +81,12 @@ TEST_F(ChannelCredsRegistryTest, Register) {
       nullptr);
 
   // Registration.
-  CoreConfiguration::Mocker mocker([](CoreConfiguration::Builder* builder) {
-    BuildCoreConfiguration(builder);
-    builder->channel_creds_registry()->RegisterChannelCredsFactory(
-        absl::make_unique<TestChannelCredsFactory>());
-  });
+  CoreConfiguration::WithSubstituteBuilder builder(
+      [](CoreConfiguration::Builder* builder) {
+        BuildCoreConfiguration(builder);
+        builder->channel_creds_registry()->RegisterChannelCredsFactory(
+            absl::make_unique<TestChannelCredsFactory>());
+      });
 
   RefCountedPtr<grpc_channel_credentials> test_cred(
       CoreConfiguration::Get().channel_creds_registry().CreateChannelCreds(


### PR DESCRIPTION
Tests cannot run back to back in the same process without side effects if any of them overrides core configuration today because we cannot back up and restore old configuration before/after the test. This CL introduces Mocker that stores current core configuration, builds custom core configuration with the provided builder, and restores old core configuration back when Mocker is destroyed.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

