### PR TITLE
Reland removing some global initialization functions

### DIFF
--- a/src/core/lib/debug/stats.cc
+++ b/src/core/lib/debug/stats.cc
@@ -31,18 +31,14 @@
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
-#include <grpc/support/sync.h>
 
 grpc_stats_data* grpc_stats_per_cpu_storage = nullptr;
 static size_t g_num_cores;
-static gpr_once g_once = GPR_ONCE_INIT;
 
 void grpc_stats_init(void) {
-  gpr_once_init(&g_once, []() {
-    g_num_cores = gpr_cpu_num_cores();
-    grpc_stats_per_cpu_storage = static_cast<grpc_stats_data*>(
-        gpr_zalloc(sizeof(grpc_stats_data) * g_num_cores));
-  });
+  g_num_cores = gpr_cpu_num_cores();
+  grpc_stats_per_cpu_storage = static_cast<grpc_stats_data*>(
+      gpr_zalloc(sizeof(grpc_stats_data) * g_num_cores));
 }
 
 void grpc_stats_collect(grpc_stats_data* output) {

--- a/src/core/lib/debug/stats.cc
+++ b/src/core/lib/debug/stats.cc
@@ -32,19 +32,26 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
 
-static const size_t g_num_cores = gpr_cpu_num_cores();
-grpc_stats_data* grpc_stats_per_cpu_storage = new grpc_stats_data[g_num_cores];
+namespace grpc_core {
+Stats* const g_stats_data = [] {
+  size_t num_cores = gpr_cpu_num_cores();
+  Stats* stats = static_cast<Stats*>(
+      gpr_zalloc(sizeof(Stats) + num_cores * sizeof(grpc_stats_data)));
+  stats->num_cores = num_cores;
+  return stats;
+}();
+}  // namespace grpc_core
 
 void grpc_stats_collect(grpc_stats_data* output) {
   memset(output, 0, sizeof(*output));
-  for (size_t core = 0; core < g_num_cores; core++) {
+  for (size_t core = 0; core < grpc_core::g_stats_data->num_cores; core++) {
     for (size_t i = 0; i < GRPC_STATS_COUNTER_COUNT; i++) {
       output->counters[i] += gpr_atm_no_barrier_load(
-          &grpc_stats_per_cpu_storage[core].counters[i]);
+          &grpc_core::g_stats_data->per_cpu[core].counters[i]);
     }
     for (size_t i = 0; i < GRPC_STATS_HISTOGRAM_BUCKETS; i++) {
       output->histograms[i] += gpr_atm_no_barrier_load(
-          &grpc_stats_per_cpu_storage[core].histograms[i]);
+          &grpc_core::g_stats_data->per_cpu[core].histograms[i]);
     }
   }
 }

--- a/src/core/lib/debug/stats.cc
+++ b/src/core/lib/debug/stats.cc
@@ -32,14 +32,8 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
 
