### PR TITLE
Revert "Remove empty function grpc_cq_global_init and grpc_executor_global_init"

### DIFF
--- a/src/core/lib/debug/stats.cc
+++ b/src/core/lib/debug/stats.cc
@@ -31,14 +31,18 @@
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
+#include <grpc/support/sync.h>
 
 grpc_stats_data* grpc_stats_per_cpu_storage = nullptr;
 static size_t g_num_cores;
+static gpr_once g_once = GPR_ONCE_INIT;
 
 void grpc_stats_init(void) {
-  g_num_cores = gpr_cpu_num_cores();
-  grpc_stats_per_cpu_storage = static_cast<grpc_stats_data*>(
-      gpr_zalloc(sizeof(grpc_stats_data) * g_num_cores));
+  gpr_once_init(&g_once, []() {
+    g_num_cores = gpr_cpu_num_cores();
+    grpc_stats_per_cpu_storage = static_cast<grpc_stats_data*>(
+        gpr_zalloc(sizeof(grpc_stats_data) * g_num_cores));
+  });
 }
 
 void grpc_stats_collect(grpc_stats_data* output) {

--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -448,4 +448,6 @@ void Executor::SetThreadingDefault(bool enable) {
   executors[static_cast<size_t>(ExecutorType::DEFAULT)]->SetThreading(enable);
 }
 
+void grpc_executor_global_init() {}
+
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/executor.h
+++ b/src/core/lib/iomgr/executor.h
@@ -114,6 +114,9 @@ class Executor {
   gpr_spinlock adding_thread_lock_;
 };
 
+// Global initializer for executor
+void grpc_executor_global_init();
+
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_IOMGR_EXECUTOR_H */

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -447,6 +447,8 @@ grpc_core::TraceFlag grpc_cq_pluck_trace(false, "queue_pluck");
 
 static void on_pollset_shutdown_done(void* arg, grpc_error_handle error);
 
+void grpc_cq_global_init() {}
+
 void grpc_completion_queue_thread_local_cache_init(grpc_completion_queue* cq) {
   if (g_cached_cq == nullptr) {
     g_cached_event = nullptr;

--- a/src/core/lib/surface/completion_queue.h
+++ b/src/core/lib/surface/completion_queue.h
@@ -71,6 +71,9 @@ void grpc_cq_internal_unref(grpc_completion_queue* cq);
 #define GRPC_CQ_INTERNAL_UNREF(cq, reason) grpc_cq_internal_unref(cq)
 #endif
 
+/* Initializes global variables used by completion queues */
+void grpc_cq_global_init();
+
 /* Flag that an operation is beginning: the completion channel will not finish
    shutdown until a corrensponding grpc_cq_end_* call is made.
    \a tag is currently used only in debug builds. Return true on success, and

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -42,6 +42,7 @@
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/executor.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/core/lib/iomgr/timer_manager.h"
 #include "src/core/lib/profiling/timers.h"
@@ -52,6 +53,7 @@
 #include "src/core/lib/surface/api_trace.h"
 #include "src/core/lib/surface/channel_init.h"
 #include "src/core/lib/surface/channel_stack_type.h"
+#include "src/core/lib/surface/completion_queue.h"
 
 /* (generated) built in registry of plugins */
 extern void grpc_register_built_in_plugins(void);
@@ -118,8 +120,9 @@ static void do_basic_init(void) {
   g_init_mu = new grpc_core::Mutex();
   g_shutting_down_cv = new grpc_core::CondVar();
   grpc_register_built_in_plugins();
+  grpc_cq_global_init();
+  grpc_core::grpc_executor_global_init();
   gpr_time_init();
-  grpc_stats_init();
 }
 
 typedef struct grpc_plugin {
@@ -150,6 +153,7 @@ void grpc_init(void) {
     }
     grpc_core::Fork::GlobalInit();
     grpc_fork_handlers_auto_register();
+    grpc_stats_init();
     grpc_core::ApplicationCallbackExecCtx::GlobalInit();
     grpc_iomgr_init();
     gpr_timers_global_init();


### PR DESCRIPTION
Reverts grpc/grpc#30370 due to internal breakage.