### PR TITLE
Create directory tree before generating load test examples.

### DIFF
--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -29,7 +29,7 @@ fi
 
 outputbasedir="${1}"
 
-mkdir -p "${outputbasedir}/templates"
+mkdir -p "${outputbasedir}/templates/psm/prebuilt"
 
 example_file() {
     local scenario="${1}"


### PR DESCRIPTION
PSM examples are created deeper and that may cause an error if the directories are not created before generating the examples.

