### PR TITLE
xDS interop: set default socket timeout to 60

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -336,6 +336,9 @@ def main(argv):
         raise app.UsageError('Too many command-line arguments.')
     load_keep_config()
 
+    # Must be called before KubernetesApiManager or GcpApiManager init.
+    xds_flags.set_socket_default_timeout_from_flag()
+
     project: str = xds_flags.PROJECT.value
     network: str = xds_flags.NETWORK.value
     gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/namespace.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/namespace.py
@@ -25,6 +25,9 @@ def main(argv):
         raise app.UsageError('Too many command-line arguments.')
     cleanup.load_keep_config()
 
+    # Must be called before KubernetesApiManager or GcpApiManager init.
+    xds_flags.set_socket_default_timeout_from_flag()
+
     project: str = xds_flags.PROJECT.value
     network: str = xds_flags.NETWORK.value
     gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
@@ -174,6 +174,9 @@ def main(argv):
     if len(argv) > 1:
         raise app.UsageError('Too many command-line arguments.')
 
+    # Must be called before KubernetesApiManager or GcpApiManager init.
+    xds_flags.set_socket_default_timeout_from_flag()
+
     k8s_api_manager = k8s.KubernetesApiManager(xds_k8s_flags.KUBE_CONTEXT.value)
 
     # Resource names.

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_td_setup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_td_setup.py
@@ -71,6 +71,9 @@ def main(argv):  # pylint: disable=too-many-locals,too-many-branches,too-many-st
     if len(argv) > 1:
         raise app.UsageError('Too many command-line arguments.')
 
+    # Must be called before KubernetesApiManager or GcpApiManager init.
+    xds_flags.set_socket_default_timeout_from_flag()
+
     command = _CMD.value
     security_mode = _SECURITY.value
 

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
@@ -59,6 +59,9 @@ def main(argv):
     if len(argv) > 1:
         raise app.UsageError('Too many command-line arguments.')
 
+    # Must be called before KubernetesApiManager or GcpApiManager init.
+    xds_flags.set_socket_default_timeout_from_flag()
+
     project: str = xds_flags.PROJECT.value
     # GCP Service Account email
     gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
@@ -50,6 +50,9 @@ def main(argv):
     if len(argv) > 1:
         raise app.UsageError('Too many command-line arguments.')
 
+    # Must be called before KubernetesApiManager or GcpApiManager init.
+    xds_flags.set_socket_default_timeout_from_flag()
+
     project: str = xds_flags.PROJECT.value
     # GCP Service Account email
     gcp_service_account: str = xds_k8s_flags.GCP_SERVICE_ACCOUNT.value

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -116,6 +116,9 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         # support current test case.
         skips.evaluate_test_config(cls.is_supported)
 
+        # Must be called before KubernetesApiManager or GcpApiManager init.
+        xds_flags.set_socket_default_timeout_from_flag()
+
         # GCP
         cls.project = xds_flags.PROJECT.value
         cls.network = xds_flags.NETWORK.value

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_test_resources.py
@@ -146,6 +146,10 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
                 'Predefined resource_suffix is not supported for UrlMap tests')
         logging.info('GcpResourceManager: resource prefix=%s, suffix=%s',
                      self.resource_prefix, self.resource_suffix)
+
+        # Must be called before KubernetesApiManager or GcpApiManager init.
+        xds_flags.set_socket_default_timeout_from_flag()
+
         # API managers
         self.k8s_api_manager = k8s.KubernetesApiManager(self.kube_context)
         self.gcp_api_manager = gcp.api.GcpApiManager()


### PR DESCRIPTION
`kubernetes` library does not provide a way to configure the default socket timeout that will be used with `urllib3` it uses under the hood. And `urllib3` default socket timeout is infinity.

This PR sets the default socket timeout using python's `socket.setdefaulttimeout()` to 60 seconds.

This affects `urllib3` directly,  and therefore `kubernetes`.
The changes is also picked up by the `google-api-python-client`, which does not use `urllib3` (it uses `httplib2`), but [respectes](https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.http-module.html#build_http) `socket.setdefaulttimeout()`.

ref b/240068800
