### PR TITLE
remove some default allocators

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -973,6 +973,7 @@ void Init_grpc_call() {
   grpc_rb_cCall = rb_define_class_under(grpc_rb_mGrpcCore, "Call", rb_cObject);
   grpc_rb_cMdAry =
       rb_define_class_under(grpc_rb_mGrpcCore, "MetadataArray", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cMdAry);
 
   /* Prevent allocation or inialization of the Call class */
   rb_define_alloc_func(grpc_rb_cCall, grpc_rb_cannot_alloc);

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -804,6 +804,7 @@ static void Init_grpc_connectivity_states() {
 
 void Init_grpc_channel() {
   grpc_rb_cChannelArgs = rb_define_class("TmpChannelArgs", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cChannelArgs);
   grpc_rb_cChannel =
       rb_define_class_under(grpc_rb_mGrpcCore, "Channel", rb_cObject);
 

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -111,6 +111,7 @@ typedef struct channel_convert_params {
 static VALUE grpc_rb_hash_convert_to_channel_args0(VALUE as_value) {
   ID id_size = rb_intern("size");
   VALUE grpc_rb_cChannelArgs = rb_define_class("TmpChannelArgs", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cChannelArgs);
   channel_convert_params* params = (channel_convert_params*)as_value;
   size_t num_args = 0;
 

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -198,6 +198,7 @@ static void Init_grpc_time_consts() {
       rb_define_module_under(grpc_rb_mGrpcCore, "TimeConsts");
   grpc_rb_cTimeVal =
       rb_define_class_under(grpc_rb_mGrpcCore, "TimeSpec", rb_cObject);
+  rb_undef_alloc_func(grpc_rb_cTimeVal);
   zero_realtime = gpr_time_0(GPR_CLOCK_REALTIME);
   inf_future_realtime = gpr_inf_future(GPR_CLOCK_REALTIME);
   inf_past_realtime = gpr_inf_past(GPR_CLOCK_REALTIME);


### PR DESCRIPTION
In Ruby 3.2 the default allocator warns if used with `Data_Wrap_Struct`. This removed the default allocator in those cases.

Ruby discussion: https://bugs.ruby-lang.org/issues/18007