-grpc_stats_data* grpc_stats_per_cpu_storage = nullptr;
-static size_t g_num_cores;
-
-void grpc_stats_init(void) {
-  g_num_cores = gpr_cpu_num_cores();
-  grpc_stats_per_cpu_storage = static_cast<grpc_stats_data*>(
-      gpr_zalloc(sizeof(grpc_stats_data) * g_num_cores));
-}
+static const size_t g_num_cores = gpr_cpu_num_cores();
+grpc_stats_data* grpc_stats_per_cpu_storage = new grpc_stats_data[g_num_cores];
 
 void grpc_stats_collect(grpc_stats_data* output) {
   memset(output, 0, sizeof(*output));

--- a/src/core/lib/debug/stats.h
+++ b/src/core/lib/debug/stats.h
@@ -35,10 +35,17 @@ typedef struct grpc_stats_data {
   gpr_atm histograms[GRPC_STATS_HISTOGRAM_BUCKETS];
 } grpc_stats_data;
 
-extern grpc_stats_data* grpc_stats_per_cpu_storage;
+namespace grpc_core {
+struct Stats {
+  size_t num_cores;
+  grpc_stats_data per_cpu[0];
+};
+extern Stats* const g_stats_data;
+}  // namespace grpc_core
 
 #define GRPC_THREAD_STATS_DATA() \
-  (&grpc_stats_per_cpu_storage[grpc_core::ExecCtx::Get()->starting_cpu()])
+  (&::grpc_core::g_stats_data    \
+        ->per_cpu[grpc_core::ExecCtx::Get()->starting_cpu()])
 
 /* Only collect stats if GRPC_COLLECT_STATS is defined or it is a debug build.
  */

--- a/src/core/lib/debug/stats.h
+++ b/src/core/lib/debug/stats.h
@@ -55,7 +55,8 @@ extern grpc_stats_data* grpc_stats_per_cpu_storage;
 #define GRPC_STATS_INC_HISTOGRAM(histogram, index)
 #endif /* defined(GRPC_COLLECT_STATS) || !defined(NDEBUG) */
 
-void grpc_stats_init(void);
+GRPC_DEPRECATED("function is no longer needed")
+inline void grpc_stats_init(void) {}
 void grpc_stats_collect(grpc_stats_data* output);
 // c = b-a
 void grpc_stats_diff(const grpc_stats_data* b, const grpc_stats_data* a,

--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -448,6 +448,4 @@ void Executor::SetThreadingDefault(bool enable) {
   executors[static_cast<size_t>(ExecutorType::DEFAULT)]->SetThreading(enable);
 }
 
-void grpc_executor_global_init() {}
-
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/executor.h
+++ b/src/core/lib/iomgr/executor.h
@@ -114,9 +114,6 @@ class Executor {
   gpr_spinlock adding_thread_lock_;
 };
 
-// Global initializer for executor
-void grpc_executor_global_init();
-
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_IOMGR_EXECUTOR_H */

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -447,8 +447,6 @@ grpc_core::TraceFlag grpc_cq_pluck_trace(false, "queue_pluck");
 
 static void on_pollset_shutdown_done(void* arg, grpc_error_handle error);
 
-void grpc_cq_global_init() {}
-
 void grpc_completion_queue_thread_local_cache_init(grpc_completion_queue* cq) {
   if (g_cached_cq == nullptr) {
     g_cached_event = nullptr;

--- a/src/core/lib/surface/completion_queue.h
+++ b/src/core/lib/surface/completion_queue.h
@@ -71,9 +71,6 @@ void grpc_cq_internal_unref(grpc_completion_queue* cq);
 #define GRPC_CQ_INTERNAL_UNREF(cq, reason) grpc_cq_internal_unref(cq)
 #endif
 
-/* Initializes global variables used by completion queues */
-void grpc_cq_global_init();
-
 /* Flag that an operation is beginning: the completion channel will not finish
    shutdown until a corrensponding grpc_cq_end_* call is made.
    \a tag is currently used only in debug builds. Return true on success, and

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -42,7 +42,6 @@
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
-#include "src/core/lib/iomgr/executor.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/core/lib/iomgr/timer_manager.h"
 #include "src/core/lib/profiling/timers.h"
@@ -53,7 +52,6 @@
 #include "src/core/lib/surface/api_trace.h"
 #include "src/core/lib/surface/channel_init.h"
 #include "src/core/lib/surface/channel_stack_type.h"
-#include "src/core/lib/surface/completion_queue.h"
 
 /* (generated) built in registry of plugins */
 extern void grpc_register_built_in_plugins(void);
@@ -120,9 +118,8 @@ static void do_basic_init(void) {
   g_init_mu = new grpc_core::Mutex();
   g_shutting_down_cv = new grpc_core::CondVar();
   grpc_register_built_in_plugins();
-  grpc_cq_global_init();
-  grpc_core::grpc_executor_global_init();
   gpr_time_init();
+  grpc_stats_init();
 }
 
 typedef struct grpc_plugin {
@@ -153,7 +150,6 @@ void grpc_init(void) {
     }
     grpc_core::Fork::GlobalInit();
     grpc_fork_handlers_auto_register();
-    grpc_stats_init();
     grpc_core::ApplicationCallbackExecCtx::GlobalInit();
     grpc_iomgr_init();
     gpr_timers_global_init();

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -119,7 +119,6 @@ static void do_basic_init(void) {
   g_shutting_down_cv = new grpc_core::CondVar();
   grpc_register_built_in_plugins();
   gpr_time_init();
-  grpc_stats_init();
 }
 
 typedef struct grpc_plugin {


### PR DESCRIPTION
CC @[panzhongxian](https://github.com/panzhongxian) 

I'll follow up with a PR to remove `grpc_stats_init` once internal usage has been removed.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

