### PR TITLE
[ObjC] run ios CronetTest from bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -704,6 +704,13 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpc_cronet_hdrs",
+    hdrs = [
+        "include/grpc/grpc_cronet.h",
+    ],
+)
+
+grpc_cc_library(
     name = "tchar",
     srcs = [
         "src/core/lib/gprpp/tchar.cc",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -88,3 +88,32 @@ pip_install(
     name = "grpc_python_dependencies",
     requirements = "@com_github_grpc_grpc//:requirements.bazel.txt",
 )
+
+http_archive(
+    name = "build_bazel_rules_swift",
+    sha256 = "12057b7aa904467284eee640de5e33853e51d8e31aae50b3fb25d2823d51c6b8",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.0.0/rules_swift.1.0.0.tar.gz",
+)
+
+http_archive(
+    name = "rules_pods",
+    urls = ["https://github.com/pinterest/PodToBUILD/releases/download/4.1.0-412495/PodToBUILD.zip"],
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+load(
+    "@rules_pods//BazelExtensions:workspace.bzl",
+    "new_pod_repository",
+)
+
+swift_rules_dependencies()
+
+new_pod_repository(
+    name = "CronetFramework",
+    is_dynamic_framework = True,
+    podspec_url = "https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/2/e/1/CronetFramework/0.0.5/CronetFramework.podspec.json",
+    url = "https://storage.googleapis.com/grpc-precompiled-binaries/cronet/Cronet.framework-v0.0.5.zip",
+)

--- a/src/objective-c/BUILD
+++ b/src/objective-c/BUILD
@@ -240,6 +240,18 @@ grpc_objc_library(
 )
 
 grpc_objc_library(
+    name = "grpc_objc_client_core_cronet_testing",
+    srcs = glob(["GRPCClient/private/GRPCCore/GRPCCoreCronet/*.m"]),
+    hdrs = glob(["GRPCClient/private/GRPCCore/GRPCCoreCronet/*.h"]),
+    deps = [
+        ":grpc_objc_client_core_internal_testing",
+        "//:grpc_cronet_hdrs",
+        "//src/core/ext/transport/cronet:grpc_transport_cronet_client_secure",
+        "@CronetFramework",
+    ],
+)
+
+grpc_objc_library(
     name = "proto_objc_rpc_internal_testing",
     srcs = [
         "ProtoRPC/ProtoRPCLegacy.m",

--- a/src/objective-c/grpc_objc_internal_library.bzl
+++ b/src/objective-c/grpc_objc_internal_library.bzl
@@ -163,6 +163,7 @@ def grpc_objc_testing_library(
         defines = defines,
         includes = includes,
         deps = deps + additional_deps,
+        testonly = 1,
     )
 
 def local_objc_grpc_library(name, deps, testing = True, srcs = [], use_well_known_protos = False, **kwargs):

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -22,6 +22,7 @@ load(
     "local_objc_grpc_library",
     "proto_library_objc_wrapper",
 )
+load("//test/core/end2end:generate_tests.bzl", "grpc_end2end_tests")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@build_bazel_rules_apple//apple:macos.bzl", "macos_unit_test")
@@ -32,6 +33,8 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["LICENSE"])
+
+grpc_end2end_tests()
 
 proto_library_objc_wrapper(
     name = "messages_proto",
@@ -184,7 +187,26 @@ grpc_objc_testing_library(
     hdrs = ["MacTests/StressTests.h"],
 )
 
-grpc_objc_ios_unit_test(
+grpc_objc_testing_library(
+    name = "CronetTests-lib",
+    srcs = [
+        "ConfigureCronet.m",
+    ] + glob([
+        "CronetTests/*.m",
+        "CronetTests/*.mm",
+    ]),
+    hdrs = [
+        "ConfigureCronet.h",
+    ],
+    deps = [
+        "InteropTests-lib",
+        "//src/objective-c:grpc_objc_client_core_cronet_testing",
+        "//test/core/end2end:end2end_tests",
+        "//third_party/objective_c/Cronet:cronet_c_for_grpc",
+    ],
+)
+
+grpc_objc_testing_library(
     name = "UnitTests",
     deps = [
         ":APIv2Tests-lib",
@@ -217,6 +239,13 @@ ios_unit_test(
     test_host = ":ios-host",
     deps = [
         ":InteropTestsRemote-lib",
+    ],
+)
+
+grpc_objc_ios_unit_test(
+    name = "CronetTests",
+    deps = [
+        "CronetTests-lib",
     ],
 )
 

--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -39,7 +39,11 @@
 #import "test/core/end2end/data/ssl_test_data.h"
 #import "test/core/util/test_config.h"
 
+#if COCOAPODS
 #import <openssl_grpc/ssl.h>
+#else
+#import <openssl/ssl.h>
+#endif
 
 static void drain_cq(grpc_completion_queue *cq) {
   grpc_event ev;

--- a/src/objective-c/tests/CronetTests/InteropTestsRemoteWithCronet.m
+++ b/src/objective-c/tests/CronetTests/InteropTestsRemoteWithCronet.m
@@ -23,7 +23,7 @@
 #import <GRPCClient/GRPCCall+Cronet.h>
 
 #import "../ConfigureCronet.h"
-#import "InteropTests.h"
+#import "../InteropTests/InteropTests.h"
 
 // The server address is derived from preprocessor macro, which is
 // in turn derived from environment variable of the same name.

--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -440,6 +440,9 @@ def grpc_end2end_tests():
             "//test/core/compression:args_utils",
             "//:grpc_http_filters",
         ],
+        visibility = [
+            "//src/objective-c/tests:__subpackages__",
+        ],
     )
     for f, fopt in END2END_FIXTURES.items():
         bin_name = "%s_test" % f

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -57,6 +57,7 @@ TEST_TARGETS=(
   //src/objective-c/tests:InteropTestsRemote
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
+  //src/objective-c/tests:CronetTests
   # codegen plugin tests
   //src/objective-c/tests:objc_codegen_plugin_test
   //src/objective-c/tests:objc_codegen_plugin_option_test

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1013,14 +1013,6 @@ class ObjCLanguage(object):
                 shortname='ios-test-cfstream-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS))
-        # TODO(jtattermusch): Create bazel target for the test and remove the test from here
-        # (how does one add the cronet dependency in bazel?)
-        out.append(
-            self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
-                                 timeout_seconds=60 * 60,
-                                 shortname='ios-test-cronettests',
-                                 cpu_cost=1e6,
-                                 environ={'SCHEME': 'CronetTests'}))
         # TODO(jtattermusch): Create bazel target for the test and remove the test from here.
         out.append(
             self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],


### PR DESCRIPTION
It's part of grpc pod migration.  https://github.com/grpc/grpc-ios/issues/104

matching the CronetTest framework artifact as in our current cocoapod builds.
will delete the temporary code for pod build when migration finish. 



How to run:
1. Start port server with tools/run_tests/start_port_server.py
2. OVERRIDE_BAZEL_VERSION=5.2.0 SCHEME=CronetTests src/objective-c/tests/run_one_test_bazel.sh 


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

@dennycd 