### PR TITLE
[ObjC]fix c++14 errors in bazel objC

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -592,7 +592,9 @@ def grpc_objc_library(
         name,
         srcs = [],
         hdrs = [],
+        non_arc_srcs = [],
         textual_hdrs = [],
+        testonly = False,
         data = [],
         deps = [],
         defines = [],
@@ -604,7 +606,9 @@ def grpc_objc_library(
         name: name of target
         hdrs: public headers
         srcs: all source files (.m)
+        non_arc_srcs: list of Objective-C files that DO NOT use ARC.
         textual_hdrs: private headers
+        testonly: Whether the binary is for tests only.
         data: any other bundle resources
         defines: preprocessors
         includes: added to search path, always [the path to objc directory]
@@ -616,7 +620,10 @@ def grpc_objc_library(
         name = name,
         hdrs = hdrs,
         srcs = srcs,
+        non_arc_srcs = non_arc_srcs,
         textual_hdrs = textual_hdrs,
+        copts = GRPC_DEFAULT_COPTS + ["-ObjC++", "-std=gnu++14"],
+        testonly = testonly,
         data = data,
         deps = deps,
         defines = defines,

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -598,6 +598,7 @@ def grpc_objc_library(
         data = [],
         deps = [],
         defines = [],
+        sdk_frameworks = [],
         includes = [],
         visibility = ["//visibility:public"]):
     """The grpc version of objc_library, only used for the Objective-C library compilation
@@ -611,6 +612,7 @@ def grpc_objc_library(
         testonly: Whether the binary is for tests only.
         data: any other bundle resources
         defines: preprocessors
+        sdk_frameworks: sdks
         includes: added to search path, always [the path to objc directory]
         deps: dependencies
         visibility: visibility, default to public
@@ -628,6 +630,7 @@ def grpc_objc_library(
         deps = deps,
         defines = defines,
         includes = includes,
+        sdk_frameworks = sdk_frameworks,
         visibility = visibility,
     )
 

--- a/src/objective-c/GRPCClient/private/GRPCCore/ChannelArgsUtil.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/ChannelArgsUtil.m
@@ -59,8 +59,8 @@ grpc_channel_args *GRPCBuildChannelArgs(NSDictionary *dictionary) {
   NSArray *keys = [dictionary allKeys];
   NSUInteger argCount = [keys count];
 
-  grpc_channel_args *channelArgs = gpr_malloc(sizeof(grpc_channel_args));
-  channelArgs->args = gpr_malloc(argCount * sizeof(grpc_arg));
+  grpc_channel_args *channelArgs = (grpc_channel_args *)gpr_malloc(sizeof(grpc_channel_args));
+  channelArgs->args = (grpc_arg *)gpr_malloc(argCount * sizeof(grpc_arg));
 
   // TODO(kriswuollett) Check that keys adhere to GRPC core library requirements
 

--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCSecureChannelFactory.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCSecureChannelFactory.m
@@ -86,17 +86,18 @@
 
   grpc_channel_credentials *creds = NULL;
   if (privateKey.length == 0 && certChain.length == 0) {
-    creds = grpc_ssl_credentials_create(rootsASCII.bytes, NULL, NULL, NULL);
+    creds = grpc_ssl_credentials_create((const char *)rootsASCII.bytes, NULL, NULL, NULL);
   } else {
     grpc_ssl_pem_key_cert_pair key_cert_pair;
     NSData *privateKeyASCII = [self nullTerminatedDataWithString:privateKey];
     NSData *certChainASCII = [self nullTerminatedDataWithString:certChain];
-    key_cert_pair.private_key = privateKeyASCII.bytes;
-    key_cert_pair.cert_chain = certChainASCII.bytes;
+    key_cert_pair.private_key = (const char *)privateKeyASCII.bytes;
+    key_cert_pair.cert_chain = (const char *)certChainASCII.bytes;
     if (key_cert_pair.private_key == NULL || key_cert_pair.cert_chain == NULL) {
-      creds = grpc_ssl_credentials_create(rootsASCII.bytes, NULL, NULL, NULL);
+      creds = grpc_ssl_credentials_create((const char *)rootsASCII.bytes, NULL, NULL, NULL);
     } else {
-      creds = grpc_ssl_credentials_create(rootsASCII.bytes, &key_cert_pair, NULL, NULL);
+      creds =
+          grpc_ssl_credentials_create((const char *)rootsASCII.bytes, &key_cert_pair, NULL, NULL);
     }
   }
 

--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCWrappedCall.m
@@ -68,7 +68,7 @@
     _op.data.send_initial_metadata.count = metadata.count;
     _op.data.send_initial_metadata.metadata = metadata.grpc_metadataArray;
     _op.data.send_initial_metadata.maybe_compression_level.is_set = false;
-    _op.data.send_initial_metadata.maybe_compression_level.level = 0;
+    _op.data.send_initial_metadata.maybe_compression_level.level = GRPC_COMPRESS_LEVEL_NONE;
     _op.flags = flags;
     _handler = handler;
   }
@@ -274,7 +274,7 @@
   @synchronized(self) {
     if (_call != NULL) {
       size_t nops = operations.count;
-      grpc_op *ops_array = gpr_malloc(nops * sizeof(grpc_op));
+      grpc_op *ops_array = (grpc_op *)gpr_malloc(nops * sizeof(grpc_op));
       size_t i = 0;
       for (GRPCOperation *operation in operations) {
         ops_array[i++] = operation.op;

--- a/src/objective-c/GRPCClient/private/GRPCCore/NSData+GRPC.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/NSData+GRPC.m
@@ -40,7 +40,7 @@ static void MallocAndCopyByteBufferToCharArray(grpc_byte_buffer *buffer, size_t 
   // because the reader takes care of automatically decompressing it
   grpc_slice slice = grpc_byte_buffer_reader_readall(&reader);
   size_t uncompressed_length = GRPC_SLICE_LENGTH(slice);
-  char *result = malloc(uncompressed_length);
+  char *result = (char *)malloc(uncompressed_length);
   if (result) {
     memcpy(result, GRPC_SLICE_START_PTR(slice), uncompressed_length);
   }

--- a/src/objective-c/GRPCClient/private/GRPCCore/NSDictionary+GRPC.m
+++ b/src/objective-c/GRPCClient/private/GRPCCore/NSDictionary+GRPC.m
@@ -37,7 +37,7 @@
 }
 
 - (void)grpc_initMetadata:(grpc_metadata *)metadata {
-  metadata->value = grpc_slice_from_copied_buffer(self.bytes, self.length);
+  metadata->value = grpc_slice_from_copied_buffer((const char *)self.bytes, self.length);
 }
 @end
 
@@ -94,7 +94,7 @@
 // Preconditions: All keys are ASCII strings. Keys ending in -bin have NSData values; the others
 // have NSString values.
 - (grpc_metadata *)grpc_metadataArray {
-  grpc_metadata *metadata = gpr_malloc([self count] * sizeof(grpc_metadata));
+  grpc_metadata *metadata = (grpc_metadata *)gpr_malloc([self count] * sizeof(grpc_metadata));
   grpc_metadata *current = metadata;
   for (NSString *key in self) {
     id value = self[key];

--- a/src/objective-c/grpc_objc_internal_library.bzl
+++ b/src/objective-c/grpc_objc_internal_library.bzl
@@ -31,6 +31,7 @@ load(
     "generate_objc_non_arc_srcs",
     "generate_objc_srcs",
 )
+load("//bazel:grpc_build_system.bzl", "grpc_objc_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load(
     "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
@@ -111,7 +112,7 @@ def grpc_objc_examples_library(
         includes: added to search path, always [the path to objc directory]
         deps: dependencies
     """
-    native.objc_library(
+    grpc_objc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs,
@@ -153,7 +154,7 @@ def grpc_objc_testing_library(
     if not name == "TestConfigs":
         additional_deps.append(":TestConfigs")
 
-    native.objc_library(
+    grpc_objc_library(
         name = name,
         hdrs = hdrs,
         srcs = srcs,
@@ -211,7 +212,7 @@ def local_objc_grpc_library(name, deps, testing = True, srcs = [], use_well_know
     else:
         library_deps.append("//src/objective-c:proto_objc_rpc")
 
-    native.objc_library(
+    grpc_objc_library(
         name = name,
         hdrs = [":" + objc_grpc_library_name + "_hdrs"],
         non_arc_srcs = [":" + objc_grpc_library_name + "_non_arc_srcs"],


### PR DESCRIPTION
It's part of grpc pod migration. 
to support #30439, since c-core changed to c++14.
https://github.com/grpc/grpc-ios/issues/104

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

