### PR TITLE
Add enablePrometheus annotation.

### DIFF
--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -100,6 +100,7 @@ psmBuildConfigs() {
         -a ci_gitCommit="${GRPC_GITREF}" \
         -a ci_gitCommit_java="${GRPC_JAVA_GITREF}" \
         -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
+        -a enablePrometheus="true" \
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" -u "${proxy_type}"\
         -a pool="${pool}" \
         --category=psm \
@@ -129,6 +130,7 @@ buildConfigs() {
         -a ci_gitCommit="${GRPC_GITREF}" \
         -a ci_gitCommit_java="${GRPC_JAVA_GITREF}" \
         -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
+        -a enablePrometheus="true" \
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=psm \
         --allow_client_language=c++ --allow_server_language=c++ \

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -100,7 +100,7 @@ psmBuildConfigs() {
         -a ci_gitCommit="${GRPC_GITREF}" \
         -a ci_gitCommit_java="${GRPC_JAVA_GITREF}" \
         -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
-        -a enablePrometheus="true" \
+        -a enablePrometheus=true \
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" -u "${proxy_type}"\
         -a pool="${pool}" \
         --category=psm \
@@ -130,7 +130,7 @@ buildConfigs() {
         -a ci_gitCommit="${GRPC_GITREF}" \
         -a ci_gitCommit_java="${GRPC_JAVA_GITREF}" \
         -a ci_gitActualCommit="${KOKORO_GIT_COMMIT}" \
-        -a enablePrometheus="true" \
+        -a enablePrometheus=true \
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=psm \
         --allow_client_language=c++ --allow_server_language=c++ \

--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -148,7 +148,7 @@ psm_basic_example() {
         -s psm_image_prefix="\${psm_image_prefix}" \
         -s psm_image_tag="\${psm_image_tag}" \
         -s timeout_seconds=900 --prefix=psm-examples -u "${uniquifier}" -r "^${scenario}$" \
-        -a enablePrometheus="true" \
+        -a enablePrometheus=true \
         --allow_client_language=c++ --allow_server_language=c++ \
         --allow_server_language=node \
         --client_channels=8 \
@@ -179,7 +179,7 @@ psm_prebuilt_example() {
         -s psm_image_tag="\${psm_image_tag}" \
         --prefix=psm-examples -u prebuilt-"${uniquifier}" -r "^${scenario}$" \
         -a pool="\${workers_pool}" \
-        -a enablePrometheus="true" \
+        -a enablePrometheus=true \
         --allow_client_language=c++ --allow_server_language=c++ \
         --allow_server_language=node \
         --client_channels=8 \

--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -148,6 +148,7 @@ psm_basic_example() {
         -s psm_image_prefix="\${psm_image_prefix}" \
         -s psm_image_tag="\${psm_image_tag}" \
         -s timeout_seconds=900 --prefix=psm-examples -u "${uniquifier}" -r "^${scenario}$" \
+        -a enablePrometheus="true" \
         --allow_client_language=c++ --allow_server_language=c++ \
         --allow_server_language=node \
         --client_channels=8 \
@@ -178,6 +179,7 @@ psm_prebuilt_example() {
         -s psm_image_tag="\${psm_image_tag}" \
         --prefix=psm-examples -u prebuilt-"${uniquifier}" -r "^${scenario}$" \
         -a pool="\${workers_pool}" \
+        -a enablePrometheus="true" \
         --allow_client_language=c++ --allow_server_language=c++ \
         --allow_server_language=node \
         --client_channels=8 \


### PR DESCRIPTION
The PR adds the enablePrometheus annotation to load tests that are
part of PSM data plan performance tests. This annotation enables
all PSM related tests to obtain data from Prometehus, even for the
regular tests.
