### PR TITLE
Fix possible integer overflow in `to_seconds_from_sub_second_time()`

### DIFF
--- a/src/core/lib/gpr/time.cc
+++ b/src/core/lib/gpr/time.cc
@@ -77,16 +77,19 @@ static gpr_timespec to_seconds_from_sub_second_time(int64_t time_in_units,
   } else if (time_in_units == INT64_MIN) {
     out = gpr_inf_past(type);
   } else {
-    if (time_in_units >= 0) {
-      out.tv_sec = time_in_units / units_per_sec;
-    } else {
-      out.tv_sec = (-((units_per_sec - 1) - (time_in_units + units_per_sec)) /
-                    units_per_sec) -
-                   1;
-    }
+    out.tv_sec = time_in_units / units_per_sec;
+    /// Our current usage does not seem to cause precision issues. Division for
+    /// integers should be enough instead of converting them to doubles for
+    /// better precision.
     out.tv_nsec =
-        static_cast<int32_t>((time_in_units - out.tv_sec * units_per_sec) *
-                             GPR_NS_PER_SEC / units_per_sec);
+        static_cast<int32_t>((time_in_units - (out.tv_sec * units_per_sec)) *
+                             (GPR_NS_PER_SEC / units_per_sec));
+    /// `out.tv_nsec` should always be positive.
+    if (out.tv_nsec < 0) {
+      out.tv_nsec += GPR_NS_PER_SEC;
+      out.tv_sec--;
+    }
+
     out.clock_type = type;
   }
   return out;

--- a/src/core/lib/gpr/time.cc
+++ b/src/core/lib/gpr/time.cc
@@ -78,9 +78,6 @@ static gpr_timespec to_seconds_from_sub_second_time(int64_t time_in_units,
     out = gpr_inf_past(type);
   } else {
     out.tv_sec = time_in_units / units_per_sec;
-    /// Our current usage does not seem to cause precision issues. Division for
-    /// integers should be enough instead of converting them to doubles for
-    /// better precision.
     out.tv_nsec =
         static_cast<int32_t>((time_in_units - (out.tv_sec * units_per_sec)) *
                              (GPR_NS_PER_SEC / units_per_sec));

--- a/src/core/lib/gpr/time.cc
+++ b/src/core/lib/gpr/time.cc
@@ -77,6 +77,8 @@ static gpr_timespec to_seconds_from_sub_second_time(int64_t time_in_units,
   } else if (time_in_units == INT64_MIN) {
     out = gpr_inf_past(type);
   } else {
+    GPR_DEBUG_ASSERT(GPR_NS_PER_SEC % units_per_sec == 0);
+
     out.tv_sec = time_in_units / units_per_sec;
     out.tv_nsec =
         static_cast<int32_t>((time_in_units - (out.tv_sec * units_per_sec)) *

--- a/test/core/filters/filter_fuzzer_corpus/testcase-6025775649521664
+++ b/test/core/filters/filter_fuzzer_corpus/testcase-6025775649521664
@@ -1,0 +1,11 @@
+filter: "http-client"
+channel_args {
+  key: "grpc.internal.transport"
+  transport {
+  }
+}
+stack_name: "$"
+actions {
+  call: 2
+  advance_time_microseconds: 9223372036854776037
+}

--- a/test/core/gpr/time_test.cc
+++ b/test/core/gpr/time_test.cc
@@ -109,14 +109,21 @@ TEST(TimeTest, Values) {
   x = gpr_time_from_micros(-(INT64_MAX - 999997), GPR_TIMESPAN);
   ASSERT_LT(x.tv_sec, 0);
   ASSERT_TRUE(x.tv_nsec >= 0 && x.tv_nsec < GPR_NS_PER_SEC);
+  EXPECT_EQ((x.tv_sec * GPR_US_PER_SEC +
+             x.tv_nsec / (GPR_NS_PER_SEC / GPR_US_PER_SEC)),
+            -(INT64_MAX - 999997));
 
   x = gpr_time_from_nanos(-(INT64_MAX - 999999997), GPR_TIMESPAN);
   ASSERT_LT(x.tv_sec, 0);
   ASSERT_TRUE(x.tv_nsec >= 0 && x.tv_nsec < GPR_NS_PER_SEC);
+  EXPECT_EQ((x.tv_sec * GPR_NS_PER_SEC + x.tv_nsec), -(INT64_MAX - 999999997));
 
   x = gpr_time_from_millis(-(INT64_MAX - 997), GPR_TIMESPAN);
   ASSERT_LT(x.tv_sec, 0);
   ASSERT_TRUE(x.tv_nsec >= 0 && x.tv_nsec < GPR_NS_PER_SEC);
+  EXPECT_EQ((x.tv_sec * GPR_MS_PER_SEC +
+             x.tv_nsec / (GPR_NS_PER_SEC / GPR_MS_PER_SEC)),
+            -(INT64_MAX - 997));
 
   /* Test general -ve values. */
   for (i = -1; i > -1000 * 1000 * 1000; i *= 7) {


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR aims to fix [b/231828673](http://b/231828673).

It is possible to experience integer overflow when the input is small (negatively). Actually unit test has test cases for that. In that case, integer overflow happens, but the behavior is still good. In other words, integer overflow does not cause problems.

This PR tries to deal with integer overflow with simpler implementation.

