### PR TITLE
Fix OutputOptions and GrpcOutputOptions (issue #25950)

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -284,10 +284,10 @@
       ProtoPath="%(_Protobuf_OutOfDateProto.AdditionalImportDirs);$(Protobuf_StandardImportsPath);%(_Protobuf_OutOfDateProto.ProtoRoot)"
       ProtoDepDir="$(Protobuf_DepFilesPath)"
       OutputDir="%(_Protobuf_OutOfDateProto.OutputDir)"
-      OutputOptions="%(_Protobuf_OutOfDateProto._OutputOptions)"
+      OutputOptions="%(_Protobuf_OutOfDateProto.OutputOptions);%(_Protobuf_OutOfDateProto._OutputOptions)"
       GrpcPluginExe="%(_Protobuf_OutOfDateProto.GrpcPluginExe)"
       GrpcOutputDir="%(_Protobuf_OutOfDateProto.GrpcOutputDir)"
-      GrpcOutputOptions="%(_Protobuf_OutOfDateProto._GrpcOutputOptions)"
+      GrpcOutputOptions="%(_Protobuf_OutOfDateProto.GrpcOutputOptions);%(_Protobuf_OutOfDateProto._GrpcOutputOptions)"
       AdditionalProtocArguments="%(_Protobuf_OutOfDateProto.AdditionalProtocArguments)"
     >
       <Output TaskParameter="GeneratedFiles" ItemName="_Protobuf_GeneratedFiles"/>


### PR DESCRIPTION
Fix for OutputOptions and GrpcOutputOptions being ignored - issue https://github.com/grpc/grpc/issues/25950

The Grpc.Tools msbuild XML needed updating to include using the user-supplied options.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

